### PR TITLE
Support nested storage struct accessors

### DIFF
--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -1053,20 +1053,35 @@ verity_contract NamedStructParamSmoke where
   function readNestedMaker (config : OrderConfig) : Address := do
     return config.maker
 
-/--
-error: top-level named struct storage fields are not supported yet (#1758); flatten the struct into explicit scalar storage fields with fixed slots, or use MappingStruct/MappingStruct2 for struct-valued mappings
--/
-#guard_msgs in
-verity_contract NamedStructStorageRejected where
+verity_contract NestedStructStorageSmoke where
   storage
-    feeConfig : FeeConfig := slot 0
+    state : StorageStruct [
+      merkleRoot : Uint256 @word 0,
+      merkleTree : StorageStruct [
+        maxIndex : Uint256 @word 0 packed(0,40),
+        numberOfLeaves : Uint256 @word 0 packed(40,40),
+        elements : Uint256 → Uint256 @word 1
+      ] @word 1,
+      verifierRouter : Address @word 4
+    ] := slot 0
 
-  struct FeeConfig where
-    borrowTakerFeeRatio : Uint256,
-    lendMakerFeeRatio : Uint256
+  function readLeaves () : Uint256 := do
+    let n ← getStorage state.merkleTree.numberOfLeaves
+    return n
 
-  function readBorrowFee () : Uint256 := do
-    return 0
+  function writeLeaves (n : Uint256) : Unit := do
+    setStorage state.merkleTree.numberOfLeaves n
+
+  function writeElement (key : Uint256, value : Uint256) : Unit := do
+    setMappingWord state.merkleTree.elements key 0 value
+
+  function readRouter () : Address := do
+    let router ← getStorageAddr state.verifierRouter
+    return router
+
+example : NestedStructStorageSmoke.state.merkleTree.numberOfLeaves.slot = 1 := by decide
+example : NestedStructStorageSmoke.state.merkleTree.elements.slot = 2 := by decide
+example : NestedStructStorageSmoke.state.verifierRouter.slot = 4 := by decide
 
 /--
 error: unknown variable 'feeConfig.borrowTakerFeeRatio'
@@ -2360,6 +2375,7 @@ end SpecGenSmoke
 #check_contract SpecialEntrypointSmoke
 #check_contract TupleSmoke
 #check_contract NamedStructParamSmoke
+#check_contract NestedStructStorageSmoke
 #check_contract NamedStructDynamicRootLeafProjection
 #check_contract CurveCutArraySmoke
 #check_contract DynamicStructArraySmoke

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -18,6 +18,7 @@ def elabVerityContract : CommandElab := fun stx => do
   let structDecls := parsed.structDecls
   let adtDecls := parsed.adtDecls
   let fields := parsed.fields
+  let storageStructAccessors := parsed.storageStructAccessors
   let errorDecls := parsed.errorDecls
   let eventDecls := parsed.eventDecls
   let constDecls := parsed.constDecls
@@ -44,7 +45,12 @@ def elabVerityContract : CommandElab := fun stx => do
       elabCommand (← mkStructEventArgInstanceCommandPublic structDecl)
 
     for field in fields do
-      elabCommand (← mkStorageDefCommandPublic field)
+      if field.emitDef then
+        elabCommand (← mkStorageDefCommandPublic field)
+
+    for accessor in storageStructAccessors do
+      for cmd in (← mkStorageStructAccessorCommandsPublic accessor) do
+        elabCommand cmd
 
     for imm in immutableDecls.zipIdx do
       elabCommand (← mkStorageDefCommandPublic (immutableStorageFieldDecl fields imm.1 imm.2))

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -6,6 +6,7 @@ open Lean
 
 declare_syntax_cat verityStorageField
 declare_syntax_cat verityStorageItem
+declare_syntax_cat verityStorageStructMember
 declare_syntax_cat verityStructMember
 declare_syntax_cat verityParam
 declare_syntax_cat verityError
@@ -33,6 +34,10 @@ declare_syntax_cat verityFunction
 
 syntax ident " : " term " := " "slot" num : verityStorageField
 syntax ident " : " term " := " "slot" num : verityStorageItem
+syntax ident " : " term " @word " num : verityStorageStructMember
+syntax ident " : " term " @word " num " packed(" num "," num ")" : verityStorageStructMember
+syntax ident " : " "StorageStruct" "[" sepBy(verityStorageStructMember, ",") "]" " @word " num : verityStorageStructMember
+syntax ident " : " "StorageStruct" "[" sepBy(verityStorageStructMember, ",") "]" " := " "slot" num : verityStorageItem
 syntax "storage_namespace " : verityStorageItem
 syntax "storage_namespace " str : verityStorageItem
 syntax "storage_namespace " "erc7201 " str : verityStorageItem

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -64,6 +64,18 @@ structure StorageFieldDecl where
   ty : StorageType
   slotNum : Nat
   adtInfo? : Option (String × Nat) := none
+  packedBits : Option (Nat × Nat) := none
+  emitDef : Bool := true
+  aliases : List String := []
+
+inductive StorageAccessorTree where
+  | leaf (name : String) (ty : StorageType) (slotNum : Nat)
+  | node (name : String) (children : Array StorageAccessorTree)
+
+structure StorageStructAccessorDecl where
+  ident : Ident
+  name : String
+  tree : StorageAccessorTree
 
 structure ParamDecl where
   ident : Ident
@@ -723,6 +735,89 @@ private def parseStorageField (newtypes : Array NewtypeDecl) (structDecls : Arra
       }
   | _ => throwErrorAt stx "invalid storage field declaration"
 
+private def pathFieldName (parts : List String) : String :=
+  String.intercalate "." parts
+
+private def pathFieldModelName (parts : List String) : String :=
+  String.intercalate "_" parts
+
+private def pathFieldIdent (root : Ident) (parts : List String) : Ident :=
+  mkIdentFrom root (Name.mkSimple (pathFieldModelName parts))
+
+private partial def parseStorageStructMember
+    (newtypes : Array NewtypeDecl)
+    (structDecls : Array StructDecl := #[])
+    (adtDecls : Array AdtDecl := #[])
+    (rootIdent : Ident)
+    (pathPrefix : List String)
+    (baseSlot : Nat)
+    (stx : TSyntax `verityStorageStructMember) :
+    CommandElabM (Array StorageFieldDecl × StorageAccessorTree) := do
+  let leafDecl (name : Ident) (ty : Term) (wordOffset : TSyntax `num)
+      (packed : Option (TSyntax `num × TSyntax `num)) := do
+    let localName := toString name.getId
+    let parts := pathPrefix ++ [localName]
+    let parsedTy ← storageTypeFromSyntax newtypes structDecls adtDecls ty
+    let packedBits ←
+      match packed with
+      | none => pure none
+      | some (offset, width) => pure (some (← natFromSyntax offset, ← natFromSyntax width))
+    let slotNum := baseSlot + (← natFromSyntax wordOffset)
+    let field : StorageFieldDecl := {
+      ident := pathFieldIdent rootIdent parts
+      name := pathFieldModelName parts
+      ty := parsedTy
+      slotNum := slotNum
+      adtInfo? :=
+        match parsedTy with
+        | .scalar (.adt adtName maxFields) => some (adtName, maxFields)
+        | _ => none
+      packedBits := packedBits
+      emitDef := false
+      aliases := [pathFieldName parts]
+    }
+    pure (#[field], StorageAccessorTree.leaf localName parsedTy slotNum)
+  match stx with
+  | `(verityStorageStructMember| $name:ident : $ty:term @word $wordOffset:num) =>
+      leafDecl name ty wordOffset none
+  | `(verityStorageStructMember| $name:ident : $ty:term @word $wordOffset:num packed($offset:num,$width:num)) =>
+      leafDecl name ty wordOffset (some (offset, width))
+  | `(verityStorageStructMember| $name:ident : StorageStruct [ $[$members:verityStorageStructMember],* ] @word $wordOffset:num) =>
+      let localName := toString name.getId
+      let childBase := baseSlot + (← natFromSyntax wordOffset)
+      let childPrefix := pathPrefix ++ [localName]
+      let mut fields : Array StorageFieldDecl := #[]
+      let mut children : Array StorageAccessorTree := #[]
+      for member in members do
+        let (memberFields, memberTree) ← parseStorageStructMember newtypes structDecls adtDecls rootIdent childPrefix childBase member
+        fields := fields ++ memberFields
+        children := children.push memberTree
+      pure (fields, StorageAccessorTree.node localName children)
+  | _ => throwErrorAt stx "invalid storage struct member declaration"
+
+private def parseStorageStructItem
+    (newtypes : Array NewtypeDecl)
+    (structDecls : Array StructDecl := #[])
+    (adtDecls : Array AdtDecl := #[])
+    (stx : TSyntax `verityStorageItem) :
+    CommandElabM (Option (Array StorageFieldDecl × StorageStructAccessorDecl)) := do
+  match stx with
+  | `(verityStorageItem| $name:ident : StorageStruct [ $[$members:verityStorageStructMember],* ] := slot $slotNum:num) =>
+      let rootName := toString name.getId
+      let baseSlot ← natFromSyntax slotNum
+      let mut fields : Array StorageFieldDecl := #[]
+      let mut children : Array StorageAccessorTree := #[]
+      for member in members do
+        let (memberFields, memberTree) ← parseStorageStructMember newtypes structDecls adtDecls name [rootName] baseSlot member
+        fields := fields ++ memberFields
+        children := children.push memberTree
+      pure (some (fields, {
+        ident := name
+        name := rootName
+        tree := StorageAccessorTree.node rootName children
+      }))
+  | _ => pure none
+
 private def parseParam (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl) (adtDecls : Array AdtDecl) (stx : Syntax) : CommandElabM ParamDecl := do
   match stx with
   | `(verityParam| $name:ident : $ty:term) =>
@@ -1217,7 +1312,7 @@ private def lookupStructMemberDecl
     (fieldName memberName : String)
     (expectNested : Bool) : CommandElabM StructMemberDecl := do
   let field ←
-    match fields.find? (fun f => f.name == fieldName) with
+    match fields.find? (fun f => f.name == fieldName || f.aliases.contains fieldName) with
     | some f => pure f
     | none => throwError s!"unknown storage field '{fieldName}'"
   let members ←
@@ -1239,7 +1334,7 @@ private def lookupStructMemberDecl
   | none => throwError s!"unknown struct member '{memberName}' on field '{fieldName}'"
 
 private def lookupStorageField (fields : Array StorageFieldDecl) (name : String) : CommandElabM StorageFieldDecl := do
-  match fields.find? (fun f => f.name == name) with
+  match fields.find? (fun f => f.name == name || f.aliases.contains name) with
   | some f => pure f
   | none => throwError s!"unknown storage field '{name}'"
 
@@ -6832,14 +6927,13 @@ private def mkModelParamsTerm (params : Array ParamDecl) : CommandElabM Term := 
     `(Compiler.CompilationModel.Param.mk $(strTerm p.name) $(← modelParamTypeTerm p.ty))
   `([ $[$xs],* ])
 
-private def mkStorageDefCommand (field : StorageFieldDecl) : CommandElabM Cmd := do
+private def storageSlotInnerTypeTerm (ty : StorageType) : CommandElabM Term := do
   let rec mkStorageMappingTy (keys : List MappingKeyType) : CommandElabM Term := do
     match keys with
     | [] => `(Uint256)
     | keyTy :: rest =>
         `(($(← storageKeyTypeContractTerm keyTy) → $(← mkStorageMappingTy rest)))
-  let storageTy ←
-    match field.ty with
+  match ty with
     | .scalar .uint256 => `(Uint256)
     | .scalar .int256 => `(Uint256)
     | .scalar .uint8 => throwError "storage field cannot be Uint8; use Uint256 encoding"
@@ -6875,8 +6969,55 @@ private def mkStorageDefCommand (field : StorageFieldDecl) : CommandElabM Cmd :=
     | .mappingStruct2 .address .uint256 _ => `(Address → Uint256 → Uint256)
     | .mappingStruct2 .uint256 .address _ => `(Uint256 → Address → Uint256)
     | .mappingStruct2 .uint256 .uint256 _ => `(Uint256 → Uint256 → Uint256)
+
+private def mkStorageDefCommand (field : StorageFieldDecl) : CommandElabM Cmd := do
+  let storageTy ← storageSlotInnerTypeTerm field.ty
   let fid := field.ident
   `(command| def $fid : Verity.StorageSlot $storageTy := ⟨$(natTerm field.slotNum)⟩)
+
+private def storageAccessorTypeName (parts : List String) : Ident :=
+  mkIdent (Name.mkSimple (String.intercalate "_" parts ++ "_StorageSlots"))
+
+private partial def storageAccessorTreeName : StorageAccessorTree → String
+  | .leaf name .. => name
+  | .node name _ => name
+
+private partial def storageAccessorTypeCommands
+    (path : List String) : StorageAccessorTree → CommandElabM (Array Cmd)
+  | .leaf .. => pure #[]
+  | .node _ children => do
+      let mut cmds : Array Cmd := #[]
+      for child in children do
+        cmds := cmds ++ (← storageAccessorTypeCommands (path ++ [storageAccessorTreeName child]) child)
+      let typeId := storageAccessorTypeName path
+      let mut fieldIds : Array Ident := #[]
+      let mut fieldTypes : Array Term := #[]
+      for child in children do
+        fieldIds := fieldIds.push (mkIdent (Name.mkSimple (storageAccessorTreeName child)))
+        match child with
+        | .leaf _ ty _ =>
+            fieldTypes := fieldTypes.push (← `(Verity.StorageSlot $(← storageSlotInnerTypeTerm ty)))
+        | .node name _ =>
+            fieldTypes := fieldTypes.push (storageAccessorTypeName (path ++ [name]))
+      cmds := cmds.push (← `(command| structure $typeId where
+          $[$fieldIds:ident : $fieldTypes:term]*))
+      pure cmds
+
+private partial def storageAccessorValueTerm : StorageAccessorTree → CommandElabM Term
+  | .leaf _ ty slotNum => do
+      `((⟨$(natTerm slotNum)⟩ : Verity.StorageSlot $(← storageSlotInnerTypeTerm ty)))
+  | .node _ children => do
+      let fieldIds := children.map (fun child => mkIdent (Name.mkSimple (storageAccessorTreeName child)))
+      let values ← children.mapM storageAccessorValueTerm
+      `({ $[$fieldIds:ident := $values:term],* })
+
+def mkStorageStructAccessorCommandsPublic
+    (accessor : StorageStructAccessorDecl) : CommandElabM (Array Cmd) := do
+  let typeCmds ← storageAccessorTypeCommands [accessor.name] accessor.tree
+  let rootType := storageAccessorTypeName [accessor.name]
+  let rootValue ← storageAccessorValueTerm accessor.tree
+  let rootCmd ← `(command| def $(accessor.ident) : $rootType := $rootValue)
+  pure (typeCmds.push rootCmd)
 
 private def packedOptionTerm (packed : Option (Nat × Nat)) : CommandElabM Term := do
   match packed with
@@ -6983,11 +7124,16 @@ def mkExecutableStructMappingCommandsPublic (fields : Array StorageFieldDecl) :
   pure cmds
 
 private def mkModelFieldTerm (field : StorageFieldDecl) : CommandElabM Term := do
+  let packedTerm ←
+    match field.packedBits with
+    | none => `(none)
+    | some (offset, width) =>
+        `(some { offset := $(natTerm offset), width := $(natTerm width) })
   `(Compiler.CompilationModel.Field.mk
       $(strTerm field.name)
       $(← modelFieldTypeTerm field.ty)
       (some $(natTerm field.slotNum))
-      none
+      $packedTerm
       [])
 
 private def mkModelErrorTerm (err : ErrorDecl) : CommandElabM Term := do
@@ -7368,12 +7514,17 @@ private def storageFieldFromItem?
       pure (some (← `(verityStorageField| $name:ident : $ty:term := slot $slotNum:num)))
   | _ => pure none
 
+private partial def offsetStorageAccessorTree (offset : Nat) : StorageAccessorTree → StorageAccessorTree
+  | .leaf name ty slotNum => .leaf name ty (slotNum + offset)
+  | .node name children => .node name (children.map (offsetStorageAccessorTree offset))
+
 structure ParsedContractSyntax where
   contractName : Ident
   newtypeDecls : Array NewtypeDecl
   structDecls : Array StructDecl
   adtDecls : Array AdtDecl
   fields : Array StorageFieldDecl
+  storageStructAccessors : Array StorageStructAccessorDecl
   errorDecls : Array ErrorDecl
   eventDecls : Array EventDecl
   constDecls : Array ConstantDecl
@@ -7459,6 +7610,7 @@ def parseContractSyntax
       -- `storage_namespace` items switch the active namespace for subsequent
       -- fields, allowing multiple ERC-7201 roots in one contract model.
       let mut parsedFields : Array StorageFieldDecl := #[]
+      let mut parsedStorageStructAccessors : Array StorageStructAccessorDecl := #[]
       let mut currentNamespaceOffset := namespaceOffset
       let mut namespaceOpt : Option Nat :=
         if nsSpec.isSome then some namespaceOffset else none
@@ -7469,18 +7621,26 @@ def parseContractSyntax
             if namespaceOpt.isNone then
               namespaceOpt := some offset
         | none =>
-            match (← storageFieldFromItem? item) with
-            | some fieldStx =>
-                let field ← parseStorageField parsedNewtypes parsedStructs parsedAdts fieldStx
-                parsedFields := parsedFields.push { field with slotNum := field.slotNum + currentNamespaceOffset }
+            match (← parseStorageStructItem parsedNewtypes parsedStructs parsedAdts item) with
+            | some (structFields, accessor) =>
+                parsedFields := parsedFields ++
+                  (structFields.map fun field => { field with slotNum := field.slotNum + currentNamespaceOffset })
+                parsedStorageStructAccessors := parsedStorageStructAccessors.push
+                  { accessor with tree := offsetStorageAccessorTree currentNamespaceOffset accessor.tree }
             | none =>
-                throwErrorAt item "unsupported storage item"
+                match (← storageFieldFromItem? item) with
+                | some fieldStx =>
+                    let field ← parseStorageField parsedNewtypes parsedStructs parsedAdts fieldStx
+                    parsedFields := parsedFields.push { field with slotNum := field.slotNum + currentNamespaceOffset }
+                | none =>
+                    throwErrorAt item "unsupported storage item"
       pure {
         contractName := contractName
         newtypeDecls := parsedNewtypes
         structDecls := parsedStructs
         adtDecls := parsedAdts
         fields := parsedFields
+        storageStructAccessors := parsedStorageStructAccessors
         errorDecls := parsedErrors
         eventDecls := parsedEvents
         constDecls := parsedConstants

--- a/artifacts/macro_property_tests/PropertyNestedStructStorageSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyNestedStructStorageSmoke.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyNestedStructStorageSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyNestedStructStorageSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("NestedStructStorageSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `readLeaves` result
+    function testTODO_ReadLeaves_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("readLeaves()"));
+        require(ok, "readLeaves reverted unexpectedly");
+        assertEq(ret.length, 32, "readLeaves ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: writeLeaves has no unexpected revert
+    function testAuto_WriteLeaves_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("writeLeaves(uint256)", uint256(1)));
+        require(ok, "writeLeaves reverted unexpectedly");
+    }
+    // Property 3: writeElement has no unexpected revert
+    function testAuto_WriteElement_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("writeElement(uint256,uint256)", uint256(1), uint256(1)));
+        require(ok, "writeElement reverted unexpectedly");
+    }
+    // Property 4: TODO decode and assert `readRouter` result
+    function testTODO_ReadRouter_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("readRouter()"));
+        require(ok, "readRouter reverted unexpectedly");
+        assertEq(ret.length, 32, "readRouter ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}


### PR DESCRIPTION
## Summary
- add a StorageStruct storage item for nested top-level storage layouts
- generate nested StorageSlot accessors so contract code can use paths like state.merkleTree.numberOfLeaves
- carry packed leaf metadata into the compilation model and keep model field names identifier-safe
- replace the old #1758 negative smoke with a positive nested storage struct regression, including packed scalar and mapping leaves

## Checks
- lake build Contracts.Smoke
- python3 scripts/check_lean_hygiene.py
- python3 scripts/check_macro_health.py
- make check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new storage syntax and codegen for nested storage slots, which can affect slot computation and compilation-model metadata for any contract using the new `StorageStruct` form.
> 
> **Overview**
> Adds a new `StorageStruct [...] := slot N` storage item that can express **nested top-level storage layouts**, including packed scalar leaves and mapping leaves, and makes those nested paths usable in contract code via generated accessors (e.g. `state.merkleTree.numberOfLeaves`).
> 
> Updates macro translation/elaboration to parse nested members, flatten them into compilation-model fields with identifier-safe names and alias-based lookup, emit separate accessor structures/values, and carry packed-bit metadata into the `CompilationModel`.
> 
> Replaces the prior negative smoke for named-struct storage with a positive `NestedStructStorageSmoke` regression (plus generated Solidity property-test stub) and wires it into `#check_contract`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f7c623a796b2b7d705a01d78cd9eddc07ea634e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->