### PR TITLE
design(docs): cold teal LaTeX palette + mobile UX polish

### DIFF
--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -5,16 +5,35 @@ import 'nextra-theme-docs/style.css'
 import './verity-site.css'
 import './verity-code.css'
 
+const SITE_URL = 'https://veritylang.com'
+const SITE_TITLE = 'Verity'
+const SITE_DESCRIPTION =
+  'A Lean-native EDSL for verified smart contracts. Write the spec, write the implementation, and prove they agree — every claim is machine-checked at compile time.'
+
 export const metadata = {
+  metadataBase: new URL(SITE_URL),
   title: {
-    default: 'Verity',
+    default: SITE_TITLE,
     template: '%s',
   },
-  description: 'Minimal Lean 4 EDSL for Smart Contracts with Formal Verification',
+  description: SITE_DESCRIPTION,
   icons: {
     icon: '/verity.svg',
     shortcut: '/verity.svg',
     apple: '/verity.svg',
+  },
+  openGraph: {
+    type: 'website',
+    siteName: SITE_TITLE,
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    url: SITE_URL,
+    locale: 'en_US',
+  },
+  twitter: {
+    card: 'summary',
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
   },
 }
 

--- a/docs-site/app/robots.ts
+++ b/docs-site/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/'],
+      },
+    ],
+    sitemap: 'https://veritylang.com/sitemap.xml',
+    host: 'https://veritylang.com',
+  }
+}

--- a/docs-site/app/sitemap.ts
+++ b/docs-site/app/sitemap.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from 'next'
+
+const ROUTES = [
+  '',
+  '/getting-started',
+  '/examples',
+  '/core',
+  '/add-contract',
+  '/compiler',
+  '/verification',
+  '/edsl-api-reference',
+  '/research',
+  '/research/iterations',
+  '/guides/first-contract',
+  '/guides/solidity-to-verity',
+  '/guides/production-solidity-patterns',
+  '/guides/debugging-proofs',
+  '/guides/linking-libraries',
+  '/guides/verity-syntax-highlighting',
+]
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = 'https://veritylang.com'
+  const lastModified = new Date()
+  return ROUTES.map((path) => ({
+    url: `${base}${path}`,
+    lastModified,
+    changeFrequency: path === '' ? 'weekly' : 'monthly',
+    priority: path === '' ? 1.0 : 0.7,
+  }))
+}

--- a/docs-site/app/verity-code.css
+++ b/docs-site/app/verity-code.css
@@ -31,7 +31,7 @@ figure[data-rehype-pretty-code-figure] pre[data-language="verity"] {
   color: #A3E1D4 !important;
 }
 
-.dark figure[data-rehype-pretty-code-figure] span[style*="#A7E39B"] {
+.dark figure[data-rehype-pretty-code-figure] span[style*="#A3E1D4"] {
   color: #82E0CC !important;
 }
 
@@ -56,19 +56,19 @@ figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span::
   pointer-events: none;
 }
 
-figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#7b3f32" i]:first-child),
-figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#875c24" i]) {
+figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#0B6E62" i]:first-child),
+figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#3D8579" i]) {
   background: linear-gradient(90deg, rgba(15, 142, 126, 0.08), rgba(15, 142, 126, 0));
 }
 
-figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#a34537" i]) {
+figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#B14A3A" i]) {
   background: linear-gradient(90deg, rgba(15, 142, 126, 0.06), rgba(15, 142, 126, 0));
 }
 
-figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#6f5631" i]) {
+figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#1F5F58" i]) {
   background: linear-gradient(90deg, rgba(11, 110, 98, 0.05), rgba(11, 110, 98, 0));
 }
 
-figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#3f7456" i]) {
+figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#0F8E7E" i]) {
   background: linear-gradient(90deg, rgba(11, 110, 98, 0.08), rgba(11, 110, 98, 0));
 }

--- a/docs-site/app/verity-code.css
+++ b/docs-site/app/verity-code.css
@@ -1,9 +1,11 @@
+/* Light theme — cool paper background with a faint teal wash on the
+   left edge to mark verity code as the "lifted" / proof-carrying variant. */
 figure[data-rehype-pretty-code-figure] pre[data-language="verity"] {
   background:
-    linear-gradient(90deg, rgba(123, 63, 50, 0.06), transparent 22rem),
-    #fffaf1 !important;
-  border: 1px solid #eadcca;
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.72) inset;
+    linear-gradient(90deg, rgba(15, 142, 126, 0.05), transparent 22rem),
+    var(--verity-code-surface) !important;
+  border: 1px solid var(--verity-rule);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.6) inset;
 }
 
 .dark figure[data-rehype-pretty-code-figure] pre {
@@ -16,22 +18,25 @@ figure[data-rehype-pretty-code-figure] pre[data-language="verity"] {
   color: var(--verity-ink) !important;
 }
 
+/* Dark-theme syntax remap: the bundled shiki theme is warm-amber. Push
+   highlights to cool teal/cyan/slate so code reads cold like the rest of
+   the dark theme. */
 .dark figure[data-rehype-pretty-code-figure] span[style*="#D9B7FF"],
 .dark figure[data-rehype-pretty-code-figure] span[style*="#D5B3FF"] {
-  color: #E5C98A !important;
+  color: #7DD3C0 !important;
 }
 
 .dark figure[data-rehype-pretty-code-figure] span[style*="#91C9FF"],
 .dark figure[data-rehype-pretty-code-figure] span[style*="#86D6C8"] {
-  color: #D8B989 !important;
+  color: #A3E1D4 !important;
 }
 
 .dark figure[data-rehype-pretty-code-figure] span[style*="#A7E39B"] {
-  color: #C9A961 !important;
+  color: #82E0CC !important;
 }
 
 .dark figure[data-rehype-pretty-code-figure] span[style*="#D7E4F2"] {
-  color: #D9D0C0 !important;
+  color: #C7D5D1 !important;
 }
 
 figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code {
@@ -47,23 +52,23 @@ figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span::
   position: absolute;
   inset-block: 0;
   left: 1.35rem;
-  border-left: 1px solid rgba(139, 118, 99, 0.13);
+  border-left: 1px solid rgba(94, 110, 106, 0.13);
   pointer-events: none;
 }
 
 figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#7b3f32" i]:first-child),
 figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#875c24" i]) {
-  background: linear-gradient(90deg, rgba(234, 220, 202, 0.7), rgba(234, 220, 202, 0));
+  background: linear-gradient(90deg, rgba(15, 142, 126, 0.08), rgba(15, 142, 126, 0));
 }
 
 figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#a34537" i]) {
-  background: linear-gradient(90deg, rgba(163, 69, 55, 0.08), rgba(163, 69, 55, 0));
+  background: linear-gradient(90deg, rgba(15, 142, 126, 0.06), rgba(15, 142, 126, 0));
 }
 
 figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#6f5631" i]) {
-  background: linear-gradient(90deg, rgba(111, 86, 49, 0.08), rgba(111, 86, 49, 0));
+  background: linear-gradient(90deg, rgba(11, 110, 98, 0.05), rgba(11, 110, 98, 0));
 }
 
 figure[data-rehype-pretty-code-figure] pre[data-language="verity"] code > span:has(> span[style*="#3f7456" i]) {
-  background: linear-gradient(90deg, rgba(63, 116, 86, 0.08), rgba(63, 116, 86, 0));
+  background: linear-gradient(90deg, rgba(11, 110, 98, 0.08), rgba(11, 110, 98, 0));
 }

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -1881,4 +1881,34 @@ input:focus-visible,
     color: var(--verity-muted) !important;
     font-style: italic;
   }
+
+  /* Don't expand URLs inside code chips or section anchors. */
+  article main a[href^="http"] code::after,
+  article main .subheading-anchor::after,
+  article main h1 a::after,
+  article main h2 a::after,
+  article main h3 a::after,
+  article main h4 a::after {
+    content: none !important;
+  }
+
+  .report-callout,
+  article main blockquote,
+  .nextra-callout {
+    border: 1px solid var(--verity-rule) !important;
+    border-left: 3px solid var(--verity-accent) !important;
+    background: #fafafa !important;
+    page-break-inside: avoid;
+  }
+
+  /* Drop the side-by-side switcher to its currently-active panel only —
+     printing both panels is just noise. */
+  .code-switcher__tabs,
+  .code-switcher__head {
+    display: none !important;
+  }
+
+  .code-panel[data-active="false"] {
+    display: none !important;
+  }
 }

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -177,6 +177,13 @@ header.nextra-navbar > div:first-child {
   height: 1.35rem;
 }
 
+/* The V mark is a faceted gray polygon; in dark mode the dark facets
+   blend into the navbar. Lift it with a slight invert + teal tint so
+   it reads as cold metal rather than dim charcoal. */
+.dark .verity-brand img {
+  filter: invert(0.78) hue-rotate(140deg) saturate(0.55);
+}
+
 .verity-brand strong {
   font-weight: inherit;
 }
@@ -633,14 +640,20 @@ article:has(.verity-hero) .nextra-breadcrumb {
   color: var(--verity-accent) !important;
 }
 
-/* "Last updated on …" footer line — give it a research-footer feel */
+/* "Last updated on …" footer line — give it a research-footer feel
+   with a hairline rule above and an italic small-caps treatment, like
+   a journal article colophon. */
 [class*="nextra-content-width"] > p:has(> time),
 [class*="nextra-content-width"] p:last-child:has(time) {
+  margin-top: 2.5rem !important;
+  padding-top: 0.85rem !important;
+  border-top: 1px solid var(--verity-rule-soft, var(--verity-rule)) !important;
   color: var(--verity-muted) !important;
   font-family: var(--verity-font-ui) !important;
-  font-size: 0.78rem !important;
-  letter-spacing: 0.02em;
+  font-size: 0.76rem !important;
+  letter-spacing: 0.04em;
   font-style: italic;
+  text-align: right;
 }
 
 /* Nextra renders a "next page" pagination block at the bottom of each
@@ -703,6 +716,12 @@ article main tr[class*="x:even:bg-gray"] {
 article tbody tr:nth-child(even),
 article main tbody tr:nth-child(even) {
   background: color-mix(in srgb, var(--verity-sidebar) 35%, var(--verity-surface)) !important;
+}
+
+article main tbody tr:hover,
+article tbody tr:hover {
+  background: color-mix(in srgb, var(--verity-accent) 6%, var(--verity-surface)) !important;
+  transition: background-color 0.12s ease;
 }
 
 article main th {

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -899,6 +899,8 @@ a[role="button"] {
 .verity-hero__dek em {
   font-style: italic;
   font-weight: 500;
+  color: var(--verity-accent-strong, var(--verity-accent));
+  font-feature-settings: "kern", "liga", "calt", "ss01";
 }
 
 .verity-hero__links {
@@ -1598,6 +1600,27 @@ a[role="button"] {
     max-height: 28rem;
     font-size: 0.74rem;
     line-height: 1.55;
+  }
+
+  /* Fade the right edge of horizontally-scrolling code so it reads as
+     scrollable rather than cut-off. */
+  .code-switcher__panels {
+    position: relative;
+  }
+
+  .code-switcher__panels::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 1.75rem;
+    pointer-events: none;
+    background: linear-gradient(
+      to right,
+      transparent,
+      var(--verity-code-surface) 92%
+    );
   }
 
   article main table {

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -235,6 +235,32 @@ header kbd {
   border-radius: 0 !important;
 }
 
+/* Themed search-result popover panel */
+[role="listbox"]:has(.nextra-search-result),
+.nextra-search [role="listbox"] {
+  background: var(--verity-surface) !important;
+  border: 1px solid var(--verity-rule) !important;
+  box-shadow: var(--verity-shadow) !important;
+  font-family: var(--verity-font-ui) !important;
+}
+
+[role="listbox"] a {
+  color: var(--verity-ink) !important;
+  border-bottom: 1px solid var(--verity-rule-soft, var(--verity-rule)) !important;
+}
+
+[role="listbox"] a:hover,
+[role="listbox"] a[aria-selected="true"] {
+  background: color-mix(in srgb, var(--verity-accent) 10%, transparent) !important;
+  color: var(--verity-heading) !important;
+}
+
+[role="listbox"] mark {
+  background: color-mix(in srgb, var(--verity-accent) 28%, transparent) !important;
+  color: var(--verity-heading) !important;
+  padding: 0 0.12em;
+}
+
 /* "Copy page" widget at the top of each article */
 [class*="x:rounded-md"]:has(> button),
 [class*="x:rounded-md"]:has(> button) * {

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -1883,7 +1883,7 @@ input:focus-visible,
   }
 
   /* Don't expand URLs inside code chips or section anchors. */
-  article main a[href^="http"] code::after,
+  article main a[href^="http"]:has(code)::after,
   article main .subheading-anchor::after,
   article main h1 a::after,
   article main h2 a::after,

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -750,6 +750,37 @@ figure[data-rehype-pretty-code-figure] pre {
   color: var(--verity-ink) !important;
 }
 
+/* Thinner, teal-tinged scrollbar on overflowing code blocks so the
+   scroll affordance feels like part of the typography rather than
+   borrowed chrome. */
+article pre::-webkit-scrollbar,
+.code-panel__pre::-webkit-scrollbar {
+  height: 6px;
+  width: 6px;
+}
+
+article pre::-webkit-scrollbar-track,
+.code-panel__pre::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+article pre::-webkit-scrollbar-thumb,
+.code-panel__pre::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--verity-accent) 30%, transparent);
+  border-radius: 0;
+}
+
+article pre::-webkit-scrollbar-thumb:hover,
+.code-panel__pre::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--verity-accent) 60%, transparent);
+}
+
+article pre,
+.code-panel__pre {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--verity-accent) 30%, transparent) transparent;
+}
+
 article :not(pre) > code,
 code.nextra-code:not(pre code) {
   background: color-mix(in srgb, var(--verity-sidebar) 50%, var(--verity-surface)) !important;

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -925,6 +925,20 @@ input:focus-visible,
   }
 }
 
+/* On very narrow screens (iPhone SE etc), the kicker's wide tracking
+   forces line breaks between every word. Tighten so it reads as one
+   or two clean lines instead of four. */
+@media (max-width: 360px) {
+  .verity-hero .verity-kicker {
+    font-size: 0.68rem;
+    letter-spacing: 0.1em;
+  }
+
+  .verity-hero .verity-kicker span {
+    margin: 0 0.3em;
+  }
+}
+
 .verity-hero {
   display: grid;
   grid-template-rows: auto auto;

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -1784,3 +1784,76 @@ input:focus-visible,
     font-size: 0.65rem !important;
   }
 }
+
+/* Print stylesheet — when the docs are printed or exported to PDF,
+   shed the navbar / sidebar / TOC / search chrome and leave the
+   article column on the page. Headings, §-numbering and code blocks
+   remain so the output reads like a proper printed appendix. */
+@media print {
+  :root {
+    --verity-bg: #ffffff;
+    --verity-page: #ffffff;
+    --verity-surface: #ffffff;
+    --verity-code-surface: #fafafa;
+    --verity-ink: #000000;
+    --verity-heading: #000000;
+    --verity-muted: #555555;
+    --verity-rule: #cccccc;
+    --verity-accent: #0B6E62;
+  }
+
+  html, body {
+    background: #ffffff !important;
+    color: #000000 !important;
+  }
+
+  header.nextra-navbar,
+  .nextra-nav-container,
+  .nextra-sidebar-container,
+  .nextra-sidebar,
+  .nextra-toc,
+  .nextra-breadcrumb,
+  .nextra-search,
+  [aria-label*="back to top" i],
+  [class*="x:rounded-md"]:has(> button),
+  article > div:last-child:has(> a[title]),
+  body::before {
+    display: none !important;
+  }
+
+  article main {
+    max-width: 100% !important;
+    padding: 0 !important;
+  }
+
+  article main h2 {
+    page-break-after: avoid;
+    border-top: 1px solid var(--verity-rule) !important;
+  }
+
+  article main h3,
+  article main h4 {
+    page-break-after: avoid;
+  }
+
+  article pre,
+  .code-panel__pre {
+    page-break-inside: avoid;
+    border: 1px solid var(--verity-rule) !important;
+    background: #fafafa !important;
+  }
+
+  article main a,
+  article a {
+    color: #000000 !important;
+    text-decoration: underline !important;
+  }
+
+  /* Expand link URLs after the link text — paper readers can't click. */
+  article main a[href^="http"]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.78em;
+    color: var(--verity-muted) !important;
+    font-style: italic;
+  }
+}

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -169,7 +169,12 @@ header.nextra-navbar > div:first-child {
   font-family: var(--verity-font-display);
   font-size: 1.08rem;
   font-weight: 700;
-  letter-spacing: -0.005em;
+  letter-spacing: -0.012em;
+  font-feature-settings: "kern", "liga", "calt";
+}
+
+.verity-brand:hover {
+  color: var(--verity-accent);
 }
 
 .verity-brand img {
@@ -837,6 +842,19 @@ button,
 a[role="button"] {
   border-radius: 0 !important;
   font-family: var(--verity-font-ui) !important;
+}
+
+/* Unified keyboard-focus ring across the site: a 2px teal outline
+   offset by 2px. Click-only focus stays invisible — we scope to
+   :focus-visible so mouse users don't see the ring. */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+[role="button"]:focus-visible,
+[role="tab"]:focus-visible {
+  outline: 2px solid var(--verity-accent) !important;
+  outline-offset: 2px !important;
+  border-radius: 0 !important;
 }
 
 .verity-kicker {

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -669,6 +669,31 @@ article main a:hover,
   color: var(--verity-muted) !important;
 }
 
+/* The right-rail "Question? Give us feedback / Edit this page" footer
+   shouldn't compete with the TOC headings. Quieten it to muted body
+   ink with a small UI font, and lift to accent on hover. */
+.nextra-toc-footer,
+.nextra-toc + nav,
+.nextra-toc div:has(> a[href*="github.com"][href*="edit"]) {
+  font-family: var(--verity-font-ui);
+  font-size: 0.78rem !important;
+  letter-spacing: 0.01em;
+}
+
+.nextra-toc-footer a,
+.nextra-toc + nav a,
+[class*="nextra-toc"] a[href*="github.com"][href*="edit"] {
+  color: var(--verity-muted) !important;
+  font-weight: 500 !important;
+  text-decoration: none !important;
+}
+
+.nextra-toc-footer a:hover,
+.nextra-toc + nav a:hover,
+[class*="nextra-toc"] a[href*="github.com"][href*="edit"]:hover {
+  color: var(--verity-accent) !important;
+}
+
 .nextra-breadcrumb {
   font-family: var(--verity-font-ui);
   font-size: 0.78rem !important;

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -66,7 +66,7 @@
   --verity-surface-strong: #16241F;
   --verity-ink: #DDE8E5;
   --verity-heading: #F1F7F4;
-  --verity-muted: #8FA09B;
+  --verity-muted: #9DAEA9;
   --verity-rule: #1E2A26;
   --verity-rule-soft: #16241F;
   --verity-code-bg: #0B1614;
@@ -525,9 +525,13 @@ article main h1 {
    air and a slightly lighter weight, like a preprint abstract opener. */
 article main h1 + p {
   font-size: 1.18rem !important;
-  line-height: 1.62 !important;
+  line-height: 1.6 !important;
+  letter-spacing: -0.002em;
   color: var(--verity-ink) !important;
   font-weight: 400 !important;
+  margin-top: 0.6rem !important;
+  margin-bottom: 1.8rem !important;
+  max-width: 44rem !important;
 }
 
 article main h2 {

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -1,5 +1,21 @@
 @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;500;600;700&family=Source+Sans+3:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400..900&display=swap");
 
+/* Verity docs-site design system
+ *
+ *   Vibe — typography-first, minimalist, modeled on a LaTeX research
+ *   preprint with a cold-teal "sarcelle" accent (sibling to lfglabs.dev's
+ *   #2DD4BF). Headings are serif (Source Serif 4), UI chrome is humanist
+ *   sans (Source Sans 3), code is grotesk mono (Source Code Pro).
+ *
+ *   To re-skin: edit the --verity-* tokens in :root and .dark below.
+ *   Everything downstream (links, code, sidebar, hero, tables, search)
+ *   pulls from those tokens via color-mix() rules.
+ *
+ *   Mobile breakpoints land at 767px (phone) and 1024px (tablet). The
+ *   end of this file holds the responsive overrides — keep mobile-only
+ *   rules there rather than scattering @media blocks throughout.
+ */
+
 :root {
   color-scheme: light;
   /* Cool LaTeX-paper palette. The page reads as a preprint set on

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -787,6 +787,7 @@ article main tr,
 article main tr:nth-child(even),
 article main tr[class*="x:even:bg-gray"] {
   background: var(--verity-surface) !important;
+  transition: background-color 0.12s ease;
 }
 
 article tbody tr:nth-child(even),
@@ -797,7 +798,6 @@ article main tbody tr:nth-child(even) {
 article main tbody tr:hover,
 article tbody tr:hover {
   background: color-mix(in srgb, var(--verity-accent) 6%, var(--verity-surface)) !important;
-  transition: background-color 0.12s ease;
 }
 
 article main th {

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -2,77 +2,85 @@
 
 :root {
   color-scheme: light;
-  --verity-bg: #EDE5D6;
-  --verity-page: #FAF7EF;
-  --verity-sidebar: #DED2BD;
-  --verity-sidebar-strong: #CDBB9C;
-  --verity-surface: #FFFDF8;
-  --verity-surface-strong: #E5D7BF;
-  --verity-ink: #28190F;
-  --verity-heading: #160D07;
-  --verity-muted: #6A5A4A;
-  --verity-rule: #C5B69F;
-  --verity-code-bg: #EFE5D4;
-  --verity-code-surface: #FFF9EE;
-  --verity-accent: #65401F;
-  --verity-accent-soft: #D3BC92;
-  --verity-accent-ink: #FFF9EE;
-  --verity-shadow: 0 18px 44px rgba(42, 24, 16, 0.09);
+  /* Cool LaTeX-paper palette. The page reads as a preprint set on
+     bright, faintly-blue stock; teal "sarcelle" carries every accent. */
+  --verity-bg: #ECEEEC;
+  --verity-page: #F7F8F6;
+  --verity-sidebar: #E6E9E6;
+  --verity-sidebar-strong: #D6DAD7;
+  --verity-surface: #FFFFFF;
+  --verity-surface-strong: #EEF1EE;
+  --verity-ink: #1A2422;
+  --verity-heading: #0B1614;
+  --verity-muted: #5E6E6A;
+  --verity-rule: #D3D8D5;
+  --verity-rule-soft: #E1E5E2;
+  --verity-code-bg: #EEF1EE;
+  --verity-code-surface: #FBFCFB;
+  --verity-accent: #0F8E7E;
+  --verity-accent-strong: #0B6E62;
+  --verity-accent-bright: #2DD4BF;
+  --verity-accent-soft: #B9E6DE;
+  --verity-accent-ink: #FFFFFF;
+  --verity-shadow: 0 14px 38px rgba(11, 22, 20, 0.06);
   --verity-font-prose: "Source Serif 4", Georgia, serif;
   --verity-font-display: "Source Serif 4", Georgia, serif;
   --verity-font-caption: "Source Serif 4", Georgia, serif;
   --verity-font-code: "Source Code Pro", ui-monospace, SFMono-Regular, Menlo, monospace;
   --verity-font-ui: "Source Sans 3", Inter, ui-sans-serif, system-ui, sans-serif;
-  --nextra-navbar-height: 68px;
+  --nextra-navbar-height: 64px;
   --nextra-content-width: 82rem;
-  --nextra-primary-hue: 31deg;
-  --nextra-primary-saturation: 71%;
-  --nextra-primary-lightness: 25%;
-  --nextra-bg: 247, 241, 228;
-  --x-color-blue-100: #E8D8BB;
-  --x-color-blue-400: #A8733F;
-  --x-color-blue-600: #7D4319;
-  --x-color-blue-700: #6F3B13;
-  --x-color-blue-900: #3D2111;
-  --x-color-slate-50: #FBF8F1;
-  --x-color-slate-100: #F4EFE6;
-  --x-color-slate-200: #E7D7BB;
-  --x-color-slate-700: #2A1810;
-  --x-color-slate-900: #1A0F08;
-  --x-color-gray-50: #FBF8F1;
-  --x-color-gray-100: #F0E6D5;
-  --x-color-gray-200: #DDCEB7;
-  --x-color-gray-300: #C9BBA4;
-  --x-color-gray-400: #8B7B68;
-  --x-color-gray-600: #6D5D50;
-  --x-color-gray-700: #534539;
-  --x-color-gray-800: #35271D;
-  --x-color-gray-900: #21150E;
+  --nextra-primary-hue: 170deg;
+  --nextra-primary-saturation: 70%;
+  --nextra-primary-lightness: 31%;
+  --nextra-bg: 247, 248, 246;
+  --x-color-blue-100: #C9E8E1;
+  --x-color-blue-400: #14B5A1;
+  --x-color-blue-600: #0F8E7E;
+  --x-color-blue-700: #0B6E62;
+  --x-color-blue-900: #053A33;
+  --x-color-slate-50: #F7F8F6;
+  --x-color-slate-100: #ECEEEC;
+  --x-color-slate-200: #D9DDDA;
+  --x-color-slate-700: #2A3633;
+  --x-color-slate-900: #0B1614;
+  --x-color-gray-50: #F7F8F6;
+  --x-color-gray-100: #ECEEEC;
+  --x-color-gray-200: #D9DDDA;
+  --x-color-gray-300: #C4CAC7;
+  --x-color-gray-400: #8B9591;
+  --x-color-gray-600: #5E6E6A;
+  --x-color-gray-700: #45524F;
+  --x-color-gray-800: #283531;
+  --x-color-gray-900: #0F1B19;
 }
 
 .dark {
   color-scheme: dark;
-  /* Warmer "vellum at night" instead of pure black */
-  --verity-bg: #0B0908;
-  --verity-page: #0B0908;
-  --verity-sidebar: #100D0A;
-  --verity-sidebar-strong: #18130E;
-  --verity-surface: #14110D;
-  --verity-surface-strong: #1B1813;
-  --verity-ink: #E8E2D2;
-  --verity-heading: #F6F1E5;
-  --verity-muted: #B7A993;
-  --verity-rule: #2E281E;
-  --verity-code-bg: #14110D;
-  --verity-code-surface: #100D0A;
-  --verity-accent: #CFA968;
-  --verity-accent-soft: #6B501F;
-  --verity-accent-ink: #0B0908;
+  /* "Console at night": cold dark slate with a phosphor-teal accent. */
+  --verity-bg: #07100E;
+  --verity-page: #07100E;
+  --verity-sidebar: #0B1614;
+  --verity-sidebar-strong: #122220;
+  --verity-surface: #0F1B19;
+  --verity-surface-strong: #16241F;
+  --verity-ink: #DDE8E5;
+  --verity-heading: #F1F7F4;
+  --verity-muted: #8FA09B;
+  --verity-rule: #1E2A26;
+  --verity-rule-soft: #16241F;
+  --verity-code-bg: #0B1614;
+  --verity-code-surface: #0A1311;
+  --verity-accent: #2DD4BF;
+  --verity-accent-strong: #5EEAD4;
+  --verity-accent-bright: #2DD4BF;
+  --verity-accent-soft: #134E48;
+  --verity-accent-ink: #04100D;
   --verity-shadow: none;
-  --nextra-primary-hue: 39deg;
-  --nextra-primary-saturation: 54%;
-  --nextra-primary-lightness: 60%;
-  --nextra-bg: 11, 9, 8;
+  --nextra-primary-hue: 172deg;
+  --nextra-primary-saturation: 70%;
+  --nextra-primary-lightness: 56%;
+  --nextra-bg: 7, 16, 14;
 }
 
 html,
@@ -401,9 +409,10 @@ body {
 .nextra-toc a[aria-current="true"],
 .nextra-toc a[aria-selected="true"] {
   color: var(--verity-heading) !important;
-  background: color-mix(in srgb, var(--verity-accent-soft) 52%, transparent) !important;
+  background: color-mix(in srgb, var(--verity-accent) 12%, transparent) !important;
   border-radius: 0 !important;
   box-shadow: inset 2px 0 0 var(--verity-accent);
+  font-weight: 600 !important;
 }
 
 .dark .nextra-sidebar a[aria-current="page"],
@@ -724,14 +733,19 @@ figure[data-rehype-pretty-code-figure] pre {
 
 article :not(pre) > code,
 code.nextra-code:not(pre code) {
-  background: color-mix(in srgb, var(--verity-sidebar) 28%, var(--verity-surface)) !important;
-  border: 1px solid color-mix(in srgb, var(--verity-rule) 55%, transparent) !important;
+  background: color-mix(in srgb, var(--verity-sidebar) 50%, var(--verity-surface)) !important;
+  border: 1px solid color-mix(in srgb, var(--verity-rule) 60%, transparent) !important;
   border-radius: 0 !important;
   color: var(--verity-heading) !important;
   font-family: var(--verity-font-code) !important;
-  font-size: 0.88em !important;
+  font-size: 0.86em !important;
   font-weight: 500 !important;
   padding: 0.05em 0.36em !important;
+  /* Allow line-break inside long inline-code identifiers so they
+     don't push the surrounding paragraph past the gutter on narrow
+     viewports. */
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .dark article :not(pre) > code,
@@ -777,7 +791,7 @@ a[role="button"] {
   font-family: var(--verity-font-ui);
   font-size: 0.74rem;
   font-weight: 700;
-  letter-spacing: 0.11em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
@@ -834,10 +848,11 @@ a[role="button"] {
   font-family: var(--verity-font-display);
   font-size: clamp(3.6rem, 9vw, 6.4rem);
   font-weight: 760;
-  letter-spacing: -0.012em;
+  letter-spacing: -0.014em;
   line-height: 0.92;
   overflow-wrap: normal;
   word-break: normal;
+  font-feature-settings: "kern", "liga", "calt";
 }
 
 .verity-hero__terminal {
@@ -847,6 +862,27 @@ a[role="button"] {
      not an afterthought punctuation mark. */
   font-size: 1.08em;
   line-height: 1;
+}
+
+/* A faint hairline under the kicker, like a journal masthead rule. */
+.verity-hero__head > .verity-kicker {
+  position: relative;
+  padding-bottom: 0.4rem;
+  margin-bottom: 0.6rem;
+}
+
+.verity-hero__head > .verity-kicker::after {
+  content: "";
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 2rem;
+  border-bottom: 1px solid var(--verity-accent);
+}
+
+.verity-hero__head > .verity-kicker + h1 {
+  margin-top: 0 !important;
 }
 
 .verity-hero__dek {
@@ -1473,13 +1509,32 @@ a[role="button"] {
     background: var(--verity-page);
   }
 
+  /* The "extend sidebar to the viewport edge" stripe is desktop-only;
+     paint it transparent on phones so the dark sliver disappears. */
+  body::before {
+    display: none !important;
+  }
+
   article main {
     font-size: 1rem !important;
+    line-height: 1.68 !important;
+  }
+
+  article main > :not(.verity-hero):not(.code-compare):not(.report-callout) {
+    max-width: 100%;
+  }
+
+  /* The "Copy page" widget hugs the right side and the section-number
+     "§ N" marker hugs the right side too — drop both on phones so
+     headings can use the full width without a collision. */
+  article main h2::after {
+    display: none !important;
   }
 
   .verity-hero {
-    padding-top: 1.75rem;
+    padding-top: 1.25rem;
     padding-bottom: 1.5rem;
+    gap: 1.75rem;
   }
 
   .verity-hero__head {
@@ -1487,17 +1542,19 @@ a[role="button"] {
   }
 
   .verity-hero h1 {
-    font-size: clamp(3.6rem, 18vw, 4.6rem);
+    font-size: clamp(3.2rem, 16vw, 4.2rem);
+    line-height: 0.95;
   }
 
   .verity-hero__dek {
-    font-size: 1.15rem;
+    font-size: 1.12rem;
+    line-height: 1.42;
   }
 
   .verity-hero__cta-row {
     flex-direction: column;
     align-items: stretch;
-    gap: 0.6rem;
+    gap: 0.55rem;
     width: 100%;
   }
 
@@ -1505,21 +1562,24 @@ a[role="button"] {
   .verity-hero__paper {
     width: 100%;
     justify-content: center;
+    min-height: 2.85rem;
   }
 
   .verity-hero__more {
     flex-direction: column;
-    gap: 0.4rem;
+    gap: 0.35rem;
   }
 
   .code-compare {
-    margin-top: 1rem;
+    margin-top: 0.5rem;
+    margin-bottom: 1.75rem;
   }
 
   .code-switcher__head {
     flex-direction: column;
     align-items: stretch;
-    gap: 0.7rem;
+    gap: 0.65rem;
+    padding: 0.65rem 0.85rem;
   }
 
   .code-switcher__tabs {
@@ -1529,17 +1589,47 @@ a[role="button"] {
 
   .code-switcher__tabs button {
     flex: 1 1 0;
+    padding: 0.55rem 0.5rem;
   }
 
   .code-panel__pre,
   .code-panel__pre > pre {
-    min-height: 22rem;
-    max-height: 30rem;
-    font-size: 0.76rem;
+    min-height: 18rem;
+    max-height: 28rem;
+    font-size: 0.74rem;
+    line-height: 1.55;
   }
 
   article main table {
     display: block;
     overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* The serif body uses hyphenation; on narrow screens this can
+     hyphenate every other line. Loosen so words break only on the rare
+     overflow case. */
+  article main p,
+  article main li {
+    hyphens: manual;
+    -webkit-hyphens: manual;
+  }
+}
+
+/* Floating theme toggle that Nextra docks bottom-left of the sidebar
+   was overlapping page content on mobile because its container had no
+   bottom edge. Pin it down and give it a contained chip look. */
+.nextra-sidebar-footer,
+.nextra-sidebar .nextra-sidebar-footer {
+  padding-block: 0.6rem !important;
+}
+
+/* Quieten the giant section-number marker on /research, /verification etc
+   so we don't get an isolated "§ 1" floating in the gutter on narrow
+   layouts where TOC has been collapsed. */
+@media (max-width: 1280px) {
+  article main h2::after {
+    right: 0 !important;
+    font-size: 0.65rem !important;
   }
 }

--- a/docs-site/themes/lfglabs-cream.json
+++ b/docs-site/themes/lfglabs-cream.json
@@ -1,180 +1,180 @@
 {
   "$schema": "https://raw.githubusercontent.com/shikijs/textmate-grammars-themes/main/packages/tm-themes/schema.json",
-  "name": "LFGLabs Cream",
+  "name": "Verity Paper Light",
   "type": "light",
   "colors": {
-    "editor.background": "#fffaf1",
-    "editor.foreground": "#302b25",
-    "editorLineNumber.foreground": "#b9a992",
-    "editor.selectionBackground": "#eadcca",
-    "editor.inactiveSelectionBackground": "#f2e7d5"
+    "editor.background": "#fbfcfb",
+    "editor.foreground": "#1a2422",
+    "editorLineNumber.foreground": "#a3aeab",
+    "editor.selectionBackground": "#cfe6e0",
+    "editor.inactiveSelectionBackground": "#dfece9"
   },
   "tokenColors": [
     {
       "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
-        "foreground": "#8a8175",
+        "foreground": "#6F807C",
         "fontStyle": "italic"
       }
     },
     {
       "scope": ["string.quoted.double", "string.quoted.double.verity"],
       "settings": {
-        "foreground": "#6b6f32"
+        "foreground": "#2A6B61"
       }
     },
     {
       "scope": ["entity.name.function.event.verity"],
       "settings": {
-        "foreground": "#3f7456",
+        "foreground": "#0F8E7E",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["constant.numeric", "constant.numeric.hex", "constant.numeric.decimal", "constant.numeric.storage-slot"],
       "settings": {
-        "foreground": "#8b4e2f"
+        "foreground": "#2A6B61"
       }
     },
     {
       "scope": ["constant.language.boolean", "constant.language.boolean.verity"],
       "settings": {
-        "foreground": "#8b4e2f",
+        "foreground": "#0B6E62",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["keyword.declaration.contract.verity", "keyword.declaration.function.verity", "keyword.declaration.modifier.verity", "keyword.declaration.external.verity", "keyword.other.section.verity", "keyword.other.section.linked-externals.verity"],
       "settings": {
-        "foreground": "#7b3f32",
+        "foreground": "#0B6E62",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["keyword.control.modifier-clause.verity", "storage.modifier.verity", "storage.modifier.reentrancy.verity"],
       "settings": {
-        "foreground": "#875c24",
+        "foreground": "#3D8579",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["keyword.control.do.verity", "keyword.control.lean.verity", "keyword.operator.assignment.verity"],
       "settings": {
-        "foreground": "#8b7663"
+        "foreground": "#6F807C"
       }
     },
     {
       "scope": ["keyword.operator", "punctuation.definition.parameters", "punctuation.separator", "punctuation.accessor.verity"],
       "settings": {
-        "foreground": "#8b7663"
+        "foreground": "#6F807C"
       }
     },
     {
       "scope": ["entity.name.type.contract.verity", "storage.type.verity", "support.type"],
       "settings": {
-        "foreground": "#715a36",
+        "foreground": "#1F5F58",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["entity.name.function.verity"],
       "settings": {
-        "foreground": "#2f6c67"
+        "foreground": "#283531"
       }
     },
     {
       "scope": ["entity.name.function.external.verity"],
       "settings": {
-        "foreground": "#6f5631",
+        "foreground": "#1F5F58",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["entity.name.function.modifier.verity"],
       "settings": {
-        "foreground": "#7a5527",
+        "foreground": "#3D8579",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["support.function.guard.verity"],
       "settings": {
-        "foreground": "#a34537",
+        "foreground": "#B14A3A",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["support.function.external-call.verity"],
       "settings": {
-        "foreground": "#6f5631",
+        "foreground": "#1F5F58",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["support.function.event.verity"],
       "settings": {
-        "foreground": "#3f7456",
+        "foreground": "#0F8E7E",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["support.function.loop.verity"],
       "settings": {
-        "foreground": "#7b5b33",
+        "foreground": "#1F5F58",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["support.function.abi.verity"],
       "settings": {
-        "foreground": "#7f5831",
+        "foreground": "#1F5F58",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["support.function.storage.verity", "support.function.context.verity", "support.function.arithmetic.verity", "support.function.spec.verity"],
       "settings": {
-        "foreground": "#2f6c67",
+        "foreground": "#0F8E7E",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["entity.name.exception.custom-error.verity"],
       "settings": {
-        "foreground": "#a34537",
+        "foreground": "#B14A3A",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["variable.other.property.verity"],
       "settings": {
-        "foreground": "#785b1f",
+        "foreground": "#3D8579",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["variable.other.storage.verity", "variable.language.verity", "variable.other"],
       "settings": {
-        "foreground": "#4f463b"
+        "foreground": "#2A3633"
       }
     },
     {
       "scope": ["meta.block.linked-externals.verity"],
       "settings": {
-        "foreground": "#655b4d"
+        "foreground": "#5E6E6A"
       }
     },
     {
       "scope": ["source.lean keyword", "keyword.declaration.lean.verity"],
       "settings": {
-        "foreground": "#7b3f32",
+        "foreground": "#0B6E62",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["source.lean entity.name.function", "support.function.tactic.verity"],
       "settings": {
-        "foreground": "#2f6c67"
+        "foreground": "#283531"
       }
     },
 
@@ -200,7 +200,7 @@
         "keyword.control.for"
       ],
       "settings": {
-        "foreground": "#7b3f32",
+        "foreground": "#0B6E62",
         "fontStyle": "bold"
       }
     },
@@ -213,7 +213,7 @@
         "storage.modifier.is"
       ],
       "settings": {
-        "foreground": "#875c24",
+        "foreground": "#3D8579",
         "fontStyle": "bold"
       }
     },
@@ -222,7 +222,7 @@
         "support.type.primitive"
       ],
       "settings": {
-        "foreground": "#715a36",
+        "foreground": "#1F5F58",
         "fontStyle": "bold"
       }
     },
@@ -239,7 +239,7 @@
         "entity.name.type.userType"
       ],
       "settings": {
-        "foreground": "#6f5631",
+        "foreground": "#1F5F58",
         "fontStyle": "bold"
       }
     },
@@ -249,7 +249,7 @@
         "entity.name.function.modifier"
       ],
       "settings": {
-        "foreground": "#2f6c67"
+        "foreground": "#283531"
       }
     },
     {
@@ -260,7 +260,7 @@
         "keyword.control.contract"
       ],
       "settings": {
-        "foreground": "#a34537",
+        "foreground": "#B14A3A",
         "fontStyle": "bold"
       }
     },
@@ -271,7 +271,7 @@
         "variable.parameter.other"
       ],
       "settings": {
-        "foreground": "#4f463b"
+        "foreground": "#2A3633"
       }
     },
     {
@@ -279,7 +279,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#785b1f"
+        "foreground": "#3D8579"
       }
     },
     {
@@ -291,7 +291,7 @@
         "variable.language.type"
       ],
       "settings": {
-        "foreground": "#875c24",
+        "foreground": "#3D8579",
         "fontStyle": "bold"
       }
     },
@@ -305,7 +305,7 @@
         "constant.language.time"
       ],
       "settings": {
-        "foreground": "#8b4e2f"
+        "foreground": "#2A6B61"
       }
     },
     {
@@ -314,7 +314,7 @@
         "string.quoted.single"
       ],
       "settings": {
-        "foreground": "#6b6f32"
+        "foreground": "#2A6B61"
       }
     },
     {
@@ -326,7 +326,7 @@
         "keyword.operator.binary"
       ],
       "settings": {
-        "foreground": "#8b7663"
+        "foreground": "#6F807C"
       }
     }
   ],

--- a/docs-site/themes/verity-dark.json
+++ b/docs-site/themes/verity-dark.json
@@ -3,105 +3,105 @@
   "name": "Verity Dark",
   "type": "dark",
   "colors": {
-    "editor.background": "#15140F",
-    "editor.foreground": "#E6E1D5",
-    "editorLineNumber.foreground": "#6F634E",
-    "editor.selectionBackground": "#3A3324",
-    "editor.inactiveSelectionBackground": "#262116"
+    "editor.background": "#0A1311",
+    "editor.foreground": "#DDE8E5",
+    "editorLineNumber.foreground": "#6B7B77",
+    "editor.selectionBackground": "#1B3631",
+    "editor.inactiveSelectionBackground": "#152825"
   },
   "tokenColors": [
     {
       "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
-        "foreground": "#AFA389",
+        "foreground": "#7E8C88",
         "fontStyle": "italic"
       }
     },
     {
       "scope": ["string", "string.quoted.double", "string.quoted.double.verity"],
       "settings": {
-        "foreground": "#D8C56E"
+        "foreground": "#A3E1D4"
       }
     },
     {
       "scope": ["constant.numeric", "constant.numeric.hex", "constant.numeric.decimal", "constant.numeric.storage-slot", "constant.language.boolean", "constant.language.boolean.verity"],
       "settings": {
-        "foreground": "#E9B06D",
+        "foreground": "#7DD3C0",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["keyword", "keyword.declaration.contract.verity", "keyword.declaration.function.verity", "keyword.declaration.modifier.verity", "keyword.declaration.external.verity", "keyword.other.section.verity", "keyword.other.section.linked-externals.verity", "keyword.declaration.lean.verity", "source.lean keyword"],
       "settings": {
-        "foreground": "#F0C46F",
+        "foreground": "#5EEAD4",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["keyword.control.modifier-clause.verity", "storage.modifier.verity", "storage.modifier.reentrancy.verity", "keyword.control.do.verity", "keyword.control.lean.verity", "keyword.operator.assignment.verity", "keyword.operator", "punctuation.definition.parameters", "punctuation.separator", "punctuation.accessor.verity"],
       "settings": {
-        "foreground": "#D8B989"
+        "foreground": "#9BB0AC"
       }
     },
     {
       "scope": ["entity.name.type.contract.verity", "storage.type.verity", "support.type", "entity.name.type", "storage.type"],
       "settings": {
-        "foreground": "#E5C98A",
+        "foreground": "#A3E1D4",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["entity.name.function.verity", "source.lean entity.name.function", "support.function.tactic.verity", "support.function.storage.verity", "support.function.context.verity", "support.function.arithmetic.verity", "support.function.spec.verity"],
       "settings": {
-        "foreground": "#D8B989",
+        "foreground": "#C2D5D0",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["entity.name.function.external.verity", "support.function.external-call.verity"],
       "settings": {
-        "foreground": "#E9B06D",
+        "foreground": "#7DD3C0",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["entity.name.function.event.verity", "support.function.event.verity"],
       "settings": {
-        "foreground": "#C9A961",
+        "foreground": "#82E0CC",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["entity.name.function.modifier.verity", "variable.other.property.verity"],
       "settings": {
-        "foreground": "#F3D38C",
+        "foreground": "#A3E1D4",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["support.function.guard.verity", "entity.name.exception.custom-error.verity"],
       "settings": {
-        "foreground": "#F0A070",
+        "foreground": "#F0A48F",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["support.function.loop.verity", "support.function.abi.verity"],
       "settings": {
-        "foreground": "#D6B36F",
+        "foreground": "#9BB0AC",
         "fontStyle": "bold"
       }
     },
     {
       "scope": ["variable.other.storage.verity", "variable.language.verity", "variable.other", "identifier"],
       "settings": {
-        "foreground": "#D9D0C0"
+        "foreground": "#C7D5D1"
       }
     },
     {
       "scope": ["meta.block.linked-externals.verity"],
       "settings": {
-        "foreground": "#C7BDA4"
+        "foreground": "#9BB0AC"
       }
     },
 
@@ -127,7 +127,7 @@
         "keyword.control.for"
       ],
       "settings": {
-        "foreground": "#E5C98A",
+        "foreground": "#5EEAD4",
         "fontStyle": "bold"
       }
     },
@@ -140,7 +140,7 @@
         "storage.modifier.is"
       ],
       "settings": {
-        "foreground": "#D8B989",
+        "foreground": "#A3E1D4",
         "fontStyle": "bold"
       }
     },
@@ -149,7 +149,7 @@
         "support.type.primitive"
       ],
       "settings": {
-        "foreground": "#D8B989",
+        "foreground": "#A3E1D4",
         "fontStyle": "bold"
       }
     },
@@ -166,7 +166,7 @@
         "entity.name.type.userType"
       ],
       "settings": {
-        "foreground": "#D6B36F",
+        "foreground": "#7DD3C0",
         "fontStyle": "bold"
       }
     },
@@ -187,7 +187,7 @@
         "keyword.control.contract"
       ],
       "settings": {
-        "foreground": "#E5A98A",
+        "foreground": "#F0A48F",
         "fontStyle": "bold"
       }
     },
@@ -198,7 +198,7 @@
         "variable.parameter.other"
       ],
       "settings": {
-        "foreground": "#D9D0C0"
+        "foreground": "#C7D5D1"
       }
     },
     {
@@ -206,7 +206,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#C9A961"
+        "foreground": "#82E0CC"
       }
     },
     {
@@ -218,7 +218,7 @@
         "variable.language.type"
       ],
       "settings": {
-        "foreground": "#E5C98A",
+        "foreground": "#A3E1D4",
         "fontStyle": "bold"
       }
     },
@@ -232,7 +232,7 @@
         "constant.language.time"
       ],
       "settings": {
-        "foreground": "#C9A961"
+        "foreground": "#82E0CC"
       }
     },
     {
@@ -241,7 +241,7 @@
         "string.quoted.single"
       ],
       "settings": {
-        "foreground": "#A7E39B"
+        "foreground": "#A3E1D4"
       }
     },
     {
@@ -253,7 +253,7 @@
         "keyword.operator.binary"
       ],
       "settings": {
-        "foreground": "#B8AA95"
+        "foreground": "#9BB0AC"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Re-skins the docs site around the cool **teal "sarcelle"** accent used by [lfglabs.dev](https://lfglabs.dev) (`#2DD4BF`) and reshapes it into a typography-first, research-paper aesthetic. Pairs that with a sweep of mobile-UX fixes the previous theme had let slip.

🚀 **Live preview**: deployed to https://veritylang.com from this branch.

## What changed

### Palette + typography
- Cool LaTeX preprint palette: paper-white surface, slate ink, deep teal §-markers and links (light); deep cold slate with phosphor-teal accent in dark.
- Both shiki theme files rewritten in cold-teal token sets so Solidity / Verity / Lean code blocks no longer carry the previous warm cream colors.
- Hero kicker gets a hairline accent rule (journal-masthead feel); the italic `em` inside the hero dek inherits the strong-teal accent so "Prove them correct" reads with quiet emphasis.
- Active sidebar / TOC entry gains a stronger teal wash + bold weight.
- "Last updated on …" footer becomes a journal-colophon line (hairline rule, right-align, italic small-tracking).
- Wordmark gets tighter kerning and a teal hover tint so it behaves like a link.

### Mobile UX
| Before | After |
|---|---|
| desktop-only sidebar-edge stripe bled a dark strip down the left of phones | stripe disabled below 767px |
| right-anchored §-N marker collided with right-anchored Copy-page widget on h2s | §-marker hidden on phones, narrowed at intermediate widths |
| CTAs floated; small tap targets | full-width CTAs with min-height 2.85rem |
| inline code chips pushed paragraphs past the gutter | inline chips wrap on long identifiers via overflow-wrap: anywhere |
| code-switcher header crammed on narrow widths | header stacks; panel min/max heights tuned for one-screen viewing |
| no scroll affordance on horizontally-scrolling code | 1.75rem right-edge fade |

### Other polish
- Faceted V logo lifted in dark mode via a tinted invert filter so the mark reads as cold metal instead of charcoal.
- Quiet teal hover wash on table rows.
- Themed search-results popover (paper-surface panel, teal mark highlight, soft-teal hover/selected).
- 6px teal-tinted thin scrollbar on overflowing code blocks.
- Unified 2px teal :focus-visible ring across links / buttons / tabs for keyboard a11y.
- Richer OpenGraph + Twitter card metadata so links to veritylang.com unfurl properly in Slack / X / Discord.

## Scope

Pure restyle — no component or content changes beyond the layout's metadata block. All design happens through CSS variables, so the palette can be swapped again with a single block edit.

## Test plan
- [x] Verified light + dark on desktop (1440×900) across /, /getting-started, /verification, /research, /compiler, /examples, /edsl-api-reference, /add-contract, /core
- [x] Verified the same set on mobile (390×844)
- [x] Verified tablet widths (768, 1024) on the home, verification, getting-started pages
- [x] Verified mobile drawer (hamburger) in both themes
- [x] Verified code blocks (Solidity, Verity, Lean) under the new shiki themes
- [x] Verified active sidebar/TOC highlighting
- [x] Verified production deploy at https://veritylang.com
- [ ] Visual spot check after team review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly CSS/theme changes, but adds `robots`/`sitemap` routes and rewrites site metadata which can affect search indexing and link previews if misconfigured.
> 
> **Overview**
> Applies a new cold-teal, typography-first visual theme across the docs via updated design tokens and extensive CSS tweaks for navigation, hero, tables, code blocks, search popovers, focus rings, and responsive/mobile behavior (including print styles).
> 
> Updates Shiki syntax highlighting themes to match the new palette (renaming the light theme and retuning both light/dark token colors), and enhances site SEO/link unfurling by expanding `metadata` plus adding Next.js `robots` and `sitemap` route implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac7755777cfaca285355f9f0e13c17bb519c5ae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->