### PR TITLE
Gate paramDynamicHeadWord helpers in reservedExternalNames + sync #1832 docs

### DIFF
--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -365,10 +365,12 @@ def validateCompileInputs (spec : CompilationModel) (selectors : List Nat) : Exc
   let mappingHelpersRequired := usesMapping fields
   let arrayHelpersRequired := contractUsesPlainArrayElement spec
   let arrayElementWordHelpersRequired := contractUsesArrayElementWord spec
+  let paramDynamicHeadWordHelpersRequired := contractUsesParamDynamicHeadWord spec
   let storageArrayHelpersRequired := contractUsesStorageArrayElement spec
   let dynamicBytesEqHelpersRequired := contractUsesDynamicBytesEq spec
   match firstReservedExternalCollision
       spec mappingHelpersRequired arrayHelpersRequired arrayElementWordHelpersRequired
+        paramDynamicHeadWordHelpersRequired
         storageArrayHelpersRequired dynamicBytesEqHelpersRequired with
   | some name =>
       if name.startsWith internalFunctionPrefix then

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -13,6 +13,7 @@ namespace Compiler.CompilationModel
 
 def reservedExternalNames
     (mappingHelpersRequired arrayHelpersRequired arrayElementWordHelpersRequired
+      paramDynamicHeadWordHelpersRequired
       storageArrayHelpersRequired dynamicBytesEqHelpersRequired : Bool) : List String :=
   let mappingHelpers := if mappingHelpersRequired then ["mappingSlot"] else []
   let arrayHelpers :=
@@ -32,9 +33,12 @@ def reservedExternalNames
     else
       []
   let paramDynamicHeadWordHelpers :=
-    [ checkedParamDynamicHeadWordCalldataHelperName
-    , checkedParamDynamicHeadWordMemoryHelperName
-    ]
+    if paramDynamicHeadWordHelpersRequired then
+      [ checkedParamDynamicHeadWordCalldataHelperName
+      , checkedParamDynamicHeadWordMemoryHelperName
+      ]
+    else
+      []
   let storageArrayHelpers :=
     if storageArrayHelpersRequired then
       [checkedStorageArrayElementHelperName]
@@ -52,6 +56,7 @@ def reservedExternalNames
 def firstReservedExternalCollision
     (spec : CompilationModel)
     (mappingHelpersRequired arrayHelpersRequired arrayElementWordHelpersRequired
+      paramDynamicHeadWordHelpersRequired
       storageArrayHelpersRequired dynamicBytesEqHelpersRequired : Bool) : Option String :=
   (spec.externals.map (·.name)).find? (fun name =>
     name.startsWith internalFunctionPrefix ||
@@ -59,6 +64,7 @@ def firstReservedExternalCollision
         mappingHelpersRequired
         arrayHelpersRequired
         arrayElementWordHelpersRequired
+        paramDynamicHeadWordHelpersRequired
         storageArrayHelpersRequired
         dynamicBytesEqHelpersRequired).contains name)
 

--- a/artifacts/interpreter_feature_matrix.json
+++ b/artifacts/interpreter_feature_matrix.json
@@ -349,6 +349,15 @@
       "IRInterpreter": "n/a",
       "EVMYulLean_bridge": "n/a",
       "proof_status": "not_modeled"
+    },
+    {
+      "feature": "paramDynamicHeadWord",
+      "constructor": "Expr.paramDynamicHeadWord",
+      "SpecInterpreter_basic": "unsupported",
+      "SpecInterpreter_fuel": "unsupported",
+      "IRInterpreter": "n/a",
+      "EVMYulLean_bridge": "n/a",
+      "proof_status": "not_modeled"
     }
   ],
   "stmt_features": [

--- a/docs/INTERPRETER_FEATURE_MATRIX.md
+++ b/docs/INTERPRETER_FEATURE_MATRIX.md
@@ -66,6 +66,7 @@ with the existing sync scripts and boundary checks.
 | Array length | `Expr.arrayLength` | ok | ok | -- | -- | proved |
 | Array element | `Expr.arrayElement` | ok | ok | -- | -- | proved |
 | Dynamic struct-array head word | `Expr.arrayElementDynamicWord` | **0** | **0** | -- | -- | n/m |
+| Direct dynamic-struct param head word | `Expr.paramDynamicHeadWord` | **0** | **0** | -- | -- | n/m |
 
 Legend: **ok** = supported, **0** = returns 0 (not modeled), **del** = delegated to Verity path, **--** = not applicable at this layer, **n/m** = not modeled in proofs.
 
@@ -183,17 +184,17 @@ Legend: **ok** = native evaluation.
 
 | Category | Proved | Assumed | Partial | Not Modeled |
 |---|---|---|---|---|
-| Expression features | 24 | 1 (`externalCall`) | 6 | 5 (`keccak256`, `call`, `staticcall`, `delegatecall`, `arrayElementDynamicWord`) |
+| Expression features | 24 | 1 (`externalCall`) | 6 | 6 (`keccak256`, `call`, `staticcall`, `delegatecall`, `arrayElementDynamicWord`, `paramDynamicHeadWord`) |
 | Statement features | 25 | 0 | 1 (`mstore`) | 6 (`calldatacopy`, `returndataCopy`, `revertReturndata`, `rawLog`, `externalCallBind`, `ecm`) |
 | Builtins (agreement) | 36 | 0 | 0 | 0 (delegated) |
 
-Proof-boundary features split across two buckets. Partially modeled features currently include runtime introspection (`blockNumber`, `contractAddress`, `chainid`) and single-word linear-memory forms (`mload`, `mstore`, `returndataOptionalBoolAt`). `selfBalance` is also partially modeled: it is compiler-supported and source-executable, but not yet included in the generic proof interpreter fragment. Fully not-modeled features currently include `keccak256`, low-level call / returndata plumbing (`call`, `staticcall`, `delegatecall`, `calldatacopy`, `returndataCopy`, `revertReturndata`), event emission (`rawLog`), and external call modules (`externalCallBind`, `ecm`). Dynamic struct-array head-word decoding (`arrayElementDynamicWord`) is also not modeled by proof interpreters yet. These features are still compiler-supported and are validated by differential testing (70,000+ test vectors against actual EVM execution).
+Proof-boundary features split across two buckets. Partially modeled features currently include runtime introspection (`blockNumber`, `contractAddress`, `chainid`) and single-word linear-memory forms (`mload`, `mstore`, `returndataOptionalBoolAt`). `selfBalance` is also partially modeled: it is compiler-supported and source-executable, but not yet included in the generic proof interpreter fragment. Fully not-modeled features currently include `keccak256`, low-level call / returndata plumbing (`call`, `staticcall`, `delegatecall`, `calldatacopy`, `returndataCopy`, `revertReturndata`), event emission (`rawLog`), and external call modules (`externalCallBind`, `ecm`). Dynamic struct-array head-word decoding (`arrayElementDynamicWord`) and direct dynamic-struct parameter head-word decoding (`paramDynamicHeadWord`) are also not modeled by proof interpreters yet. These features are still compiler-supported and are validated by differential testing (70,000+ test vectors against actual EVM execution).
 
 ---
 
 ## Known Limitations
 
-1. **Nested dynamic ABI decoding**: The compiler can read checked static leaf words from calldata arrays whose tuple/struct elements contain nested dynamic members via `Expr.arrayElementDynamicWord`. This is a compilation-level ABI decoder surface for Unlink-style transaction arrays; proof interpreters do not model those decoded words yet.
+1. **Nested dynamic ABI decoding**: The compiler can read checked static leaf words from calldata arrays whose tuple/struct elements contain nested dynamic members via `Expr.arrayElementDynamicWord`, and from direct struct parameters whose ABI encoding is dynamic via `Expr.paramDynamicHeadWord` (#1832). These are compilation-level ABI decoder surfaces for Unlink-style transaction arrays and the `Transaction` / `WithdrawalTransaction` / `AdapterTransaction` direct-parameter shapes; proof interpreters do not model those decoded words yet.
 
 2. **Runtime environment reads**: `address(this).balance` lowers to Yul `selfbalance()` and runs against `ContractState.selfBalance` on the executable source path, with Foundry differential coverage against Solidity. The current generic proof interpreters do not model this balance read yet.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,6 +149,14 @@ Already-supported items that should not become new roadmap work:
 - Named struct field access for calldata array elements is already available
   through `struct` declarations and `arrayElement` field projection, lowering to
   `Expr.arrayElementDynamicWord` where needed.
+- Named struct field access for *direct* struct parameters whose ABI encoding
+  is dynamic (carries nested dynamic members) lowers to
+  `Expr.paramDynamicHeadWord` (#1832 / #1843), with the param loader producing
+  a correctly-positioned `_data_offset` thanks to #1839 / #1841.
+- `requires(<role>)` accepts both scalar Address-typed slots (the canonical
+  `onlyOwner` shape) and `Address → Uint256` mapping fields (the
+  `onlyRelayer` / `onlyMinter` role-as-mapping shape) without writing the
+  3-line preamble by hand (#1837 / #1840).
 - ERC-20 `balanceOf`, `allowance`, and `totalSupply` ECMs already exist under
   `Compiler/Modules/ERC20.lean` alongside the safe token write modules.
 
@@ -165,14 +173,17 @@ Translation tracking:
 - The verity-benchmark case
   [`cases/unlink_xyz/pool/`](https://github.com/lfglabs-dev/verity-benchmark/tree/main/cases/unlink_xyz/pool)
   is the canonical Verity model of `UnlinkPool` and the verified-DSL surface
-  side of [#1760](https://github.com/lfglabs-dev/verity/issues/1760). It is
-  currently at `stage: scoped` because three public ZK entry points (`transfer`,
-  `withdraw`, `adapterWithdraw`) take struct-array parameters with nested
-  dynamic members (`uint256[] nullifierHashes`, `uint256[] newCommitments`,
-  `Ciphertext[] ciphertexts`, `Call[] calls`). The macro currently rejects
-  struct-parameter projection from an ABI-dynamic root at
-  `Verity/Macro/Translate.lean:1715`. Promotion to `build_green` is the
-  Unlink-side trigger for closing #1760.
+  side of [#1760](https://github.com/lfglabs-dev/verity/issues/1760). The macro
+  surface that previously blocked it — struct-parameter projection from an
+  ABI-dynamic root for single-word static leaves — shipped as
+  `Expr.paramDynamicHeadWord` via [#1843](https://github.com/lfglabs-dev/verity/pull/1843)
+  on top of the prerequisite param-loader fix
+  ([#1841](https://github.com/lfglabs-dev/verity/pull/1841)) and the
+  validator-wildcard refactor that escapes Lean's `_mutual.eq_def` heartbeat
+  ceiling ([#1842](https://github.com/lfglabs-dev/verity/pull/1842)).
+  Promotion to `build_green` now requires the benchmark to bump its lakefile
+  pin past those merges and fill in the `transfer`, `withdraw`, and
+  `emergencyWithdraw` entry-point bodies from `UnlinkPool.sol:309-583`.
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses [Cursor Bugbot's low-severity finding](https://github.com/lfglabs-dev/verity/pull/1843#discussion_r4432) on #1843: `paramDynamicHeadWordHelpers` was unconditionally included in `reservedExternalNames` while every other helper group (`mappingHelpers`, `arrayHelpers`, `arrayElementWordHelpers`, `storageArrayHelpers`, `dynamicBytesEqHelpers`) is gated on a `*Required` boolean. Threads the missing `paramDynamicHeadWordHelpersRequired` parameter through `reservedExternalNames` and `firstReservedExternalCollision`, with `Dispatch.compileValidatedCore` passing `contractUsesParamDynamicHeadWord spec` (already computed for helper emission).

Also brings the documentation surface in sync with #1832 / #1843:

- `docs/ROADMAP.md`: removes the stale "macro currently rejects struct-parameter projection from an ABI-dynamic root" note in the Unlink translation tracking section; adds two entries to the already-supported list — `Expr.paramDynamicHeadWord` (#1832/#1843) and mapping-keyed `requires(<role>)` (#1837/#1840).
- `docs/INTERPRETER_FEATURE_MATRIX.md`: new "Direct dynamic-struct param head word" row mirroring the existing `arrayElementDynamicWord` row, plus the proof-status summary and the nested-dynamic-ABI-decoding limitations section now mention `paramDynamicHeadWord` alongside `arrayElementDynamicWord`.
- `artifacts/interpreter_feature_matrix.json`: matching machine-readable entry so the macro-health gate's manifest stays in sync.

## Test plan

- [x] `lake build` succeeds (all 105 targets).
- [x] `make check` passes locally (macro health, IR/Yul identity diff, selector audit, property-test artifacts).
- [x] Behavioural diff is pure-extensional: contracts using `paramDynamicHeadWord` see the helper names reserved (same as before this PR); contracts not using it no longer have a spurious reservation.

## Scope

Pure refactor + docs sync. No semantic, trust, or CI boundary change — `AUDIT.md` / `AXIOMS.md` / `TRUST_ASSUMPTIONS.md` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only affects reserved-name collision checking and documentation/artifact manifests; runtime codegen and semantics are unchanged aside from avoiding spurious name reservations when `paramDynamicHeadWord` isn’t used.
> 
> **Overview**
> Fixes reserved-name validation to **only reserve `paramDynamicHeadWord` helper symbols when the contract actually uses `Expr.paramDynamicHeadWord`**, by threading a new `paramDynamicHeadWordHelpersRequired` boolean through `Dispatch.compileValidatedCore`/`validateCompileInputs` into `reservedExternalNames` and `firstReservedExternalCollision`.
> 
> Updates the interpreter feature matrix (Markdown + JSON) and roadmap docs to include `paramDynamicHeadWord` and to refresh the nested-dynamic ABI decoding limitations/translation tracking text accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ddd162320b2c678c3f4581e230f1cffaf7e7579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->