### PR TITLE
Test closed PR CI cleanup concurrency

### DIFF
--- a/.github/workflows/cancel-closed-pr-ci.yml
+++ b/.github/workflows/cancel-closed-pr-ci.yml
@@ -52,3 +52,5 @@ jobs:
               fi
             done
           done
+
+# End-to-end cleanup workflow test only.


### PR DESCRIPTION
Temporary PR to verify the closed-PR cleanup workflow concurrency cancellation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a trailing comment to a GitHub Actions workflow; no logic, permissions, or execution changes.
> 
> **Overview**
> Adds a note to `.github/workflows/cancel-closed-pr-ci.yml` clarifying the workflow is *for end-to-end cleanup testing only*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b22f4faff89fe2dc18ca4daff2e053f955ed0ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->