### PR TITLE
Fix genDynamicParamLoads off-by-one for dynamic-tuple params (#1839)

### DIFF
--- a/Compiler/CompilationModel/ParamLoading.lean
+++ b/Compiler/CompilationModel/ParamLoading.lean
@@ -21,6 +21,15 @@ private def dynamicArrayElementStrideWords (elemTy : ParamType) : Nat :=
   else
     max 1 (paramHeadSize elemTy / 32)
 
+/-- Whether the dynamic param shape is length-prefixed in the ABI tail.
+    Dynamic arrays (`T[]`), `bytes`, and `string` all begin with a 32-byte
+    length word followed by data. Dynamic tuples (structs containing nested
+    dynamic members) do not — their offset pointer dereferences directly
+    to the first head word of the tuple's encoding. (verity#1839) -/
+private def isLengthPrefixedDynamicShape : ParamType → Bool
+  | ParamType.bytes | ParamType.string | ParamType.array _ => true
+  | _ => false
+
 private def genDynamicParamLoads
     (loadWord : YulExpr → YulExpr) (sizeExpr : YulExpr) (headSize : Nat)
     (baseOffset : Nat) (name : String) (ty : ParamType) (headOffset : Nat) :
@@ -45,36 +54,48 @@ private def genDynamicParamLoads
   ]) [
     YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
   ]
-  let lengthLoad := YulStmt.let_ s!"{name}_length"
-    (loadWord absoluteOffset)
-  let tailHeadEndName := s!"{name}_tail_head_end"
-  let tailHeadEndLoad := YulStmt.let_ tailHeadEndName
-    (YulExpr.call "add" [absoluteOffset, YulExpr.lit 32])
-  let tailRemainingName := s!"{name}_tail_remaining"
-  let tailRemainingLoad := YulStmt.let_ tailRemainingName
-    (YulExpr.call "sub" [sizeExpr, YulExpr.ident tailHeadEndName])
-  let lengthBoundsCheck :=
-    match ty with
-    | ParamType.bytes | ParamType.string =>
-        [YulStmt.if_ (YulExpr.call "gt" [
-            YulExpr.ident s!"{name}_length",
-            YulExpr.ident tailRemainingName
-          ]) [
-            YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
-          ]]
-    | ParamType.array elemTy =>
-        let elemWords := dynamicArrayElementStrideWords elemTy
-        [YulStmt.if_ (YulExpr.call "gt" [
-            YulExpr.ident s!"{name}_length",
-            YulExpr.call "div" [YulExpr.ident tailRemainingName, YulExpr.lit (32 * elemWords)]
-          ]) [
-            YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
-          ]]
-    | _ => []
-  let dataOffsetLoad := YulStmt.let_ s!"{name}_data_offset"
-    (YulExpr.ident tailHeadEndName)
-  [offsetLoad, offsetBoundsCheck, absoluteOffsetLoad, absoluteBoundsCheck, lengthLoad, tailHeadEndLoad, tailRemainingLoad]
-    ++ lengthBoundsCheck ++ [dataOffsetLoad]
+  let preamble := [offsetLoad, offsetBoundsCheck, absoluteOffsetLoad, absoluteBoundsCheck]
+  if isLengthPrefixedDynamicShape ty then
+    -- Length-prefixed shape (T[] / bytes / string): the offset points to a
+    -- length word, the data starts 32 bytes later.
+    let lengthLoad := YulStmt.let_ s!"{name}_length"
+      (loadWord absoluteOffset)
+    let tailHeadEndName := s!"{name}_tail_head_end"
+    let tailHeadEndLoad := YulStmt.let_ tailHeadEndName
+      (YulExpr.call "add" [absoluteOffset, YulExpr.lit 32])
+    let tailRemainingName := s!"{name}_tail_remaining"
+    let tailRemainingLoad := YulStmt.let_ tailRemainingName
+      (YulExpr.call "sub" [sizeExpr, YulExpr.ident tailHeadEndName])
+    let lengthBoundsCheck :=
+      match ty with
+      | ParamType.bytes | ParamType.string =>
+          [YulStmt.if_ (YulExpr.call "gt" [
+              YulExpr.ident s!"{name}_length",
+              YulExpr.ident tailRemainingName
+            ]) [
+              YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+            ]]
+      | ParamType.array elemTy =>
+          let elemWords := dynamicArrayElementStrideWords elemTy
+          [YulStmt.if_ (YulExpr.call "gt" [
+              YulExpr.ident s!"{name}_length",
+              YulExpr.call "div" [YulExpr.ident tailRemainingName, YulExpr.lit (32 * elemWords)]
+            ]) [
+              YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+            ]]
+      | _ => []
+    let dataOffsetLoad := YulStmt.let_ s!"{name}_data_offset"
+      (YulExpr.ident tailHeadEndName)
+    preamble ++ [lengthLoad, tailHeadEndLoad, tailRemainingLoad]
+      ++ lengthBoundsCheck ++ [dataOffsetLoad]
+  else
+    -- Dynamic tuple / fixedArray-with-dynamic-head: no length word; the
+    -- offset points directly to the first head word of the tuple. Set
+    -- `_data_offset` straight to `_abs_offset` so downstream Expr lowerings
+    -- read `_data_offset + word_offset * 32` (verity#1839, prerequisite
+    -- for verity#1832 macro routing).
+    let dataOffsetLoad := YulStmt.let_ s!"{name}_data_offset" absoluteOffset
+    preamble ++ [dataOffsetLoad]
 
 def genScalarLoad
     (loadWord : YulExpr → YulExpr) (name : String) (ty : ParamType) (offset : Nat) :


### PR DESCRIPTION
## Summary

Fixes the latent off-by-one bug in `genDynamicParamLoads` where dynamic-tuple parameters got a spurious `_length` load (actually pointing at the tuple's first head word) and a `_data_offset` shifted by +32 bytes.

Prerequisite for #1832 — once the macro routes direct dynamic-tuple parameter projections, this loader has to produce a correctly-positioned `_data_offset`.

Fixes #1839.

## Bug

For a Solidity function `foo(Txn calldata txn)` where `Txn` is ABI-dynamic (carries nested dynamic members), the calldata layout is:

```
[selector(4)] [offset_to_txn(32)] [Txn encoded...]
                                  ^
                                  txn_abs_offset = 4 + offset_to_txn
                                  Txn head word 0 starts here (no length prefix)
```

Old generated loader:
- `txn_length = calldataload(txn_abs_offset)` — actually the **first head word** of Txn, not a length
- `txn_data_offset = txn_abs_offset + 32` — **32 bytes past** the real Txn data start

Net effect: every `txn.<field>` read would land on the wrong word.

The bug was latent because `Verity/Macro/Translate.lean:1715` currently rejects every routing path that would exercise it. But #1832 unblocks that path.

## Fix

A local predicate `isLengthPrefixedDynamicShape : ParamType → Bool` partitions the dynamic shapes:

- **True** for `ParamType.bytes` / `ParamType.string` / `ParamType.array _`: unchanged behaviour (`[length(32)][data...]`).
- **False** for `ParamType.tuple _` and other dynamic shapes: no length word — `{name}_data_offset` is set directly to `{name}_abs_offset`.

The shared preamble (`{name}_offset` load, offset bounds check, `{name}_abs_offset` binding, absolute bounds check) is factored out; only the length-prefix-specific reads diverge.

## Test plan

- [x] `lake build` succeeds
- [x] `make check` passes locally (macro health, IR/Yul identity diff, selector audit, property-test artifacts)
- [x] No existing smoke contract exercises the dynamic-tuple path today — the new branch is byte-identical for all currently-callable paths. New coverage lands with #1832's macro routing.

## Scope

No semantic, trust, or CI boundary change — `AUDIT.md` / `AXIOMS.md` / `TRUST_ASSUMPTIONS.md` unaffected. Length-prefixed shape behaviour is byte-for-byte unchanged (same Yul statements emitted in the same order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ABI calldata decoding for dynamic parameters; incorrect branching could break decoding for tuples/arrays/bytes and cause runtime reverts or mis-read fields, though the change is narrowly scoped and preserves prior behavior for length-prefixed types.
> 
> **Overview**
> Fixes `genDynamicParamLoads` to distinguish **length-prefixed** dynamic ABI shapes (`T[]`, `bytes`, `string`) from **dynamic tuples**.
> 
> For length-prefixed types, the loader behavior is unchanged (load `{name}_length`, bounds-check against remaining tail, set `{name}_data_offset = abs_offset + 32`). For non-length-prefixed dynamic shapes (notably dynamic tuples), it no longer loads a bogus `_length` word and instead sets `{name}_data_offset` directly to `{name}_abs_offset`, avoiding the prior +32-byte misalignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33cbf09183c1126470ecb12abf5605a31bb15615. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->