### PR TITLE
Test closed PR CI cleanup

### DIFF
--- a/.github/workflows/cancel-closed-pr-ci.yml
+++ b/.github/workflows/cancel-closed-pr-ci.yml
@@ -48,3 +48,5 @@ jobs:
               fi
             done
           done
+
+# End-to-end cleanup workflow test only.


### PR DESCRIPTION
Temporary PR to verify the closed-PR cleanup workflow. This PR will be closed unmerged after the workflow queues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds a comment and does not change workflow behavior or permissions.
> 
> **Overview**
> Adds a trailing comment to `.github/workflows/cancel-closed-pr-ci.yml` to clearly label the workflow as *end-to-end cleanup test-only*, without changing any CI cancellation logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6164255fe57388f70c72af3b243728a9878270aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->