### PR TITLE
Support internal array return registers

### DIFF
--- a/Compiler/CompilationModel/Compile.lean
+++ b/Compiler/CompilationModel/Compile.lean
@@ -310,12 +310,23 @@ def compileStmt (fields : List Field) (events : List EventDef := [])
       let lenIdent := YulExpr.ident s!"{name}_length"
       let dataOffset := YulExpr.ident s!"{name}_data_offset"
       let byteLen := YulExpr.call "mul" [lenIdent, YulExpr.lit 32]
-      pure ([
-        YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit 32]),
-        YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 32, lenIdent]),
-      ] ++ dynamicCopyData dynamicSource (YulExpr.lit 64) dataOffset byteLen ++ [
-        YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.call "add" [YulExpr.lit 64, byteLen]])
-      ])
+      if isInternal then
+        match internalRetNames with
+        | offsetRet :: lengthRet :: _ =>
+            pure [
+              YulStmt.assign offsetRet dataOffset,
+              YulStmt.assign lengthRet lenIdent,
+              YulStmt.leave
+            ]
+        | _ =>
+            throw s!"Compilation error: internal array return target is missing offset/length registers"
+      else
+        pure ([
+          YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit 32]),
+          YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 32, lenIdent]),
+        ] ++ dynamicCopyData dynamicSource (YulExpr.lit 64) dataOffset byteLen ++ [
+          YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.call "add" [YulExpr.lit 64, byteLen]])
+        ])
   | Stmt.returnBytes name => do
       let lenIdent := YulExpr.ident s!"{name}_length"
       let dataOffset := YulExpr.ident s!"{name}_data_offset"

--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -18,8 +18,13 @@ def pickFreshInternalRetName (usedNames : List String) (idx : Nat) : String :=
 
 /-- Generate fresh internal return variable names for an internal function. -/
 def freshInternalRetNames (returns : List ParamType) (usedNames : List String) : List String :=
-  let (_, namesRev) := returns.zipIdx.foldl
-    (fun (acc : List String × List String) (_retTy, idx) =>
+  let retIndices :=
+    returns.zipIdx.flatMap fun (retTy, idx) =>
+      match retTy with
+      | ParamType.array _ => [idx, idx]
+      | _ => [idx]
+  let (_, namesRev) := retIndices.foldl
+    (fun (acc : List String × List String) idx =>
       let (used, names) := acc
       let fresh := pickFreshInternalRetName used idx
       (fresh :: used, fresh :: names))

--- a/Compiler/CompilationModel/ExpressionCompile.lean
+++ b/Compiler/CompilationModel/ExpressionCompile.lean
@@ -255,12 +255,20 @@ def compileExpr (fields : List Field)
       let argExprs ← compileExprList fields dynamicSource args
       pure (YulExpr.call (internalFunctionYulName functionName) argExprs)
   | Expr.arrayLength name => pure (YulExpr.ident s!"{name}_length")
+  | Expr.memoryArrayLength name => pure (YulExpr.ident s!"{name}_length")
   | Expr.arrayElement name index => do
       let indexExpr ← compileExpr fields dynamicSource index
       let helperName := match dynamicSource with
         | .calldata => checkedArrayElementCalldataHelperName
         | .memory => checkedArrayElementMemoryHelperName
       pure (YulExpr.call helperName [
+        YulExpr.ident s!"{name}_data_offset",
+        YulExpr.ident s!"{name}_length",
+        indexExpr
+      ])
+  | Expr.memoryArrayElement name index => do
+      let indexExpr ← compileExpr fields dynamicSource index
+      pure (YulExpr.call checkedArrayElementMemoryHelperName [
         YulExpr.ident s!"{name}_data_offset",
         YulExpr.ident s!"{name}_length",
         indexExpr

--- a/Compiler/CompilationModel/LogicalPurity.lean
+++ b/Compiler/CompilationModel/LogicalPurity.lean
@@ -22,6 +22,7 @@ partial def exprContainsCallLike (expr : Expr) : Bool :=
       exprContainsCallLike key1 || exprContainsCallLike key2
   | Expr.storageArrayElement _ index
   | Expr.arrayElement _ index
+  | Expr.memoryArrayElement _ index
   | Expr.arrayElementWord _ index _ _
   | Expr.arrayElementDynamicWord _ index _
   | Expr.arrayElementDynamicDataOffset _ index
@@ -62,7 +63,8 @@ partial def exprContainsCallLike (expr : Expr) : Bool :=
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
-  | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
@@ -130,7 +132,7 @@ def exprContainsUnsafeLogicalCallLike (expr : Expr) : Bool :=
   | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _
   | Expr.structMember2 _ key1 key2 _ =>
       exprContainsUnsafeLogicalCallLike key1 || exprContainsUnsafeLogicalCallLike key2
-  | Expr.storageArrayElement _ index | Expr.arrayElement _ index
+  | Expr.storageArrayElement _ index | Expr.arrayElement _ index | Expr.memoryArrayElement _ index
   | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
   | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
@@ -169,7 +171,8 @@ def exprContainsUnsafeLogicalCallLike (expr : Expr) : Bool :=
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
-  | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -117,6 +117,11 @@ def validateScopedExprIdentifiers
           throw s!"Compilation error: {context} Expr.arrayLength '{name}' requires array parameter, got {repr ty}"
       | none =>
           throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.arrayLength"
+  | Expr.memoryArrayLength name =>
+      if localScope.contains s!"{name}_data_offset" && localScope.contains s!"{name}_length" then
+        pure ()
+      else
+        throw s!"Compilation error: {context} Expr.memoryArrayLength '{name}' requires local bindings '{name}_data_offset' and '{name}_length'"
   | Expr.storageArrayLength _ =>
       pure ()
   | Expr.storageArrayElement _ index => do
@@ -132,6 +137,12 @@ def validateScopedExprIdentifiers
           throw s!"Compilation error: {context} Expr.arrayElement '{name}' requires array parameter, got {repr ty}"
       | none =>
           throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.arrayElement"
+      validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount index
+  | Expr.memoryArrayElement name index => do
+      if localScope.contains s!"{name}_data_offset" && localScope.contains s!"{name}_length" then
+        pure ()
+      else
+        throw s!"Compilation error: {context} Expr.memoryArrayElement '{name}' requires local bindings '{name}_data_offset' and '{name}_length'"
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount index
   | Expr.arrayElementWord name index elementWords wordOffset => do
       if elementWords == 0 then

--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -59,6 +59,7 @@ private partial def collectLowLevelExprMechanics : Expr → List String
   | .mappingUint _ key
   | .storageArrayElement _ key
   | .arrayElement _ key
+  | .memoryArrayElement _ key
   | .arrayElementWord _ key _ _
   | .arrayElementDynamicWord _ key _
   | .arrayElementDynamicMemberLength _ key _ =>
@@ -128,6 +129,7 @@ private partial def collectAxiomatizedExprPrimitives : Expr → List String
   | .mappingUint _ key
   | .storageArrayElement _ key
   | .arrayElement _ key
+  | .memoryArrayElement _ key
   | .arrayElementWord _ key _ _
   | .arrayElementDynamicWord _ key _
   | .arrayElementDynamicMemberLength _ key _ =>
@@ -454,6 +456,7 @@ private partial def collectEventEmissionExprMechanics : Expr → List String
       keys.flatMap collectEventEmissionExprMechanics
   | .mappingUint _ key
   | .arrayElement _ key
+  | .memoryArrayElement _ key
   | .arrayElementWord _ key _ _
   | .arrayElementDynamicWord _ key _
   | .arrayElementDynamicMemberLength _ key _ =>
@@ -621,6 +624,7 @@ private partial def collectRuntimeIntrospectionExprMechanics : Expr → List Str
       keys.flatMap collectRuntimeIntrospectionExprMechanics
   | .mappingUint _ key
   | .arrayElement _ key
+  | .memoryArrayElement _ key
   | .arrayElementWord _ key _ _
   | .arrayElementDynamicWord _ key _
   | .arrayElementDynamicMemberLength _ key _ =>
@@ -778,6 +782,7 @@ private partial def collectExternalExprNames : Expr → List String
       keys.flatMap collectExternalExprNames
   | .mappingUint _ key
   | .arrayElement _ key
+  | .memoryArrayElement _ key
   | .arrayElementWord _ key _ _
   | .arrayElementDynamicWord _ key _
   | .arrayElementDynamicMemberLength _ key _ =>

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -341,6 +341,12 @@ inductive Expr
   | internalCall (functionName : String) (args : List Expr)  -- Internal function call (#181)
   | arrayLength (name : String)  -- Length of a dynamic array parameter (#180)
   | arrayElement (name : String) (index : Expr)  -- Checked element access of a dynamic array parameter (revert on out-of-range) (#180)
+  /-- Length of a memory-backed dynamic array binding, e.g. an internal helper
+      returning `(data_offset, length)`. -/
+  | memoryArrayLength (name : String)
+  /-- Checked element access for a memory-backed dynamic array binding with
+      single-word static elements. -/
+  | memoryArrayElement (name : String) (index : Expr)
   /-- Checked word access inside a dynamic array element.  `elementWords` is the
       static ABI word width of one element and `wordOffset` is the word inside
       that element.  This supports arrays of static tuple/struct-like values. -/

--- a/Compiler/CompilationModel/UsageAnalysis.lean
+++ b/Compiler/CompilationModel/UsageAnalysis.lean
@@ -92,7 +92,7 @@ end
 
 mutual
 def exprUsesArrayElementKind (includePlain includeWord : Bool) : Expr → Bool
-  | Expr.arrayElement _ index =>
+  | Expr.arrayElement _ index | Expr.memoryArrayElement _ index =>
       let nested := exprUsesArrayElementKind includePlain includeWord index
       if nested then true else includePlain
   | Expr.arrayElementWord _ index _ _ =>
@@ -187,6 +187,7 @@ def exprUsesArrayElementKind (includePlain includeWord : Bool) : Expr → Bool
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.memoryArrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
@@ -310,7 +311,8 @@ attribute [simp] exprUsesArrayElementKind exprListUsesArrayElementKind
 
 mutual
 def exprUsesArrayElement : Expr → Bool
-  | Expr.arrayElement _ _ | Expr.arrayElementWord _ _ _ _ | Expr.arrayElementDynamicWord _ _ _
+  | Expr.arrayElement _ _ | Expr.memoryArrayElement _ _
+  | Expr.arrayElementWord _ _ _ _ | Expr.arrayElementDynamicWord _ _ _
   | Expr.arrayElementDynamicDataOffset _ _
   | Expr.arrayElementDynamicMemberDataOffset _ _ _
   | Expr.arrayElementDynamicMemberLength _ _ _
@@ -360,6 +362,7 @@ def exprUsesArrayElement : Expr → Bool
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.memoryArrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
@@ -513,7 +516,7 @@ def exprUsesParamDynamicHeadWord : Expr → Bool
       exprUsesParamDynamicHeadWord innerIndex
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _
   | Expr.mappingUint _ key | Expr.structMember _ key _
-  | Expr.storageArrayElement _ key | Expr.arrayElement _ key
+  | Expr.storageArrayElement _ key | Expr.arrayElement _ key | Expr.memoryArrayElement _ key
   | Expr.arrayElementWord _ key _ _ | Expr.arrayElementDynamicWord _ key _
   | Expr.arrayElementDynamicDataOffset _ key
   | Expr.arrayElementDynamicMemberDataOffset _ key _
@@ -559,6 +562,7 @@ def exprUsesParamDynamicHeadWord : Expr → Bool
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.memoryArrayLength _
   | Expr.storageArrayLength _
   | Expr.dynamicBytesEq _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
@@ -654,7 +658,7 @@ def exprUsesMulDiv512 : Expr → Bool
   | Expr.mulDiv512Down _ _ _ | Expr.mulDiv512Up _ _ _ => true
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _
   | Expr.mappingUint _ key | Expr.structMember _ key _
-  | Expr.storageArrayElement _ key | Expr.arrayElement _ key
+  | Expr.storageArrayElement _ key | Expr.arrayElement _ key | Expr.memoryArrayElement _ key
   | Expr.arrayElementWord _ key _ _ | Expr.arrayElementDynamicWord _ key _
   | Expr.arrayElementDynamicDataOffset _ key
   | Expr.arrayElementDynamicMemberDataOffset _ key _
@@ -696,6 +700,7 @@ def exprUsesMulDiv512 : Expr → Bool
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.memoryArrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
@@ -855,7 +860,8 @@ def exprUsesStorageArrayElement : Expr → Bool
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
-  | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
@@ -863,7 +869,8 @@ def exprUsesStorageArrayElement : Expr → Bool
       false
   | Expr.paramDynamicMemberElement _ _ innerIndex =>
       exprUsesStorageArrayElement innerIndex
-  | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElement _ index | Expr.memoryArrayElement _ index
+  | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
   | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
@@ -986,7 +993,7 @@ def exprUsesDynamicBytesEq : Expr → Bool
   | Expr.returndataOptionalBoolAt outOffset => exprUsesDynamicBytesEq outOffset
   | Expr.externalCall _ args | Expr.internalCall _ args =>
       exprListUsesDynamicBytesEq args
-  | Expr.storageArrayElement _ index | Expr.arrayElement _ index
+  | Expr.storageArrayElement _ index | Expr.arrayElement _ index | Expr.memoryArrayElement _ index
   | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
   | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
@@ -1013,7 +1020,8 @@ def exprUsesDynamicBytesEq : Expr → Bool
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
-  | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -270,14 +270,15 @@ def exprReadsStateOrEnv : Expr → Bool
   | Expr.externalCall name args =>
       if name == builtinExpName then exprListReadsStateOrEnv args else true
   | Expr.internalCall _ _ => true
-  | Expr.arrayLength _ => false
+  | Expr.arrayLength _ | Expr.memoryArrayLength _ => false
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _ => false
   | Expr.paramDynamicMemberElement _ _ innerIndex => exprReadsStateOrEnv innerIndex
   | Expr.storageArrayLength _ => true
   | Expr.storageArrayElement _ index => true || exprReadsStateOrEnv index
-  | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElement _ index | Expr.memoryArrayElement _ index
+  | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
   | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ => exprReadsStateOrEnv index
@@ -358,7 +359,8 @@ def exprWritesState : Expr → Bool
       false
   | Expr.storageArrayElement _ index =>
       exprWritesState index
-  | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElement _ index | Expr.memoryArrayElement _ index
+  | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
   | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
@@ -371,6 +373,7 @@ def exprWritesState : Expr → Bool
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.memoryArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
@@ -516,7 +519,8 @@ def exprHasUntrackableWrites : Expr → Bool
   | Expr.ite cond thenVal elseVal =>
       exprHasUntrackableWrites cond || exprHasUntrackableWrites thenVal || exprHasUntrackableWrites elseVal
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
-  | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.arrayElementWord _ key _ _
+  | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.memoryArrayElement _ key
+  | Expr.arrayElementWord _ key _ _
   | Expr.arrayElementDynamicWord _ key _
   | Expr.arrayElementDynamicDataOffset _ key
   | Expr.arrayElementDynamicMemberDataOffset _ key _
@@ -543,6 +547,7 @@ def exprHasUntrackableWrites : Expr → Bool
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.memoryArrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
@@ -662,7 +667,8 @@ def exprContainsExternalCall : Expr → Bool
   | Expr.ite cond thenVal elseVal =>
       exprContainsExternalCall cond || exprContainsExternalCall thenVal || exprContainsExternalCall elseVal
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
-  | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.arrayElementWord _ key _ _
+  | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.memoryArrayElement _ key
+  | Expr.arrayElementWord _ key _ _
   | Expr.arrayElementDynamicWord _ key _
   | Expr.arrayElementDynamicDataOffset _ key
   | Expr.arrayElementDynamicMemberDataOffset _ key _
@@ -694,6 +700,7 @@ def exprContainsExternalCall : Expr → Bool
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.memoryArrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
@@ -738,7 +745,8 @@ def exprMayContainExternalCall : Expr → Bool
   | Expr.ite cond thenVal elseVal =>
       exprMayContainExternalCall cond || exprMayContainExternalCall thenVal || exprMayContainExternalCall elseVal
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
-  | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.arrayElementWord _ key _ _
+  | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.memoryArrayElement _ key
+  | Expr.arrayElementWord _ key _ _
   | Expr.arrayElementDynamicWord _ key _
   | Expr.arrayElementDynamicDataOffset _ key
   | Expr.arrayElementDynamicMemberDataOffset _ key _
@@ -768,6 +776,7 @@ def exprMayContainExternalCall : Expr → Bool
   | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
+  | Expr.memoryArrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
@@ -1193,7 +1202,8 @@ def exprContainsAdtConstruct : Expr → Bool
   | Expr.bitNot a | Expr.logicalNot a | Expr.extcodesize a
   | Expr.mload a | Expr.tload a | Expr.calldataload a
   | Expr.returndataOptionalBoolAt a
-  | Expr.storageArrayElement _ a | Expr.arrayElement _ a | Expr.arrayElementWord _ a _ _
+  | Expr.storageArrayElement _ a | Expr.arrayElement _ a | Expr.memoryArrayElement _ a
+  | Expr.arrayElementWord _ a _ _
   | Expr.arrayElementDynamicWord _ a _
   | Expr.arrayElementDynamicDataOffset _ a
   | Expr.arrayElementDynamicMemberDataOffset _ a _
@@ -1236,7 +1246,7 @@ def exprContainsAdtConstruct : Expr → Bool
   | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp | Expr.blockNumber
   | Expr.blobbasefee | Expr.calldatasize | Expr.returndataSize
   | Expr.localVar _
-  | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.arrayLength _ | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -138,19 +138,16 @@ def validateReturnShapesInStmt (fnName : String) (params : List Param)
       else
         pure ()
   | Stmt.returnArray name =>
-      if isInternal then
-        throw s!"Compilation error: internal function '{fnName}' cannot use Stmt.returnArray; only static returns via Stmt.return/Stmt.returnValues are supported ({issue625Ref})."
-      else
-        match findParamType params name with
-        | some ty =>
-            if !isWordArrayParam ty then
-              throw s!"Compilation error: function '{fnName}' uses Stmt.returnArray with parameter '{name}' of type {repr ty}; only arrays with single-word static elements are currently supported"
-            else if expectedReturns == [ty] then
-              pure ()
-            else
-              throw s!"Compilation error: function '{fnName}' uses Stmt.returnArray to return parameter '{name}' of type {repr ty}, but declared returns are {repr expectedReturns}"
-        | none =>
-            throw s!"Compilation error: function '{fnName}' returnArray references unknown parameter '{name}'"
+      match findParamType params name with
+      | some ty =>
+          if !isWordArrayParam ty then
+            throw s!"Compilation error: function '{fnName}' uses Stmt.returnArray with parameter '{name}' of type {repr ty}; only arrays with single-word static elements are currently supported"
+          else if expectedReturns == [ty] then
+            pure ()
+          else
+            throw s!"Compilation error: function '{fnName}' uses Stmt.returnArray to return parameter '{name}' of type {repr ty}, but declared returns are {repr expectedReturns}"
+      | none =>
+          throw s!"Compilation error: function '{fnName}' returnArray references unknown parameter '{name}'"
   | Stmt.returnBytes name =>
       if isInternal then
         throw s!"Compilation error: internal function '{fnName}' cannot use Stmt.returnBytes; only static returns via Stmt.return/Stmt.returnValues are supported ({issue625Ref})."

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -199,6 +199,7 @@ def validateInternalCallShapesInExpr
       validateInternalCallShapesInExpr functions callerName key
   | Expr.storageArrayElement _ index
   | Expr.arrayElement _ index
+  | Expr.memoryArrayElement _ index
   | Expr.arrayElementWord _ index _ _
   | Expr.arrayElementDynamicWord _ index _
   | Expr.arrayElementDynamicDataOffset _ index
@@ -246,7 +247,7 @@ def validateInternalCallShapesInExpr
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize
   | Expr.localVar _
-  | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.arrayLength _ | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
@@ -470,6 +471,7 @@ def validateExternalCallTargetsInExpr
       validateExternalCallTargetsInExprList externals context args
   | Expr.storageArrayElement _ index
   | Expr.arrayElement _ index
+  | Expr.memoryArrayElement _ index
   | Expr.arrayElementWord _ index _ _
   | Expr.arrayElementDynamicWord _ index _
   | Expr.arrayElementDynamicDataOffset _ index
@@ -515,7 +517,7 @@ def validateExternalCallTargetsInExpr
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize
   | Expr.localVar _
-  | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.arrayLength _ | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -111,6 +111,13 @@ def internalCallYulArgCountForParam : ParamType → Nat
 def internalCallYulArgCount (params : List Param) : Nat :=
   params.foldl (fun acc param => acc + internalCallYulArgCountForParam param.ty) 0
 
+def internalReturnYulCountForType : ParamType → Nat
+  | ParamType.array _ => 2
+  | _ => 1
+
+def internalReturnYulCount (returns : List ParamType) : Nat :=
+  returns.foldl (fun acc retTy => acc + internalReturnYulCountForType retTy) 0
+
 def linkedExternalCallYulArgCountForParam : ParamType → Nat
   | ParamType.array elemTy => if isSingleWordStaticParamType elemTy then 2 else 1
   | ParamType.bytes | ParamType.string => 2
@@ -139,8 +146,8 @@ def validateInternalCallShapesInExpr
       if args.length != expectedArgs then
         throw s!"Compilation error: function '{callerName}' calls internal function '{calleeName}' with {args.length} Yul arg(s), expected {expectedArgs} ({issue625Ref})."
       let returns ← functionReturns callee
-      if returns.length != 1 then
-        throw s!"Compilation error: function '{callerName}' uses Expr.internalCall '{calleeName}' but callee returns {returns.length} values; use Stmt.internalCallAssign for multi-return calls ({issue625Ref})."
+      if returns.length != 1 || internalReturnYulCount returns != 1 then
+        throw s!"Compilation error: function '{callerName}' uses Expr.internalCall '{calleeName}' but callee returns {returns.length} logical value(s) / {internalReturnYulCount returns} Yul value(s); use Stmt.internalCallAssign for multi-return calls ({issue625Ref})."
   | Expr.call gas target value inOffset inSize outOffset outSize => do
       validateInternalCallShapesInExpr functions callerName gas
       validateInternalCallShapesInExpr functions callerName target
@@ -349,8 +356,9 @@ def validateInternalCallShapesInStmt
       if args.length != expectedArgs then
         throw s!"Compilation error: function '{callerName}' calls internal function '{calleeName}' with {args.length} Yul arg(s), expected {expectedArgs} ({issue625Ref})."
       let returns ← functionReturns callee
-      if returns.length != names.length then
-        throw s!"Compilation error: function '{callerName}' binds {names.length} values from internal function '{calleeName}', but callee returns {returns.length} ({issue625Ref})."
+      let expectedReturns := internalReturnYulCount returns
+      if expectedReturns != names.length then
+        throw s!"Compilation error: function '{callerName}' binds {names.length} Yul value(s) from internal function '{calleeName}', but callee returns {returns.length} logical value(s) / {expectedReturns} Yul value(s) ({issue625Ref})."
   | Stmt.rawLog topics dataOffset dataSize => do
       validateInternalCallShapesInExprList functions callerName topics
       validateInternalCallShapesInExpr functions callerName dataOffset

--- a/Compiler/CompilationModel/ValidationHelpers.lean
+++ b/Compiler/CompilationModel/ValidationHelpers.lean
@@ -77,12 +77,13 @@ def collectExprNames : Expr → List String
   | Expr.localVar name => [name]
   | Expr.externalCall name args => name :: collectExprListNames args
   | Expr.internalCall name args => name :: collectExprListNames args
-  | Expr.arrayLength name => [name]
+  | Expr.arrayLength name | Expr.memoryArrayLength name => [name]
   | Expr.paramDynamicHeadWord name _ => [name]
   | Expr.paramDynamicMemberLength name _
   | Expr.paramDynamicMemberDataOffset name _ => [name]
   | Expr.paramDynamicMemberElement name _ innerIndex => name :: collectExprNames innerIndex
-  | Expr.arrayElement name index | Expr.arrayElementWord name index _ _
+  | Expr.arrayElement name index | Expr.memoryArrayElement name index
+  | Expr.arrayElementWord name index _ _
   | Expr.arrayElementDynamicWord name index _
   | Expr.arrayElementDynamicDataOffset name index
   | Expr.arrayElementDynamicMemberDataOffset name index _

--- a/Compiler/CompilationModel/ValidationInterop.lean
+++ b/Compiler/CompilationModel/ValidationInterop.lean
@@ -83,7 +83,8 @@ def validateInteropExpr (context : String) : Expr → Except String Unit
       validateInteropExprList context args
   | Expr.storageArrayElement _ index =>
       validateInteropExpr context index
-  | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.arrayElement _ index | Expr.memoryArrayElement _ index
+  | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
   | Expr.arrayElementDynamicDataOffset _ index
   | Expr.arrayElementDynamicMemberDataOffset _ index _
   | Expr.arrayElementDynamicMemberLength _ index _ =>
@@ -124,7 +125,7 @@ def validateInteropExpr (context : String) : Expr → Except String Unit
   | Expr.storage _ | Expr.storageAddr _
   | Expr.caller | Expr.blockTimestamp | Expr.blockNumber
   | Expr.localVar _
-  | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.arrayLength _ | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -2652,13 +2652,13 @@ private def internalAddressArrayReturnSpec : CompilationModel := {
     },
     { name := "countEchoed"
       params := [{ name := "recipients", ty := ParamType.array ParamType.address }]
-      returnType := none
+      returnType := some FieldType.address
       body := [
         Stmt.internalCallAssign
           ["echoed_data_offset", "echoed_length"]
           "echoArray"
           [Expr.param "recipients_data_offset", Expr.param "recipients_length"],
-        Stmt.stop
+        Stmt.return (Expr.memoryArrayElement "echoed" (Expr.literal 0))
       ]
     }
   ]
@@ -4253,6 +4253,13 @@ set_option maxRecDepth 4096 in
     | _ => false
   expectTrue "internal address[] helper return binds data offset and length"
     internalAddressArrayReturnShape
+  let internalAddressArrayReturnYul ←
+    expectCompileToYul
+      "internal address[] helper return can be read as memory array"
+      internalAddressArrayReturnSpec
+  expectTrue "internal array return callers read returned array data from memory"
+    (contains internalAddressArrayReturnYul
+      s!"{checkedArrayElementMemoryHelperName}(echoed_data_offset, echoed_length, 0)")
   let addressStorageWordReturnCompiled :=
     match Compiler.CompilationModel.compile addressStorageWordReturnSpec
         (selectorsFor addressStorageWordReturnSpec) with

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -2638,6 +2638,32 @@ private def addressArrayReturnSpec : CompilationModel := {
   ]
 }
 
+private def internalAddressArrayReturnSpec : CompilationModel := {
+  name := "InternalAddressArrayReturn"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "echoArray"
+      params := [{ name := "recipients", ty := ParamType.array ParamType.address }]
+      returnType := none
+      returns := [ParamType.array ParamType.address]
+      body := [Stmt.returnArray "recipients"]
+      isInternal := true
+    },
+    { name := "countEchoed"
+      params := [{ name := "recipients", ty := ParamType.array ParamType.address }]
+      returnType := none
+      body := [
+        Stmt.internalCallAssign
+          ["echoed_data_offset", "echoed_length"]
+          "echoArray"
+          [Expr.param "recipients_data_offset", Expr.param "recipients_length"],
+        Stmt.stop
+      ]
+    }
+  ]
+}
+
 private def addressStorageWordReturnSpec : CompilationModel := {
   name := "AddressStorageWordReturn"
   fields := []
@@ -4208,6 +4234,25 @@ set_option maxRecDepth 4096 in
     | .ok _ => true
     | .error _ => false
   expectTrue "address[] params can round-trip through returnArray" addressArrayReturnCompiled
+  let internalAddressArrayReturnContract ←
+    expectCompile
+      "internal address[] helper return lowers to offset/length Yul returns"
+      internalAddressArrayReturnSpec
+  let internalAddressArrayReturnShape :=
+    match internalAddressArrayReturnContract.internalFunctions.find? (fun stmt =>
+        match stmt with
+        | Compiler.Yul.YulStmt.funcDef name _ _ _ => name == "internal_echoArray"
+        | _ => false) with
+    | some (Compiler.Yul.YulStmt.funcDef "internal_echoArray"
+        ["recipients_data_offset", "recipients_length"]
+        [retOffset, retLength]
+        [Compiler.Yul.YulStmt.assign assignedOffset (Compiler.Yul.YulExpr.ident "recipients_data_offset"),
+         Compiler.Yul.YulStmt.assign assignedLength (Compiler.Yul.YulExpr.ident "recipients_length"),
+         Compiler.Yul.YulStmt.leave]) =>
+        retOffset == assignedOffset && retLength == assignedLength && retOffset != retLength
+    | _ => false
+  expectTrue "internal address[] helper return binds data offset and length"
+    internalAddressArrayReturnShape
   let addressStorageWordReturnCompiled :=
     match Compiler.CompilationModel.compile addressStorageWordReturnSpec
         (selectorsFor addressStorageWordReturnSpec) with

--- a/Compiler/Proofs/IRGeneration/ExprCore.lean
+++ b/Compiler/Proofs/IRGeneration/ExprCore.lean
@@ -37,7 +37,8 @@ def exprBoundNames : Expr → List String
   | .externalCall _ args | .internalCall _ args | .adtConstruct _ _ args => exprListBoundNames args
   | .adtTag _ field => [field]
   | .adtField _ _ _ _ storageField => [storageField]
-  | .arrayElement name index | .arrayElementWord name index _ _
+  | .arrayElement name index | .memoryArrayElement name index
+  | .arrayElementWord name index _ _
   | .arrayElementDynamicWord name index _
   | .arrayElementDynamicDataOffset name index
   | .arrayElementDynamicMemberDataOffset name index _
@@ -49,7 +50,7 @@ def exprBoundNames : Expr → List String
   | .paramDynamicMemberDataOffset name _ => [name]
   | .paramDynamicMemberElement name _ innerIndex =>
       name :: exprBoundNames innerIndex
-  | .arrayLength name => [name]
+  | .arrayLength name | .memoryArrayLength name => [name]
   | .storageArrayLength name => [name]
   | .storageArrayElement name index => name :: exprBoundNames index
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -574,6 +574,8 @@ private def ceilDivVal (lhs rhs : Verity.Core.Uint256) : Nat :=
   if lhs == 0 then 0 else ((lhs - 1) / rhs + 1).val
 
 def evalExpr (fields : List Field) (state : RuntimeState) : Expr → Option Nat
+  | .memoryArrayLength _ => none
+  | .memoryArrayElement _ _ => none
   | .arrayElementDynamicDataOffset _ _ => none
   | .arrayElementDynamicMemberLength _ _ _ => none
   | .arrayElementDynamicMemberDataOffset _ _ _ => none
@@ -973,6 +975,12 @@ private theorem evalExpr_arrayLength
     (state : RuntimeState)
     (name : String) :
     evalExpr fields state (.arrayLength name) = none := rfl
+
+private theorem evalExpr_memoryArrayLength
+    (fields : List Field)
+    (state : RuntimeState)
+    (name : String) :
+    evalExpr fields state (.memoryArrayLength name) = none := rfl
 
 private theorem evalExpr_dynamicBytesEq
     (fields : List Field)
@@ -1391,6 +1399,13 @@ private theorem evalExpr_arrayElement
     (name : String)
     (index : Expr) :
     evalExpr fields state (.arrayElement name index) = none := rfl
+
+private theorem evalExpr_memoryArrayElement
+    (fields : List Field)
+    (state : RuntimeState)
+    (name : String)
+    (index : Expr) :
+    evalExpr fields state (.memoryArrayElement name index) = none := rfl
 
 private theorem evalExpr_arrayElementWord
     (fields : List Field)
@@ -2777,7 +2792,8 @@ mutual
     | .mulDiv512Down _ _ _ | .mulDiv512Up _ _ _
     | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
     | .paramDynamicMemberDataOffset _ _ | .paramDynamicMemberElement _ _ _
-    | .arrayLength _ | .arrayElement _ _
+    | .arrayLength _ | .memoryArrayLength _
+    | .arrayElement _ _ | .memoryArrayElement _ _
     | .arrayElementWord _ _ _ _ | .arrayElementDynamicWord _ _ _
     | .arrayElementDynamicDataOffset _ _
     | .arrayElementDynamicMemberLength _ _ _
@@ -3699,6 +3715,8 @@ mutual
           evalExpr_returndataSize]
     | arrayLength _ =>
         simpa [evalExprWithHelpers, evalExpr_arrayLength]
+    | memoryArrayLength _ =>
+        simpa [evalExprWithHelpers, evalExpr_memoryArrayLength]
     | dynamicBytesEq _ _ =>
         simpa [evalExprWithHelpers, evalExpr_dynamicBytesEq]
     | externalCall _ _ =>
@@ -3794,6 +3812,8 @@ mutual
         simpa [evalExprWithHelpers, evalExpr_mapping, evalExpr_mappingUint, hb]
     | arrayElement _ b =>
         simp [evalExprWithHelpers, evalExpr_arrayElement]
+    | memoryArrayElement _ b =>
+        simp [evalExprWithHelpers, evalExpr_memoryArrayElement]
     | arrayElementWord _ b _ _ =>
         simp [evalExprWithHelpers, evalExpr_arrayElementWord]
     | arrayElementDynamicWord _ b _ =>

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -557,13 +557,15 @@ def exprTouchesUnsupportedConstructorRawCalldataSurface : Expr → Bool
   | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
   | .blobbasefee | .constructorArg _ | .returndataSize | .extcodesize _ => false
   | .calldatasize => true
-  | .storage _ | .storageAddr _ | .arrayLength _ | .storageArrayLength _ => false
+  | .storage _ | .storageAddr _ | .arrayLength _ | .memoryArrayLength _
+  | .storageArrayLength _ => false
   | .logicalNot a | .bitNot a | .mload a | .tload a | .returndataOptionalBoolAt a =>
       exprTouchesUnsupportedConstructorRawCalldataSurface a
   | .calldataload _ =>
       true
   | .mapping _ a | .mappingWord _ a _ | .mappingPackedWord _ a _ _
   | .mappingUint _ a | .structMember _ a _ | .arrayElement _ a
+  | .memoryArrayElement _ a
   | .arrayElementWord _ a _ _
   | .arrayElementDynamicWord _ a _
   | .arrayElementDynamicDataOffset _ a
@@ -731,7 +733,8 @@ def exprTouchesUnsupportedCoreSurface : Expr → Bool
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
   | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
-  | .arrayLength _ | .arrayElement _ _ | .arrayElementWord _ _ _ _
+  | .arrayLength _ | .memoryArrayLength _
+  | .arrayElement _ _ | .memoryArrayElement _ _ | .arrayElementWord _ _ _ _
   | .arrayElementDynamicWord _ _ _
   | .arrayElementDynamicDataOffset _ _
   | .arrayElementDynamicMemberLength _ _ _
@@ -777,7 +780,8 @@ def exprTouchesUnsupportedStateSurface : Expr → Bool
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
-  | .arrayLength _ | .arrayElement _ _ | .arrayElementWord _ _ _ _
+  | .arrayLength _ | .memoryArrayLength _
+  | .arrayElement _ _ | .memoryArrayElement _ _ | .arrayElementWord _ _ _ _
   | .arrayElementDynamicWord _ _ _
   | .arrayElementDynamicMemberLength _ _ _
   | .arrayElementDynamicDataOffset _ _
@@ -800,6 +804,7 @@ def exprTouchesUnsupportedCallSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
+  | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ => false
@@ -813,7 +818,8 @@ def exprTouchesUnsupportedCallSurface : Expr → Bool
       exprTouchesUnsupportedCallSurface a || exprTouchesUnsupportedCallSurface b
   | .min a b | .max a b | .wMulDown a b | .wDivUp a b | .ceilDiv a b =>
       exprTouchesUnsupportedCallSurface a || exprTouchesUnsupportedCallSurface b
-  | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .arrayElementWord _ b _ _
+  | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .memoryArrayElement _ b
+  | .arrayElementWord _ b _ _
   | .arrayElementDynamicWord _ b _
   | .storageArrayElement _ b =>
       exprTouchesUnsupportedCallSurface b
@@ -850,6 +856,7 @@ def exprTouchesUnsupportedHelperSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
+  | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ | .externalCall _ _ => false
@@ -864,7 +871,8 @@ def exprTouchesUnsupportedHelperSurface : Expr → Bool
       exprTouchesUnsupportedHelperSurface a || exprTouchesUnsupportedHelperSurface b
   | .min a b | .max a b | .wMulDown a b | .wDivUp a b | .ceilDiv a b =>
       exprTouchesUnsupportedHelperSurface a || exprTouchesUnsupportedHelperSurface b
-  | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .arrayElementWord _ b _ _
+  | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .memoryArrayElement _ b
+  | .arrayElementWord _ b _ _
   | .arrayElementDynamicWord _ b _
   | .storageArrayElement _ b =>
       exprTouchesUnsupportedHelperSurface b
@@ -909,6 +917,7 @@ def exprTouchesInternalHelperSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
+  | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ | .externalCall _ _ => false
@@ -923,7 +932,8 @@ def exprTouchesInternalHelperSurface : Expr → Bool
       exprTouchesInternalHelperSurface a || exprTouchesInternalHelperSurface b
   | .min a b | .max a b | .wMulDown a b | .wDivUp a b | .ceilDiv a b =>
       exprTouchesInternalHelperSurface a || exprTouchesInternalHelperSurface b
-  | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .arrayElementWord _ b _ _
+  | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .memoryArrayElement _ b
+  | .arrayElementWord _ b _ _
   | .arrayElementDynamicWord _ b _
   | .arrayElementDynamicDataOffset _ b
   | .arrayElementDynamicMemberLength _ b _
@@ -963,6 +973,7 @@ def exprTouchesUnsupportedForeignSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
+  | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ | .internalCall _ _ => false
@@ -977,7 +988,8 @@ def exprTouchesUnsupportedForeignSurface : Expr → Bool
       exprTouchesUnsupportedForeignSurface a || exprTouchesUnsupportedForeignSurface b
   | .min a b | .max a b | .wMulDown a b | .wDivUp a b | .ceilDiv a b =>
       exprTouchesUnsupportedForeignSurface a || exprTouchesUnsupportedForeignSurface b
-  | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .arrayElementWord _ b _ _
+  | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .memoryArrayElement _ b
+  | .arrayElementWord _ b _ _
   | .arrayElementDynamicWord _ b _
   | .arrayElementDynamicMemberLength _ b _
   | .arrayElementDynamicDataOffset _ b
@@ -1015,6 +1027,7 @@ def exprTouchesUnsupportedLowLevelSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
+  | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ | .internalCall _ _ | .externalCall _ _ => false
@@ -1028,7 +1041,8 @@ def exprTouchesUnsupportedLowLevelSurface : Expr → Bool
       exprTouchesUnsupportedLowLevelSurface a || exprTouchesUnsupportedLowLevelSurface b
   | .min a b | .max a b | .wMulDown a b | .wDivUp a b | .ceilDiv a b =>
       exprTouchesUnsupportedLowLevelSurface a || exprTouchesUnsupportedLowLevelSurface b
-  | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .arrayElementWord _ b _ _
+  | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .memoryArrayElement _ b
+  | .arrayElementWord _ b _ _
   | .arrayElementDynamicWord _ b _
   | .arrayElementDynamicDataOffset _ b
   | .arrayElementDynamicMemberLength _ b _
@@ -1093,7 +1107,8 @@ def exprTouchesUnsupportedContractSurface (expr : Expr) : Bool :=
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
   | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
-  | .arrayLength _ | .arrayElement _ _ | .arrayElementWord _ _ _ _
+  | .arrayLength _ | .memoryArrayLength _
+  | .arrayElement _ _ | .memoryArrayElement _ _ | .arrayElementWord _ _ _ _
   | .arrayElementDynamicWord _ _ _
   | .arrayElementDynamicDataOffset _ _
   | .arrayElementDynamicMemberLength _ _ _
@@ -1703,6 +1718,7 @@ mutual
         calleeName :: exprListInternalHelperCallNames args
     | .mapping _ key | .mappingWord _ key _ | .mappingPackedWord _ key _ _
     | .mappingUint _ key | .structMember _ key _ | .arrayElement _ key
+    | .memoryArrayElement _ key
     | .arrayElementWord _ key _ _
     | .arrayElementDynamicWord _ key _
     | .arrayElementDynamicDataOffset _ key
@@ -1763,7 +1779,7 @@ mutual
     | .caller | .contractAddress | .chainid | .msgValue | .selfBalance
     | .blockTimestamp | .blockNumber | .blobbasefee
     | .calldatasize | .returndataSize
-    | .localVar _ | .arrayLength _ | .storageArrayLength _
+    | .localVar _ | .arrayLength _ | .memoryArrayLength _ | .storageArrayLength _
     | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
     | .paramDynamicMemberDataOffset _ _
     | .dynamicBytesEq _ _
@@ -3221,7 +3237,7 @@ mutual
     | literal _ | param _ | caller | contractAddress | chainid | msgValue | selfBalance
     | blockTimestamp | blockNumber | localVar _ | storage _ | storageAddr _
     | constructorArg _ | blobbasefee | calldatasize | returndataSize
-    | arrayLength _ | storageArrayLength _ | dynamicBytesEq _ _
+    | arrayLength _ | memoryArrayLength _ | storageArrayLength _ | dynamicBytesEq _ _
     | paramDynamicHeadWord _ _ | paramDynamicMemberLength _ _
     | paramDynamicMemberDataOffset _ _
     | externalCall _ _ =>
@@ -3266,7 +3282,8 @@ mutual
         simp only [exprTouchesUnsupportedHelperSurface] at hsurface
         simp [exprTouchesInternalHelperSurface,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface]
-    | mapping _ b | mappingUint _ b | arrayElement _ b | arrayElementWord _ b _ _
+    | mapping _ b | mappingUint _ b | arrayElement _ b | memoryArrayElement _ b
+    | arrayElementWord _ b _ _
     | arrayElementDynamicWord _ b _
     | storageArrayElement _ b
     | mappingWord _ b _ | mappingPackedWord _ b _ _ | structMember _ b _ =>
@@ -3637,6 +3654,7 @@ private theorem exprTouchesUnsupportedCallSurface_eq_featureOr
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
   | extcodesize _
   | returndataOptionalBoolAt _ | keccak256 _ _ | arrayLength _
+  | memoryArrayLength _
   | storageArrayLength _ | dynamicBytesEq _ _ =>
       simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
@@ -3666,7 +3684,8 @@ private theorem exprTouchesUnsupportedCallSurface_eq_featureOr
       simp only [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
       exact exprTouchesUnsupportedCallSurface_eq_featureOr b
-  | mapping _ b | mappingUint _ b | arrayElement _ b | arrayElementWord _ b _ _
+  | mapping _ b | mappingUint _ b | arrayElement _ b | memoryArrayElement _ b
+  | arrayElementWord _ b _ _
   | storageArrayElement _ b =>
       simp only [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
@@ -3844,7 +3863,7 @@ private theorem exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
   | paramDynamicMemberDataOffset _ _ | paramDynamicMemberElement _ _ _ =>
       cases hcore
   | constructorArg _
-  | returndataSize | arrayLength _ | storageArrayLength _
+  | returndataSize | arrayLength _ | memoryArrayLength _ | storageArrayLength _
   | returndataOptionalBoolAt _ | extcodesize _
   | dynamicBytesEq _ _ | keccak256 _ _ =>
       cases hcore
@@ -3923,7 +3942,8 @@ private theorem exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
   | mapping _ _ | mappingWord _ _ _ | mappingPackedWord _ _ _ _
   | mapping2 _ _ _ | mapping2Word _ _ _ _ | mappingUint _ _
   | mappingChain _ _ | structMember _ _ _ | structMember2 _ _ _ _
-  | arrayElement _ _ | arrayElementWord _ _ _ _ | arrayElementDynamicWord _ _ _
+  | arrayElement _ _ | memoryArrayElement _ _ | arrayElementWord _ _ _ _
+  | arrayElementDynamicWord _ _ _
   | arrayElementDynamicDataOffset _ _
   | arrayElementDynamicMemberLength _ _ _
   | arrayElementDynamicMemberDataOffset _ _ _
@@ -4222,13 +4242,14 @@ theorem exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
   | storage _ | storageAddr _ | internalCall _ _ | externalCall _ _
   | constructorArg _ | keccak256 _ _
   | returndataSize | extcodesize _
-  | returndataOptionalBoolAt _ | arrayLength _ | storageArrayLength _
+  | returndataOptionalBoolAt _ | arrayLength _ | memoryArrayLength _ | storageArrayLength _
   | dynamicBytesEq _ _
   | call _ _ _ _ _ _ _ | staticcall _ _ _ _ _ _ | delegatecall _ _ _ _ _ _
   | mapping _ _ | mappingWord _ _ _ | mappingPackedWord _ _ _ _
   | mapping2 _ _ _ | mapping2Word _ _ _ _ | mappingUint _ _
   | structMember _ _ _ | structMember2 _ _ _ _
-  | arrayElement _ _ | arrayElementWord _ _ _ _ | arrayElementDynamicWord _ _ _
+  | arrayElement _ _ | memoryArrayElement _ _ | arrayElementWord _ _ _ _
+  | arrayElementDynamicWord _ _ _
   | arrayElementDynamicDataOffset _ _
   | arrayElementDynamicMemberLength _ _ _
   | arrayElementDynamicMemberDataOffset _ _ _

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2743,6 +2743,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_calldatasize  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_returndataSize  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayLength  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_memoryArrayLength  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_dynamicBytesEq  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_externalCall  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mload  -- private
@@ -2792,6 +2793,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mapping  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mappingUint  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayElement  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_memoryArrayElement  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayElementWord  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayElementDynamicWord  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayElementDynamicDataOffset  -- private
@@ -5582,4 +5584,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5296 theorems/lemmas (3564 public, 1732 private, 0 sorry'd)
+-- Total: 5298 theorems/lemmas (3564 public, 1734 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- expand logical internal array returns to offset/length Yul return registers
- compile internal returnArray as offset/length assignments plus leave
- add memory-backed dynamic array accessors for returned `(data_offset, length)` bindings
- add CompilationModel regressions for internal address[] helper returns and memory-backed reads

## Verification
- lake build Compiler.CompilationModelFeatureTest
- lake build Contracts.Smoke Compiler.CompilationModelFeatureTest
- lake build PrintAxioms
- python3 scripts/generate_print_axioms.py --check
- python3 scripts/check_axioms.py
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes internal function return lowering and validation to treat array returns as two Yul values (offset/length), which can affect codegen and call-shape checking across the compiler pipeline.
> 
> **Overview**
> Internal `Stmt.returnArray` is now supported by lowering dynamic array returns to two internal return registers (offset + length) and `leave`, instead of ABI-encoding and `return`.
> 
> The internal dispatch/validation pipeline is updated to account for array returns expanding to *two* Yul values: `freshInternalRetNames` generates extra return registers, and `ValidationCalls` enforces Yul-level arity for `Expr.internalCall`/`Stmt.internalCallAssign`.
> 
> Adds `Expr.memoryArrayLength`/`Expr.memoryArrayElement` for reading memory-backed array bindings (e.g. from internal helper returns) and threads these constructors through scope validation, purity/usage analyses, trust-surface checks, and proof scaffolding. Includes new feature tests asserting internal `address[]` round-trips and callers read via the memory array helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b517341c4ff6ef5b4856c32e6999b742def30889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->