### PR TITLE
Support Unlink helper and storage fidelity

### DIFF
--- a/Compiler/CompilationModel/AbiEncoding.lean
+++ b/Compiler/CompilationModel/AbiEncoding.lean
@@ -325,7 +325,7 @@ def revertWithCustomError (dynamicSource : DynamicDataSource)
         | Expr.param name =>
             if isDynamicParamType ty then
               let dstName := s!"__err_arg{idx}_dst"
-              let srcBase := indexedDynamicBaseOffsetExpr dynamicSource name
+              let srcBase := YulExpr.ident s!"{name}_data_offset"
               let (encStmts, encLen) ←
                 compileUnindexedAbiEncode dynamicSource ty srcBase (YulExpr.ident dstName) s!"__err_arg{idx}"
               pure ([
@@ -348,7 +348,7 @@ def revertWithCustomError (dynamicSource : DynamicDataSource)
         match srcExpr with
         | Expr.param name =>
             let dstName := s!"__err_arg{idx}_dst"
-            let srcBase := indexedDynamicBaseOffsetExpr dynamicSource name
+            let srcBase := YulExpr.call "sub" [YulExpr.ident s!"{name}_data_offset", YulExpr.lit 32]
             let (encStmts, encLen) ←
               compileUnindexedAbiEncode dynamicSource ty srcBase (YulExpr.ident dstName) s!"__err_arg{idx}"
             pure ([

--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -6,6 +6,7 @@
 -/
 import Compiler.CompilationModel.Compile
 import Compiler.CompilationModel.ParamLoading
+import Compiler.CompilationModel.ScopeValidation
 
 namespace Compiler.CompilationModel
 
@@ -36,11 +37,23 @@ def internalFunctionYulParamNames (params : List Param) : List String :=
     match param.ty with
     | ParamType.array _ =>
         [s!"{param.name}_data_offset", s!"{param.name}_length"]
+    | ParamType.bytes | ParamType.string =>
+        [s!"{param.name}_data_offset", s!"{param.name}_length"]
+    | ParamType.fixedArray _ _ =>
+        if isDynamicParamType param.ty then
+          [s!"{param.name}_data_offset"]
+        else
+          staticParamBindingNames param.name param.ty
     | ParamType.tuple _ =>
         if isDynamicParamType param.ty then
           [s!"{param.name}_data_offset"]
         else
-          [param.name]
+          staticParamBindingNames param.name param.ty
+    | ParamType.newtypeOf _ baseTy =>
+        if isDynamicParamType param.ty then
+          [s!"{param.name}_data_offset"]
+        else
+          staticParamBindingNames param.name baseTy
     | _ => [param.name]
 
 -- Compile internal function to a Yul function definition (#181)

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -7,6 +7,7 @@ import Compiler.CompilationModel.AbiTypeLayout
 import Compiler.CompilationModel.DynamicData
 import Compiler.CompilationModel.InternalNaming
 import Compiler.CompilationModel.IssueRefs
+import Compiler.CompilationModel.ScopeValidation
 import Compiler.CompilationModel.UsageAnalysis
 
 namespace Compiler.CompilationModel
@@ -88,7 +89,9 @@ def firstReservedExternalCollision
 
 def internalDynamicParamSupported : ParamType → Bool
   | ParamType.array _ => true
+  | ParamType.bytes | ParamType.string => true
   | ty@(ParamType.tuple _) => isDynamicParamType ty
+  | ty@(ParamType.fixedArray _ _) => isDynamicParamType ty
   | _ => false
 
 def firstUnsupportedInternalDynamicParam
@@ -106,6 +109,13 @@ def firstUnsupportedInternalDynamicParam
 
 def internalCallYulArgCountForParam : ParamType → Nat
   | ParamType.array _ => 2
+  | ParamType.bytes | ParamType.string => 2
+  | ty@(ParamType.fixedArray _ _) =>
+      if isDynamicParamType ty then 1 else (staticParamBindingNames "__arg" ty).length
+  | ty@(ParamType.tuple _) =>
+      if isDynamicParamType ty then 1 else (staticParamBindingNames "__arg" ty).length
+  | ParamType.newtypeOf _ baseTy =>
+      internalCallYulArgCountForParam baseTy
   | _ => 1
 
 def internalCallYulArgCount (params : List Param) : Nat :=

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -3168,11 +3168,11 @@ verity_contract MultiNamespaceStorageSmoke where
 #check_contract MultiNamespaceStorageSmoke
 
 example : MultiNamespaceStorageSmoke.stateMerkleRoot.slot =
-    0xd7df6c02d48ad87762ead6689b0b308617a10b99ac21276cc6fd199681dcb000 := by native_decide
+    0xd7df6c02d48ad87762ead6689b0b308617a10b99ac21276cc6fd199681dcb000 := by decide
 example : MultiNamespaceStorageSmoke.stateVerifierRouter.slot =
-    0xd7df6c02d48ad87762ead6689b0b308617a10b99ac21276cc6fd199681dcb004 := by native_decide
+    0xd7df6c02d48ad87762ead6689b0b308617a10b99ac21276cc6fd199681dcb004 := by decide
 example : MultiNamespaceStorageSmoke.relayersSlot.slot =
-    0xd8b607728433c567965c4023813a35a19b26751353d5652c8798f8eea4b19b00 := by native_decide
+    0xd8b607728433c567965c4023813a35a19b26751353d5652c8798f8eea4b19b00 := by decide
 example : MultiNamespaceStorageSmoke.stateMerkleRoot.slot ≠ MultiNamespaceStorageSmoke.relayersSlot.slot := by decide
 example : MultiNamespaceStorageSmoke.spec.storageNamespace.isSome = true := rfl
 

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -1442,11 +1442,7 @@ example :
           (Compiler.CompilationModel.Expr.localVar "total")
       ] := rfl
 
-/--
-error: helper call 'consumePayload' uses a parameter or return type that direct macro helper lowering does not support yet; only static non-fallback/non-receive helpers can be lowered to internal specs
--/
-#guard_msgs in
-verity_contract DirectHelperCallDynamicEffectRejected where
+verity_contract DirectHelperCallBytesEffectSmoke where
   storage
 
   function consumePayload (_payload : Bytes) : Unit := do
@@ -1455,25 +1451,17 @@ verity_contract DirectHelperCallDynamicEffectRejected where
   function run (payload : Bytes) : Unit := do
     consumePayload payload
 
-/--
-error: helper call 'measurePayload' uses a parameter or return type that direct macro helper lowering does not support yet; only static non-fallback/non-receive helpers can be lowered to internal specs
--/
-#guard_msgs in
-verity_contract DirectHelperCallDynamicBindRejected where
+verity_contract DirectHelperCallBytesBindSmoke where
   storage
 
-  function measurePayload (_payload : Bytes) : Uint256 := do
-    return 0
+  function samePayload (lhs : Bytes, rhs : Bytes) : Bool := do
+    return (lhs == rhs)
 
-  function run (payload : Bytes) : Uint256 := do
-    let measured ← measurePayload payload
-    return measured
+  function run (payload : Bytes) : Bool := do
+    let same ← samePayload payload payload
+    return same
 
-/--
-error: helper call 'fanoutPayload' uses a parameter or return type that direct macro helper lowering does not support yet; only static non-fallback/non-receive helpers can be lowered to internal specs
--/
-#guard_msgs in
-verity_contract DirectHelperCallDynamicTupleRejected where
+verity_contract DirectHelperCallBytesTupleSmoke where
   storage
 
   function fanoutPayload (_payload : Bytes) : Tuple [Uint256, Uint256] := do
@@ -1482,6 +1470,47 @@ verity_contract DirectHelperCallDynamicTupleRejected where
   function run (payload : Bytes) : Tuple [Uint256, Uint256] := do
     let (left, right) ← fanoutPayload payload
     return (left, right)
+
+verity_contract DirectHelperCallStaticCompositeSmoke where
+  storage
+    sentinel : Uint256 := slot 0
+
+  struct TokenPermissions where
+    token : Address,
+    amount : Uint256
+
+  struct PermitTransferFrom where
+    permitted : TokenPermissions,
+    nonce : Uint256,
+    deadline : Uint256
+
+  function transferWithBalanceCheck
+      (permit : PermitTransferFrom, depositor : Address, signature : Bytes,
+       amount : Uint256, noteCommitment : Bytes32) : Uint256 := do
+    let _depositorWord := addressToWord depositor
+    let _noteCommitment := noteCommitment
+    let sigSame := signature == signature
+    if sigSame then
+      return (add permit.permitted.amount amount)
+    else
+      return permit.nonce
+
+  function allow_post_interaction_writes run
+      (permit : PermitTransferFrom, depositor : Address, signature : Bytes,
+       amount : Uint256, noteCommitment : Bytes32) : Uint256 := do
+    let checked ← transferWithBalanceCheck permit depositor signature amount noteCommitment
+    setStorage sentinel checked
+    return checked
+
+verity_contract DirectHelperCallUint256Bytes32AliasSmoke where
+  storage
+    sentinel : Uint256 := slot 0
+
+  function rememberDigest (digest : Bytes32) : Unit := do
+    setStorage sentinel digest
+
+  function run (word : Uint256) : Unit := do
+    rememberDigest word
 
 verity_contract Uint8Smoke where
   storage
@@ -1594,6 +1623,34 @@ verity_contract StructMappingSmoke where
   function approvalNonce (owner : Address, spender : Address) : Uint256 := do
     let nextNonce ← structMember2 "approvals" owner spender "nonce"
     return nextNonce
+
+verity_contract UintKeyStructMappingSmoke where
+  storage
+    circuits : MappingStruct(Uint256,[
+      verifier @word 0 packed(0,160),
+      inputCount @word 0 packed(160,16),
+      outputCount @word 0 packed(176,16),
+      active @word 0 packed(192,8)
+    ]) := slot 0
+
+  constants
+    TRUE_WORD : Uint256 := 1
+
+  function setCircuit
+      (circuitId : Uint256, verifierAddr : Address, inputCount : Uint256,
+       outputCount : Uint256) : Unit := do
+    setStructMember "circuits" circuitId "verifier" verifierAddr
+    setStructMember "circuits" circuitId "inputCount" inputCount
+    setStructMember "circuits" circuitId "outputCount" outputCount
+    setStructMember "circuits" circuitId "active" TRUE_WORD
+
+  function getCircuit
+      (circuitId : Uint256) : Tuple [Address, Uint256, Uint256, Uint256] := do
+    let verifierAddr ← structMember "circuits" circuitId "verifier"
+    let inputCount ← structMember "circuits" circuitId "inputCount"
+    let outputCount ← structMember "circuits" circuitId "outputCount"
+    let active ← structMember "circuits" circuitId "active"
+    return (verifierAddr, inputCount, outputCount, active)
 
 private def _structMemberExecutableHelper :
     String → Address → String → Contract Uint256 :=
@@ -2310,6 +2367,11 @@ end SpecGenSmoke
 #check_contract DirectHelperCallSmoke
 #check_contract MultiReturnHelperSmoke
 #check_contract ArrayHelperCallSmoke
+#check_contract DirectHelperCallBytesEffectSmoke
+#check_contract DirectHelperCallBytesBindSmoke
+#check_contract DirectHelperCallBytesTupleSmoke
+#check_contract DirectHelperCallStaticCompositeSmoke
+#check_contract DirectHelperCallUint256Bytes32AliasSmoke
 #check_contract ForEachMutableLocalSmoke
 #check_contract Uint8Smoke
 #check_contract AddressHelpersSmoke
@@ -2319,6 +2381,7 @@ end SpecGenSmoke
 #check_contract HelperExternalArgumentSmoke
 #check_contract BlockTimestampSmoke
 #check_contract StructMappingSmoke
+#check_contract UintKeyStructMappingSmoke
 #check_contract ExternalCallSmoke
 #check_contract TryExternalCallSmoke
 #check_contract LinkedExternalDynamicArgSmoke
@@ -3079,6 +3142,39 @@ example : CustomNamespacedSmoke.spec.storageNamespace.isSome = true := rfl
 example : CustomNamespacedSmoke.storageNamespace = CustomNamespacedSmoke.spec.storageNamespace.get! := rfl
 example : CustomNamespacedSmoke.storageNamespace = 105542539407630759878214364786123406227647255732885741380220581264062975076298 := rfl
 example : CustomNamespacedSmoke.storageNamespace ≠ 67387409610395734986217237394999073412260967828994783805404864304835768435504 := by decide
+
+-- Multiple namespace roots in one contract. Each `storage_namespace` item
+-- inside the storage block applies to subsequent fields until the next item.
+verity_contract MultiNamespaceStorageSmoke where
+  storage
+    storage_namespace erc7201 "unlink.storage.State"
+    stateMerkleRoot : Uint256 := slot 0
+    stateVerifierRouter : Address := slot 4
+    storage_namespace erc7201 "unlink.storage.UnlinkPoolRelayers"
+    relayersSlot : Address → Uint256 := slot 0
+
+  function writeState (root : Uint256, router : Address) : Unit := do
+    setStorage stateMerkleRoot root
+    setStorageAddr stateVerifierRouter router
+
+  function readStateRoot () : Uint256 := do
+    let value ← getStorage stateMerkleRoot
+    return value
+
+  function readRelayer (account : Address) : Uint256 := do
+    let enabled ← getMapping relayersSlot account
+    return enabled
+
+#check_contract MultiNamespaceStorageSmoke
+
+example : MultiNamespaceStorageSmoke.stateMerkleRoot.slot =
+    0xd7df6c02d48ad87762ead6689b0b308617a10b99ac21276cc6fd199681dcb000 := by native_decide
+example : MultiNamespaceStorageSmoke.stateVerifierRouter.slot =
+    0xd7df6c02d48ad87762ead6689b0b308617a10b99ac21276cc6fd199681dcb004 := by native_decide
+example : MultiNamespaceStorageSmoke.relayersSlot.slot =
+    0xd8b607728433c567965c4023813a35a19b26751353d5652c8798f8eea4b19b00 := by native_decide
+example : MultiNamespaceStorageSmoke.stateMerkleRoot.slot ≠ MultiNamespaceStorageSmoke.relayersSlot.slot := by decide
+example : MultiNamespaceStorageSmoke.spec.storageNamespace.isSome = true := rfl
 
 -- ADT (inductive) section smoke test (#1727, Axis 1 Steps 5a/5b)
 -- Declares algebraic data types with typed variant fields.

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -5,6 +5,7 @@ namespace Verity.Macro
 open Lean
 
 declare_syntax_cat verityStorageField
+declare_syntax_cat verityStorageItem
 declare_syntax_cat verityStructMember
 declare_syntax_cat verityParam
 declare_syntax_cat verityError
@@ -31,6 +32,10 @@ declare_syntax_cat verityModifierUse
 declare_syntax_cat verityFunction
 
 syntax ident " : " term " := " "slot" num : verityStorageField
+syntax ident " : " term " := " "slot" num : verityStorageItem
+syntax "storage_namespace " : verityStorageItem
+syntax "storage_namespace " str : verityStorageItem
+syntax "storage_namespace " "erc7201 " str : verityStorageItem
 syntax ident " @word " num : verityStructMember
 syntax ident " @word " num " packed(" num "," num ")" : verityStructMember
 syntax "MappingStruct(" term "," "[" sepBy(verityStructMember, ",") "]" ")" : term
@@ -60,6 +65,7 @@ syntax "| " ident : verityAdtVariant
 syntax ident " := " verityAdtVariant+ : verityAdtDecl
 syntax "storage_namespace " : verityNamespaceSpec
 syntax "storage_namespace " str : verityNamespaceSpec
+syntax "storage_namespace " "erc7201 " str : verityNamespaceSpec
 syntax "initializer(" ident ")" : verityInitGuard
 syntax "reinitializer(" ident ", " num ")" : verityInitGuard
 syntax "ecmCall " term:max ppSpace term:max : term
@@ -89,7 +95,7 @@ syntax (name := verityContractCmd)
   ("types " verityNewtype+)?
   ("inductive " verityAdtDecl+)?
   (verityNamespaceSpec)?
-  "storage " verityStorageField*
+  "storage " verityStorageItem*
   (verityStructDecl)*
   ("errors " verityError+)?
   ("event_defs " verityEvent+)?

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1761,7 +1761,10 @@ private def numericLiteralCompatibleValueType : ValueType → Bool
   | _ => false
 
 private def argumentTypeMatchesParam (arg : Term) (argTy paramTy : ValueType) : Bool :=
-  argTy == paramTy || (argTy == .uint256 && isNatLiteralTerm arg && numericLiteralCompatibleValueType paramTy)
+  argTy == paramTy ||
+    (argTy == .uint256 && paramTy == .bytes32) ||
+    (argTy == .bytes32 && paramTy == .uint256) ||
+    (argTy == .uint256 && isNatLiteralTerm arg && numericLiteralCompatibleValueType paramTy)
 
 private def argumentTypesMatchParams (args : Array Term) (argTypes : Array ValueType)
     (params : Array ParamDecl) : Bool :=
@@ -2499,6 +2502,7 @@ private partial def hasDynamicInternalHelperType (ty : ValueType) : Bool :=
 
 private def supportsInternalHelperParamType (ty : ValueType) : Bool :=
   match ty with
+  | .string | .bytes => true
   | .array _ => true
   | .struct _ _ => true
   | .tuple _ => true
@@ -4582,6 +4586,34 @@ private def tupleReturnValueExprs?
       | _ =>
           pure none
 
+private partial def staticInternalHelperBindingNames (name : String) (ty : ValueType) : List String :=
+  match ty with
+  | .uint256 | .int256 | .uint8 | .address | .bool | .bytes32 => [name]
+  | .fixedArray elemTy size =>
+      (List.range size).flatMap fun idx =>
+        staticInternalHelperBindingNames s!"{name}_{idx}" elemTy
+  | .tuple elemTys =>
+      let rec goTuple (tys : List ValueType) (idx : Nat) : List String :=
+        match tys with
+        | [] => []
+        | elemTy :: rest =>
+            staticInternalHelperBindingNames s!"{name}_{idx}" elemTy ++ goTuple rest (idx + 1)
+      goTuple elemTys 0
+  | .struct _ fields =>
+      let rec goStruct (fs : List (String × ValueType)) (idx : Nat) : List String :=
+        match fs with
+        | [] => []
+        | field :: rest =>
+            staticInternalHelperBindingNames s!"{name}_{idx}" field.snd ++ goStruct rest (idx + 1)
+      goStruct fields 0
+  | .newtype _ baseTy => staticInternalHelperBindingNames name baseTy
+  | _ => []
+
+private def isStaticCompositeInternalHelperType : ValueType → Bool
+  | .tuple _ | .struct _ _ | .fixedArray _ _ => true
+  | .newtype _ baseTy => isStaticCompositeInternalHelperType baseTy
+  | _ => false
+
 private def translateInternalHelperCallArgs
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
@@ -4654,7 +4686,12 @@ private def translateInternalHelperCallArgs
           match directParamNameWithType? params arg with
           | some (name, ty) =>
               if valueTypeUsesDynamicData ty then
-                out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
+                match fnParam.ty with
+                | .bytes | .string =>
+                    out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
+                    out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
+                | _ =>
+                    out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
               else
                 out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
           | none =>
@@ -4666,7 +4703,19 @@ private def translateInternalHelperCallArgs
               else
                 out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
         else
-          out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+          if isStaticCompositeInternalHelperType fnParam.ty then
+            match directParamNameWithType? params arg with
+            | some (name, ty) =>
+                let bindingNames := staticInternalHelperBindingNames name ty
+                if bindingNames.isEmpty then
+                  out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                else
+                  for bindingName in bindingNames do
+                    out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm bindingName)))
+            | none =>
+                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+          else
+            out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
   pure out
 
 private def translateLinkedExternalCallArgs
@@ -7268,6 +7317,57 @@ def computeStorageNamespace (contractName : String) : Nat :=
 def computeStorageNamespaceKey (key : String) : Nat :=
   KeccakEngine.keccak256_str_nat key
 
+private def natToBytes32BE (n : Nat) : ByteArray :=
+  let bytes := (List.range 32).map fun idx =>
+    UInt8.ofNat ((n / (256 ^ (31 - idx))) % 256)
+  ⟨bytes.toArray⟩
+
+/-- Compute an ERC-7201 namespace root:
+    `keccak256(abi.encode(uint256(keccak256(key)) - 1)) & ~bytes32(uint256(0xff))`. -/
+def computeERC7201StorageNamespaceKey (key : String) : Nat :=
+  let keyHash := KeccakEngine.keccak256_str_nat key
+  let encoded := natToBytes32BE (keyHash - 1)
+  let slotHash := KeccakEngine.byteArrayToNatBE (KeccakEngine.keccak256 encoded)
+  (slotHash / 256) * 256
+
+private def namespaceOffsetFromSpec
+    (contractName : Ident) (spec : TSyntax `verityNamespaceSpec) : CommandElabM Nat := do
+  match spec with
+  | `(verityNamespaceSpec| storage_namespace erc7201 $customKey:str) =>
+      match customKey.raw.isStrLit? with
+      | some key => pure (computeERC7201StorageNamespaceKey key)
+      | none => throwErrorAt customKey "expected storage namespace string literal"
+  | `(verityNamespaceSpec| storage_namespace $customKey:str) =>
+      match customKey.raw.isStrLit? with
+      | some key => pure (computeStorageNamespaceKey key)
+      | none => throwErrorAt customKey "expected storage namespace string literal"
+  | `(verityNamespaceSpec| storage_namespace) =>
+      pure (computeStorageNamespace (toString contractName.getId))
+  | _ =>
+      throwErrorAt spec "unsupported storage namespace syntax"
+
+private def namespaceOffsetFromStorageItem?
+    (contractName : Ident) (item : TSyntax `verityStorageItem) : CommandElabM (Option Nat) := do
+  match item with
+  | `(verityStorageItem| storage_namespace erc7201 $customKey:str) =>
+      match customKey.raw.isStrLit? with
+      | some key => pure (some (computeERC7201StorageNamespaceKey key))
+      | none => throwErrorAt customKey "expected storage namespace string literal"
+  | `(verityStorageItem| storage_namespace $customKey:str) =>
+      match customKey.raw.isStrLit? with
+      | some key => pure (some (computeStorageNamespaceKey key))
+      | none => throwErrorAt customKey "expected storage namespace string literal"
+  | `(verityStorageItem| storage_namespace) =>
+      pure (some (computeStorageNamespace (toString contractName.getId)))
+  | _ => pure none
+
+private def storageFieldFromItem?
+    (item : TSyntax `verityStorageItem) : CommandElabM (Option (TSyntax `verityStorageField)) := do
+  match item with
+  | `(verityStorageItem| $name:ident : $ty:term := slot $slotNum:num) =>
+      pure (some (← `(verityStorageField| $name:ident : $ty:term := slot $slotNum:num)))
+  | _ => pure none
+
 structure ParsedContractSyntax where
   contractName : Ident
   newtypeDecls : Array NewtypeDecl
@@ -7288,7 +7388,7 @@ def parseContractSyntax
     (stx : Syntax)
     : CommandElabM ParsedContractSyntax := do
   match stx with
-  | `(command| verity_contract $contractName:ident where $[types $[$newtypeDecls:verityNewtype]*]? $[inductive $[$adtDecls:verityAdtDecl]*]? $[$nsSpec:verityNamespaceSpec]? storage $[$storageFields:verityStorageField]* $[$structDecls:verityStructDecl]* $[errors $[$errorDecls:verityError]*]? $[event_defs $[$eventDecls:verityEvent]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$entrypoints:veritySpecialEntrypoint]* $[$modifierDecls:verityModifier]* $[$functions:verityFunction]*) =>
+  | `(command| verity_contract $contractName:ident where $[types $[$newtypeDecls:verityNewtype]*]? $[inductive $[$adtDecls:verityAdtDecl]*]? $[$nsSpec:verityNamespaceSpec]? storage $[$storageItems:verityStorageItem]* $[$structDecls:verityStructDecl]* $[errors $[$errorDecls:verityError]*]? $[event_defs $[$eventDecls:verityEvent]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$entrypoints:veritySpecialEntrypoint]* $[$modifierDecls:verityModifier]* $[$functions:verityFunction]*) =>
       -- Parse newtypes first — they are needed by all downstream type resolution
       let parsedNewtypes ←
         match newtypeDecls with
@@ -7328,25 +7428,12 @@ def parseContractSyntax
       for adtDecl in parsedAdts do
         if builtinTypeNames.contains adtDecl.name then
           throwErrorAt adtDecl.ident s!"ADT name '{adtDecl.name}' shadows a built-in type"
-      -- Compute namespace offset (#1730, Axis 4 Steps 4b/4c): when `storage_namespace`
-      -- is present, every user-declared slot N becomes (namespaceBase + N).
-      -- With `storage_namespace "custom"`, the custom string replaces the default
-      -- "{ContractName}.storage.v0" key.
+      -- Compute the initial namespace offset (#1730, Axis 4 Steps 4b/4c).
+      -- A legacy `storage_namespace` before `storage` applies to all following
+      -- fields until overridden by an in-storage `storage_namespace` item.
       let namespaceOffset : Nat ←
         match nsSpec with
-        | some spec =>
-            -- `storage_namespace` alone → default; `storage_namespace "key"` → custom.
-            -- Match the syntax category directly so the custom string is not lost
-            -- behind parser wrapper nodes.
-            match spec with
-            | `(verityNamespaceSpec| storage_namespace $customKey:str) =>
-                match customKey.raw.isStrLit? with
-                | some key => pure (computeStorageNamespaceKey key)
-                | none => throwErrorAt customKey "expected storage namespace string literal"
-            | `(verityNamespaceSpec| storage_namespace) =>
-                pure (computeStorageNamespace (toString contractName.getId))
-            | _ =>
-                throwErrorAt spec "unsupported storage namespace syntax"
+        | some spec => namespaceOffsetFromSpec contractName spec
         | none => pure 0
       let parsedErrors ←
         match errorDecls with
@@ -7368,13 +7455,26 @@ def parseContractSyntax
         match externalDecls with
         | some decls => decls.mapM (parseExternal parsedNewtypes parsedStructs parsedAdts)
         | none => pure #[]
-      -- Apply namespace offset to parsed storage fields (#1730, Axis 4 Step 4b)
-      let parsedFields ← storageFields.mapM (parseStorageField parsedNewtypes parsedStructs parsedAdts)
-      let parsedFields := parsedFields.map fun field =>
-        { field with slotNum := field.slotNum + namespaceOffset }
-      -- Compute the Option Nat for the spec's storageNamespace field (#1730, Axis 4 Step 4d)
-      let namespaceOpt : Option Nat :=
+      -- Apply namespace offsets to parsed storage fields (#1730).  In-storage
+      -- `storage_namespace` items switch the active namespace for subsequent
+      -- fields, allowing multiple ERC-7201 roots in one contract model.
+      let mut parsedFields : Array StorageFieldDecl := #[]
+      let mut currentNamespaceOffset := namespaceOffset
+      let mut namespaceOpt : Option Nat :=
         if nsSpec.isSome then some namespaceOffset else none
+      for item in storageItems do
+        match (← namespaceOffsetFromStorageItem? contractName item) with
+        | some offset =>
+            currentNamespaceOffset := offset
+            if namespaceOpt.isNone then
+              namespaceOpt := some offset
+        | none =>
+            match (← storageFieldFromItem? item) with
+            | some fieldStx =>
+                let field ← parseStorageField parsedNewtypes parsedStructs parsedAdts fieldStx
+                parsedFields := parsedFields.push { field with slotNum := field.slotNum + currentNamespaceOffset }
+            | none =>
+                throwErrorAt item "unsupported storage item"
       pure {
         contractName := contractName
         newtypeDecls := parsedNewtypes

--- a/artifacts/macro_property_tests/PropertyDirectHelperCallBytesBindSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyDirectHelperCallBytesBindSmoke.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyDirectHelperCallBytesBindSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyDirectHelperCallBytesBindSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("DirectHelperCallBytesBindSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: samePayload matches the expected dynamic-parameter comparison result
+    function testAuto_SamePayload_ComparesDirectDynamicParamsEq() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("samePayload(bytes,bytes)", hex"CAFE", hex"CAFE"));
+        require(ok, "samePayload reverted unexpectedly");
+        assertEq(ret.length, 32, "samePayload ABI return length mismatch (expected 32 bytes)");
+        bool actual = abi.decode(ret, (bool));
+        bool expected = true;
+        assertEq(actual, expected, "samePayload should preserve the configured comparison result");
+        assertTrue(actual, "samePayload should return true for the configured bytes comparison");
+    }
+    // Property 2: run decodes and matches the inferred straight-line result
+    function testAuto_Run_ReturnsInferredStraightLineResult() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("run(bytes)", hex"CAFE"));
+        require(ok, "run reverted unexpectedly");
+        assertEq(ret.length, 32, "run ABI return length mismatch (expected 32 bytes)");
+        bool actual = abi.decode(ret, (bool));
+        assertEq(actual, (hex"CAFE" == hex"CAFE"), "run should preserve the inferred result");
+    }
+}

--- a/artifacts/macro_property_tests/PropertyDirectHelperCallBytesEffectSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyDirectHelperCallBytesEffectSmoke.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyDirectHelperCallBytesEffectSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyDirectHelperCallBytesEffectSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("DirectHelperCallBytesEffectSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: consumePayload has no unexpected revert
+    function testAuto_ConsumePayload_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("consumePayload(bytes)", hex"CAFE"));
+        require(ok, "consumePayload reverted unexpectedly");
+    }
+    // Property 2: run has no unexpected revert
+    function testAuto_Run_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("run(bytes)", hex"CAFE"));
+        require(ok, "run reverted unexpectedly");
+    }
+}

--- a/artifacts/macro_property_tests/PropertyDirectHelperCallBytesTupleSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyDirectHelperCallBytesTupleSmoke.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyDirectHelperCallBytesTupleSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyDirectHelperCallBytesTupleSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("DirectHelperCallBytesTupleSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: fanoutPayload decodes and matches the inferred tuple result
+    function testAuto_FanoutPayload_ReturnsInferredTupleResult() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("fanoutPayload(bytes)", hex"CAFE"));
+        require(ok, "fanoutPayload reverted unexpectedly");
+        require(ret.length >= 64, "fanoutPayload ABI tuple return payload unexpectedly short");
+        (uint256 actual0, uint256 actual1) = abi.decode(ret, (uint256, uint256));
+        assertEq(actual0, 0, "fanoutPayload tuple element 0 should preserve the inferred result");
+        assertEq(actual1, 1, "fanoutPayload tuple element 1 should preserve the inferred result");
+    }
+    // Property 2: run decodes and matches the inferred tuple result
+    function testAuto_Run_ReturnsInferredTupleResult() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("run(bytes)", hex"CAFE"));
+        require(ok, "run reverted unexpectedly");
+        require(ret.length >= 64, "run ABI tuple return payload unexpectedly short");
+        (uint256 actual0, uint256 actual1) = abi.decode(ret, (uint256, uint256));
+        assertEq(actual0, 0, "run tuple element 0 should preserve the inferred result");
+        assertEq(actual1, 1, "run tuple element 1 should preserve the inferred result");
+    }
+}

--- a/artifacts/macro_property_tests/PropertyDirectHelperCallStaticCompositeSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyDirectHelperCallStaticCompositeSmoke.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyDirectHelperCallStaticCompositeSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyDirectHelperCallStaticCompositeSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("DirectHelperCallStaticCompositeSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+}

--- a/artifacts/macro_property_tests/PropertyDirectHelperCallUint256Bytes32AliasSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyDirectHelperCallUint256Bytes32AliasSmoke.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyDirectHelperCallUint256Bytes32AliasSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyDirectHelperCallUint256Bytes32AliasSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("DirectHelperCallUint256Bytes32AliasSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: rememberDigest has no unexpected revert
+    function testAuto_RememberDigest_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("rememberDigest(bytes32)", bytes32(uint256(0xBEEF))));
+        require(ok, "rememberDigest reverted unexpectedly");
+    }
+    // Property 2: run has no unexpected revert
+    function testAuto_Run_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("run(uint256)", uint256(1)));
+        require(ok, "run reverted unexpectedly");
+    }
+}

--- a/artifacts/macro_property_tests/PropertyMultiNamespaceStorageSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyMultiNamespaceStorageSmoke.t.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyMultiNamespaceStorageSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyMultiNamespaceStorageSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("MultiNamespaceStorageSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: writeState has no unexpected revert
+    function testAuto_WriteState_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("writeState(uint256,address)", uint256(1), alice));
+        require(ok, "writeState reverted unexpectedly");
+    }
+    // Property 2: readStateRoot reads storage slot 0 and decodes the result
+    function testAuto_ReadStateRoot_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("readStateRoot()"));
+        require(ok, "readStateRoot reverted unexpectedly");
+        assertEq(ret.length, 32, "readStateRoot ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "readStateRoot should return storage slot 0");
+    }
+    // Property 3: readRelayer reads the configured mapping value
+    function testAuto_ReadRelayer_ReadsConfiguredMapping() public {
+        uint256 expected = uint256(1);
+        vm.store(target, _mappingSlot(bytes32(uint256(uint160(alice))), 0), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("readRelayer(address)", alice));
+        require(ok, "readRelayer reverted unexpectedly");
+        assertEq(ret.length, 32, "readRelayer ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "readRelayer should decode the configured mapping value");
+    }
+}

--- a/artifacts/macro_property_tests/PropertyUintKeyStructMappingSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyUintKeyStructMappingSmoke.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyUintKeyStructMappingSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyUintKeyStructMappingSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("UintKeyStructMappingSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+}


### PR DESCRIPTION
## Summary

- lower internal helper params for `bytes` / `string` and static composite helper params
- support direct forwarding of `bytes` / `string` and flattened static composite params through macro helper calls
- add `storage_namespace erc7201 "..."` and namespace switches inside one storage block
- add Unlink-shaped smoke coverage for helper calls, multiple ERC-7201 roots, and VerifierRouter-style `MappingStruct(Uint256, ...)`

## Validation

- `lake build Contracts.Smoke`

## Notes

This intentionally leaves top-level/nested storage structs as a separate follow-up (#1758). The Unlink benchmark can now use exact ERC-7201 roots, but `StateStorage.data` / `LazyIMTData` still need first-class nested struct support to remove the remaining structural flattening.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Medium-to-high risk because it changes internal helper ABI lowering (dynamic `bytes`/`string`, tuple/fixed-array flattening) and storage slot namespace computation (including ERC-7201 and mid-storage switches), which can silently alter calldata layouts and storage addressing.
> 
> **Overview**
> **Internal helper ABI lowering is expanded.** Internal function params now lower `bytes`/`string` as `(data_offset, length)`, and static composite params (`tuple`, `fixedArray`, `struct`/`newtype` composites) can be passed by flattening into multiple Yul args; validation arg-count logic is updated accordingly and custom-error encoding is adjusted to use the new dynamic param bindings.
> 
> **Storage namespace support is extended.** The macro now accepts `storage_namespace erc7201 "…"`, computes ERC-7201 roots, and allows `storage_namespace` items *inside* a `storage` block to switch the active namespace for subsequent fields (enabling multiple roots per contract).
> 
> **Coverage/tests are updated.** Smoke contracts are revised/added to exercise bytes helper calls, static composite helper forwarding, uint256↔bytes32 argument aliasing, uint-keyed `MappingStruct`, and multi-namespace storage; matching auto-generated Solidity property-test stubs are added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d0e4cae02d3f72915fe159eb068cf0fcdb753d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->