### PR TITLE
Support array params in internal helpers

### DIFF
--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -26,13 +26,23 @@ def freshInternalRetNames (returns : List ParamType) (usedNames : List String) :
     (usedNames, [])
   namesRev.reverse
 
+def internalFunctionYulParamNames (params : List Param) : List String :=
+  params.flatMap fun param =>
+    match param.ty with
+    | ParamType.array elemTy =>
+        if isSingleWordStaticParamType elemTy then
+          [s!"{param.name}_data_offset", s!"{param.name}_length"]
+        else
+          [param.name]
+    | _ => [param.name]
+
 -- Compile internal function to a Yul function definition (#181)
 def compileInternalFunction (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
     (adtTypes : List AdtTypeDef := []) (spec : FunctionSpec) :
     Except String YulStmt := do
   validateFunctionSpec spec
   let returns ← functionReturns spec
-  let paramNames := spec.params.map (·.name)
+  let paramNames := internalFunctionYulParamNames spec.params
   let usedNames := paramNames ++ collectStmtListBindNames spec.body
   let retNames := freshInternalRetNames returns usedNames
   let bodyStmts ← compileStmtList fields events errors .calldata retNames true
@@ -47,10 +57,10 @@ theorem compileInternalFunction_ok_components
       validateFunctionSpec spec = Except.ok () ∧
       functionReturns spec = Except.ok returns ∧
       compileStmtList fields events errors .calldata retNames true
-        (spec.params.map (·.name) ++ retNames) [] spec.body = Except.ok bodyStmts ∧
+        (internalFunctionYulParamNames spec.params ++ retNames) [] spec.body = Except.ok bodyStmts ∧
       stmt = YulStmt.funcDef
         (internalFunctionYulName spec.name)
-        (spec.params.map (·.name))
+        (internalFunctionYulParamNames spec.params)
         retNames
         bodyStmts := by
   unfold compileInternalFunction at hcompile
@@ -67,11 +77,11 @@ theorem compileInternalFunction_ok_components
       cases hbody :
           compileStmtList fields events errors .calldata
             (freshInternalRetNames returns
-              (spec.params.map (·.name) ++ collectStmtListBindNames spec.body))
+              (internalFunctionYulParamNames spec.params ++ collectStmtListBindNames spec.body))
             true
-            (spec.params.map (·.name) ++
+            (internalFunctionYulParamNames spec.params ++
               freshInternalRetNames returns
-                (spec.params.map (·.name) ++ collectStmtListBindNames spec.body))
+                (internalFunctionYulParamNames spec.params ++ collectStmtListBindNames spec.body))
             []
             spec.body
       · rw [hbody] at hcompile
@@ -82,7 +92,7 @@ theorem compileInternalFunction_ok_components
         refine
           ⟨returns,
             freshInternalRetNames returns
-              (spec.params.map (·.name) ++ collectStmtListBindNames spec.body),
+              (internalFunctionYulParamNames spec.params ++ collectStmtListBindNames spec.body),
             bodyStmts,
             ?_⟩
         exact ⟨by simp, by simp,
@@ -97,29 +107,29 @@ theorem compileInternalFunction_some_ok_of_components
     (hretNames :
       retNames =
         freshInternalRetNames returns
-          (spec.params.map (·.name) ++ collectStmtListBindNames spec.body))
+          (internalFunctionYulParamNames spec.params ++ collectStmtListBindNames spec.body))
     (hbody :
       compileStmtList fields events errors .calldata retNames true
-        (spec.params.map (·.name) ++ retNames) [] spec.body = Except.ok bodyStmts) :
+        (internalFunctionYulParamNames spec.params ++ retNames) [] spec.body = Except.ok bodyStmts) :
     compileInternalFunction fields events errors [] spec =
       Except.ok
         (YulStmt.funcDef
           (internalFunctionYulName spec.name)
-          (spec.params.map (·.name))
+          (internalFunctionYulParamNames spec.params)
           retNames
           bodyStmts) := by
   have hbody' :
       compileStmtList fields events errors .calldata
         (freshInternalRetNames returns
-          (spec.params.map (·.name) ++ collectStmtListBindNames spec.body))
+          (internalFunctionYulParamNames spec.params ++ collectStmtListBindNames spec.body))
         true
-        (spec.params.map (·.name) ++
+        (internalFunctionYulParamNames spec.params ++
           freshInternalRetNames returns
-            (spec.params.map (·.name) ++ collectStmtListBindNames spec.body))
+            (internalFunctionYulParamNames spec.params ++ collectStmtListBindNames spec.body))
         []
         spec.body = Except.ok bodyStmts := by
     simpa [hretNames] using hbody
-  let paramNames := spec.params.map (·.name)
+  let paramNames := internalFunctionYulParamNames spec.params
   let compiledName := internalFunctionYulName spec.name
   have hmap :
       (YulStmt.funcDef
@@ -228,9 +238,9 @@ private def validateCompileInputsBeforeFieldWriteConflict
       throw s!"Compilation error: slotAliasRanges[{idxA}]={a.sourceStart}..{a.sourceEnd} and slotAliasRanges[{idxB}]={b.sourceStart}..{b.sourceEnd} overlap in source slots in {spec.name} ({issue623Ref}). Ensure slotAliasRanges source intervals are disjoint."
   | none =>
       pure ()
-  match firstInternalDynamicParam spec.functions with
+  match firstUnsupportedInternalDynamicParam spec.functions with
   | some (fnName, paramName, ty) =>
-      throw s!"Compilation error: internal function '{fnName}' parameter '{paramName}' has dynamic type {repr ty}, which is currently unsupported ({issue753Ref}). Internal dynamic ABI lowering is not implemented yet."
+      throw s!"Compilation error: internal function '{fnName}' parameter '{paramName}' has unsupported dynamic type {repr ty} ({issue753Ref}). Internal dynamic ABI lowering currently supports only dynamic arrays with single-word static elements."
   | none =>
       pure ()
   match firstDuplicateFunctionParamName spec.functions with

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -78,7 +78,11 @@ def firstReservedExternalCollision
         storageArrayHelpersRequired
         dynamicBytesEqHelpersRequired).contains name)
 
-def firstInternalDynamicParam
+def internalDynamicParamSupported : ParamType → Bool
+  | ParamType.array elemTy => isSingleWordStaticParamType elemTy
+  | _ => false
+
+def firstUnsupportedInternalDynamicParam
     (fns : List FunctionSpec) : Option (String × String × ParamType) :=
   let rec goFns : List FunctionSpec → Option (String × String × ParamType)
     | [] => none
@@ -86,10 +90,17 @@ def firstInternalDynamicParam
         if !fn.isInternal then
           goFns rest
         else
-          match fn.params.find? (fun p => isDynamicParamType p.ty) with
+          match fn.params.find? (fun p => isDynamicParamType p.ty && !internalDynamicParamSupported p.ty) with
           | some p => some (fn.name, p.name, p.ty)
           | none => goFns rest
   goFns fns
+
+def internalCallYulArgCountForParam : ParamType → Nat
+  | ParamType.array elemTy => if isSingleWordStaticParamType elemTy then 2 else 1
+  | _ => 1
+
+def internalCallYulArgCount (params : List Param) : Nat :=
+  params.foldl (fun acc param => acc + internalCallYulArgCountForParam param.ty) 0
 
 def findInternalFunctionByName (functions : List FunctionSpec)
     (callerName calleeName : String) : Except String FunctionSpec := do
@@ -107,8 +118,9 @@ def validateInternalCallShapesInExpr
   | Expr.internalCall calleeName args => do
       validateInternalCallShapesInExprList functions callerName args
       let callee ← findInternalFunctionByName functions callerName calleeName
-      if args.length != callee.params.length then
-        throw s!"Compilation error: function '{callerName}' calls internal function '{calleeName}' with {args.length} args, expected {callee.params.length} ({issue625Ref})."
+      let expectedArgs := internalCallYulArgCount callee.params
+      if args.length != expectedArgs then
+        throw s!"Compilation error: function '{callerName}' calls internal function '{calleeName}' with {args.length} Yul arg(s), expected {expectedArgs} ({issue625Ref})."
       let returns ← functionReturns callee
       if returns.length != 1 then
         throw s!"Compilation error: function '{callerName}' uses Expr.internalCall '{calleeName}' but callee returns {returns.length} values; use Stmt.internalCallAssign for multi-return calls ({issue625Ref})."
@@ -287,8 +299,9 @@ def validateInternalCallShapesInStmt
   | Stmt.internalCall calleeName args => do
       validateInternalCallShapesInExprList functions callerName args
       let callee ← findInternalFunctionByName functions callerName calleeName
-      if args.length != callee.params.length then
-        throw s!"Compilation error: function '{callerName}' calls internal function '{calleeName}' with {args.length} args, expected {callee.params.length} ({issue625Ref})."
+      let expectedArgs := internalCallYulArgCount callee.params
+      if args.length != expectedArgs then
+        throw s!"Compilation error: function '{callerName}' calls internal function '{calleeName}' with {args.length} Yul arg(s), expected {expectedArgs} ({issue625Ref})."
       let returns ← functionReturns callee
       if !returns.isEmpty then
         throw s!"Compilation error: function '{callerName}' uses Stmt.internalCall '{calleeName}' but callee returns {returns.length} values; use Expr.internalCall for single-return or Stmt.internalCallAssign for multi-return calls ({issue625Ref})."
@@ -309,8 +322,9 @@ def validateInternalCallShapesInStmt
           pure ()
       validateInternalCallShapesInExprList functions callerName args
       let callee ← findInternalFunctionByName functions callerName calleeName
-      if args.length != callee.params.length then
-        throw s!"Compilation error: function '{callerName}' calls internal function '{calleeName}' with {args.length} args, expected {callee.params.length} ({issue625Ref})."
+      let expectedArgs := internalCallYulArgCount callee.params
+      if args.length != expectedArgs then
+        throw s!"Compilation error: function '{callerName}' calls internal function '{calleeName}' with {args.length} Yul arg(s), expected {expectedArgs} ({issue625Ref})."
       let returns ← functionReturns callee
       if returns.length != names.length then
         throw s!"Compilation error: function '{callerName}' binds {names.length} values from internal function '{calleeName}', but callee returns {returns.length} ({issue625Ref})."

--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -5039,8 +5039,8 @@ These theorems decompose the output of compilation functions to extract the
 exact IR structure, bridging compilation model data to `findInternalFunction?`. -/
 
 /-- The output of a successful `compileInternalFunction` is always a `funcDef`
-with Yul name `internalFunctionYulName spec.name` and parameter names
-`spec.params.map (·.name)`. -/
+with Yul name `internalFunctionYulName spec.name` and the expanded internal
+Yul parameter names for `spec.params`. -/
 theorem compileInternalFunction_output_shape
     {fields : List CompilationModel.Field}
     {events : List CompilationModel.EventDef}
@@ -5051,7 +5051,7 @@ theorem compileInternalFunction_output_shape
     ∃ retNames bodyStmts,
       stmt = YulStmt.funcDef
         (CompilationModel.internalFunctionYulName spec.name)
-        (spec.params.map (·.name))
+        (CompilationModel.internalFunctionYulParamNames spec.params)
         retNames bodyStmts := by
   simp only [CompilationModel.compileInternalFunction, bind, Except.bind] at hok
   -- Split on each fallible sub-computation; error cases are contradictory.
@@ -5112,12 +5112,12 @@ theorem findInternalFunction?_exact_of_compileInternalFunction_mem_unique
     ∃ retNames bodyStmts,
       findInternalFunction? contract (CompilationModel.internalFunctionYulName spec.name) =
         some { name := CompilationModel.internalFunctionYulName spec.name,
-               params := spec.params.map (·.name),
+               params := CompilationModel.internalFunctionYulParamNames spec.params,
                rets := retNames,
                body := bodyStmts } ∧
       compiledStmt = YulStmt.funcDef
         (CompilationModel.internalFunctionYulName spec.name)
-        (spec.params.map (·.name))
+        (CompilationModel.internalFunctionYulParamNames spec.params)
         retNames bodyStmts := by
   obtain ⟨retNames, bodyStmts, hshape⟩ := compileInternalFunction_output_shape hok
   refine ⟨retNames, bodyStmts, ?_, hshape⟩

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -2445,8 +2445,6 @@ mutual
       (fields : List Field)
       (fuel : Nat)
       (state : RuntimeState) : Expr → Option Nat
-    | .arrayElementDynamicMemberLength _ _ _ => none
-    | .arrayElementDynamicMemberElement _ _ _ _ => none
     | .literal n => some (wordNormalize n)
     | .param name => some (lookupValue state.bindings name)
       | .storage fieldName =>

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -334,6 +334,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.LeanDefHelperSmoke.spec
   , Contracts.Smoke.DirectHelperCallSmoke.spec
   , Contracts.Smoke.MultiReturnHelperSmoke.spec
+  , Contracts.Smoke.ArrayHelperCallSmoke.spec
   , Contracts.Smoke.InitializerSmoke.spec
   , Contracts.Smoke.ConstantSmoke.spec
   , Contracts.Smoke.ImmutableSmoke.spec
@@ -459,6 +460,7 @@ private def expectedExternalSignatures : List (String × List String) :=
   , ("DirectHelperCallSmoke", ["addToTotal(uint256)", "readTotalPlus(uint256)", "pairWithTotal(uint256)",
       "runHelpers(uint256,uint256,uint256)", "snapshot()"])
   , ("MultiReturnHelperSmoke", ["summarize(uint256)", "useSummary(uint256)"])
+  , ("ArrayHelperCallSmoke", ["first(uint256[])", "useFirst(uint256[])"])
   , ("InitializerSmoke", ["initOwner(address)", "upgradeToV2()"])
   , ("ConstantSmoke", ["feeOn(uint256)", "treasuryAddr()"])
   , ("ImmutableSmoke", ["supplyCap()", "treasuryAddr()", "shadowed(uint256)"])
@@ -597,6 +599,7 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("LeanDefHelperSmoke", ["0x42dbad08", "0x9ca603a4"])
   , ("DirectHelperCallSmoke", ["0x623f577a", "0xe9696d56", "0xe176587e", "0xa392867e", "0x9711715a"])
   , ("MultiReturnHelperSmoke", ["0x9c9c9cd5", "0xbe1e29cd"])
+  , ("ArrayHelperCallSmoke", ["0x665cb27f", "0x3a11b9c7"])
   , ("InitializerSmoke", ["0x0d009297", "0xcc01053e"])
   , ("ConstantSmoke", ["0x9c421eb5", "0x30d9a62a"])
   , ("ImmutableSmoke", ["0x8f770ad0", "0x30d9a62a", "0x655b96ec"])
@@ -987,6 +990,17 @@ private def checkMultiReturnHelperSmoke : IO Unit := do
         helperName == "internal_summarize"
     | _ => false)
 
+private def checkArrayHelperCallSmoke : IO Unit := do
+  expectTrue
+    "ArrayHelperCallSmoke: dynamic Array helper arg expands to offset/length Yul args"
+    (match Contracts.Smoke.ArrayHelperCallSmoke.useFirst_modelBody with
+    | [Stmt.letVar "x"
+          (Expr.internalCall "internal_first"
+            [Expr.param "xs_data_offset", Expr.param "xs_length"]),
+        Stmt.setStorage "ok" (Expr.localVar "x"),
+        Stmt.stop] => true
+    | _ => false)
+
 private def checkNamedStructParamSmoke : IO Unit := do
   expectTrue
     "NamedStructParamSmoke: nested struct leaf projection uses recursive tuple binding"
@@ -1180,6 +1194,7 @@ private def checkSpec (spec : CompilationModel) : IO Unit := do
   checkSpecialEntrypointSmoke
   checkDirectHelperCallSmoke
   checkMultiReturnHelperSmoke
+  checkArrayHelperCallSmoke
   checkNamedStructParamSmoke
   checkCurveCutArraySmoke
   checkDynamicStructArraySmoke

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -122,6 +122,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.LeanDefHelperSmoke.spec
   , Contracts.Smoke.DirectHelperCallSmoke.spec
   , Contracts.Smoke.MultiReturnHelperSmoke.spec
+  , Contracts.Smoke.ArrayHelperCallSmoke.spec
   , Contracts.Smoke.InitializerSmoke.spec
   , Contracts.Smoke.ConstantSmoke.spec
   , Contracts.Smoke.ImmutableSmoke.spec

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -1355,6 +1355,40 @@ verity_contract MultiReturnHelperSmoke where
     let (head, tail) ← summarize seed
     return (add head tail)
 
+verity_contract ArrayHelperCallSmoke where
+  storage
+    ok : Uint256 := slot 0
+
+  function first (xs : Array Uint256) : Uint256 := do
+    return arrayElement xs 0
+
+  function allow_post_interaction_writes useFirst (xs : Array Uint256) : Unit := do
+    let x ← first xs
+    setStorage ok x
+
+example :
+    ArrayHelperCallSmoke.first_modelBody =
+      [ Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.arrayElement
+            "xs"
+            (Compiler.CompilationModel.Expr.literal 0))
+      ] := rfl
+
+example :
+    ArrayHelperCallSmoke.useFirst_modelBody =
+      [ Compiler.CompilationModel.Stmt.letVar
+          "x"
+          (Compiler.CompilationModel.Expr.internalCall
+            "internal_first"
+            [ Compiler.CompilationModel.Expr.param "xs_data_offset"
+            , Compiler.CompilationModel.Expr.param "xs_length"
+            ])
+      , Compiler.CompilationModel.Stmt.setStorage
+          "ok"
+          (Compiler.CompilationModel.Expr.localVar "x")
+      , Compiler.CompilationModel.Stmt.stop
+      ] := rfl
+
 verity_contract ForEachMutableLocalSmoke where
   storage
     seen : Uint256 := slot 0
@@ -1999,6 +2033,7 @@ end SpecGenSmoke
 #check_contract PackedStorageWriteSmoke
 #check_contract DirectHelperCallSmoke
 #check_contract MultiReturnHelperSmoke
+#check_contract ArrayHelperCallSmoke
 #check_contract ForEachMutableLocalSmoke
 #check_contract Uint8Smoke
 #check_contract AddressHelpersSmoke

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2082,10 +2082,15 @@ private partial def hasDynamicInternalHelperType (ty : ValueType) : Bool :=
   | .struct _ fields => fields.any (fun field => hasDynamicInternalHelperType field.snd)
   | _ => false
 
+private def supportsInternalHelperParamType (ty : ValueType) : Bool :=
+  match ty with
+  | .array elemTy => isSingleWordStaticValueType elemTy
+  | _ => !hasDynamicInternalHelperType ty
+
 private def supportsInternalHelperSpec (fn : FunctionDecl) : Bool :=
   fn.name != "fallback" &&
     fn.name != "receive" &&
-    fn.params.all (fun param => !hasDynamicInternalHelperType param.ty) &&
+    fn.params.all (fun param => supportsInternalHelperParamType param.ty) &&
     !hasDynamicInternalHelperType fn.returnTy
 
 private def ensureSupportsInternalHelperSpec
@@ -3830,6 +3835,34 @@ private def tupleReturnValueExprs?
       | _ =>
           pure none
 
+private def translateInternalHelperCallArgs
+    (fields : Array StorageFieldDecl)
+    (constDecls : Array ConstantDecl)
+    (immutableDecls : Array ImmutableDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (fn : FunctionDecl)
+    (argTerms : Array Term) : CommandElabM (Array Term) := do
+  let mut out : Array Term := #[]
+  for idx in [:argTerms.size] do
+    let some arg := argTerms[idx]? | pure ()
+    let some fnParam := fn.params[idx]? | pure ()
+    match fnParam.ty with
+    | .array elemTy =>
+        if isSingleWordStaticValueType elemTy then
+          match directParamNameWithType? params arg with
+          | some (name, _) =>
+              out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
+              out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
+          | none =>
+              throwErrorAt arg
+                s!"helper call '{fn.name}' Array parameter '{fnParam.name}' currently requires a direct Array parameter reference"
+        else
+          out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+    | _ =>
+        out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+  pure out
+
 private def tupleInternalCallAssignStmt?
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
@@ -3855,8 +3888,8 @@ private def tupleInternalCallAssignStmt?
   match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals rhs with
   | some (fn, argTerms) =>
       ensureSupportsInternalHelperSpec rhs fn
-      let argExprs ← argTerms.mapM
-        (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+      let argExprs ← translateInternalHelperCallArgs
+        fields constDecls immutableDecls params locals fn argTerms
       pure (some (← `(Compiler.CompilationModel.Stmt.internalCallAssign
         [ $[$resultNameTerms],* ]
         $(strTerm (internalHelperSpecNameFor fn))
@@ -4146,8 +4179,8 @@ private def translateBindSource
       match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals rhs with
       | some (fn, argTerms) =>
           ensureSupportsInternalHelperSpec rhs fn
-          let argExprs ← argTerms.mapM
-            (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+          let argExprs ← translateInternalHelperCallArgs
+            fields constDecls immutableDecls params locals fn argTerms
           `(Compiler.CompilationModel.Expr.internalCall
               $(strTerm (internalHelperSpecNameFor fn))
               [ $[$argExprs],* ])
@@ -5041,8 +5074,8 @@ private def translateEffectStmt
           if fn.returnTy != .unit then
             throwErrorAt stx
               s!"helper call '{fn.name}' returns {renderValueType fn.returnTy}; use `let ... ← {fn.name} ...` or tuple destructuring"
-          let argExprs ← argTerms.mapM
-            (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+          let argExprs ← translateInternalHelperCallArgs
+            fields constDecls immutableDecls params locals fn argTerms
           `(Compiler.CompilationModel.Stmt.internalCall
               $(strTerm (internalHelperSpecNameFor fn))
               [ $[$argExprs],* ])

--- a/artifacts/macro_property_tests/PropertyArrayHelperCallSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyArrayHelperCallSmoke.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyArrayHelperCallSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyArrayHelperCallSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("ArrayHelperCallSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `first` result
+    function testTODO_First_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("first(uint256[])", _singletonUintArray(1)));
+        require(ok, "first reverted unexpectedly");
+        assertEq(ret.length, 32, "first ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+
+    function _singletonUintArray(uint256 x) internal pure returns (uint256[] memory arr) {
+        arr = new uint256[](1);
+        arr[0] = x;
+    }
+}


### PR DESCRIPTION
## Summary
- allow internal helpers to accept dynamic Array parameters with single-word static elements
- expand those helper parameters to Yul offset/length pairs at function definition and macro call sites
- add ArrayHelperCallSmoke plus invariant, selector, fuzz, and macro property coverage

## Verification
- lake build
- python3 scripts/check_macro_health.py
- make check
- lake build PrintAxioms
- lake env lean PrintAxioms.lean | python3 scripts/check_axioms.py --report

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes internal-function ABI lowering by expanding certain array parameters into multiple Yul arguments, which can break call/definition alignment and affect generated code shape across contracts; coverage is added but the surface area spans compiler, macro translation, and proofs.
> 
> **Overview**
> Internal helper compilation now expands supported dynamic array parameters into two Yul parameters (`*_data_offset` and `*_length`) via `internalFunctionYulParamNames`, and updates internal-call validation to check **Yul argument count** (not source-level param count) and to reject unsupported dynamic internal params with a clearer error.
> 
> Macro translation now allows helpers with `Array` params (only when elements are single-word static) and rewrites helper call arguments accordingly, requiring direct parameter references for such arrays.
> 
> Adds a new `ArrayHelperCallSmoke` contract plus invariant/round-trip fuzz wiring and a generated Solidity property test stub to exercise the new lowering and call-shape expectations, and updates related IR proof shape lemmas to match the new parameter naming/arity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af11db5e524fe0d8e72aee34665606033d65a75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->