### PR TITLE
Support projected array member args

### DIFF
--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -29,11 +29,8 @@ def freshInternalRetNames (returns : List ParamType) (usedNames : List String) :
 def internalFunctionYulParamNames (params : List Param) : List String :=
   params.flatMap fun param =>
     match param.ty with
-    | ParamType.array elemTy =>
-        if isSingleWordStaticParamType elemTy then
-          [s!"{param.name}_data_offset", s!"{param.name}_length"]
-        else
-          [param.name]
+    | ParamType.array _ =>
+        [s!"{param.name}_data_offset", s!"{param.name}_length"]
     | _ => [param.name]
 
 -- Compile internal function to a Yul function definition (#181)
@@ -436,6 +433,8 @@ def compileValidatedCore (spec : CompilationModel) (selectors : List Nat) : Exce
       -- correct and avoids a separate predicate.
       , checkedArrayElementDynamicMemberLengthCalldataHelper
       , checkedArrayElementDynamicMemberLengthMemoryHelper
+      , checkedArrayElementDynamicMemberDataOffsetCalldataHelper
+      , checkedArrayElementDynamicMemberDataOffsetMemoryHelper
       -- verity#1849 G2: dynamic-member element helpers gated the same way.
       , checkedArrayElementDynamicMemberElementCalldataHelper
       , checkedArrayElementDynamicMemberElementMemoryHelper

--- a/Compiler/CompilationModel/DynamicData.lean
+++ b/Compiler/CompilationModel/DynamicData.lean
@@ -44,6 +44,12 @@ def checkedArrayElementDynamicMemberLengthCalldataHelperName : String :=
 def checkedArrayElementDynamicMemberLengthMemoryHelperName : String :=
   "__verity_array_element_dynamic_member_length_memory_checked"
 
+def checkedArrayElementDynamicMemberDataOffsetCalldataHelperName : String :=
+  "__verity_array_element_dynamic_member_data_offset_calldata_checked"
+
+def checkedArrayElementDynamicMemberDataOffsetMemoryHelperName : String :=
+  "__verity_array_element_dynamic_member_data_offset_memory_checked"
+
 def checkedArrayElementDynamicMemberElementCalldataHelperName : String :=
   "__verity_array_element_dynamic_member_element_calldata_checked"
 
@@ -266,6 +272,70 @@ def checkedArrayElementDynamicMemberLengthCalldataHelper : YulStmt :=
 def checkedArrayElementDynamicMemberLengthMemoryHelper : YulStmt :=
   checkedArrayElementDynamicMemberLengthHelper
     checkedArrayElementDynamicMemberLengthMemoryHelperName
+    "mload"
+    none
+
+/-- Yul helper for `Expr.arrayElementDynamicMemberDataOffset`.
+    It follows the same ABI walk as the dynamic-member length helper, but
+    returns the offset of the first element word after the member length
+    word.  This matches the `_data_offset` convention used for direct
+    dynamic-array parameters. -/
+private def checkedArrayElementDynamicMemberDataOffsetHelper
+    (helperName loadOp : String) (sizeExpr? : Option YulExpr) : YulStmt :=
+  let offsetTableBytes := YulExpr.call "mul" [YulExpr.ident "length", YulExpr.lit 32]
+  let elementOffsetSlot := YulExpr.call "add" [
+    YulExpr.ident "data_offset",
+    YulExpr.call "mul" [YulExpr.ident "index", YulExpr.lit 32]
+  ]
+  let elementHeadPos := YulExpr.call "add" [
+    YulExpr.ident "data_offset",
+    YulExpr.ident "__element_rel_offset"
+  ]
+  let memberHeadSlot := YulExpr.call "add" [
+    YulExpr.ident "__element_head_pos",
+    YulExpr.call "mul" [YulExpr.ident "word_offset", YulExpr.lit 32]
+  ]
+  let memberDataPos := YulExpr.call "add" [
+    YulExpr.ident "__element_head_pos",
+    YulExpr.ident "__member_rel_offset"
+  ]
+  let sizeCheck :=
+    match sizeExpr? with
+    | some sizeExpr =>
+        [YulStmt.if_ (YulExpr.call "gt" [
+          YulExpr.ident "__member_data_pos",
+          YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
+        ]) [
+          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        ]]
+    | none => []
+  YulStmt.funcDef helperName ["data_offset", "length", "index", "word_offset"] ["word"] (
+    [
+      YulStmt.if_ (YulExpr.call "iszero" [
+        YulExpr.call "lt" [YulExpr.ident "index", YulExpr.ident "length"]
+      ]) [
+        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      ],
+      YulStmt.let_ "__element_rel_offset" (YulExpr.call loadOp [elementOffsetSlot]),
+      YulStmt.if_ (YulExpr.call "lt" [YulExpr.ident "__element_rel_offset", offsetTableBytes]) [
+        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      ],
+      YulStmt.let_ "__element_head_pos" elementHeadPos,
+      YulStmt.let_ "__member_rel_offset" (YulExpr.call loadOp [memberHeadSlot]),
+      YulStmt.let_ "__member_data_pos" memberDataPos
+    ] ++ sizeCheck ++ [
+      YulStmt.assign "word" (YulExpr.call "add" [YulExpr.ident "__member_data_pos", YulExpr.lit 32])
+    ])
+
+def checkedArrayElementDynamicMemberDataOffsetCalldataHelper : YulStmt :=
+  checkedArrayElementDynamicMemberDataOffsetHelper
+    checkedArrayElementDynamicMemberDataOffsetCalldataHelperName
+    "calldataload"
+    (some (YulExpr.call "calldatasize" []))
+
+def checkedArrayElementDynamicMemberDataOffsetMemoryHelper : YulStmt :=
+  checkedArrayElementDynamicMemberDataOffsetHelper
+    checkedArrayElementDynamicMemberDataOffsetMemoryHelperName
     "mload"
     none
 

--- a/Compiler/CompilationModel/ExpressionCompile.lean
+++ b/Compiler/CompilationModel/ExpressionCompile.lean
@@ -312,6 +312,17 @@ def compileExpr (fields : List Field)
         indexExpr,
         YulExpr.lit wordOffset
       ])
+  | Expr.arrayElementDynamicMemberDataOffset name index wordOffset => do
+      let indexExpr ← compileExpr fields dynamicSource index
+      let helperName := match dynamicSource with
+        | .calldata => checkedArrayElementDynamicMemberDataOffsetCalldataHelperName
+        | .memory => checkedArrayElementDynamicMemberDataOffsetMemoryHelperName
+      pure (YulExpr.call helperName [
+        YulExpr.ident s!"{name}_data_offset",
+        YulExpr.ident s!"{name}_length",
+        indexExpr,
+        YulExpr.lit wordOffset
+      ])
   | Expr.arrayElementDynamicMemberElement name index wordOffset innerIndex => do
       let indexExpr ← compileExpr fields dynamicSource index
       let innerIndexExpr ← compileExpr fields dynamicSource innerIndex

--- a/Compiler/CompilationModel/LogicalPurity.lean
+++ b/Compiler/CompilationModel/LogicalPurity.lean
@@ -24,6 +24,7 @@ partial def exprContainsCallLike (expr : Expr) : Bool :=
   | Expr.arrayElement _ index
   | Expr.arrayElementWord _ index _ _
   | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
       exprContainsCallLike index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex =>
@@ -126,6 +127,7 @@ def exprContainsUnsafeLogicalCallLike (expr : Expr) : Bool :=
       exprContainsUnsafeLogicalCallLike key1 || exprContainsUnsafeLogicalCallLike key2
   | Expr.storageArrayElement _ index | Expr.arrayElement _ index
   | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _
   | Expr.returndataOptionalBoolAt index =>
       exprContainsUnsafeLogicalCallLike index

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -185,6 +185,22 @@ def validateScopedExprIdentifiers
       | none =>
           throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.arrayElementDynamicMemberLength"
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount index
+  | Expr.arrayElementDynamicMemberDataOffset name index wordOffset => do
+      match findParamType params name with
+      | some ty@(ParamType.array elemTy) =>
+          if isDynamicParamType elemTy then
+            let expectedWords := paramLocalHeadWords elemTy
+            if wordOffset < expectedWords then
+              pure ()
+            else
+              throw s!"Compilation error: {context} Expr.arrayElementDynamicMemberDataOffset '{name}' wordOffset {wordOffset} is outside dynamic element head width {expectedWords} for {repr ty}"
+          else
+            throw s!"Compilation error: {context} Expr.arrayElementDynamicMemberDataOffset '{name}' requires an array parameter with dynamic ABI elements, got {repr ty}"
+      | some ty =>
+          throw s!"Compilation error: {context} Expr.arrayElementDynamicMemberDataOffset '{name}' requires array parameter, got {repr ty}"
+      | none =>
+          throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.arrayElementDynamicMemberDataOffset"
+      validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount index
   | Expr.arrayElementDynamicMemberElement name index wordOffset innerIndex => do
       match findParamType params name with
       | some ty@(ParamType.array elemTy) =>

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -366,6 +366,11 @@ inductive Expr
       e.g. `txn.nullifierHashes.length` where `txn` is an element of a
       struct-array parameter.  (verity#1849, G1) -/
   | arrayElementDynamicMemberLength (name : String) (index : Expr) (wordOffset : Nat)
+  /-- Data offset of a dynamic word-array member nested inside a
+      struct-array element.  The returned word points at the first element
+      word (immediately after the member's ABI length word), matching the
+      `_data_offset` convention used for direct dynamic-array parameters. -/
+  | arrayElementDynamicMemberDataOffset (name : String) (index : Expr) (wordOffset : Nat)
   /-- Element access into a dynamic word-array member nested inside a
       struct-array element.  Given a struct-array parameter `name` indexed
       at `index`, dereferences the head pointer at `wordOffset` (relative

--- a/Compiler/CompilationModel/UsageAnalysis.lean
+++ b/Compiler/CompilationModel/UsageAnalysis.lean
@@ -101,6 +101,9 @@ def exprUsesArrayElementKind (includePlain includeWord : Bool) : Expr → Bool
   | Expr.arrayElementDynamicWord _ index _ =>
       let nested := exprUsesArrayElementKind includePlain includeWord index
       if nested then true else includeWord
+  | Expr.arrayElementDynamicMemberDataOffset _ index _ =>
+      let nested := exprUsesArrayElementKind includePlain includeWord index
+      if nested then true else includeWord
   | Expr.arrayElementDynamicMemberLength _ index _ =>
       let nested := exprUsesArrayElementKind includePlain includeWord index
       if nested then true else includeWord
@@ -301,6 +304,7 @@ attribute [simp] exprUsesArrayElementKind exprListUsesArrayElementKind
 mutual
 def exprUsesArrayElement : Expr → Bool
   | Expr.arrayElement _ _ | Expr.arrayElementWord _ _ _ _ | Expr.arrayElementDynamicWord _ _ _
+  | Expr.arrayElementDynamicMemberDataOffset _ _ _
   | Expr.arrayElementDynamicMemberLength _ _ _
   | Expr.arrayElementDynamicMemberElement _ _ _ _ =>
       true
@@ -495,6 +499,7 @@ def exprUsesParamDynamicHeadWord : Expr → Bool
   | Expr.mappingUint _ key | Expr.structMember _ key _
   | Expr.storageArrayElement _ key | Expr.arrayElement _ key
   | Expr.arrayElementWord _ key _ _ | Expr.arrayElementDynamicWord _ key _
+  | Expr.arrayElementDynamicMemberDataOffset _ key _
   | Expr.arrayElementDynamicMemberLength _ key _ =>
       exprUsesParamDynamicHeadWord key
   | Expr.arrayElementDynamicMemberElement _ key _ innerKey =>
@@ -634,6 +639,7 @@ def exprUsesMulDiv512 : Expr → Bool
   | Expr.mappingUint _ key | Expr.structMember _ key _
   | Expr.storageArrayElement _ key | Expr.arrayElement _ key
   | Expr.arrayElementWord _ key _ _ | Expr.arrayElementDynamicWord _ key _
+  | Expr.arrayElementDynamicMemberDataOffset _ key _
   | Expr.arrayElementDynamicMemberLength _ key _ =>
       exprUsesMulDiv512 key
   | Expr.arrayElementDynamicMemberElement _ key _ innerKey =>
@@ -832,6 +838,7 @@ def exprUsesStorageArrayElement : Expr → Bool
   | Expr.adtTag _ _ =>
       false
   | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
       exprUsesStorageArrayElement index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex =>
@@ -954,6 +961,7 @@ def exprUsesDynamicBytesEq : Expr → Bool
       exprListUsesDynamicBytesEq args
   | Expr.storageArrayElement _ index | Expr.arrayElement _ index
   | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ => exprUsesDynamicBytesEq index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex =>
       exprUsesDynamicBytesEq index || exprUsesDynamicBytesEq innerIndex

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -278,6 +278,7 @@ def exprReadsStateOrEnv : Expr → Bool
   | Expr.storageArrayLength _ => true
   | Expr.storageArrayElement _ index => true || exprReadsStateOrEnv index
   | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ => exprReadsStateOrEnv index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex =>
       exprReadsStateOrEnv index || exprReadsStateOrEnv innerIndex
@@ -357,6 +358,7 @@ def exprWritesState : Expr → Bool
   | Expr.storageArrayElement _ index =>
       exprWritesState index
   | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
       exprWritesState index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex =>
@@ -510,6 +512,7 @@ def exprHasUntrackableWrites : Expr → Bool
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
   | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.arrayElementWord _ key _ _
   | Expr.arrayElementDynamicWord _ key _
+  | Expr.arrayElementDynamicMemberDataOffset _ key _
   | Expr.arrayElementDynamicMemberLength _ key _
   | Expr.storageArrayElement _ key =>
       exprHasUntrackableWrites key
@@ -650,6 +653,7 @@ def exprContainsExternalCall : Expr → Bool
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
   | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.arrayElementWord _ key _ _
   | Expr.arrayElementDynamicWord _ key _
+  | Expr.arrayElementDynamicMemberDataOffset _ key _
   | Expr.arrayElementDynamicMemberLength _ key _
   | Expr.storageArrayElement _ key =>
       exprContainsExternalCall key
@@ -720,6 +724,7 @@ def exprMayContainExternalCall : Expr → Bool
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
   | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.arrayElementWord _ key _ _
   | Expr.arrayElementDynamicWord _ key _
+  | Expr.arrayElementDynamicMemberDataOffset _ key _
   | Expr.arrayElementDynamicMemberLength _ key _
   | Expr.storageArrayElement _ key =>
       exprMayContainExternalCall key
@@ -1169,6 +1174,7 @@ def exprContainsAdtConstruct : Expr → Bool
   | Expr.returndataOptionalBoolAt a
   | Expr.storageArrayElement _ a | Expr.arrayElement _ a | Expr.arrayElementWord _ a _ _
   | Expr.arrayElementDynamicWord _ a _
+  | Expr.arrayElementDynamicMemberDataOffset _ a _
   | Expr.arrayElementDynamicMemberLength _ a _ =>
       exprContainsAdtConstruct a
   | Expr.arrayElementDynamicMemberElement _ a _ b =>

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -79,7 +79,7 @@ def firstReservedExternalCollision
         dynamicBytesEqHelpersRequired).contains name)
 
 def internalDynamicParamSupported : ParamType → Bool
-  | ParamType.array elemTy => isSingleWordStaticParamType elemTy
+  | ParamType.array _ => true
   | _ => false
 
 def firstUnsupportedInternalDynamicParam
@@ -96,7 +96,7 @@ def firstUnsupportedInternalDynamicParam
   goFns fns
 
 def internalCallYulArgCountForParam : ParamType → Nat
-  | ParamType.array elemTy => if isSingleWordStaticParamType elemTy then 2 else 1
+  | ParamType.array _ => 2
   | _ => 1
 
 def internalCallYulArgCount (params : List Param) : Nat :=
@@ -185,6 +185,7 @@ def validateInternalCallShapesInExpr
   | Expr.arrayElement _ index
   | Expr.arrayElementWord _ index _ _
   | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
       validateInternalCallShapesInExpr functions callerName index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex => do
@@ -449,6 +450,7 @@ def validateExternalCallTargetsInExpr
   | Expr.arrayElement _ index
   | Expr.arrayElementWord _ index _ _
   | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
       validateExternalCallTargetsInExpr externals context index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex => do

--- a/Compiler/CompilationModel/ValidationHelpers.lean
+++ b/Compiler/CompilationModel/ValidationHelpers.lean
@@ -81,6 +81,7 @@ def collectExprNames : Expr → List String
   | Expr.paramDynamicHeadWord name _ => [name]
   | Expr.arrayElement name index | Expr.arrayElementWord name index _ _
   | Expr.arrayElementDynamicWord name index _
+  | Expr.arrayElementDynamicMemberDataOffset name index _
   | Expr.arrayElementDynamicMemberLength name index _ =>
       name :: collectExprNames index
   | Expr.arrayElementDynamicMemberElement name index _ innerIndex =>

--- a/Compiler/CompilationModel/ValidationInterop.lean
+++ b/Compiler/CompilationModel/ValidationInterop.lean
@@ -84,6 +84,7 @@ def validateInteropExpr (context : String) : Expr → Except String Unit
   | Expr.storageArrayElement _ index =>
       validateInteropExpr context index
   | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
       validateInteropExpr context index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex => do

--- a/Compiler/Proofs/IRGeneration/ExprCore.lean
+++ b/Compiler/Proofs/IRGeneration/ExprCore.lean
@@ -39,6 +39,7 @@ def exprBoundNames : Expr → List String
   | .adtField _ _ _ _ storageField => [storageField]
   | .arrayElement name index | .arrayElementWord name index _ _
   | .arrayElementDynamicWord name index _
+  | .arrayElementDynamicMemberDataOffset name index _
   | .arrayElementDynamicMemberLength name index _ => name :: exprBoundNames index
   | .arrayElementDynamicMemberElement name index _ innerIndex =>
       name :: (exprBoundNames index ++ exprBoundNames innerIndex)

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -369,6 +369,8 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.ExternalCallSmoke.spec
   , Contracts.Smoke.TryExternalCallSmoke.spec
   , Contracts.Smoke.LinkedExternalDynamicArgSmoke.spec
+  , Contracts.Smoke.LinkedExternalProjectedArrayArgSmoke.spec
+  , Contracts.Smoke.NestedStructArrayProjectionSmoke.spec
   , Contracts.Smoke.ExternalCallMultiReturn.spec
   , Contracts.Smoke.ERC20HelperSmoke.spec
   , Contracts.Smoke.GenericECMReadSmoke.spec
@@ -519,6 +521,11 @@ private def expectedExternalSignatures : List (String × List String) :=
   , ("TryExternalCallSmoke", ["tryEcho(uint256)"])
   , ("LinkedExternalDynamicArgSmoke", ["hashLeaves(uint256[])", "sendLeaves(uint256[])",
       "tryHash(uint256[])", "hashPayload(bytes)"])
+  , ("LinkedExternalProjectedArrayArgSmoke",
+      ["tryHashNullifiers((uint256,uint256[],uint256[])[],uint256)"])
+  , ("NestedStructArrayProjectionSmoke",
+      ["withdrawalAmount(((uint256[2],uint256[2][2],uint256[2]),uint256,uint256,uint256[],uint256[],uint256,(uint256,address,uint256),uint256[])[],uint256)",
+       "withdrawalAmountViaHelper(((uint256[2],uint256[2][2],uint256[2]),uint256,uint256,uint256[],uint256[],uint256,(uint256,address,uint256),uint256[])[],uint256)"])
   , ("ExternalCallMultiReturn", ["callFanout(uint256)", "noop()"])
   , ("ERC20HelperSmoke", ["pushTokens(address,address,uint256)", "pullTokens(address,address,address,uint256)",
       "approveTokens(address,address,uint256)", "snapshotBalance(address,address)",
@@ -647,6 +654,8 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("TryExternalCallSmoke", ["0xaf842e53"])
   , ("LinkedExternalDynamicArgSmoke", ["0xf1b3ebc7", "0x3f87a475", "0x35ea2663",
       "0xc58b0a4d"])
+  , ("LinkedExternalProjectedArrayArgSmoke", ["0x2bda60e2"])
+  , ("NestedStructArrayProjectionSmoke", ["0x714fb4de", "0x8999bcc3"])
   , ("ExternalCallMultiReturn", ["0x70fce9a3", "0x5dfc2e4a"])
   , ("ERC20HelperSmoke", ["0xa6c29ca3", "0x6aa209a6", "0x912d6e28", "0x48476c71", "0xdac24aaf",
       "0x7247c4a5"])

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -154,6 +154,8 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.ExternalCallSmoke.spec
   , Contracts.Smoke.TryExternalCallSmoke.spec
   , Contracts.Smoke.LinkedExternalDynamicArgSmoke.spec
+  , Contracts.Smoke.LinkedExternalProjectedArrayArgSmoke.spec
+  , Contracts.Smoke.NestedStructArrayProjectionSmoke.spec
   , Contracts.Smoke.ExternalCallMultiReturn.spec
   , Contracts.Smoke.ERC20HelperSmoke.spec
   , Contracts.Smoke.GenericECMReadSmoke.spec

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -1689,6 +1689,117 @@ example :
           (Compiler.CompilationModel.Expr.localVar "h")
       ] := rfl
 
+verity_contract LinkedExternalProjectedArrayArgSmoke where
+  storage
+
+  struct Transaction where
+    merkleRoot : Uint256,
+    nullifierHashes : Array Uint256,
+    newCommitments : Array Uint256
+
+  linked_externals
+    external hashArray(Array Uint256) -> (Uint256)
+    external hashArray_try(Array Uint256) -> (Bool, Uint256)
+
+  function tryHashNullifiers (txs : Array Transaction, idx : Uint256) : Uint256 := do
+    let (_success, h) ← tryExternalCall "hashArray" [(arrayElement txs idx).nullifierHashes]
+    return h
+
+example :
+    LinkedExternalProjectedArrayArgSmoke.tryHashNullifiers_modelBody =
+      [ Compiler.CompilationModel.Stmt.tryExternalCallBind
+          "_success"
+          ["h"]
+          "hashArray"
+          [ Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
+              "txs"
+              (Compiler.CompilationModel.Expr.param "idx")
+              1
+          , Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+              "txs"
+              (Compiler.CompilationModel.Expr.param "idx")
+              1
+          ]
+      , Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.localVar "h")
+      ] := rfl
+
+verity_contract NestedStructArrayProjectionSmoke where
+  storage
+
+  struct Proof where
+    pA : FixedArray Uint256 2,
+    pB : FixedArray (FixedArray Uint256 2) 2,
+    pC : FixedArray Uint256 2
+
+  struct Note where
+    npk : Uint256,
+    token : Address,
+    amount : Uint256
+
+  struct WithdrawalTransaction where
+    proof : Proof,
+    circuitId : Uint256,
+    merkleRoot : Uint256,
+    nullifierHashes : Array Uint256,
+    newCommitments : Array Uint256,
+    contextHash : Uint256,
+    withdrawal : Note,
+    ciphertexts : Array Uint256
+
+  function withdrawalAmount (txs : Array WithdrawalTransaction, idx : Uint256) : Uint256 := do
+    return (arrayElement txs idx).withdrawal.amount
+
+  function consumeNullifiers (nullifiers : Array Uint256) : Unit := do
+    let _len := arrayLength nullifiers
+    pure ()
+
+  function withdrawalAmountViaHelper (txs : Array WithdrawalTransaction, idx : Uint256) : Uint256 := do
+    let amount ← withdrawalAmount txs idx
+    return amount
+
+  function consumeNullifiersViaHelper (txs : Array WithdrawalTransaction, idx : Uint256) : Unit := do
+    consumeNullifiers (arrayElement txs idx).nullifierHashes
+
+example :
+    NestedStructArrayProjectionSmoke.withdrawalAmount_modelBody =
+      [ Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.arrayElementDynamicWord
+            "txs"
+            (Compiler.CompilationModel.Expr.param "idx")
+            15)
+      ] := rfl
+
+example :
+    NestedStructArrayProjectionSmoke.withdrawalAmountViaHelper_modelBody =
+      [ Compiler.CompilationModel.Stmt.letVar
+          "amount"
+          (Compiler.CompilationModel.Expr.internalCall
+            "internal_withdrawalAmount"
+            [ Compiler.CompilationModel.Expr.param "txs_data_offset"
+            , Compiler.CompilationModel.Expr.param "txs_length"
+            , Compiler.CompilationModel.Expr.param "idx"
+            ])
+      , Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.localVar "amount")
+      ] := rfl
+
+example :
+    NestedStructArrayProjectionSmoke.consumeNullifiersViaHelper_modelBody =
+      [ Compiler.CompilationModel.Stmt.internalCall
+          "internal_consumeNullifiers"
+          [ Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
+              "txs"
+              (Compiler.CompilationModel.Expr.param "idx")
+              10
+          , Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+              "txs"
+              (Compiler.CompilationModel.Expr.param "idx")
+              10
+          ]
+      , Compiler.CompilationModel.Stmt.stop
+      ] := rfl
+
 example :
     LinkedExternalDynamicArgSmoke.hashPayload_modelBody =
       [ Compiler.CompilationModel.Stmt.return
@@ -2111,6 +2222,8 @@ end SpecGenSmoke
 #check_contract ExternalCallSmoke
 #check_contract TryExternalCallSmoke
 #check_contract LinkedExternalDynamicArgSmoke
+#check_contract LinkedExternalProjectedArrayArgSmoke
+#check_contract NestedStructArrayProjectionSmoke
 #check_contract ExternalCallMultiReturn
 #check_contract Contracts.Vault
 

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1669,10 +1669,10 @@ private partial def structProjectionPath? (stx : Term) : Option (Term × List St
           some (mkIdent (Name.mkSimple root), field :: rest)
       | _ => none
   | `(term| $base:term.$field:ident) =>
-      let fieldName := toString field.getId
+      let fieldPath := (toString field.getId).splitOn "."
       match structProjectionPath? base with
-      | some (root, path) => some (root, path ++ [fieldName])
-      | none => some (base, [fieldName])
+      | some (root, path) => some (root, path ++ fieldPath)
+      | none => some (base, fieldPath)
   | _ => none
 
 private partial def structFieldPath?
@@ -2139,7 +2139,7 @@ private partial def hasDynamicInternalHelperType (ty : ValueType) : Bool :=
 
 private def supportsInternalHelperParamType (ty : ValueType) : Bool :=
   match ty with
-  | .array elemTy => isSingleWordStaticValueType elemTy
+  | .array _ => true
   | _ => !hasDynamicInternalHelperType ty
 
 private def supportsInternalHelperSpec (fn : FunctionDecl) : Bool :=
@@ -2315,6 +2315,10 @@ private partial def inferPureExprType
     | some ty => pure ty
     | none => throwPureContextAccessorError stx name
   if let some (_, index, fieldTy, _, _) := arrayElementStructProjection? params stx then
+    requireWordLikeType index "arrayElement index" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals index visitingConstants)
+    pure fieldTy
+  else
+  if let some (_, index, fieldTy, _, _) := arrayElementDynamicMemberProjection? params stx then
     requireWordLikeType index "arrayElement index" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals index visitingConstants)
     pure fieldTy
   else
@@ -2527,7 +2531,15 @@ private partial def inferPureExprType
           for x in xs do
             -- verity#1849, G3: accept `Array <wordLike>` / `bytes` / `string`
             -- direct param refs alongside word-like args.
-            requireWordOrDirectArrayType x s!"externalCall '{extName}' argument" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x visitingConstants)
+            if let some (_, _, fieldTy, _elemTy, _) := arrayElementDynamicMemberProjection? params x then
+              match fieldTy with
+              | .array elemTy =>
+                  unless externalCallDynamicArgSupported (.array elemTy) do
+                    throwErrorAt x s!"externalCall '{extName}' dynamic-member argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
+              | _ =>
+                  throwErrorAt x s!"externalCall '{extName}' dynamic-member argument requires an Array-typed member, got {renderValueType fieldTy}"
+            else
+              requireWordOrDirectArrayType x s!"externalCall '{extName}' argument" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x visitingConstants)
       | _ => throwErrorAt args "expected list literal [..]"
       match externalDecls.find? (fun ext => ext.name == extName) with
       | some ext =>
@@ -2741,8 +2753,16 @@ private partial def inferBindSourceType
           for x in xs do
             -- verity#1849, G3: accept `Array <wordLike>` / `bytes` / `string`
             -- direct param refs alongside word-like args.
-            requireWordOrDirectArrayType x s!"tryExternalCall '{extName}' argument"
-              (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x)
+            if let some (_, _, fieldTy, _elemTy, _) := arrayElementDynamicMemberProjection? params x then
+              match fieldTy with
+              | .array elemTy =>
+                  unless externalCallDynamicArgSupported (.array elemTy) do
+                    throwErrorAt x s!"tryExternalCall '{extName}' dynamic-member argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
+              | _ =>
+                  throwErrorAt x s!"tryExternalCall '{extName}' dynamic-member argument requires an Array-typed member, got {renderValueType fieldTy}"
+            else
+              requireWordOrDirectArrayType x s!"tryExternalCall '{extName}' argument"
+                (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x)
       | _ => throwErrorAt args "expected list literal [..]"
       match externalDecls.find? (fun ext => ext.name == extName) with
       | some ext =>
@@ -3915,17 +3935,30 @@ private def translateInternalHelperCallArgs
     let some arg := argTerms[idx]? | pure ()
     let some fnParam := fn.params[idx]? | pure ()
     match fnParam.ty with
-    | .array elemTy =>
-        if isSingleWordStaticValueType elemTy then
-          match directParamNameWithType? params arg with
-          | some (name, _) =>
-              out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
-              out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
-          | none =>
+    | .array _ =>
+        match directParamNameWithType? params arg with
+        | some (name, _) =>
+            out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
+            out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
+        | none =>
+            if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
+                arrayElementDynamicMemberProjection? params arg then
+              match fieldTy with
+              | .array _ =>
+                  let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                  out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
+                    $(strTerm paramName)
+                    $indexExpr
+                    $(natTerm wordOffset)))
+                  out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+                    $(strTerm paramName)
+                    $indexExpr
+                    $(natTerm wordOffset)))
+              | _ =>
+                  throwErrorAt arg s!"helper call '{fn.name}' Array parameter '{fnParam.name}' requires an Array-typed projected member, got {renderValueType fieldTy}"
+            else
               throwErrorAt arg
-                s!"helper call '{fn.name}' Array parameter '{fnParam.name}' currently requires a direct Array parameter reference"
-        else
-          out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                s!"helper call '{fn.name}' Array parameter '{fnParam.name}' currently requires a direct Array parameter reference or projected struct-array member"
     | _ =>
         out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
   pure out
@@ -3947,7 +3980,26 @@ private def translateLinkedExternalCallArgs
         else
           out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
     | none =>
-        out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+        if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
+            arrayElementDynamicMemberProjection? params arg then
+          match fieldTy with
+          | .array elemTy =>
+              if externalCallDynamicArgSupported (.array elemTy) then
+                let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
+                  $(strTerm paramName)
+                  $indexExpr
+                  $(natTerm wordOffset)))
+                out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+                  $(strTerm paramName)
+                  $indexExpr
+                  $(natTerm wordOffset)))
+              else
+                throwErrorAt arg s!"linked external dynamic-member argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
+          | _ =>
+              throwErrorAt arg s!"linked external dynamic-member argument requires an Array-typed member, got {renderValueType fieldTy}"
+        else
+          out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
   pure out
 
 private def tupleInternalCallAssignStmt?

--- a/scripts/check_macro_property_test_generation.py
+++ b/scripts/check_macro_property_test_generation.py
@@ -27,6 +27,8 @@ EXCLUDED_CONTRACTS = {
     "ArrayElementDynamicMemberElementSmoke",
     "UnlinkPoolShapeCheckSmoke",
     "FixedArrayStructSmoke",
+    "LinkedExternalProjectedArrayArgSmoke",
+    "NestedStructArrayProjectionSmoke",
     # The generated no-revert stub cannot currently fund the contract before
     # exercising `callWithValue`; Lean/Yul/trust-report tests cover this ECM.
     "CallWithValueSmoke",


### PR DESCRIPTION
## Summary
- add `arrayElementDynamicMemberDataOffset` for forwarding projected dynamic array members to linked externals
- split dotted projection identifiers so nested struct leaves like `(arrayElement txs i).withdrawal.amount` lower correctly
- add smoke coverage for linked external projected array args and nested struct-array projection offsets

## Verification
- `lake build Contracts.Smoke`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ABI lowering and helper emission for struct-array dynamic members and relaxes internal-call parameter handling for arrays, which could affect generated Yul offsets and runtime safety if miscomputed.
> 
> **Overview**
> Adds a new IR expression `Expr.arrayElementDynamicMemberDataOffset` plus checked Yul helpers (calldata + memory) to compute the data pointer for dynamic array members nested inside struct-array elements, enabling forwarding projected members as `(data_offset, length)` pairs.
> 
> Updates macro translation/typechecking to accept projected dynamic array members as arguments to linked externals and internal helpers, and fixes dotted projection parsing by splitting `field` identifiers on `.` so nested leaves lower correctly.
> 
> Broadens internal function array ABI lowering to always use `{name}_data_offset/{name}_length` (and adjusts arg-count/support checks accordingly), and extends validation/usage-analysis/purity passes and smoke tests to cover the new expression and projection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 849d0e8ec1c91964ab3305002835ef3c5fa4cd61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->