### PR TITLE
Remove dead isRuntimeIntrospectionMechanic helpers

### DIFF
--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -411,14 +411,6 @@ private def isProxyUpgradeabilityMechanic (mechanic : String) : Bool :=
 private def collectProxyUpgradeabilityMechanicsFromMechanics (mechanics : List String) : List String :=
   dedupPreserve (mechanics.filter isProxyUpgradeabilityMechanic)
 
-private def isRuntimeIntrospectionMechanic (mechanic : String) : Bool :=
-  match mechanic with
-  | "blockNumber" | "contractAddress" | "chainid" | "blobbasefee" => true
-  | _ => false
-
-private def collectRuntimeIntrospectionMechanicsFromMechanics (mechanics : List String) : List String :=
-  dedupPreserve (mechanics.filter isRuntimeIntrospectionMechanic)
-
 private partial def collectEventEmissionExprMechanics : Expr → List String
   | .externalCall _ args
   | .internalCall _ args =>


### PR DESCRIPTION
## Summary

Closes the [Cursor Bugbot finding](https://cursor.com/docs/bugbot) on #1830:

> Adding \`\"blobbasefee\"\` to \`isRuntimeIntrospectionMechanic\` has no effect.
> This function is only used by \`collectRuntimeIntrospectionMechanicsFromMechanics\`,
> which is never called anywhere in the codebase.

\`isRuntimeIntrospectionMechanic\` was introduced in #1489 in parallel
with \`isLinearMemoryMechanic\` and \`isProxyUpgradeabilityMechanic\`, but
unlike those siblings it never got wired into the trust-surface
reporting. The actual deny-gate path is
\`collectRuntimeIntrospectionExprMechanics\` (AST-walk over expressions),
which was updated correctly in #1830 and stays.

Drop both dead helpers rather than wiring them in: there is no list of
mechanic strings flowing into the runtime-introspection bucket that
would benefit from a filter-by-name layer.

## Test plan

- [x] \`make check\` green locally.
- [x] No other callers of either symbol in \`Compiler/\` or \`Verity/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)