### PR TITLE
Support macro allocation of memory arrays

### DIFF
--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -532,7 +532,17 @@ def validateScopedStmtIdentifiers
           throw s!"Compilation error: {context} ECM '{mod.name}' redeclares result '{rv}' in the same scope"
         scope := rv :: scope
       pure scope
-  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _
+  | Stmt.returnArray name =>
+      match findParamType params name with
+      | some (ParamType.array _) => pure localScope
+      | some ty =>
+          throw s!"Compilation error: {context} Stmt.returnArray '{name}' requires array parameter or memory-array local, got {repr ty}"
+      | none =>
+          if localScope.contains s!"{name}_data_offset" && localScope.contains s!"{name}_length" then
+            pure localScope
+          else
+            throw s!"Compilation error: {context} Stmt.returnArray '{name}' requires parameter '{name}' or local bindings '{name}_data_offset' and '{name}_length'"
+  | Stmt.returnBytes _ | Stmt.returnStorageWords _
   | Stmt.revertReturndata | Stmt.stop =>
       pure localScope
 termination_by s => sizeOf s

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -66,7 +66,7 @@ def validateStmtParamReferences (fnName : String) (params : List Param) :
           else
             throw s!"Compilation error: function '{fnName}' returnArray '{name}' requires an array parameter with single-word static elements, got {repr ty}"
       | none =>
-          throw s!"Compilation error: function '{fnName}' returnArray references unknown parameter '{name}'"
+          pure ()
   | Stmt.returnBytes name =>
       match findParamType params name with
       | some ParamType.bytes | some ParamType.string => pure ()
@@ -147,7 +147,14 @@ def validateReturnShapesInStmt (fnName : String) (params : List Param)
           else
             throw s!"Compilation error: function '{fnName}' uses Stmt.returnArray to return parameter '{name}' of type {repr ty}, but declared returns are {repr expectedReturns}"
       | none =>
-          throw s!"Compilation error: function '{fnName}' returnArray references unknown parameter '{name}'"
+          match expectedReturns with
+          | [ty] =>
+              if isWordArrayParam ty then
+                pure ()
+              else
+                throw s!"Compilation error: function '{fnName}' uses Stmt.returnArray with memory array '{name}', but declared return type {repr ty} is not a supported word array"
+          | _ =>
+              throw s!"Compilation error: function '{fnName}' returnArray references unknown parameter '{name}'"
   | Stmt.returnBytes name =>
       if isInternal then
         throw s!"Compilation error: internal function '{fnName}' cannot use Stmt.returnBytes; only static returns via Stmt.return/Stmt.returnValues are supported ({issue625Ref})."

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -1668,6 +1668,25 @@ verity_contract MacroDynamicArray where
     let forwarded ← echoAmounts echoed
     return (arrayElement forwarded 0)
 
+  function compactAmounts (amounts : Array Uint256) : Array Uint256 := do
+    let mut count := 0
+    forEach "i" (arrayLength amounts) (do
+      let value := arrayElement amounts i
+      if value != 0 then
+        count := add count 1
+      else
+        pure ())
+    let compacted ← allocArray count
+    let mut j := 0
+    forEach "i" (arrayLength amounts) (do
+      let value := arrayElement amounts i
+      if value != 0 then
+        setMemoryArrayElement compacted j value
+        j := add j 1
+      else
+        pure ())
+    returnArray compacted
+
   function echoRecipients (recipients : Array Address) : Array Address := do
     returnArray recipients
 
@@ -1731,6 +1750,46 @@ def forwardedEchoedAmountPassesMemoryArray : Bool :=
   | _ => false
 
 example : forwardedEchoedAmountPassesMemoryArray = true := by native_decide
+
+def compactAmountsAllocatesMemoryArray : Bool :=
+  let body := MacroDynamicArray.compactAmounts_modelBody
+  body.any (fun stmt =>
+    match stmt with
+    | Stmt.letVar "compacted_length" (Expr.localVar "count") => true
+    | _ => false) &&
+  body.any (fun stmt =>
+    match stmt with
+    | Stmt.letVar "compacted_data_offset"
+        (Expr.add (Expr.mload (Expr.literal 64)) (Expr.literal 32)) => true
+    | _ => false) &&
+  body.any (fun stmt =>
+    match stmt with
+    | Stmt.returnArray "compacted" => true
+    | _ => false)
+
+example : compactAmountsAllocatesMemoryArray = true := by native_decide
+
+def compactAmountsWritesMemoryArray : Bool :=
+  let body := MacroDynamicArray.compactAmounts_modelBody
+  body.any (fun stmt =>
+    match stmt with
+    | Stmt.forEach "i" (Expr.arrayLength "amounts") loopBody =>
+        loopBody.any (fun inner =>
+          match inner with
+          | Stmt.ite _ thenBranch _ =>
+              thenBranch.any (fun branchStmt =>
+                match branchStmt with
+                | Stmt.unsafeBlock "write memory-backed uint256 array element"
+                    [Stmt.mstore
+                      (Expr.add (Expr.localVar "compacted_data_offset")
+                        (Expr.mul (Expr.localVar "j") (Expr.literal 32)))
+                      (Expr.localVar "value")] =>
+                    true
+                | _ => false)
+          | _ => false)
+    | _ => false)
+
+example : compactAmountsWritesMemoryArray = true := by native_decide
 
 def echoRecipientsModelUsesReturnArray : Bool :=
   match MacroDynamicArray.echoRecipients_modelBody with

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -217,6 +217,13 @@ def arrayElementChecked {α : Type} (values : Array α) (index : Uint256) : Cont
     ContractResult.success (values[(index : Nat)]'h) state
   else
     ContractResult.revert "Array index out of bounds" state
+def allocArray (len : Uint256) : Contract (Array Uint256) :=
+  pure (Array.replicate (len : Nat) 0)
+def setMemoryArrayElement (values : Array Uint256) (index value : Uint256) : Contract Unit :=
+  let _ := values
+  let _ := index
+  let _ := value
+  pure ()
 def returnArray {α : Type} (values : Array α) : Contract (Array α) := pure values
 def returnValues (_values : List Uint256) : Contract Unit := pure ()
 def returnBytes {α : Type} (value : α) : Contract α := pure value

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1995,6 +1995,14 @@ private def localMemoryArray?
   | .memoryArray, .array elemTy => some (name, elemTy)
   | _, _ => none
 
+private def requireSupportedMemoryArrayLocal
+    (stx : Term)
+    (context : String)
+    (locals : Array TypedLocal) : CommandElabM (String × ValueType) := do
+  match localMemoryArray? locals stx with
+  | some (name, elemTy) => pure (name, elemTy)
+  | none => throwErrorAt stx s!"{context} requires a memory-backed Array local"
+
 private def localArrayElementStructProjectionResolved?
     (locals : Array TypedLocal)
     (stx : Term) : Option (String × Term × ValueType × ValueType × Nat) := do
@@ -5068,16 +5076,25 @@ private partial def validateDoElemExprTypes
               requireSupportedLocalBindingType name s!"local binding '{toString name.getId}'" ty
               pure <| locals.push (mkTypedLocal (toString name.getId) ty)
       | `(doElem| let $name:ident ← $rhs:term) =>
-          match ← localInternalArrayReturnBind? fields constDecls immutableDecls externalDecls functions params locals rhs with
-          | some (_, _, elemTy) =>
+          match stripParens rhs with
+          | `(term| allocArray $len:term) =>
+              requireWordLikeType len "allocArray length"
+                (← inferPureExprType fields constDecls immutableDecls externalDecls params locals len)
               pure <| locals.push
                 { name := toString name.getId
-                  ty := .array elemTy
+                  ty := .array .uint256
                   source := .memoryArray }
-          | none =>
-              let ty ← inferBindSourceType fields constDecls immutableDecls externalDecls functions params locals rhs
-              requireSupportedLocalBindingType name s!"local binding '{toString name.getId}'" ty
-              pure <| locals.push (mkTypedLocal (toString name.getId) ty)
+          | _ =>
+              match ← localInternalArrayReturnBind? fields constDecls immutableDecls externalDecls functions params locals rhs with
+              | some (_, _, elemTy) =>
+                  pure <| locals.push
+                    { name := toString name.getId
+                      ty := .array elemTy
+                      source := .memoryArray }
+              | none =>
+                  let ty ← inferBindSourceType fields constDecls immutableDecls externalDecls functions params locals rhs
+                  requireSupportedLocalBindingType name s!"local binding '{toString name.getId}'" ty
+                  pure <| locals.push (mkTypedLocal (toString name.getId) ty)
       | `(doElem| $name:ident := $rhs:term) =>
           let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals rhs
           pure locals
@@ -5197,6 +5214,15 @@ private partial def validateEffectStmtExprTypes
       for key in (← expectMappingKeyTerms keys) do
         let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals key
       let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals value
+  | `(term| setMemoryArrayElement $name:term $index:term $value:term) => do
+      let (_, elemTy) ← requireSupportedMemoryArrayLocal name "setMemoryArrayElement" locals
+      unless isSingleWordStaticValueType elemTy do
+        throwErrorAt name s!"setMemoryArrayElement currently supports only Array<wordLike> memory locals, got Array {renderValueType elemTy}"
+      requireWordLikeType index "memory array index"
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals index)
+      requireDeclaredValueType value "setMemoryArrayElement value" elemTy
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals value)
+      pure ()
   | `(term| mstore $offset:term $value:term) | `(term| tstore $offset:term $value:term) => do
       let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals offset
       let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals value
@@ -5225,8 +5251,13 @@ private partial def validateEffectStmtExprTypes
         args "ECM argument"
       pure ()
   | `(term| returnArray $name:term) => do
-      let ty ← requireDirectParamRef name "returnArray" params
-      requireSupportedReturnArrayType name "returnArray" ty
+      match localMemoryArray? locals name with
+      | some (_, elemTy) =>
+          unless isSingleWordStaticValueType elemTy do
+            throwErrorAt name s!"returnArray currently supports only Array<wordLike> memory locals, got Array {renderValueType elemTy}"
+      | none =>
+          let ty ← requireDirectParamRef name "returnArray" params
+          requireSupportedReturnArrayType name "returnArray" ty
   | `(term| returnBytes $name:term) => do
       let ty ← requireDirectParamRef name "returnBytes" params
       requireSupportedReturnBytesType name "returnBytes" ty
@@ -5653,6 +5684,21 @@ private def translateEffectStmt
       `(Compiler.CompilationModel.Stmt.require
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond)
           $(strTerm (← expectStringLiteral msg)))
+  | `(term| setMemoryArrayElement $name:term $index:term $value:term) => do
+      let (arrayName, elemTy) ← requireSupportedMemoryArrayLocal name "setMemoryArrayElement" locals
+      unless isSingleWordStaticValueType elemTy do
+        throwErrorAt name s!"setMemoryArrayElement currently supports only Array<wordLike> memory locals, got Array {renderValueType elemTy}"
+      let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+      let valueExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals value
+      let dataOffsetExpr : Term ←
+        `(Compiler.CompilationModel.Expr.localVar $(strTerm (memoryArrayDataOffsetName arrayName)))
+      let elementOffsetExpr : Term ←
+        `(Compiler.CompilationModel.Expr.add
+            $dataOffsetExpr
+            (Compiler.CompilationModel.Expr.mul $indexExpr (Compiler.CompilationModel.Expr.literal 32)))
+      `(Compiler.CompilationModel.Stmt.unsafeBlock
+          "write memory-backed uint256 array element"
+          [Compiler.CompilationModel.Stmt.mstore $elementOffsetExpr $valueExpr])
   | `(term| mstore $offset:term $value:term) =>
       `(Compiler.CompilationModel.Stmt.mstore
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset)
@@ -5992,6 +6038,40 @@ private partial def translateDoElem
                         $(strTerm targetFn)
                         [ $[$argExprs],* ]))],
                   locals.push (mkTypedLocal varName .bool),
+                  mutableLocals)
+          | `(term| allocArray $len:term) =>
+              requireWordLikeType len "allocArray length"
+                (← inferPureExprType fields constDecls immutableDecls externalDecls params locals len)
+              let lenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals len
+              let lengthName := memoryArrayLengthName varName
+              let dataOffsetName := memoryArrayDataOffsetName varName
+              let lengthLocal : Term ← `(Compiler.CompilationModel.Expr.localVar $(strTerm lengthName))
+              let dataOffsetLocal : Term ← `(Compiler.CompilationModel.Expr.localVar $(strTerm dataOffsetName))
+              let dataOffsetExpr : Term ←
+                `(Compiler.CompilationModel.Expr.add
+                    (Compiler.CompilationModel.Expr.mload (Compiler.CompilationModel.Expr.literal 64))
+                    (Compiler.CompilationModel.Expr.literal 32))
+              let arrayHeadExpr : Term ←
+                `(Compiler.CompilationModel.Expr.sub $dataOffsetLocal (Compiler.CompilationModel.Expr.literal 32))
+              let freePtrExpr : Term ←
+                `(Compiler.CompilationModel.Expr.add
+                    $dataOffsetLocal
+                    (Compiler.CompilationModel.Expr.mul $lengthLocal (Compiler.CompilationModel.Expr.literal 32)))
+              pure
+                (#[
+                    (← `(Compiler.CompilationModel.Stmt.letVar $(strTerm lengthName) $lenExpr)),
+                    (← `(Compiler.CompilationModel.Stmt.letVar $(strTerm dataOffsetName) $dataOffsetExpr)),
+                    (← `(Compiler.CompilationModel.Stmt.unsafeBlock
+                          "allocate memory-backed uint256 array"
+                          [Compiler.CompilationModel.Stmt.mstore $arrayHeadExpr $lengthLocal,
+                           Compiler.CompilationModel.Stmt.mstore
+                            (Compiler.CompilationModel.Expr.literal 64)
+                            $freePtrExpr]))
+                  ],
+                  locals.push
+                    { name := varName
+                      ty := .array .uint256
+                      source := .memoryArray },
                   mutableLocals)
           | _ =>
               match ← localInternalArrayReturnBind? fields constDecls immutableDecls externalDecls functions params locals rhs with


### PR DESCRIPTION
## Summary
- add macro support for `allocArray` memory-backed `uint256[]` locals
- add `setMemoryArrayElement` lowering for memory array writes
- allow `returnArray` to return compiler-tracked memory array locals
- cover allocation, writes, and return shape with native-decide regressions

## Verification
- `git diff --check`
- `lake build Compiler.CompilationModelFeatureTest`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_axioms.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates macro translation and compilation-model validation to recognize/emit memory-backed `uint256[]` locals, which can affect generated Yul memory layout and return behavior. While scoped to arrays and guarded by new checks/tests, mistakes could cause incorrect codegen or runtime memory corruption.
> 
> **Overview**
> Enables macros to create and use *memory-backed* `uint256[]` locals via `allocArray`, including lowering to Yul-style memory allocation (updating free memory pointer) and introducing `setMemoryArrayElement` to write elements.
> 
> Extends identifier/return-shape validation so `returnArray` can return these memory-array locals (not just parameters), with stricter scope/type checks, and adds feature tests that assert the allocation, write, and `Stmt.returnArray` shapes in the generated compilation model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78716210e9d019e424934a2162ab39df9c0668a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->