### PR TITLE
Expose ABI head word helper

### DIFF
--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -211,6 +211,7 @@ def revertReturndata : Contract Unit := pure ()
 def arrayLength {α : Type} (values : Array α) : Uint256 := values.size
 def arrayElement {α : Type} [Inhabited α] (values : Array α) (index : Uint256) : α :=
   values.getD (index : Nat) (Inhabited.default : α)
+def abiHeadWord {α : Type} [Inhabited α] (_value : α) (_wordOffset : Uint256) : Uint256 := 0
 def arrayElementChecked {α : Type} (values : Array α) (index : Uint256) : Contract α := fun state =>
   if h : (index : Nat) < values.size then
     ContractResult.success (values[(index : Nat)]'h) state

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -507,7 +507,9 @@ private def expectedExternalSignatures : List (String × List String) :=
   , ("FixedArrayStructSmoke", ["rootOf(((uint256[2],uint256[2][2],uint256[2]),uint256,uint256,uint256[],uint256[],uint256,(uint256,uint256[3])[])[],uint256)",
       "nullifierCountOf(((uint256[2],uint256[2][2],uint256[2]),uint256,uint256,uint256[],uint256[],uint256,(uint256,uint256[3])[])[],uint256)",
       "commitmentCountOf(((uint256[2],uint256[2][2],uint256[2]),uint256,uint256,uint256[],uint256[],uint256,(uint256,uint256[3])[])[],uint256)",
-      "ciphertextCountOf(((uint256[2],uint256[2][2],uint256[2]),uint256,uint256,uint256[],uint256[],uint256,(uint256,uint256[3])[])[],uint256)"])
+      "ciphertextCountOf(((uint256[2],uint256[2][2],uint256[2]),uint256,uint256,uint256[],uint256[],uint256,(uint256,uint256[3])[])[],uint256)",
+      "proofPA0Of(((uint256[2],uint256[2][2],uint256[2]),uint256,uint256,uint256[],uint256[],uint256,(uint256,uint256[3])[])[],uint256)",
+      "proofPC1OfTxn(((uint256[2],uint256[2][2],uint256[2]),uint256,uint256,uint256[],uint256[],uint256,(uint256,uint256[3])[]))"])
   , ("UnlinkPoolShapeCheckSmoke", ["nullifierCountOf((uint256,uint256[],uint256[],uint256)[],uint256)",
       "commitmentCountOf((uint256,uint256[],uint256[],uint256)[],uint256)",
       "nullifierAt((uint256,uint256[],uint256[],uint256)[],uint256,uint256)",
@@ -651,7 +653,8 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("ForEachMutableLocalSmoke", ["0x60bc84bc", "0x566ab477", "0x463324b5"])
   , ("ArrayElementDynamicMemberLengthSmoke", ["0xfbb81f5b"])
   , ("ArrayElementDynamicMemberElementSmoke", ["0x1ffe901b"])
-  , ("FixedArrayStructSmoke", ["0xe6f8cf0c", "0xf7910f7f", "0x82db9141", "0x82cb906c"])
+  , ("FixedArrayStructSmoke", ["0xe6f8cf0c", "0xf7910f7f", "0x82db9141", "0x82cb906c",
+      "0xaa7bf00c", "0xd1469472"])
   , ("UnlinkPoolShapeCheckSmoke", ["0x4b6e2141", "0xdb1ca006", "0x41620c25", "0x76524b94",
       "0xfc01c1ec", "0xe4a609b8", "0x2e759c7f"])
   , ("StructMappingSmoke", ["0x468c900e", "0xe7933b6a", "0x8d22ea2a", "0xf4536007", "0xcb01943e",

--- a/Contracts/Smoke/FixedArrayStructSmoke.lean
+++ b/Contracts/Smoke/FixedArrayStructSmoke.lean
@@ -42,6 +42,12 @@ verity_contract FixedArrayStructSmoke where
   function ciphertextCountOf (txs : Array Transaction, idx : Uint256) : Uint256 := do
     return arrayLength (arrayElement txs idx).ciphertexts
 
+  function proofPA0Of (txs : Array Transaction, idx : Uint256) : Uint256 := do
+    return abiHeadWord (arrayElement txs idx) 0
+
+  function proofPC1OfTxn (txn : Transaction) : Uint256 := do
+    return abiHeadWord txn 7
+
 example :
     FixedArrayStructSmoke.rootOf_modelBody =
       [ Compiler.CompilationModel.Stmt.return
@@ -76,6 +82,23 @@ example :
             "txs"
             (Compiler.CompilationModel.Expr.param "idx")
             13)
+      ] := rfl
+
+example :
+    FixedArrayStructSmoke.proofPA0Of_modelBody =
+      [ Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.arrayElementDynamicWord
+            "txs"
+            (Compiler.CompilationModel.Expr.param "idx")
+            0)
+      ] := rfl
+
+example :
+    FixedArrayStructSmoke.proofPC1OfTxn_modelBody =
+      [ Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.paramDynamicHeadWord
+            "txn"
+            7)
       ] := rfl
 
 end Contracts.Smoke

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1887,6 +1887,28 @@ private def arrayElementDynamicTupleArg?
         none
   | _ => none
 
+private def abiHeadWordTarget?
+    (params : Array ParamDecl)
+    (stx : Term) : Option (String × Option Term × ValueType) := do
+  match stripParens stx with
+  | `(term| arrayElement $name:term $index:term) =>
+      let paramName ←
+        match stripParens name with
+        | `(term| $id:ident) => some (toString id.getId)
+        | _ => none
+      let param ← params.find? (fun p => p.name == paramName)
+      let elemTy ← match param.ty with
+        | .array elemTy => some elemTy
+        | _ => none
+      some (paramName, some index, elemTy)
+  | _ => do
+      let paramName ←
+        match stripParens stx with
+        | `(term| $id:ident) => some (toString id.getId)
+        | _ => none
+      let param ← params.find? (fun p => p.name == paramName)
+      some (paramName, none, param.ty)
+
 private def isParamStructNonLeafProjection (params : Array ParamDecl) (stx : Term) : Bool :=
   match paramStructProjectionResolved? params stx with
   | some (_, fieldTy, _) => !isSingleWordStaticValueType fieldTy
@@ -2390,6 +2412,25 @@ private partial def inferPureExprType
       match params[(← natFromSyntax idx)]? with
       | some param => pure param.ty
       | none => throwErrorAt stx s!"constructorArg index {idx.raw.reprint.getD ""} is out of bounds"
+  | `(term| abiHeadWord $target:term $wordOffset:num) => do
+      let offset ← natFromSyntax wordOffset
+      let some (_, index?, ty) := abiHeadWordTarget? params target
+        | throwErrorAt target "abiHeadWord requires a direct parameter or `arrayElement <param> <index>` target"
+      if let some index := index? then
+        requireWordLikeType index "arrayElement index"
+          (← inferPureExprType fields constDecls immutableDecls externalDecls params locals index visitingConstants)
+      let headWords? :=
+        if valueTypeUsesDynamicData ty then
+          abiLocalHeadWordCount? ty
+        else
+          staticAbiWordCount? ty
+      match headWords? with
+      | some headWords =>
+          unless offset < headWords do
+            throwErrorAt stx s!"abiHeadWord offset {offset} is out of bounds for target with {headWords} ABI head word(s)"
+      | none =>
+          throwErrorAt target s!"abiHeadWord target type has no ABI head-word layout: {renderValueType ty}"
+      pure .uint256
   | `(term| Verity.msgSender) =>
       throwPureContextAccessorError stx "msgSender"
   | `(term| Verity.msgValue) =>
@@ -3334,6 +3375,34 @@ partial def translatePureExprWithTypes
   | `(term| false) => `(Compiler.CompilationModel.Expr.literal 0)
   | `(term| constructorArg $idx:num) =>
       `(Compiler.CompilationModel.Expr.constructorArg $idx)
+  | `(term| abiHeadWord $target:term $wordOffset:num) => do
+      let offset ← natFromSyntax wordOffset
+      let some (paramName, index?, ty) := abiHeadWordTarget? params target
+        | throwErrorAt target "abiHeadWord requires a direct parameter or `arrayElement <param> <index>` target"
+      match index? with
+      | some index =>
+          let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+          if valueTypeUsesDynamicData ty then
+            `(Compiler.CompilationModel.Expr.arrayElementDynamicWord
+              $(strTerm paramName)
+              $indexExpr
+              $(natTerm offset))
+          else
+            let elementWords ←
+              match staticAbiWordCount? ty with
+              | some n => pure n
+              | none => throwErrorAt target "abiHeadWord array element target requires a static ABI word layout"
+            `(Compiler.CompilationModel.Expr.arrayElementWord
+              $(strTerm paramName)
+              $indexExpr
+              $(natTerm elementWords)
+              $(natTerm offset))
+      | none =>
+          unless valueTypeUsesDynamicData ty do
+            throwErrorAt target "abiHeadWord direct parameter targets must have dynamic ABI head layout"
+          `(Compiler.CompilationModel.Expr.paramDynamicHeadWord
+            $(strTerm paramName)
+            $(natTerm offset))
   | `(term| Verity.msgSender) =>
       throwPureContextAccessorError stx "msgSender"
   | `(term| Verity.msgValue) =>


### PR DESCRIPTION
## Summary
- add `abiHeadWord` as a macro-level helper for constant ABI head-word reads
- lower dynamic struct-array elements to `arrayElementDynamicWord` and dynamic struct params to `paramDynamicHeadWord`
- cover Unlink-shaped proof words in fixed-array struct smoke tests

## Checks
- lake build Contracts.Smoke.FixedArrayStructSmoke
- lake build Contracts.Smoke Contracts.MacroTranslateInvariantTest Contracts.MacroTranslateRoundTripFuzz Compiler.CompilationModelFeatureTest
- lake build PrintAxioms
- python3 scripts/generate_print_axioms.py --check
- python3 scripts/check_axioms.py
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies macro translation/type-checking and ABI-layout lowering for struct/array parameters, which could affect generated IR/Yul for contracts using these patterns. Changes are bounded and covered by updated smoke/invariant tests but still touch core compilation logic.
> 
> **Overview**
> Exposes a new `abiHeadWord` helper (stubbed in `Contracts/Common.lean`) and teaches `Verity/Macro/Translate.lean` to type-check and lower `abiHeadWord <param|arrayElement param idx> <offset>` into the appropriate compilation-model expression (`paramDynamicHeadWord`, `arrayElementDynamicWord`, or `arrayElementWord`) with bounds/layout validation.
> 
> Extends `FixedArrayStructSmoke` with functions that read proof words via `abiHeadWord`, adds corresponding model-body expectations, and updates `MacroTranslateInvariantTest` pinned external signature/selector snapshots to include the new entrypoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2df6116026895f3e7b7f839e67588f78f48c672e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->