### PR TITLE
Fail closed on blobbasefee under strict deny gates (#1829)

### DIFF
--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -413,7 +413,7 @@ private def collectProxyUpgradeabilityMechanicsFromMechanics (mechanics : List S
 
 private def isRuntimeIntrospectionMechanic (mechanic : String) : Bool :=
   match mechanic with
-  | "blockNumber" | "contractAddress" | "chainid" => true
+  | "blockNumber" | "contractAddress" | "chainid" | "blobbasefee" => true
   | _ => false
 
 private def collectRuntimeIntrospectionMechanicsFromMechanics (mechanics : List String) : List String :=
@@ -555,7 +555,7 @@ def collectEventEmissionMechanics (spec : CompilationModel) : List String :=
 private def isDeniedLowLevelMechanic (mechanic : String) : Bool :=
   match mechanic with
   | "call" | "staticcall" | "delegatecall" | "returndataSize" | "returndataCopy"
-  | "revertReturndata" | "returndataOptionalBoolAt" => true
+  | "revertReturndata" | "returndataOptionalBoolAt" | "blobbasefee" => true
   | _ => false
 
 private def collectDeniedLowLevelMechanicsFromMechanics (mechanics : List String) : List String :=
@@ -582,6 +582,7 @@ private partial def collectRuntimeIntrospectionExprMechanics : Expr → List Str
   | .contractAddress => ["contractAddress"]
   | .chainid => ["chainid"]
   | .blockNumber => ["blockNumber"]
+  | .blobbasefee => ["blobbasefee"]
   | .externalCall _ args
   | .internalCall _ args =>
       args.flatMap collectRuntimeIntrospectionExprMechanics

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -4518,6 +4518,12 @@ set_option maxRecDepth 4096 in
   expectTrue "macro blobbasefee trust report surfaces the post-core builtin"
     (contains macroBlobbasefeeTrustReport "\"modeledLowLevelMechanics\"" &&
       contains macroBlobbasefeeTrustReport "\"blobbasefee\"")
+  -- Regression for issue #1829: blobbasefee must also surface under the
+  -- runtime-introspection category so that --deny-runtime-introspection
+  -- fails closed on the post-Dencun environment opcode.
+  expectTrue "macro blobbasefee trust report classifies the builtin under runtime introspection"
+    (contains macroBlobbasefeeTrustReport
+      "\"partiallyModeledRuntimeIntrospection\":[\"blobbasefee\"]")
   let macroExternalYul ←
     expectCompileToYul "macro external smoke spec" MacroExternalSmoke.MacroExternal.spec
   expectTrue "macro externalCall lowers to the linked external symbol"

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -393,6 +393,23 @@ private def runtimeIntrospectionTrustSurfaceSpec : CompilationModel := {
   ]
 }
 
+private def blobbasefeeTrustSurfaceSpec : CompilationModel := {
+  name := "BlobbasefeeTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "exerciseBlobbasefee"
+      params := []
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Stmt.letVar "fee" Expr.blobbasefee,
+        Stmt.returnValues [Expr.localVar "fee"]
+      ]
+    }
+  ]
+}
+
 private def primitiveOnlyTrustSurfaceSpec : CompilationModel := {
   name := "PrimitiveOnlyTrustSurface"
   fields := [{ name := "digest", ty := FieldType.uint256 }]
@@ -1754,6 +1771,26 @@ unsafe def runTests : IO Unit := do
   if !deniedRuntimeIntrospectionTrustReportWritten then
     throw (IO.userError "✗ denied runtime-introspection compile still writes trust report file")
   IO.println "✓ denied runtime-introspection compile still writes trust report file"
+
+  -- Regression for issue #1829: blobbasefee must fail closed under
+  -- --deny-runtime-introspection because the proof interpreters do not
+  -- model the post-Dencun environment opcode.
+  let deniedBlobbasefeeRuntimeReportPath := s!"{trustReportDir}/trust-report-denied-blobbasefee-runtime.json"
+  expectFailureContains
+    "compileSpecsWithOptions rejects blobbasefee under deny-runtime-introspection"
+    (compileSpecsWithOptions
+      [blobbasefeeTrustSurfaceSpec] outDir false [] {} none (some deniedBlobbasefeeRuntimeReportPath) none none false false false false false false false true false)
+    "Partially modeled runtime-introspection mechanics remain:\n- BlobbasefeeTrustSurface [function:exerciseBlobbasefee]: blobbasefee"
+
+  -- Regression for issue #1829: blobbasefee must also fail closed under
+  -- --deny-low-level-mechanics, because the low-level mechanics report
+  -- continues to surface it as a modeled low-level builtin.
+  let deniedBlobbasefeeLowLevelReportPath := s!"{trustReportDir}/trust-report-denied-blobbasefee-lowlevel.json"
+  expectFailureContains
+    "compileSpecsWithOptions rejects blobbasefee under deny-low-level-mechanics"
+    (compileSpecsWithOptions
+      [blobbasefeeTrustSurfaceSpec] outDir false [] {} none (some deniedBlobbasefeeLowLevelReportPath) none none false false false false false false true false false)
+    "Low-level mechanics remain:\n- BlobbasefeeTrustSurface [function:exerciseBlobbasefee]: blobbasefee"
 
   let deniedProxyUpgradeabilityTrustReportPath := s!"{trustReportDir}/trust-report-denied-proxy-upgradeability.json"
   expectFailureContains


### PR DESCRIPTION
## Summary

Fixes #1829. The post-Dencun `blobbasefee` opcode now triggers both the
`--deny-runtime-introspection` and `--deny-low-level-mechanics` gates so
that strict compilation success implies the artifact is inside the
proof-interpreter-covered fragment for environment opcodes.

- `collectRuntimeIntrospectionExprMechanics` emits `"blobbasefee"` for
  `Expr.blobbasefee`; the field `partiallyModeledRuntimeIntrospection`
  now lists it.
- `isRuntimeIntrospectionMechanic` and `isDeniedLowLevelMechanic`
  classifiers recognize `"blobbasefee"`.
- Regression coverage exercises both deny gates on a new
  `BlobbasefeeTrustSurface` fixture; the existing `MacroBlobbasefee`
  feature test asserts the new runtime-introspection classification.

## Test plan

- [x] `lake build Compiler.CompilationModel.TrustSurface`
- [x] `lake build Compiler.CompileDriverTest` — new assertions pass
- [x] `lake build Compiler.CompilationModelFeatureTest` — new trust-report
      assertion passes
- [x] `make check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens fail-closed deny behavior for the post-Dencun `blobbasefee` opcode, which may cause previously-successful strict builds to fail and requires updates to expectations/tests.
> 
> **Overview**
> Ensures the post-Dencun `blobbasefee` opcode **fails closed** under strict compilation deny gates by surfacing it as both a modeled low-level mechanic and a *partially modeled runtime-introspection* mechanic.
> 
> Updates `TrustSurface` classification/collection so `Expr.blobbasefee` is reported under `partiallyModeledRuntimeIntrospection`, and extends the low-level deny classifier to include `blobbasefee`. Adds regression tests/fixtures (`BlobbasefeeTrustSurface`) asserting `--deny-runtime-introspection` and `--deny-low-level-mechanics` reject specs using `blobbasefee`, and updates the existing macro feature test to check the new trust-report category.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb1b4b81f344266c15554b9957b77e85485feabb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->