### PR TITLE
docs: track verity-benchmark unlink_xyz/pool case in roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -160,6 +160,20 @@ Package-boundary rule for the Unlink audit:
 - Keep Verity-core additions protocol-agnostic. A feature belongs in Verity core
   only if it models ordinary Solidity/EVM behavior or reusable audit ergonomics.
 
+Translation tracking:
+
+- The verity-benchmark case
+  [`cases/unlink_xyz/pool/`](https://github.com/lfglabs-dev/verity-benchmark/tree/main/cases/unlink_xyz/pool)
+  is the canonical Verity model of `UnlinkPool` and the verified-DSL surface
+  side of [#1760](https://github.com/lfglabs-dev/verity/issues/1760). It is
+  currently at `stage: scoped` because three public ZK entry points (`transfer`,
+  `withdraw`, `adapterWithdraw`) take struct-array parameters with nested
+  dynamic members (`uint256[] nullifierHashes`, `uint256[] newCommitments`,
+  `Ciphertext[] ciphertexts`, `Call[] calls`). The macro currently rejects
+  struct-parameter projection from an ABI-dynamic root at
+  `Verity/Macro/Translate.lean:1715`. Promotion to `build_green` is the
+  Unlink-side trigger for closing #1760.
+
 ---
 
 ## Lessons from UnlinkPool (#185)


### PR DESCRIPTION
## Summary

Adds a translation-tracking note to the Unlink Audit Readiness section
of `docs/ROADMAP.md` pointing at the new
[lfglabs-dev/verity-benchmark#39](https://github.com/lfglabs-dev/verity-benchmark/pull/39)
case (`cases/unlink_xyz/pool/`). Names it as the Unlink-side trigger
for closing #1760 and cites the exact macro rejection point
(`Verity/Macro/Translate.lean:1715`) that gates promotion to
`build_green`.

## Test plan

- [x] Docs-only change; no code paths modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only update that adds a tracking note and links; no code or build behavior changes.
> 
> **Overview**
> Adds a new **"Translation tracking"** note to `docs/ROADMAP.md` under the Unlink audit readiness section, pointing to the canonical `verity-benchmark` `cases/unlink_xyz/pool/` model.
> 
> The note explains why the case is currently `stage: scoped` (macro rejection for struct-array params with nested dynamic members) and identifies the specific blocker location (`Verity/Macro/Translate.lean:1715`) as the Unlink-side trigger for closing issue `#1760`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9aa9294f587bbffa0819edad56a5b69cc8b55bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->