### PR TITLE
Extend requires(<role>) to accept Address→Uint256 mapping roles (#1837)

### DIFF
--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -369,6 +369,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.CEISmoke.spec
   , Contracts.Smoke.CEILadderSmoke.spec
   , Contracts.Smoke.RolesSmoke.spec
+  , Contracts.Smoke.RolesMappingSmoke.spec
   , Contracts.Smoke.NewtypeSmoke.spec
   , Contracts.Smoke.NewtypeStorageSmoke.spec
   , Contracts.Smoke.NamespacedStorageSmoke.spec
@@ -500,6 +501,7 @@ private def expectedExternalSignatures : List (String × List String) :=
   , ("CEISmoke", ["increment()", "getCounter()", "updateThenCall(uint256)", "callThenUpdate(uint256)"])
   , ("CEILadderSmoke", ["callThenStoreGuarded(uint256)", "callThenStoreProved(uint256)", "storeThenCall(uint256)", "increment()"])
   , ("RolesSmoke", ["setCounter(uint256)", "getCounter()"])
+  , ("RolesMappingSmoke", ["setCounter(uint256)", "getCounter()"])
   , ("NewtypeSmoke", ["mint(uint256,uint256)", "setMinter(address)", "getNextTokenId()"])
   , ("NewtypeStorageSmoke", ["setTokenId(uint256)", "getTokenId()", "setAdmin(address)", "getAdmin()"])
   , ("NamespacedStorageSmoke", ["deposit(uint256)", "getOwner()"])
@@ -612,6 +614,7 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("CEISmoke", ["0xd09de08a", "0x8ada066e", "0x8c468aed", "0x4955cfdb"])
   , ("CEILadderSmoke", ["0xaf0ac94c", "0xe9ab4836", "0xb6fbe456", "0xd09de08a"])
   , ("RolesSmoke", ["0x8bb5d9c3", "0x8ada066e"])
+  , ("RolesMappingSmoke", ["0x8bb5d9c3", "0x8ada066e"])
   , ("NewtypeSmoke", ["0x1b2ef1ca", "0xfca3b5aa", "0xcaa0f92a"])
   , ("NewtypeStorageSmoke", ["0xc929ccf3", "0x010a38f5", "0x704b6c02", "0x6e9960c3"])
   , ("NamespacedStorageSmoke", ["0xb6b55f25", "0x893d20e8"])
@@ -729,6 +732,10 @@ private def checkMutabilitySmoke : IO Unit := do
   let _ := @Contracts.Smoke.RolesSmoke.setCounter_requires_role
   -- getCounter has no requires → gets normal _cei_compliant
   let _ := @Contracts.Smoke.RolesSmoke.getCounter_cei_compliant
+  -- Mapping-keyed roles (verity#1837): setCounter with requires(relayers : Address → Uint256)
+  -- still produces the _requires_role theorem.
+  let _ := @Contracts.Smoke.RolesMappingSmoke.setCounter_requires_role
+  let _ := @Contracts.Smoke.RolesMappingSmoke.getCounter_cei_compliant
   -- Verify NewtypeSmoke generates standard _cei_compliant theorems (#1727, Axis 1 Step 3a).
   -- Newtypes are erased — functions compile with base types.
   let _ := @Contracts.Smoke.NewtypeSmoke.mint_cei_compliant

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -152,6 +152,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.CEISmoke.spec
   , Contracts.Smoke.CEILadderSmoke.spec
   , Contracts.Smoke.RolesSmoke.spec
+  , Contracts.Smoke.RolesMappingSmoke.spec
   , Contracts.Smoke.NewtypeSmoke.spec
   , Contracts.Smoke.NewtypeStorageSmoke.spec
   , Contracts.Smoke.NamespacedStorageSmoke.spec

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -2486,6 +2486,32 @@ verity_contract RolesSmoke where
     let current ← getStorage counter
     return current
 
+-- Mapping-keyed roles / requires(<mapping>) smoke test (verity#1837)
+--
+-- For role-as-mapping access control (the `onlyRelayer` / `onlyMinter`
+-- pattern), the role storage is a `mapping(address => uint256)` (0/1 flag)
+-- instead of a scalar Address. `requires(relayers)` then auto-injects
+-- `require(storage[relayers][caller] != 0) "Access denied: caller is not relayers"`.
+verity_contract RolesMappingSmoke where
+  storage
+    relayers : Address → Uint256 := slot 0
+    counter  : Uint256 := slot 1
+
+  constructor (initialRelayer : Address) := do
+    setMapping relayers initialRelayer 1
+
+  -- requires(relayers) auto-injects:
+  --   let sender ← msgSender
+  --   let value  ← getMapping relayers sender
+  --   require (value != 0) "Access denied: caller is not relayers"
+  function setCounter (value : Uint256) requires(relayers) : Unit := do
+    setStorage counter value
+
+  -- Normal function without access control
+  function getCounter () : Uint256 := do
+    let current ← getStorage counter
+    return current
+
 -- Newtype smoke test (#1727, Axis 1 Step 3a)
 -- Declares semantic newtypes that are erased to base types at EVM level
 verity_contract NewtypeSmoke where
@@ -2516,6 +2542,7 @@ verity_contract NewtypeSmoke where
     return current
 
 #check_contract RolesSmoke
+#check_contract RolesMappingSmoke
 #check_contract NewtypeSmoke
 
 -- Smoke test for newtype-TYPED storage fields (not just newtype params).

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1208,60 +1208,96 @@ private def mkInitGuardedBody
                   $[$elems:doElem]*)
       | _ => throwErrorAt fn.body "function body must be a do block"
 
+/-- Classifies a `requires(role)` annotation by the shape of the named storage
+    field. `scalarAddress` is the canonical `onlyOwner` shape — a scalar
+    Address-typed slot; the macro injects `require (caller == storage[slot])`.
+    `mappingAddress` is the role-as-mapping shape (e.g. `onlyRelayer`,
+    `onlyMinter`) — a `mapping(address => uint256)` slot used as a 0/1 flag;
+    the macro injects `require (storage[slot][caller] != 0)`. (verity#1837) -/
+private inductive RoleKind where
+  | scalarAddress
+  | mappingAddress
+
 /-- Resolve the storage field referenced by a `requires(role)` annotation.
-    The role must be an Address-typed scalar storage field. -/
+    Accepts either an Address-typed scalar field (`onlyOwner`-style) or an
+    `Address → Uint256` mapping field (`onlyRelayer`-style, verity#1837). -/
 private def resolveRoleField
     (fields : Array StorageFieldDecl) (roleIdent : Ident) (fnIdent : Ident)
-    : CommandElabM StorageFieldDecl := do
+    : CommandElabM (StorageFieldDecl × RoleKind) := do
   let roleName := toString roleIdent.getId
   match fields.find? (fun f => f.name == roleName) with
   | none =>
       throwErrorAt roleIdent s!"function '{toString fnIdent.getId}': requires references unknown storage field '{roleName}'; known fields: {(fields.map (·.name)).toList}"
   | some field =>
       match field.ty with
-      | .scalar .address | .scalar (.newtype _ .address) => pure field
-      | _ => throwErrorAt roleIdent s!"function '{toString fnIdent.getId}': requires({roleName}) must reference an Address-typed storage field, but '{roleName}' has a different type"
+      | .scalar .address | .scalar (.newtype _ .address) =>
+          pure (field, .scalarAddress)
+      | .mappingAddressToUint256 =>
+          pure (field, .mappingAddress)
+      | _ => throwErrorAt roleIdent s!"function '{toString fnIdent.getId}': requires({roleName}) must reference an Address-typed scalar storage field or an Address→Uint256 mapping (role-as-mapping), but '{roleName}' has a different type"
 
 /-- Generate IR-level prelude statements for a `requires(role)` annotation.
-    Injects `Stmt.require (Expr.eq Expr.caller (Expr.storage roleField)) "Access denied: only role"`.
-    (#1728, Axis 2 Step 2c) -/
+    Scalar Address: injects `Stmt.require (Expr.eq Expr.caller (Expr.storageAddr roleField)) message`.
+    Address→Uint256 mapping: injects `Stmt.require (Expr.mapping roleField Expr.caller) message`
+    (the truthy check works because the value is 0 or non-zero).
+    (#1728, Axis 2 Step 2c; mapping-keyed extension verity#1837) -/
 private def roleGuardPreludeStmtTerms
     (fields : Array StorageFieldDecl)
     (fn : FunctionDecl) : CommandElabM (Array Term) := do
   match fn.requiresRole with
   | none => pure #[]
   | some roleIdent =>
-      let field ← resolveRoleField fields roleIdent fn.ident
+      let (field, kind) ← resolveRoleField fields roleIdent fn.ident
       let message := strTerm s!"Access denied: caller is not {field.name}"
-      pure #[
-        ← `(Compiler.CompilationModel.Stmt.require
-              (Compiler.CompilationModel.Expr.eq
-                (Compiler.CompilationModel.Expr.caller)
-                (Compiler.CompilationModel.Expr.storageAddr $(strTerm field.name)))
-              $message)
-      ]
+      match kind with
+      | .scalarAddress =>
+          pure #[
+            ← `(Compiler.CompilationModel.Stmt.require
+                  (Compiler.CompilationModel.Expr.eq
+                    (Compiler.CompilationModel.Expr.caller)
+                    (Compiler.CompilationModel.Expr.storageAddr $(strTerm field.name)))
+                  $message)
+          ]
+      | .mappingAddress =>
+          pure #[
+            ← `(Compiler.CompilationModel.Stmt.require
+                  (Compiler.CompilationModel.Expr.mapping $(strTerm field.name)
+                    Compiler.CompilationModel.Expr.caller)
+                  $message)
+          ]
 
 /-- Transform the source-level do-block body to inject a role access control check
-    at the start.  Injects `let __sender ← msgSender; let __roleHolder ← getStorageAddr field;
-    require (__sender == __roleHolder) "Access denied: caller is not role"`.
-    (#1728, Axis 2 Step 2c) -/
+    at the start. Scalar Address: `let __sender ← msgSender; let __roleHolder ← getStorageAddr field;
+    require (__sender == __roleHolder) message`. Address→Uint256 mapping:
+    `let __sender ← msgSender; let __roleValue ← getMapping field __sender;
+    require (__roleValue != 0) message`.
+    (#1728, Axis 2 Step 2c; mapping-keyed extension verity#1837) -/
 private def mkRoleGuardedBody
     (fields : Array StorageFieldDecl)
     (fn : FunctionDecl) : CommandElabM Term := do
   match fn.requiresRole with
   | none => pure fn.body
   | some roleIdent =>
-      let field ← resolveRoleField fields roleIdent fn.ident
+      let (field, kind) ← resolveRoleField fields roleIdent fn.ident
       let senderVar := mkIdent (Name.mkSimple s!"__verity_role_sender_{field.name}")
-      let holderVar := mkIdent (Name.mkSimple s!"__verity_role_holder_{field.name}")
       let message := strTerm s!"Access denied: caller is not {field.name}"
       match fn.body with
       | `(term| do $[$elems:doElem]*) =>
-          `(do
-              let $senderVar ← msgSender
-              let $holderVar ← getStorageAddr $field.ident
-              require ($senderVar == $holderVar) $message
-              $[$elems:doElem]*)
+          match kind with
+          | .scalarAddress =>
+              let holderVar := mkIdent (Name.mkSimple s!"__verity_role_holder_{field.name}")
+              `(do
+                  let $senderVar ← msgSender
+                  let $holderVar ← getStorageAddr $field.ident
+                  require ($senderVar == $holderVar) $message
+                  $[$elems:doElem]*)
+          | .mappingAddress =>
+              let valueVar := mkIdent (Name.mkSimple s!"__verity_role_value_{field.name}")
+              `(do
+                  let $senderVar ← msgSender
+                  let $valueVar ← getMapping $field.ident $senderVar
+                  require ($valueVar != 0) $message
+                  $[$elems:doElem]*)
       | _ => throwErrorAt fn.body "function body must be a do block"
 
 private def mkImmutableBoundBody

--- a/artifacts/macro_property_tests/PropertyRolesMappingSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyRolesMappingSmoke.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyRolesMappingSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyRolesMappingSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYulWithArgs("RolesMappingSmoke", abi.encode(alice));
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: getCounter reads storage slot 1 and decodes the result
+    function testAuto_GetCounter_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(1)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCounter()"));
+        require(ok, "getCounter reverted unexpectedly");
+        assertEq(ret.length, 32, "getCounter ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getCounter should return storage slot 1");
+    }
+}


### PR DESCRIPTION
## Summary

- Extends `requires(<role>)` to accept `Address → Uint256` mapping fields in addition to scalar Address fields — covers the `onlyRelayer` / `onlyMinter` / `onlyBackend` access-control pattern.
- Macro auto-injects `let sender ← msgSender; let value ← getMapping field sender; require (value != 0) message` for the mapping form (vs. `require(caller == storage[slot]) message` for the existing scalar form).
- Adds `Contracts.Smoke.RolesMappingSmoke` and threads it through the macro invariant / round-trip-fuzz / property-test indexes.

Fixes #1837.

## Why

Today the only role gating shape supported by the macro is a scalar `address` slot. For Unlink, Permit2-relayed flows, and other production contracts where the relayer/minter/backend set is membership-checked, the natural shape is `mapping(address => bool)` (encoded as `mapping(address => uint256)` of 0/1). Without this, every relayer-gated entry point carries a 3-line preamble:

```lean
function adapterDeposit (...) := do
  let sender ← msgSender
  let isR ← getMapping relayersSlot sender
  requireError (isR != 0) PoolUnauthorizedRelayer()
  ...
```

After this change, the same is one line:

```lean
function adapterDeposit (...) requires(relayersSlot) := do
  ...
```

Symmetric with the existing scalar form.

## How

`resolveRoleField` (Verity/Macro/Translate.lean) now returns a `(StorageFieldDecl × RoleKind)` pair where `RoleKind = scalarAddress | mappingAddress`. The two emitting helpers — `roleGuardPreludeStmtTerms` (IR-level) and `mkRoleGuardedBody` (source-level, for downstream Lean theorems) — branch on the kind:

- Scalar Address: unchanged. `Stmt.require (Expr.eq Expr.caller (Expr.storageAddr field)) msg`.
- Address → Uint256 mapping: `Stmt.require (Expr.mapping field Expr.caller) msg` (truthy check works because the value is 0 or non-zero).

`_requires_role` theorem generation, modifies tracking, CEI compliance, no-external-calls, and frame proofs all flow through unchanged because the IR shape is still a single `Stmt.require` at the start of the body.

## Test plan

- [x] `Contracts.Smoke.RolesMappingSmoke` `#check_contract ok`
- [x] `_requires_role` theorem exists for `setCounter` on `RolesMappingSmoke` (assertion in `Contracts/MacroTranslateInvariantTest.lean`)
- [x] `RolesMappingSmoke` listed in invariant suite spec list, function-signature index, selector index
- [x] `RolesMappingSmoke` listed in round-trip fuzz suite
- [x] Property test artifact at `artifacts/macro_property_tests/PropertyRolesMappingSmoke.t.sol` auto-generated and `make check`'s macro-health gate is green
- [x] `make check` passes locally (linear-memory boundary, axiomatized-primitive boundary, struct-mapping surface, solc pin, property manifest, issue templates, docs workflow, macro health, IR/Yul identity diff, selector audit)
- [x] Full `lake build` succeeds

## Scope

Pure macro surface extension. No semantic, trust, or CI boundary change → `AUDIT.md` / `AXIOMS.md` / `TRUST_ASSUMPTIONS.md` unaffected.

## Downstream

verity-benchmark `cases/unlink_xyz/pool/Contract.lean` carries `onlyRelayer` boilerplate in every relayer-gated entrypoint, plus a `WORKAROUNDS.txt` entry. Once this lands, the boilerplate collapses to `requires(relayersSlot)`. Follow-up benchmark PR is queued for after the lakefile-pinned verity commit advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches access-control macro expansion (`requires(...)`) and changes generated IR/source prelude for eligible storage types, so misclassification could weaken or break role checks; scope is limited and covered by new smoke/invariant/fuzz tests.
> 
> **Overview**
> Extends `requires(<role>)` so it can reference either a scalar `Address` storage slot *or* an `Address → Uint256` mapping used as a 0/1 membership flag. The macro now classifies the role field (`RoleKind`) and injects either the existing `caller == storageAddr` check or a new mapping lookup check (`getMapping` / `Expr.mapping`) at the start of the function body.
> 
> Adds a new `RolesMappingSmoke` contract and threads it through invariant and round-trip fuzz harnesses, including pinned signature/selector snapshots and theorem-existence checks. Also adds an auto-generated Solidity property-test stub `PropertyRolesMappingSmoke.t.sol` for the new smoke contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49164a47ab0b26c8cb1d9fa2838f044c2c109148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->