### PR TITLE
Support projected static composite event payloads

### DIFF
--- a/Compiler/CompilationModel/EventEmission.lean
+++ b/Compiler/CompilationModel/EventEmission.lean
@@ -134,6 +134,31 @@ def compileAdtEventWordStores (eventName : String) (paramName : String)
   | _ =>
       throw s!"Compilation error: ADT event param '{paramName}' in event '{eventName}' currently requires direct ADT parameter reference so payload fields can be encoded ({issue586Ref})."
 
+def compileStaticCompositeEventWordStores
+    (dynamicSource : DynamicDataSource) (eventName paramName : String)
+    (ty : ParamType) (srcExpr : Expr) (argExpr basePtr : YulExpr) :
+    Except String (List YulStmt) :=
+  match srcExpr with
+  | Expr.param name =>
+      let leaves := staticCompositeLeaves name ty
+      pure <| leaves.zipIdx.map fun ((leafTy, leafExpr), wordIdx) =>
+        YulStmt.expr (YulExpr.call "mstore" [
+          YulExpr.call "add" [basePtr, YulExpr.lit (wordIdx * 32)],
+          normalizeEventWord leafTy leafExpr
+        ])
+  | Expr.paramDynamicStaticComposite _ _ =>
+      pure <| (staticCompositeLeafTypeOffsets 0 ty).map fun (leafOffset, leafTy) =>
+        let loadExpr := dynamicWordLoad dynamicSource (YulExpr.call "add" [
+          argExpr,
+          YulExpr.lit leafOffset
+        ])
+        YulStmt.expr (YulExpr.call "mstore" [
+          YulExpr.call "add" [basePtr, YulExpr.lit leafOffset],
+          normalizeEventWord leafTy loadExpr
+        ])
+  | _ =>
+      throw s!"Compilation error: static composite event param '{paramName}' in event '{eventName}' currently requires direct parameter reference or projected static composite source ({issue586Ref})."
+
 def compileScalarEmitFromCompiledArgs
     (eventDef : EventDef) (args : List Expr) (compiledArgs : List YulExpr) :
     List YulStmt :=
@@ -411,17 +436,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
                 | _ =>
                     throw s!"Compilation error: unindexed dynamic composite event param '{p.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
               else
-                match srcExpr with
-                | Expr.param name =>
-                    let leaves := staticCompositeLeaves name p.ty
-                    let stores := leaves.zipIdx.map fun ((leafTy, leafExpr), wordIdx) =>
-                      YulStmt.expr (YulExpr.call "mstore" [
-                        YulExpr.call "add" [YulExpr.ident "__evt_ptr", YulExpr.lit (headOffset + wordIdx * 32)],
-                        normalizeEventWord leafTy leafExpr
-                      ])
-                    pure stores
-                | _ =>
-                    throw s!"Compilation error: unindexed static composite event param '{p.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
+                compileStaticCompositeEventWordStores dynamicSource eventName p.name p.ty srcExpr argExpr curHeadPtr
           | ParamType.adt _ maxFields =>
               compileAdtEventWordStores eventName p.name srcExpr argExpr curHeadPtr maxFields
           | _ =>
@@ -590,21 +605,13 @@ def compileEmit (fields : List Field) (events : List EventDef)
           | _ =>
               throw s!"Compilation error: indexed dynamic composite event param '{p.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
         else
-          match srcExpr with
-          | Expr.param name =>
-              let topicName := s!"__evt_topic{idx + 1}"
-              let leaves := staticCompositeLeaves name p.ty
-              let stores := leaves.zipIdx.map fun ((leafTy, leafExpr), wordIdx) =>
-                YulStmt.expr (YulExpr.call "mstore" [
-                  YulExpr.call "add" [YulExpr.ident "__evt_ptr", YulExpr.lit (wordIdx * 32)],
-                  normalizeEventWord leafTy leafExpr
-                ])
-              pure (stores ++ [YulStmt.let_ topicName (YulExpr.call "keccak256" [
-                YulExpr.ident "__evt_ptr",
-                YulExpr.lit (eventHeadWordSize p.ty)
-              ])], YulExpr.ident topicName)
-          | _ =>
-              throw s!"Compilation error: indexed static composite event param '{p.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
+          let topicName := s!"__evt_topic{idx + 1}"
+          let stores ← compileStaticCompositeEventWordStores dynamicSource eventName p.name p.ty
+            srcExpr argExpr (YulExpr.ident "__evt_ptr")
+          pure (stores ++ [YulStmt.let_ topicName (YulExpr.call "keccak256" [
+            YulExpr.ident "__evt_ptr",
+            YulExpr.lit (eventHeadWordSize p.ty)
+          ])], YulExpr.ident topicName)
     | ParamType.adt _ maxFields =>
         let topicName := s!"__evt_topic{idx + 1}"
         let stores ← compileAdtEventWordStores eventName p.name srcExpr argExpr

--- a/Compiler/CompilationModel/ExpressionCompile.lean
+++ b/Compiler/CompilationModel/ExpressionCompile.lean
@@ -345,6 +345,11 @@ def compileExpr (fields : List Field)
         YulExpr.lit wordOffset,
         innerIndexExpr
       ])
+  | Expr.paramDynamicStaticComposite name wordOffset =>
+      pure (YulExpr.call "add" [
+        YulExpr.ident s!"{name}_data_offset",
+        YulExpr.lit (wordOffset * 32)
+      ])
   | Expr.arrayElementDynamicMemberLength name index wordOffset => do
       let indexExpr ← compileExpr fields dynamicSource index
       let helperName := match dynamicSource with

--- a/Compiler/CompilationModel/LogicalPurity.lean
+++ b/Compiler/CompilationModel/LogicalPurity.lean
@@ -66,6 +66,7 @@ partial def exprContainsCallLike (expr : Expr) : Bool :=
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ =>
@@ -174,6 +175,7 @@ def exprContainsUnsafeLogicalCallLike (expr : Expr) : Bool :=
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ =>

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -256,6 +256,21 @@ def validateScopedExprIdentifiers
           throw s!"Compilation error: {context} Expr.paramDynamicHeadWord '{name}' requires a tuple parameter, got {repr ty}"
       | none =>
           throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.paramDynamicHeadWord"
+  | Expr.paramDynamicStaticComposite name wordOffset => do
+      match findParamType params name with
+      | some ty@(ParamType.tuple _) =>
+          if isDynamicParamType ty then
+            let expectedWords := paramLocalHeadWords ty
+            if wordOffset < expectedWords then
+              pure ()
+            else
+              throw s!"Compilation error: {context} Expr.paramDynamicStaticComposite '{name}' wordOffset {wordOffset} is outside head width {expectedWords} for {repr ty}"
+          else
+            throw s!"Compilation error: {context} Expr.paramDynamicStaticComposite '{name}' requires a dynamically-encoded tuple parameter, got {repr ty}"
+      | some ty =>
+          throw s!"Compilation error: {context} Expr.paramDynamicStaticComposite '{name}' requires a tuple parameter, got {repr ty}"
+      | none =>
+          throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.paramDynamicStaticComposite"
   | Expr.paramDynamicMemberLength name wordOffset
   | Expr.paramDynamicMemberDataOffset name wordOffset => do
       match findParamType params name with

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -380,6 +380,10 @@ inductive Expr
   /-- Element access into an `Array<wordLike>` dynamic member inside a
       directly-passed dynamic tuple parameter. -/
   | paramDynamicMemberElement (name : String) (wordOffset : Nat) (innerIndex : Expr)
+  /-- Base pointer for a static composite member inside a directly-passed
+      dynamic tuple parameter. Event lowering uses this as the start of the
+      projected tuple's ABI words and then encodes each static leaf. -/
+  | paramDynamicStaticComposite (name : String) (wordOffset : Nat)
   /-- Length of a dynamic member inside a struct-array element.  Given a
       struct-array parameter `name` indexed at `index`, dereferences the
       head pointer at `wordOffset` (relative to the element's head

--- a/Compiler/CompilationModel/UsageAnalysis.lean
+++ b/Compiler/CompilationModel/UsageAnalysis.lean
@@ -190,6 +190,7 @@ def exprUsesArrayElementKind (includePlain includeWord : Bool) : Expr → Bool
   | Expr.memoryArrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ =>
@@ -365,6 +366,7 @@ def exprUsesArrayElement : Expr → Bool
   | Expr.memoryArrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ =>
@@ -509,7 +511,8 @@ def contractUsesArrayElementWord (spec : CompilationModel) : Bool :=
 -- `SupportedSpec.lean` can simp/unfold each case.
 mutual
 def exprUsesParamDynamicHeadWord : Expr → Bool
-  | Expr.paramDynamicHeadWord _ _ => true
+  | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _ => true
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _ => true
   | Expr.paramDynamicMemberElement _ _ innerIndex =>
@@ -703,6 +706,7 @@ def exprUsesMulDiv512 : Expr → Bool
   | Expr.memoryArrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.dynamicBytesEq _ _
@@ -863,6 +867,7 @@ def exprUsesStorageArrayElement : Expr → Bool
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ =>
@@ -1023,6 +1028,7 @@ def exprUsesDynamicBytesEq : Expr → Bool
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ =>

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -279,6 +279,7 @@ def exprReadsStateOrEnv : Expr → Bool
   | Expr.internalCall _ _ => true
   | Expr.arrayLength _ | Expr.memoryArrayLength _ => false
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _ => false
   | Expr.paramDynamicMemberElement _ _ innerIndex => exprReadsStateOrEnv innerIndex
@@ -382,6 +383,7 @@ def exprWritesState : Expr → Bool
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
@@ -557,6 +559,7 @@ def exprHasUntrackableWrites : Expr → Bool
   | Expr.memoryArrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.dynamicBytesEq _ _
@@ -710,6 +713,7 @@ def exprContainsExternalCall : Expr → Bool
   | Expr.memoryArrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
@@ -786,6 +790,7 @@ def exprMayContainExternalCall : Expr → Bool
   | Expr.memoryArrayLength _
   | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>
@@ -1255,6 +1260,7 @@ def exprContainsAdtConstruct : Expr → Bool
   | Expr.localVar _
   | Expr.arrayLength _ | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.adtTag _ _ | Expr.adtField _ _ _ _ _ =>

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -249,6 +249,7 @@ def validateInternalCallShapesInExpr
   | Expr.localVar _
   | Expr.arrayLength _ | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.dynamicBytesEq _ _
@@ -519,6 +520,7 @@ def validateExternalCallTargetsInExpr
   | Expr.localVar _
   | Expr.arrayLength _ | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.dynamicBytesEq _ _

--- a/Compiler/CompilationModel/ValidationEvents.lean
+++ b/Compiler/CompilationModel/ValidationEvents.lean
@@ -151,8 +151,11 @@ partial def validateEventArgShapesInStmt (fnName : String) (params : List Param)
                           throw s!"Compilation error: function '{fnName}' event '{eventName}' param '{eventParam.name}' expects {repr eventParam.ty}, got parameter '{name}' of type {repr ty} ({issue586Ref})."
                     | none =>
                         throw s!"Compilation error: function '{fnName}' event '{eventName}' references unknown parameter '{name}' ({issue586Ref})."
+                | Expr.paramDynamicStaticComposite _ _ =>
+                    if eventIsDynamicType eventParam.ty then
+                      throw s!"Compilation error: function '{fnName}' unindexed dynamic composite event param '{eventParam.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
                 | _ =>
-                    throw s!"Compilation error: function '{fnName}' unindexed composite event param '{eventParam.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
+                    throw s!"Compilation error: function '{fnName}' unindexed composite event param '{eventParam.name}' in event '{eventName}' currently requires direct parameter reference or projected static composite source ({issue586Ref})."
           | ParamType.bytes | ParamType.string =>
               match arg with
               | Expr.param name =>
@@ -214,8 +217,11 @@ partial def validateEventArgShapesInStmt (fnName : String) (params : List Param)
                         throw s!"Compilation error: function '{fnName}' event '{eventName}' param '{eventParam.name}' expects {repr eventParam.ty}, got parameter '{name}' of type {repr ty} ({issue586Ref})."
                   | none =>
                       throw s!"Compilation error: function '{fnName}' event '{eventName}' references unknown parameter '{name}' ({issue586Ref})."
+              | Expr.paramDynamicStaticComposite _ _ =>
+                  if eventIsDynamicType eventParam.ty then
+                    throw s!"Compilation error: function '{fnName}' indexed dynamic composite event param '{eventParam.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
               | _ =>
-                  throw s!"Compilation error: function '{fnName}' indexed composite event param '{eventParam.name}' in event '{eventName}' currently requires direct parameter reference ({issue586Ref})."
+                  throw s!"Compilation error: function '{fnName}' indexed composite event param '{eventParam.name}' in event '{eventName}' currently requires direct parameter reference or projected static composite source ({issue586Ref})."
           | _ => pure ()
   | Stmt.ite _ thenBranch elseBranch => do
       thenBranch.forM (validateEventArgShapesInStmt fnName params events)

--- a/Compiler/CompilationModel/ValidationHelpers.lean
+++ b/Compiler/CompilationModel/ValidationHelpers.lean
@@ -79,6 +79,7 @@ def collectExprNames : Expr → List String
   | Expr.internalCall name args => name :: collectExprListNames args
   | Expr.arrayLength name | Expr.memoryArrayLength name => [name]
   | Expr.paramDynamicHeadWord name _ => [name]
+  | Expr.paramDynamicStaticComposite name _ => [name]
   | Expr.paramDynamicMemberLength name _
   | Expr.paramDynamicMemberDataOffset name _ => [name]
   | Expr.paramDynamicMemberElement name _ innerIndex => name :: collectExprNames innerIndex

--- a/Compiler/CompilationModel/ValidationInterop.lean
+++ b/Compiler/CompilationModel/ValidationInterop.lean
@@ -127,6 +127,7 @@ def validateInteropExpr (context : String) : Expr → Except String Unit
   | Expr.localVar _
   | Expr.arrayLength _ | Expr.memoryArrayLength _ | Expr.storageArrayLength _
   | Expr.paramDynamicHeadWord _ _
+  | Expr.paramDynamicStaticComposite _ _
   | Expr.paramDynamicMemberLength _ _
   | Expr.paramDynamicMemberDataOffset _ _
   | Expr.dynamicBytesEq _ _

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -1985,10 +1985,20 @@ open Verity.EVM.Uint256
 verity_contract MacroEventTrace where
   storage
 
+  struct Note where
+    npk : Uint256,
+    token : Address,
+    amount : Uint256
+
+  struct Transaction where
+    withdrawal : Note,
+    ciphertexts : Array Uint256
+
   event_defs
     event Transfer(@indexed amount : Uint256, total : Uint256)
     event Amounts(total : Uint256, values : Array Uint256)
     event MemoryAmounts(values : Array Uint256)
+    event NoteLogged(note : Note)
 
   function emitNamed (amount : Uint256, bonus : Uint256) : Unit := do
     emit "Transfer" [amount, add amount bonus]
@@ -1999,6 +2009,9 @@ verity_contract MacroEventTrace where
   function emitMemoryArray (len : Uint256) : Unit := do
     let values ← allocArray len
     emit "MemoryAmounts" [values]
+
+  function emitNote (txn : Transaction) : Unit := do
+    emit "NoteLogged" [txn.withdrawal]
 
   function emitDynamicLog
       (topic0 : Uint256, topic1 : Uint256, dataOffset : Uint256, dataSize : Uint256) : Unit := do
@@ -2039,6 +2052,15 @@ def emitMemoryArrayModelUsesMemoryArrayLength : Bool :=
     | _ => false)
 
 example : emitMemoryArrayModelUsesMemoryArrayLength = true := by native_decide
+
+def emitNoteModelUsesProjectedStaticComposite : Bool :=
+  match MacroEventTrace.emitNote_modelBody with
+  | [Stmt.emit "NoteLogged" [Expr.paramDynamicStaticComposite "txn" 0],
+      Stmt.stop] =>
+      true
+  | _ => false
+
+example : emitNoteModelUsesProjectedStaticComposite = true := by native_decide
 
 def emitDynamicLogModelUsesStmtRawLog : Bool :=
   match MacroEventTrace.emitDynamicLog_modelBody with
@@ -2668,6 +2690,37 @@ private def projectedArrayEventSourceSpec : CompilationModel := {
   events := [
     { name := "Amounts"
       params := [{ name := "values", ty := ParamType.array ParamType.uint256, kind := EventParamKind.unindexed }]
+    }
+  ]
+}
+
+private def projectedStaticCompositeEventSourceSpec : CompilationModel := {
+  name := "ProjectedStaticCompositeEventSource"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "log"
+      params := [
+        { name := "payload",
+          ty := ParamType.tuple [
+            ParamType.tuple [ParamType.uint256, ParamType.address, ParamType.uint256],
+            ParamType.array ParamType.uint256
+          ] }
+      ]
+      returnType := none
+      body := [
+        Stmt.emit "NoteLogged" [Expr.paramDynamicStaticComposite "payload" 0],
+        Stmt.stop
+      ]
+    }
+  ]
+  events := [
+    { name := "NoteLogged"
+      params := [
+        { name := "note",
+          ty := ParamType.tuple [ParamType.uint256, ParamType.address, ParamType.uint256],
+          kind := EventParamKind.unindexed }
+      ]
     }
   ]
 }
@@ -4407,6 +4460,13 @@ set_option maxRecDepth 4096 in
     | .error _ => false
   expectTrue "projected dynamic array event sources compile for unindexed uint256[] params"
     projectedArrayEventsCompile
+  let projectedStaticCompositeEventsCompile :=
+    match Compiler.CompilationModel.compile projectedStaticCompositeEventSourceSpec
+        (selectorsFor projectedStaticCompositeEventSourceSpec) with
+    | .ok _ => true
+    | .error _ => false
+  expectTrue "projected static composite event sources compile for unindexed tuple params"
+    projectedStaticCompositeEventsCompile
   let stringArrayEventsCompile :=
     match Compiler.CompilationModel.compile Contracts.StringArrayEventSmoke.spec
         (selectorsFor Contracts.StringArrayEventSmoke.spec) with

--- a/Compiler/Proofs/IRGeneration/ExprCore.lean
+++ b/Compiler/Proofs/IRGeneration/ExprCore.lean
@@ -46,6 +46,7 @@ def exprBoundNames : Expr → List String
   | .arrayElementDynamicMemberElement name index _ innerIndex =>
       name :: (exprBoundNames index ++ exprBoundNames innerIndex)
   | .paramDynamicHeadWord name _ => [name]
+  | .paramDynamicStaticComposite name _ => [name]
   | .paramDynamicMemberLength name _
   | .paramDynamicMemberDataOffset name _ => [name]
   | .paramDynamicMemberElement name _ innerIndex =>

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -583,6 +583,7 @@ def evalExpr (fields : List Field) (state : RuntimeState) : Expr → Option Nat
   | .paramDynamicMemberLength _ _ => none
   | .paramDynamicMemberDataOffset _ _ => none
   | .paramDynamicMemberElement _ _ _ => none
+  | .paramDynamicStaticComposite _ _ => none
   | .literal n => some (wordNormalize n)
   | .param name => some (lookupValue state.bindings name)
     | .storage fieldName =>
@@ -1055,6 +1056,13 @@ private theorem evalExpr_paramDynamicHeadWord
     (name : String)
     (wordOffset : Nat) :
     evalExpr fields state (.paramDynamicHeadWord name wordOffset) = none := rfl
+
+private theorem evalExpr_paramDynamicStaticComposite
+    (fields : List Field)
+    (state : RuntimeState)
+    (name : String)
+    (wordOffset : Nat) :
+    evalExpr fields state (.paramDynamicStaticComposite name wordOffset) = none := rfl
 
 private theorem evalExpr_paramDynamicMemberLength
     (fields : List Field)
@@ -2790,7 +2798,8 @@ mutual
     -- the 200 000-heartbeat ceiling whenever a new `Expr` constructor
     -- lands (verity#1842).
     | .mulDiv512Down _ _ _ | .mulDiv512Up _ _ _
-    | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+    | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
+    | .paramDynamicMemberLength _ _
     | .paramDynamicMemberDataOffset _ _ | .paramDynamicMemberElement _ _ _
     | .arrayLength _ | .memoryArrayLength _
     | .arrayElement _ _ | .memoryArrayElement _ _
@@ -3865,6 +3874,8 @@ mutual
         simp [evalExprWithHelpers, evalExpr_mulDiv512Down, evalExpr_mulDiv512Up]
     | paramDynamicHeadWord _ _ =>
         simp [evalExprWithHelpers, evalExpr_paramDynamicHeadWord]
+    | paramDynamicStaticComposite _ _ =>
+        simp [evalExprWithHelpers, evalExpr_paramDynamicStaticComposite]
     | paramDynamicMemberLength _ _ | paramDynamicMemberDataOffset _ _ =>
         simp [evalExprWithHelpers, evalExpr_paramDynamicMemberLength,
           evalExpr_paramDynamicMemberDataOffset]

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -598,7 +598,8 @@ def exprTouchesUnsupportedConstructorRawCalldataSurface : Expr → Bool
   -- `paramDynamicHeadWord` reads the head section of an ABI-decoded
   -- parameter; like `param _` it does not touch raw calldata, so the
   -- constructor-arg precondition is unaffected.
-  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
+  | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _ => false
   | .mappingChain _ keys | .internalCall _ keys | .externalCall _ keys =>
       exprListTouchesUnsupportedConstructorRawCalldataSurface keys
@@ -740,7 +741,8 @@ def exprTouchesUnsupportedCoreSurface : Expr → Bool
   | .arrayElementDynamicMemberLength _ _ _
   | .arrayElementDynamicMemberDataOffset _ _ _
   | .arrayElementDynamicMemberElement _ _ _ _
-  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
+  | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _ | .paramDynamicMemberElement _ _ _
   | .mulDiv512Down _ _ _ | .mulDiv512Up _ _ _
   | .storageArrayLength _ | .storageArrayElement _ _
@@ -787,7 +789,8 @@ def exprTouchesUnsupportedStateSurface : Expr → Bool
   | .arrayElementDynamicDataOffset _ _
   | .arrayElementDynamicMemberDataOffset _ _ _
   | .arrayElementDynamicMemberElement _ _ _ _
-  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
+  | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _ | .paramDynamicMemberElement _ _ _
   | .dynamicBytesEq _ _ => false
   | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedStateSurface a
@@ -805,7 +808,8 @@ def exprTouchesUnsupportedCallSurface : Expr → Bool
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
   | .memoryArrayLength _
-  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
+  | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ => false
   | .paramDynamicMemberElement _ _ b =>
@@ -857,7 +861,8 @@ def exprTouchesUnsupportedHelperSurface : Expr → Bool
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
   | .memoryArrayLength _
-  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
+  | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ | .externalCall _ _ => false
   | .paramDynamicMemberElement _ _ b =>
@@ -918,7 +923,8 @@ def exprTouchesInternalHelperSurface : Expr → Bool
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
   | .memoryArrayLength _
-  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
+  | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ | .externalCall _ _ => false
   | .paramDynamicMemberElement _ _ b =>
@@ -974,7 +980,8 @@ def exprTouchesUnsupportedForeignSurface : Expr → Bool
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
   | .memoryArrayLength _
-  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
+  | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ | .internalCall _ _ => false
   | .paramDynamicMemberElement _ _ b =>
@@ -1028,7 +1035,8 @@ def exprTouchesUnsupportedLowLevelSurface : Expr → Bool
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .keccak256 _ _ | .arrayLength _
   | .memoryArrayLength _
-  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
+  | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _
   | .storageArrayLength _ | .internalCall _ _ | .externalCall _ _ => false
   | .paramDynamicMemberElement _ _ b =>
@@ -1114,7 +1122,8 @@ def exprTouchesUnsupportedContractSurface (expr : Expr) : Bool :=
   | .arrayElementDynamicMemberLength _ _ _
   | .arrayElementDynamicMemberDataOffset _ _ _
   | .arrayElementDynamicMemberElement _ _ _ _
-  | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+  | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
+  | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _ | .paramDynamicMemberElement _ _ _
   | .mulDiv512Down _ _ _ | .mulDiv512Up _ _ _
   | .storageArrayLength _ | .storageArrayElement _ _
@@ -1780,7 +1789,8 @@ mutual
     | .blockTimestamp | .blockNumber | .blobbasefee
     | .calldatasize | .returndataSize
     | .localVar _ | .arrayLength _ | .memoryArrayLength _ | .storageArrayLength _
-    | .paramDynamicHeadWord _ _ | .paramDynamicMemberLength _ _
+    | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
+    | .paramDynamicMemberLength _ _
     | .paramDynamicMemberDataOffset _ _
     | .dynamicBytesEq _ _
     | .adtConstruct _ _ _ | .adtTag _ _ | .adtField _ _ _ _ _ =>
@@ -3238,7 +3248,8 @@ mutual
     | blockTimestamp | blockNumber | localVar _ | storage _ | storageAddr _
     | constructorArg _ | blobbasefee | calldatasize | returndataSize
     | arrayLength _ | memoryArrayLength _ | storageArrayLength _ | dynamicBytesEq _ _
-    | paramDynamicHeadWord _ _ | paramDynamicMemberLength _ _
+    | paramDynamicHeadWord _ _ | paramDynamicStaticComposite _ _
+    | paramDynamicMemberLength _ _
     | paramDynamicMemberDataOffset _ _
     | externalCall _ _ =>
         simp [exprTouchesInternalHelperSurface]
@@ -3638,7 +3649,8 @@ private theorem exprTouchesUnsupportedCallSurface_eq_featureOr
   | literal _ | param _ | caller | contractAddress
   | chainid | msgValue | selfBalance | blockTimestamp | blockNumber
   | localVar _ | storage _ | storageAddr _
-  | paramDynamicHeadWord _ _ | paramDynamicMemberLength _ _
+  | paramDynamicHeadWord _ _ | paramDynamicStaticComposite _ _
+  | paramDynamicMemberLength _ _
   | paramDynamicMemberDataOffset _ _
   | constructorArg _ | blobbasefee | calldatasize | returndataSize =>
       simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
@@ -3859,7 +3871,8 @@ private theorem exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
       simp [exprTouchesUnsupportedCoreSurface] at hcore
   | storage _ | storageAddr _ =>
       cases hstate
-  | paramDynamicHeadWord _ _ | paramDynamicMemberLength _ _
+  | paramDynamicHeadWord _ _ | paramDynamicStaticComposite _ _
+  | paramDynamicMemberLength _ _
   | paramDynamicMemberDataOffset _ _ | paramDynamicMemberElement _ _ _ =>
       cases hcore
   | constructorArg _
@@ -4254,7 +4267,8 @@ theorem exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
   | arrayElementDynamicMemberLength _ _ _
   | arrayElementDynamicMemberDataOffset _ _ _
   | arrayElementDynamicMemberElement _ _ _ _
-  | paramDynamicHeadWord _ _ | paramDynamicMemberLength _ _
+  | paramDynamicHeadWord _ _ | paramDynamicStaticComposite _ _
+  | paramDynamicMemberLength _ _
   | paramDynamicMemberDataOffset _ _ | paramDynamicMemberElement _ _ _
   | storageArrayElement _ _
   | mappingChain _ _ =>

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2755,6 +2755,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mulDiv512Down  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mulDiv512Up  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_paramDynamicHeadWord  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_paramDynamicStaticComposite  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_paramDynamicMemberLength  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_paramDynamicMemberDataOffset  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_paramDynamicMemberElement  -- private
@@ -5584,4 +5585,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5298 theorems/lemmas (3564 public, 1734 private, 0 sorry'd)
+-- Total: 5299 theorems/lemmas (3564 public, 1735 private, 0 sorry'd)

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -28,6 +28,7 @@ def elabVerityContract : CommandElab := fun stx => do
 
     for structDecl in structDecls do
       elabCommand (← mkStructDefCommandPublic structDecl)
+      elabCommand (← mkStructEventArgInstanceCommandPublic structDecl)
 
     for field in fields do
       elabCommand (← mkStorageDefCommandPublic field)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1932,6 +1932,33 @@ private def paramDynamicMemberProjection?
     | .array _ | .bytes | .string => some (root, fieldTy, wordOffset)
     | _ => none
 
+private def paramDynamicStaticCompositeProjection?
+    (params : Array ParamDecl)
+    (stx : Term) : Option (String × ValueType × Nat) := do
+  let (root, path) ←
+    match (stripParens stx).raw with
+    | .ident _ raw _ _ =>
+        let parts := raw.toString.splitOn "."
+        let rec findParamPath : List String → Option (String × List String)
+          | [] | [_] => none
+          | rootName :: fieldName :: rest =>
+              if params.any (fun p => p.name == rootName) then
+                some (rootName, fieldName :: rest)
+              else
+                findParamPath (fieldName :: rest)
+        findParamPath parts
+    | _ =>
+        let (rootStx, path) ← structProjectionPath? stx
+        match stripParens rootStx with
+        | `(term| $id:ident) => some (toString id.getId, path)
+        | _ => none
+  let param ← params.find? (fun p => p.name == root)
+  let (fieldTy, wordOffset) ← structFieldHeadOffset? param.ty path
+  if !valueTypeUsesDynamicData fieldTy && !isSingleWordStaticValueType fieldTy then
+    some (root, fieldTy, wordOffset)
+  else
+    none
+
 private def arrayElementDynamicTupleArg?
     (params : Array ParamDecl)
     (stx : Term) : Option (String × Term × ValueType) := do
@@ -4651,6 +4678,11 @@ private def translateEmitArgExpr
     `(Compiler.CompilationModel.Expr.paramDynamicMemberLength
         $(strTerm paramName)
         $(natTerm wordOffset))
+  else if let some (paramName, _fieldTy, wordOffset) :=
+      paramDynamicStaticCompositeProjection? params stx then
+    `(Compiler.CompilationModel.Expr.paramDynamicStaticComposite
+        $(strTerm paramName)
+        $(natTerm wordOffset))
   else
     translatePureExprWithTypes fields constDecls immutableDecls params locals stx
 
@@ -4665,6 +4697,19 @@ private def expectEmitExprList
   | `(term| [ $[$xs],* ]) =>
       xs.mapM (translateEmitArgExpr fields constDecls immutableDecls params locals)
   | _ => throwErrorAt stx "expected list literal [..]"
+
+private def inferEmitArgExprType
+    (fields : Array StorageFieldDecl)
+    (constDecls : Array ConstantDecl)
+    (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (stx : Term) : CommandElabM ValueType := do
+  if let some (_, fieldTy, _) := paramDynamicStaticCompositeProjection? params stx then
+    pure fieldTy
+  else
+    inferPureExprType fields constDecls immutableDecls externalDecls params locals stx
 
 private def translateBindSource
     (fields : Array StorageFieldDecl)
@@ -5282,11 +5327,18 @@ private partial def validateEffectStmtExprTypes
       | _ => throwErrorAt topics "expected list literal [..]"
       let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals dataOffset
       let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals dataSize
-  | `(term| returnValues $values:term) | `(term| emit $_eventName:term $values:term) => do
+  | `(term| returnValues $values:term) => do
       match stripParens values with
       | `(term| [ $[$xs],* ]) =>
           for x in xs do
             let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals x
+      | _ => throwErrorAt values "expected list literal [..]"
+      pure ()
+  | `(term| emit $_eventName:term $values:term) => do
+      match stripParens values with
+      | `(term| [ $[$xs],* ]) =>
+          for x in xs do
+            let _ ← inferEmitArgExprType fields constDecls immutableDecls externalDecls params locals x
       | _ => throwErrorAt values "expected list literal [..]"
       pure ()
   | `(term| ecmDo $_module:term $args:term) => do
@@ -7002,6 +7054,11 @@ def mkStructDefCommandPublic (decl : StructDecl) : CommandElabM Cmd := do
   `(command| structure $structId where
       $[$fieldIds:ident : $fieldTys:term]*
       deriving Repr, Inhabited)
+
+def mkStructEventArgInstanceCommandPublic (decl : StructDecl) : CommandElabM Cmd := do
+  let structId := decl.ident
+  `(command| instance : CoeTC $structId _root_.Contracts.EventArg where
+      coe _ := _root_.Contracts.EventArg.word (0 : _root_.Verity.Uint256))
 
 /-- Generate a `def storageNamespace : Nat := <keccak-value>` command for
     the current contract.  Uses the resolved namespace value from


### PR DESCRIPTION
## Summary
- add `Expr.paramDynamicStaticComposite` for static composite fields projected from dynamically encoded tuple parameters
- lower projected static composite event payloads by loading ABI words from the dynamic parameter data region
- allow source-shaped `emit "NoteLogged" [txn.withdrawal]` in the macro path and add regression coverage

## Verification
- `git diff --check`
- `lake build Compiler.CompilationModelFeatureTest`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_axioms.py`
- `lake build Benchmark.Cases.UnlinkXyz.Pool.Compile` in `verity-benchmark` against this local Verity checkout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches event ABI/log emission and macro translation logic; incorrect offsets/word loading could silently produce malformed event data/topics even though scope/shape validations and feature tests were updated.
> 
> **Overview**
> Enables `emit` arguments to reference *static composite* fields projected out of a dynamically-encoded tuple parameter via a new `Expr.paramDynamicStaticComposite` projection.
> 
> Event lowering now accepts these projected sources for static composite event params and encodes them by loading ABI words from the dynamic parameter’s data region (applies to both unindexed payload storage and indexed topic hashing).
> 
> Macro translation/typing and validations were updated to recognize and typecheck these projections for `emit`, and feature tests + proof/analysis utilities were extended to cover the new `Expr` constructor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b251a41f969abe478cee2cd3479254c1539bd39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->