### PR TITLE
Test closed PR CI cleanup again

### DIFF
--- a/.github/workflows/cancel-closed-pr-ci.yml
+++ b/.github/workflows/cancel-closed-pr-ci.yml
@@ -48,3 +48,5 @@ jobs:
               fi
             done
           done
+
+# End-to-end cleanup workflow test only.


### PR DESCRIPTION
Temporary PR to verify the closed-PR cleanup workflow after matching exact runner labels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds a comment to the GitHub Actions workflow with no behavioral changes.
> 
> **Overview**
> Adds a clarifying comment to `.github/workflows/cancel-closed-pr-ci.yml` noting it is for an end-to-end cleanup workflow test; no CI cancellation logic is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fe8b6673239545dbb991f114b4c168549a09c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->