### PR TITLE
Cancel stale PR CI on close

### DIFF
--- a/.github/workflows/cancel-closed-pr-ci.yml
+++ b/.github/workflows/cancel-closed-pr-ci.yml
@@ -1,0 +1,50 @@
+name: Cancel closed PR CI
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cancel:
+    name: Cancel stale PR workflow runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Cancel queued and running CI for the closed PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          statuses=(queued in_progress waiting requested pending)
+
+          for status in "${statuses[@]}"; do
+            gh api \
+              --method GET \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "/repos/${REPO}/actions/runs" \
+              -f event=pull_request \
+              -f status="$status" \
+              -f per_page=100 \
+              --paginate \
+              --jq '.workflow_runs[]
+                | select((.id | tostring) != env.CURRENT_RUN_ID)
+                | select(.head_branch == env.HEAD_BRANCH)
+                | select(.head_repository.full_name == env.HEAD_REPOSITORY)
+                | .id' |
+            while read -r run_id; do
+              if [ -n "$run_id" ]; then
+                echo "Canceling stale ${status} PR run ${run_id}"
+                gh run cancel "$run_id" -R "$REPO" || true
+              fi
+            done
+          done


### PR DESCRIPTION
## Summary
- add a GitHub-hosted cleanup workflow for closed PRs
- cancel queued/running `pull_request` runs for the closed PR's head branch and repository
- avoid relying on self-hosted runners so cleanup still runs when the build lane is saturated

## Validation
- parsed workflow YAML with `npx --yes js-yaml`
- extracted embedded Bash and ran `bash -n`
- ran `shellcheck -s bash` on the embedded script
- ran `actionlint` 1.7.7 against the workflow
- exercised the GitHub Actions API query in read-only mode for active statuses

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an automation that uses `pull_request_target` plus `actions: write` to cancel workflow runs; while scoped to run cancellation, it touches privileged GitHub Actions APIs and could mis-cancel runs if branch/repo matching is wrong.
> 
> **Overview**
> Adds a new GitHub Actions workflow, `cancel-closed-pr-ci.yml`, triggered on `pull_request_target: closed` to automatically cancel queued/in-progress `pull_request` CI runs for the closed PR.
> 
> The job queries the Actions runs API for matching `head_branch`/`head_repository` and cancels any still-active runs (excluding the current cleanup run) using `gh run cancel`, requiring `actions: write` permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3038879f98380f71fd1659ba43c6fed2cf3c25b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->