### PR TITLE
Support dynamic args in linked external calls

### DIFF
--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -102,6 +102,14 @@ def internalCallYulArgCountForParam : ParamType → Nat
 def internalCallYulArgCount (params : List Param) : Nat :=
   params.foldl (fun acc param => acc + internalCallYulArgCountForParam param.ty) 0
 
+def linkedExternalCallYulArgCountForParam : ParamType → Nat
+  | ParamType.array elemTy => if isSingleWordStaticParamType elemTy then 2 else 1
+  | ParamType.bytes | ParamType.string => 2
+  | _ => 1
+
+def linkedExternalCallYulArgCount (params : List ParamType) : Nat :=
+  params.foldl (fun acc paramTy => acc + linkedExternalCallYulArgCountForParam paramTy) 0
+
 def findInternalFunctionByName (functions : List FunctionSpec)
     (callerName calleeName : String) : Except String FunctionSpec := do
   let candidates := functions.filter (fun fn => fn.isInternal && fn.name == calleeName)
@@ -379,8 +387,9 @@ def validateExternalCallTargetsInExpr
         | none =>
             throw s!"Compilation error: {context} references unknown external call target '{name}' ({issue732Ref}). Declare it in spec.externals."
         | some ext =>
-            if args.length != ext.params.length then
-              throw s!"Compilation error: {context} calls external '{name}' with {args.length} args, but spec.externals declares {ext.params.length} ({issue184Ref})."
+            let expectedArgs := linkedExternalCallYulArgCount ext.params
+            if args.length != expectedArgs then
+              throw s!"Compilation error: {context} calls external '{name}' with {args.length} Yul arg(s), expected {expectedArgs} ({issue184Ref})."
             let returns ← externalFunctionReturns ext
             if returns.length != 1 then
               throw s!"Compilation error: {context} uses Expr.externalCall '{name}' but spec.externals declares {returns.length} return values; Expr.externalCall requires exactly 1 ({issue184Ref})."
@@ -565,8 +574,9 @@ def validateExternalCallTargetsInStmt
       | none =>
           throw s!"Compilation error: {context} uses Stmt.externalCallBind with unknown external function '{externalName}'."
       | some ext => do
-          if args.length != ext.params.length then
-            throw s!"Compilation error: {context} calls external function '{externalName}' with {args.length} args, expected {ext.params.length}."
+          let expectedArgs := linkedExternalCallYulArgCount ext.params
+          if args.length != expectedArgs then
+            throw s!"Compilation error: {context} calls external function '{externalName}' with {args.length} Yul arg(s), expected {expectedArgs}."
           let returns ← externalFunctionReturns ext
           if returns.length != resultVars.length then
             throw s!"Compilation error: {context} binds {resultVars.length} values from external function '{externalName}', but it returns {returns.length}."
@@ -584,8 +594,9 @@ def validateExternalCallTargetsInStmt
       | none =>
           throw s!"Compilation error: {context} uses Stmt.tryExternalCallBind with unknown external function '{externalName}'."
       | some ext => do
-          if args.length != ext.params.length then
-            throw s!"Compilation error: {context} calls external function '{externalName}' with {args.length} args, expected {ext.params.length}."
+          let expectedArgs := linkedExternalCallYulArgCount ext.params
+          if args.length != expectedArgs then
+            throw s!"Compilation error: {context} calls external function '{externalName}' with {args.length} Yul arg(s), expected {expectedArgs}."
           let returns ← externalFunctionReturns ext
           if returns.length != resultVars.length then
             throw s!"Compilation error: {context} binds {resultVars.length} values from external function '{externalName}', but it returns {returns.length}."

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -254,6 +254,10 @@ instance : ExternalArg Address where
   toWord value := value.toNat
 instance : ExternalArg Bool where
   toWord value := if value then 1 else 0
+instance [ExternalArg α] : ExternalArg (Array α) where
+  toWord values := values.size
+instance : ExternalArg ByteArray where
+  toWord bytes := bytes.size
 instance : ExternalResult Uint256 where
   fromWord value := value
 instance : ExternalResult Int256 where
@@ -270,6 +274,8 @@ def externalCallWords {α : Type} [ExternalResult α] (name : String) (args : Li
   ExternalResult.fromWord (externalCallStubWord name args)
 def tryExternalCallWords {α : Type} [Inhabited α] (_name : String) (_args : List Uint256) : Contract (Bool × α) :=
   pure (false, (Inhabited.default : α))
+def externalCallBind {α : Type} [ExternalArg α] (_names : List String) (_name : String) (_args : List α) : Contract Unit :=
+  pure ()
 private def erc20ReadStubWord (name : String) (args : List Uint256) : Uint256 :=
   externalCallStubWord name args
 macro_rules

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -366,6 +366,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.StructMappingSmoke.spec
   , Contracts.Smoke.ExternalCallSmoke.spec
   , Contracts.Smoke.TryExternalCallSmoke.spec
+  , Contracts.Smoke.LinkedExternalDynamicArgSmoke.spec
   , Contracts.Smoke.ExternalCallMultiReturn.spec
   , Contracts.Smoke.ERC20HelperSmoke.spec
   , Contracts.Smoke.GenericECMReadSmoke.spec
@@ -510,6 +511,8 @@ private def expectedExternalSignatures : List (String × List String) :=
       "approvalNonce(address,address)"])
   , ("ExternalCallSmoke", ["storeEcho(uint256)", "getEchoedValue()"])
   , ("TryExternalCallSmoke", ["tryEcho(uint256)"])
+  , ("LinkedExternalDynamicArgSmoke", ["hashLeaves(uint256[])", "sendLeaves(uint256[])",
+      "tryHash(uint256[])", "hashPayload(bytes)"])
   , ("ExternalCallMultiReturn", ["callFanout(uint256)", "noop()"])
   , ("ERC20HelperSmoke", ["pushTokens(address,address,uint256)", "pullTokens(address,address,address,uint256)",
       "approveTokens(address,address,uint256)", "snapshotBalance(address,address)",
@@ -635,6 +638,8 @@ private def expectedExternalSelectors : List (String × List String) :=
       "0x6c241120"])
   , ("ExternalCallSmoke", ["0x32fdff86", "0x21209dbd"])
   , ("TryExternalCallSmoke", ["0xaf842e53"])
+  , ("LinkedExternalDynamicArgSmoke", ["0xf1b3ebc7", "0x3f87a475", "0x35ea2663",
+      "0xc58b0a4d"])
   , ("ExternalCallMultiReturn", ["0x70fce9a3", "0x5dfc2e4a"])
   , ("ERC20HelperSmoke", ["0xa6c29ca3", "0x6aa209a6", "0x912d6e28", "0x48476c71", "0xdac24aaf",
       "0x7247c4a5"])

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -151,6 +151,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.StructMappingSmoke.spec
   , Contracts.Smoke.ExternalCallSmoke.spec
   , Contracts.Smoke.TryExternalCallSmoke.spec
+  , Contracts.Smoke.LinkedExternalDynamicArgSmoke.spec
   , Contracts.Smoke.ExternalCallMultiReturn.spec
   , Contracts.Smoke.ERC20HelperSmoke.spec
   , Contracts.Smoke.GenericECMReadSmoke.spec

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -1634,6 +1634,71 @@ verity_contract TryExternalCallSmoke where
     else
       setStorage callSucceeded 0
 
+verity_contract LinkedExternalDynamicArgSmoke where
+  storage
+  linked_externals
+    external hashArray(Array Uint256) -> (Uint256)
+    external hashArray_try(Array Uint256) -> (Bool, Uint256)
+    external notifyArray(Array Uint256)
+    external hashBytes(Bytes) -> (Uint256)
+
+  function hashLeaves (leaves : Array Uint256) : Uint256 := do
+    return externalCall "hashArray" [leaves]
+
+  function sendLeaves (leaves : Array Uint256) : Unit := do
+    externalCallBind [] "notifyArray" [leaves]
+
+  function tryHash (leaves : Array Uint256) : Uint256 := do
+    let (_success, h) ← tryExternalCall "hashArray" [leaves]
+    return h
+
+  function hashPayload (payload : Bytes) : Uint256 := do
+    return externalCall "hashBytes" [payload]
+
+example :
+    LinkedExternalDynamicArgSmoke.hashLeaves_modelBody =
+      [ Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.externalCall
+            "hashArray"
+            [ Compiler.CompilationModel.Expr.param "leaves_data_offset"
+            , Compiler.CompilationModel.Expr.param "leaves_length"
+            ])
+      ] := rfl
+
+example :
+    LinkedExternalDynamicArgSmoke.sendLeaves_modelBody =
+      [ Compiler.CompilationModel.Stmt.externalCallBind
+          []
+          "notifyArray"
+          [ Compiler.CompilationModel.Expr.param "leaves_data_offset"
+          , Compiler.CompilationModel.Expr.param "leaves_length"
+          ]
+      , Compiler.CompilationModel.Stmt.stop
+      ] := rfl
+
+example :
+    LinkedExternalDynamicArgSmoke.tryHash_modelBody =
+      [ Compiler.CompilationModel.Stmt.tryExternalCallBind
+          "_success"
+          ["h"]
+          "hashArray"
+          [ Compiler.CompilationModel.Expr.param "leaves_data_offset"
+          , Compiler.CompilationModel.Expr.param "leaves_length"
+          ]
+      , Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.localVar "h")
+      ] := rfl
+
+example :
+    LinkedExternalDynamicArgSmoke.hashPayload_modelBody =
+      [ Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.externalCall
+            "hashBytes"
+            [ Compiler.CompilationModel.Expr.param "payload_data_offset"
+            , Compiler.CompilationModel.Expr.param "payload_length"
+            ])
+      ] := rfl
+
 verity_contract ERC20HelperSmoke where
   storage
     lastBalance : Uint256 := slot 0
@@ -1773,13 +1838,13 @@ verity_contract ERC20HelperShadowWriteRejected where
     safeTransfer token toAddr amount
 
 /--
- error: linked external 'describe' uses unsupported parameter type; executable externalCall currently supports only Uint256, Int256, Uint8, Address, Bytes32, and Bool
+ error: linked external 'describe' uses unsupported return type; executable externalCall currently supports only Uint256, Int256, Uint8, Address, Bytes32, and Bool
 -/
 #guard_msgs in
 verity_contract ExternalCallUnsupportedType where
   storage
   linked_externals
-    external describe(String) -> (Uint256)
+    external describe(Uint256) -> (String)
 
   function noop () : Unit := do
     pure ()
@@ -2045,6 +2110,7 @@ end SpecGenSmoke
 #check_contract StructMappingSmoke
 #check_contract ExternalCallSmoke
 #check_contract TryExternalCallSmoke
+#check_contract LinkedExternalDynamicArgSmoke
 #check_contract ExternalCallMultiReturn
 #check_contract Contracts.Vault
 

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1083,6 +1083,12 @@ private def externalExecutableWordType? : ValueType → Bool
   | .newtype _ baseType => externalExecutableWordType? baseType
   | _ => false
 
+private def externalExecutableParamType? : ValueType → Bool
+  | .array elemTy => externalExecutableWordType? elemTy
+  | .bytes | .string => true
+  | .newtype _ baseType => externalExecutableParamType? baseType
+  | ty => externalExecutableWordType? ty
+
 private def validateExternalExecutableType
     (extIdent : Ident)
     (extName : String)
@@ -1091,6 +1097,14 @@ private def validateExternalExecutableType
   if !externalExecutableWordType? ty then
     throwErrorAt extIdent
       s!"linked external '{extName}' uses unsupported {role} type; executable externalCall currently supports only Uint256, Int256, Uint8, Address, Bytes32, and Bool"
+
+private def validateExternalExecutableParamType
+    (extIdent : Ident)
+    (extName : String)
+    (ty : ValueType) : CommandElabM Unit := do
+  if !externalExecutableParamType? ty then
+    throwErrorAt extIdent
+      s!"linked external '{extName}' uses unsupported parameter type; executable externalCall currently supports word-like values plus direct Array<word-like>, Bytes, and String calldata parameters"
 
 private def tupleElemsFromTerm? (stx : Term) : Option (Array Term) :=
   tupleElemsFromSyntax? (stripParens stx).raw |>.map (·.map (fun syn => ⟨syn⟩))
@@ -1468,6 +1482,12 @@ private def isSingleWordStaticValueType : ValueType → Bool
   | .bool => true
   | .newtype _ baseType => isSingleWordStaticValueType baseType
   | ty => isWordLikeValueType ty
+
+private def externalCallDynamicArgSupported (ty : ValueType) : Bool :=
+  match ty with
+  | .array elemTy => isSingleWordStaticValueType elemTy
+  | .bytes | .string => true
+  | _ => false
 
 private partial def staticAbiWordCount? : ValueType → Option Nat
   | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool => some 1
@@ -2802,7 +2822,7 @@ private partial def inferTupleSourceTypes?
           match stripParens args with
           | `(term| [ $[$xs],* ]) =>
               for x in xs do
-                requireWordLikeType x s!"tryExternalCall '{extName}' argument"
+                requireWordOrDirectArrayType x s!"tryExternalCall '{extName}' argument"
                   (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x)
           | _ => throwErrorAt args "expected list literal [..]"
           match externalDecls.find? (fun ext => ext.name == extName) with
@@ -3452,7 +3472,19 @@ partial def translatePureExprWithTypes
       let extName := ← expectStringOrIdent name
       let argsExprs ←
         match stripParens args with
-        | `(term| [ $[$xs],* ]) => xs.mapM (fun x => translatePureExprWithTypes fields constDecls immutableDecls params locals x visitingConstants)
+        | `(term| [ $[$xs],* ]) => do
+            let mut out : Array Term := #[]
+            for arg in xs do
+              match directParamNameWithType? params arg with
+              | some (name, ty) =>
+                  if externalCallDynamicArgSupported ty then
+                    out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
+                    out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
+                  else
+                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+              | none =>
+                  out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+            pure out
         | _ => throwErrorAt args "expected list literal [..]"
       `(Compiler.CompilationModel.Expr.externalCall $(strTerm extName) [ $[$argsExprs],* ])
   | `(term| structMember $field:term $key:term $member:term) =>
@@ -3863,6 +3895,26 @@ private def translateInternalHelperCallArgs
         out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
   pure out
 
+private def translateLinkedExternalCallArgs
+    (fields : Array StorageFieldDecl)
+    (constDecls : Array ConstantDecl)
+    (immutableDecls : Array ImmutableDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (argTerms : Array Term) : CommandElabM (Array Term) := do
+  let mut out : Array Term := #[]
+  for arg in argTerms do
+    match directParamNameWithType? params arg with
+    | some (name, ty) =>
+        if externalCallDynamicArgSupported ty then
+          out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
+          out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
+        else
+          out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+    | none =>
+        out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+  pure out
+
 private def tupleInternalCallAssignStmt?
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
@@ -3928,7 +3980,7 @@ private def tryExternalCallBindStmt?
       let extName := ← expectStringOrIdent name
       let argExprs ← match stripParens args with
         | `(term| [ $[$xs],* ]) =>
-            xs.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+            translateLinkedExternalCallArgs fields constDecls immutableDecls params locals xs
         | _ => throwErrorAt args "expected list literal [..]"
       -- names[0] is the success flag, names[1..] are result vars
       let initialUsedNames := (params.toList.map (fun p => p.name)) ++ (typedLocalNames locals).toList ++ (names.filterMap id).toList
@@ -5043,7 +5095,11 @@ private def translateEffectStmt
       let resultNames := ← expectStringList names
       let resultNameTerms := resultNames.map strTerm
       let targetFn := ← expectStringOrIdent fnName
-      let argExprs ← expectExprList fields constDecls immutableDecls params locals args
+      let argExprs ←
+        match stripParens args with
+        | `(term| [ $[$xs],* ]) =>
+            translateLinkedExternalCallArgs fields constDecls immutableDecls params locals xs
+        | _ => throwErrorAt args "expected list literal [..]"
       `(Compiler.CompilationModel.Stmt.externalCallBind
           [ $[$resultNameTerms],* ]
           $(strTerm targetFn)
@@ -6334,7 +6390,7 @@ def validateExternalDeclsPublic
     -- only supports single-return, but tryExternalCall supports any return count.
     -- (#1727, Axis 1 Step 5f)
     for paramTy in ext.params do
-      validateExternalExecutableType ext.ident ext.name paramTy "parameter"
+      validateExternalExecutableParamType ext.ident ext.name paramTy
     for returnTy in ext.returnTys do
       validateExternalExecutableType ext.ident ext.name returnTy "return"
     seenNames := seenNames.push ext.name

--- a/artifacts/macro_property_tests/PropertyLinkedExternalDynamicArgSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyLinkedExternalDynamicArgSmoke.t.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyLinkedExternalDynamicArgSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyLinkedExternalDynamicArgSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("LinkedExternalDynamicArgSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `hashLeaves` result
+    function testTODO_HashLeaves_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("hashLeaves(uint256[])", _singletonUintArray(1)));
+        require(ok, "hashLeaves reverted unexpectedly");
+        assertEq(ret.length, 32, "hashLeaves ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: sendLeaves has no unexpected revert
+    function testAuto_SendLeaves_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("sendLeaves(uint256[])", _singletonUintArray(1)));
+        require(ok, "sendLeaves reverted unexpectedly");
+    }
+    // Property 3: TODO decode and assert `tryHash` result
+    function testTODO_TryHash_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryHash(uint256[])", _singletonUintArray(1)));
+        require(ok, "tryHash reverted unexpectedly");
+        assertEq(ret.length, 32, "tryHash ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 4: TODO decode and assert `hashPayload` result
+    function testTODO_HashPayload_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("hashPayload(bytes)", hex"CAFE"));
+        require(ok, "hashPayload reverted unexpectedly");
+        assertEq(ret.length, 32, "hashPayload ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+
+    function _singletonUintArray(uint256 x) internal pure returns (uint256[] memory arr) {
+        arr = new uint256[](1);
+        arr[0] = x;
+    }
+}


### PR DESCRIPTION
## Summary
- expand direct Array/Bytes/String params to calldata pointer/length args for linked external call lowering
- allow dynamic calldata params in linked external declarations while keeping return types word-only
- add LinkedExternalDynamicArgSmoke and macro property artifact coverage

## Verification
- lake build
- python3 scripts/check_macro_health.py
- make check
- lake build PrintAxioms
- lake env lean PrintAxioms.lean | python3 scripts/check_axioms.py --report

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the ABI lowering/validation path for linked externals by expanding dynamic calldata parameters into offset/length Yul args; mistakes here could break external-call correctness or cause subtle runtime ABI mismatches.
> 
> **Overview**
> Linked external calls can now accept dynamic calldata parameters (*direct* `Array<word-like>`, `Bytes`, and `String`) by lowering those arguments into `{param}_data_offset`/`{param}_length` pairs for `externalCall`, `tryExternalCall`, and `externalCallBind`.
> 
> Validation is updated to count the *expanded* Yul argument shape for linked externals (including improved error messages) while keeping linked external return types restricted to word-like types. Adds `ExternalArg` instances for `Array`/`ByteArray`, introduces a new `LinkedExternalDynamicArgSmoke` contract + selector snapshots, and generates a new Solidity property-test artifact covering the new calling convention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13734280d99d575f3ce116b76e0743680d1b49ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->