### PR TITLE
Support dynamic array event sources

### DIFF
--- a/Compiler/CompilationModel/EventEmission.lean
+++ b/Compiler/CompilationModel/EventEmission.lean
@@ -49,6 +49,36 @@ def eventLogArgs
   [YulExpr.ident "__evt_ptr", dataSizeExpr, YulExpr.ident "__evt_topic0"] ++
     indexedTopicParts.map (·.2)
 
+structure EventDynamicArraySource where
+  lengthExpr : YulExpr
+  dataOffsetExpr : YulExpr
+  source : DynamicDataSource
+
+def eventDynamicArraySource?
+    (fields : List Field) (dynamicSource : DynamicDataSource) :
+    Expr → Except String (Option EventDynamicArraySource)
+  | Expr.param name =>
+      pure (some
+        { lengthExpr := YulExpr.ident s!"{name}_length"
+          dataOffsetExpr := indexedDynamicBaseOffsetExpr dynamicSource name
+          source := dynamicSource })
+  | Expr.memoryArrayLength name =>
+      pure (some
+        { lengthExpr := YulExpr.ident s!"{name}_length"
+          dataOffsetExpr := YulExpr.ident s!"{name}_data_offset"
+          source := .memory })
+  | e@(Expr.paramDynamicMemberLength name wordOffset) => do
+      let dataOffsetExpr ← compileExpr fields dynamicSource
+        (Expr.paramDynamicMemberDataOffset name wordOffset)
+      let lengthExpr ← compileExpr fields dynamicSource e
+      pure (some { lengthExpr, dataOffsetExpr, source := dynamicSource })
+  | e@(Expr.arrayElementDynamicMemberLength name index wordOffset) => do
+      let dataOffsetExpr ← compileExpr fields dynamicSource
+        (Expr.arrayElementDynamicMemberDataOffset name index wordOffset)
+      let lengthExpr ← compileExpr fields dynamicSource e
+      pure (some { lengthExpr, dataOffsetExpr, source := dynamicSource })
+  | _ => pure none
+
 def eventParamScalarCompileSupported (ty : ParamType) : Bool :=
   match ty with
   | .uint256 | .int256 | .uint8 | .address | .bool | .bytes32 => true
@@ -289,8 +319,8 @@ def compileEmit (fields : List Field) (events : List EventDef)
                   | _ =>
                       throw s!"Compilation error: unindexed dynamic array event param '{p.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
               else if indexedDynamicArrayElemSupported elemTy then
-                match srcExpr with
-                | Expr.param name =>
+                match ← eventDynamicArraySource? fields dynamicSource srcExpr with
+                | some source =>
                     let lenName := s!"__evt_arg{argIdx}_len"
                     let dstName := s!"__evt_arg{argIdx}_dst"
                     let elemWordSize := eventHeadWordSize elemTy
@@ -301,7 +331,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
                     let loopIndexName := s!"__evt_arg{argIdx}_i"
                     let leafStores :=
                       (staticCompositeLeafTypeOffsets 0 elemTy).map fun (leafOffset, leafTy) =>
-                        let loadExpr := dynamicWordLoad dynamicSource (YulExpr.call "add" [
+                        let loadExpr := dynamicWordLoad source.source (YulExpr.call "add" [
                           YulExpr.ident elemBaseName,
                           YulExpr.lit leafOffset
                         ])
@@ -311,7 +341,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
                         ])
                     pure ([
                       YulStmt.expr (YulExpr.call "mstore" [curHeadPtr, YulExpr.ident "__evt_data_tail"]),
-                      YulStmt.let_ lenName (YulExpr.ident s!"{name}_length"),
+                      YulStmt.let_ lenName source.lengthExpr,
                       YulStmt.let_ dstName (YulExpr.call "add" [YulExpr.ident "__evt_ptr", YulExpr.ident "__evt_data_tail"]),
                       YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident dstName, YulExpr.ident lenName]),
                       YulStmt.let_ byteLenName (YulExpr.call "mul" [YulExpr.ident lenName, YulExpr.lit elemWordSize]),
@@ -321,7 +351,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
                         [YulStmt.assign loopIndexName (YulExpr.call "add" [YulExpr.ident loopIndexName, YulExpr.lit 1])]
                         ([
                           YulStmt.let_ elemBaseName (YulExpr.call "add" [
-                            YulExpr.ident s!"{name}_data_offset",
+                            source.dataOffsetExpr,
                             YulExpr.call "mul" [YulExpr.ident loopIndexName, YulExpr.lit elemWordSize]
                           ]),
                           YulStmt.let_ elemOutBaseName (YulExpr.call "add" [
@@ -345,8 +375,8 @@ def compileEmit (fields : List Field) (events : List EventDef)
                         YulExpr.call "add" [YulExpr.lit 32, YulExpr.ident paddedName]
                       ])
                     ])
-                | _ =>
-                    throw s!"Compilation error: unindexed dynamic array event param '{p.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
+                | none =>
+                    throw s!"Compilation error: unindexed dynamic array event param '{p.name}' in event '{eventName}' currently requires a direct or projected dynamic array reference ({issue586Ref})."
               else if eventIsDynamicType elemTy then
                 match srcExpr with
                 | Expr.param name =>
@@ -482,8 +512,8 @@ def compileEmit (fields : List Field) (events : List EventDef)
                 throw s!"Compilation error: indexed dynamic array event param '{p.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
         | _ =>
             if indexedDynamicArrayElemSupported elemTy then
-              match srcExpr with
-              | Expr.param name =>
+              match ← eventDynamicArraySource? fields dynamicSource srcExpr with
+              | some source =>
                   let topicName := s!"__evt_topic{idx + 1}"
                   let byteLenName := s!"__evt_arg{idx}_byte_len"
                   let elemWordSize := eventHeadWordSize elemTy
@@ -492,7 +522,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
                   let loopIndexName := s!"__evt_arg{idx}_i"
                   let leafStores :=
                     (staticCompositeLeafTypeOffsets 0 elemTy).map fun (leafOffset, leafTy) =>
-                      let loadExpr := dynamicWordLoad dynamicSource (YulExpr.call "add" [
+                      let loadExpr := dynamicWordLoad source.source (YulExpr.call "add" [
                         YulExpr.ident elemBaseName,
                         YulExpr.lit leafOffset
                       ])
@@ -505,16 +535,16 @@ def compileEmit (fields : List Field) (events : List EventDef)
                       ])
                   let hashStmts := [
                     YulStmt.let_ byteLenName (YulExpr.call "mul" [
-                      YulExpr.ident s!"{name}_length",
+                      source.lengthExpr,
                       YulExpr.lit elemWordSize
                     ]),
                     YulStmt.for_
                       [YulStmt.let_ loopIndexName (YulExpr.lit 0)]
-                      (YulExpr.call "lt" [YulExpr.ident loopIndexName, YulExpr.ident s!"{name}_length"])
+                      (YulExpr.call "lt" [YulExpr.ident loopIndexName, source.lengthExpr])
                       [YulStmt.assign loopIndexName (YulExpr.call "add" [YulExpr.ident loopIndexName, YulExpr.lit 1])]
                       ([
                         YulStmt.let_ elemBaseName (YulExpr.call "add" [
-                          YulExpr.ident s!"{name}_data_offset",
+                          source.dataOffsetExpr,
                           YulExpr.call "mul" [YulExpr.ident loopIndexName, YulExpr.lit elemWordSize]
                         ]),
                         YulStmt.let_ elemOutBaseName (YulExpr.call "add" [
@@ -528,8 +558,8 @@ def compileEmit (fields : List Field) (events : List EventDef)
                     ])
                   ]
                   pure (hashStmts, YulExpr.ident topicName)
-              | _ =>
-                  throw s!"Compilation error: indexed dynamic array event param '{p.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
+              | none =>
+                  throw s!"Compilation error: indexed dynamic array event param '{p.name}' in event '{eventName}' currently requires a direct or projected dynamic array reference ({issue586Ref})."
             else if eventIsDynamicType elemTy then
               match srcExpr with
               | Expr.param name =>

--- a/Compiler/CompilationModel/ValidationEvents.lean
+++ b/Compiler/CompilationModel/ValidationEvents.lean
@@ -27,6 +27,24 @@ def validateDirectParamCustomErrorArg
   | _ =>
       throw s!"Compilation error: function '{fnName}' custom error '{errorName}' parameter of type {repr expectedTy} currently requires direct parameter reference ({issue586Ref})."
 
+def validateEventDynamicArrayArg
+    (fnName eventName paramName : String) (params : List Param)
+    (expectedTy : ParamType) (arg : Expr) : Except String Unit := do
+  match arg with
+  | Expr.param name =>
+      match findParamType params name with
+      | some ty =>
+          if ty != expectedTy then
+            throw s!"Compilation error: function '{fnName}' event '{eventName}' param '{paramName}' expects {repr expectedTy}, got parameter '{name}' of type {repr ty} ({issue586Ref})."
+      | none =>
+          throw s!"Compilation error: function '{fnName}' event '{eventName}' references unknown parameter '{name}' ({issue586Ref})."
+  | Expr.memoryArrayLength _
+  | Expr.paramDynamicMemberLength _ _
+  | Expr.arrayElementDynamicMemberLength _ _ _ =>
+      pure ()
+  | _ =>
+      throw s!"Compilation error: function '{fnName}' dynamic array event param '{paramName}' in event '{eventName}' currently requires a direct or projected dynamic array reference ({issue586Ref})."
+
 mutual
 def validateCustomErrorArgShapesInStmt (fnName : String) (params : List Param)
     (errors : List ErrorDef) : Stmt → Except String Unit
@@ -110,16 +128,7 @@ partial def validateEventArgShapesInStmt (fnName : String) (params : List Param)
                   | _ =>
                       throw s!"Compilation error: function '{fnName}' unindexed dynamic array event param '{eventParam.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
               else if indexedDynamicArrayElemSupported elemTy then
-                match arg with
-                | Expr.param name =>
-                    match findParamType params name with
-                    | some ty =>
-                        if ty != eventParam.ty then
-                          throw s!"Compilation error: function '{fnName}' event '{eventName}' param '{eventParam.name}' expects {repr eventParam.ty}, got parameter '{name}' of type {repr ty} ({issue586Ref})."
-                    | none =>
-                        throw s!"Compilation error: function '{fnName}' event '{eventName}' references unknown parameter '{name}' ({issue586Ref})."
-                | _ =>
-                    throw s!"Compilation error: function '{fnName}' unindexed dynamic array event param '{eventParam.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
+                validateEventDynamicArrayArg fnName eventName eventParam.name params eventParam.ty arg
               else if eventIsDynamicType elemTy then
                 match arg with
                 | Expr.param name =>
@@ -183,16 +192,19 @@ partial def validateEventArgShapesInStmt (fnName : String) (params : List Param)
                   | _ =>
                       throw s!"Compilation error: function '{fnName}' indexed dynamic array event param '{eventParam.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
               | _ =>
-                  match arg with
-                  | Expr.param name =>
-                      match findParamType params name with
-                      | some ty =>
-                          if ty != eventParam.ty then
-                            throw s!"Compilation error: function '{fnName}' event '{eventName}' param '{eventParam.name}' expects {repr eventParam.ty}, got parameter '{name}' of type {repr ty} ({issue586Ref})."
-                      | none =>
-                          throw s!"Compilation error: function '{fnName}' event '{eventName}' references unknown parameter '{name}' ({issue586Ref})."
-                  | _ =>
-                      throw s!"Compilation error: function '{fnName}' indexed dynamic array event param '{eventParam.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
+                  if indexedDynamicArrayElemSupported elemTy then
+                    validateEventDynamicArrayArg fnName eventName eventParam.name params eventParam.ty arg
+                  else
+                    match arg with
+                    | Expr.param name =>
+                        match findParamType params name with
+                        | some ty =>
+                            if ty != eventParam.ty then
+                              throw s!"Compilation error: function '{fnName}' event '{eventName}' param '{eventParam.name}' expects {repr eventParam.ty}, got parameter '{name}' of type {repr ty} ({issue586Ref})."
+                        | none =>
+                            throw s!"Compilation error: function '{fnName}' event '{eventName}' references unknown parameter '{name}' ({issue586Ref})."
+                    | _ =>
+                        throw s!"Compilation error: function '{fnName}' indexed dynamic array event param '{eventParam.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
           | ParamType.fixedArray _ _ | ParamType.tuple _ =>
               match arg with
               | Expr.param name =>

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -2554,6 +2554,50 @@ private def stringEventMismatchSpec : CompilationModel := {
   ]
 }
 
+private def memoryArrayEventSourceSpec : CompilationModel := {
+  name := "MemoryArrayEventSource"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "log"
+      params := []
+      returnType := none
+      body := [
+        Stmt.letVar "values_length" (Expr.literal 2),
+        Stmt.letVar "values_data_offset" (Expr.literal 128),
+        Stmt.emit "Amounts" [Expr.memoryArrayLength "values"],
+        Stmt.stop
+      ]
+    }
+  ]
+  events := [
+    { name := "Amounts"
+      params := [{ name := "values", ty := ParamType.array ParamType.uint256, kind := EventParamKind.unindexed }]
+    }
+  ]
+}
+
+private def projectedArrayEventSourceSpec : CompilationModel := {
+  name := "ProjectedArrayEventSource"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "log"
+      params := [{ name := "payload", ty := ParamType.tuple [ParamType.array ParamType.uint256] }]
+      returnType := none
+      body := [
+        Stmt.emit "Amounts" [Expr.paramDynamicMemberLength "payload" 0],
+        Stmt.stop
+      ]
+    }
+  ]
+  events := [
+    { name := "Amounts"
+      params := [{ name := "values", ty := ParamType.array ParamType.uint256, kind := EventParamKind.unindexed }]
+    }
+  ]
+}
+
 private def eventEncodingRegressionSpec : CompilationModel := {
   name := "EventEncodingRegression"
   fields := []
@@ -4275,6 +4319,20 @@ set_option maxRecDepth 4096 in
     "string events reject bytes parameters"
     stringEventMismatchSpec
     "event 'MessageLogged' param 'message' expects"
+  let memoryArrayEventsCompile :=
+    match Compiler.CompilationModel.compile memoryArrayEventSourceSpec
+        (selectorsFor memoryArrayEventSourceSpec) with
+    | .ok _ => true
+    | .error _ => false
+  expectTrue "memory array event sources compile for unindexed uint256[] params"
+    memoryArrayEventsCompile
+  let projectedArrayEventsCompile :=
+    match Compiler.CompilationModel.compile projectedArrayEventSourceSpec
+        (selectorsFor projectedArrayEventSourceSpec) with
+    | .ok _ => true
+    | .error _ => false
+  expectTrue "projected dynamic array event sources compile for unindexed uint256[] params"
+    projectedArrayEventsCompile
   let stringArrayEventsCompile :=
     match Compiler.CompilationModel.compile Contracts.StringArrayEventSmoke.spec
         (selectorsFor Contracts.StringArrayEventSmoke.spec) with

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -4623,6 +4623,49 @@ private def expectExprList
       xs.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)
   | _ => throwErrorAt stx "expected list literal [..]"
 
+private def translateEmitArgExpr
+    (fields : Array StorageFieldDecl)
+    (constDecls : Array ConstantDecl)
+    (immutableDecls : Array ImmutableDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (stx : Term) : CommandElabM Term := do
+  if let some (name, _) := localMemoryArray? locals stx then
+    `(Compiler.CompilationModel.Expr.memoryArrayLength $(strTerm name))
+  else if let some (paramName, index, _fieldTy, _elemTy, wordOffset) :=
+      localArrayElementDynamicMemberProjection? locals stx then
+    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+    `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+        $(strTerm paramName)
+        $indexExpr
+        $(natTerm wordOffset))
+  else if let some (paramName, index, _fieldTy, _elemTy, wordOffset) :=
+      arrayElementDynamicMemberProjection? params stx then
+    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+    `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+        $(strTerm paramName)
+        $indexExpr
+        $(natTerm wordOffset))
+  else if let some (paramName, _fieldTy, wordOffset) :=
+      paramDynamicMemberProjection? params stx then
+    `(Compiler.CompilationModel.Expr.paramDynamicMemberLength
+        $(strTerm paramName)
+        $(natTerm wordOffset))
+  else
+    translatePureExprWithTypes fields constDecls immutableDecls params locals stx
+
+private def expectEmitExprList
+    (fields : Array StorageFieldDecl)
+    (constDecls : Array ConstantDecl)
+    (immutableDecls : Array ImmutableDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (stx : Term) : CommandElabM (Array Term) := do
+  match stripParens stx with
+  | `(term| [ $[$xs],* ]) =>
+      xs.mapM (translateEmitArgExpr fields constDecls immutableDecls params locals)
+  | _ => throwErrorAt stx "expected list literal [..]"
+
 private def translateBindSource
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
@@ -5730,7 +5773,7 @@ private def translateEffectStmt
       `(Compiler.CompilationModel.Stmt.returnStorageWords $(strTerm (← expectStringOrIdent name)))
   | `(term| emit $eventName:term $args:term) =>
       let evName := ← expectStringOrIdent eventName
-      let argExprs ← expectExprList fields constDecls immutableDecls params locals args
+      let argExprs ← expectEmitExprList fields constDecls immutableDecls params locals args
       `(Compiler.CompilationModel.Stmt.emit $(strTerm evName) [ $[$argExprs],* ])
   | `(term| rawLog $topics:term $dataOffset:term $dataSize:term) =>
       let topicExprs ← expectExprList fields constDecls immutableDecls params locals topics


### PR DESCRIPTION
## Summary
- allow event encoding to source uint256[]-style dynamic array payloads from memory-backed locals and projected dynamic members
- validate the new event argument sentinel forms for supported dynamic array element types
- lower macro emit arguments for memory arrays and projected dynamic arrays to the compilation model event-source expressions
- add compilation-model feature coverage for memory-backed and projected event array sources

## Notes
This extends the encoder/model path needed for source-shaped dynamic array event payloads. The current executable surface still has , so fully source-level heterogeneous event argument lists remain a separate follow-up.

## Verification
- git diff --check
- lake build Compiler.CompilationModelFeatureTest
- lake build PrintAxioms
- python3 scripts/generate_print_axioms.py --check
- python3 scripts/check_axioms.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends event ABI encoding/validation for dynamic arrays and changes macro lowering of `emit` arguments, which can affect generated Yul for event payloads and topic hashing. Scope is limited to dynamic-array event args, with added feature tests to catch regressions.
> 
> **Overview**
> Enables event emission to source `uint256[]`-style dynamic array payloads not only from direct parameters, but also from **memory-backed locals** and **projected dynamic members** (via new sentinel `Expr.*Length` forms), by plumbing a unified `EventDynamicArraySource` into both indexed-topic hashing and unindexed data encoding.
> 
> Adds validation for these new event-argument shapes, updates the Verity macro so `emit` lowers eligible array expressions into the new sentinels, and adds compilation-model feature tests that ensure both memory and projected dynamic array sources compile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4081e3180831402da712be57dd50ffc7f095841f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->