### PR TITLE
Add multi-result ECM bind syntax

### DIFF
--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -23,6 +23,12 @@ macro_rules
           let _ := $_module
           let _ := $_args
           pure ())
+  | `(doElem| ecmBind [ $[$names:ident],* ] $_module:term $_args:term) =>
+      `(doElem| do
+          let _ := $_module
+          let _ := $_args
+          $[let $names := (0 : Uint256)]*
+          pure ())
   | `(doElem| unsafe $_reason:str do $body:doSeq) =>
       `(doElem| do $body)
   | `(doElem| tryCatch $attempt:term (fun $name:ident => do $[$elems:doElem]*)) => do

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -375,6 +375,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.ExternalCallMultiReturn.spec
   , Contracts.Smoke.ERC20HelperSmoke.spec
   , Contracts.Smoke.GenericECMReadSmoke.spec
+  , Contracts.Smoke.GenericECMMultiResultSmoke.spec
   , Contracts.Smoke.GenericECMWriteSmoke.spec
   , Contracts.Smoke.CallWithValueSmoke.spec
   , Contracts.Smoke.BubblingValueCallECMSmoke.spec
@@ -541,6 +542,7 @@ private def expectedExternalSignatures : List (String × List String) :=
       "approveTokens(address,address,uint256)", "snapshotBalance(address,address)",
       "snapshotAllowance(address,address,address)", "snapshotSupply(address)"])
   , ("GenericECMReadSmoke", ["snapshotQuote(address,address)"])
+  , ("GenericECMMultiResultSmoke", ["addPoints(uint256,uint256,uint256,uint256)"])
   , ("GenericECMWriteSmoke", ["runEffect(uint256,uint256)"])
   , ("CallWithValueSmoke", ["execute(address,uint256,uint256,uint256)", "executeBytes(address,uint256,bytes)"])
   , ("BubblingValueCallECMSmoke", ["forwardNoOutput(address,uint256,uint256,uint256)"])
@@ -672,6 +674,7 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("ERC20HelperSmoke", ["0xa6c29ca3", "0x6aa209a6", "0x912d6e28", "0x48476c71", "0xdac24aaf",
       "0x7247c4a5"])
   , ("GenericECMReadSmoke", ["0x78f2e50f"])
+  , ("GenericECMMultiResultSmoke", ["0xac9b48fe"])
   , ("GenericECMWriteSmoke", ["0xc1192eb1"])
   , ("CallWithValueSmoke", ["0xde3a04ad", "0xb1d30765"])
   , ("BubblingValueCallECMSmoke", ["0x7ba1ade4"])

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -160,6 +160,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.ExternalCallMultiReturn.spec
   , Contracts.Smoke.ERC20HelperSmoke.spec
   , Contracts.Smoke.GenericECMReadSmoke.spec
+  , Contracts.Smoke.GenericECMMultiResultSmoke.spec
   , Contracts.Smoke.GenericECMWriteSmoke.spec
   , Contracts.Smoke.CallWithValueSmoke.spec
   , Contracts.Smoke.BubblingValueCallECMSmoke.spec

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -13,6 +13,7 @@ import Contracts.ERC721.ERC721
 import Compiler.Modules.Calls
 import Compiler.Modules.ERC20
 import Compiler.Modules.Oracle
+import Compiler.Modules.Precompiles
 
 namespace Contracts.Smoke
 
@@ -1907,6 +1908,19 @@ verity_contract GenericECMReadSmoke where
     setStorage lastQuote quote
     return quote
 
+verity_contract GenericECMMultiResultSmoke where
+  storage
+    lastX : Uint256 := slot 0
+    lastY : Uint256 := slot 1
+
+  function allow_post_interaction_writes addPoints
+      (x1 : Uint256, y1 : Uint256, x2 : Uint256, y2 : Uint256) : Unit := do
+    ecmBind [sumX, sumY]
+      (Compiler.Modules.Precompiles.bn256AddModule "sumX" "sumY")
+      [x1, y1, x2, y2]
+    setStorage lastX sumX
+    setStorage lastY sumY
+
 verity_contract GenericECMWriteSmoke where
   storage
 
@@ -2536,6 +2550,30 @@ example :
           (Compiler.CompilationModel.Expr.localVar "quote")
       , Compiler.CompilationModel.Stmt.return
           (Compiler.CompilationModel.Expr.localVar "quote")
+      ] := rfl
+
+example :
+    (Compiler.CompilationModel.FunctionSpec.body
+      (GenericECMMultiResultSmoke.addPoints_model : Compiler.CompilationModel.FunctionSpec)) =
+    GenericECMMultiResultSmoke.addPoints_modelBody := by
+  simpa using GenericECMMultiResultSmoke.addPoints_semantic_preservation
+
+example :
+    GenericECMMultiResultSmoke.addPoints_modelBody =
+      [ Compiler.CompilationModel.Stmt.ecm
+          (Compiler.Modules.Precompiles.bn256AddModule "sumX" "sumY")
+          [ Compiler.CompilationModel.Expr.param "x1"
+          , Compiler.CompilationModel.Expr.param "y1"
+          , Compiler.CompilationModel.Expr.param "x2"
+          , Compiler.CompilationModel.Expr.param "y2"
+          ]
+      , Compiler.CompilationModel.Stmt.setStorage
+          "lastX"
+          (Compiler.CompilationModel.Expr.localVar "sumX")
+      , Compiler.CompilationModel.Stmt.setStorage
+          "lastY"
+          (Compiler.CompilationModel.Expr.localVar "sumY")
+      , Compiler.CompilationModel.Stmt.stop
       ] := rfl
 
 example :

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -72,6 +72,7 @@ macro_rules
 syntax "revert " ident "(" sepBy(term, ",") ")" : doElem
 syntax "revertError " ident "(" sepBy(term, ",") ")" : doElem
 syntax "requireError " term:max ppSpace ident "(" sepBy(term, ",") ")" : doElem
+syntax "ecmBind " term:max ppSpace term:max ppSpace term:max : doElem
 syntax (priority := high) "unsafe " str " do " doSeq : doElem
 syntax "constructor " "(" sepBy(verityParam, ",") ")" (ppSpace verityLocalObligations)? " := " term : verityConstructor
 syntax "constructor " "(" sepBy(verityParam, ",") ")" " payable" (ppSpace verityLocalObligations)? " := " term : verityConstructor

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -4111,6 +4111,14 @@ private def validateSingleResultEcmModuleTerm
     throwErrorAt moduleTerm
       s!"ecmCall must elaborate to an ECM module binding exactly ['{boundVarName}'], but '{mod.name}' binds {repr mod.resultVars}"
 
+private def validateResultEcmModuleTerm
+    (moduleTerm : Term)
+    (boundVarNames : Array String) : CommandElabM Unit := do
+  let mod ← unsafe evalExternalCallModuleTerm moduleTerm
+  if mod.resultVars != boundVarNames.toList then
+    throwErrorAt moduleTerm
+      s!"ecmBind must elaborate to an ECM module binding exactly {repr boundVarNames.toList}, but '{mod.name}' binds {repr mod.resultVars}"
+
 private def arrayElementTupleElemExprs?
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
@@ -5238,6 +5246,13 @@ private partial def validateDoElemExprTypes
       | `(doElem| unsafe $_reason:str do $body:doSeq) =>
           validateDoSeqExprTypes ownerName fields constDecls immutableDecls externalDecls errorDecls functions params locals body
           pure locals
+      | `(doElem| ecmBind $names:term $module:term $args:term) =>
+          let resultVars ← expectStringList names
+          ensureFreshLocalNames (typedLocalNames locals) (resultVars.map some) names
+          validateWordLikeExprListLiteral fields constDecls immutableDecls externalDecls params locals
+            args "ECM argument"
+          validateResultEcmModuleTerm module resultVars
+          pure <| locals ++ resultVars.map (fun name => mkTypedLocal name .uint256)
       | `(doElem| $stmt:term) =>
           validateEffectStmtExprTypes fields constDecls immutableDecls externalDecls functions params locals stmt
           pure locals
@@ -6305,6 +6320,18 @@ private partial def translateDoElem
                     $(Lean.Quote.quote reasonStr)
                     [ $[$bodyStmts],* ]))],
               locals,
+              mutableLocals)
+      | `(doElem| ecmBind $names:term $module:term $args:term) =>
+          let resultVars ← expectStringList names
+          ensureFreshLocalNames localNames (resultVars.map some) names
+          validateResultEcmModuleTerm module resultVars
+          let argExprs ← expectExprList fields constDecls immutableDecls params locals args
+          let typedLocals := resultVars.map (fun name => mkTypedLocal name .uint256)
+          pure
+            (#[(← `(Compiler.CompilationModel.Stmt.ecm
+                    $module
+                    [ $[$argExprs],* ]))],
+              locals ++ typedLocals,
               mutableLocals)
       | `(doElem| $stmt:term) =>
           pure (#[(← translateEffectStmt fields constDecls immutableDecls externalDecls functions params locals stmt)], locals, mutableLocals)

--- a/artifacts/macro_property_tests/PropertyGenericECMMultiResultSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyGenericECMMultiResultSmoke.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyGenericECMMultiResultSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyGenericECMMultiResultSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("GenericECMMultiResultSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+}


### PR DESCRIPTION
## Summary
- add `ecmBind [x, y] module [args]` as a macro-surface do element for multi-result ECM modules
- validate bound result names against the module and expose them as `Uint256` locals to later statements
- add executable placeholder expansion and smoke coverage using `bn256AddModule`

## Verification
- `lake build Contracts.Smoke`
- `git diff --check`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_axioms.py`
- `lake build Benchmark.Cases.UnlinkXyz.Pool.Compile` in `verity-benchmark` against this local Verity checkout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the Verity macro surface and translation pipeline for ECM calls, which can affect compilation/semantic preservation for contracts using external modules. Changes are localized but touch core elaboration/validation logic and add new smoke coverage.
> 
> **Overview**
> Adds a new do-element syntax, `ecmBind [x, y, ...] module [args]`, to bind **multiple** result words from an ECM module and introduce them as fresh `Uint256` locals for subsequent statements.
> 
> Updates macro translation to typecheck `ecmBind` arguments, validate that the bound names exactly match the module’s declared `resultVars`, and lower the statement to a single `CompilationModel.Stmt.ecm` while extending the local environment.
> 
> Introduces a new smoke contract `GenericECMMultiResultSmoke` (using `bn256AddModule`) plus proof/model expectations, wires it into invariant + round-trip fuzz harness spec lists and selector/signature snapshots, and adds an auto-generated Solidity property test stub for the new smoke contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6621277f16c116b83fa0de8ad16fe714bf3282dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->