### PR TITLE
Test PR-number cleanup concurrency

### DIFF
--- a/.github/workflows/cancel-closed-pr-ci.yml
+++ b/.github/workflows/cancel-closed-pr-ci.yml
@@ -52,3 +52,5 @@ jobs:
               fi
             done
           done
+
+# End-to-end cleanup workflow test only.


### PR DESCRIPTION
Temporary PR to verify PR-number concurrency cancellation on close.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this change is comment-only and does not alter workflow behavior or permissions.
> 
> **Overview**
> Adds a trailing comment to `.github/workflows/cancel-closed-pr-ci.yml` clarifying the workflow is *test-only* for end-to-end cleanup verification; no functional CI logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d699e4e9a73b0a939c30840ad1008f7a01ff022b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->