### PR TITLE
Test verify close concurrency cleanup

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1656,3 +1656,5 @@ jobs:
                 body
               });
             }
+
+# End-to-end verify close cleanup test only.


### PR DESCRIPTION
Temporary PR to verify Verify proofs cancels stale PR runs on close via PR-number concurrency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only a trailing comment to the `verify.yml` GitHub Actions workflow; no behavioral or execution changes to CI logic.
> 
> **Overview**
> Adds a trailing comment to `.github/workflows/verify.yml` marking this PR as an end-to-end test for PR-close concurrency cleanup, without changing the workflow behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73414cbdf01e7485935f3de645ad1ab5e4c923a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->