### PR TITLE
UnlinkPool.transfer revert-form: G1 projection inside requireError == X

### DIFF
--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -497,7 +497,9 @@ private def expectedExternalSignatures : List (String × List String) :=
   , ("UnlinkPoolShapeCheckSmoke", ["nullifierCountOf((uint256,uint256[],uint256[],uint256)[],uint256)",
       "commitmentCountOf((uint256,uint256[],uint256[],uint256)[],uint256)",
       "nullifierAt((uint256,uint256[],uint256[],uint256)[],uint256,uint256)",
-      "commitmentAt((uint256,uint256[],uint256[],uint256)[],uint256,uint256)"])
+      "commitmentAt((uint256,uint256[],uint256[],uint256)[],uint256,uint256)",
+      "validateInputShape((uint256,uint256[],uint256[],uint256)[],uint256,uint256)",
+      "validateOutputShape((uint256,uint256[],uint256[],uint256)[],uint256,uint256)"])
   , ("StructMappingSmoke", ["setPosition(address,uint256,uint256,address)", "totalPositionShares(address)",
       "delegateOf(address)", "setApproval(address,address,uint256,uint256)", "approvalOf(address,address)",
       "approvalNonce(address,address)"])
@@ -620,7 +622,8 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("MathlibReservedBinderEscape", ["0x4fee5360", "0x4d1b4491"])
   , ("ArrayElementDynamicMemberLengthSmoke", ["0xfbb81f5b"])
   , ("ArrayElementDynamicMemberElementSmoke", ["0x1ffe901b"])
-  , ("UnlinkPoolShapeCheckSmoke", ["0x4b6e2141", "0xdb1ca006", "0x41620c25", "0x76524b94"])
+  , ("UnlinkPoolShapeCheckSmoke", ["0x4b6e2141", "0xdb1ca006", "0x41620c25", "0x76524b94",
+      "0xfc01c1ec", "0xe4a609b8"])
   , ("StructMappingSmoke", ["0x468c900e", "0xe7933b6a", "0x8d22ea2a", "0xf4536007", "0xcb01943e",
       "0x6c241120"])
   , ("ExternalCallSmoke", ["0x32fdff86", "0x21209dbd"])

--- a/Contracts/Smoke/UnlinkPoolShapeCheckSmoke.lean
+++ b/Contracts/Smoke/UnlinkPoolShapeCheckSmoke.lean
@@ -44,6 +44,10 @@ verity_contract UnlinkPoolShapeCheckSmoke where
     newCommitments : Array Uint256,
     contextHash : Uint256
 
+  errors
+    error PoolInvalidInputShape ()
+    error PoolInvalidOutputShape ()
+
   -- G1: read the `.length` of a dynamic member inside a struct-array
   -- element. The macro lowers this to
   -- `Expr.arrayElementDynamicMemberLength "txs" (param "idx") wordOffset`
@@ -64,14 +68,30 @@ verity_contract UnlinkPoolShapeCheckSmoke where
   function commitmentAt (txs : Array Transaction, idx : Uint256, k : Uint256) : Uint256 := do
     return arrayElement (arrayElement txs idx).newCommitments k
 
-  -- The full shape-check pattern from `UnlinkPool.transfer` (UnlinkPool.sol:341-342)
-  -- is `if (txn.nullifierHashes.length != c.inputCount) revert PoolInvalidInputShape();`.
-  -- Translating the `requireError`/`revert` form requires combining G1 with the
-  -- existing `cmp_eq` boolean predicate; the `cmp_eq` arm currently rejects
-  -- the G1 projection on the compile-model path, so we leave the
-  -- straight-line G1/G2 reads above and document the residual gap rather
-  -- than ship a half-working revert form. The next session adds the
-  -- `cmp_eq (G1) X` lift via the same projection helper.
+  -- Mirrors UnlinkPool.transfer's `if (txn.nullifierHashes.length != c.inputCount)
+  -- revert PoolInvalidInputShape();` (UnlinkPool.sol:341). `requireError`
+  -- reverts when the predicate is `false`, so the Solidity inequality flips to
+  -- an equality predicate on `requireError`.
+  function validateInputShape (txs : Array Transaction, idx : Uint256, expectedInputCount : Uint256) : Unit := do
+    requireError ((arrayLength (arrayElement txs idx).nullifierHashes) == expectedInputCount)
+      PoolInvalidInputShape ()
+
+  -- Mirrors UnlinkPool.sol:342, same shape for the output commitments.
+  function validateOutputShape (txs : Array Transaction, idx : Uint256, expectedOutputCount : Uint256) : Unit := do
+    requireError ((arrayLength (arrayElement txs idx).newCommitments) == expectedOutputCount)
+      PoolInvalidOutputShape ()
+
+  -- NOTE: the full `forEach` loop over `txs` calling `validateInputShape` /
+  -- `validateOutputShape` per element (mirroring `UnlinkPool.transfer`'s
+  -- outer for loop) currently hits the known `forEach` macro-source
+  -- limitation: the loop binder isn't visible to executable-Lean
+  -- references inside the body (see `ForEachMutableLocalMacroRejected`
+  -- in this file's sibling tests, and the P1 "`forEach`
+  -- mutable-local verification/docs" item in `docs/ROADMAP.md`). The
+  -- single-tx shape-check helpers above already exercise the canonical
+  -- G1 + G2 sites from the production audit code; wrapping them in the
+  -- outer loop is the follow-up once the `forEach` body-elaboration
+  -- limitation is lifted.
 
 example :
     UnlinkPoolShapeCheckSmoke.nullifierCountOf_modelBody =


### PR DESCRIPTION
## Summary

Smallest of the deferred follow-ups from PR #1854. The previous spike documented `requireError(cmp_eq G1 X) E ()` as a residual gap; empirical retest shows the existing `==` operator path already accepts G1 projections on both sides, so the gap was a non-issue — the spike used the non-existent `cmp_eq` identifier instead of `==`.

Extend `Contracts/Smoke/UnlinkPoolShapeCheckSmoke.lean` with the canonical revert-shape functions from `UnlinkPool.transfer`:

```lean
function validateInputShape (txs : Array Transaction, idx : Uint256, expectedInputCount : Uint256) : Unit := do
  requireError ((arrayLength (arrayElement txs idx).nullifierHashes) == expectedInputCount)
    PoolInvalidInputShape ()
```

This is the line-for-line translation of `UnlinkPool.sol:341` (`if (txn.nullifierHashes.length != c.inputCount) revert PoolInvalidInputShape();`). The shape-check pattern is the entire per-tx validation phase that `transfer` runs before mutating state.

## Residual gap noted inline

Wrapping the two `validateInputShape` / `validateOutputShape` helpers in an outer `forEach "i" (arrayLength txs) (...)` loop currently hits a separate macro-source limitation: the `forEach` body's loop binder isn't visible to executable-Lean references inside the body, which is the known `ForEachMutableLocalMacroRejected` pattern in `Contracts/Smoke.lean`. The contract-level inline comment documents this; the canonical G1 + G2 single-tx readers and the two revert wrappers cover the full shape-validation contract today.

## Test plan

- [x] `lake build` is fully green locally.
- [x] `scripts/check_macro_health.py` reports "macro health checks passed".
- [x] Two new ABI signatures + selectors (`0xfc01c1ec` / `0xe4a609b8`) registered in `MacroTranslateInvariantTest`.
- [ ] CI exercises the new revert form through the existing invariant test path.

## What's still left after this

- **`forEach` loop-binder visibility** inside the body for compound projections (P1 roadmap item: "`forEach` mutable-local verification/docs").
- **verity#1824**: internal helpers with `Array` parameters. Macro gate `supportsInternalHelperSpec` rejects helpers whose params/return contain `.array _`. Lifting requires both relaxing the gate AND extending the IR-level `Expr.internalCall` Yul lowering to pass dynamic-data params as `<name>_data_offset` + `<name>_length` Yul arg pairs (the macro alone would emit a single Yul ident, which is wrong for the Solidity calling convention).
- **Full G3 ABI encoding** for dynamic-array args to externalCall / emit (macro-level relax shipped in #1854; IR-level encoding remains).
- **Nested static struct + fixed arrays** (`Proof { uint256[2] pA; uint256[2][2] pB; uint256[2] pC; }` and `Ciphertext[]`) needed to translate the production `Transaction` struct end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new smoke-test entrypoints and updates the pinned ABI/selector snapshots; no compiler/core logic changes.
> 
> **Overview**
> Adds `PoolInvalidInputShape`/`PoolInvalidOutputShape` custom errors and two new external functions (`validateInputShape`, `validateOutputShape`) to `UnlinkPoolShapeCheckSmoke`, exercising `requireError` with dynamic-member `.length` projections.
> 
> Updates `MacroTranslateInvariantTest`’s pinned external signature and selector snapshots to include the two new entrypoints (`0xfc01c1ec`, `0xe4a609b8`) for `UnlinkPoolShapeCheckSmoke`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d91d1aaa9008f04867d3a3ee0755ec790885d35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->