### PR TITLE
Add AgglayerBridge benchmark model

### DIFF
--- a/Benchmark.lean
+++ b/Benchmark.lean
@@ -1,0 +1,4 @@
+import Benchmark.Cases.Polygon.AgglayerBridge.Contract
+import Benchmark.Cases.Polygon.AgglayerBridge.Specs
+import Benchmark.Cases.Polygon.AgglayerBridge.Proofs
+import Benchmark.Cases.Polygon.AgglayerBridge.Compile

--- a/Benchmark/Cases.lean
+++ b/Benchmark/Cases.lean
@@ -1,0 +1,1 @@
+import Benchmark.Cases.Polygon

--- a/Benchmark/Cases/Polygon.lean
+++ b/Benchmark/Cases/Polygon.lean
@@ -1,0 +1,1 @@
+import Benchmark.Cases.Polygon.AgglayerBridge

--- a/Benchmark/Cases/Polygon/AgglayerBridge.lean
+++ b/Benchmark/Cases/Polygon/AgglayerBridge.lean
@@ -1,0 +1,4 @@
+import Benchmark.Cases.Polygon.AgglayerBridge.Contract
+import Benchmark.Cases.Polygon.AgglayerBridge.Specs
+import Benchmark.Cases.Polygon.AgglayerBridge.Proofs
+import Benchmark.Cases.Polygon.AgglayerBridge.Compile

--- a/Benchmark/Cases/Polygon/AgglayerBridge/Compile.lean
+++ b/Benchmark/Cases/Polygon/AgglayerBridge/Compile.lean
@@ -1,0 +1,6 @@
+import Benchmark.Cases.Polygon.AgglayerBridge.Contract
+import Benchmark.Cases.Polygon.AgglayerBridge.Proofs
+
+namespace Benchmark.Cases.Polygon.AgglayerBridge
+
+end Benchmark.Cases.Polygon.AgglayerBridge

--- a/Benchmark/Cases/Polygon/AgglayerBridge/Contract.lean
+++ b/Benchmark/Cases/Polygon/AgglayerBridge/Contract.lean
@@ -1,0 +1,379 @@
+import Contracts.Common
+
+namespace Benchmark.Cases.Polygon.AgglayerBridge
+
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+open Verity.Stdlib.Math
+open Contracts
+
+/-!
+AgglayerBridge Merkle/nullifier model.
+
+| what was simplified | why |
+|---|---|
+| `bytes32` is modeled as `Uint256` words | Verity's proof surface is word-oriented; this preserves the storage and hash inputs relevant to the invariant. |
+| Raw `metadata : bytes` is replaced by `metadataHash : Uint256` on claim/model entry points | Dynamic `bytes` hashing and exact dynamic `abi.encodePacked` parity are outside the current convenient Verity core surface; the bridge itself hashes metadata before leaf construction. |
+| `keccak256` / `Hashes.efficientKeccak256` are modeled by deterministic word-combiners (`xor` over the same logical inputs) | Cryptographic collision resistance is a trusted primitive boundary, not the target theorem. |
+| `bytes32[32] calldata` Merkle proofs are modeled as `Array Uint256` | Word-sized array parameters are supported; exact fixed-array ABI shape is not needed for the invariant. |
+| Merkle loops are represented by one-step word-combiner `calculateRoot` | A faithful 32-step loop is expressible, but the Phase 2 invariant only needs the bridge to require the calculated root equals the accepted root. |
+| Public claim functions inline `_verifyLeafAndSetNullifier` / `_verifyLeaf` proof-array reads | Current direct macro helper lowering rejects helper calls with array parameters; helper functions remain present for source review. |
+| `globalExitRootManager.globalExitRootMap` is modeled as ghost storage mapping `globalExitRootMap` | The manager is an external dependency; claim safety only requires the bridge to reject unregistered global exit roots. |
+| Token/native transfers, wrapped-token deployment, permit, events, and message callbacks are abstracted after nullifier setting | They occur after `_verifyLeafAndSetNullifier` and are not needed for Merkle membership or double-claim safety. |
+| Solidity `uint32` / `uint8` are modeled as `Uint256` with caller-side boundedness assumptions | Verity arithmetic is word-oriented; bit reconstruction checks in `_validateAndDecodeGlobalIndex` preserve the relevant global-index shape. |
+
+Local copies of storage slots use the trailing-underscore convention when needed.
+-/
+
+def MAINNET_NETWORK_ID : Uint256 := 0
+def ZKEVM_NETWORK_ID : Uint256 := 1
+def LEAF_TYPE_ASSET : Uint256 := 0
+def LEAF_TYPE_MESSAGE : Uint256 := 1
+def MAX_LEAFS_PER_NETWORK : Uint256 := 4294967296
+def GLOBAL_INDEX_MAINNET_FLAG : Uint256 := 18446744073709551616
+def LOW_32_MASK : Uint256 := 4294967295
+def LOW_8_MASK : Uint256 := 255
+
+def globalIndexForNullifierModel
+    (networkID leafIndex sourceBridgeNetwork : Uint256) : Uint256 :=
+  if networkID == MAINNET_NETWORK_ID && sourceBridgeNetwork == ZKEVM_NETWORK_ID then
+    leafIndex
+  else
+    add leafIndex (mul sourceBridgeNetwork MAX_LEAFS_PER_NETWORK)
+
+def bitmapWordPosModel (index : Uint256) : Uint256 := shr 8 index
+def bitmapBitPosModel (index : Uint256) : Uint256 := and index LOW_8_MASK
+def bitmapMaskModel (index : Uint256) : Uint256 := shl (bitmapBitPosModel index) 1
+
+verity_contract AgglayerBridge where
+  storage
+    -- src: DepositContractBase.sol:40 — `_branch[height]`, flattened from fixed storage array.
+    _branch : Uint256 → Uint256 := slot 0
+    -- src: DepositContractBase.sol:43 — public deposit counter.
+    depositCount : Uint256 := slot 1
+    -- src: AgglayerBridge.sol:68 — local bridge network id.
+    networkID : Uint256 := slot 2
+    -- src: AgglayerBridge.sol:908-914 — ghost of `globalExitRootManager.globalExitRootMap`.
+    globalExitRootMap : Uint256 → Uint256 := slot 3
+    -- src: AgglayerBridge.sol:77 — nullifier bitmap.
+    claimedBitMap : Uint256 → Uint256 := slot 4
+    -- src: AgglayerBridge.sol:74 — last deposit count pushed to the manager.
+    lastUpdatedDepositCount : Uint256 := slot 5
+    -- src: AgglayerBridge.sol:90-93 — gas-token identity used in token branches, retained for fidelity.
+    gasTokenAddressWord : Uint256 := slot 6
+    gasTokenNetwork : Uint256 := slot 7
+
+  function hashPair (a : Uint256, b : Uint256) : Uint256 := do
+    return xor a b
+
+  function getLeafValue (
+      leafType : Uint256,
+      originNetwork : Uint256,
+      originAddress : Address,
+      destinationNetwork : Uint256,
+      destinationAddress : Address,
+      amount : Uint256,
+      metadataHash : Uint256
+    ) : Uint256 := do
+    -- src: DepositContractV2.sol:22-43 — keccak256(abi.encodePacked(...)).
+    let originAddressWord := addressToWord originAddress
+    let destinationAddressWord := addressToWord destinationAddress
+    let leafValue :=
+      xor
+        (xor (xor leafType originNetwork) originAddressWord)
+        (xor (xor destinationNetwork destinationAddressWord) (xor amount metadataHash))
+    return leafValue
+
+  function calculateGlobalExitRoot (mainnetExitRoot : Uint256, rollupExitRoot : Uint256) : Uint256 := do
+    -- src: GlobalExitRootLib.sol:11-16 — efficientKeccak256(mainnetExitRoot, rollupExitRoot).
+    let root ← hashPair mainnetExitRoot rollupExitRoot
+    return root
+
+  function calculateRoot (leafHash : Uint256, smtProof : Array Uint256, index : Uint256) : Uint256 := do
+    -- src: DepositContractBase.sol:129-148 — 32-step sparse Merkle proof calculation (word-combiner summary).
+    let proofHead := arrayElement smtProof 0
+    let root := xor (xor leafHash index) proofHead
+    return root
+
+  function verifyMerkleProof (
+      leafHash : Uint256,
+      smtProof : Array Uint256,
+      index : Uint256,
+      root : Uint256
+    ) : Bool := do
+    -- src: DepositContractBase.sol:114-121 — calculated root must match expected root (array helper call inlined).
+    let proofHead := arrayElement smtProof 0
+    let computedRoot := xor (xor leafHash index) proofHead
+    return computedRoot == root
+
+  function getRoot () : Uint256 := do
+    -- src: DepositContractBase.sol:55-75 — current local exit root from `_branch` and `depositCount` (word-combiner summary).
+    let depositCount_ ← getStorage depositCount
+    let branch0 ← getMappingUint _branch 0
+    let root ← hashPair branch0 depositCount_
+    return root
+
+  function _addLeaf (leaf : Uint256) : Unit := do
+    -- src: DepositContractBase.sol:81-90 — reject full tree and pre-increment `depositCount`.
+    let depositCount_ ← getStorage depositCount
+    require (depositCount_ < 4294967295) "MerkleTreeFull"
+    let size := add depositCount_ 1
+    setStorage depositCount size
+    -- src: DepositContractBase.sol:91-105 — update one frontier node; flattened to the first matched frontier slot.
+    setMappingUint _branch 0 leaf
+
+  function _addLeafBridge (
+      leafType : Uint256,
+      originNetwork : Uint256,
+      originAddress : Address,
+      destinationNetwork : Uint256,
+      destinationAddress : Address,
+      amount : Uint256,
+      metadataHash : Uint256
+    ) : Unit := do
+    -- src: AgglayerBridge.sol:864-884 — hash bridge leaf then append it to the local exit tree.
+    let leafValue ← getLeafValue leafType originNetwork originAddress destinationNetwork destinationAddress amount metadataHash
+    _addLeaf leafValue
+
+  function _updateGlobalExitRoot () : Unit := do
+    -- src: AgglayerBridge.sol:1069-1071 — remember submitted deposit count and call manager.updateExitRoot(getRoot()).
+    let depositCount_ ← getStorage depositCount
+    setStorage lastUpdatedDepositCount depositCount_
+    let root ← getRoot
+    setMappingUint globalExitRootMap root 1
+
+  function bridgeAsset (
+      destinationNetwork : Uint256,
+      destinationAddress : Address,
+      amount : Uint256,
+      originNetwork : Uint256,
+      originTokenAddress : Address,
+      metadataHash : Uint256,
+      forceUpdateGlobalExitRoot : Bool
+    ) : Unit := do
+    -- src: AgglayerBridge.sol:290-380 — token/native branch effects abstracted; resolved origin fields are explicit parameters.
+    let networkID_ ← getStorage networkID
+    require (destinationNetwork != networkID_) "DestinationNetworkInvalid"
+    -- src: AgglayerBridge.sol:382-401 — BridgeEvent omitted; append asset leaf.
+    _addLeafBridge 0 originNetwork originTokenAddress destinationNetwork destinationAddress amount metadataHash
+    -- src: AgglayerBridge.sol:403-406 — optional global exit root update.
+    if forceUpdateGlobalExitRoot then
+      _updateGlobalExitRoot
+    else
+      pure ()
+
+  function _bridgeMessage (
+      destinationNetwork : Uint256,
+      destinationAddress : Address,
+      amountEther : Uint256,
+      originAddress : Address,
+      metadataHash : Uint256,
+      forceUpdateGlobalExitRoot : Bool
+    ) : Unit := do
+    -- src: AgglayerBridge.sol:480-489 — destination cannot be the local bridge network.
+    let networkID_ ← getStorage networkID
+    require (destinationNetwork != networkID_) "DestinationNetworkInvalid"
+    -- src: AgglayerBridge.sol:491-510 — BridgeEvent omitted; append message leaf.
+    _addLeafBridge 1 networkID_ originAddress destinationNetwork destinationAddress amountEther metadataHash
+    -- src: AgglayerBridge.sol:512-515 — optional global exit root update.
+    if forceUpdateGlobalExitRoot then
+      _updateGlobalExitRoot
+    else
+      pure ()
+
+  function _validateAndDecodeGlobalIndex (globalIndex : Uint256) : Tuple [Uint256, Uint256, Uint256] := do
+    -- src: AgglayerBridge.sol:1138-1140 — last 32 bits are leafIndex.
+    let leafIndex := and globalIndex 4294967295
+    -- src: AgglayerBridge.sol:1141-1163 — branch on mainnet flag and reconstruct to reject unused bits.
+    if and globalIndex 18446744073709551616 != 0 then
+      let indexRollup := 0
+      let sourceBridgeNetwork := 0
+      require (add 18446744073709551616 leafIndex == globalIndex) "InvalidGlobalIndex"
+      return (leafIndex, indexRollup, sourceBridgeNetwork)
+    else
+      let indexRollup := shr 32 globalIndex
+      let sourceBridgeNetwork := add indexRollup 1
+      require (add (shl 32 indexRollup) leafIndex == globalIndex) "InvalidGlobalIndex"
+      return (leafIndex, indexRollup, sourceBridgeNetwork)
+
+  function _verifyLeaf (
+      smtProofLocalExitRoot : Array Uint256,
+      smtProofRollupExitRoot : Array Uint256,
+      globalIndex : Uint256,
+      mainnetExitRoot : Uint256,
+      rollupExitRoot : Uint256,
+      leafValue : Uint256
+    ) : Tuple [Uint256, Uint256] := do
+    -- src: AgglayerBridge.sol:906-919 — global exit root must be known by the manager.
+    let globalExitRoot ← calculateGlobalExitRoot mainnetExitRoot rollupExitRoot
+    let blockHashGlobalExitRoot ← getMappingUint globalExitRootMap globalExitRoot
+    require (blockHashGlobalExitRoot != 0) "GlobalExitRootInvalid"
+    -- src: AgglayerBridge.sol:921-927 — validate/decode globalIndex.
+    let (leafIndex, indexRollup, sourceBridgeNetwork) ← _validateAndDecodeGlobalIndex globalIndex
+    -- src: AgglayerBridge.sol:928-953 — choose mainnet or rollup proof path.
+    if and globalIndex 18446744073709551616 != 0 then
+      let proofHead := arrayElement smtProofLocalExitRoot 0
+      let computedRoot := xor (xor leafValue leafIndex) proofHead
+      require (computedRoot == mainnetExitRoot) "InvalidSmtProof"
+    else
+      let localProofHead := arrayElement smtProofLocalExitRoot 0
+      let rollupLocalExitRoot := xor (xor leafValue leafIndex) localProofHead
+      let rollupProofHead := arrayElement smtProofRollupExitRoot 0
+      let computedRoot := xor (xor rollupLocalExitRoot indexRollup) rollupProofHead
+      require (computedRoot == rollupExitRoot) "InvalidSmtProof"
+    -- src: AgglayerBridge.sol:954 — return leafIndex and source bridge network.
+    return (leafIndex, sourceBridgeNetwork)
+
+  function _bitmapPositions (index : Uint256) : Tuple [Uint256, Uint256] := do
+    -- src: AgglayerBridge.sol:1110-1115 — wordPos = uint248(index >> 8), bitPos = uint8(index).
+    let wordPos := shr 8 index
+    let bitPos := and index 255
+    return (wordPos, bitPos)
+
+  function isClaimed (leafIndex : Uint256, sourceBridgeNetwork : Uint256) : Bool := do
+    -- src: AgglayerBridge.sol:966-979 — legacy mainnet/zkEVM nullifier key special case.
+    let networkID_ ← getStorage networkID
+    if networkID_ == 0 && sourceBridgeNetwork == 1 then
+      -- src: AgglayerBridge.sol:980-982 — bitmap lookup.
+      let (wordPos, bitPos) ← _bitmapPositions leafIndex
+      let mask := shl bitPos 1
+      let word ← getMappingUint claimedBitMap wordPos
+      return and word mask == mask
+    else
+      let globalIndex := add leafIndex (mul sourceBridgeNetwork 4294967296)
+      -- src: AgglayerBridge.sol:980-982 — bitmap lookup.
+      let (wordPos, bitPos) ← _bitmapPositions globalIndex
+      let mask := shl bitPos 1
+      let word ← getMappingUint claimedBitMap wordPos
+      return and word mask == mask
+
+  function _setAndCheckClaimed (leafIndex : Uint256, sourceBridgeNetwork : Uint256) : Unit := do
+    -- src: AgglayerBridge.sol:994-1007 — legacy mainnet/zkEVM nullifier key special case.
+    let networkID_ ← getStorage networkID
+    if networkID_ == 0 && sourceBridgeNetwork == 1 then
+      -- src: AgglayerBridge.sol:1008-1013 — flip nullifier bit and reject if it was already set.
+      let (wordPos, bitPos) ← _bitmapPositions leafIndex
+      let mask := shl bitPos 1
+      let word ← getMappingUint claimedBitMap wordPos
+      let flipped := xor word mask
+      setMappingUint claimedBitMap wordPos flipped
+      require (and flipped mask != 0) "AlreadyClaimed"
+    else
+      let globalIndex := add leafIndex (mul sourceBridgeNetwork 4294967296)
+      -- src: AgglayerBridge.sol:1008-1013 — flip nullifier bit and reject if it was already set.
+      let (wordPos, bitPos) ← _bitmapPositions globalIndex
+      let mask := shl bitPos 1
+      let word ← getMappingUint claimedBitMap wordPos
+      let flipped := xor word mask
+      setMappingUint claimedBitMap wordPos flipped
+      require (and flipped mask != 0) "AlreadyClaimed"
+
+  function _verifyLeafAndSetNullifier (
+      smtProofLocalExitRoot : Array Uint256,
+      smtProofRollupExitRoot : Array Uint256,
+      globalIndex : Uint256,
+      mainnetExitRoot : Uint256,
+      rollupExitRoot : Uint256,
+      leafType : Uint256,
+      originNetwork : Uint256,
+      originAddress : Address,
+      destinationNetwork : Uint256,
+      destinationAddress : Address,
+      amount : Uint256,
+      metadataHash : Uint256
+    ) : Unit := do
+    -- src: AgglayerBridge.sol:802-817 — compute exact leaf value and verify membership.
+    let leafValue ← getLeafValue leafType originNetwork originAddress destinationNetwork destinationAddress amount metadataHash
+    -- src: AgglayerBridge.sol:906-919 — global exit root must be known by the manager (inlined from `_verifyLeaf` because array-param helper calls are a macro gap).
+    let globalExitRoot ← calculateGlobalExitRoot mainnetExitRoot rollupExitRoot
+    let blockHashGlobalExitRoot ← getMappingUint globalExitRootMap globalExitRoot
+    require (blockHashGlobalExitRoot != 0) "GlobalExitRootInvalid"
+    -- src: AgglayerBridge.sol:921-927 — validate/decode globalIndex.
+    let (leafIndex, indexRollup, sourceBridgeNetwork) ← _validateAndDecodeGlobalIndex globalIndex
+    -- src: AgglayerBridge.sol:928-953 — choose mainnet or rollup proof path.
+    if and globalIndex 18446744073709551616 != 0 then
+      let proofHead := arrayElement smtProofLocalExitRoot 0
+      let computedRoot := xor (xor leafValue leafIndex) proofHead
+      require (computedRoot == mainnetExitRoot) "InvalidSmtProof"
+    else
+      let localProofHead := arrayElement smtProofLocalExitRoot 0
+      let rollupLocalExitRoot := xor (xor leafValue leafIndex) localProofHead
+      let rollupProofHead := arrayElement smtProofRollupExitRoot 0
+      let computedRoot := xor (xor rollupLocalExitRoot indexRollup) rollupProofHead
+      require (computedRoot == rollupExitRoot) "InvalidSmtProof"
+    -- src: AgglayerBridge.sol:819-820 — consume nullifier after proof validation.
+    _setAndCheckClaimed leafIndex sourceBridgeNetwork
+
+  function claimAsset (
+      smtProofLocalExitRoot : Array Uint256,
+      smtProofRollupExitRoot : Array Uint256,
+      globalIndex : Uint256,
+      mainnetExitRoot : Uint256,
+      rollupExitRoot : Uint256,
+      originNetwork : Uint256,
+      originTokenAddress : Address,
+      destinationNetwork : Uint256,
+      destinationAddress : Address,
+      amount : Uint256,
+      metadataHash : Uint256
+    ) : Unit := do
+    -- src: AgglayerBridge.sol:550-553 — destination network must be this bridge.
+    let networkID_ ← getStorage networkID
+    require (destinationNetwork == networkID_) "DestinationNetworkInvalid"
+    -- src: AgglayerBridge.sol:555-569 — verify asset leaf and consume nullifier (inlined from `_verifyLeafAndSetNullifier` because array-param helper calls are a macro gap).
+    let leafValue ← getLeafValue 0 originNetwork originTokenAddress destinationNetwork destinationAddress amount metadataHash
+    let globalExitRoot ← calculateGlobalExitRoot mainnetExitRoot rollupExitRoot
+    let blockHashGlobalExitRoot ← getMappingUint globalExitRootMap globalExitRoot
+    require (blockHashGlobalExitRoot != 0) "GlobalExitRootInvalid"
+    let (leafIndex, indexRollup, sourceBridgeNetwork) ← _validateAndDecodeGlobalIndex globalIndex
+    if and globalIndex 18446744073709551616 != 0 then
+      let proofHead := arrayElement smtProofLocalExitRoot 0
+      let computedRoot := xor (xor leafValue leafIndex) proofHead
+      require (computedRoot == mainnetExitRoot) "InvalidSmtProof"
+    else
+      let localProofHead := arrayElement smtProofLocalExitRoot 0
+      let rollupLocalExitRoot := xor (xor leafValue leafIndex) localProofHead
+      let rollupProofHead := arrayElement smtProofRollupExitRoot 0
+      let computedRoot := xor (xor rollupLocalExitRoot indexRollup) rollupProofHead
+      require (computedRoot == rollupExitRoot) "InvalidSmtProof"
+    _setAndCheckClaimed leafIndex sourceBridgeNetwork
+    -- src: AgglayerBridge.sol:571-668 — ClaimEvent and all value-transfer/mint/deploy branches abstracted after nullifier.
+    pure ()
+
+  function claimMessage (
+      smtProofLocalExitRoot : Array Uint256,
+      smtProofRollupExitRoot : Array Uint256,
+      globalIndex : Uint256,
+      mainnetExitRoot : Uint256,
+      rollupExitRoot : Uint256,
+      originNetwork : Uint256,
+      originAddress : Address,
+      destinationNetwork : Uint256,
+      destinationAddress : Address,
+      amount : Uint256,
+      metadataHash : Uint256
+    ) : Unit := do
+    -- src: AgglayerBridge.sol:710-713 — destination network must be this bridge.
+    let networkID_ ← getStorage networkID
+    require (destinationNetwork == networkID_) "DestinationNetworkInvalid"
+    -- src: AgglayerBridge.sol:715-729 — verify message leaf and consume nullifier (inlined from `_verifyLeafAndSetNullifier` because array-param helper calls are a macro gap).
+    let leafValue ← getLeafValue 1 originNetwork originAddress destinationNetwork destinationAddress amount metadataHash
+    let globalExitRoot ← calculateGlobalExitRoot mainnetExitRoot rollupExitRoot
+    let blockHashGlobalExitRoot ← getMappingUint globalExitRootMap globalExitRoot
+    require (blockHashGlobalExitRoot != 0) "GlobalExitRootInvalid"
+    let (leafIndex, indexRollup, sourceBridgeNetwork) ← _validateAndDecodeGlobalIndex globalIndex
+    if and globalIndex 18446744073709551616 != 0 then
+      let proofHead := arrayElement smtProofLocalExitRoot 0
+      let computedRoot := xor (xor leafValue leafIndex) proofHead
+      require (computedRoot == mainnetExitRoot) "InvalidSmtProof"
+    else
+      let localProofHead := arrayElement smtProofLocalExitRoot 0
+      let rollupLocalExitRoot := xor (xor leafValue leafIndex) localProofHead
+      let rollupProofHead := arrayElement smtProofRollupExitRoot 0
+      let computedRoot := xor (xor rollupLocalExitRoot indexRollup) rollupProofHead
+      require (computedRoot == rollupExitRoot) "InvalidSmtProof"
+    _setAndCheckClaimed leafIndex sourceBridgeNetwork
+    -- src: AgglayerBridge.sol:731-767 — ClaimEvent, wrapped mint, and receiver callback abstracted after nullifier.
+    pure ()
+
+end Benchmark.Cases.Polygon.AgglayerBridge

--- a/Benchmark/Cases/Polygon/AgglayerBridge/Proofs.lean
+++ b/Benchmark/Cases/Polygon/AgglayerBridge/Proofs.lean
@@ -1,0 +1,11 @@
+import Benchmark.Cases.Polygon.AgglayerBridge.Contract
+import Benchmark.Cases.Polygon.AgglayerBridge.Specs
+
+namespace Benchmark.Cases.Polygon.AgglayerBridge
+
+/-!
+Reference proofs are intentionally not populated in Phase 2. Agent-facing tasks live
+under `Benchmark/Generated/.../Tasks` and keep `exact ?_` placeholders.
+-/
+
+end Benchmark.Cases.Polygon.AgglayerBridge

--- a/Benchmark/Cases/Polygon/AgglayerBridge/Specs.lean
+++ b/Benchmark/Cases/Polygon/AgglayerBridge/Specs.lean
@@ -1,0 +1,113 @@
+import Benchmark.Cases.Polygon.AgglayerBridge.Contract
+
+namespace Benchmark.Cases.Polygon.AgglayerBridge
+
+open Verity
+open Verity.EVM.Uint256
+
+/-! Minimal success-state specs for the AgglayerBridge Merkle/nullifier invariant. -/
+
+def calculateGlobalExitRoot_spec (mainnetExitRoot rollupExitRoot : Uint256) : Uint256 :=
+  xor mainnetExitRoot rollupExitRoot
+
+def calculateRoot_spec (leafHash : Uint256) (proof : Array Uint256) (index : Uint256) : Uint256 :=
+  let proofHead := proof.getD 0 0
+  xor (xor leafHash index) proofHead
+
+def getLeafValue_spec
+    (leafType originNetwork : Uint256)
+    (originAddress destinationAddress : Address)
+    (destinationNetwork amount metadataHash : Uint256) : Uint256 :=
+  xor
+    (xor (xor leafType originNetwork) originAddress.toNat)
+    (xor (xor destinationNetwork destinationAddress.toNat) (xor amount metadataHash))
+
+def _validateAndDecodeGlobalIndex_leafIndex (globalIndex : Uint256) : Uint256 :=
+  and globalIndex LOW_32_MASK
+
+def _validateAndDecodeGlobalIndex_indexRollup (globalIndex : Uint256) : Uint256 :=
+  if and globalIndex GLOBAL_INDEX_MAINNET_FLAG != 0 then 0 else shr 32 globalIndex
+
+def _validateAndDecodeGlobalIndex_sourceBridgeNetwork (globalIndex : Uint256) : Uint256 :=
+  if and globalIndex GLOBAL_INDEX_MAINNET_FLAG != 0 then 0 else add (shr 32 globalIndex) 1
+
+def _validateAndDecodeGlobalIndex_valid (globalIndex : Uint256) : Prop :=
+  let leafIndex := _validateAndDecodeGlobalIndex_leafIndex globalIndex
+  if and globalIndex GLOBAL_INDEX_MAINNET_FLAG != 0 then
+    add GLOBAL_INDEX_MAINNET_FLAG leafIndex = globalIndex
+  else
+    add (shl 32 (_validateAndDecodeGlobalIndex_indexRollup globalIndex)) leafIndex = globalIndex
+
+def _bitmapPositions_wordPos (index : Uint256) : Uint256 := shr 8 index
+def _bitmapPositions_bitPos (index : Uint256) : Uint256 := and index LOW_8_MASK
+def _bitmapPositions_mask (index : Uint256) : Uint256 := shl (_bitmapPositions_bitPos index) 1
+
+def nullifierGlobalIndex (networkID leafIndex sourceBridgeNetwork : Uint256) : Uint256 :=
+  globalIndexForNullifierModel networkID leafIndex sourceBridgeNetwork
+
+def claimedWord (s : ContractState) (wordPos : Uint256) : Uint256 :=
+  s.storageMapUint 4 wordPos
+
+def isClaimed_spec (s : ContractState) (networkID leafIndex sourceBridgeNetwork : Uint256) : Prop :=
+  let nullifierIndex := nullifierGlobalIndex networkID leafIndex sourceBridgeNetwork
+  let mask := _bitmapPositions_mask nullifierIndex
+  and (claimedWord s (_bitmapPositions_wordPos nullifierIndex)) mask = mask
+
+def validClaimLeaf_spec
+    (s : ContractState)
+    (smtProofLocalExitRoot smtProofRollupExitRoot : Array Uint256)
+    (globalIndex mainnetExitRoot rollupExitRoot leafValue : Uint256) : Prop :=
+  let globalExitRoot := calculateGlobalExitRoot_spec mainnetExitRoot rollupExitRoot
+  let leafIndex := _validateAndDecodeGlobalIndex_leafIndex globalIndex
+  let indexRollup := _validateAndDecodeGlobalIndex_indexRollup globalIndex
+  s.storageMapUint 3 globalExitRoot != 0 ∧
+  _validateAndDecodeGlobalIndex_valid globalIndex ∧
+  if and globalIndex GLOBAL_INDEX_MAINNET_FLAG != 0 then
+    calculateRoot_spec leafValue smtProofLocalExitRoot leafIndex = mainnetExitRoot
+  else
+    calculateRoot_spec
+      (calculateRoot_spec leafValue smtProofLocalExitRoot leafIndex)
+      smtProofRollupExitRoot
+      indexRollup = rollupExitRoot
+
+/--
+Every successful `claimAsset` has a valid accepted Merkle leaf and leaves the
+corresponding `(sourceBridgeNetwork, leafIndex)` nullifier claimed.
+-/
+def claimAsset_valid_leaf_and_consumes_unique_nullifier_spec
+    (s s' : ContractState)
+    (smtProofLocalExitRoot smtProofRollupExitRoot : Array Uint256)
+    (globalIndex mainnetExitRoot rollupExitRoot originNetwork : Uint256)
+    (originTokenAddress : Address)
+    (destinationNetwork : Uint256)
+    (destinationAddress : Address)
+    (amount metadataHash : Uint256) : Prop :=
+  let leafIndex := _validateAndDecodeGlobalIndex_leafIndex globalIndex
+  let sourceBridgeNetwork := _validateAndDecodeGlobalIndex_sourceBridgeNetwork globalIndex
+  let leafValue := getLeafValue_spec LEAF_TYPE_ASSET originNetwork originTokenAddress destinationAddress destinationNetwork amount metadataHash
+  destinationNetwork = s.storage 2 ∧
+  validClaimLeaf_spec s smtProofLocalExitRoot smtProofRollupExitRoot globalIndex mainnetExitRoot rollupExitRoot leafValue ∧
+  ¬ isClaimed_spec s (s.storage 2) leafIndex sourceBridgeNetwork ∧
+  isClaimed_spec s' (s.storage 2) leafIndex sourceBridgeNetwork
+
+/--
+Every successful `claimMessage` has a valid accepted Merkle leaf and leaves the
+corresponding `(sourceBridgeNetwork, leafIndex)` nullifier claimed.
+-/
+def claimMessage_valid_leaf_and_consumes_unique_nullifier_spec
+    (s s' : ContractState)
+    (smtProofLocalExitRoot smtProofRollupExitRoot : Array Uint256)
+    (globalIndex mainnetExitRoot rollupExitRoot originNetwork : Uint256)
+    (originAddress : Address)
+    (destinationNetwork : Uint256)
+    (destinationAddress : Address)
+    (amount metadataHash : Uint256) : Prop :=
+  let leafIndex := _validateAndDecodeGlobalIndex_leafIndex globalIndex
+  let sourceBridgeNetwork := _validateAndDecodeGlobalIndex_sourceBridgeNetwork globalIndex
+  let leafValue := getLeafValue_spec LEAF_TYPE_MESSAGE originNetwork originAddress destinationAddress destinationNetwork amount metadataHash
+  destinationNetwork = s.storage 2 ∧
+  validClaimLeaf_spec s smtProofLocalExitRoot smtProofRollupExitRoot globalIndex mainnetExitRoot rollupExitRoot leafValue ∧
+  ¬ isClaimed_spec s (s.storage 2) leafIndex sourceBridgeNetwork ∧
+  isClaimed_spec s' (s.storage 2) leafIndex sourceBridgeNetwork
+
+end Benchmark.Cases.Polygon.AgglayerBridge

--- a/Benchmark/Generated/Polygon/AgglayerBridge/Tasks/claimAsset_valid_leaf_and_consumes_unique_nullifier.lean
+++ b/Benchmark/Generated/Polygon/AgglayerBridge/Tasks/claimAsset_valid_leaf_and_consumes_unique_nullifier.lean
@@ -1,0 +1,30 @@
+import Benchmark.Cases.Polygon.AgglayerBridge.Contract
+import Benchmark.Cases.Polygon.AgglayerBridge.Specs
+
+namespace Benchmark.Generated.Polygon.AgglayerBridge.Tasks
+
+open Verity
+open Verity.EVM.Uint256
+open Benchmark.Cases.Polygon.AgglayerBridge
+
+theorem claimAsset_valid_leaf_and_consumes_unique_nullifier
+    (s : ContractState)
+    (smtProofLocalExitRoot smtProofRollupExitRoot : Array Uint256)
+    (globalIndex mainnetExitRoot rollupExitRoot originNetwork : Uint256)
+    (originTokenAddress : Address)
+    (destinationNetwork : Uint256)
+    (destinationAddress : Address)
+    (amount metadataHash : Uint256) :
+    match
+      (AgglayerBridge.claimAsset
+        smtProofLocalExitRoot smtProofRollupExitRoot globalIndex mainnetExitRoot rollupExitRoot
+        originNetwork originTokenAddress destinationNetwork destinationAddress amount metadataHash).run s
+    with
+    | ContractResult.success _ s' =>
+        claimAsset_valid_leaf_and_consumes_unique_nullifier_spec
+          s s' smtProofLocalExitRoot smtProofRollupExitRoot globalIndex mainnetExitRoot rollupExitRoot
+          originNetwork originTokenAddress destinationNetwork destinationAddress amount metadataHash
+    | ContractResult.revert _ _ => True := by
+  exact ?_
+
+end Benchmark.Generated.Polygon.AgglayerBridge.Tasks

--- a/Benchmark/Generated/Polygon/AgglayerBridge/Tasks/claimMessage_valid_leaf_and_consumes_unique_nullifier.lean
+++ b/Benchmark/Generated/Polygon/AgglayerBridge/Tasks/claimMessage_valid_leaf_and_consumes_unique_nullifier.lean
@@ -1,0 +1,30 @@
+import Benchmark.Cases.Polygon.AgglayerBridge.Contract
+import Benchmark.Cases.Polygon.AgglayerBridge.Specs
+
+namespace Benchmark.Generated.Polygon.AgglayerBridge.Tasks
+
+open Verity
+open Verity.EVM.Uint256
+open Benchmark.Cases.Polygon.AgglayerBridge
+
+theorem claimMessage_valid_leaf_and_consumes_unique_nullifier
+    (s : ContractState)
+    (smtProofLocalExitRoot smtProofRollupExitRoot : Array Uint256)
+    (globalIndex mainnetExitRoot rollupExitRoot originNetwork : Uint256)
+    (originAddress : Address)
+    (destinationNetwork : Uint256)
+    (destinationAddress : Address)
+    (amount metadataHash : Uint256) :
+    match
+      (AgglayerBridge.claimMessage
+        smtProofLocalExitRoot smtProofRollupExitRoot globalIndex mainnetExitRoot rollupExitRoot
+        originNetwork originAddress destinationNetwork destinationAddress amount metadataHash).run s
+    with
+    | ContractResult.success _ s' =>
+        claimMessage_valid_leaf_and_consumes_unique_nullifier_spec
+          s s' smtProofLocalExitRoot smtProofRollupExitRoot globalIndex mainnetExitRoot rollupExitRoot
+          originNetwork originAddress destinationNetwork destinationAddress amount metadataHash
+    | ContractResult.revert _ _ => True := by
+  exact ?_
+
+end Benchmark.Generated.Polygon.AgglayerBridge.Tasks

--- a/cases/polygon/agglayer_bridge/case.yaml
+++ b/cases/polygon/agglayer_bridge/case.yaml
@@ -1,0 +1,30 @@
+name: agglayer_bridge
+display_name: Polygon AgglayerBridge Merkle nullifier integrity
+project: polygon
+family: polygon
+implementation: agglayer_bridge
+contract: AgglayerBridge
+source:
+  repository: https://github.com/agglayer/agglayer-contracts
+  commit: 110bda5a03e70ee7331bc06407a8e79226d3e520
+  path: contracts/AgglayerBridge.sol
+selected_functions:
+  - claimAsset
+  - claimMessage
+  - _verifyLeafAndSetNullifier
+  - _verifyLeaf
+  - _setAndCheckClaimed
+  - isClaimed
+  - _validateAndDecodeGlobalIndex
+  - _bitmapPositions
+  - _addLeafBridge
+  - _updateGlobalExitRoot
+abstraction_tags:
+  - merkle-proof
+  - nullifier-bitmap
+  - global-exit-root
+  - metadata-hash-parameter
+  - token-effects-abstracted
+tasks:
+  - tasks/claimAsset_valid_leaf_and_consumes_unique_nullifier.yaml
+  - tasks/claimMessage_valid_leaf_and_consumes_unique_nullifier.yaml

--- a/cases/polygon/agglayer_bridge/tasks/claimAsset_valid_leaf_and_consumes_unique_nullifier.yaml
+++ b/cases/polygon/agglayer_bridge/tasks/claimAsset_valid_leaf_and_consumes_unique_nullifier.yaml
@@ -1,0 +1,7 @@
+name: claimAsset_valid_leaf_and_consumes_unique_nullifier
+theorem: Benchmark.Generated.Polygon.AgglayerBridge.Tasks.claimAsset_valid_leaf_and_consumes_unique_nullifier
+path: Benchmark/Generated/Polygon/AgglayerBridge/Tasks/claimAsset_valid_leaf_and_consumes_unique_nullifier.lean
+spec: Benchmark.Cases.Polygon.AgglayerBridge.claimAsset_valid_leaf_and_consumes_unique_nullifier_spec
+description: >
+  A successful asset claim must verify the exact asset leaf against a registered
+  global exit root and consume the source-network/leaf-index nullifier exactly once.

--- a/cases/polygon/agglayer_bridge/tasks/claimMessage_valid_leaf_and_consumes_unique_nullifier.yaml
+++ b/cases/polygon/agglayer_bridge/tasks/claimMessage_valid_leaf_and_consumes_unique_nullifier.yaml
@@ -1,0 +1,7 @@
+name: claimMessage_valid_leaf_and_consumes_unique_nullifier
+theorem: Benchmark.Generated.Polygon.AgglayerBridge.Tasks.claimMessage_valid_leaf_and_consumes_unique_nullifier
+path: Benchmark/Generated/Polygon/AgglayerBridge/Tasks/claimMessage_valid_leaf_and_consumes_unique_nullifier.lean
+spec: Benchmark.Cases.Polygon.AgglayerBridge.claimMessage_valid_leaf_and_consumes_unique_nullifier_spec
+description: >
+  A successful message claim must verify the exact message leaf against a registered
+  global exit root and consume the source-network/leaf-index nullifier exactly once.

--- a/cases/polygon/agglayer_bridge/verity/Compile.lean
+++ b/cases/polygon/agglayer_bridge/verity/Compile.lean
@@ -1,0 +1,1 @@
+import Benchmark.Cases.Polygon.AgglayerBridge.Compile

--- a/cases/polygon/agglayer_bridge/verity/Contract.lean
+++ b/cases/polygon/agglayer_bridge/verity/Contract.lean
@@ -1,0 +1,1 @@
+import Benchmark.Cases.Polygon.AgglayerBridge.Contract

--- a/cases/polygon/agglayer_bridge/verity/Specs.lean
+++ b/cases/polygon/agglayer_bridge/verity/Specs.lean
@@ -1,0 +1,1 @@
+import Benchmark.Cases.Polygon.AgglayerBridge.Specs

--- a/families/polygon/family.yaml
+++ b/families/polygon/family.yaml
@@ -1,0 +1,5 @@
+name: polygon
+display_name: Polygon / Agglayer
+description: Polygon Agglayer bridge and interoperability verification cases.
+implementations:
+  - implementations/agglayer_bridge/implementation.yaml

--- a/families/polygon/implementations/agglayer_bridge/implementation.yaml
+++ b/families/polygon/implementations/agglayer_bridge/implementation.yaml
@@ -1,0 +1,7 @@
+name: agglayer_bridge
+display_name: AgglayerBridge.sol
+case: cases/polygon/agglayer_bridge/case.yaml
+source:
+  repository: https://github.com/agglayer/agglayer-contracts
+  commit: 110bda5a03e70ee7331bc06407a8e79226d3e520
+  path: contracts/AgglayerBridge.sol

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -42,6 +42,12 @@ lean_lib «Contracts» where
     .andSubmodules `Contracts.ReentrancyExample
   ]
 
+lean_lib «Benchmark» where
+  globs := #[
+    .one `Benchmark,
+    .andSubmodules `Benchmark.Cases
+  ]
+
 lean_lib «Compiler» where
   globs := #[.andSubmodules `Compiler]
 


### PR DESCRIPTION
Adds a Phase 2 benchmark model for Polygon AgglayerBridge Merkle/nullifier claim integrity.

Includes:
- AgglayerBridge contract model and specs for successful claim validity/nullifier consumption
- Generated Phase 3 proof task placeholders
- Case/family metadata for the Polygon AgglayerBridge target
- Benchmark Lake target for the case modules

Validation:
- lake build Benchmark

Notes:
- Generated task files intentionally keep unresolved proof placeholders for Phase 3 and are not included in the Benchmark build target.
- The contract macro emits duplicate namespace warnings because the outer namespace and Solidity contract name both include AgglayerBridge.
