### PR TITLE
Accept struct-parameter projection from ABI-dynamic root (#1832)

### DIFF
--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -395,6 +395,7 @@ def compileValidatedCore (spec : CompilationModel) (selectors : List Nat) : Exce
   let mappingHelpersRequired := usesMapping fields
   let arrayHelpersRequired := contractUsesPlainArrayElement spec
   let arrayElementWordHelpersRequired := contractUsesArrayElementWord spec
+  let paramDynamicHeadWordHelpersRequired := contractUsesParamDynamicHeadWord spec
   let storageArrayHelpersRequired := contractUsesStorageArrayElement spec
   let dynamicBytesEqHelpersRequired := contractUsesDynamicBytesEq spec
   let fallbackSpec ← pickUniqueFunctionByName "fallback" spec.functions
@@ -414,6 +415,12 @@ def compileValidatedCore (spec : CompilationModel) (selectors : List Nat) : Exce
       , checkedArrayElementWordMemoryHelper
       , checkedArrayElementDynamicWordCalldataHelper
       , checkedArrayElementDynamicWordMemoryHelper
+      ]
+    else
+      []) ++
+    (if paramDynamicHeadWordHelpersRequired then
+      [ checkedParamDynamicHeadWordCalldataHelper
+      , checkedParamDynamicHeadWordMemoryHelper
       ]
     else
       [])

--- a/Compiler/CompilationModel/DynamicData.lean
+++ b/Compiler/CompilationModel/DynamicData.lean
@@ -32,6 +32,12 @@ def checkedArrayElementDynamicWordCalldataHelperName : String :=
 def checkedArrayElementDynamicWordMemoryHelperName : String :=
   "__verity_array_element_dynamic_word_memory_checked"
 
+def checkedParamDynamicHeadWordCalldataHelperName : String :=
+  "__verity_param_dynamic_head_word_calldata_checked"
+
+def checkedParamDynamicHeadWordMemoryHelperName : String :=
+  "__verity_param_dynamic_head_word_memory_checked"
+
 def checkedStorageArrayElementHelperName : String :=
   "__verity_storage_array_element_checked"
 
@@ -130,6 +136,39 @@ def checkedArrayElementDynamicWordCalldataHelper : YulStmt :=
 
 def checkedArrayElementDynamicWordMemoryHelper : YulStmt :=
   checkedArrayElementDynamicWordHelper checkedArrayElementDynamicWordMemoryHelperName "mload" none
+
+/-- Yul helper for `Expr.paramDynamicHeadWord` (verity#1832). Reads the
+    word at `data_offset + word_offset * 32`, where `data_offset` is the
+    `{name}_data_offset` produced by `genDynamicParamLoads` for a
+    dynamic-tuple parameter (verity#1839 ensures this points at the
+    first head word of the tuple, not 32 bytes past it). Reverts if the
+    computed position would read past `calldatasize - 32` (calldata
+    variant); the memory variant trusts its source. -/
+private def checkedParamDynamicHeadWordHelper (helperName loadOp : String) (sizeExpr? : Option YulExpr) : YulStmt :=
+  let wordPos := YulExpr.call "add" [
+    YulExpr.ident "data_offset",
+    YulExpr.call "mul" [YulExpr.ident "word_offset", YulExpr.lit 32]
+  ]
+  let sizeCheck :=
+    match sizeExpr? with
+    | some sizeExpr =>
+        [YulStmt.if_ (YulExpr.call "gt" [
+          YulExpr.ident "__head_word_pos",
+          YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
+        ]) [
+          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        ]]
+    | none => []
+  YulStmt.funcDef helperName ["data_offset", "word_offset"] ["word"] (
+    [YulStmt.let_ "__head_word_pos" wordPos] ++ sizeCheck ++ [
+      YulStmt.assign "word" (YulExpr.call loadOp [YulExpr.ident "__head_word_pos"])
+    ])
+
+def checkedParamDynamicHeadWordCalldataHelper : YulStmt :=
+  checkedParamDynamicHeadWordHelper checkedParamDynamicHeadWordCalldataHelperName "calldataload" (some (YulExpr.call "calldatasize" []))
+
+def checkedParamDynamicHeadWordMemoryHelper : YulStmt :=
+  checkedParamDynamicHeadWordHelper checkedParamDynamicHeadWordMemoryHelperName "mload" none
 
 def checkedStorageArrayElementHelper : YulStmt :=
   YulStmt.funcDef checkedStorageArrayElementHelperName ["slot", "index"] ["word"] [

--- a/Compiler/CompilationModel/ExpressionCompile.lean
+++ b/Compiler/CompilationModel/ExpressionCompile.lean
@@ -293,6 +293,14 @@ def compileExpr (fields : List Field)
         indexExpr,
         YulExpr.lit wordOffset
       ])
+  | Expr.paramDynamicHeadWord name wordOffset => do
+      let helperName := match dynamicSource with
+        | .calldata => checkedParamDynamicHeadWordCalldataHelperName
+        | .memory => checkedParamDynamicHeadWordMemoryHelperName
+      pure (YulExpr.call helperName [
+        YulExpr.ident s!"{name}_data_offset",
+        YulExpr.lit wordOffset
+      ])
   | Expr.storageArrayLength field =>
       match findFieldWithResolvedSlot fields field with
       | some (f, slot) =>

--- a/Compiler/CompilationModel/LogicalPurity.lean
+++ b/Compiler/CompilationModel/LogicalPurity.lean
@@ -55,6 +55,7 @@ partial def exprContainsCallLike (expr : Expr) : Bool :=
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.paramDynamicHeadWord _ _
   | Expr.adtTag _ _ =>
       false
 partial def exprListContainsCallLike : List Expr → Bool
@@ -146,6 +147,7 @@ def exprContainsUnsafeLogicalCallLike (expr : Expr) : Bool :=
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.paramDynamicHeadWord _ _
   | Expr.adtTag _ _ =>
       false
 termination_by sizeOf expr

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -167,6 +167,21 @@ def validateScopedExprIdentifiers
       | none =>
           throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.arrayElementDynamicWord"
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount index
+  | Expr.paramDynamicHeadWord name wordOffset => do
+      match findParamType params name with
+      | some ty@(ParamType.tuple _) =>
+          if isDynamicParamType ty then
+            let expectedWords := paramLocalHeadWords ty
+            if wordOffset < expectedWords then
+              pure ()
+            else
+              throw s!"Compilation error: {context} Expr.paramDynamicHeadWord '{name}' wordOffset {wordOffset} is outside head width {expectedWords} for {repr ty}"
+          else
+            throw s!"Compilation error: {context} Expr.paramDynamicHeadWord '{name}' requires a dynamically-encoded tuple parameter, got {repr ty}"
+      | some ty =>
+          throw s!"Compilation error: {context} Expr.paramDynamicHeadWord '{name}' requires a tuple parameter, got {repr ty}"
+      | none =>
+          throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.paramDynamicHeadWord"
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
   | Expr.structMember _ key _ =>
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount key

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -350,6 +350,14 @@ inductive Expr
       nested dynamic members; `wordOffset` indexes the element head after the
       ABI element offset has been resolved. -/
   | arrayElementDynamicWord (name : String) (index : Expr) (wordOffset : Nat)
+  /-- Checked word access inside the head of a directly-passed struct/tuple
+      parameter whose ABI encoding is dynamic.  `wordOffset` indexes the
+      parameter's head section after the outer offset pointer has been
+      resolved by the parameter loader.  Used for `param.field` projections
+      where `param` is a struct that carries nested dynamic members and the
+      projected field is a single-word static leaf at a fixed head offset.
+      (verity#1832) -/
+  | paramDynamicHeadWord (name : String) (wordOffset : Nat)
   | storageArrayLength (field : String)  -- Read the length word of a storage dynamic array (#1571)
   | storageArrayElement (field : String) (index : Expr)  -- Checked element access of a storage dynamic array (#1571)
   /-- Equality on direct `bytes` / `string` parameters loaded from calldata or memory.

--- a/Compiler/CompilationModel/UsageAnalysis.lean
+++ b/Compiler/CompilationModel/UsageAnalysis.lean
@@ -175,6 +175,7 @@ def exprUsesArrayElementKind (includePlain includeWord : Bool) : Expr → Bool
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.storageArrayLength _
+  | Expr.paramDynamicHeadWord _ _
   | Expr.adtTag _ _ =>
       false
 termination_by e => sizeOf e
@@ -339,6 +340,7 @@ def exprUsesArrayElement : Expr → Bool
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.storageArrayLength _
+  | Expr.paramDynamicHeadWord _ _
   | Expr.adtTag _ _ =>
       false
 termination_by e => sizeOf e
@@ -473,6 +475,99 @@ def contractUsesArrayElementWord (spec : CompilationModel) : Bool :=
   contractUsesArrayElement spec &&
     (constructorUsesArrayElementWord spec.constructor || spec.functions.any functionUsesArrayElementWord)
 
+/-- Whether the given expression syntactically contains an
+    `Expr.paramDynamicHeadWord` (verity#1832). Walks the expression tree
+    rather than threading another flag through `exprUsesArrayElementKind`. -/
+partial def exprUsesParamDynamicHeadWord : Expr → Bool
+  | Expr.paramDynamicHeadWord _ _ => true
+  | e => match e with
+    | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _
+    | Expr.mappingUint _ key | Expr.structMember _ key _
+    | Expr.storageArrayElement _ key | Expr.arrayElement _ key
+    | Expr.arrayElementWord _ key _ _ | Expr.arrayElementDynamicWord _ key _ =>
+        exprUsesParamDynamicHeadWord key
+    | Expr.mappingChain _ keys => keys.any exprUsesParamDynamicHeadWord
+    | Expr.mapping2 _ k1 k2 | Expr.mapping2Word _ k1 k2 _ | Expr.structMember2 _ k1 k2 _ =>
+        exprUsesParamDynamicHeadWord k1 || exprUsesParamDynamicHeadWord k2
+    | Expr.call gas target value inOffset inSize outOffset outSize =>
+        [gas, target, value, inOffset, inSize, outOffset, outSize].any
+          exprUsesParamDynamicHeadWord
+    | Expr.staticcall gas target inOffset inSize outOffset outSize
+    | Expr.delegatecall gas target inOffset inSize outOffset outSize =>
+        [gas, target, inOffset, inSize, outOffset, outSize].any
+          exprUsesParamDynamicHeadWord
+    | Expr.extcodesize a | Expr.mload a | Expr.tload a | Expr.calldataload a
+    | Expr.returndataOptionalBoolAt a | Expr.bitNot a | Expr.logicalNot a =>
+        exprUsesParamDynamicHeadWord a
+    | Expr.keccak256 a b =>
+        exprUsesParamDynamicHeadWord a || exprUsesParamDynamicHeadWord b
+    | Expr.externalCall _ args | Expr.internalCall _ args | Expr.adtConstruct _ _ args =>
+        args.any exprUsesParamDynamicHeadWord
+    | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b
+    | Expr.mod a b | Expr.smod a b
+    | Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b
+    | Expr.sar a b | Expr.signextend a b
+    | Expr.eq a b | Expr.ge a b | Expr.gt a b | Expr.sgt a b | Expr.lt a b | Expr.slt a b
+    | Expr.le a b | Expr.logicalAnd a b | Expr.logicalOr a b
+    | Expr.wMulDown a b | Expr.wDivUp a b | Expr.min a b | Expr.max a b | Expr.ceilDiv a b =>
+        exprUsesParamDynamicHeadWord a || exprUsesParamDynamicHeadWord b
+    | Expr.mulDivDown a b c | Expr.mulDivUp a b c | Expr.ite a b c =>
+        exprUsesParamDynamicHeadWord a || exprUsesParamDynamicHeadWord b ||
+        exprUsesParamDynamicHeadWord c
+    | _ => false
+
+partial def stmtUsesParamDynamicHeadWord : Stmt → Bool
+  | Stmt.letVar _ value | Stmt.assignVar _ value | Stmt.setStorage _ value
+  | Stmt.setStorageAddr _ value | Stmt.setStorageWord _ _ value
+  | Stmt.storageArrayPush _ value | Stmt.return value | Stmt.require value _ =>
+      exprUsesParamDynamicHeadWord value
+  | Stmt.setStorageArrayElement _ index value =>
+      exprUsesParamDynamicHeadWord index || exprUsesParamDynamicHeadWord value
+  | Stmt.requireError cond _ args =>
+      exprUsesParamDynamicHeadWord cond || args.any exprUsesParamDynamicHeadWord
+  | Stmt.revertError _ args | Stmt.emit _ args | Stmt.returnValues args =>
+      args.any exprUsesParamDynamicHeadWord
+  | Stmt.mstore offset value | Stmt.tstore offset value =>
+      exprUsesParamDynamicHeadWord offset || exprUsesParamDynamicHeadWord value
+  | Stmt.calldatacopy a b c | Stmt.returndataCopy a b c =>
+      exprUsesParamDynamicHeadWord a || exprUsesParamDynamicHeadWord b ||
+      exprUsesParamDynamicHeadWord c
+  | Stmt.setMapping _ k v | Stmt.setMappingWord _ k _ v
+  | Stmt.setMappingPackedWord _ k _ _ v | Stmt.setMappingUint _ k v
+  | Stmt.setStructMember _ k _ v =>
+      exprUsesParamDynamicHeadWord k || exprUsesParamDynamicHeadWord v
+  | Stmt.setMappingChain _ keys v =>
+      keys.any exprUsesParamDynamicHeadWord || exprUsesParamDynamicHeadWord v
+  | Stmt.setMapping2 _ k1 k2 v | Stmt.setMapping2Word _ k1 k2 _ v
+  | Stmt.setStructMember2 _ k1 k2 _ v =>
+      exprUsesParamDynamicHeadWord k1 || exprUsesParamDynamicHeadWord k2 ||
+      exprUsesParamDynamicHeadWord v
+  | Stmt.ite cond thenBranch elseBranch =>
+      exprUsesParamDynamicHeadWord cond ||
+      thenBranch.any stmtUsesParamDynamicHeadWord ||
+      elseBranch.any stmtUsesParamDynamicHeadWord
+  | Stmt.forEach _ count body =>
+      exprUsesParamDynamicHeadWord count || body.any stmtUsesParamDynamicHeadWord
+  | Stmt.unsafeBlock _ body =>
+      body.any stmtUsesParamDynamicHeadWord
+  | Stmt.matchAdt _ scrutinee branches =>
+      exprUsesParamDynamicHeadWord scrutinee ||
+        branches.any (fun (_, _, body) => body.any stmtUsesParamDynamicHeadWord)
+  | Stmt.internalCall _ args | Stmt.internalCallAssign _ _ args
+  | Stmt.externalCallBind _ _ args | Stmt.tryExternalCallBind _ _ _ args
+  | Stmt.ecm _ args =>
+      args.any exprUsesParamDynamicHeadWord
+  | Stmt.rawLog topics dataOffset dataSize =>
+      topics.any exprUsesParamDynamicHeadWord ||
+      exprUsesParamDynamicHeadWord dataOffset || exprUsesParamDynamicHeadWord dataSize
+  | _ => false
+
+def contractUsesParamDynamicHeadWord (spec : CompilationModel) : Bool :=
+  (match spec.constructor with
+    | none => false
+    | some ctor => ctor.body.any stmtUsesParamDynamicHeadWord) ||
+  spec.functions.any (fun fn => fn.body.any stmtUsesParamDynamicHeadWord)
+
 private def nestedPlainWithWordIndex : Expr :=
   Expr.arrayElement "plain" (Expr.arrayElementWord "word" (Expr.literal 0) 1 0)
 
@@ -545,6 +640,7 @@ def exprUsesStorageArrayElement : Expr → Bool
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.paramDynamicHeadWord _ _
   | Expr.adtTag _ _ =>
       false
   | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _ =>
@@ -688,6 +784,7 @@ def exprUsesDynamicBytesEq : Expr → Bool
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.paramDynamicHeadWord _ _
   | Expr.adtTag _ _ =>
       false
 termination_by e => sizeOf e

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -274,6 +274,7 @@ def exprReadsStateOrEnv : Expr → Bool
       if name == builtinExpName then exprListReadsStateOrEnv args else true
   | Expr.internalCall _ _ => true
   | Expr.arrayLength _ => false
+  | Expr.paramDynamicHeadWord _ _ => false
   | Expr.storageArrayLength _ => true
   | Expr.storageArrayElement _ index => true || exprReadsStateOrEnv index
   | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _ => exprReadsStateOrEnv index
@@ -352,7 +353,14 @@ def exprWritesState : Expr → Bool
       exprWritesState index
   | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _ =>
       exprWritesState index
-  | _ =>
+  -- Pure leaves: no state writes. Listed explicitly to avoid `_mutual.eq_def`
+  -- heartbeat-ceiling failures when new constructors land.
+  | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
+  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
+  | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
+  | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.paramDynamicHeadWord _ _
+  | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
       false
 termination_by e => sizeOf e
 decreasing_by all_goals simp_wf; all_goals omega
@@ -634,7 +642,16 @@ def exprContainsExternalCall : Expr → Bool
   | Expr.adtConstruct _ _ args =>
       exprListContainsExternalCall args
   | Expr.dynamicBytesEq _ _ => false
-  | _ => false
+  -- Pure leaves: no external call inside. Listed explicitly to avoid
+  -- `_mutual.eq_def` heartbeat-ceiling failures when new constructors land.
+  | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
+  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
+  | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
+  | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.storageArrayLength _
+  | Expr.paramDynamicHeadWord _ _
+  | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
+      false
 termination_by e => sizeOf e
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -689,7 +706,16 @@ def exprMayContainExternalCall : Expr → Bool
   | Expr.adtConstruct _ _ args =>
       exprListMayContainExternalCall args
   | Expr.dynamicBytesEq _ _ => false
-  | _ => false
+  -- Pure leaves: no external call inside. Listed explicitly to avoid
+  -- `_mutual.eq_def` heartbeat-ceiling failures when new constructors land.
+  | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
+  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
+  | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
+  | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.storageArrayLength _
+  | Expr.paramDynamicHeadWord _ _
+  | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
+      false
 termination_by e => sizeOf e
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -1145,6 +1171,7 @@ def exprContainsAdtConstruct : Expr → Bool
   | Expr.blobbasefee | Expr.calldatasize | Expr.returndataSize
   | Expr.localVar _
   | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.paramDynamicHeadWord _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
       false
 termination_by e => sizeOf e

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -31,6 +31,10 @@ def reservedExternalNames
       ]
     else
       []
+  let paramDynamicHeadWordHelpers :=
+    [ checkedParamDynamicHeadWordCalldataHelperName
+    , checkedParamDynamicHeadWordMemoryHelperName
+    ]
   let storageArrayHelpers :=
     if storageArrayHelpersRequired then
       [checkedStorageArrayElementHelperName]
@@ -43,7 +47,7 @@ def reservedExternalNames
       []
   let builtins := [builtinExpName]
   let entrypoints := ["fallback", "receive"]
-  (mappingHelpers ++ arrayHelpers ++ arrayElementWordHelpers ++ storageArrayHelpers ++ dynamicBytesEqHelpers ++ builtins ++ entrypoints).eraseDups
+  (mappingHelpers ++ arrayHelpers ++ arrayElementWordHelpers ++ paramDynamicHeadWordHelpers ++ storageArrayHelpers ++ dynamicBytesEqHelpers ++ builtins ++ entrypoints).eraseDups
 
 def firstReservedExternalCollision
     (spec : CompilationModel)
@@ -182,6 +186,7 @@ def validateInternalCallShapesInExpr
   | Expr.calldatasize | Expr.returndataSize
   | Expr.localVar _
   | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.paramDynamicHeadWord _ _
   | Expr.dynamicBytesEq _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
       pure ()
@@ -435,6 +440,7 @@ def validateExternalCallTargetsInExpr
   | Expr.calldatasize | Expr.returndataSize
   | Expr.localVar _
   | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.paramDynamicHeadWord _ _
   | Expr.dynamicBytesEq _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
       pure ()

--- a/Compiler/CompilationModel/ValidationHelpers.lean
+++ b/Compiler/CompilationModel/ValidationHelpers.lean
@@ -78,6 +78,7 @@ def collectExprNames : Expr → List String
   | Expr.externalCall name args => name :: collectExprListNames args
   | Expr.internalCall name args => name :: collectExprListNames args
   | Expr.arrayLength name => [name]
+  | Expr.paramDynamicHeadWord name _ => [name]
   | Expr.arrayElement name index | Expr.arrayElementWord name index _ _
   | Expr.arrayElementDynamicWord name index _ =>
       name :: collectExprNames index

--- a/Compiler/CompilationModel/ValidationInterop.lean
+++ b/Compiler/CompilationModel/ValidationInterop.lean
@@ -116,6 +116,7 @@ def validateInteropExpr (context : String) : Expr → Except String Unit
   | Expr.caller | Expr.blockTimestamp | Expr.blockNumber
   | Expr.localVar _
   | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.paramDynamicHeadWord _ _
   | Expr.dynamicBytesEq _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
       pure ()

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -338,6 +338,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.BytesEqSmoke.spec
   , Contracts.Smoke.TupleSmoke.spec
   , Contracts.Smoke.NamedStructParamSmoke.spec
+  , Contracts.Smoke.NamedStructDynamicRootLeafProjection.spec
   , Contracts.Smoke.CurveCutArraySmoke.spec
   , Contracts.Smoke.DynamicStructArraySmoke.spec
   , Contracts.Smoke.PackedStorageWriteSmoke.spec
@@ -458,6 +459,7 @@ private def expectedExternalSignatures : List (String × List String) :=
   , ("TupleSmoke", ["setFromPair((uint256,uint256))", "getPair(uint256)", "processConfig((address,address,uint256))"])
   , ("NamedStructParamSmoke", ["readBorrowFee((uint256,uint256))", "storeNestedFee(((uint256,uint256),address),uint256)",
       "readNestedMaker(((uint256,uint256),address))"])
+  , ("NamedStructDynamicRootLeafProjection", ["goodDynamicLeaf((uint256[],address))"])
   , ("CurveCutArraySmoke", ["firstCutXt((uint256,uint256,int256)[])", "returnCut((uint256,uint256,int256)[],uint256)",
       "storeCut((uint256,uint256,int256)[],uint256)", "storeTwoCuts((uint256,uint256,int256)[],uint256,uint256)"])
   , ("DynamicStructArraySmoke", ["tokenOf((uint256[],(address,uint256,bytes32),(uint256[],bytes32)[],address,uint256)[],uint256)",
@@ -579,6 +581,7 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("BytesEqSmoke", ["0xfc39552e", "0x2c16057d", "0x3eb6f0de"])
   , ("TupleSmoke", ["0x712ea680", "0xbdf391cc", "0x01b427d2"])
   , ("NamedStructParamSmoke", ["0xa01f780b", "0x38946c6d", "0x596635bb"])
+  , ("NamedStructDynamicRootLeafProjection", ["0x08ec4886"])
   , ("CurveCutArraySmoke", ["0xefca8f0f", "0x6f413e6b", "0x0d7610a3", "0xbea7dfd2"])
   , ("DynamicStructArraySmoke", ["0xcbe2b47b", "0x587d08b7", "0x0b7d2799", "0x1fae5c19"])
   , ("PackedStorageWriteSmoke", ["0xa0522387", "0x233ab149"])

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -122,6 +122,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.TypedImmutableSmoke.spec
   , Contracts.Smoke.TupleSmoke.spec
   , Contracts.Smoke.NamedStructParamSmoke.spec
+  , Contracts.Smoke.NamedStructDynamicRootLeafProjection.spec
   , Contracts.Smoke.CurveCutArraySmoke.spec
   , Contracts.Smoke.DynamicStructArraySmoke.spec
   , Contracts.Smoke.PackedStorageWriteSmoke.spec

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -1053,18 +1053,17 @@ verity_contract NamedStructDynamicProjectionRejected where
     let notes := config.notes
     return 0
 
-/--
-error: struct parameter projection from an ABI-dynamic root is not supported; use a static struct parameter or wait for nested-dynamic ABI decoding (#1832)
--/
-#guard_msgs in
-verity_contract NamedStructDynamicRootLeafProjectionRejected where
+-- Dynamic-root leaf projection (verity#1832): a single-word static field
+-- on a struct parameter whose ABI encoding is dynamic (carries nested
+-- dynamic members) is now supported. Lowers to `Expr.paramDynamicHeadWord`.
+verity_contract NamedStructDynamicRootLeafProjection where
   storage
 
   struct DynamicConfig where
     notes : Array Uint256,
     maker : Address
 
-  function badDynamicLeaf (config : DynamicConfig) : Address := do
+  function goodDynamicLeaf (config : DynamicConfig) : Address := do
     return config.maker
 
 /--
@@ -1896,6 +1895,7 @@ end SpecGenSmoke
 #check_contract SpecialEntrypointSmoke
 #check_contract TupleSmoke
 #check_contract NamedStructParamSmoke
+#check_contract NamedStructDynamicRootLeafProjection
 #check_contract CurveCutArraySmoke
 #check_contract DynamicStructArraySmoke
 #check_contract PackedStorageWriteSmoke

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1732,23 +1732,51 @@ private def paramStructProjection?
   else
     none
 
+/-- Resolve a `param.field[.field2…]` projection where `param` is a struct
+    parameter whose ABI encoding is dynamic (carries nested dynamic
+    members) and the projected leaf is a single-word static value at a
+    fixed head offset. Returns `(paramName, fieldTy, wordOffset)`. The
+    word offset is the head-word index relative to the parameter's
+    `{name}_data_offset`, which after verity#1839 points at the first
+    head word of the encoded tuple (no length prefix). (verity#1832) -/
+private def paramDynamicHeadProjection?
+    (params : Array ParamDecl)
+    (stx : Term) : Option (String × ValueType × Nat) := do
+  let (root, path) ←
+    match (stripParens stx).raw with
+    | .ident _ raw _ _ =>
+        let parts := raw.toString.splitOn "."
+        let rec findParamPath : List String → Option (String × List String)
+          | [] | [_] => none
+          | rootName :: fieldName :: rest =>
+              if params.any (fun p => p.name == rootName) then
+                some (rootName, fieldName :: rest)
+              else
+                findParamPath (fieldName :: rest)
+        findParamPath parts
+    | _ =>
+        let (rootStx, path) ← structProjectionPath? stx
+        match stripParens rootStx with
+        | `(term| $id:ident) => some (toString id.getId, path)
+        | _ => none
+  let param ← params.find? (fun p => p.name == root)
+  if !valueTypeUsesDynamicData param.ty then
+    none
+  else
+    let (fieldTy, wordOffset) ← structFieldHeadOffset? param.ty path
+    if isSingleWordStaticValueType fieldTy then
+      some (root, fieldTy, wordOffset)
+    else
+      none
+
 private def isParamStructNonLeafProjection (params : Array ParamDecl) (stx : Term) : Bool :=
   match paramStructProjectionResolved? params stx with
   | some (_, fieldTy, _) => !isSingleWordStaticValueType fieldTy
   | none => false
 
-private def isParamStructDynamicRootProjection (params : Array ParamDecl) (stx : Term) : Bool :=
-  match paramStructProjectionResolved? params stx with
-  | some (_, fieldTy, rootTy) => isSingleWordStaticValueType fieldTy && valueTypeUsesDynamicData rootTy
-  | none => false
-
 private def throwStructNonLeafProjectionError (stx : Term) : CommandElabM α :=
   throwErrorAt stx
     "non-leaf struct parameter projection is not supported; project a scalar or static single-word leaf field instead (#1832)"
-
-private def throwStructDynamicRootProjectionError (stx : Term) : CommandElabM α :=
-  throwErrorAt stx
-    "struct parameter projection from an ABI-dynamic root is not supported; use a static struct parameter or wait for nested-dynamic ABI decoding (#1832)"
 
 private def renderValueType (ty : ValueType) : String :=
   reprStr ty
@@ -2191,8 +2219,8 @@ private partial def inferPureExprType
     requireWordLikeType index "arrayElement index" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals index visitingConstants)
     pure fieldTy
   else
-  if isParamStructDynamicRootProjection params stx then
-    throwStructDynamicRootProjectionError stx
+  if let some (_, fieldTy, _) := paramDynamicHeadProjection? params stx then
+    pure fieldTy
   else
   if isParamStructNonLeafProjection params stx then
     throwStructNonLeafProjectionError stx
@@ -3033,8 +3061,13 @@ partial def translatePureExprWithTypes
         $(natTerm elementWords)
         $(natTerm wordOffset))
   else
-  if isParamStructDynamicRootProjection params stx then
-    throwStructDynamicRootProjectionError stx
+  -- Direct dynamic-tuple parameter leaf projection (verity#1832): read a
+  -- single-word static field at a fixed head offset from a dynamically
+  -- encoded struct parameter.
+  if let some (paramName, _fieldTy, wordOffset) := paramDynamicHeadProjection? params stx then
+    `(Compiler.CompilationModel.Expr.paramDynamicHeadWord
+      $(strTerm paramName)
+      $(natTerm wordOffset))
   else
   if isParamStructNonLeafProjection params stx then
     throwStructNonLeafProjectionError stx

--- a/artifacts/macro_property_tests/PropertyNamedStructDynamicRootLeafProjection.t.sol
+++ b/artifacts/macro_property_tests/PropertyNamedStructDynamicRootLeafProjection.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyNamedStructDynamicRootLeafProjectionTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyNamedStructDynamicRootLeafProjectionTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("NamedStructDynamicRootLeafProjection");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `goodDynamicLeaf` result
+    function testTODO_GoodDynamicLeaf_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("goodDynamicLeaf((uint256[],address))", abi.decode(abi.encode(_singletonUintArray(1), alice), (uint256[], address))));
+        require(ok, "goodDynamicLeaf reverted unexpectedly");
+        assertEq(ret.length, 32, "goodDynamicLeaf ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Expr.paramDynamicHeadWord (name : String) (wordOffset : Nat)` and routes direct dynamic-tuple parameter leaf projections through it. Closes the single remaining genuinely-open P0 item from umbrella #1760 (see [audit comment](https://github.com/lfglabs-dev/verity/issues/1760#issuecomment-4428577644) for why the other two `P0 — no existing issue` checkboxes were already shipped).

Fixes #1832. **Depends on #1841 (param-loader fix) and #1842 (wildcard refactor).**

## What now works

```lean
struct DynamicConfig where
  notes : Array Uint256,   -- makes DynamicConfig ABI-dynamic
  maker : Address

function read (config : DynamicConfig) : Address := do
  return config.maker     -- now lowers to Expr.paramDynamicHeadWord
```

Before this PR the macro rejected the above with the diagnostic _"struct parameter projection from an ABI-dynamic root is not supported; use a static struct parameter or wait for nested-dynamic ABI decoding"_ (`Verity/Macro/Translate.lean:1715`).

## Implementation

- New Expr constructor `Expr.paramDynamicHeadWord (name : String) (wordOffset : Nat)` (`Compiler/CompilationModel/Types.lean`).
- New Yul helpers `__verity_param_dynamic_head_word_{calldata,memory}_checked` reading `data_offset + word_offset * 32` with a `calldatasize - 32` upper bound check (`Compiler/CompilationModel/DynamicData.lean`).
- Helper emission gated on a new `contractUsesParamDynamicHeadWord` detector (`UsageAnalysis.lean`), threaded through `Dispatch.compileValidatedCore` and `ValidationCalls.reservedExternalNames`.
- New macro resolver `paramDynamicHeadProjection?` shadow-mirrors `paramStructProjectionResolved?` but uses `structFieldHeadOffset?` (the same helper the array case already uses via `arrayElementStructProjectionResolved?`) to compute the head-word offset. Routing in `translatePureExprWithTypes` and `inferPureExprType` checks this resolver first when the param is ABI-dynamic.
- Rejection helpers `isParamStructDynamicRootProjection` and `throwStructDynamicRootProjectionError` removed; the non-leaf rejection stays.
- `paramDynamicHeadWord` case added to every existing `Expr` traversal: `LogicalPurity` (pure leaves), `UsageAnalysis` (4 sites), `Validation` (3 sites + `exprWritesState`/`exprContainsExternalCall`/`exprMayContainExternalCall` wildcard expansion), `ValidationHelpers`, `ScopeValidation` (substantive tuple-shape + wordOffset bounds check), `ValidationInterop`, `ValidationCalls`, `ExpressionCompile` (lowering).

## Smoke + invariant + property-test coverage

- `Contracts.Smoke.NamedStructDynamicRootLeafProjection` replaces the previous rejection `#guard_msgs` test with an accepted contract.
- Listed in `MacroTranslateInvariantTest` (spec list, function signature index, selector index) and `MacroTranslateRoundTripFuzz` (spec list).
- Auto-generated Foundry property stub at `artifacts/macro_property_tests/PropertyNamedStructDynamicRootLeafProjection.t.sol`.

## Test plan

- [x] `lake build` succeeds (all 105 targets).
- [x] `make check` passes locally (macro health, IR/Yul identity diff, selector audit, property-test artifacts).
- [x] The previously-rejected shape now compiles end-to-end with the new helper emitted.

## Scope

No new axiom or trust surface — the helper is local bytes-reading with a `calldatasize - 32` bound check. `AUDIT.md` / `AXIOMS.md` / `TRUST_ASSUMPTIONS.md` unaffected.

`docs/INTERPRETER_FEATURE_MATRIX.md` deserves a parallel "Param dynamic head word" row alongside the existing "Dynamic struct-array head word"; doc update is queued for a follow-up.

## Downstream

verity-benchmark `cases/unlink_xyz/pool/Contract.lean` carries `BLOCKED(verity#1832)` markers on the three public ZK entry points (`transfer` / `withdraw` / `emergencyWithdraw` — bodies at `UnlinkPool.sol:309-583`). Once this PR (and its two prerequisites) reaches the lakefile pin, those markers come down and the entrypoints can be filled in. Foundry differential test against `solc`-emitted ABI for the full `Transaction` struct is a follow-up; the current property-test artifact is the baseline that `make check` enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: adds a new expression form and Yul helper used in ABI decoding paths; mistakes in head-offset calculation or bounds checks could cause incorrect reads or unexpected reverts for dynamic tuple parameters.
> 
> **Overview**
> Adds support for projecting a single-word *static leaf field* from a struct/tuple parameter whose ABI encoding is dynamic (nested dynamic members), by introducing `Expr.paramDynamicHeadWord` and routing `param.field` macro translations through it.
> 
> Implements new checked Yul helpers (`__verity_param_dynamic_head_word_{calldata,memory}_checked`) and emits them only when used via a new `contractUsesParamDynamicHeadWord` analysis, with corresponding reserved-name handling and compilation/validation traversal updates.
> 
> Updates smoke/fuzz/invariant coverage by replacing the prior rejection test with an accepted `NamedStructDynamicRootLeafProjection` contract and adding the generated Foundry property-test stub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22a884829fc532fcfbd4413f9eba118430433dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->