### PR TITLE
Add addPanic/subPanic/mulPanic/divPanic for Solidity-0.8 arithmetic (#1752)

### DIFF
--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -321,6 +321,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.StorageWordsBoolSmoke.spec
   , Contracts.Smoke.CustomErrorSmoke.spec
   , Contracts.Smoke.SafeMulRequireSmoke.spec
+  , Contracts.Smoke.ArithmeticPanicSmoke.spec
   , Contracts.Smoke.SignedBuiltinSmoke.spec
   , Contracts.Smoke.StatelessSmoke.spec
   , Contracts.Smoke.MutabilitySmoke.spec
@@ -434,6 +435,7 @@ private def expectedExternalSignatures : List (String × List String) :=
   , ("StorageWordsBoolSmoke", ["extSloadsLike(bool[])"])
   , ("CustomErrorSmoke", ["echo(uint256)"])
   , ("SafeMulRequireSmoke", ["multiplyStored(uint256)", "divideStored(uint256)"])
+  , ("ArithmeticPanicSmoke", ["deposit(uint256)", "withdraw(uint256)", "scaleStored(uint256)", "shareStored(uint256)"])
   , ("SignedBuiltinSmoke", ["signedDiv(uint256,uint256)", "signedMod(uint256,uint256)", "signedLt(uint256,uint256)",
       "signedGt(uint256,uint256)", "arithmeticShift(uint256,uint256)", "signExtended()", "shiftedMask()",
       "signedDivSurface(int256,int256)", "signedModSurface(int256,int256)", "signedDivViaLocal(uint256,int256)",
@@ -562,6 +564,7 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("StorageWordsBoolSmoke", ["0x873bc011"])
   , ("CustomErrorSmoke", ["0x6279e43c"])
   , ("SafeMulRequireSmoke", ["0x678f717b", "0x2b0262e3"])
+  , ("ArithmeticPanicSmoke", ["0xb6b55f25", "0x2e1a7d4d", "0xb219df1a", "0xc712757d"])
   , ("SignedBuiltinSmoke", ["0x5aafa47b", "0x1c781eb5", "0x2ff7ce03", "0x5f28fa76", "0x49795601",
       "0xcc634d7f", "0x7c4ab1e5", "0x44b95b1e", "0x17ea5a3e", "0x6344ce8c", "0xf6814165", "0xae1a9a3e",
       "0x6622d274", "0x176a2ce1", "0x504d2488", "0xd5451d16", "0x22cfe3c6"])

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -109,6 +109,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.StorageWordsBoolSmoke.spec
   , Contracts.Smoke.CustomErrorSmoke.spec
   , Contracts.Smoke.SafeMulRequireSmoke.spec
+  , Contracts.Smoke.ArithmeticPanicSmoke.spec
   , Contracts.Smoke.SignedBuiltinSmoke.spec
   , Contracts.Smoke.StatelessSmoke.spec
   , Contracts.Smoke.MutabilitySmoke.spec

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -342,6 +342,44 @@ verity_contract SafeMulRequireSmoke where
     setStorage product next
     return next
 
+-- Solidity-0.8 default-revert arithmetic (verity#1752).
+--
+-- `addPanic` / `subPanic` / `mulPanic` / `divPanic` are ergonomic bind
+-- sources that model the Solidity 0.8 default semantics for `a + b`,
+-- `a - b`, `a * b`, `a / b` on `uint256`: revert with `Panic(0x11)` on
+-- overflow / underflow and `Panic(0x12)` on division by zero, rather
+-- than wrapping mod `2^256`. They desugar to the same IR as
+-- `let x ← requireSomeUint (safeXxx a b) "<fixed message>"`, which
+-- collapses the visual divergence from the Solidity source while
+-- still reverting on the same boundary conditions.
+verity_contract ArithmeticPanicSmoke where
+  storage
+    balance : Uint256 := slot 0
+
+  function deposit (amount : Uint256) : Uint256 := do
+    let current ← getStorage balance
+    let next ← addPanic current amount
+    setStorage balance next
+    return next
+
+  function withdraw (amount : Uint256) : Uint256 := do
+    let current ← getStorage balance
+    let next ← subPanic current amount
+    setStorage balance next
+    return next
+
+  function scaleStored (factor : Uint256) : Uint256 := do
+    let current ← getStorage balance
+    let next ← mulPanic current factor
+    setStorage balance next
+    return next
+
+  function shareStored (divisor : Uint256) : Uint256 := do
+    let current ← getStorage balance
+    let next ← divPanic current divisor
+    setStorage balance next
+    return next
+
 verity_contract SignedBuiltinSmoke where
   storage
     signedSlot : Int256 := slot 0
@@ -1890,6 +1928,7 @@ end SpecGenSmoke
 #check_contract StorageWordsSmoke
 #check_contract CustomErrorSmoke
 #check_contract SafeMulRequireSmoke
+#check_contract ArithmeticPanicSmoke
 #check_contract SignedBuiltinSmoke
 #check_contract StatelessSmoke
 #check_contract SpecialEntrypointSmoke

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2637,6 +2637,20 @@ private partial def inferBindSourceType
           requireWordLikeType b "safe uint helper" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals b)
           pure .uint256
       | _ => throwErrorAt rhs "unsupported requireSomeUint source; expected safeAdd, safeSub, safeMul, or safeDiv"
+  -- Solidity-0.8 default-revert arithmetic (verity#1752). `addPanic`,
+  -- `subPanic`, `mulPanic`, `divPanic` are ergonomic shorthands for the
+  -- corresponding `requireSomeUint (safeXxx a b) <fixed Panic-style message>`
+  -- pattern.  They match the surface of Solidity's `a + b` / `a - b` / `a * b`
+  -- / `a / b` operators on `uint256`, where overflow / underflow / division
+  -- by zero reverts with `Panic(0x11)` / `Panic(0x12)` rather than wrapping
+  -- mod 2^256.
+  | `(term| addPanic $a:term $b:term)
+  | `(term| subPanic $a:term $b:term)
+  | `(term| mulPanic $a:term $b:term)
+  | `(term| divPanic $a:term $b:term) => do
+      requireWordLikeType a "panic uint helper" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a)
+      requireWordLikeType b "panic uint helper" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals b)
+      pure .uint256
   | _ =>
       match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals rhs with
       | some (fn, _argTerms) =>
@@ -4080,6 +4094,59 @@ private def translateSafeRequireBind
           ])
       | _ =>
           throwErrorAt rhs "unsupported requireSomeUint source; expected safeAdd, safeSub, safeMul, or safeDiv"
+  -- Solidity-0.8 default-revert arithmetic (verity#1752): `let x ← addPanic a b`
+  -- lowers to the same IR as
+  -- `let x ← requireSomeUint (safeAdd a b) "Panic(0x11): arithmetic overflow"`,
+  -- and analogously for `subPanic` / `mulPanic` / `divPanic`. The fixed
+  -- message mirrors Solidity 0.8's `Panic(0x11)` (overflow / underflow)
+  -- and `Panic(0x12)` (division by zero) opcodes.
+  | `(term| addPanic $a:term $b:term) =>
+      let msgLit := strTerm "Panic(0x11): arithmetic overflow"
+      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
+      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let valueExpr : Term ← `(Compiler.CompilationModel.Expr.add $aExpr $bExpr)
+      let guardExpr : Term ← `(Compiler.CompilationModel.Expr.ge $valueExpr $aExpr)
+      pure (some #[
+        (← `(Compiler.CompilationModel.Stmt.require $guardExpr $msgLit)),
+        (← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $valueExpr))
+      ])
+  | `(term| subPanic $a:term $b:term) =>
+      let msgLit := strTerm "Panic(0x11): arithmetic underflow"
+      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
+      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let valueExpr : Term ← `(Compiler.CompilationModel.Expr.sub $aExpr $bExpr)
+      let guardExpr : Term ← `(Compiler.CompilationModel.Expr.ge $aExpr $bExpr)
+      pure (some #[
+        (← `(Compiler.CompilationModel.Stmt.require $guardExpr $msgLit)),
+        (← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $valueExpr))
+      ])
+  | `(term| mulPanic $a:term $b:term) =>
+      let msgLit := strTerm "Panic(0x11): arithmetic overflow"
+      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
+      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let valueExpr : Term ← `(Compiler.CompilationModel.Expr.mul $aExpr $bExpr)
+      let zeroExpr : Term ← `(Compiler.CompilationModel.Expr.literal 0)
+      let divisorZeroExpr : Term ← `(Compiler.CompilationModel.Expr.eq $bExpr $zeroExpr)
+      let quotientExpr : Term ← `(Compiler.CompilationModel.Expr.div $valueExpr $bExpr)
+      let noOverflowExpr : Term ← `(Compiler.CompilationModel.Expr.eq $quotientExpr $aExpr)
+      let guardExpr : Term ← `(Compiler.CompilationModel.Expr.logicalOr $divisorZeroExpr $noOverflowExpr)
+      pure (some #[
+        (← `(Compiler.CompilationModel.Stmt.require $guardExpr $msgLit)),
+        (← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $valueExpr))
+      ])
+  | `(term| divPanic $a:term $b:term) =>
+      let msgLit := strTerm "Panic(0x12): division by zero"
+      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
+      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let valueExpr : Term ← `(Compiler.CompilationModel.Expr.div $aExpr $bExpr)
+      let zeroExpr : Term ← `(Compiler.CompilationModel.Expr.literal 0)
+      let guardExpr : Term ←
+        `(Compiler.CompilationModel.Expr.logicalNot
+            (Compiler.CompilationModel.Expr.eq $bExpr $zeroExpr))
+      pure (some #[
+        (← `(Compiler.CompilationModel.Stmt.require $guardExpr $msgLit)),
+        (← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $valueExpr))
+      ])
   | _ => pure none
 
 private def lookupFunctionByNameAndArity

--- a/Verity/Stdlib/Math.lean
+++ b/Verity/Stdlib/Math.lean
@@ -125,6 +125,45 @@ def requireSomeUint (opt : Option Uint256) (message : String) : Contract Uint256
     -- Return 0 as a fallback for type checking
     return 0
 
+/-! ### Solidity-0.8 default-revert arithmetic (verity#1752)
+
+These wrappers expose the same semantics as Solidity 0.8's `a + b` / `a - b` /
+`a * b` / `a / b` on `uint256`, where overflow / underflow / division-by-zero
+reverts with `Panic(0x11)` / `Panic(0x12)` rather than wrapping mod `2^256`.
+
+They are thin compositions of `safeAdd` / `safeSub` / `safeMul` / `safeDiv` with
+`requireSomeUint`, recognised by the `verity_contract` macro as ergonomic bind
+sources so contract authors can write the Solidity-faithful form on one line:
+
+```lean
+let total ← addPanic total amount
+```
+
+instead of the visually divergent
+
+```lean
+let total ← requireSomeUint (safeAdd total amount) "Overflow"
+```
+
+The macro lowers `let x ← addPanic a b` directly to the same IR as
+`let x ← requireSomeUint (safeAdd a b) "Panic(0x11): arithmetic overflow"`. -/
+
+/-- `a + b` on `Uint256` with Solidity-0.8 panic-on-overflow semantics. -/
+def addPanic (a b : Uint256) : Contract Uint256 :=
+  requireSomeUint (safeAdd a b) "Panic(0x11): arithmetic overflow"
+
+/-- `a - b` on `Uint256` with Solidity-0.8 panic-on-underflow semantics. -/
+def subPanic (a b : Uint256) : Contract Uint256 :=
+  requireSomeUint (safeSub a b) "Panic(0x11): arithmetic underflow"
+
+/-- `a * b` on `Uint256` with Solidity-0.8 panic-on-overflow semantics. -/
+def mulPanic (a b : Uint256) : Contract Uint256 :=
+  requireSomeUint (safeMul a b) "Panic(0x11): arithmetic overflow"
+
+/-- `a / b` on `Uint256` with Solidity-0.8 panic-on-division-by-zero semantics. -/
+def divPanic (a b : Uint256) : Contract Uint256 :=
+  requireSomeUint (safeDiv a b) "Panic(0x12): division by zero"
+
 -- Full-result simp lemmas for requireSomeUint
 @[simp] theorem requireSomeUint_some (v : Uint256) (msg : String) (s : ContractState) :
   (requireSomeUint (some v) msg).run s = ContractResult.success v s := rfl

--- a/artifacts/macro_property_tests/PropertyArithmeticPanicSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyArithmeticPanicSmoke.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyArithmeticPanicSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyArithmeticPanicSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("ArithmeticPanicSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `deposit` result
+    function testTODO_Deposit_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("deposit(uint256)", uint256(1)));
+        require(ok, "deposit reverted unexpectedly");
+        assertEq(ret.length, 32, "deposit ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: TODO decode and assert `withdraw` result
+    function testTODO_Withdraw_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("withdraw(uint256)", uint256(1)));
+        require(ok, "withdraw reverted unexpectedly");
+        assertEq(ret.length, 32, "withdraw ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 3: TODO decode and assert `scaleStored` result
+    function testTODO_ScaleStored_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("scaleStored(uint256)", uint256(1)));
+        require(ok, "scaleStored reverted unexpectedly");
+        assertEq(ret.length, 32, "scaleStored ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 4: TODO decode and assert `shareStored` result
+    function testTODO_ShareStored_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("shareStored(uint256)", uint256(1)));
+        require(ok, "shareStored reverted unexpectedly");
+        assertEq(ret.length, 32, "shareStored ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}


### PR DESCRIPTION
## Summary

Adds ergonomic bind-source shorthands for the Solidity-0.8 default-revert arithmetic semantics that #1752 flagged as a faithfulness gap. `addPanic` / `subPanic` / `mulPanic` / `divPanic` collapse the visual divergence of the existing `requireSomeUint (safeXxx a b) "<message>"` pattern into one line that mirrors the Solidity source:

```lean
-- before: visually diverges from `total + amount` in Solidity
let total ← requireSomeUint (safeAdd total amount) "Overflow"

-- after: one-line equivalent
let total ← addPanic total amount
```

The IR emitted is byte-for-byte identical to the desugared form — same `Stmt.require` guard, same `Stmt.letVar`, same Yul output, same gas, same proof obligations.

Fixes #1752.

## What changes

- `Verity.Stdlib.Math.addPanic` / `subPanic` / `mulPanic` / `divPanic` (`Verity/Stdlib/Math.lean`): thin `Contract Uint256` wrappers around `requireSomeUint (safeXxx a b) "<fixed Panic-style message>"`. The fixed messages map to the Solidity 0.8 panic codes — `Panic(0x11)` for arithmetic overflow / underflow and `Panic(0x12)` for division by zero.
- `Verity/Macro/Translate.lean`: recognises `let x ← addPanic a b` (and the other three forms) as bind sources, type-checks the operands as word-like, and emits the same IR as the existing `requireSomeUint (safeXxx a b) "..."` arms.
- `Contracts.Smoke.ArithmeticPanicSmoke`: smoke contract exercising all four operators.
- `Contracts.MacroTranslateInvariantTest`: spec list, function-signature index, selector index.
- `Contracts.MacroTranslateRoundTripFuzz`: spec list.
- `artifacts/macro_property_tests/PropertyArithmeticPanicSmoke.t.sol`: auto-generated Foundry property stub.

## Test plan

- [x] `lake build` succeeds (all 105 targets).
- [x] `make check` passes locally (macro health, IR/Yul identity diff, selector audit, property-test artifacts).
- [x] Existing `requireSomeUint (safeXxx ...)` call sites are unaffected.
- [x] The new bind sources type-check as expected for Uint256 operands.

## Scope

No semantic, trust, or CI boundary change. `AUDIT.md` / `AXIOMS.md` / `TRUST_ASSUMPTIONS.md` unaffected. The new bind sources reuse the exact IR shape of the established `safeAdd` / `safeSub` / `safeMul` / `safeDiv` machinery, so the existing correctness proofs for that pattern carry over without modification.

The pre-existing wrapping `add` / `sub` / `mul` / `div` operators remain unchanged — they continue to model the EVM `ADD` / `SUB` / `MUL` / `DIV` opcodes, which is the correct level of abstraction for non-Solidity-0.8 targets (raw Yul, Vyper, lower-level patches). Authors who want Solidity 0.8 default-revert semantics opt in via the `*Panic` variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `verity_contract` macro translation/type-inference to add new bind-source forms; while intended to be IR-equivalent to existing patterns, any mistake could change overflow/underflow guards or revert messages in generated contracts.
> 
> **Overview**
> Adds Solidity-0.8-style panic-on-overflow/underflow/div0 helpers `addPanic`/`subPanic`/`mulPanic`/`divPanic` to `Verity.Stdlib.Math`, with fixed `Panic(0x11)`/`Panic(0x12)` revert messages.
> 
> Extends `Verity/Macro/Translate.lean` to recognize these helpers as first-class bind sources (type-checking operands as word-like and lowering to the same `Stmt.require` + arithmetic IR pattern), and introduces a new `ArithmeticPanicSmoke` contract plus updates to macro translation test/fuzz harnesses and generated Foundry property stubs to cover it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c6e7b7c5799d6e71b2c27c4015d92b74afc723f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->