### PR TITLE
Allow array values in executable emit calls

### DIFF
--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -1987,9 +1987,18 @@ verity_contract MacroEventTrace where
 
   event_defs
     event Transfer(@indexed amount : Uint256, total : Uint256)
+    event Amounts(total : Uint256, values : Array Uint256)
+    event MemoryAmounts(values : Array Uint256)
 
   function emitNamed (amount : Uint256, bonus : Uint256) : Unit := do
     emit "Transfer" [amount, add amount bonus]
+
+  function emitArray (total : Uint256, values : Array Uint256) : Unit := do
+    emit "Amounts" [total, values]
+
+  function emitMemoryArray (len : Uint256) : Unit := do
+    let values ← allocArray len
+    emit "MemoryAmounts" [values]
 
   function emitDynamicLog
       (topic0 : Uint256, topic1 : Uint256, dataOffset : Uint256, dataSize : Uint256) : Unit := do
@@ -2004,6 +2013,33 @@ def emitNamedModelUsesStmtEmit : Bool :=
 
 example : emitNamedModelUsesStmtEmit = true := by native_decide
 
+def emitArrayModelUsesDynamicArrayParam : Bool :=
+  match MacroEventTrace.emitArray_modelBody with
+  | [Stmt.emit "Amounts" [Expr.param "total", Expr.param "values"],
+      Stmt.stop] =>
+      true
+  | _ => false
+
+example : emitArrayModelUsesDynamicArrayParam = true := by native_decide
+
+def emitMemoryArrayModelUsesMemoryArrayLength : Bool :=
+  let body := MacroEventTrace.emitMemoryArray_modelBody
+  body.any (fun stmt =>
+    match stmt with
+    | Stmt.letVar "values_length" (Expr.param "len") => true
+    | _ => false) &&
+  body.any (fun stmt =>
+    match stmt with
+    | Stmt.letVar "values_data_offset"
+        (Expr.add (Expr.mload (Expr.literal 64)) (Expr.literal 32)) => true
+    | _ => false) &&
+  body.any (fun stmt =>
+    match stmt with
+    | Stmt.emit "MemoryAmounts" [Expr.memoryArrayLength "values"] => true
+    | _ => false)
+
+example : emitMemoryArrayModelUsesMemoryArrayLength = true := by native_decide
+
 def emitDynamicLogModelUsesStmtRawLog : Bool :=
   match MacroEventTrace.emitDynamicLog_modelBody with
   | [Stmt.rawLog
@@ -2017,13 +2053,29 @@ def emitDynamicLogModelUsesStmtRawLog : Bool :=
 example : emitDynamicLogModelUsesStmtRawLog = true := by native_decide
 
 def eventTraceSpecCarriesEventMetadata : Bool :=
-  match MacroEventTrace.spec.events with
-  | [{ name := "Transfer",
-       params := [
-        { name := "amount", ty := ParamType.uint256, kind := EventParamKind.indexed },
-        { name := "total", ty := ParamType.uint256, kind := EventParamKind.unindexed }
-       ] }] => true
-  | _ => false
+  MacroEventTrace.spec.events.any (fun ev =>
+    match ev with
+    | { name := "Transfer",
+        params := [
+          { name := "amount", ty := ParamType.uint256, kind := EventParamKind.indexed },
+          { name := "total", ty := ParamType.uint256, kind := EventParamKind.unindexed }
+        ] } => true
+    | _ => false) &&
+  MacroEventTrace.spec.events.any (fun ev =>
+    match ev with
+    | { name := "Amounts",
+        params := [
+          { name := "total", ty := ParamType.uint256, kind := EventParamKind.unindexed },
+          { name := "values", ty := ParamType.array ParamType.uint256, kind := EventParamKind.unindexed }
+        ] } => true
+    | _ => false) &&
+  MacroEventTrace.spec.events.any (fun ev =>
+    match ev with
+    | { name := "MemoryAmounts",
+        params := [
+          { name := "values", ty := ParamType.array ParamType.uint256, kind := EventParamKind.unindexed }
+        ] } => true
+    | _ => false)
 
 example : eventTraceSpecCarriesEventMetadata = true := by native_decide
 
@@ -2037,6 +2089,28 @@ def emitNamedExecutableAppendsNamedEvent : Bool :=
   | .revert _ _ => false
 
 example : emitNamedExecutableAppendsNamedEvent = true := by native_decide
+
+def emitArrayExecutableAppendsArrayLengthPlaceholder : Bool :=
+  match MacroEventTrace.emitArray 7 #[11, 13] Verity.defaultState with
+  | .success () state =>
+      match state.events with
+      | [{ name := "Amounts", args := [7, 2], indexedArgs := [] }] =>
+          state.sender == Verity.defaultState.sender
+      | _ => false
+  | .revert _ _ => false
+
+example : emitArrayExecutableAppendsArrayLengthPlaceholder = true := by native_decide
+
+def emitMemoryArrayExecutableAppendsArrayLengthPlaceholder : Bool :=
+  match MacroEventTrace.emitMemoryArray 3 Verity.defaultState with
+  | .success () state =>
+      match state.events with
+      | [{ name := "MemoryAmounts", args := [3], indexedArgs := [] }] =>
+          state.sender == Verity.defaultState.sender
+      | _ => false
+  | .revert _ _ => false
+
+example : emitMemoryArrayExecutableAppendsArrayLengthPlaceholder = true := by native_decide
 
 def emitDynamicLogExecutableAppendsLowLevelTrace : Bool :=
   match MacroEventTrace.emitDynamicLog 3 4 64 96 Verity.defaultState with

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -228,7 +228,28 @@ def returnArray {α : Type} (values : Array α) : Contract (Array α) := pure va
 def returnValues (_values : List Uint256) : Contract Unit := pure ()
 def returnBytes {α : Type} (value : α) : Contract α := pure value
 def returnStorageWords {α : Type} (_slots : Array α) : Contract (Array Uint256) := pure #[]
-def emit (name : String) (args : List Uint256) : Contract Unit := emitEvent name args
+
+inductive EventArg where
+  | word (value : Uint256)
+  | dynamicArray (length : Uint256)
+deriving Repr, DecidableEq
+
+namespace EventArg
+
+def toWord : EventArg → Uint256
+  | .word value => value
+  | .dynamicArray length => length
+
+end EventArg
+
+instance : Coe Uint256 EventArg where
+  coe value := EventArg.word value
+
+instance (α : Type) : CoeTC (Array α) EventArg where
+  coe values := EventArg.dynamicArray values.size
+
+def emit (name : String) (args : List EventArg) : Contract Unit :=
+  emitEvent name (args.map EventArg.toWord)
 def setPackedStorage {α : Type} (rootSlot : StorageSlot α) (wordOffset : Nat)
     (word : Uint256) : Contract Unit := fun state =>
   let targetSlot := (rootSlot.slot + wordOffset) % Compiler.Constants.evmModulus


### PR DESCRIPTION
## Summary
- add `Contracts.EventArg` so executable `emit` calls can accept scalar words and array values in one argument list
- coerce array event arguments to dynamic-array length placeholders for the executable event trace
- add macro smoke coverage for scalar plus array event emits and memory-array event emits

## Verification
- git diff --check
- lake build Compiler.CompilationModelFeatureTest
- lake build PrintAxioms
- python3 scripts/generate_print_axioms.py --check
- python3 scripts/check_axioms.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `Contracts.emit` API and its coercions, which could subtly affect executable event traces for existing contracts, especially around dynamic array arguments. The change is conceptually small but touches a commonly used surface in contract stubs/tests.
> 
> **Overview**
> Extends executable event emission to accept a mixed argument list of scalar words and dynamic arrays by introducing `Contracts.EventArg` and updating `emit` to map arrays to a *dynamic-array length placeholder* in the event trace.
> 
> Adds macro smoke coverage for emitting events with array parameters, including emitting an allocated memory array, and updates event-metadata assertions to cover the new array-typed events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dfe314bdd2a57dbed36c33b9f6a0a35629f1772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->