### PR TITLE
Add «to»/«from» escaped binder regression smoke for #1847

### DIFF
--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -354,6 +354,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.HelperExternalArgumentSmoke.spec
   , Contracts.Smoke.BlockTimestampSmoke.spec
   , Contracts.Smoke.SelfBalanceSmoke.spec
+  , Contracts.Smoke.MathlibReservedBinderEscape.spec
   , Contracts.Smoke.StructMappingSmoke.spec
   , Contracts.Smoke.ExternalCallSmoke.spec
   , Contracts.Smoke.TryExternalCallSmoke.spec
@@ -484,6 +485,7 @@ private def expectedExternalSignatures : List (String × List String) :=
       "bindExternalArg(uint256)", "tupleExternalArg(uint256)", "statementExternalArg(uint256)"])
   , ("BlockTimestampSmoke", ["nowish()", "timestampPlus(uint256)", "blobFeePlus(uint256)"])
   , ("SelfBalanceSmoke", ["currentBalance()", "balancePlus(uint256)"])
+  , ("MathlibReservedBinderEscape", ["transferLike(address,uint256)", "transferLikeFrom(address,address,uint256)"])
   , ("StructMappingSmoke", ["setPosition(address,uint256,uint256,address)", "totalPositionShares(address)",
       "delegateOf(address)", "setApproval(address,address,uint256,uint256)", "approvalOf(address,address)",
       "approvalNonce(address,address)"])
@@ -603,6 +605,7 @@ private def expectedExternalSelectors : List (String × List String) :=
       "0xb503d0dd", "0xcdc18015", "0xe41657c6"])
   , ("BlockTimestampSmoke", ["0xa676760e", "0x8c041599", "0x7150df5e"])
   , ("SelfBalanceSmoke", ["0xce845d1d", "0x13b0662c"])
+  , ("MathlibReservedBinderEscape", ["0x4fee5360", "0x4d1b4491"])
   , ("StructMappingSmoke", ["0x468c900e", "0xe7933b6a", "0x8d22ea2a", "0xf4536007", "0xcb01943e",
       "0x6c241120"])
   , ("ExternalCallSmoke", ["0x32fdff86", "0x21209dbd"])

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -7,6 +7,7 @@ import Compiler.Selector
 import Compiler.Hex
 import Contracts
 import Contracts.Smoke
+import Contracts.Smoke.MathlibReservedBinderEscape
 import Contracts.Smoke.PackedHashECMSmoke
 import Contracts.Smoke.SelfBalanceSmoke
 import Contracts.ProxyUpgradeabilityMacroSmoke

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -7,6 +7,7 @@ import Contracts.ProxyUpgradeabilityMacroSmoke
 import Contracts.ProxyUpgradeabilityLayoutCompatibleSmoke
 import Contracts.ProxyUpgradeabilityLayoutIncompatibleSmoke
 import Contracts.Smoke
+import Contracts.Smoke.MathlibReservedBinderEscape
 import Contracts.Smoke.PackedHashECMSmoke
 import Contracts.Smoke.SelfBalanceSmoke
 
@@ -138,6 +139,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.HelperExternalArgumentSmoke.spec
   , Contracts.Smoke.BlockTimestampSmoke.spec
   , Contracts.Smoke.SelfBalanceSmoke.spec
+  , Contracts.Smoke.MathlibReservedBinderEscape.spec
   , Contracts.Smoke.StructMappingSmoke.spec
   , Contracts.Smoke.ExternalCallSmoke.spec
   , Contracts.Smoke.TryExternalCallSmoke.spec

--- a/Contracts/Smoke/MathlibReservedBinderEscape.lean
+++ b/Contracts/Smoke/MathlibReservedBinderEscape.lean
@@ -1,0 +1,63 @@
+import Contracts.Common
+
+namespace Contracts.Smoke
+
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+-- Regression test for verity#1847: Mathlib-reserved short identifiers
+-- (`to`, `from`, `at`, ...) can be used as `verity_contract` parameter
+-- binders and references via Lean's `«…»` raw-identifier escape, even
+-- after Mathlib pulls them in as syntax tokens. The compiled
+-- CompilationModel preserves the underlying name without guillemets, so
+-- ABI and audit reports stay consistent with the Solidity-faithful name.
+verity_contract MathlibReservedBinderEscape where
+  storage
+    balances : Address → Uint256 := slot 0
+
+  function transferLike («to» : Address, amount : Uint256) : Uint256 := do
+    let current ← getMapping balances «to»
+    setMapping balances «to» (add current amount)
+    return amount
+
+  function transferLikeFrom («from» : Address, «to» : Address, amount : Uint256) : Uint256 := do
+    let srcBal ← getMapping balances «from»
+    setMapping balances «from» (sub srcBal amount)
+    let dstBal ← getMapping balances «to»
+    setMapping balances «to» (add dstBal amount)
+    return amount
+
+example :
+    MathlibReservedBinderEscape.transferLike_modelBody =
+      [ Compiler.CompilationModel.Stmt.letVar "current"
+          (Compiler.CompilationModel.Expr.mapping "balances" (Compiler.CompilationModel.Expr.param "to"))
+      , Compiler.CompilationModel.Stmt.setMapping "balances"
+          (Compiler.CompilationModel.Expr.param "to")
+          (Compiler.CompilationModel.Expr.add
+            (Compiler.CompilationModel.Expr.localVar "current")
+            (Compiler.CompilationModel.Expr.param "amount"))
+      , Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.param "amount")
+      ] := rfl
+
+example :
+    MathlibReservedBinderEscape.transferLikeFrom_modelBody =
+      [ Compiler.CompilationModel.Stmt.letVar "srcBal"
+          (Compiler.CompilationModel.Expr.mapping "balances" (Compiler.CompilationModel.Expr.param "from"))
+      , Compiler.CompilationModel.Stmt.setMapping "balances"
+          (Compiler.CompilationModel.Expr.param "from")
+          (Compiler.CompilationModel.Expr.sub
+            (Compiler.CompilationModel.Expr.localVar "srcBal")
+            (Compiler.CompilationModel.Expr.param "amount"))
+      , Compiler.CompilationModel.Stmt.letVar "dstBal"
+          (Compiler.CompilationModel.Expr.mapping "balances" (Compiler.CompilationModel.Expr.param "to"))
+      , Compiler.CompilationModel.Stmt.setMapping "balances"
+          (Compiler.CompilationModel.Expr.param "to")
+          (Compiler.CompilationModel.Expr.add
+            (Compiler.CompilationModel.Expr.localVar "dstBal")
+            (Compiler.CompilationModel.Expr.param "amount"))
+      , Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.param "amount")
+      ] := rfl
+
+end Contracts.Smoke

--- a/artifacts/macro_property_tests/PropertyMathlibReservedBinderEscape.t.sol
+++ b/artifacts/macro_property_tests/PropertyMathlibReservedBinderEscape.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyMathlibReservedBinderEscapeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/MathlibReservedBinderEscape.lean
+ */
+contract PropertyMathlibReservedBinderEscapeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("MathlibReservedBinderEscape");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `transferLike` result
+    function testTODO_TransferLike_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("transferLike(address,uint256)", alice, uint256(1)));
+        require(ok, "transferLike reverted unexpectedly");
+        assertEq(ret.length, 32, "transferLike ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: TODO decode and assert `transferLikeFrom` result
+    function testTODO_TransferLikeFrom_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("transferLikeFrom(address,address,uint256)", alice, alice, uint256(1)));
+        require(ok, "transferLikeFrom reverted unexpectedly");
+        assertEq(ret.length, 32, "transferLikeFrom ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/scripts/generate_macro_property_tests.py
+++ b/scripts/generate_macro_property_tests.py
@@ -25,7 +25,7 @@ FUNCTION_RE = re.compile(
     r"^\s*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*:\s*(.+?)\s*:=\s*",
 )
 CONSTRUCTOR_RE = re.compile(r"^\s*constructor\s*\(([^)]*)\)\s*:=\s*")
-PARAM_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*$")
+PARAM_RE = re.compile(r"^\s*«?([A-Za-z_][A-Za-z0-9_]*)»?\s*:\s*(.+?)\s*$")
 NEWTYPE_RE = re.compile(
     r"^\s*([A-Z][A-Za-z0-9_]*)\s*:\s*([A-Za-z0-9_]+)\s*$",
 )

--- a/scripts/generate_macro_property_tests.py
+++ b/scripts/generate_macro_property_tests.py
@@ -25,70 +25,76 @@ FUNCTION_RE = re.compile(
     r"^\s*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*:\s*(.+?)\s*:=\s*",
 )
 CONSTRUCTOR_RE = re.compile(r"^\s*constructor\s*\(([^)]*)\)\s*:=\s*")
-PARAM_RE = re.compile(r"^\s*«?([A-Za-z_][A-Za-z0-9_]*)»?\s*:\s*(.+?)\s*$")
+# `_IDENT` captures a user-facing identifier with optional `«…»` raw-identifier
+# escape (verity#1847). The capture group excludes the guillemets so downstream
+# name lookups stay consistent with the compiled CompilationModel param/field
+# names (which are stored without guillemets).
+_IDENT = r"«?([A-Za-z_][A-Za-z0-9_]*)»?"
+
+PARAM_RE = re.compile(rf"^\s*{_IDENT}\s*:\s*(.+?)\s*$")
 NEWTYPE_RE = re.compile(
     r"^\s*([A-Z][A-Za-z0-9_]*)\s*:\s*([A-Za-z0-9_]+)\s*$",
 )
 STRUCT_RE = re.compile(r"^\s*struct\s+([A-Za-z_][A-Za-z0-9_]*)\s+where\s*(.*?)\s*$")
 STORAGE_RE = re.compile(
-    r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*:=\s*slot\s+([0-9]+)\s*$",
+    rf"^\s*{_IDENT}\s*:\s*(.+?)\s*:=\s*slot\s+([0-9]+)\s*$",
 )
 VALUE_BINDING_RE = re.compile(
-    r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*:=\s*(.+?)\s*$",
+    rf"^\s*{_IDENT}\s*:\s*(.+?)\s*:=\s*(.+?)\s*$",
 )
 STORAGE_READ_RE = re.compile(
-    r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*(getStorage|getStorageAddr)\s+([A-Za-z_][A-Za-z0-9_]*)$"
+    rf"let\s+{_IDENT}\s*←\s*(getStorage|getStorageAddr)\s+{_IDENT}$"
 )
 STORAGE_ARRAY_LENGTH_RE = re.compile(
-    r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*getStorageArrayLength\s+([A-Za-z_][A-Za-z0-9_]*)$"
+    rf"let\s+{_IDENT}\s*←\s*getStorageArrayLength\s+{_IDENT}$"
 )
 STORAGE_ARRAY_ELEMENT_RE = re.compile(
-    r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*getStorageArrayElement\s+"
-    r"([A-Za-z_][A-Za-z0-9_]*)\s+([0-9]+)$"
+    rf"let\s+{_IDENT}\s*←\s*getStorageArrayElement\s+"
+    rf"{_IDENT}\s+([0-9]+)$"
 )
 MAPPING_READ_RE = re.compile(
-    r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*"
+    rf"let\s+{_IDENT}\s*←\s*"
     r"(getMapping|getMappingUint|getMappingAddr|getMappingUintAddr)\s+"
-    r"([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)$"
+    rf"{_IDENT}\s+{_IDENT}$"
 )
 MAPPING2_READ_RE = re.compile(
-    r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*getMapping2\s+"
-    r"([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)$"
+    rf"let\s+{_IDENT}\s*←\s*getMapping2\s+"
+    rf"{_IDENT}\s+{_IDENT}\s+{_IDENT}$"
 )
 MAPPING_WORD_READ_RE = re.compile(
-    r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*getMappingWord\s+"
-    r"([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s+([0-9]+)$"
+    rf"let\s+{_IDENT}\s*←\s*getMappingWord\s+"
+    rf"{_IDENT}\s+{_IDENT}\s+([0-9]+)$"
 )
 MAPPING_N_READ_RE = re.compile(
-    r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*getMappingN\s+"
-    r"([A-Za-z_][A-Za-z0-9_]*)\s+\[(.+)\]$"
+    rf"let\s+{_IDENT}\s*←\s*getMappingN\s+"
+    rf"{_IDENT}\s+\[(.+)\]$"
 )
 STRUCT_MEMBER_READ_RE = re.compile(
-    r'let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*structMember\s+"([^"]+)"\s+'
-    r'([A-Za-z_][A-Za-z0-9_]*)\s+"([^"]+)"$'
+    rf'let\s+{_IDENT}\s*←\s*structMember\s+"([^"]+)"\s+'
+    rf'{_IDENT}\s+"([^"]+)"$'
 )
 STRUCT_MEMBER2_READ_RE = re.compile(
-    r'let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*structMember2\s+"([^"]+)"\s+'
-    r'([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s+"([^"]+)"$'
+    rf'let\s+{_IDENT}\s*←\s*structMember2\s+"([^"]+)"\s+'
+    rf'{_IDENT}\s+{_IDENT}\s+"([^"]+)"$'
 )
 NON_ZERO_REQUIRE_RE = re.compile(
-    r'require\s+\(([A-Za-z_][A-Za-z0-9_]*)\s*!=\s*0\)\s+"[^"]+"$'
+    rf'require\s+\({_IDENT}\s*!=\s*0\)\s+"[^"]+"$'
 )
 BUILTIN_READ_RE = re.compile(
-    r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*(msgSender|msgValue)$"
+    rf"let\s+{_IDENT}\s*←\s*(msgSender|msgValue)$"
 )
 EXTERNAL_READ_RE = re.compile(
-    r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*(balanceOf|allowance|totalSupply)\s+(.+)$"
+    rf"let\s+{_IDENT}\s*←\s*(balanceOf|allowance|totalSupply)\s+(.+)$"
 )
 ORACLE_ECM_MODULE_RE = re.compile(
     r"\(fun resultVar => Compiler\.Modules\.Oracle\.oracleReadUint256Module resultVar "
     r"(0x[0-9A-Fa-f]+|[0-9]+)\s+([0-9]+)\)"
 )
 PARAM_COMPARE_RETURN_RE = re.compile(
-    r"return\s+\(?([A-Za-z_][A-Za-z0-9_]*)\s*(==|!=)\s*([A-Za-z_][A-Za-z0-9_]*)\)?$"
+    rf"return\s+\(?{_IDENT}\s*(==|!=)\s*{_IDENT}\)?$"
 )
 PARAM_COMPARE_BRANCH_RE = re.compile(
-    r"if\s+([A-Za-z_][A-Za-z0-9_]*)\s*(==|!=)\s*([A-Za-z_][A-Za-z0-9_]*)\s+then$"
+    rf"if\s+{_IDENT}\s*(==|!=)\s*{_IDENT}\s+then$"
 )
 
 


### PR DESCRIPTION
## Summary

The Mathlib bump that pulled `Mathlib.Tactic.Common` into the verity import graph turns short verbs (`to`, `from`, `at`, `do`, ...) into Lean syntax tokens, colliding with `verity_contract` binders that try to reuse Solidity-faithful parameter names.

Issue #1847 listed `«…»` raw-identifier escape as the planned workaround, but claimed `verityParam`'s `ident " : " term` syntax rejected it. An empirical retest against `Verity/Macro/Syntax.lean:34` shows it is in fact accepted:

- `function f («to» : Address) := do ...` parses cleanly.
- The binder can be referenced as `«to»` inside the function body (`getMapping balances «to»`, `setMapping balances «to» ...`).
- The compiled `CompilationModel` preserves the underlying name **without** guillemets, so the generated ABI and audit / trust reports keep the Solidity-faithful name (`Expr.param "to"`).

This PR locks in that contract with a regression smoke contract `MathlibReservedBinderEscape`:

- Two functions (`transferLike`, `transferLikeFrom`) that use `«to»` and `«from»` as binders and mapping keys.
- `rfl` assertions over `transferLike_modelBody` / `transferLikeFrom_modelBody` confirming `Expr.param "to"` and `Expr.param "from"` show up in the IR.
- Wired into the existing `Contracts.MacroTranslateInvariantTest` import list so the roundtrip / build chain exercises it.

This documents the working escape pattern in code so future contract authors do not have to relearn it, and gives us a fail-fast canary if a future Lean / Mathlib bump regresses raw-identifier handling at the macro boundary.

## Test plan

- [x] `lake build Contracts.MacroTranslateInvariantTest` is green locally (the new smoke file builds and the existing IR↔Yul randomized differential checks still pass).
- [x] `lake build Contracts.Smoke.MathlibReservedBinderEscape` is green locally; `rfl` assertions on `_modelBody` pass, proving the macro extracts `to` / `from` as the underlying param names.
- [x] No proof / axiom / trust surface change; `AUDIT.md`, `TRUST_ASSUMPTIONS.md`, `AXIOMS.md` not affected.
- [ ] CI exercises the contract via the existing `MacroTranslateInvariantTest` import path.

Closes #1847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds a new regression smoke contract and updates test harnesses/snapshots; the only behavior change is broader identifier parsing in the property-test generator, which is low risk but could affect stub generation for unusual parameter names.
> 
> **Overview**
> Adds `MathlibReservedBinderEscape` smoke contract to ensure `verity_contract` supports Mathlib-reserved short names via `«…»` escaped binders, and asserts the compiled model uses underlying param names (`"to"`, `"from"`) without guillemets.
> 
> Wires this new spec into the macro translation invariant and round-trip fuzz harnesses, including pinned signature/selector snapshot entries.
> 
> Updates `scripts/generate_macro_property_tests.py` to parse parameter/storage identifiers with optional `«…»` escapes, and adds the corresponding generated Foundry property-test stub `PropertyMathlibReservedBinderEscape.t.sol`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f609e4d05506214ba9d1cd088995b4fe0c3c5edd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->