### PR TITLE
Fix audit-step exhaustiveness errors after #1761 / #1832

### DIFF
--- a/Compiler/CompilationModel/UsageAnalysis.lean
+++ b/Compiler/CompilationModel/UsageAnalysis.lean
@@ -475,60 +475,83 @@ def contractUsesArrayElementWord (spec : CompilationModel) : Bool :=
   contractUsesArrayElement spec &&
     (constructorUsesArrayElementWord spec.constructor || spec.functions.any functionUsesArrayElementWord)
 
-/-- Whether the given expression syntactically contains an
-    `Expr.paramDynamicHeadWord` (verity#1832). Walks the expression tree
-    rather than threading another flag through `exprUsesArrayElementKind`. -/
-partial def exprUsesParamDynamicHeadWord : Expr → Bool
+-- Whether the given expression syntactically contains an
+-- `Expr.paramDynamicHeadWord` (verity#1832). Plain `def` (not `partial`) so the
+-- `SupportedSpec.contractUsesParamDynamicHeadWord_eq_false` proof chain in
+-- `SupportedSpec.lean` can simp/unfold each case.
+mutual
+def exprUsesParamDynamicHeadWord : Expr → Bool
   | Expr.paramDynamicHeadWord _ _ => true
-  | e => match e with
-    | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _
-    | Expr.mappingUint _ key | Expr.structMember _ key _
-    | Expr.storageArrayElement _ key | Expr.arrayElement _ key
-    | Expr.arrayElementWord _ key _ _ | Expr.arrayElementDynamicWord _ key _ =>
-        exprUsesParamDynamicHeadWord key
-    | Expr.mappingChain _ keys => keys.any exprUsesParamDynamicHeadWord
-    | Expr.mapping2 _ k1 k2 | Expr.mapping2Word _ k1 k2 _ | Expr.structMember2 _ k1 k2 _ =>
-        exprUsesParamDynamicHeadWord k1 || exprUsesParamDynamicHeadWord k2
-    | Expr.call gas target value inOffset inSize outOffset outSize =>
-        [gas, target, value, inOffset, inSize, outOffset, outSize].any
-          exprUsesParamDynamicHeadWord
-    | Expr.staticcall gas target inOffset inSize outOffset outSize
-    | Expr.delegatecall gas target inOffset inSize outOffset outSize =>
-        [gas, target, inOffset, inSize, outOffset, outSize].any
-          exprUsesParamDynamicHeadWord
-    | Expr.extcodesize a | Expr.mload a | Expr.tload a | Expr.calldataload a
-    | Expr.returndataOptionalBoolAt a | Expr.bitNot a | Expr.logicalNot a =>
-        exprUsesParamDynamicHeadWord a
-    | Expr.keccak256 a b =>
-        exprUsesParamDynamicHeadWord a || exprUsesParamDynamicHeadWord b
-    | Expr.externalCall _ args | Expr.internalCall _ args | Expr.adtConstruct _ _ args =>
-        args.any exprUsesParamDynamicHeadWord
-    | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b
-    | Expr.mod a b | Expr.smod a b
-    | Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b
-    | Expr.sar a b | Expr.signextend a b
-    | Expr.eq a b | Expr.ge a b | Expr.gt a b | Expr.sgt a b | Expr.lt a b | Expr.slt a b
-    | Expr.le a b | Expr.logicalAnd a b | Expr.logicalOr a b
-    | Expr.wMulDown a b | Expr.wDivUp a b | Expr.min a b | Expr.max a b | Expr.ceilDiv a b =>
-        exprUsesParamDynamicHeadWord a || exprUsesParamDynamicHeadWord b
-    | Expr.mulDivDown a b c | Expr.mulDivUp a b c
-    | Expr.mulDiv512Down a b c | Expr.mulDiv512Up a b c
-    | Expr.ite a b c =>
-        exprUsesParamDynamicHeadWord a || exprUsesParamDynamicHeadWord b ||
-        exprUsesParamDynamicHeadWord c
-    | _ => false
+  | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _
+  | Expr.mappingUint _ key | Expr.structMember _ key _
+  | Expr.storageArrayElement _ key | Expr.arrayElement _ key
+  | Expr.arrayElementWord _ key _ _ | Expr.arrayElementDynamicWord _ key _ =>
+      exprUsesParamDynamicHeadWord key
+  | Expr.mappingChain _ keys => exprListUsesParamDynamicHeadWord keys
+  | Expr.mapping2 _ k1 k2 | Expr.mapping2Word _ k1 k2 _ | Expr.structMember2 _ k1 k2 _ =>
+      exprUsesParamDynamicHeadWord k1 || exprUsesParamDynamicHeadWord k2
+  | Expr.call gas target value inOffset inSize outOffset outSize =>
+      exprUsesParamDynamicHeadWord gas || exprUsesParamDynamicHeadWord target ||
+      exprUsesParamDynamicHeadWord value || exprUsesParamDynamicHeadWord inOffset ||
+      exprUsesParamDynamicHeadWord inSize || exprUsesParamDynamicHeadWord outOffset ||
+      exprUsesParamDynamicHeadWord outSize
+  | Expr.staticcall gas target inOffset inSize outOffset outSize
+  | Expr.delegatecall gas target inOffset inSize outOffset outSize =>
+      exprUsesParamDynamicHeadWord gas || exprUsesParamDynamicHeadWord target ||
+      exprUsesParamDynamicHeadWord inOffset || exprUsesParamDynamicHeadWord inSize ||
+      exprUsesParamDynamicHeadWord outOffset || exprUsesParamDynamicHeadWord outSize
+  | Expr.extcodesize a | Expr.mload a | Expr.tload a | Expr.calldataload a
+  | Expr.returndataOptionalBoolAt a | Expr.bitNot a | Expr.logicalNot a =>
+      exprUsesParamDynamicHeadWord a
+  | Expr.keccak256 a b =>
+      exprUsesParamDynamicHeadWord a || exprUsesParamDynamicHeadWord b
+  | Expr.externalCall _ args | Expr.internalCall _ args | Expr.adtConstruct _ _ args =>
+      exprListUsesParamDynamicHeadWord args
+  | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b
+  | Expr.mod a b | Expr.smod a b
+  | Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b
+  | Expr.sar a b | Expr.signextend a b
+  | Expr.eq a b | Expr.ge a b | Expr.gt a b | Expr.sgt a b | Expr.lt a b | Expr.slt a b
+  | Expr.le a b | Expr.logicalAnd a b | Expr.logicalOr a b
+  | Expr.wMulDown a b | Expr.wDivUp a b | Expr.min a b | Expr.max a b | Expr.ceilDiv a b =>
+      exprUsesParamDynamicHeadWord a || exprUsesParamDynamicHeadWord b
+  | Expr.mulDivDown a b c | Expr.mulDivUp a b c
+  | Expr.mulDiv512Down a b c | Expr.mulDiv512Up a b c
+  | Expr.ite a b c =>
+      exprUsesParamDynamicHeadWord a || exprUsesParamDynamicHeadWord b ||
+      exprUsesParamDynamicHeadWord c
+  | Expr.literal _ | Expr.param _ | Expr.constructorArg _
+  | Expr.storage _ | Expr.storageAddr _
+  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
+  | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
+  | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.storageArrayLength _
+  | Expr.dynamicBytesEq _ _
+  | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
+      false
+termination_by e => sizeOf e
+decreasing_by all_goals simp_wf; all_goals omega
 
-partial def stmtUsesParamDynamicHeadWord : Stmt → Bool
+def exprListUsesParamDynamicHeadWord : List Expr → Bool
+  | [] => false
+  | e :: es => exprUsesParamDynamicHeadWord e || exprListUsesParamDynamicHeadWord es
+termination_by es => sizeOf es
+decreasing_by all_goals simp_wf; all_goals omega
+end
+
+mutual
+def stmtUsesParamDynamicHeadWord : Stmt → Bool
   | Stmt.letVar _ value | Stmt.assignVar _ value | Stmt.setStorage _ value
   | Stmt.setStorageAddr _ value | Stmt.setStorageWord _ _ value
   | Stmt.storageArrayPush _ value | Stmt.return value | Stmt.require value _ =>
       exprUsesParamDynamicHeadWord value
   | Stmt.setStorageArrayElement _ index value =>
       exprUsesParamDynamicHeadWord index || exprUsesParamDynamicHeadWord value
+  | Stmt.storageArrayPop _ => false
   | Stmt.requireError cond _ args =>
-      exprUsesParamDynamicHeadWord cond || args.any exprUsesParamDynamicHeadWord
+      exprUsesParamDynamicHeadWord cond || exprListUsesParamDynamicHeadWord args
   | Stmt.revertError _ args | Stmt.emit _ args | Stmt.returnValues args =>
-      args.any exprUsesParamDynamicHeadWord
+      exprListUsesParamDynamicHeadWord args
   | Stmt.mstore offset value | Stmt.tstore offset value =>
       exprUsesParamDynamicHeadWord offset || exprUsesParamDynamicHeadWord value
   | Stmt.calldatacopy a b c | Stmt.returndataCopy a b c =>
@@ -539,30 +562,48 @@ partial def stmtUsesParamDynamicHeadWord : Stmt → Bool
   | Stmt.setStructMember _ k _ v =>
       exprUsesParamDynamicHeadWord k || exprUsesParamDynamicHeadWord v
   | Stmt.setMappingChain _ keys v =>
-      keys.any exprUsesParamDynamicHeadWord || exprUsesParamDynamicHeadWord v
+      exprListUsesParamDynamicHeadWord keys || exprUsesParamDynamicHeadWord v
   | Stmt.setMapping2 _ k1 k2 v | Stmt.setMapping2Word _ k1 k2 _ v
   | Stmt.setStructMember2 _ k1 k2 _ v =>
       exprUsesParamDynamicHeadWord k1 || exprUsesParamDynamicHeadWord k2 ||
       exprUsesParamDynamicHeadWord v
   | Stmt.ite cond thenBranch elseBranch =>
       exprUsesParamDynamicHeadWord cond ||
-      thenBranch.any stmtUsesParamDynamicHeadWord ||
-      elseBranch.any stmtUsesParamDynamicHeadWord
+        stmtListUsesParamDynamicHeadWord thenBranch ||
+        stmtListUsesParamDynamicHeadWord elseBranch
   | Stmt.forEach _ count body =>
-      exprUsesParamDynamicHeadWord count || body.any stmtUsesParamDynamicHeadWord
+      exprUsesParamDynamicHeadWord count || stmtListUsesParamDynamicHeadWord body
   | Stmt.unsafeBlock _ body =>
-      body.any stmtUsesParamDynamicHeadWord
+      stmtListUsesParamDynamicHeadWord body
   | Stmt.matchAdt _ scrutinee branches =>
-      exprUsesParamDynamicHeadWord scrutinee ||
-        branches.any (fun (_, _, body) => body.any stmtUsesParamDynamicHeadWord)
+      exprUsesParamDynamicHeadWord scrutinee || matchBranchesUseParamDynamicHeadWord branches
   | Stmt.internalCall _ args | Stmt.internalCallAssign _ _ args
   | Stmt.externalCallBind _ _ args | Stmt.tryExternalCallBind _ _ _ args
   | Stmt.ecm _ args =>
-      args.any exprUsesParamDynamicHeadWord
+      exprListUsesParamDynamicHeadWord args
   | Stmt.rawLog topics dataOffset dataSize =>
-      topics.any exprUsesParamDynamicHeadWord ||
-      exprUsesParamDynamicHeadWord dataOffset || exprUsesParamDynamicHeadWord dataSize
-  | _ => false
+      exprListUsesParamDynamicHeadWord topics ||
+        exprUsesParamDynamicHeadWord dataOffset ||
+        exprUsesParamDynamicHeadWord dataSize
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _
+  | Stmt.revertReturndata | Stmt.stop =>
+      false
+termination_by s => sizeOf s
+decreasing_by all_goals simp_wf; all_goals omega
+
+def stmtListUsesParamDynamicHeadWord : List Stmt → Bool
+  | [] => false
+  | s :: ss => stmtUsesParamDynamicHeadWord s || stmtListUsesParamDynamicHeadWord ss
+termination_by ss => sizeOf ss
+decreasing_by all_goals simp_wf; all_goals omega
+
+def matchBranchesUseParamDynamicHeadWord : List (String × List String × List Stmt) → Bool
+  | [] => false
+  | (_, _, body) :: rest =>
+      stmtListUsesParamDynamicHeadWord body || matchBranchesUseParamDynamicHeadWord rest
+termination_by bs => sizeOf bs
+decreasing_by all_goals simp_wf; all_goals omega
+end
 
 def contractUsesParamDynamicHeadWord (spec : CompilationModel) : Bool :=
   (match spec.constructor with
@@ -570,54 +611,80 @@ def contractUsesParamDynamicHeadWord (spec : CompilationModel) : Bool :=
     | some ctor => ctor.body.any stmtUsesParamDynamicHeadWord) ||
   spec.functions.any (fun fn => fn.body.any stmtUsesParamDynamicHeadWord)
 
-/-- Whether the given expression syntactically contains an
-    `Expr.mulDiv512Down` or `Expr.mulDiv512Up` (verity#1761). -/
-partial def exprUsesMulDiv512 : Expr → Bool
+-- Whether the given expression syntactically contains an
+-- `Expr.mulDiv512Down` or `Expr.mulDiv512Up` (verity#1761).
+-- Plain `def` (not `partial`) so the `SupportedSpec.contractUsesMulDiv512_eq_false`
+-- proof chain in `SupportedSpec.lean` can simp/unfold each case.
+mutual
+def exprUsesMulDiv512 : Expr → Bool
   | Expr.mulDiv512Down _ _ _ | Expr.mulDiv512Up _ _ _ => true
-  | e => match e with
-    | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _
-    | Expr.mappingUint _ key | Expr.structMember _ key _
-    | Expr.storageArrayElement _ key | Expr.arrayElement _ key
-    | Expr.arrayElementWord _ key _ _ | Expr.arrayElementDynamicWord _ key _ =>
-        exprUsesMulDiv512 key
-    | Expr.mappingChain _ keys => keys.any exprUsesMulDiv512
-    | Expr.mapping2 _ k1 k2 | Expr.mapping2Word _ k1 k2 _ | Expr.structMember2 _ k1 k2 _ =>
-        exprUsesMulDiv512 k1 || exprUsesMulDiv512 k2
-    | Expr.call gas target value inOffset inSize outOffset outSize =>
-        [gas, target, value, inOffset, inSize, outOffset, outSize].any exprUsesMulDiv512
-    | Expr.staticcall gas target inOffset inSize outOffset outSize
-    | Expr.delegatecall gas target inOffset inSize outOffset outSize =>
-        [gas, target, inOffset, inSize, outOffset, outSize].any exprUsesMulDiv512
-    | Expr.extcodesize a | Expr.mload a | Expr.tload a | Expr.calldataload a
-    | Expr.returndataOptionalBoolAt a | Expr.bitNot a | Expr.logicalNot a =>
-        exprUsesMulDiv512 a
-    | Expr.keccak256 a b =>
-        exprUsesMulDiv512 a || exprUsesMulDiv512 b
-    | Expr.externalCall _ args | Expr.internalCall _ args | Expr.adtConstruct _ _ args =>
-        args.any exprUsesMulDiv512
-    | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b
-    | Expr.mod a b | Expr.smod a b
-    | Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b
-    | Expr.sar a b | Expr.signextend a b
-    | Expr.eq a b | Expr.ge a b | Expr.gt a b | Expr.sgt a b | Expr.lt a b | Expr.slt a b
-    | Expr.le a b | Expr.logicalAnd a b | Expr.logicalOr a b
-    | Expr.wMulDown a b | Expr.wDivUp a b | Expr.min a b | Expr.max a b | Expr.ceilDiv a b =>
-        exprUsesMulDiv512 a || exprUsesMulDiv512 b
-    | Expr.mulDivDown a b c | Expr.mulDivUp a b c | Expr.ite a b c =>
-        exprUsesMulDiv512 a || exprUsesMulDiv512 b || exprUsesMulDiv512 c
-    | _ => false
+  | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _
+  | Expr.mappingUint _ key | Expr.structMember _ key _
+  | Expr.storageArrayElement _ key | Expr.arrayElement _ key
+  | Expr.arrayElementWord _ key _ _ | Expr.arrayElementDynamicWord _ key _ =>
+      exprUsesMulDiv512 key
+  | Expr.mappingChain _ keys => exprListUsesMulDiv512 keys
+  | Expr.mapping2 _ k1 k2 | Expr.mapping2Word _ k1 k2 _ | Expr.structMember2 _ k1 k2 _ =>
+      exprUsesMulDiv512 k1 || exprUsesMulDiv512 k2
+  | Expr.call gas target value inOffset inSize outOffset outSize =>
+      exprUsesMulDiv512 gas || exprUsesMulDiv512 target || exprUsesMulDiv512 value ||
+      exprUsesMulDiv512 inOffset || exprUsesMulDiv512 inSize ||
+      exprUsesMulDiv512 outOffset || exprUsesMulDiv512 outSize
+  | Expr.staticcall gas target inOffset inSize outOffset outSize
+  | Expr.delegatecall gas target inOffset inSize outOffset outSize =>
+      exprUsesMulDiv512 gas || exprUsesMulDiv512 target ||
+      exprUsesMulDiv512 inOffset || exprUsesMulDiv512 inSize ||
+      exprUsesMulDiv512 outOffset || exprUsesMulDiv512 outSize
+  | Expr.extcodesize a | Expr.mload a | Expr.tload a | Expr.calldataload a
+  | Expr.returndataOptionalBoolAt a | Expr.bitNot a | Expr.logicalNot a =>
+      exprUsesMulDiv512 a
+  | Expr.keccak256 a b =>
+      exprUsesMulDiv512 a || exprUsesMulDiv512 b
+  | Expr.externalCall _ args | Expr.internalCall _ args | Expr.adtConstruct _ _ args =>
+      exprListUsesMulDiv512 args
+  | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b
+  | Expr.mod a b | Expr.smod a b
+  | Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b
+  | Expr.sar a b | Expr.signextend a b
+  | Expr.eq a b | Expr.ge a b | Expr.gt a b | Expr.sgt a b | Expr.lt a b | Expr.slt a b
+  | Expr.le a b | Expr.logicalAnd a b | Expr.logicalOr a b
+  | Expr.wMulDown a b | Expr.wDivUp a b | Expr.min a b | Expr.max a b | Expr.ceilDiv a b =>
+      exprUsesMulDiv512 a || exprUsesMulDiv512 b
+  | Expr.mulDivDown a b c | Expr.mulDivUp a b c | Expr.ite a b c =>
+      exprUsesMulDiv512 a || exprUsesMulDiv512 b || exprUsesMulDiv512 c
+  | Expr.literal _ | Expr.param _ | Expr.constructorArg _
+  | Expr.storage _ | Expr.storageAddr _
+  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
+  | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
+  | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.storageArrayLength _
+  | Expr.paramDynamicHeadWord _ _
+  | Expr.dynamicBytesEq _ _
+  | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
+      false
+termination_by e => sizeOf e
+decreasing_by all_goals simp_wf; all_goals omega
 
-partial def stmtUsesMulDiv512 : Stmt → Bool
+def exprListUsesMulDiv512 : List Expr → Bool
+  | [] => false
+  | e :: es => exprUsesMulDiv512 e || exprListUsesMulDiv512 es
+termination_by es => sizeOf es
+decreasing_by all_goals simp_wf; all_goals omega
+end
+
+mutual
+def stmtUsesMulDiv512 : Stmt → Bool
   | Stmt.letVar _ value | Stmt.assignVar _ value | Stmt.setStorage _ value
   | Stmt.setStorageAddr _ value | Stmt.setStorageWord _ _ value
   | Stmt.storageArrayPush _ value | Stmt.return value | Stmt.require value _ =>
       exprUsesMulDiv512 value
   | Stmt.setStorageArrayElement _ index value =>
       exprUsesMulDiv512 index || exprUsesMulDiv512 value
+  | Stmt.storageArrayPop _ => false
   | Stmt.requireError cond _ args =>
-      exprUsesMulDiv512 cond || args.any exprUsesMulDiv512
+      exprUsesMulDiv512 cond || exprListUsesMulDiv512 args
   | Stmt.revertError _ args | Stmt.emit _ args | Stmt.returnValues args =>
-      args.any exprUsesMulDiv512
+      exprListUsesMulDiv512 args
   | Stmt.mstore offset value | Stmt.tstore offset value =>
       exprUsesMulDiv512 offset || exprUsesMulDiv512 value
   | Stmt.calldatacopy a b c | Stmt.returndataCopy a b c =>
@@ -627,29 +694,46 @@ partial def stmtUsesMulDiv512 : Stmt → Bool
   | Stmt.setStructMember _ k _ v =>
       exprUsesMulDiv512 k || exprUsesMulDiv512 v
   | Stmt.setMappingChain _ keys v =>
-      keys.any exprUsesMulDiv512 || exprUsesMulDiv512 v
+      exprListUsesMulDiv512 keys || exprUsesMulDiv512 v
   | Stmt.setMapping2 _ k1 k2 v | Stmt.setMapping2Word _ k1 k2 _ v
   | Stmt.setStructMember2 _ k1 k2 _ v =>
       exprUsesMulDiv512 k1 || exprUsesMulDiv512 k2 || exprUsesMulDiv512 v
   | Stmt.ite cond thenBranch elseBranch =>
       exprUsesMulDiv512 cond ||
-      thenBranch.any stmtUsesMulDiv512 ||
-      elseBranch.any stmtUsesMulDiv512
+        stmtListUsesMulDiv512 thenBranch ||
+        stmtListUsesMulDiv512 elseBranch
   | Stmt.forEach _ count body =>
-      exprUsesMulDiv512 count || body.any stmtUsesMulDiv512
+      exprUsesMulDiv512 count || stmtListUsesMulDiv512 body
   | Stmt.unsafeBlock _ body =>
-      body.any stmtUsesMulDiv512
+      stmtListUsesMulDiv512 body
   | Stmt.matchAdt _ scrutinee branches =>
-      exprUsesMulDiv512 scrutinee ||
-        branches.any (fun (_, _, body) => body.any stmtUsesMulDiv512)
+      exprUsesMulDiv512 scrutinee || matchBranchesUseMulDiv512 branches
   | Stmt.internalCall _ args | Stmt.internalCallAssign _ _ args
   | Stmt.externalCallBind _ _ args | Stmt.tryExternalCallBind _ _ _ args
   | Stmt.ecm _ args =>
-      args.any exprUsesMulDiv512
+      exprListUsesMulDiv512 args
   | Stmt.rawLog topics dataOffset dataSize =>
-      topics.any exprUsesMulDiv512 ||
-      exprUsesMulDiv512 dataOffset || exprUsesMulDiv512 dataSize
-  | _ => false
+      exprListUsesMulDiv512 topics ||
+        exprUsesMulDiv512 dataOffset || exprUsesMulDiv512 dataSize
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _
+  | Stmt.revertReturndata | Stmt.stop =>
+      false
+termination_by s => sizeOf s
+decreasing_by all_goals simp_wf; all_goals omega
+
+def stmtListUsesMulDiv512 : List Stmt → Bool
+  | [] => false
+  | s :: ss => stmtUsesMulDiv512 s || stmtListUsesMulDiv512 ss
+termination_by ss => sizeOf ss
+decreasing_by all_goals simp_wf; all_goals omega
+
+def matchBranchesUseMulDiv512 : List (String × List String × List Stmt) → Bool
+  | [] => false
+  | (_, _, body) :: rest =>
+      stmtListUsesMulDiv512 body || matchBranchesUseMulDiv512 rest
+termination_by bs => sizeOf bs
+decreasing_by all_goals simp_wf; all_goals omega
+end
 
 def contractUsesMulDiv512 (spec : CompilationModel) : Bool :=
   (match spec.constructor with

--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -539,10 +539,15 @@ private theorem compileValidatedCore_ok_yields_internalFunctions_nil
     hSupported.contractUsesStorageArrayElement_eq_false
   have hdynamicBytesEq : contractUsesDynamicBytesEq model = false :=
     hSupported.contractUsesDynamicBytesEq_eq_false
+  have hmulDiv512 : contractUsesMulDiv512 model = false :=
+    hSupported.contractUsesMulDiv512_eq_false
+  have hparamDyn : contractUsesParamDynamicHeadWord model = false :=
+    hSupported.contractUsesParamDynamicHeadWord_eq_false
   unfold compileValidatedCore at hcore
   rw [hSupported.normalizedFields, hfallback, hreceive,
     contractUsesPlainArrayElement, contractUsesArrayElementWord, harray,
-    hstorageArray, hdynamicBytesEq, hnoInternalFns, hSupported.noAdtTypes] at hcore
+    hstorageArray, hdynamicBytesEq, hmulDiv512, hparamDyn,
+    hnoInternalFns, hSupported.noAdtTypes] at hcore
   simp only [bind, Except.bind, pure, Except.pure, List.mapM_nil] at hcore
   rcases hmap :
       ((model.functions.filter
@@ -875,6 +880,10 @@ theorem compile_ok_yields_internalFunctions_nil_except_mapping_writes
     hSupported.contractUsesStorageArrayElement_eq_false
   have hdynamicBytesEq : contractUsesDynamicBytesEq model = false :=
     hSupported.contractUsesDynamicBytesEq_eq_false
+  have hmulDiv512 : contractUsesMulDiv512 model = false :=
+    hSupported.contractUsesMulDiv512_eq_false
+  have hparamDyn : contractUsesParamDynamicHeadWord model = false :=
+    hSupported.contractUsesParamDynamicHeadWord_eq_false
   unfold CompilationModel.compile at hcompile
   simp only [bind, Except.bind] at hcompile
   rcases hvalidate : validateCompileInputs model selectors with _ | validated
@@ -883,7 +892,8 @@ theorem compile_ok_yields_internalFunctions_nil_except_mapping_writes
     unfold compileValidatedCore at hcompile
     rw [hSupported.normalizedFields, hfallback, hreceive,
       contractUsesPlainArrayElement, contractUsesArrayElementWord, harray,
-      hstorageArray, hdynamicBytesEq, hnoInternalFns, hSupported.noAdtTypes] at hcompile
+      hstorageArray, hdynamicBytesEq, hmulDiv512, hparamDyn,
+      hnoInternalFns, hSupported.noAdtTypes] at hcompile
     simp only [bind, Except.bind, pure, Except.pure, List.mapM_nil] at hcompile
     rcases hmap :
         ((model.functions.filter

--- a/Compiler/Proofs/IRGeneration/ContractShape.lean
+++ b/Compiler/Proofs/IRGeneration/ContractShape.lean
@@ -159,10 +159,15 @@ private theorem compileValidatedCore_ok_yields_internalFunctions_nil
     hSupported.contractUsesStorageArrayElement_eq_false
   have hdynamicBytesEq : contractUsesDynamicBytesEq model = false :=
     hSupported.contractUsesDynamicBytesEq_eq_false
+  have hmulDiv512 : contractUsesMulDiv512 model = false :=
+    hSupported.contractUsesMulDiv512_eq_false
+  have hparamDyn : contractUsesParamDynamicHeadWord model = false :=
+    hSupported.contractUsesParamDynamicHeadWord_eq_false
   unfold compileValidatedCore at hcore
   rw [hSupported.normalizedFields, hfallback, hreceive,
     contractUsesPlainArrayElement, contractUsesArrayElementWord, harray,
-    hstorageArray, hdynamicBytesEq, hnoInternalFns, hSupported.noAdtTypes] at hcore
+    hstorageArray, hdynamicBytesEq, hmulDiv512, hparamDyn,
+    hnoInternalFns, hSupported.noAdtTypes] at hcore
   simp only [bind, Except.bind, pure, Except.pure, List.mapM_nil] at hcore
   rcases hmap :
       ((model.functions.filter

--- a/Compiler/Proofs/IRGeneration/GenericInduction.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction.lean
@@ -3249,6 +3249,15 @@ private theorem exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_fals
         (exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false hsurface.1.1)
         (exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false hsurface.1.2)
         (exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false hsurface.2)
+  | .mulDiv512Down _ _ _, hsurface | .mulDiv512Up _ _ _, hsurface =>
+      -- `mulDiv512Down/Up` is unsupported by the contract surface (verity#1761
+      -- codegen-only; no `ExprCompileCore` constructor), so this branch is
+      -- vacuous.
+      simp [exprTouchesUnsupportedContractSurface] at hsurface
+  | .paramDynamicHeadWord _ _, hsurface =>
+      -- Same vacuous handling for `paramDynamicHeadWord` (verity#1832
+      -- codegen-only).
+      simp [exprTouchesUnsupportedContractSurface] at hsurface
 
 private theorem fieldName_mem_fields_of_findFieldWithResolvedSlot_some
     {fields : List Field}

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -1022,6 +1022,25 @@ private theorem evalExpr_keccak256
     (a b : Expr) :
     evalExpr fields state (.keccak256 a b) = none := rfl
 
+private theorem evalExpr_mulDiv512Down
+    (fields : List Field)
+    (state : RuntimeState)
+    (a b c : Expr) :
+    evalExpr fields state (.mulDiv512Down a b c) = none := rfl
+
+private theorem evalExpr_mulDiv512Up
+    (fields : List Field)
+    (state : RuntimeState)
+    (a b c : Expr) :
+    evalExpr fields state (.mulDiv512Up a b c) = none := rfl
+
+private theorem evalExpr_paramDynamicHeadWord
+    (fields : List Field)
+    (state : RuntimeState)
+    (name : String)
+    (wordOffset : Nat) :
+    evalExpr fields state (.paramDynamicHeadWord name wordOffset) = none := rfl
+
 private theorem evalExpr_call
     (fields : List Field)
     (state : RuntimeState)
@@ -2688,7 +2707,21 @@ mutual
     | .calldataload offset => do
         let resolvedOffset ← evalExprWithHelpers spec fields fuel state offset
         some (Compiler.Proofs.YulGeneration.calldataloadWord state.selector state.world.calldata resolvedOffset)
-    | _ => none
+    -- Unmodeled / codegen-only constructors (no helper-aware semantics yet).
+    -- Listed explicitly rather than via `| _ => none` so the
+    -- `_mutual.eq_def` deriver does not enumerate the complement and trip
+    -- the 200 000-heartbeat ceiling whenever a new `Expr` constructor
+    -- lands (verity#1842).
+    | .mulDiv512Down _ _ _ | .mulDiv512Up _ _ _
+    | .paramDynamicHeadWord _ _
+    | .arrayLength _ | .arrayElement _ _
+    | .arrayElementWord _ _ _ _ | .arrayElementDynamicWord _ _ _
+    | .extcodesize _ | .returndataSize | .returndataOptionalBoolAt _
+    | .keccak256 _ _
+    | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
+    | .externalCall _ _ | .mappingChain _ _
+    | .dynamicBytesEq _ _
+    | .adtConstruct _ _ _ | .adtTag _ _ | .adtField _ _ _ _ _ => none
   termination_by expr => (fuel, sizeOf expr)
   decreasing_by all_goals (simp_wf; omega)
   def evalExprListWithHelpers
@@ -3731,6 +3764,10 @@ mutual
         have hc :=
           evalExprWithHelpers_eq_evalExpr_of_helperSurfaceClosed spec fields fuel state c hsurface.2
         simpa [evalExprWithHelpers, evalExpr_mulDivDown, evalExpr_mulDivUp, ha, hb, hc]
+    | mulDiv512Down _ _ _ | mulDiv512Up _ _ _ =>
+        simp [evalExprWithHelpers, evalExpr_mulDiv512Down, evalExpr_mulDiv512Up]
+    | paramDynamicHeadWord _ _ =>
+        simp [evalExprWithHelpers, evalExpr_paramDynamicHeadWord]
     | ite cond thenVal elseVal =>
         simp only [exprTouchesUnsupportedHelperSurface, Bool.or_eq_false_iff] at hsurface
         have hcond :=

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -580,10 +580,15 @@ def exprTouchesUnsupportedConstructorRawCalldataSurface : Expr → Bool
       exprTouchesUnsupportedConstructorRawCalldataSurface a ||
         exprTouchesUnsupportedConstructorRawCalldataSurface b
   | .dynamicBytesEq _ _ => false
-  | .ite c t e | .mulDivDown c t e | .mulDivUp c t e =>
+  | .ite c t e | .mulDivDown c t e | .mulDivUp c t e
+  | .mulDiv512Down c t e | .mulDiv512Up c t e =>
       exprTouchesUnsupportedConstructorRawCalldataSurface c ||
         exprTouchesUnsupportedConstructorRawCalldataSurface t ||
         exprTouchesUnsupportedConstructorRawCalldataSurface e
+  -- `paramDynamicHeadWord` reads the head section of an ABI-decoded
+  -- parameter; like `param _` it does not touch raw calldata, so the
+  -- constructor-arg precondition is unaffected.
+  | .paramDynamicHeadWord _ _ => false
   | .mappingChain _ keys | .internalCall _ keys | .externalCall _ keys =>
       exprListTouchesUnsupportedConstructorRawCalldataSurface keys
   | .keccak256 a b =>
@@ -705,6 +710,11 @@ def exprTouchesUnsupportedCoreSurface : Expr → Bool
   | .slt a b | .sgt a b | .sdiv a b | .smod a b | .sar a b | .signextend a b =>
       exprTouchesUnsupportedCoreSurface a || exprTouchesUnsupportedCoreSurface b
   | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedCoreSurface a
+  -- `mulDiv512Down/Up` (verity#1761) and `paramDynamicHeadWord` (verity#1832)
+  -- are codegen-only additions whose runtime Yul helpers the current core
+  -- proof framework does not model yet. They join `arrayElement*` /
+  -- `dynamicBytesEq` in the unsupported-core surface so `SupportedSpec`
+  -- continues to exclude contracts that use them.
   | .mapping _ _ | .mappingWord _ _ _ | .mappingPackedWord _ _ _ _
   | .mapping2 _ _ _ | .mapping2Word _ _ _ _ | .mappingUint _ _ | .mappingChain _ _
   | .structMember _ _ _ | .structMember2 _ _ _ _
@@ -714,6 +724,8 @@ def exprTouchesUnsupportedCoreSurface : Expr → Bool
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
   | .arrayLength _ | .arrayElement _ _ | .arrayElementWord _ _ _ _
   | .arrayElementDynamicWord _ _ _
+  | .paramDynamicHeadWord _ _
+  | .mulDiv512Down _ _ _ | .mulDiv512Up _ _ _
   | .storageArrayLength _ | .storageArrayElement _ _
   | .dynamicBytesEq _ _
   | .adtConstruct _ _ _ | .adtTag _ _ | .adtField _ _ _ _ _ => true
@@ -743,7 +755,8 @@ def exprTouchesUnsupportedStateSurface : Expr → Bool
         exprTouchesUnsupportedStateSurface elseVal
   | .shl a b | .shr a b | .sar a b | .signextend a b =>
       exprTouchesUnsupportedStateSurface a || exprTouchesUnsupportedStateSurface b
-  | .mulDivDown a b c | .mulDivUp a b c =>
+  | .mulDivDown a b c | .mulDivUp a b c
+  | .mulDiv512Down a b c | .mulDiv512Up a b c =>
       exprTouchesUnsupportedStateSurface a || exprTouchesUnsupportedStateSurface b ||
         exprTouchesUnsupportedStateSurface c
   | .constructorArg _ | .blobbasefee | .keccak256 _ _
@@ -752,6 +765,7 @@ def exprTouchesUnsupportedStateSurface : Expr → Bool
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
   | .arrayLength _ | .arrayElement _ _ | .arrayElementWord _ _ _ _
   | .arrayElementDynamicWord _ _ _
+  | .paramDynamicHeadWord _ _
   | .dynamicBytesEq _ _ => false
   | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedStateSurface a
   | .adtConstruct _ _ _ | .adtTag _ _ | .adtField _ _ _ _ _ => true
@@ -767,6 +781,7 @@ def exprTouchesUnsupportedCallSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
+  | .paramDynamicHeadWord _ _
   | .storageArrayLength _ => false
   | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedCallSurface a
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
@@ -789,7 +804,8 @@ def exprTouchesUnsupportedCallSurface : Expr → Bool
         exprTouchesUnsupportedCallSurface elseVal
   | .mapping2 _ a b | .mapping2Word _ a b _ | .structMember2 _ a b _ =>
       exprTouchesUnsupportedCallSurface a || exprTouchesUnsupportedCallSurface b
-  | .mulDivDown a b c | .mulDivUp a b c =>
+  | .mulDivDown a b c | .mulDivUp a b c
+  | .mulDiv512Down a b c | .mulDiv512Up a b c =>
       exprTouchesUnsupportedCallSurface a ||
         exprTouchesUnsupportedCallSurface b ||
         exprTouchesUnsupportedCallSurface c
@@ -808,6 +824,7 @@ def exprTouchesUnsupportedHelperSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
+  | .paramDynamicHeadWord _ _
   | .storageArrayLength _ | .externalCall _ _ => false
   | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedHelperSurface a
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => false
@@ -831,7 +848,8 @@ def exprTouchesUnsupportedHelperSurface : Expr → Bool
         exprTouchesUnsupportedHelperSurface elseVal
   | .mapping2 _ a b | .mapping2Word _ a b _ | .structMember2 _ a b _ =>
       exprTouchesUnsupportedHelperSurface a || exprTouchesUnsupportedHelperSurface b
-  | .mulDivDown a b c | .mulDivUp a b c =>
+  | .mulDivDown a b c | .mulDivUp a b c
+  | .mulDiv512Down a b c | .mulDiv512Up a b c =>
       exprTouchesUnsupportedHelperSurface a ||
         exprTouchesUnsupportedHelperSurface b ||
         exprTouchesUnsupportedHelperSurface c
@@ -858,6 +876,7 @@ def exprTouchesInternalHelperSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
+  | .paramDynamicHeadWord _ _
   | .storageArrayLength _ | .externalCall _ _ => false
   | .mload a | .tload a | .calldataload a => exprTouchesInternalHelperSurface a
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => false
@@ -883,7 +902,8 @@ def exprTouchesInternalHelperSurface : Expr → Bool
         exprTouchesInternalHelperSurface elseVal
   | .mapping2 _ a b | .mapping2Word _ a b _ | .structMember2 _ a b _ =>
       exprTouchesInternalHelperSurface a || exprTouchesInternalHelperSurface b
-  | .mulDivDown a b c | .mulDivUp a b c =>
+  | .mulDivDown a b c | .mulDivUp a b c
+  | .mulDiv512Down a b c | .mulDiv512Up a b c =>
       exprTouchesInternalHelperSurface a ||
         exprTouchesInternalHelperSurface b ||
         exprTouchesInternalHelperSurface c
@@ -902,6 +922,7 @@ def exprTouchesUnsupportedForeignSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
+  | .paramDynamicHeadWord _ _
   | .storageArrayLength _ | .internalCall _ _ => false
   | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedForeignSurface a
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => false
@@ -925,7 +946,8 @@ def exprTouchesUnsupportedForeignSurface : Expr → Bool
         exprTouchesUnsupportedForeignSurface elseVal
   | .mapping2 _ a b | .mapping2Word _ a b _ | .structMember2 _ a b _ =>
       exprTouchesUnsupportedForeignSurface a || exprTouchesUnsupportedForeignSurface b
-  | .mulDivDown a b c | .mulDivUp a b c =>
+  | .mulDivDown a b c | .mulDivUp a b c
+  | .mulDiv512Down a b c | .mulDiv512Up a b c =>
       exprTouchesUnsupportedForeignSurface a ||
         exprTouchesUnsupportedForeignSurface b ||
         exprTouchesUnsupportedForeignSurface c
@@ -944,6 +966,7 @@ def exprTouchesUnsupportedLowLevelSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
+  | .paramDynamicHeadWord _ _
   | .storageArrayLength _ | .internalCall _ _ | .externalCall _ _ => false
   | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedLowLevelSurface a
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
@@ -966,7 +989,8 @@ def exprTouchesUnsupportedLowLevelSurface : Expr → Bool
         exprTouchesUnsupportedLowLevelSurface elseVal
   | .mapping2 _ a b | .mapping2Word _ a b _ | .structMember2 _ a b _ =>
       exprTouchesUnsupportedLowLevelSurface a || exprTouchesUnsupportedLowLevelSurface b
-  | .mulDivDown a b c | .mulDivUp a b c =>
+  | .mulDivDown a b c | .mulDivUp a b c
+  | .mulDiv512Down a b c | .mulDiv512Up a b c =>
       exprTouchesUnsupportedLowLevelSurface a ||
         exprTouchesUnsupportedLowLevelSurface b ||
         exprTouchesUnsupportedLowLevelSurface c
@@ -1014,6 +1038,8 @@ def exprTouchesUnsupportedContractSurface (expr : Expr) : Bool :=
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
   | .arrayLength _ | .arrayElement _ _ | .arrayElementWord _ _ _ _
   | .arrayElementDynamicWord _ _ _
+  | .paramDynamicHeadWord _ _
+  | .mulDiv512Down _ _ _ | .mulDiv512Up _ _ _
   | .storageArrayLength _ | .storageArrayElement _ _
   | .dynamicBytesEq _ _
   | .adtConstruct _ _ _ | .adtTag _ _ | .adtField _ _ _ _ _ => true
@@ -1646,7 +1672,8 @@ mutual
     | .slt a b | .le a b | .logicalAnd a b | .logicalOr a b | .wMulDown a b
     | .wDivUp a b | .min a b | .max a b | .ceilDiv a b =>
         exprInternalHelperCallNames a ++ exprInternalHelperCallNames b
-    | .mulDivDown a b c | .mulDivUp a b c =>
+    | .mulDivDown a b c | .mulDivUp a b c
+    | .mulDiv512Down a b c | .mulDiv512Up a b c =>
         exprInternalHelperCallNames a ++ exprInternalHelperCallNames b ++
           exprInternalHelperCallNames c
     | .bitNot a | .logicalNot a =>
@@ -1656,7 +1683,21 @@ mutual
           exprInternalHelperCallNames elseVal
     | .externalCall _ args =>
         exprListInternalHelperCallNames args
-    | _ =>
+    -- Pure leaves: no internal helper calls. Listed explicitly (rather than
+    -- via `| _ => []`) so the equation-lemma deriver does not have to
+    -- enumerate the complement of every pattern above. This avoids the
+    -- `_mutual.eq_def` 200 000-heartbeat ceiling when new `Expr` constructors
+    -- land (verity#1842 captured the same pitfall for the Expr→Except
+    -- validators).
+    | .literal _ | .param _ | .constructorArg _
+    | .storage _ | .storageAddr _
+    | .caller | .contractAddress | .chainid | .msgValue | .selfBalance
+    | .blockTimestamp | .blockNumber | .blobbasefee
+    | .calldatasize | .returndataSize
+    | .localVar _ | .arrayLength _ | .storageArrayLength _
+    | .paramDynamicHeadWord _ _
+    | .dynamicBytesEq _ _
+    | .adtConstruct _ _ _ | .adtTag _ _ | .adtField _ _ _ _ _ =>
         []
   termination_by e => sizeOf e
   decreasing_by all_goals simp_wf; all_goals omega
@@ -3111,6 +3152,7 @@ mutual
     | blockTimestamp | blockNumber | localVar _ | storage _ | storageAddr _
     | constructorArg _ | blobbasefee | calldatasize | returndataSize
     | arrayLength _ | storageArrayLength _ | dynamicBytesEq _ _
+    | paramDynamicHeadWord _ _
     | externalCall _ _ =>
         simp [exprTouchesInternalHelperSurface]
     | adtConstruct _ _ _ | adtTag _ _ | adtField _ _ _ _ _ =>
@@ -3172,7 +3214,8 @@ mutual
         simp [exprTouchesInternalHelperSurface,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed ha,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hb]
-    | mulDivDown a b c | mulDivUp a b c =>
+    | mulDivDown a b c | mulDivUp a b c
+  | mulDiv512Down a b c | mulDiv512Up a b c =>
         simp only [exprTouchesUnsupportedHelperSurface, Bool.or_eq_false_iff] at hsurface
         simp [exprTouchesInternalHelperSurface,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.1.1,
@@ -3498,6 +3541,7 @@ private theorem exprTouchesUnsupportedCallSurface_eq_featureOr
   | literal _ | param _ | caller | contractAddress
   | chainid | msgValue | selfBalance | blockTimestamp | blockNumber
   | localVar _ | storage _ | storageAddr _
+  | paramDynamicHeadWord _ _
   | constructorArg _ | blobbasefee | calldatasize | returndataSize =>
       simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
@@ -3574,7 +3618,8 @@ private theorem exprTouchesUnsupportedCallSurface_eq_featureOr
       rw [exprTouchesUnsupportedCallSurface_eq_featureOr a,
           exprTouchesUnsupportedCallSurface_eq_featureOr b]
       simp [Bool.or_assoc, Bool.or_left_comm, Bool.or_comm]
-  | mulDivDown a b c | mulDivUp a b c =>
+  | mulDivDown a b c | mulDivUp a b c
+  | mulDiv512Down a b c | mulDiv512Up a b c =>
       simp only [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
       rw [exprTouchesUnsupportedCallSurface_eq_featureOr a,
@@ -3702,6 +3747,8 @@ private theorem exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
       simp [exprTouchesUnsupportedCoreSurface] at hcore
   | storage _ | storageAddr _ =>
       cases hstate
+  | paramDynamicHeadWord _ _ =>
+      cases hcore
   | constructorArg _
   | returndataSize | arrayLength _ | storageArrayLength _
   | returndataOptionalBoolAt _ | extcodesize _
@@ -3769,6 +3816,8 @@ private theorem exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
         exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed a hcore.1.1 hstate.1.1 hcalls.1.1,
         exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed b hcore.1.2 hstate.1.2 hcalls.1.2,
         exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed c hcore.2 hstate.2 hcalls.2]
+  | mulDiv512Down _ _ _ | mulDiv512Up _ _ _ =>
+      simp [exprTouchesUnsupportedCoreSurface] at hcore
   | logicalNot a =>
       simp only [exprTouchesUnsupportedCoreSurface] at hcore
       simp only [exprTouchesUnsupportedStateSurface] at hstate
@@ -4082,6 +4131,7 @@ theorem exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
   | mapping2 _ _ _ | mapping2Word _ _ _ _ | mappingUint _ _
   | structMember _ _ _ | structMember2 _ _ _ _
   | arrayElement _ _ | arrayElementWord _ _ _ _ | arrayElementDynamicWord _ _ _
+  | paramDynamicHeadWord _ _
   | storageArrayElement _ _
   | mappingChain _ _ =>
       simp [exprTouchesUnsupportedContractSurface] at hsurface
@@ -4114,6 +4164,8 @@ theorem exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
         exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed hsurface.1.1,
         exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed hsurface.1.2,
         exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed hsurface.2]
+  | mulDiv512Down _ _ _ | mulDiv512Up _ _ _ =>
+      simp [exprTouchesUnsupportedContractSurface] at hsurface
   | ite cond thenVal elseVal =>
       simp only [exprTouchesUnsupportedContractSurface, Bool.or_eq_false_iff] at hsurface
       simp [exprTouchesUnsupportedHelperSurface,

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -3215,7 +3215,7 @@ mutual
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed ha,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hb]
     | mulDivDown a b c | mulDivUp a b c
-  | mulDiv512Down a b c | mulDiv512Up a b c =>
+    | mulDiv512Down a b c | mulDiv512Up a b c =>
         simp only [exprTouchesUnsupportedHelperSurface, Bool.or_eq_false_iff] at hsurface
         simp [exprTouchesInternalHelperSurface,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.1.1,

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -5178,6 +5178,566 @@ private theorem listAny_eq_false_of_mem_eq_false
         exact hmem y (by simp [hy])
       simp [List.any_cons, hx, listAny_eq_false_of_mem_eq_false f xs hxs]
 
+-- Helper: ExprCompileCore expressions never use mulDiv512 (verity#1761)
+private theorem exprCompileCore_usesMulDiv512_false
+    {expr : Expr}
+    (hcore : FunctionBody.ExprCompileCore expr) :
+    exprUsesMulDiv512 expr = false := by
+  induction hcore with
+  | literal | param | localVar | caller | contractAddress | msgValue
+    | blockTimestamp | blockNumber | chainid
+    | blobbasefee | calldatasize =>
+      simp only [exprUsesMulDiv512, Bool.false_or]
+  | add _ _ ihL ihR | sub _ _ ihL ihR | mul _ _ ihL ihR
+    | div _ _ ihL ihR | mod _ _ ihL ihR | eq _ _ ihL ihR
+    | lt _ _ ihL ihR | gt _ _ ihL ihR | ge _ _ ihL ihR
+    | le _ _ ihL ihR | logicalAnd _ _ ihL ihR | logicalOr _ _ ihL ihR
+    | bitAnd _ _ ihL ihR | bitOr _ _ ihL ihR | bitXor _ _ ihL ihR
+    | shl _ _ ihL ihR | shr _ _ ihL ihR
+    | min _ _ ihL ihR | max _ _ ihL ihR | ceilDiv _ _ ihL ihR
+    | wMulDown _ _ ihL ihR | wDivUp _ _ ihL ihR
+    | slt _ _ ihL ihR | sgt _ _ ihL ihR | sdiv _ _ ihL ihR
+    | smod _ _ ihL ihR | sar _ _ ihL ihR | signextend _ _ ihL ihR =>
+      simp only [exprUsesMulDiv512, ihL, ihR, Bool.false_or]
+  | mulDivDown _ _ _ ihA ihB ihC | mulDivUp _ _ _ ihA ihB ihC =>
+      simp only [exprUsesMulDiv512, ihA, ihB, ihC, Bool.false_or]
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih =>
+      simp only [exprUsesMulDiv512, ih, Bool.false_or]
+  | ite _ _ _ ihC ihT ihE =>
+      simp only [exprUsesMulDiv512, ihC, ihT, ihE, Bool.false_or]
+
+-- Helper: ExprCompileCore expressions never use paramDynamicHeadWord (verity#1832)
+private theorem exprCompileCore_usesParamDynamicHeadWord_false
+    {expr : Expr}
+    (hcore : FunctionBody.ExprCompileCore expr) :
+    exprUsesParamDynamicHeadWord expr = false := by
+  induction hcore with
+  | literal | param | localVar | caller | contractAddress | msgValue
+    | blockTimestamp | blockNumber | chainid
+    | blobbasefee | calldatasize =>
+      simp only [exprUsesParamDynamicHeadWord, Bool.false_or]
+  | add _ _ ihL ihR | sub _ _ ihL ihR | mul _ _ ihL ihR
+    | div _ _ ihL ihR | mod _ _ ihL ihR | eq _ _ ihL ihR
+    | lt _ _ ihL ihR | gt _ _ ihL ihR | ge _ _ ihL ihR
+    | le _ _ ihL ihR | logicalAnd _ _ ihL ihR | logicalOr _ _ ihL ihR
+    | bitAnd _ _ ihL ihR | bitOr _ _ ihL ihR | bitXor _ _ ihL ihR
+    | shl _ _ ihL ihR | shr _ _ ihL ihR
+    | min _ _ ihL ihR | max _ _ ihL ihR | ceilDiv _ _ ihL ihR
+    | wMulDown _ _ ihL ihR | wDivUp _ _ ihL ihR
+    | slt _ _ ihL ihR | sgt _ _ ihL ihR | sdiv _ _ ihL ihR
+    | smod _ _ ihL ihR | sar _ _ ihL ihR | signextend _ _ ihL ihR =>
+      simp only [exprUsesParamDynamicHeadWord, ihL, ihR, Bool.false_or]
+  | mulDivDown _ _ _ ihA ihB ihC | mulDivUp _ _ _ ihA ihB ihC =>
+      simp only [exprUsesParamDynamicHeadWord, ihA, ihB, ihC, Bool.false_or]
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih =>
+      simp only [exprUsesParamDynamicHeadWord, ih, Bool.false_or]
+  | ite _ _ _ ihC ihT ihE =>
+      simp only [exprUsesParamDynamicHeadWord, ihC, ihT, ihE, Bool.false_or]
+
+-- Helper: ExprCompileCore lists never use mulDiv512
+private theorem exprListCompileCore_usesMulDiv512_false
+    {exprs : List Expr}
+    (hcore : ∀ expr ∈ exprs, FunctionBody.ExprCompileCore expr) :
+    exprListUsesMulDiv512 exprs = false := by
+  induction exprs with
+  | nil => simp only [exprListUsesMulDiv512, Bool.false_or]
+  | cons e rest ih =>
+      simp only [exprListUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false (hcore e (List.mem_cons_self ..)),
+        ih (fun e he => hcore e (List.mem_cons_of_mem _ he)), Bool.false_or]
+
+-- Helper: ExprCompileCore lists never use paramDynamicHeadWord
+private theorem exprListCompileCore_usesParamDynamicHeadWord_false
+    {exprs : List Expr}
+    (hcore : ∀ expr ∈ exprs, FunctionBody.ExprCompileCore expr) :
+    exprListUsesParamDynamicHeadWord exprs = false := by
+  induction exprs with
+  | nil => simp only [exprListUsesParamDynamicHeadWord, Bool.false_or]
+  | cons e rest ih =>
+      simp only [exprListUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false (hcore e (List.mem_cons_self ..)),
+        ih (fun e he => hcore e (List.mem_cons_of_mem _ he)), Bool.false_or]
+
+-- Helper: StmtListCompileCore never uses mulDiv512
+private theorem stmtListCompileCore_usesMulDiv512_false
+    {scope : List String} {stmts : List Stmt}
+    (hcore : FunctionBody.StmtListCompileCore scope stmts) :
+    stmtListUsesMulDiv512 stmts = false := by
+  induction hcore with
+  | nil => simp only [stmtListUsesMulDiv512, Bool.false_or]
+  | letVar hvalue _ _ ih =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]; assumption
+  | assignVar hvalue _ _ ih =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]; assumption
+  | require_ hcond _ _ ih =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hcond, Bool.false_or]; assumption
+  | return_ hvalue _ _ ih =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]; assumption
+  | stop _ ih =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512, Bool.false_or]; assumption
+  | mstore hoffset _ hvalue _ _ ih =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hoffset,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]; assumption
+  | tstore hoffset _ hvalue _ _ ih =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hoffset,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]; assumption
+
+-- Helper: StmtListCompileCore never uses paramDynamicHeadWord
+private theorem stmtListCompileCore_usesParamDynamicHeadWord_false
+    {scope : List String} {stmts : List Stmt}
+    (hcore : FunctionBody.StmtListCompileCore scope stmts) :
+    stmtListUsesParamDynamicHeadWord stmts = false := by
+  induction hcore with
+  | nil => simp only [stmtListUsesParamDynamicHeadWord, Bool.false_or]
+  | letVar hvalue _ _ ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]; assumption
+  | assignVar hvalue _ _ ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]; assumption
+  | require_ hcond _ _ ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hcond, Bool.false_or]; assumption
+  | return_ hvalue _ _ ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]; assumption
+  | stop _ ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord, Bool.false_or]; assumption
+  | mstore hoffset _ hvalue _ _ ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hoffset,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]; assumption
+  | tstore hoffset _ hvalue _ _ ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hoffset,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]; assumption
+
+-- Helper: StmtListTerminalCore never uses mulDiv512
+private theorem stmtListTerminalCore_usesMulDiv512_false
+    {scope : List String} {stmts : List Stmt}
+    (hcore : FunctionBody.StmtListTerminalCore scope stmts) :
+    stmtListUsesMulDiv512 stmts = false := by
+  induction hcore with
+  | letVar hvalue _ _ ih =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]; assumption
+  | assignVar hvalue _ _ ih =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]; assumption
+  | require_ hcond _ _ ih =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hcond, Bool.false_or]; assumption
+  | return_ hvalue _ ih =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hvalue,
+        stmtListCompileCore_usesMulDiv512_false ih, Bool.false_or]
+  | stop ih =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        stmtListCompileCore_usesMulDiv512_false ih, Bool.false_or]
+  | ite hcond _ _ _ hCompile ih_then ih_else =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hcond, ih_then, ih_else,
+        stmtListCompileCore_usesMulDiv512_false hCompile, Bool.false_or]
+  | mstore hoffset _ hvalue _ _ ih =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hoffset,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]; assumption
+  | tstore hoffset _ hvalue _ _ ih =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hoffset,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]; assumption
+
+-- Helper: StmtListTerminalCore never uses paramDynamicHeadWord
+private theorem stmtListTerminalCore_usesParamDynamicHeadWord_false
+    {scope : List String} {stmts : List Stmt}
+    (hcore : FunctionBody.StmtListTerminalCore scope stmts) :
+    stmtListUsesParamDynamicHeadWord stmts = false := by
+  induction hcore with
+  | letVar hvalue _ _ ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]; assumption
+  | assignVar hvalue _ _ ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]; assumption
+  | require_ hcond _ _ ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hcond, Bool.false_or]; assumption
+  | return_ hvalue _ ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue,
+        stmtListCompileCore_usesParamDynamicHeadWord_false ih, Bool.false_or]
+  | stop ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        stmtListCompileCore_usesParamDynamicHeadWord_false ih, Bool.false_or]
+  | ite hcond _ _ _ hCompile ih_then ih_else =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hcond, ih_then, ih_else,
+        stmtListCompileCore_usesParamDynamicHeadWord_false hCompile, Bool.false_or]
+  | mstore hoffset _ hvalue _ _ ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hoffset,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]; assumption
+  | tstore hoffset _ hvalue _ _ ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hoffset,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]; assumption
+
+private theorem stmtListUsesMulDiv512_append (xs ys : List Stmt) :
+    stmtListUsesMulDiv512 (xs ++ ys) =
+      (stmtListUsesMulDiv512 xs || stmtListUsesMulDiv512 ys) := by
+  induction xs with
+  | nil => simp only [List.nil_append, stmtListUsesMulDiv512, Bool.false_or]
+  | cons x xs' ih =>
+      simp only [List.cons_append, stmtListUsesMulDiv512, Bool.false_or]
+      rw [ih, Bool.or_assoc]
+
+private theorem stmtListUsesParamDynamicHeadWord_append (xs ys : List Stmt) :
+    stmtListUsesParamDynamicHeadWord (xs ++ ys) =
+      (stmtListUsesParamDynamicHeadWord xs || stmtListUsesParamDynamicHeadWord ys) := by
+  induction xs with
+  | nil => simp only [List.nil_append, stmtListUsesParamDynamicHeadWord, Bool.false_or]
+  | cons x xs' ih =>
+      simp only [List.cons_append, stmtListUsesParamDynamicHeadWord, Bool.false_or]
+      rw [ih, Bool.or_assoc]
+
+-- SupportedStmtList never uses mulDiv512
+open Verity.Core.Free in
+private theorem supportedStmtList_usesMulDiv512_false
+    {fields : List Field} {scope : List String} {stmts : List Stmt}
+    (h : SupportedStmtList fields scope stmts) :
+    stmtListUsesMulDiv512 stmts = false := by
+  induction h with
+  | compileCore hcore => exact stmtListCompileCore_usesMulDiv512_false hcore
+  | terminalCore hterminal => exact stmtListTerminalCore_usesMulDiv512_false hterminal
+  | setStorageSingleSlot hvalue _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]
+  | setStorageAddrSingleSlot hvalue _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]
+  | mstoreSingle hoffset _ hvalue _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hoffset,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]
+  | tstoreSingle hoffset _ hvalue _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hoffset,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]
+  | letStorageField _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512, exprUsesMulDiv512, Bool.false_or]
+  | letStorageAddrField _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512, exprUsesMulDiv512, Bool.false_or]
+  | assignStorageField _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512, exprUsesMulDiv512, Bool.false_or]
+  | assignStorageAddrField _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512, exprUsesMulDiv512, Bool.false_or]
+  | emitEvent hcoreAll _ =>
+      simpa [stmtListUsesMulDiv512, stmtUsesMulDiv512]
+        using exprListCompileCore_usesMulDiv512_false hcoreAll
+  | letMappingField hkey _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512, exprUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hkey, Bool.false_or]
+  | letMappingWordField hkey _ _ | letMappingUintField hkey _ _
+  | letMappingPackedWordField hkey _ _ | letStructMemberField hkey _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512, exprUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hkey, Bool.false_or]
+  | letMapping2Field hkey1 _ hkey2 _ _ | letMapping2WordField hkey1 _ hkey2 _ _
+  | letStructMember2Field hkey1 _ hkey2 _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512, exprUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hkey1,
+        exprCompileCore_usesMulDiv512_false hkey2, Bool.false_or]
+  | setMappingUintSingle hkey _ hvalue _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hkey,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]
+  | setMappingChainSingle hkeys _ hvalue _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprListCompileCore_usesMulDiv512_false hkeys,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]
+  | setMappingSingle hkey _ hvalue _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hkey,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]
+  | setMappingWordSingle hkey _ hvalue _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hkey,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]
+  | setMappingPackedWordSingle hkey _ hvalue _ _ _ _ _ _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hkey,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]
+  | setStructMemberSingle hkey _ hvalue _ _ _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hkey,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]
+  | setMapping2Single hkey1 _ hkey2 _ hvalue _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hkey1,
+        exprCompileCore_usesMulDiv512_false hkey2,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]
+  | setMapping2WordSingle hkey1 _ hkey2 _ hvalue _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hkey1,
+        exprCompileCore_usesMulDiv512_false hkey2,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]
+  | setStructMember2Single hkey1 _ hkey2 _ hvalue _ _ _ _ =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hkey1,
+        exprCompileCore_usesMulDiv512_false hkey2,
+        exprCompileCore_usesMulDiv512_false hvalue, Bool.false_or]
+  | requireClause clause _ ih =>
+      simp only [stmtListUsesMulDiv512, Bool.or_eq_false_iff, Bool.false_or]
+      exact ⟨by cases clause with | mk family n m p q message =>
+          cases family with
+          | binary op =>
+              cases op <;> simp only [RequireLiteralGuardFamilyClause.toStmt,
+                stmtUsesMulDiv512, exprUsesMulDiv512, Bool.false_or]
+          | andEqLt =>
+              simp only [RequireLiteralGuardFamilyClause.toStmt,
+                stmtUsesMulDiv512, exprUsesMulDiv512, Bool.false_or]
+          | orEqLt =>
+              simp only [RequireLiteralGuardFamilyClause.toStmt,
+                stmtUsesMulDiv512, exprUsesMulDiv512, Bool.false_or], ih⟩
+  | iteTerminal hcond _ hthen helse =>
+      simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512,
+        exprCompileCore_usesMulDiv512_false hcond,
+        stmtListTerminalCore_usesMulDiv512_false hthen,
+        stmtListTerminalCore_usesMulDiv512_false helse, Bool.false_or]
+  | @append _ pfx sfx _ _ ihPfx ihSfx =>
+      rw [stmtListUsesMulDiv512_append, ihPfx, ihSfx]
+      simp
+
+-- SupportedStmtList never uses paramDynamicHeadWord
+open Verity.Core.Free in
+private theorem supportedStmtList_usesParamDynamicHeadWord_false
+    {fields : List Field} {scope : List String} {stmts : List Stmt}
+    (h : SupportedStmtList fields scope stmts) :
+    stmtListUsesParamDynamicHeadWord stmts = false := by
+  induction h with
+  | compileCore hcore => exact stmtListCompileCore_usesParamDynamicHeadWord_false hcore
+  | terminalCore hterminal => exact stmtListTerminalCore_usesParamDynamicHeadWord_false hterminal
+  | setStorageSingleSlot hvalue _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]
+  | setStorageAddrSingleSlot hvalue _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]
+  | mstoreSingle hoffset _ hvalue _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hoffset,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]
+  | tstoreSingle hoffset _ hvalue _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hoffset,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]
+  | letStorageField _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord, exprUsesParamDynamicHeadWord, Bool.false_or]
+  | letStorageAddrField _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord, exprUsesParamDynamicHeadWord, Bool.false_or]
+  | assignStorageField _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord, exprUsesParamDynamicHeadWord, Bool.false_or]
+  | assignStorageAddrField _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord, exprUsesParamDynamicHeadWord, Bool.false_or]
+  | emitEvent hcoreAll _ =>
+      simpa [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord]
+        using exprListCompileCore_usesParamDynamicHeadWord_false hcoreAll
+  | letMappingField hkey _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord, exprUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey, Bool.false_or]
+  | letMappingWordField hkey _ _ | letMappingUintField hkey _ _
+  | letMappingPackedWordField hkey _ _ | letStructMemberField hkey _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord, exprUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey, Bool.false_or]
+  | letMapping2Field hkey1 _ hkey2 _ _ | letMapping2WordField hkey1 _ hkey2 _ _
+  | letStructMember2Field hkey1 _ hkey2 _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord, exprUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey1,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey2, Bool.false_or]
+  | setMappingUintSingle hkey _ hvalue _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]
+  | setMappingChainSingle hkeys _ hvalue _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprListCompileCore_usesParamDynamicHeadWord_false hkeys,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]
+  | setMappingSingle hkey _ hvalue _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]
+  | setMappingWordSingle hkey _ hvalue _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]
+  | setMappingPackedWordSingle hkey _ hvalue _ _ _ _ _ _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]
+  | setStructMemberSingle hkey _ hvalue _ _ _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]
+  | setMapping2Single hkey1 _ hkey2 _ hvalue _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey1,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey2,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]
+  | setMapping2WordSingle hkey1 _ hkey2 _ hvalue _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey1,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey2,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]
+  | setStructMember2Single hkey1 _ hkey2 _ hvalue _ _ _ _ =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey1,
+        exprCompileCore_usesParamDynamicHeadWord_false hkey2,
+        exprCompileCore_usesParamDynamicHeadWord_false hvalue, Bool.false_or]
+  | requireClause clause _ ih =>
+      simp only [stmtListUsesParamDynamicHeadWord, Bool.or_eq_false_iff, Bool.false_or]
+      exact ⟨by cases clause with | mk family n m p q message =>
+          cases family with
+          | binary op =>
+              cases op <;> simp only [RequireLiteralGuardFamilyClause.toStmt,
+                stmtUsesParamDynamicHeadWord, exprUsesParamDynamicHeadWord, Bool.false_or]
+          | andEqLt =>
+              simp only [RequireLiteralGuardFamilyClause.toStmt,
+                stmtUsesParamDynamicHeadWord, exprUsesParamDynamicHeadWord, Bool.false_or]
+          | orEqLt =>
+              simp only [RequireLiteralGuardFamilyClause.toStmt,
+                stmtUsesParamDynamicHeadWord, exprUsesParamDynamicHeadWord, Bool.false_or], ih⟩
+  | iteTerminal hcond _ hthen helse =>
+      simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
+        exprCompileCore_usesParamDynamicHeadWord_false hcond,
+        stmtListTerminalCore_usesParamDynamicHeadWord_false hthen,
+        stmtListTerminalCore_usesParamDynamicHeadWord_false helse, Bool.false_or]
+  | @append _ pfx sfx _ _ ihPfx ihSfx =>
+      rw [stmtListUsesParamDynamicHeadWord_append, ihPfx, ihSfx]
+      simp
+
+private theorem stmtListUsesMulDiv512_eq_any (stmts : List Stmt) :
+    stmtListUsesMulDiv512 stmts = stmts.any stmtUsesMulDiv512 := by
+  induction stmts with
+  | nil => simp [stmtListUsesMulDiv512, List.any]
+  | cons s ss ih => simp [stmtListUsesMulDiv512, List.any_cons, ih]
+
+private theorem stmtListUsesParamDynamicHeadWord_eq_any (stmts : List Stmt) :
+    stmtListUsesParamDynamicHeadWord stmts = stmts.any stmtUsesParamDynamicHeadWord := by
+  induction stmts with
+  | nil => simp [stmtListUsesParamDynamicHeadWord, List.any]
+  | cons s ss ih => simp [stmtListUsesParamDynamicHeadWord, List.any_cons, ih]
+
+theorem SupportedSpec.contractUsesMulDiv512_eq_false
+    {spec : CompilationModel} {selectors : List Nat}
+    (hSupported : SupportedSpec spec selectors) :
+    contractUsesMulDiv512 spec = false := by
+  have hfunctions : ∀ fn ∈ spec.functions, fn.body.any stmtUsesMulDiv512 = false := by
+    intro fn hmem
+    have := supportedStmtList_usesMulDiv512_false
+      (hSupported.functions fn hmem).body.stmtList
+    rw [stmtListUsesMulDiv512_eq_any] at this
+    simpa using this
+  have hfunctionsAny :
+      spec.functions.any (fun fn => fn.body.any stmtUsesMulDiv512) = false :=
+    listAny_eq_false_of_mem_eq_false
+      (fun fn => fn.body.any stmtUsesMulDiv512) spec.functions hfunctions
+  cases hctor : spec.constructor with
+  | none =>
+      simp [contractUsesMulDiv512, hctor, hfunctionsAny]
+  | some ctor =>
+      have hctorMulDiv :
+          ctor.body.any stmtUsesMulDiv512 = false := by
+        have := supportedStmtList_usesMulDiv512_false
+          (hSupported.constructor ctor hctor).body.stmtList
+        rw [stmtListUsesMulDiv512_eq_any] at this
+        simpa using this
+      simp [contractUsesMulDiv512, hctor, hctorMulDiv, hfunctionsAny]
+
+theorem SupportedSpec.contractUsesParamDynamicHeadWord_eq_false
+    {spec : CompilationModel} {selectors : List Nat}
+    (hSupported : SupportedSpec spec selectors) :
+    contractUsesParamDynamicHeadWord spec = false := by
+  have hfunctions :
+      ∀ fn ∈ spec.functions, fn.body.any stmtUsesParamDynamicHeadWord = false := by
+    intro fn hmem
+    have := supportedStmtList_usesParamDynamicHeadWord_false
+      (hSupported.functions fn hmem).body.stmtList
+    rw [stmtListUsesParamDynamicHeadWord_eq_any] at this
+    simpa using this
+  have hfunctionsAny :
+      spec.functions.any (fun fn => fn.body.any stmtUsesParamDynamicHeadWord) = false :=
+    listAny_eq_false_of_mem_eq_false
+      (fun fn => fn.body.any stmtUsesParamDynamicHeadWord) spec.functions hfunctions
+  cases hctor : spec.constructor with
+  | none =>
+      simp [contractUsesParamDynamicHeadWord, hctor, hfunctionsAny]
+  | some ctor =>
+      have hctorParam :
+          ctor.body.any stmtUsesParamDynamicHeadWord = false := by
+        have := supportedStmtList_usesParamDynamicHeadWord_false
+          (hSupported.constructor ctor hctor).body.stmtList
+        rw [stmtListUsesParamDynamicHeadWord_eq_any] at this
+        simpa using this
+      simp [contractUsesParamDynamicHeadWord, hctor, hctorParam, hfunctionsAny]
+
+theorem SupportedSpecExceptMappingWrites.contractUsesMulDiv512_eq_false
+    {spec : CompilationModel} {selectors : List Nat}
+    (hSupported : SupportedSpecExceptMappingWrites spec selectors) :
+    contractUsesMulDiv512 spec = false := by
+  have hfunctions : ∀ fn ∈ spec.functions, fn.body.any stmtUsesMulDiv512 = false := by
+    intro fn hmem
+    have := supportedStmtList_usesMulDiv512_false
+      (hSupported.functions fn hmem).body.stmtList
+    rw [stmtListUsesMulDiv512_eq_any] at this
+    simpa using this
+  have hfunctionsAny :
+      spec.functions.any (fun fn => fn.body.any stmtUsesMulDiv512) = false :=
+    listAny_eq_false_of_mem_eq_false
+      (fun fn => fn.body.any stmtUsesMulDiv512) spec.functions hfunctions
+  cases hctor : spec.constructor with
+  | none =>
+      simp [contractUsesMulDiv512, hctor, hfunctionsAny]
+  | some ctor =>
+      have hctorMulDiv :
+          ctor.body.any stmtUsesMulDiv512 = false := by
+        have := supportedStmtList_usesMulDiv512_false
+          (hSupported.constructor ctor hctor).body.stmtList
+        rw [stmtListUsesMulDiv512_eq_any] at this
+        simpa using this
+      simp [contractUsesMulDiv512, hctor, hctorMulDiv, hfunctionsAny]
+
+theorem SupportedSpecExceptMappingWrites.contractUsesParamDynamicHeadWord_eq_false
+    {spec : CompilationModel} {selectors : List Nat}
+    (hSupported : SupportedSpecExceptMappingWrites spec selectors) :
+    contractUsesParamDynamicHeadWord spec = false := by
+  have hfunctions :
+      ∀ fn ∈ spec.functions, fn.body.any stmtUsesParamDynamicHeadWord = false := by
+    intro fn hmem
+    have := supportedStmtList_usesParamDynamicHeadWord_false
+      (hSupported.functions fn hmem).body.stmtList
+    rw [stmtListUsesParamDynamicHeadWord_eq_any] at this
+    simpa using this
+  have hfunctionsAny :
+      spec.functions.any (fun fn => fn.body.any stmtUsesParamDynamicHeadWord) = false :=
+    listAny_eq_false_of_mem_eq_false
+      (fun fn => fn.body.any stmtUsesParamDynamicHeadWord) spec.functions hfunctions
+  cases hctor : spec.constructor with
+  | none =>
+      simp [contractUsesParamDynamicHeadWord, hctor, hfunctionsAny]
+  | some ctor =>
+      have hctorParam :
+          ctor.body.any stmtUsesParamDynamicHeadWord = false := by
+        have := supportedStmtList_usesParamDynamicHeadWord_false
+          (hSupported.constructor ctor hctor).body.stmtList
+        rw [stmtListUsesParamDynamicHeadWord_eq_any] at this
+        simpa using this
+      simp [contractUsesParamDynamicHeadWord, hctor, hctorParam, hfunctionsAny]
+
 theorem SupportedSpec.noInternalFunctions
     {spec : CompilationModel} {selectors : List Nat}
     (hSupported : SupportedSpec spec selectors) :

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2710,6 +2710,9 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_extcodesize  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_returndataOptionalBoolAt  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_keccak256  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mulDiv512Down  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mulDiv512Up  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_paramDynamicHeadWord  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_call  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_staticcall  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_delegatecall  -- private
@@ -5498,4 +5501,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5212 theorems/lemmas (3508 public, 1704 private, 0 sorry'd)
+-- Total: 5215 theorems/lemmas (3508 public, 1707 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2990,6 +2990,24 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.stmtListUsesStorageArrayElement_eq_any  -- private
   -- Compiler.Proofs.IRGeneration.stmtListUsesDynamicBytesEq_eq_any  -- private
   -- Compiler.Proofs.IRGeneration.listAny_eq_false_of_mem_eq_false  -- private
+  -- Compiler.Proofs.IRGeneration.exprCompileCore_usesMulDiv512_false  -- private
+  -- Compiler.Proofs.IRGeneration.exprCompileCore_usesParamDynamicHeadWord_false  -- private
+  -- Compiler.Proofs.IRGeneration.exprListCompileCore_usesMulDiv512_false  -- private
+  -- Compiler.Proofs.IRGeneration.exprListCompileCore_usesParamDynamicHeadWord_false  -- private
+  -- Compiler.Proofs.IRGeneration.stmtListCompileCore_usesMulDiv512_false  -- private
+  -- Compiler.Proofs.IRGeneration.stmtListCompileCore_usesParamDynamicHeadWord_false  -- private
+  -- Compiler.Proofs.IRGeneration.stmtListTerminalCore_usesMulDiv512_false  -- private
+  -- Compiler.Proofs.IRGeneration.stmtListTerminalCore_usesParamDynamicHeadWord_false  -- private
+  -- Compiler.Proofs.IRGeneration.stmtListUsesMulDiv512_append  -- private
+  -- Compiler.Proofs.IRGeneration.stmtListUsesParamDynamicHeadWord_append  -- private
+  -- Compiler.Proofs.IRGeneration.supportedStmtList_usesMulDiv512_false  -- private
+  -- Compiler.Proofs.IRGeneration.supportedStmtList_usesParamDynamicHeadWord_false  -- private
+  -- Compiler.Proofs.IRGeneration.stmtListUsesMulDiv512_eq_any  -- private
+  -- Compiler.Proofs.IRGeneration.stmtListUsesParamDynamicHeadWord_eq_any  -- private
+  Compiler.Proofs.IRGeneration.SupportedSpec.contractUsesMulDiv512_eq_false
+  Compiler.Proofs.IRGeneration.SupportedSpec.contractUsesParamDynamicHeadWord_eq_false
+  Compiler.Proofs.IRGeneration.SupportedSpecExceptMappingWrites.contractUsesMulDiv512_eq_false
+  Compiler.Proofs.IRGeneration.SupportedSpecExceptMappingWrites.contractUsesParamDynamicHeadWord_eq_false
   Compiler.Proofs.IRGeneration.SupportedSpec.noInternalFunctions
   Compiler.Proofs.IRGeneration.SupportedSpecExceptMappingWrites.noInternalFunctions
   Compiler.Proofs.IRGeneration.SupportedSpec.contractUsesArrayElement_eq_false
@@ -5501,4 +5519,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5215 theorems/lemmas (3508 public, 1707 private, 0 sorry'd)
+-- Total: 5233 theorems/lemmas (3512 public, 1721 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -153,6 +153,11 @@ ALLOWLIST: set[str] = {
     "supportedStmtList_usesStorageArrayElement_false",
     "supportedStmtList_usesDynamicBytesEq_false",
     "supportedStmtList_usesArrayElement_false",
+    # Mirror of supportedStmtList_usesDynamicBytesEq_false for verity#1761/#1832:
+    # one explicit case per SupportedStmtList constructor, dispatching to the
+    # matching exprCompileCore_uses{MulDiv512,ParamDynamicHeadWord}_false leaf.
+    "supportedStmtList_usesMulDiv512_false",
+    "supportedStmtList_usesParamDynamicHeadWord_false",
     # --- Mapping slot and field resolution proofs ---
     "findResolvedFieldAtSlotCopyFrom_of_member",
     "firstFieldWriteSlotConflictCopyFrom_some_of_seen_slot_member",


### PR DESCRIPTION
## Summary

The `Verify proofs` workflow's `Prebuild shared audit Lean targets` step
(`lake build PrintAxioms`) has been failing on main since the
codegen-only #1832 (`paramDynamicHeadWord`) and #1761
(`mulDiv512Down`, `mulDiv512Up`) constructors landed: those PRs added
new `Expr` constructors but did not update the matching exhaustiveness
sites in the proof framework. Every PR's build job has been red and
every main push since #1843 shows the same trail of
`error: Missing cases:` / `Cannot derive ... _mutual.eq_def` /
`trying to realize ... eq_1 but enableRealizationsForConst must be
called for ...` lines.

This PR brings the audit-step surface predicates, proof tactics, and
the downstream `compileValidatedCore_ok_yields_internalFunctions_nil`
chain back into sync with the current `Expr` constructor set.

## Phase 1 — exhaustiveness fix (commit d78b35c8)

- **`Compiler/Proofs/IRGeneration/SupportedSpec.lean`**
  - Add `paramDynamicHeadWord` and `mulDiv512Down/Up` to the
    unsupported-by-core and unsupported-by-contract surface buckets in
    the 9 `exprTouches*Surface` defs (these constructors lower to
    runtime Yul helpers the current core proof framework does not model
    yet, so they correctly widen the unsupported surface).
  - Split the proof tactics that destructure `hcore` over
    `mulDivDown/Up` so the new constructors derive False from
    `exprTouchesUnsupportedCoreSurface = false` (`true = false`),
    since they sit in the unsupported group.
  - Expand the trailing `| _ => []` wildcard in
    `exprInternalHelperCallNames` to an explicit constructor list.
    This is the verity#1842 mitigation for the `_mutual.eq_def`
    200 000-heartbeat ceiling.

- **`Compiler/Proofs/IRGeneration/SourceSemantics.lean`**
  - Add `evalExpr_mulDiv512Down`, `evalExpr_mulDiv512Up`,
    `evalExpr_paramDynamicHeadWord` simp lemmas (each `:= rfl`).
  - Expand the `| _ => none` wildcard in `evalExprWithHelpers` to an
    explicit leaf list.
  - Add the `evalExprWithHelpers_eq_evalExpr_of_helperSurfaceClosed`
    arms for `mulDiv512Down/Up` and `paramDynamicHeadWord`.

- **`Compiler/Proofs/IRGeneration/GenericInduction.lean`**
  - Add `mulDiv512Down/Up` and `paramDynamicHeadWord` arms to
    `exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false`.

After phase 1, `lake build PrintAxioms` was reduced to a single
remaining error: `ContractShape.lean:178:6 tactic 'rfl' failed`.

## Phase 2 — close `ContractShape:178` rfl (commit 02197191)

`compileValidatedCore_ok_yields_internalFunctions_nil` could no longer
reduce `internalFunctions` to `[]` because `compileValidatedCore` emits
two new conditional helper lists guarded by `contractUsesMulDiv512`
and `contractUsesParamDynamicHeadWord`. Those flags need to be
provably false on every `SupportedSpec`.

Two blockers stood in the way:

1. `exprUsesMulDiv512` / `exprUsesParamDynamicHeadWord` and their stmt
   mirrors were `partial def`s, so `simp` / `unfold` / `decide` / `rfl`
   could not reduce concrete leaves. Converted all four to plain `def`s
   with explicit `termination_by` / `decreasing_by`, mirroring the
   `exprUsesArrayElement` template, in
   `Compiler/CompilationModel/UsageAnalysis.lean`.

2. No `SupportedSpec.contractUsesXxx_eq_false` existed for the two new
   flags. Added the full proof chain for both, mirroring the existing
   `supportedStmtList_usesDynamicBytesEq_false` template:
   `exprCompileCore_usesXxx_false` (by induction on
   `FunctionBody.ExprCompileCore`), `exprListCompileCore_*`,
   `stmtListCompileCore_*` / `stmtListTerminalCore_*` /
   `stmtListUsesXxx_append`, `supportedStmtList_usesXxx_false` (by
   induction on `SupportedStmtList`, case-by-case),
   `stmtListUsesXxx_eq_any`, and the
   `SupportedSpec[ExceptMappingWrites].contractUsesXxx_eq_false`
   theorems in `Compiler/Proofs/IRGeneration/SupportedSpec.lean`.

Wired the new hypotheses (`hmulDiv512`, `hparamDyn`) into:
- `compileValidatedCore_ok_yields_internalFunctions_nil` in
  `Compiler/Proofs/IRGeneration/ContractShape.lean:138`.
- `compile_ok_yields_internalFunctions_nil[_except_mapping_writes]`
  in `Compiler/Proofs/IRGeneration/Contract.lean`.

## Build status

After both commits:

- `lake build PrintAxioms` — green.
- `make check` — passes (with `Contracts/UnlinkPool/` temporarily moved
  out of the working tree, per the project's untracked-dir hygiene check).

`PrintAxioms.lean` regenerated by `scripts/generate_print_axioms.py`.
`scripts/check_proof_length.py` allowlist updated for
`supportedStmtList_usesMulDiv512_false` (107 lines) and
`supportedStmtList_usesParamDynamicHeadWord_false` (105 lines), both
direct mirrors of `supportedStmtList_usesDynamicBytesEq_false`.

## Why this is worth merging

- Every error in the original "Before" block is no-progress noise that
  has been hiding real downstream proof issues. Eliminating them brings
  the audit log to green.
- The eq_def heartbeat fix (`exprInternalHelperCallNames` wildcard
  expansion + `evalExprWithHelpers` wildcard expansion) prevents future
  `Expr` constructor additions from cascading into the same noise.
- All edits preserve the existing trust model — `mulDiv512` and
  `paramDynamicHeadWord` were already not modeled by the core proof
  framework; the surface predicates now correctly reflect that, and the
  contract-level "uses" gates are provably false on every supported
  spec.

## Test plan

- [x] `lake build Compiler.Proofs.IRGeneration.SupportedSpec` passes locally.
- [x] `lake build Compiler.Proofs.IRGeneration.SourceSemantics` passes locally.
- [x] `lake build Compiler.Proofs.IRGeneration.GenericInduction` passes locally.
- [x] `lake build Compiler.Proofs.IRGeneration.ContractShape` passes locally.
- [x] `lake build Compiler.Proofs.IRGeneration.Contract` passes locally.
- [x] `lake build PrintAxioms` fully green locally.
- [x] `make check` passes locally.
- [ ] CI on this PR shows the audit step fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates compiler usage-analysis and proof surface predicates around new `Expr` constructors; while intended to be proof-only/exhaustiveness fixes, mistakes could change helper-inclusion conditions or supported-spec gating during compilation.
> 
> **Overview**
> Fixes proof/audit build failures caused by newly added codegen-only `Expr` constructors (`mulDiv512Down/Up`, `paramDynamicHeadWord`) by making the IR-generation proof framework exhaustive again.
> 
> This converts `exprUses{MulDiv512,ParamDynamicHeadWord}` and statement scans from `partial def` to terminating `def`s (with explicit list/branch helpers) so `simp` can unfold them, and wires new “must be false for supported specs” lemmas into the `compileValidatedCore` proof chains.
> 
> It also classifies these constructors as unsupported surfaces in `SupportedSpec`, adds vacuous/exhaustive handling in `GenericInduction` and `SourceSemantics` (including explicit “unmodeled/codegen-only” `evalExprWithHelpers` cases and simp lemmas), and updates `PrintAxioms.lean` plus the proof-length allowlist for the new large mirror proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b00e6b5de51f20a7bd6ddecbbac1e44943ed0d14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->