### PR TITLE
Support dynamic struct element helper args

### DIFF
--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -31,6 +31,11 @@ def internalFunctionYulParamNames (params : List Param) : List String :=
     match param.ty with
     | ParamType.array _ =>
         [s!"{param.name}_data_offset", s!"{param.name}_length"]
+    | ParamType.tuple _ =>
+        if isDynamicParamType param.ty then
+          [s!"{param.name}_data_offset"]
+        else
+          [param.name]
     | _ => [param.name]
 
 -- Compile internal function to a Yul function definition (#181)
@@ -427,6 +432,8 @@ def compileValidatedCore (spec : CompilationModel) (selectors : List Nat) : Exce
       , checkedArrayElementWordMemoryHelper
       , checkedArrayElementDynamicWordCalldataHelper
       , checkedArrayElementDynamicWordMemoryHelper
+      , checkedArrayElementDynamicDataOffsetCalldataHelper
+      , checkedArrayElementDynamicDataOffsetMemoryHelper
       -- verity#1849 G1: dynamic-member length helpers share the
       -- `arrayElementWord` gate because they read the same struct-array
       -- elements and have negligible code size; conservative emission is
@@ -444,6 +451,12 @@ def compileValidatedCore (spec : CompilationModel) (selectors : List Nat) : Exce
     (if paramDynamicHeadWordHelpersRequired then
       [ checkedParamDynamicHeadWordCalldataHelper
       , checkedParamDynamicHeadWordMemoryHelper
+      , checkedParamDynamicMemberLengthCalldataHelper
+      , checkedParamDynamicMemberLengthMemoryHelper
+      , checkedParamDynamicMemberDataOffsetCalldataHelper
+      , checkedParamDynamicMemberDataOffsetMemoryHelper
+      , checkedParamDynamicMemberElementCalldataHelper
+      , checkedParamDynamicMemberElementMemoryHelper
       ]
     else
       []) ++

--- a/Compiler/CompilationModel/DynamicData.lean
+++ b/Compiler/CompilationModel/DynamicData.lean
@@ -32,11 +32,35 @@ def checkedArrayElementDynamicWordCalldataHelperName : String :=
 def checkedArrayElementDynamicWordMemoryHelperName : String :=
   "__verity_array_element_dynamic_word_memory_checked"
 
+def checkedArrayElementDynamicDataOffsetCalldataHelperName : String :=
+  "__verity_array_element_dynamic_data_offset_calldata_checked"
+
+def checkedArrayElementDynamicDataOffsetMemoryHelperName : String :=
+  "__verity_array_element_dynamic_data_offset_memory_checked"
+
 def checkedParamDynamicHeadWordCalldataHelperName : String :=
   "__verity_param_dynamic_head_word_calldata_checked"
 
 def checkedParamDynamicHeadWordMemoryHelperName : String :=
   "__verity_param_dynamic_head_word_memory_checked"
+
+def checkedParamDynamicMemberLengthCalldataHelperName : String :=
+  "__verity_param_dynamic_member_length_calldata_checked"
+
+def checkedParamDynamicMemberLengthMemoryHelperName : String :=
+  "__verity_param_dynamic_member_length_memory_checked"
+
+def checkedParamDynamicMemberDataOffsetCalldataHelperName : String :=
+  "__verity_param_dynamic_member_data_offset_calldata_checked"
+
+def checkedParamDynamicMemberDataOffsetMemoryHelperName : String :=
+  "__verity_param_dynamic_member_data_offset_memory_checked"
+
+def checkedParamDynamicMemberElementCalldataHelperName : String :=
+  "__verity_param_dynamic_member_element_calldata_checked"
+
+def checkedParamDynamicMemberElementMemoryHelperName : String :=
+  "__verity_param_dynamic_member_element_memory_checked"
 
 def checkedArrayElementDynamicMemberLengthCalldataHelperName : String :=
   "__verity_array_element_dynamic_member_length_calldata_checked"
@@ -165,6 +189,59 @@ def checkedArrayElementDynamicWordCalldataHelper : YulStmt :=
 def checkedArrayElementDynamicWordMemoryHelper : YulStmt :=
   checkedArrayElementDynamicWordHelper checkedArrayElementDynamicWordMemoryHelperName "mload" none
 
+/-- Yul helper for `Expr.arrayElementDynamicDataOffset`.  Resolves the
+    element head of a dynamically encoded array element and returns that
+    absolute offset so the element can be forwarded as a dynamic tuple
+    parameter to an internal helper. -/
+private def checkedArrayElementDynamicDataOffsetHelper
+    (helperName loadOp : String) (sizeExpr? : Option YulExpr) : YulStmt :=
+  let offsetTableBytes := YulExpr.call "mul" [YulExpr.ident "length", YulExpr.lit 32]
+  let elementOffsetSlot := YulExpr.call "add" [
+    YulExpr.ident "data_offset",
+    YulExpr.call "mul" [YulExpr.ident "index", YulExpr.lit 32]
+  ]
+  let elementHeadPos := YulExpr.call "add" [
+    YulExpr.ident "data_offset",
+    YulExpr.ident "__element_rel_offset"
+  ]
+  let sizeCheck :=
+    match sizeExpr? with
+    | some sizeExpr =>
+        [YulStmt.if_ (YulExpr.call "gt" [
+          YulExpr.ident "__element_head_pos",
+          YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
+        ]) [
+          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        ]]
+    | none => []
+  YulStmt.funcDef helperName ["data_offset", "length", "index"] ["word"] (
+    [
+      YulStmt.if_ (YulExpr.call "iszero" [
+        YulExpr.call "lt" [YulExpr.ident "index", YulExpr.ident "length"]
+      ]) [
+        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      ],
+      YulStmt.let_ "__element_rel_offset" (YulExpr.call loadOp [elementOffsetSlot]),
+      YulStmt.if_ (YulExpr.call "lt" [YulExpr.ident "__element_rel_offset", offsetTableBytes]) [
+        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      ],
+      YulStmt.let_ "__element_head_pos" elementHeadPos
+    ] ++ sizeCheck ++ [
+      YulStmt.assign "word" (YulExpr.ident "__element_head_pos")
+    ])
+
+def checkedArrayElementDynamicDataOffsetCalldataHelper : YulStmt :=
+  checkedArrayElementDynamicDataOffsetHelper
+    checkedArrayElementDynamicDataOffsetCalldataHelperName
+    "calldataload"
+    (some (YulExpr.call "calldatasize" []))
+
+def checkedArrayElementDynamicDataOffsetMemoryHelper : YulStmt :=
+  checkedArrayElementDynamicDataOffsetHelper
+    checkedArrayElementDynamicDataOffsetMemoryHelperName
+    "mload"
+    none
+
 /-- Yul helper for `Expr.paramDynamicHeadWord` (verity#1832). Reads the
     word at `data_offset + word_offset * 32`, where `data_offset` is the
     `{name}_data_offset` produced by `genDynamicParamLoads` for a
@@ -197,6 +274,143 @@ def checkedParamDynamicHeadWordCalldataHelper : YulStmt :=
 
 def checkedParamDynamicHeadWordMemoryHelper : YulStmt :=
   checkedParamDynamicHeadWordHelper checkedParamDynamicHeadWordMemoryHelperName "mload" none
+
+/-- Shared helper for dynamic members nested in a directly passed dynamic
+    tuple parameter.  `data_offset` points at the tuple head.  The member's
+    head word stores a tuple-relative offset to its length word. -/
+private def checkedParamDynamicMemberLengthHelper
+    (helperName loadOp : String) (sizeExpr? : Option YulExpr) : YulStmt :=
+  let memberHeadSlot := YulExpr.call "add" [
+    YulExpr.ident "data_offset",
+    YulExpr.call "mul" [YulExpr.ident "word_offset", YulExpr.lit 32]
+  ]
+  let memberDataPos := YulExpr.call "add" [
+    YulExpr.ident "data_offset",
+    YulExpr.ident "__member_rel_offset"
+  ]
+  let sizeCheck :=
+    match sizeExpr? with
+    | some sizeExpr =>
+        [YulStmt.if_ (YulExpr.call "gt" [
+          YulExpr.ident "__member_data_pos",
+          YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
+        ]) [
+          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        ]]
+    | none => []
+  YulStmt.funcDef helperName ["data_offset", "word_offset"] ["word"] (
+    [
+      YulStmt.let_ "__member_rel_offset" (YulExpr.call loadOp [memberHeadSlot]),
+      YulStmt.let_ "__member_data_pos" memberDataPos
+    ] ++ sizeCheck ++ [
+      YulStmt.assign "word" (YulExpr.call loadOp [YulExpr.ident "__member_data_pos"])
+    ])
+
+def checkedParamDynamicMemberLengthCalldataHelper : YulStmt :=
+  checkedParamDynamicMemberLengthHelper
+    checkedParamDynamicMemberLengthCalldataHelperName
+    "calldataload"
+    (some (YulExpr.call "calldatasize" []))
+
+def checkedParamDynamicMemberLengthMemoryHelper : YulStmt :=
+  checkedParamDynamicMemberLengthHelper
+    checkedParamDynamicMemberLengthMemoryHelperName
+    "mload"
+    none
+
+private def checkedParamDynamicMemberDataOffsetHelper
+    (helperName loadOp : String) (sizeExpr? : Option YulExpr) : YulStmt :=
+  let memberHeadSlot := YulExpr.call "add" [
+    YulExpr.ident "data_offset",
+    YulExpr.call "mul" [YulExpr.ident "word_offset", YulExpr.lit 32]
+  ]
+  let memberDataPos := YulExpr.call "add" [
+    YulExpr.ident "data_offset",
+    YulExpr.ident "__member_rel_offset"
+  ]
+  let sizeCheck :=
+    match sizeExpr? with
+    | some sizeExpr =>
+        [YulStmt.if_ (YulExpr.call "gt" [
+          YulExpr.ident "__member_data_pos",
+          YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
+        ]) [
+          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        ]]
+    | none => []
+  YulStmt.funcDef helperName ["data_offset", "word_offset"] ["word"] (
+    [
+      YulStmt.let_ "__member_rel_offset" (YulExpr.call loadOp [memberHeadSlot]),
+      YulStmt.let_ "__member_data_pos" memberDataPos
+    ] ++ sizeCheck ++ [
+      YulStmt.assign "word" (YulExpr.call "add" [YulExpr.ident "__member_data_pos", YulExpr.lit 32])
+    ])
+
+def checkedParamDynamicMemberDataOffsetCalldataHelper : YulStmt :=
+  checkedParamDynamicMemberDataOffsetHelper
+    checkedParamDynamicMemberDataOffsetCalldataHelperName
+    "calldataload"
+    (some (YulExpr.call "calldatasize" []))
+
+def checkedParamDynamicMemberDataOffsetMemoryHelper : YulStmt :=
+  checkedParamDynamicMemberDataOffsetHelper
+    checkedParamDynamicMemberDataOffsetMemoryHelperName
+    "mload"
+    none
+
+private def checkedParamDynamicMemberElementHelper
+    (helperName loadOp : String) (sizeExpr? : Option YulExpr) : YulStmt :=
+  let memberHeadSlot := YulExpr.call "add" [
+    YulExpr.ident "data_offset",
+    YulExpr.call "mul" [YulExpr.ident "word_offset", YulExpr.lit 32]
+  ]
+  let memberDataPos := YulExpr.call "add" [
+    YulExpr.ident "data_offset",
+    YulExpr.ident "__member_rel_offset"
+  ]
+  let wordPos := YulExpr.call "add" [
+    YulExpr.ident "__member_data_pos",
+    YulExpr.call "add" [
+      YulExpr.lit 32,
+      YulExpr.call "mul" [YulExpr.ident "inner_index", YulExpr.lit 32]
+    ]
+  ]
+  let sizeCheck :=
+    match sizeExpr? with
+    | some sizeExpr =>
+        [YulStmt.if_ (YulExpr.call "gt" [
+          YulExpr.ident "__word_pos",
+          YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
+        ]) [
+          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        ]]
+    | none => []
+  YulStmt.funcDef helperName ["data_offset", "word_offset", "inner_index"] ["word"] (
+    [
+      YulStmt.let_ "__member_rel_offset" (YulExpr.call loadOp [memberHeadSlot]),
+      YulStmt.let_ "__member_data_pos" memberDataPos,
+      YulStmt.let_ "__member_length" (YulExpr.call loadOp [YulExpr.ident "__member_data_pos"]),
+      YulStmt.if_ (YulExpr.call "iszero" [
+        YulExpr.call "lt" [YulExpr.ident "inner_index", YulExpr.ident "__member_length"]
+      ]) [
+        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      ],
+      YulStmt.let_ "__word_pos" wordPos
+    ] ++ sizeCheck ++ [
+      YulStmt.assign "word" (YulExpr.call loadOp [YulExpr.ident "__word_pos"])
+    ])
+
+def checkedParamDynamicMemberElementCalldataHelper : YulStmt :=
+  checkedParamDynamicMemberElementHelper
+    checkedParamDynamicMemberElementCalldataHelperName
+    "calldataload"
+    (some (YulExpr.call "calldatasize" []))
+
+def checkedParamDynamicMemberElementMemoryHelper : YulStmt :=
+  checkedParamDynamicMemberElementHelper
+    checkedParamDynamicMemberElementMemoryHelperName
+    "mload"
+    none
 
 /-- Yul helper for `Expr.arrayElementDynamicMemberLength` (verity#1849, G1).
     Reads the length word of a dynamically-sized member nested inside a

--- a/Compiler/CompilationModel/ExpressionCompile.lean
+++ b/Compiler/CompilationModel/ExpressionCompile.lean
@@ -293,6 +293,16 @@ def compileExpr (fields : List Field)
         indexExpr,
         YulExpr.lit wordOffset
       ])
+  | Expr.arrayElementDynamicDataOffset name index => do
+      let indexExpr ← compileExpr fields dynamicSource index
+      let helperName := match dynamicSource with
+        | .calldata => checkedArrayElementDynamicDataOffsetCalldataHelperName
+        | .memory => checkedArrayElementDynamicDataOffsetMemoryHelperName
+      pure (YulExpr.call helperName [
+        YulExpr.ident s!"{name}_data_offset",
+        YulExpr.ident s!"{name}_length",
+        indexExpr
+      ])
   | Expr.paramDynamicHeadWord name wordOffset => do
       let helperName := match dynamicSource with
         | .calldata => checkedParamDynamicHeadWordCalldataHelperName
@@ -300,6 +310,32 @@ def compileExpr (fields : List Field)
       pure (YulExpr.call helperName [
         YulExpr.ident s!"{name}_data_offset",
         YulExpr.lit wordOffset
+      ])
+  | Expr.paramDynamicMemberLength name wordOffset => do
+      let helperName := match dynamicSource with
+        | .calldata => checkedParamDynamicMemberLengthCalldataHelperName
+        | .memory => checkedParamDynamicMemberLengthMemoryHelperName
+      pure (YulExpr.call helperName [
+        YulExpr.ident s!"{name}_data_offset",
+        YulExpr.lit wordOffset
+      ])
+  | Expr.paramDynamicMemberDataOffset name wordOffset => do
+      let helperName := match dynamicSource with
+        | .calldata => checkedParamDynamicMemberDataOffsetCalldataHelperName
+        | .memory => checkedParamDynamicMemberDataOffsetMemoryHelperName
+      pure (YulExpr.call helperName [
+        YulExpr.ident s!"{name}_data_offset",
+        YulExpr.lit wordOffset
+      ])
+  | Expr.paramDynamicMemberElement name wordOffset innerIndex => do
+      let innerIndexExpr ← compileExpr fields dynamicSource innerIndex
+      let helperName := match dynamicSource with
+        | .calldata => checkedParamDynamicMemberElementCalldataHelperName
+        | .memory => checkedParamDynamicMemberElementMemoryHelperName
+      pure (YulExpr.call helperName [
+        YulExpr.ident s!"{name}_data_offset",
+        YulExpr.lit wordOffset,
+        innerIndexExpr
       ])
   | Expr.arrayElementDynamicMemberLength name index wordOffset => do
       let indexExpr ← compileExpr fields dynamicSource index

--- a/Compiler/CompilationModel/LogicalPurity.lean
+++ b/Compiler/CompilationModel/LogicalPurity.lean
@@ -24,11 +24,14 @@ partial def exprContainsCallLike (expr : Expr) : Bool :=
   | Expr.arrayElement _ index
   | Expr.arrayElementWord _ index _ _
   | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
       exprContainsCallLike index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex =>
       exprContainsCallLike index || exprContainsCallLike innerIndex
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
+      exprContainsCallLike innerIndex
   | Expr.dynamicBytesEq _ _ =>
       false
   | Expr.mload offset | Expr.tload offset | Expr.calldataload offset | Expr.extcodesize offset |
@@ -61,6 +64,8 @@ partial def exprContainsCallLike (expr : Expr) : Bool :=
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ =>
       false
 partial def exprListContainsCallLike : List Expr → Bool
@@ -127,12 +132,15 @@ def exprContainsUnsafeLogicalCallLike (expr : Expr) : Bool :=
       exprContainsUnsafeLogicalCallLike key1 || exprContainsUnsafeLogicalCallLike key2
   | Expr.storageArrayElement _ index | Expr.arrayElement _ index
   | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _
   | Expr.returndataOptionalBoolAt index =>
       exprContainsUnsafeLogicalCallLike index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex =>
       exprContainsUnsafeLogicalCallLike index || exprContainsUnsafeLogicalCallLike innerIndex
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
+      exprContainsUnsafeLogicalCallLike innerIndex
   | Expr.dynamicBytesEq _ _ =>
       false
   | Expr.extcodesize addr =>
@@ -163,6 +171,8 @@ def exprContainsUnsafeLogicalCallLike (expr : Expr) : Bool :=
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ =>
       false
 termination_by sizeOf expr

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -169,6 +169,18 @@ def validateScopedExprIdentifiers
       | none =>
           throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.arrayElementDynamicWord"
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount index
+  | Expr.arrayElementDynamicDataOffset name index => do
+      match findParamType params name with
+      | some ty@(ParamType.array elemTy) =>
+          if isDynamicParamType elemTy then
+            pure ()
+          else
+            throw s!"Compilation error: {context} Expr.arrayElementDynamicDataOffset '{name}' requires an array parameter with dynamic ABI elements, got {repr ty}"
+      | some ty =>
+          throw s!"Compilation error: {context} Expr.arrayElementDynamicDataOffset '{name}' requires array parameter, got {repr ty}"
+      | none =>
+          throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.arrayElementDynamicDataOffset"
+      validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount index
   | Expr.arrayElementDynamicMemberLength name index wordOffset => do
       match findParamType params name with
       | some ty@(ParamType.array elemTy) =>
@@ -233,6 +245,38 @@ def validateScopedExprIdentifiers
           throw s!"Compilation error: {context} Expr.paramDynamicHeadWord '{name}' requires a tuple parameter, got {repr ty}"
       | none =>
           throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.paramDynamicHeadWord"
+  | Expr.paramDynamicMemberLength name wordOffset
+  | Expr.paramDynamicMemberDataOffset name wordOffset => do
+      match findParamType params name with
+      | some ty@(ParamType.tuple _) =>
+          if isDynamicParamType ty then
+            let expectedWords := paramLocalHeadWords ty
+            if wordOffset < expectedWords then
+              pure ()
+            else
+              throw s!"Compilation error: {context} dynamic member projection '{name}' wordOffset {wordOffset} is outside head width {expectedWords} for {repr ty}"
+          else
+            throw s!"Compilation error: {context} dynamic member projection '{name}' requires a dynamically-encoded tuple parameter, got {repr ty}"
+      | some ty =>
+          throw s!"Compilation error: {context} dynamic member projection '{name}' requires a tuple parameter, got {repr ty}"
+      | none =>
+          throw s!"Compilation error: {context} references unknown parameter '{name}' in dynamic member projection"
+  | Expr.paramDynamicMemberElement name wordOffset innerIndex => do
+      match findParamType params name with
+      | some ty@(ParamType.tuple _) =>
+          if isDynamicParamType ty then
+            let expectedWords := paramLocalHeadWords ty
+            if wordOffset < expectedWords then
+              pure ()
+            else
+              throw s!"Compilation error: {context} Expr.paramDynamicMemberElement '{name}' wordOffset {wordOffset} is outside head width {expectedWords} for {repr ty}"
+          else
+            throw s!"Compilation error: {context} Expr.paramDynamicMemberElement '{name}' requires a dynamically-encoded tuple parameter, got {repr ty}"
+      | some ty =>
+          throw s!"Compilation error: {context} Expr.paramDynamicMemberElement '{name}' requires a tuple parameter, got {repr ty}"
+      | none =>
+          throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.paramDynamicMemberElement"
+      validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount innerIndex
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
   | Expr.structMember _ key _ =>
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount key

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -350,6 +350,12 @@ inductive Expr
       nested dynamic members; `wordOffset` indexes the element head after the
       ABI element offset has been resolved. -/
   | arrayElementDynamicWord (name : String) (index : Expr) (wordOffset : Nat)
+  /-- Data offset of a dynamically-sized array element.  Given an array
+      parameter whose elements are dynamically encoded tuples/structs,
+      bounds-checks `index`, resolves the element offset table entry, and
+      returns the element head offset.  This is the dynamic-tuple analogue of
+      forwarding `(arrayElement <param> <i>)` into an internal helper. -/
+  | arrayElementDynamicDataOffset (name : String) (index : Expr)
   /-- Checked word access inside the head of a directly-passed struct/tuple
       parameter whose ABI encoding is dynamic.  `wordOffset` indexes the
       parameter's head section after the outer offset pointer has been
@@ -358,6 +364,16 @@ inductive Expr
       projected field is a single-word static leaf at a fixed head offset.
       (verity#1832) -/
   | paramDynamicHeadWord (name : String) (wordOffset : Nat)
+  /-- Length of a dynamic member inside a directly-passed dynamic tuple
+      parameter.  `wordOffset` points at the member's ABI head word relative to
+      `{name}_data_offset`. -/
+  | paramDynamicMemberLength (name : String) (wordOffset : Nat)
+  /-- Data offset of a dynamic member inside a directly-passed dynamic tuple
+      parameter, returning the first element word after the member length. -/
+  | paramDynamicMemberDataOffset (name : String) (wordOffset : Nat)
+  /-- Element access into an `Array<wordLike>` dynamic member inside a
+      directly-passed dynamic tuple parameter. -/
+  | paramDynamicMemberElement (name : String) (wordOffset : Nat) (innerIndex : Expr)
   /-- Length of a dynamic member inside a struct-array element.  Given a
       struct-array parameter `name` indexed at `index`, dereferences the
       head pointer at `wordOffset` (relative to the element's head

--- a/Compiler/CompilationModel/UsageAnalysis.lean
+++ b/Compiler/CompilationModel/UsageAnalysis.lean
@@ -101,6 +101,9 @@ def exprUsesArrayElementKind (includePlain includeWord : Bool) : Expr → Bool
   | Expr.arrayElementDynamicWord _ index _ =>
       let nested := exprUsesArrayElementKind includePlain includeWord index
       if nested then true else includeWord
+  | Expr.arrayElementDynamicDataOffset _ index =>
+      let nested := exprUsesArrayElementKind includePlain includeWord index
+      if nested then true else includeWord
   | Expr.arrayElementDynamicMemberDataOffset _ index _ =>
       let nested := exprUsesArrayElementKind includePlain includeWord index
       if nested then true else includeWord
@@ -186,8 +189,12 @@ def exprUsesArrayElementKind (includePlain includeWord : Bool) : Expr → Bool
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ =>
       false
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
+      exprUsesArrayElementKind includePlain includeWord innerIndex
 termination_by e => sizeOf e
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -304,6 +311,7 @@ attribute [simp] exprUsesArrayElementKind exprListUsesArrayElementKind
 mutual
 def exprUsesArrayElement : Expr → Bool
   | Expr.arrayElement _ _ | Expr.arrayElementWord _ _ _ _ | Expr.arrayElementDynamicWord _ _ _
+  | Expr.arrayElementDynamicDataOffset _ _
   | Expr.arrayElementDynamicMemberDataOffset _ _ _
   | Expr.arrayElementDynamicMemberLength _ _ _
   | Expr.arrayElementDynamicMemberElement _ _ _ _ =>
@@ -354,8 +362,12 @@ def exprUsesArrayElement : Expr → Bool
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ =>
       false
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
+      exprUsesArrayElement innerIndex
 termination_by e => sizeOf e
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -495,10 +507,15 @@ def contractUsesArrayElementWord (spec : CompilationModel) : Bool :=
 mutual
 def exprUsesParamDynamicHeadWord : Expr → Bool
   | Expr.paramDynamicHeadWord _ _ => true
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _ => true
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
+      exprUsesParamDynamicHeadWord innerIndex
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _
   | Expr.mappingUint _ key | Expr.structMember _ key _
   | Expr.storageArrayElement _ key | Expr.arrayElement _ key
   | Expr.arrayElementWord _ key _ _ | Expr.arrayElementDynamicWord _ key _
+  | Expr.arrayElementDynamicDataOffset _ key
   | Expr.arrayElementDynamicMemberDataOffset _ key _
   | Expr.arrayElementDynamicMemberLength _ key _ =>
       exprUsesParamDynamicHeadWord key
@@ -639,6 +656,7 @@ def exprUsesMulDiv512 : Expr → Bool
   | Expr.mappingUint _ key | Expr.structMember _ key _
   | Expr.storageArrayElement _ key | Expr.arrayElement _ key
   | Expr.arrayElementWord _ key _ _ | Expr.arrayElementDynamicWord _ key _
+  | Expr.arrayElementDynamicDataOffset _ key
   | Expr.arrayElementDynamicMemberDataOffset _ key _
   | Expr.arrayElementDynamicMemberLength _ key _ =>
       exprUsesMulDiv512 key
@@ -680,9 +698,13 @@ def exprUsesMulDiv512 : Expr → Bool
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.dynamicBytesEq _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
       false
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
+      exprUsesMulDiv512 innerIndex
 termination_by e => sizeOf e
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -835,9 +857,14 @@ def exprUsesStorageArrayElement : Expr → Bool
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ =>
       false
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
+      exprUsesStorageArrayElement innerIndex
   | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
       exprUsesStorageArrayElement index
@@ -961,6 +988,7 @@ def exprUsesDynamicBytesEq : Expr → Bool
       exprListUsesDynamicBytesEq args
   | Expr.storageArrayElement _ index | Expr.arrayElement _ index
   | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ => exprUsesDynamicBytesEq index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex =>
@@ -987,8 +1015,12 @@ def exprUsesDynamicBytesEq : Expr → Bool
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ =>
       false
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
+      exprUsesDynamicBytesEq innerIndex
 termination_by e => sizeOf e
 decreasing_by all_goals simp_wf; all_goals omega
 

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -274,10 +274,14 @@ def exprReadsStateOrEnv : Expr → Bool
       if name == builtinExpName then exprListReadsStateOrEnv args else true
   | Expr.internalCall _ _ => true
   | Expr.arrayLength _ => false
-  | Expr.paramDynamicHeadWord _ _ => false
+  | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _ => false
+  | Expr.paramDynamicMemberElement _ _ innerIndex => exprReadsStateOrEnv innerIndex
   | Expr.storageArrayLength _ => true
   | Expr.storageArrayElement _ index => true || exprReadsStateOrEnv index
   | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ => exprReadsStateOrEnv index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex =>
@@ -358,6 +362,7 @@ def exprWritesState : Expr → Bool
   | Expr.storageArrayElement _ index =>
       exprWritesState index
   | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
       exprWritesState index
@@ -370,8 +375,12 @@ def exprWritesState : Expr → Bool
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
       false
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
+      exprWritesState innerIndex
 termination_by e => sizeOf e
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -512,6 +521,7 @@ def exprHasUntrackableWrites : Expr → Bool
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
   | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.arrayElementWord _ key _ _
   | Expr.arrayElementDynamicWord _ key _
+  | Expr.arrayElementDynamicDataOffset _ key
   | Expr.arrayElementDynamicMemberDataOffset _ key _
   | Expr.arrayElementDynamicMemberLength _ key _
   | Expr.storageArrayElement _ key =>
@@ -538,11 +548,15 @@ def exprHasUntrackableWrites : Expr → Bool
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.dynamicBytesEq _ _
   | Expr.externalCall _ _ | Expr.call _ _ _ _ _ _ _
   | Expr.staticcall _ _ _ _ _ _ | Expr.delegatecall _ _ _ _ _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
       false
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
+      exprHasUntrackableWrites innerIndex
 termination_by e => sizeOf e
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -653,12 +667,15 @@ def exprContainsExternalCall : Expr → Bool
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
   | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.arrayElementWord _ key _ _
   | Expr.arrayElementDynamicWord _ key _
+  | Expr.arrayElementDynamicDataOffset _ key
   | Expr.arrayElementDynamicMemberDataOffset _ key _
   | Expr.arrayElementDynamicMemberLength _ key _
   | Expr.storageArrayElement _ key =>
       exprContainsExternalCall key
   | Expr.arrayElementDynamicMemberElement _ key _ innerKey =>
       exprContainsExternalCall key || exprContainsExternalCall innerKey
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
+      exprContainsExternalCall innerIndex
   | Expr.mappingChain _ keys =>
       exprListContainsExternalCall keys
   | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _
@@ -682,6 +699,8 @@ def exprContainsExternalCall : Expr → Bool
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
       false
 termination_by e => sizeOf e
@@ -724,12 +743,15 @@ def exprMayContainExternalCall : Expr → Bool
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
   | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.arrayElementWord _ key _ _
   | Expr.arrayElementDynamicWord _ key _
+  | Expr.arrayElementDynamicDataOffset _ key
   | Expr.arrayElementDynamicMemberDataOffset _ key _
   | Expr.arrayElementDynamicMemberLength _ key _
   | Expr.storageArrayElement _ key =>
       exprMayContainExternalCall key
   | Expr.arrayElementDynamicMemberElement _ key _ innerKey =>
       exprMayContainExternalCall key || exprMayContainExternalCall innerKey
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
+      exprMayContainExternalCall innerIndex
   | Expr.mappingChain _ keys =>
       exprListMayContainExternalCall keys
   | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _
@@ -751,6 +773,8 @@ def exprMayContainExternalCall : Expr → Bool
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
       false
 termination_by e => sizeOf e
@@ -1174,11 +1198,14 @@ def exprContainsAdtConstruct : Expr → Bool
   | Expr.returndataOptionalBoolAt a
   | Expr.storageArrayElement _ a | Expr.arrayElement _ a | Expr.arrayElementWord _ a _ _
   | Expr.arrayElementDynamicWord _ a _
+  | Expr.arrayElementDynamicDataOffset _ a
   | Expr.arrayElementDynamicMemberDataOffset _ a _
   | Expr.arrayElementDynamicMemberLength _ a _ =>
       exprContainsAdtConstruct a
   | Expr.arrayElementDynamicMemberElement _ a _ b =>
       exprContainsAdtConstruct a || exprContainsAdtConstruct b
+  | Expr.paramDynamicMemberElement _ _ a =>
+      exprContainsAdtConstruct a
   | Expr.ite cond thenVal elseVal =>
       exprContainsAdtConstruct cond || exprContainsAdtConstruct thenVal ||
         exprContainsAdtConstruct elseVal
@@ -1214,6 +1241,8 @@ def exprContainsAdtConstruct : Expr → Bool
   | Expr.localVar _
   | Expr.arrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
       false
 termination_by e => sizeOf e

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -30,6 +30,8 @@ def reservedExternalNames
       , checkedArrayElementWordMemoryHelperName
       , checkedArrayElementDynamicWordCalldataHelperName
       , checkedArrayElementDynamicWordMemoryHelperName
+      , checkedArrayElementDynamicDataOffsetCalldataHelperName
+      , checkedArrayElementDynamicDataOffsetMemoryHelperName
       ]
     else
       []
@@ -37,6 +39,12 @@ def reservedExternalNames
     if paramDynamicHeadWordHelpersRequired then
       [ checkedParamDynamicHeadWordCalldataHelperName
       , checkedParamDynamicHeadWordMemoryHelperName
+      , checkedParamDynamicMemberLengthCalldataHelperName
+      , checkedParamDynamicMemberLengthMemoryHelperName
+      , checkedParamDynamicMemberDataOffsetCalldataHelperName
+      , checkedParamDynamicMemberDataOffsetMemoryHelperName
+      , checkedParamDynamicMemberElementCalldataHelperName
+      , checkedParamDynamicMemberElementMemoryHelperName
       ]
     else
       []
@@ -80,6 +88,7 @@ def firstReservedExternalCollision
 
 def internalDynamicParamSupported : ParamType → Bool
   | ParamType.array _ => true
+  | ty@(ParamType.tuple _) => isDynamicParamType ty
   | _ => false
 
 def firstUnsupportedInternalDynamicParam
@@ -185,11 +194,14 @@ def validateInternalCallShapesInExpr
   | Expr.arrayElement _ index
   | Expr.arrayElementWord _ index _ _
   | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
       validateInternalCallShapesInExpr functions callerName index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex => do
       validateInternalCallShapesInExpr functions callerName index
+      validateInternalCallShapesInExpr functions callerName innerIndex
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
       validateInternalCallShapesInExpr functions callerName innerIndex
   | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b | Expr.mod a b | Expr.smod a b |
     Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b |
@@ -229,6 +241,8 @@ def validateInternalCallShapesInExpr
   | Expr.localVar _
   | Expr.arrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.dynamicBytesEq _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
       pure ()
@@ -450,11 +464,14 @@ def validateExternalCallTargetsInExpr
   | Expr.arrayElement _ index
   | Expr.arrayElementWord _ index _ _
   | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
       validateExternalCallTargetsInExpr externals context index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex => do
       validateExternalCallTargetsInExpr externals context index
+      validateExternalCallTargetsInExpr externals context innerIndex
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
       validateExternalCallTargetsInExpr externals context innerIndex
   | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b | Expr.mod a b | Expr.smod a b |
     Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b |
@@ -492,6 +509,8 @@ def validateExternalCallTargetsInExpr
   | Expr.localVar _
   | Expr.arrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.dynamicBytesEq _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
       pure ()

--- a/Compiler/CompilationModel/ValidationHelpers.lean
+++ b/Compiler/CompilationModel/ValidationHelpers.lean
@@ -79,8 +79,12 @@ def collectExprNames : Expr → List String
   | Expr.internalCall name args => name :: collectExprListNames args
   | Expr.arrayLength name => [name]
   | Expr.paramDynamicHeadWord name _ => [name]
+  | Expr.paramDynamicMemberLength name _
+  | Expr.paramDynamicMemberDataOffset name _ => [name]
+  | Expr.paramDynamicMemberElement name _ innerIndex => name :: collectExprNames innerIndex
   | Expr.arrayElement name index | Expr.arrayElementWord name index _ _
   | Expr.arrayElementDynamicWord name index _
+  | Expr.arrayElementDynamicDataOffset name index
   | Expr.arrayElementDynamicMemberDataOffset name index _
   | Expr.arrayElementDynamicMemberLength name index _ =>
       name :: collectExprNames index

--- a/Compiler/CompilationModel/ValidationInterop.lean
+++ b/Compiler/CompilationModel/ValidationInterop.lean
@@ -84,11 +84,14 @@ def validateInteropExpr (context : String) : Expr → Except String Unit
   | Expr.storageArrayElement _ index =>
       validateInteropExpr context index
   | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
       validateInteropExpr context index
   | Expr.arrayElementDynamicMemberElement _ index _ innerIndex => do
       validateInteropExpr context index
+      validateInteropExpr context innerIndex
+  | Expr.paramDynamicMemberElement _ _ innerIndex =>
       validateInteropExpr context innerIndex
   | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b | Expr.mod a b | Expr.smod a b |
     Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b |
@@ -123,6 +126,8 @@ def validateInteropExpr (context : String) : Expr → Except String Unit
   | Expr.localVar _
   | Expr.arrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.paramDynamicMemberDataOffset _ _
   | Expr.dynamicBytesEq _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
       pure ()

--- a/Compiler/Proofs/IRGeneration/ExprCore.lean
+++ b/Compiler/Proofs/IRGeneration/ExprCore.lean
@@ -39,11 +39,16 @@ def exprBoundNames : Expr → List String
   | .adtField _ _ _ _ storageField => [storageField]
   | .arrayElement name index | .arrayElementWord name index _ _
   | .arrayElementDynamicWord name index _
+  | .arrayElementDynamicDataOffset name index
   | .arrayElementDynamicMemberDataOffset name index _
   | .arrayElementDynamicMemberLength name index _ => name :: exprBoundNames index
   | .arrayElementDynamicMemberElement name index _ innerIndex =>
       name :: (exprBoundNames index ++ exprBoundNames innerIndex)
   | .paramDynamicHeadWord name _ => [name]
+  | .paramDynamicMemberLength name _
+  | .paramDynamicMemberDataOffset name _ => [name]
+  | .paramDynamicMemberElement name _ innerIndex =>
+      name :: exprBoundNames innerIndex
   | .arrayLength name => [name]
   | .storageArrayLength name => [name]
   | .storageArrayElement name index => name :: exprBoundNames index

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -574,8 +574,13 @@ private def ceilDivVal (lhs rhs : Verity.Core.Uint256) : Nat :=
   if lhs == 0 then 0 else ((lhs - 1) / rhs + 1).val
 
 def evalExpr (fields : List Field) (state : RuntimeState) : Expr → Option Nat
+  | .arrayElementDynamicDataOffset _ _ => none
   | .arrayElementDynamicMemberLength _ _ _ => none
+  | .arrayElementDynamicMemberDataOffset _ _ _ => none
   | .arrayElementDynamicMemberElement _ _ _ _ => none
+  | .paramDynamicMemberLength _ _ => none
+  | .paramDynamicMemberDataOffset _ _ => none
+  | .paramDynamicMemberElement _ _ _ => none
   | .literal n => some (wordNormalize n)
   | .param name => some (lookupValue state.bindings name)
     | .storage fieldName =>
@@ -1043,6 +1048,28 @@ private theorem evalExpr_paramDynamicHeadWord
     (wordOffset : Nat) :
     evalExpr fields state (.paramDynamicHeadWord name wordOffset) = none := rfl
 
+private theorem evalExpr_paramDynamicMemberLength
+    (fields : List Field)
+    (state : RuntimeState)
+    (name : String)
+    (wordOffset : Nat) :
+    evalExpr fields state (.paramDynamicMemberLength name wordOffset) = none := rfl
+
+private theorem evalExpr_paramDynamicMemberDataOffset
+    (fields : List Field)
+    (state : RuntimeState)
+    (name : String)
+    (wordOffset : Nat) :
+    evalExpr fields state (.paramDynamicMemberDataOffset name wordOffset) = none := rfl
+
+private theorem evalExpr_paramDynamicMemberElement
+    (fields : List Field)
+    (state : RuntimeState)
+    (name : String)
+    (wordOffset : Nat)
+    (innerIndex : Expr) :
+    evalExpr fields state (.paramDynamicMemberElement name wordOffset innerIndex) = none := rfl
+
 private theorem evalExpr_call
     (fields : List Field)
     (state : RuntimeState)
@@ -1381,6 +1408,13 @@ private theorem evalExpr_arrayElementDynamicWord
     (wordOffset : Nat) :
     evalExpr fields state (.arrayElementDynamicWord name index wordOffset) = none := rfl
 
+private theorem evalExpr_arrayElementDynamicDataOffset
+    (fields : List Field)
+    (state : RuntimeState)
+    (name : String)
+    (index : Expr) :
+    evalExpr fields state (.arrayElementDynamicDataOffset name index) = none := rfl
+
 private theorem evalExpr_arrayElementDynamicMemberLength
     (fields : List Field)
     (state : RuntimeState)
@@ -1388,6 +1422,14 @@ private theorem evalExpr_arrayElementDynamicMemberLength
     (index : Expr)
     (wordOffset : Nat) :
     evalExpr fields state (.arrayElementDynamicMemberLength name index wordOffset) = none := rfl
+
+private theorem evalExpr_arrayElementDynamicMemberDataOffset
+    (fields : List Field)
+    (state : RuntimeState)
+    (name : String)
+    (index : Expr)
+    (wordOffset : Nat) :
+    evalExpr fields state (.arrayElementDynamicMemberDataOffset name index wordOffset) = none := rfl
 
 private theorem evalExpr_arrayElementDynamicMemberElement
     (fields : List Field)
@@ -2733,10 +2775,13 @@ mutual
     -- the 200 000-heartbeat ceiling whenever a new `Expr` constructor
     -- lands (verity#1842).
     | .mulDiv512Down _ _ _ | .mulDiv512Up _ _ _
-    | .paramDynamicHeadWord _ _
+    | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+    | .paramDynamicMemberDataOffset _ _ | .paramDynamicMemberElement _ _ _
     | .arrayLength _ | .arrayElement _ _
     | .arrayElementWord _ _ _ _ | .arrayElementDynamicWord _ _ _
+    | .arrayElementDynamicDataOffset _ _
     | .arrayElementDynamicMemberLength _ _ _
+    | .arrayElementDynamicMemberDataOffset _ _ _
     | .arrayElementDynamicMemberElement _ _ _ _
     | .extcodesize _ | .returndataSize | .returndataOptionalBoolAt _
     | .keccak256 _ _
@@ -3753,8 +3798,12 @@ mutual
         simp [evalExprWithHelpers, evalExpr_arrayElementWord]
     | arrayElementDynamicWord _ b _ =>
         simp [evalExprWithHelpers, evalExpr_arrayElementDynamicWord]
+    | arrayElementDynamicDataOffset _ b =>
+        simp [evalExprWithHelpers, evalExpr_arrayElementDynamicDataOffset]
     | arrayElementDynamicMemberLength _ b _ =>
         simp [evalExprWithHelpers, evalExpr_arrayElementDynamicMemberLength]
+    | arrayElementDynamicMemberDataOffset _ b _ =>
+        simp [evalExprWithHelpers, evalExpr_arrayElementDynamicMemberDataOffset]
     | arrayElementDynamicMemberElement _ a _ b =>
         simp [evalExprWithHelpers, evalExpr_arrayElementDynamicMemberElement]
     | mappingWord _ b _ | mappingPackedWord _ b _ _ | structMember _ b _ =>
@@ -3796,6 +3845,14 @@ mutual
         simp [evalExprWithHelpers, evalExpr_mulDiv512Down, evalExpr_mulDiv512Up]
     | paramDynamicHeadWord _ _ =>
         simp [evalExprWithHelpers, evalExpr_paramDynamicHeadWord]
+    | paramDynamicMemberLength _ _ | paramDynamicMemberDataOffset _ _ =>
+        simp [evalExprWithHelpers, evalExpr_paramDynamicMemberLength,
+          evalExpr_paramDynamicMemberDataOffset]
+    | paramDynamicMemberElement _ _ b =>
+        simp only [exprTouchesUnsupportedHelperSurface] at hsurface
+        have hb :=
+          evalExprWithHelpers_eq_evalExpr_of_helperSurfaceClosed spec fields fuel state b hsurface
+        simpa [evalExprWithHelpers, evalExpr_paramDynamicMemberElement, hb]
     | ite cond thenVal elseVal =>
         simp only [exprTouchesUnsupportedHelperSurface, Bool.or_eq_false_iff] at hsurface
         have hcond :=

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -566,8 +566,12 @@ def exprTouchesUnsupportedConstructorRawCalldataSurface : Expr → Bool
   | .mappingUint _ a | .structMember _ a _ | .arrayElement _ a
   | .arrayElementWord _ a _ _
   | .arrayElementDynamicWord _ a _
+  | .arrayElementDynamicDataOffset _ a
   | .arrayElementDynamicMemberLength _ a _
+  | .arrayElementDynamicMemberDataOffset _ a _
   | .storageArrayElement _ a =>
+      exprTouchesUnsupportedConstructorRawCalldataSurface a
+  | .paramDynamicMemberElement _ _ a =>
       exprTouchesUnsupportedConstructorRawCalldataSurface a
   | .arrayElementDynamicMemberElement _ a _ b =>
       exprTouchesUnsupportedConstructorRawCalldataSurface a ||
@@ -592,7 +596,8 @@ def exprTouchesUnsupportedConstructorRawCalldataSurface : Expr → Bool
   -- `paramDynamicHeadWord` reads the head section of an ABI-decoded
   -- parameter; like `param _` it does not touch raw calldata, so the
   -- constructor-arg precondition is unaffected.
-  | .paramDynamicHeadWord _ _ => false
+  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicMemberDataOffset _ _ => false
   | .mappingChain _ keys | .internalCall _ keys | .externalCall _ keys =>
       exprListTouchesUnsupportedConstructorRawCalldataSurface keys
   | .keccak256 a b =>
@@ -728,9 +733,12 @@ def exprTouchesUnsupportedCoreSurface : Expr → Bool
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
   | .arrayLength _ | .arrayElement _ _ | .arrayElementWord _ _ _ _
   | .arrayElementDynamicWord _ _ _
+  | .arrayElementDynamicDataOffset _ _
   | .arrayElementDynamicMemberLength _ _ _
+  | .arrayElementDynamicMemberDataOffset _ _ _
   | .arrayElementDynamicMemberElement _ _ _ _
-  | .paramDynamicHeadWord _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicMemberDataOffset _ _ | .paramDynamicMemberElement _ _ _
   | .mulDiv512Down _ _ _ | .mulDiv512Up _ _ _
   | .storageArrayLength _ | .storageArrayElement _ _
   | .dynamicBytesEq _ _
@@ -772,8 +780,11 @@ def exprTouchesUnsupportedStateSurface : Expr → Bool
   | .arrayLength _ | .arrayElement _ _ | .arrayElementWord _ _ _ _
   | .arrayElementDynamicWord _ _ _
   | .arrayElementDynamicMemberLength _ _ _
+  | .arrayElementDynamicDataOffset _ _
+  | .arrayElementDynamicMemberDataOffset _ _ _
   | .arrayElementDynamicMemberElement _ _ _ _
-  | .paramDynamicHeadWord _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicMemberDataOffset _ _ | .paramDynamicMemberElement _ _ _
   | .dynamicBytesEq _ _ => false
   | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedStateSurface a
   | .adtConstruct _ _ _ | .adtTag _ _ | .adtField _ _ _ _ _ => true
@@ -789,8 +800,11 @@ def exprTouchesUnsupportedCallSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
-  | .paramDynamicHeadWord _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ => false
+  | .paramDynamicMemberElement _ _ b =>
+      exprTouchesUnsupportedCallSurface b
   | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedCallSurface a
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
   | .bitAnd a b | .bitOr a b | .bitXor a b | .eq a b
@@ -803,7 +817,9 @@ def exprTouchesUnsupportedCallSurface : Expr → Bool
   | .arrayElementDynamicWord _ b _
   | .storageArrayElement _ b =>
       exprTouchesUnsupportedCallSurface b
+  | .arrayElementDynamicDataOffset _ _
   | .arrayElementDynamicMemberLength _ _ _
+  | .arrayElementDynamicMemberDataOffset _ _ _
   | .arrayElementDynamicMemberElement _ _ _ _ => true
   | .mappingChain _ _ => true
   | .bitNot a | .logicalNot a | .mappingWord _ a _ | .mappingPackedWord _ a _ _
@@ -834,8 +850,11 @@ def exprTouchesUnsupportedHelperSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
-  | .paramDynamicHeadWord _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ | .externalCall _ _ => false
+  | .paramDynamicMemberElement _ _ b =>
+      exprTouchesUnsupportedHelperSurface b
   | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedHelperSurface a
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => false
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
@@ -849,7 +868,9 @@ def exprTouchesUnsupportedHelperSurface : Expr → Bool
   | .arrayElementDynamicWord _ b _
   | .storageArrayElement _ b =>
       exprTouchesUnsupportedHelperSurface b
+  | .arrayElementDynamicDataOffset _ _
   | .arrayElementDynamicMemberLength _ _ _
+  | .arrayElementDynamicMemberDataOffset _ _ _
   | .arrayElementDynamicMemberElement _ _ _ _ => true
   | .mappingChain _ _ => true
   | .bitNot a | .logicalNot a | .mappingWord _ a _ | .mappingPackedWord _ a _ _
@@ -888,8 +909,11 @@ def exprTouchesInternalHelperSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
-  | .paramDynamicHeadWord _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ | .externalCall _ _ => false
+  | .paramDynamicMemberElement _ _ b =>
+      exprTouchesInternalHelperSurface b
   | .mload a | .tload a | .calldataload a => exprTouchesInternalHelperSurface a
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => false
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
@@ -901,7 +925,9 @@ def exprTouchesInternalHelperSurface : Expr → Bool
       exprTouchesInternalHelperSurface a || exprTouchesInternalHelperSurface b
   | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .arrayElementWord _ b _ _
   | .arrayElementDynamicWord _ b _
+  | .arrayElementDynamicDataOffset _ b
   | .arrayElementDynamicMemberLength _ b _
+  | .arrayElementDynamicMemberDataOffset _ b _
   | .storageArrayElement _ b =>
       exprTouchesInternalHelperSurface b
   | .arrayElementDynamicMemberElement _ a _ b =>
@@ -937,8 +963,11 @@ def exprTouchesUnsupportedForeignSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
-  | .paramDynamicHeadWord _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ | .internalCall _ _ => false
+  | .paramDynamicMemberElement _ _ b =>
+      exprTouchesUnsupportedForeignSurface b
   | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedForeignSurface a
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => false
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
@@ -951,6 +980,8 @@ def exprTouchesUnsupportedForeignSurface : Expr → Bool
   | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .arrayElementWord _ b _ _
   | .arrayElementDynamicWord _ b _
   | .arrayElementDynamicMemberLength _ b _
+  | .arrayElementDynamicDataOffset _ b
+  | .arrayElementDynamicMemberDataOffset _ b _
   | .storageArrayElement _ b =>
       exprTouchesUnsupportedForeignSurface b
   | .arrayElementDynamicMemberElement _ a _ b =>
@@ -984,8 +1015,11 @@ def exprTouchesUnsupportedLowLevelSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
-  | .paramDynamicHeadWord _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ | .internalCall _ _ | .externalCall _ _ => false
+  | .paramDynamicMemberElement _ _ b =>
+      exprTouchesUnsupportedLowLevelSurface b
   | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedLowLevelSurface a
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
   | .bitAnd a b | .bitOr a b | .bitXor a b | .eq a b
@@ -996,7 +1030,9 @@ def exprTouchesUnsupportedLowLevelSurface : Expr → Bool
       exprTouchesUnsupportedLowLevelSurface a || exprTouchesUnsupportedLowLevelSurface b
   | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .arrayElementWord _ b _ _
   | .arrayElementDynamicWord _ b _
+  | .arrayElementDynamicDataOffset _ b
   | .arrayElementDynamicMemberLength _ b _
+  | .arrayElementDynamicMemberDataOffset _ b _
   | .storageArrayElement _ b =>
       exprTouchesUnsupportedLowLevelSurface b
   | .arrayElementDynamicMemberElement _ a _ b =>
@@ -1059,9 +1095,12 @@ def exprTouchesUnsupportedContractSurface (expr : Expr) : Bool :=
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
   | .arrayLength _ | .arrayElement _ _ | .arrayElementWord _ _ _ _
   | .arrayElementDynamicWord _ _ _
+  | .arrayElementDynamicDataOffset _ _
   | .arrayElementDynamicMemberLength _ _ _
+  | .arrayElementDynamicMemberDataOffset _ _ _
   | .arrayElementDynamicMemberElement _ _ _ _
-  | .paramDynamicHeadWord _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicMemberDataOffset _ _ | .paramDynamicMemberElement _ _ _
   | .mulDiv512Down _ _ _ | .mulDiv512Up _ _ _
   | .storageArrayLength _ | .storageArrayElement _ _
   | .dynamicBytesEq _ _
@@ -1666,10 +1705,14 @@ mutual
     | .mappingUint _ key | .structMember _ key _ | .arrayElement _ key
     | .arrayElementWord _ key _ _
     | .arrayElementDynamicWord _ key _
+    | .arrayElementDynamicDataOffset _ key
     | .arrayElementDynamicMemberLength _ key _
+    | .arrayElementDynamicMemberDataOffset _ key _
     | .storageArrayElement _ key | .mload key | .tload key | .calldataload key
     | .extcodesize key | .returndataOptionalBoolAt key =>
         exprInternalHelperCallNames key
+    | .paramDynamicMemberElement _ _ innerKey =>
+        exprInternalHelperCallNames innerKey
     | .arrayElementDynamicMemberElement _ key _ innerKey =>
         exprInternalHelperCallNames key ++ exprInternalHelperCallNames innerKey
     | .mappingChain _ keys =>
@@ -1721,7 +1764,8 @@ mutual
     | .blockTimestamp | .blockNumber | .blobbasefee
     | .calldatasize | .returndataSize
     | .localVar _ | .arrayLength _ | .storageArrayLength _
-    | .paramDynamicHeadWord _ _
+    | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+    | .paramDynamicMemberDataOffset _ _
     | .dynamicBytesEq _ _
     | .adtConstruct _ _ _ | .adtTag _ _ | .adtField _ _ _ _ _ =>
         []
@@ -3178,7 +3222,8 @@ mutual
     | blockTimestamp | blockNumber | localVar _ | storage _ | storageAddr _
     | constructorArg _ | blobbasefee | calldatasize | returndataSize
     | arrayLength _ | storageArrayLength _ | dynamicBytesEq _ _
-    | paramDynamicHeadWord _ _
+    | paramDynamicHeadWord _ _ | paramDynamicMemberLength _ _
+    | paramDynamicMemberDataOffset _ _
     | externalCall _ _ =>
         simp [exprTouchesInternalHelperSurface]
     | adtConstruct _ _ _ | adtTag _ _ | adtField _ _ _ _ _ =>
@@ -3228,7 +3273,13 @@ mutual
         simp only [exprTouchesUnsupportedHelperSurface] at hsurface
         simp [exprTouchesInternalHelperSurface,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface]
+    | paramDynamicMemberElement _ _ b =>
+        simp only [exprTouchesUnsupportedHelperSurface] at hsurface
+        simp [exprTouchesInternalHelperSurface,
+          exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface]
+    | arrayElementDynamicDataOffset _ _
     | arrayElementDynamicMemberLength _ _ _
+    | arrayElementDynamicMemberDataOffset _ _ _
     | arrayElementDynamicMemberElement _ _ _ _ =>
         simp [exprTouchesUnsupportedHelperSurface] at hsurface
     | mapping2 _ a b | mapping2Word _ a b _ | structMember2 _ a b _ =>
@@ -3570,7 +3621,8 @@ private theorem exprTouchesUnsupportedCallSurface_eq_featureOr
   | literal _ | param _ | caller | contractAddress
   | chainid | msgValue | selfBalance | blockTimestamp | blockNumber
   | localVar _ | storage _ | storageAddr _
-  | paramDynamicHeadWord _ _
+  | paramDynamicHeadWord _ _ | paramDynamicMemberLength _ _
+  | paramDynamicMemberDataOffset _ _
   | constructorArg _ | blobbasefee | calldatasize | returndataSize =>
       simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
@@ -3610,6 +3662,10 @@ private theorem exprTouchesUnsupportedCallSurface_eq_featureOr
       simp only [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
       exact exprTouchesUnsupportedCallSurface_eq_featureOr a
+  | paramDynamicMemberElement _ _ b =>
+      simp only [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
+        exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
+      exact exprTouchesUnsupportedCallSurface_eq_featureOr b
   | mapping _ b | mappingUint _ b | arrayElement _ b | arrayElementWord _ b _ _
   | storageArrayElement _ b =>
       simp only [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
@@ -3619,7 +3675,9 @@ private theorem exprTouchesUnsupportedCallSurface_eq_featureOr
       simp only [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
       exact exprTouchesUnsupportedCallSurface_eq_featureOr b
-  | arrayElementDynamicMemberLength _ _ _ =>
+  | arrayElementDynamicDataOffset _ _
+  | arrayElementDynamicMemberLength _ _ _
+  | arrayElementDynamicMemberDataOffset _ _ _ =>
       simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
   | arrayElementDynamicMemberElement _ a _ b =>
@@ -3782,7 +3840,8 @@ private theorem exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
       simp [exprTouchesUnsupportedCoreSurface] at hcore
   | storage _ | storageAddr _ =>
       cases hstate
-  | paramDynamicHeadWord _ _ =>
+  | paramDynamicHeadWord _ _ | paramDynamicMemberLength _ _
+  | paramDynamicMemberDataOffset _ _ | paramDynamicMemberElement _ _ _ =>
       cases hcore
   | constructorArg _
   | returndataSize | arrayLength _ | storageArrayLength _
@@ -3865,7 +3924,9 @@ private theorem exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
   | mapping2 _ _ _ | mapping2Word _ _ _ _ | mappingUint _ _
   | mappingChain _ _ | structMember _ _ _ | structMember2 _ _ _ _
   | arrayElement _ _ | arrayElementWord _ _ _ _ | arrayElementDynamicWord _ _ _
+  | arrayElementDynamicDataOffset _ _
   | arrayElementDynamicMemberLength _ _ _
+  | arrayElementDynamicMemberDataOffset _ _ _
   | arrayElementDynamicMemberElement _ _ _ _
   | storageArrayElement _ _
   | call _ _ _ _ _ _ _ | staticcall _ _ _ _ _ _ | delegatecall _ _ _ _ _ _
@@ -4168,9 +4229,12 @@ theorem exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
   | mapping2 _ _ _ | mapping2Word _ _ _ _ | mappingUint _ _
   | structMember _ _ _ | structMember2 _ _ _ _
   | arrayElement _ _ | arrayElementWord _ _ _ _ | arrayElementDynamicWord _ _ _
+  | arrayElementDynamicDataOffset _ _
   | arrayElementDynamicMemberLength _ _ _
+  | arrayElementDynamicMemberDataOffset _ _ _
   | arrayElementDynamicMemberElement _ _ _ _
-  | paramDynamicHeadWord _ _
+  | paramDynamicHeadWord _ _ | paramDynamicMemberLength _ _
+  | paramDynamicMemberDataOffset _ _ | paramDynamicMemberElement _ _ _
   | storageArrayElement _ _
   | mappingChain _ _ =>
       simp [exprTouchesUnsupportedContractSurface] at hsurface

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -371,6 +371,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.LinkedExternalDynamicArgSmoke.spec
   , Contracts.Smoke.LinkedExternalProjectedArrayArgSmoke.spec
   , Contracts.Smoke.NestedStructArrayProjectionSmoke.spec
+  , Contracts.Smoke.DynamicStructElementHelperArgSmoke.spec
   , Contracts.Smoke.ExternalCallMultiReturn.spec
   , Contracts.Smoke.ERC20HelperSmoke.spec
   , Contracts.Smoke.GenericECMReadSmoke.spec
@@ -525,7 +526,12 @@ private def expectedExternalSignatures : List (String × List String) :=
       ["tryHashNullifiers((uint256,uint256[],uint256[])[],uint256)"])
   , ("NestedStructArrayProjectionSmoke",
       ["withdrawalAmount(((uint256[2],uint256[2][2],uint256[2]),uint256,uint256,uint256[],uint256[],uint256,(uint256,address,uint256),uint256[])[],uint256)",
-       "withdrawalAmountViaHelper(((uint256[2],uint256[2][2],uint256[2]),uint256,uint256,uint256[],uint256[],uint256,(uint256,address,uint256),uint256[])[],uint256)"])
+       "consumeNullifiers(uint256[])",
+       "withdrawalAmountViaHelper(((uint256[2],uint256[2][2],uint256[2]),uint256,uint256,uint256[],uint256[],uint256,(uint256,address,uint256),uint256[])[],uint256)",
+       "consumeNullifiersViaHelper(((uint256[2],uint256[2][2],uint256[2]),uint256,uint256,uint256[],uint256[],uint256,(uint256,address,uint256),uint256[])[],uint256)"])
+  , ("DynamicStructElementHelperArgSmoke",
+      ["consumeValues(uint256[])", "inspect((uint256,uint256[]))",
+       "inspectAt((uint256,uint256[])[],uint256)"])
   , ("ExternalCallMultiReturn", ["callFanout(uint256)", "noop()"])
   , ("ERC20HelperSmoke", ["pushTokens(address,address,uint256)", "pullTokens(address,address,address,uint256)",
       "approveTokens(address,address,uint256)", "snapshotBalance(address,address)",
@@ -655,7 +661,8 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("LinkedExternalDynamicArgSmoke", ["0xf1b3ebc7", "0x3f87a475", "0x35ea2663",
       "0xc58b0a4d"])
   , ("LinkedExternalProjectedArrayArgSmoke", ["0x2bda60e2"])
-  , ("NestedStructArrayProjectionSmoke", ["0x714fb4de", "0x8999bcc3"])
+  , ("NestedStructArrayProjectionSmoke", ["0x714fb4de", "0x14750c34", "0x8999bcc3", "0x5d157fb5"])
+  , ("DynamicStructElementHelperArgSmoke", ["0x3464e97c", "0x291f8f0b", "0xef6057fa"])
   , ("ExternalCallMultiReturn", ["0x70fce9a3", "0x5dfc2e4a"])
   , ("ERC20HelperSmoke", ["0xa6c29ca3", "0x6aa209a6", "0x912d6e28", "0x48476c71", "0xdac24aaf",
       "0x7247c4a5"])

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -156,6 +156,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.LinkedExternalDynamicArgSmoke.spec
   , Contracts.Smoke.LinkedExternalProjectedArrayArgSmoke.spec
   , Contracts.Smoke.NestedStructArrayProjectionSmoke.spec
+  , Contracts.Smoke.DynamicStructElementHelperArgSmoke.spec
   , Contracts.Smoke.ExternalCallMultiReturn.spec
   , Contracts.Smoke.ERC20HelperSmoke.spec
   , Contracts.Smoke.GenericECMReadSmoke.spec

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -1102,7 +1102,7 @@ verity_contract NamedStructTupleProjectionRejected where
     return pair_0
 
 /--
-error: non-leaf struct parameter projection is not supported; project a scalar or static single-word leaf field instead (#1832)
+error: local binding 'notes' currently cannot bind dynamic values (Verity.Macro.ValueType.array (Verity.Macro.ValueType.uint256)) to local variables on the compilation-model path; use the parameter directly
 -/
 #guard_msgs in
 verity_contract NamedStructDynamicProjectionRejected where
@@ -1798,6 +1798,62 @@ example :
               10
           ]
       , Compiler.CompilationModel.Stmt.stop
+      ] := rfl
+
+verity_contract DynamicStructElementHelperArgSmoke where
+  storage
+
+  struct Transaction where
+    id : Uint256,
+    values : Array Uint256
+
+  function consumeValues (values : Array Uint256) : Uint256 := do
+    return arrayLength values
+
+  function inspect (txn : Transaction) : Uint256 := do
+    let first := arrayElement txn.values 0
+    let count ← consumeValues txn.values
+    return add txn.id (add first count)
+
+  function inspectAt (txs : Array Transaction, idx : Uint256) : Uint256 := do
+    let total ← inspect (arrayElement txs idx)
+    return total
+
+example :
+    DynamicStructElementHelperArgSmoke.inspect_modelBody =
+      [ Compiler.CompilationModel.Stmt.letVar
+          "first"
+          (Compiler.CompilationModel.Expr.paramDynamicMemberElement
+            "txn"
+            1
+            (Compiler.CompilationModel.Expr.literal 0))
+      , Compiler.CompilationModel.Stmt.letVar
+          "count"
+          (Compiler.CompilationModel.Expr.internalCall
+            "internal_consumeValues"
+            [ Compiler.CompilationModel.Expr.paramDynamicMemberDataOffset "txn" 1
+            , Compiler.CompilationModel.Expr.paramDynamicMemberLength "txn" 1
+            ])
+      , Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.add
+            (Compiler.CompilationModel.Expr.paramDynamicHeadWord "txn" 0)
+            (Compiler.CompilationModel.Expr.add
+              (Compiler.CompilationModel.Expr.localVar "first")
+              (Compiler.CompilationModel.Expr.localVar "count")))
+      ] := rfl
+
+example :
+    DynamicStructElementHelperArgSmoke.inspectAt_modelBody =
+      [ Compiler.CompilationModel.Stmt.letVar
+          "total"
+          (Compiler.CompilationModel.Expr.internalCall
+            "internal_inspect"
+            [ Compiler.CompilationModel.Expr.arrayElementDynamicDataOffset
+                "txs"
+                (Compiler.CompilationModel.Expr.param "idx")
+            ])
+      , Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.localVar "total")
       ] := rfl
 
 example :

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2754,6 +2754,9 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mulDiv512Down  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mulDiv512Up  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_paramDynamicHeadWord  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_paramDynamicMemberLength  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_paramDynamicMemberDataOffset  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_paramDynamicMemberElement  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_call  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_staticcall  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_delegatecall  -- private
@@ -2791,7 +2794,9 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayElement  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayElementWord  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayElementDynamicWord  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayElementDynamicDataOffset  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayElementDynamicMemberLength  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayElementDynamicMemberDataOffset  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayElementDynamicMemberElement  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mappingWord  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mappingPackedWord  -- private
@@ -5577,4 +5582,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5291 theorems/lemmas (3564 public, 1727 private, 0 sorry'd)
+-- Total: 5296 theorems/lemmas (3564 public, 1732 private, 0 sorry'd)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1839,6 +1839,54 @@ private def paramDynamicHeadProjection?
     else
       none
 
+private def paramDynamicMemberProjection?
+    (params : Array ParamDecl)
+    (stx : Term) : Option (String × ValueType × Nat) := do
+  let (root, path) ←
+    match (stripParens stx).raw with
+    | .ident _ raw _ _ =>
+        let parts := raw.toString.splitOn "."
+        let rec findParamPath : List String → Option (String × List String)
+          | [] | [_] => none
+          | rootName :: fieldName :: rest =>
+              if params.any (fun p => p.name == rootName) then
+                some (rootName, fieldName :: rest)
+              else
+                findParamPath (fieldName :: rest)
+        findParamPath parts
+    | _ =>
+        let (rootStx, path) ← structProjectionPath? stx
+        match stripParens rootStx with
+        | `(term| $id:ident) => some (toString id.getId, path)
+        | _ => none
+  let param ← params.find? (fun p => p.name == root)
+  if !valueTypeUsesDynamicData param.ty then
+    none
+  else
+    let (fieldTy, wordOffset) ← structFieldHeadOffset? param.ty path
+    match fieldTy with
+    | .array _ | .bytes | .string => some (root, fieldTy, wordOffset)
+    | _ => none
+
+private def arrayElementDynamicTupleArg?
+    (params : Array ParamDecl)
+    (stx : Term) : Option (String × Term × ValueType) := do
+  match stripParens stx with
+  | `(term| arrayElement $name:term $index:term) =>
+      let paramName ←
+        match stripParens name with
+        | `(term| $id:ident) => some (toString id.getId)
+        | _ => none
+      let param ← params.find? (fun p => p.name == paramName)
+      let elemTy ← match param.ty with
+        | .array elemTy => some elemTy
+        | _ => none
+      if valueTypeUsesDynamicData elemTy then
+        some (paramName, index, elemTy)
+      else
+        none
+  | _ => none
+
 private def isParamStructNonLeafProjection (params : Array ParamDecl) (stx : Term) : Bool :=
   match paramStructProjectionResolved? params stx with
   | some (_, fieldTy, _) => !isSingleWordStaticValueType fieldTy
@@ -2140,6 +2188,8 @@ private partial def hasDynamicInternalHelperType (ty : ValueType) : Bool :=
 private def supportsInternalHelperParamType (ty : ValueType) : Bool :=
   match ty with
   | .array _ => true
+  | .struct _ _ => true
+  | .tuple _ => true
   | _ => !hasDynamicInternalHelperType ty
 
 private def supportsInternalHelperSpec (fn : FunctionDecl) : Bool :=
@@ -2325,6 +2375,9 @@ private partial def inferPureExprType
   if let some (_, fieldTy, _) := paramDynamicHeadProjection? params stx then
     pure fieldTy
   else
+  if let some (_, fieldTy, _) := paramDynamicMemberProjection? params stx then
+    pure fieldTy
+  else
   if isParamStructNonLeafProjection params stx then
     throwStructNonLeafProjectionError stx
   else
@@ -2489,6 +2542,8 @@ private partial def inferPureExprType
       -- element type. Lowers through `Expr.arrayElementDynamicMemberLength`.
       if let some _ := arrayElementDynamicMemberProjection? params name then
         pure .uint256
+      else if let some _ := paramDynamicMemberProjection? params name then
+        pure .uint256
       else
         match lookupNamedValueType? constDecls immutableDecls params locals (← expectStringOrIdent name) with
         | some (.array _) => pure .uint256
@@ -2507,9 +2562,29 @@ private partial def inferPureExprType
               throwErrorAt name s!"arrayElement on a dynamic member of a struct-array element currently supports only Array<wordLike> members, got Array {renderValueType elemTy}"
         | _ =>
             throwErrorAt name s!"arrayElement on a struct-array element projection requires an Array-typed dynamic member, got {renderValueType fieldTy}"
+      else if let some (_, fieldTy, _) := paramDynamicMemberProjection? params name then
+        match fieldTy with
+        | .array elemTy =>
+            if isSingleWordStaticValueType elemTy then
+              pure elemTy
+            else
+              throwErrorAt name s!"arrayElement on a dynamic member of a struct parameter currently supports only Array<wordLike> members, got Array {renderValueType elemTy}"
+        | _ =>
+            throwErrorAt name s!"arrayElement on a struct parameter projection requires an Array-typed dynamic member, got {renderValueType fieldTy}"
       else
         let sourceTy ← requireDirectParamRef name "arrayElement" params
-        requireSupportedArrayElementSourceType name "arrayElement" sourceTy
+        match sourceTy with
+        | .array elemTy =>
+            match elemTy with
+            | .struct _ _ | .tuple _ =>
+              if valueTypeUsesDynamicData elemTy then
+                pure elemTy
+              else
+                requireSupportedArrayElementSourceType name "arrayElement" sourceTy
+            | _ =>
+              requireSupportedArrayElementSourceType name "arrayElement" sourceTy
+        | _ =>
+            requireSupportedArrayElementSourceType name "arrayElement" sourceTy
   | `(term| mulDivDown $a $b $c) | `(term| mulDivUp $a $b $c) => do
       for arg in [a, b, c] do
         requireWordLikeType arg "mulDiv" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
@@ -2532,6 +2607,13 @@ private partial def inferPureExprType
             -- verity#1849, G3: accept `Array <wordLike>` / `bytes` / `string`
             -- direct param refs alongside word-like args.
             if let some (_, _, fieldTy, _elemTy, _) := arrayElementDynamicMemberProjection? params x then
+              match fieldTy with
+              | .array elemTy =>
+                  unless externalCallDynamicArgSupported (.array elemTy) do
+                    throwErrorAt x s!"externalCall '{extName}' dynamic-member argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
+              | _ =>
+                  throwErrorAt x s!"externalCall '{extName}' dynamic-member argument requires an Array-typed member, got {renderValueType fieldTy}"
+            else if let some (_, fieldTy, _) := paramDynamicMemberProjection? params x then
               match fieldTy with
               | .array elemTy =>
                   unless externalCallDynamicArgSupported (.array elemTy) do
@@ -3238,6 +3320,9 @@ partial def translatePureExprWithTypes
       $(strTerm paramName)
       $(natTerm wordOffset))
   else
+  if (paramDynamicMemberProjection? params stx).isSome then
+    throwErrorAt stx "dynamic struct parameter member cannot be used as a scalar expression; pass it to a helper/external expecting an Array or use arrayLength/arrayElement"
+  else
   if isParamStructNonLeafProjection params stx then
     throwStructNonLeafProjectionError stx
   else
@@ -3466,6 +3551,11 @@ partial def translatePureExprWithTypes
             $(strTerm paramName)
             $indexExpr
             $(natTerm wordOffset))
+      else if let some (paramName, _fieldTy, wordOffset) :=
+          paramDynamicMemberProjection? params name then
+        `(Compiler.CompilationModel.Expr.paramDynamicMemberLength
+            $(strTerm paramName)
+            $(natTerm wordOffset))
       else
         `(Compiler.CompilationModel.Expr.arrayLength $(strTerm (← expectStringOrIdent name)))
   | `(term| arrayElement $name:term $index:term) =>
@@ -3478,6 +3568,13 @@ partial def translatePureExprWithTypes
         `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberElement
             $(strTerm paramName)
             $outerIndexExpr
+            $(natTerm wordOffset)
+            $innerIndexExpr)
+      else if let some (paramName, _fieldTy, wordOffset) :=
+          paramDynamicMemberProjection? params name then
+        let innerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+        `(Compiler.CompilationModel.Expr.paramDynamicMemberElement
+            $(strTerm paramName)
             $(natTerm wordOffset)
             $innerIndexExpr)
       else
@@ -3956,11 +4053,39 @@ private def translateInternalHelperCallArgs
                     $(natTerm wordOffset)))
               | _ =>
                   throwErrorAt arg s!"helper call '{fn.name}' Array parameter '{fnParam.name}' requires an Array-typed projected member, got {renderValueType fieldTy}"
+            else if let some (paramName, fieldTy, wordOffset) :=
+                paramDynamicMemberProjection? params arg then
+              match fieldTy with
+              | .array _ =>
+                  out := out.push (← `(Compiler.CompilationModel.Expr.paramDynamicMemberDataOffset
+                    $(strTerm paramName)
+                    $(natTerm wordOffset)))
+                  out := out.push (← `(Compiler.CompilationModel.Expr.paramDynamicMemberLength
+                    $(strTerm paramName)
+                    $(natTerm wordOffset)))
+              | _ =>
+                  throwErrorAt arg s!"helper call '{fn.name}' Array parameter '{fnParam.name}' requires an Array-typed projected member, got {renderValueType fieldTy}"
             else
               throwErrorAt arg
                 s!"helper call '{fn.name}' Array parameter '{fnParam.name}' currently requires a direct Array parameter reference or projected struct-array member"
     | _ =>
-        out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+        if valueTypeUsesDynamicData fnParam.ty then
+          match directParamNameWithType? params arg with
+          | some (name, ty) =>
+              if valueTypeUsesDynamicData ty then
+                out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
+              else
+                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+          | none =>
+              if let some (paramName, index, _elemTy) := arrayElementDynamicTupleArg? params arg then
+                let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicDataOffset
+                  $(strTerm paramName)
+                  $indexExpr))
+              else
+                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+        else
+          out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
   pure out
 
 private def translateLinkedExternalCallArgs
@@ -3993,6 +4118,21 @@ private def translateLinkedExternalCallArgs
                 out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
                   $(strTerm paramName)
                   $indexExpr
+                  $(natTerm wordOffset)))
+              else
+                throwErrorAt arg s!"linked external dynamic-member argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
+          | _ =>
+              throwErrorAt arg s!"linked external dynamic-member argument requires an Array-typed member, got {renderValueType fieldTy}"
+        else if let some (paramName, fieldTy, wordOffset) :=
+            paramDynamicMemberProjection? params arg then
+          match fieldTy with
+          | .array elemTy =>
+              if externalCallDynamicArgSupported (.array elemTy) then
+                out := out.push (← `(Compiler.CompilationModel.Expr.paramDynamicMemberDataOffset
+                  $(strTerm paramName)
+                  $(natTerm wordOffset)))
+                out := out.push (← `(Compiler.CompilationModel.Expr.paramDynamicMemberLength
+                  $(strTerm paramName)
                   $(natTerm wordOffset)))
               else
                 throwErrorAt arg s!"linked external dynamic-member argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"

--- a/artifacts/macro_property_tests/PropertyDynamicStructElementHelperArgSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyDynamicStructElementHelperArgSmoke.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyDynamicStructElementHelperArgSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyDynamicStructElementHelperArgSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("DynamicStructElementHelperArgSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `consumeValues` result
+    function testTODO_ConsumeValues_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("consumeValues(uint256[])", _singletonUintArray(1)));
+        require(ok, "consumeValues reverted unexpectedly");
+        assertEq(ret.length, 32, "consumeValues ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: TODO decode and assert `inspect` result
+    function testTODO_Inspect_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("inspect((uint256,uint256[]))", abi.decode(abi.encode(uint256(1), _singletonUintArray(1)), (uint256, uint256[]))));
+        require(ok, "inspect reverted unexpectedly");
+        assertEq(ret.length, 32, "inspect ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 3: TODO decode and assert `inspectAt` result
+    function testTODO_InspectAt_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("inspectAt((uint256,uint256[])[],uint256)", abi.decode(abi.encode(uint256(0)), ((uint256,uint256[])[])), uint256(1)));
+        require(ok, "inspectAt reverted unexpectedly");
+        assertEq(ret.length, 32, "inspectAt ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+
+    function _singletonUintArray(uint256 x) internal pure returns (uint256[] memory arr) {
+        arr = new uint256[](1);
+        arr[0] = x;
+    }
+}

--- a/scripts/generate_macro_property_tests.py
+++ b/scripts/generate_macro_property_tests.py
@@ -669,10 +669,7 @@ def _example_value(lean_ty: str) -> str:
             return "_singletonBoolArray(true)"
         if elem == "Bytes32":
             return "_singletonBytes32Array(bytes32(uint256(0xBEEF)))"
-        raise ValueError(
-            "unsupported Lean array element type for generated example value: "
-            f"{elem!r}"
-        )
+        return f"abi.decode(abi.encode(uint256(0)), ({_sol_type(ty)}))"
     if ty.startswith("Tuple [") and ty.endswith("]"):
         inner = ty[len("Tuple [") : -1]
         elems = _parse_tuple_elements(inner)

--- a/scripts/test_generate_macro_property_tests.py
+++ b/scripts/test_generate_macro_property_tests.py
@@ -344,7 +344,7 @@ class RenderTests(unittest.TestCase):
         self.assertIn("_singletonBoolArray", rendered)
         self.assertIn('abi.encodeWithSignature("consume(bool[])", _singletonBoolArray(true))', rendered)
 
-    def test_render_dynamic_element_array_still_fails_closed(self) -> None:
+    def test_render_dynamic_element_array_uses_abi_decode_fallback(self) -> None:
         contract = gen.ContractDecl(
             name="ArrayBytesConsumer",
             constructor=None,
@@ -354,8 +354,9 @@ class RenderTests(unittest.TestCase):
             ),
             storage_slots={},
         )
-        with self.assertRaisesRegex(ValueError, "unsupported Lean array element type"):
-            gen.render_contract_test(contract)
+        rendered = gen.render_contract_test(contract)
+        self.assertIn('abi.encodeWithSignature("consume(bytes[])"', rendered)
+        self.assertIn("abi.decode(abi.encode(uint256(0)), (bytes[]))", rendered)
 
     def test_render_dynamic_return_shape_assertion(self) -> None:
         contract = gen.ContractDecl(


### PR DESCRIPTION
## Summary
- add IR/Yul helpers for forwarding dynamic struct-array elements into internal helpers
- support dynamic tuple parameter member length/data/element projection in the macro
- add smoke, invariant, round-trip, and generated property-test coverage

## Tests
- lake build
- lake build Contracts.Smoke
- lake build Compiler.Proofs.IRGeneration.ExprCore
- python3 scripts/check_macro_health.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ABI encoding/offset calculations and macro lowering for dynamic tuple/struct parameters, which can cause subtle miscompilations if offsets/length checks are wrong; changes are localized but span compiler, validators, and proofs.
> 
> **Overview**
> Adds new IR/Yul support for passing **dynamically encoded struct/tuple values** into internal helpers by introducing `Expr.arrayElementDynamicDataOffset` plus dynamic-member projections (`Expr.paramDynamicMemberLength`, `Expr.paramDynamicMemberDataOffset`, `Expr.paramDynamicMemberElement`) and compiling them to new checked Yul helpers (calldata + memory variants).
> 
> Extends validation/usage analysis/purity checks and internal helper parameter lowering to recognize these new expression forms, and updates the macro translator to lower dynamic struct-member uses in `arrayLength`/`arrayElement`, external/linked calls, and internal helper calls (including allowing struct/tuple helper params).
> 
> Adds a new smoke contract (`DynamicStructElementHelperArgSmoke`) and updates invariant/round-trip fuzz suites and generated Solidity property-test scaffolding; the property-test generator now falls back to an `abi.decode(abi.encode(...))` placeholder for unsupported array element example values instead of failing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92514c63b28951feb857bc6a6ace8bba76f0e49a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->