### PR TITLE
docs: refresh Unlink roadmap blockers

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -183,18 +183,16 @@ Translation tracking:
   ceiling ([#1842](https://github.com/lfglabs-dev/verity/pull/1842)). The
   verity-benchmark pin has been bumped past those merges
   ([verity-benchmark#44](https://github.com/lfglabs-dev/verity-benchmark/pull/44)).
-- Promotion of the `unlink_xyz/pool` case to `build_green` is still blocked.
-  An empirical pilot against `verity-benchmark@1e9b631` confirmed that
-  writing the `transfer` / `withdraw` / `emergencyWithdraw` bodies needs
-  three further macro lifts beyond the single-word static leaf projections
-  delivered by #1832 / #1843, tracked under
-  [#1849](https://github.com/lfglabs-dev/verity/issues/1849):
-  `arrayLength` on a struct-element dynamic member (G1), element indexing
-  on struct-element dynamic members (G2), and pass-through of dynamic-array
-  arguments to `tryExternalCall` / `emit` / `revertError` (G3). The last
-  piece, plus [#1824](https://github.com/lfglabs-dev/verity/issues/1824)
-  (internal helpers with Array parameters), is the final gate on the body
-  translation.
+- The `unlink_xyz/pool` body-translation blockers tracked under
+  [#1849](https://github.com/lfglabs-dev/verity/issues/1849) and
+  [#1824](https://github.com/lfglabs-dev/verity/issues/1824) have shipped:
+  struct-element dynamic member length/index paths, dynamic-array
+  pass-through to `tryExternalCall` / `emit` / `revertError`, and internal
+  helpers with `Array` parameters are now supported. The remaining
+  `build_green` work has shifted to internal-helper ABI lowering for
+  `bytes` / `string` and composite helper parameters
+  ([#1889](https://github.com/lfglabs-dev/verity/issues/1889)), plus the
+  Verity-core versus `unlink-verity` package-boundary work above.
 
 ---
 


### PR DESCRIPTION
## Summary

- refresh the Unlink roadmap translation-tracking section after #1824/#1849 landed
- point the remaining `build_green` blocker at #1889 and the package-boundary work

## Testing

- not run; docs-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change updating roadmap text and issue links; no code or behavior changes.
> 
> **Overview**
> Refreshes `docs/ROADMAP.md` to mark the prior `unlink_xyz/pool` body-translation blockers (tracked under `#1849`/`#1824`) as shipped and to update the described remaining `build_green` blockers.
> 
> Replaces the old “pilot confirmed remaining macro lifts” text with a new note that the outstanding work is now internal-helper ABI lowering for `bytes`/`string` and composite helper parameters (`#1889`), plus the Verity-core vs `unlink-verity` package-boundary work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40e7b918dae17852cc6355cb762cd4437b8d3144. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->