### PR TITLE
Dedupe Compiler.Modules.Calls import in Contracts.Smoke

### DIFF
--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -12,7 +12,6 @@ import Contracts.ERC20.ERC20
 import Contracts.ERC721.ERC721
 import Compiler.Modules.Calls
 import Compiler.Modules.ERC20
-import Compiler.Modules.Calls
 import Compiler.Modules.Oracle
 
 namespace Contracts.Smoke


### PR DESCRIPTION
## Summary

Closes the Cursor Bugbot finding on #1810: \`import Compiler.Modules.Calls\` appeared twice in \`Contracts/Smoke.lean\` (lines 13 and 15). The new line was added during the \`CallWithValueSmoke\` wire-up but the pre-existing line was not removed. Lean tolerates duplicate imports silently, so this is a cosmetic cleanup.

## Test plan

- [x] One-line removal in \`Contracts/Smoke.lean\`. No code behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cosmetic change: removes a redundant duplicate import in `Contracts/Smoke.lean` with no behavior impact.
> 
> **Overview**
> Removes a duplicate `import Compiler.Modules.Calls` from `Contracts/Smoke.lean`, leaving a single import entry and avoiding redundant module inclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 994145cb5d2094d2b0cd8fa17c1e2b1ae780dbeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->