### PR TITLE
Remove leave-aware dispatcher continuation

### DIFF
--- a/Compiler/CodegenCommon.lean
+++ b/Compiler/CodegenCommon.lean
@@ -48,6 +48,12 @@ private def yulReturnRuntime : YulStmt :=
     YulExpr.call "datasize" [YulExpr.str "runtime"]
   ])
 
+def initFreeMemoryPointer : YulStmt :=
+  YulStmt.expr (YulExpr.call "mstore" [
+    YulExpr.lit Compiler.Constants.freeMemoryPointer,
+    YulExpr.lit 128
+  ])
+
 def mappingSlotFuncAt (scratchBase : Nat) : YulStmt :=
   let keyPtr := scratchBase
   let slotPtr := scratchBase + 32
@@ -134,7 +140,7 @@ def buildSwitch
 def runtimeCode (contract : IRContract) : List YulStmt :=
   let mapping := if contract.usesMapping then [mappingSlotFuncAt 0] else []
   let internals := contract.internalFunctions
-  mapping ++ internals ++ [buildSwitch contract.functions contract.fallbackEntrypoint contract.receiveEntrypoint]
+  mapping ++ internals ++ [initFreeMemoryPointer, buildSwitch contract.functions contract.fallbackEntrypoint contract.receiveEntrypoint]
 
 private def profileSortsOutput (profile : BackendProfile) : Bool :=
   match profile with
@@ -174,14 +180,14 @@ private def runtimeCodeWithEmitOptions (contract : IRContract) (options : YulEmi
   let internals := internalHelpersForProfile options.backendProfile contract.internalFunctions
   let sortCases := profileSortsDispatchCases options.backendProfile
   let switchStmt := buildSwitch contract.functions contract.fallbackEntrypoint contract.receiveEntrypoint sortCases
-  mapping ++ internals ++ [switchStmt]
+  mapping ++ internals ++ [initFreeMemoryPointer, switchStmt]
 
 private def deployCodeWithProfile (contract : IRContract) (profile : BackendProfile)
     (mappingSlotScratchBase : Nat := 0) : List YulStmt :=
   let valueGuard := if contract.constructorPayable then [] else [callvalueGuard]
   let mapping := if contract.usesMapping then [mappingSlotFuncAt mappingSlotScratchBase] else []
   let internals := internalHelpersForProfile profile contract.internalFunctions
-  valueGuard ++ mapping ++ internals ++ contract.deploy ++ [yulDatacopy, yulReturnRuntime]
+  [initFreeMemoryPointer] ++ valueGuard ++ mapping ++ internals ++ contract.deploy ++ [yulDatacopy, yulReturnRuntime]
 
 private def deployCode (contract : IRContract) : List YulStmt :=
   deployCodeWithProfile contract .semantic

--- a/Compiler/Proofs/EndToEnd.lean
+++ b/Compiler/Proofs/EndToEnd.lean
@@ -20268,86 +20268,6 @@ private theorem NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevivedLeaveAw
     (NativeGeneratedSelectorHitUserBodyPreservesBridgeAtFuelRevived.of_leave_body
       irContract tx hLeave)
 
-/-- Pre-packaged type of the dispatcher continuation that
-`nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFuel_revivedLeaveAware_and_continuation`
-expects at its `hCont` parameter — the leave-aware version that takes
-`NativeBlockPreservesWord_revived` at the matched-flag position.
-
-E2/E4/E6 SuccessBridge chains take this as a hypothesis (TODO: build a
-parallel `_revived`-aware dispatcher continuation provider mirroring
-`nativeGeneratedCallDispatcherResult_selector_hit_ok_matchesIR_forall_of_compile_ok_supported`
-so callers can discharge it automatically). -/
-private def LeaveAwareCallDispatcherContinuation
-    (irContract : IRContract)
-    (tx : IRTransaction)
-    (state : IRState)
-    (observableSlots : List Nat) : Prop :=
-  ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
-    (reservedNames : List String) (n0 : Nat)
-    (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
-    (body' bodyNative : List EvmYul.Yul.Ast.Stmt)
-    (bodyStart bodyEnd userBodyStart : Nat),
-    Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
-        (Compiler.emitYul irContract).runtimeCode = .ok nativeContract →
-    irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
-        some fn →
-    cases'.find? (fun entry => entry.1 == tx.functionSelector) =
-        some (tx.functionSelector, body') →
-    Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
-        reservedNames bodyStart
-        (Compiler.Proofs.YulGeneration.Backends.Native.switchCaseBody fn) =
-          .ok (body', bodyEnd) →
-    Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
-        reservedNames userBodyStart fn.body =
-          .ok (bodyNative, bodyEnd) →
-    ∀ (final : EvmYul.Yul.State) (nativeYul : YulResult),
-      (∀ pre suffix,
-        cases' = pre ++ (tx.functionSelector, body') :: suffix →
-        EvmYul.Yul.exec
-          (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
-            suffix.length + 10)
-          (.Block bodyNative)
-          (some nativeContract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-            nativeContract
-            (YulTransaction.ofIR tx)
-            state.storage
-            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-              (Compiler.runtimeCode irContract) observableSlots)
-            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
-              reservedNames n0)
-            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
-          .ok final) →
-      (∀ pre suffix,
-        cases' = pre ++ (tx.functionSelector, body') :: suffix →
-        Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_revived
-          (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
-            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
-              reservedNames n0))
-          (EvmYul.UInt256.ofNat 1) bodyNative
-          (some nativeContract)) →
-      Compiler.Proofs.YulGeneration.Backends.Native.projectResult
-        (YulTransaction.ofIR tx) state.storage state.events
-        (.ok
-          (((final.reviveJump.overwrite?
-            (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-              nativeContract
-              (YulTransaction.ofIR tx) state.storage
-              (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-                (Compiler.runtimeCode irContract) observableSlots))).setStore
-            (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-              nativeContract
-              (YulTransaction.ofIR tx) state.storage
-              (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-                (Compiler.runtimeCode irContract) observableSlots))), [])) =
-        nativeYul →
-      nativeResultsMatchOn observableSlots
-        (interpretIR irContract tx state) (.ok nativeYul) →
-      nativeResultsMatchOn observableSlots
-        (interpretIR irContract tx state)
-        (nativeGeneratedCallDispatcherResultOf irContract tx state
-          observableSlots nativeContract)
-
 /-- One-shot constructor for the leave-aware revived exec bridge for the
 `[.block [.leave]]` body shape. Composes the existing exec-only
 `of_block_leave` leaf with the `_revived` Preserves bridge `of_block_leave`. -/
@@ -21939,72 +21859,6 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
     (hUserBodyBridge :
       NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevivedLeaveAware irContract tx
         state observableSlots)
-    (hCont :
-      ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
-        (reservedNames : List String) (n0 : Nat)
-        (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
-        (body' bodyNative : List EvmYul.Yul.Ast.Stmt)
-        (bodyStart bodyEnd userBodyStart : Nat),
-        Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
-            (Compiler.emitYul irContract).runtimeCode = .ok nativeContract →
-        irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
-            some fn →
-        cases'.find? (fun entry => entry.1 == tx.functionSelector) =
-            some (tx.functionSelector, body') →
-        Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
-            reservedNames bodyStart
-            (Compiler.Proofs.YulGeneration.Backends.Native.switchCaseBody fn) =
-              .ok (body', bodyEnd) →
-        Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
-            reservedNames userBodyStart fn.body =
-              .ok (bodyNative, bodyEnd) →
-        ∀ (final : EvmYul.Yul.State) (nativeYul : YulResult),
-          (∀ pre suffix,
-            cases' = pre ++ (tx.functionSelector, body') :: suffix →
-            EvmYul.Yul.exec
-              (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
-                suffix.length + 10)
-              (.Block bodyNative)
-              (some nativeContract)
-              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-                nativeContract
-                (YulTransaction.ofIR tx)
-                state.storage
-                (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-                  (Compiler.runtimeCode irContract) observableSlots)
-                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
-                  reservedNames n0)
-                Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
-              .ok final) →
-          (∀ pre suffix,
-            cases' = pre ++ (tx.functionSelector, body') :: suffix →
-            Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_revived
-              (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
-                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
-                  reservedNames n0))
-              (EvmYul.UInt256.ofNat 1) bodyNative
-              (some nativeContract)) →
-          Compiler.Proofs.YulGeneration.Backends.Native.projectResult
-            (YulTransaction.ofIR tx) state.storage state.events
-            (.ok
-              (((final.reviveJump.overwrite?
-                (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                  nativeContract
-                  (YulTransaction.ofIR tx) state.storage
-                  (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-                    (Compiler.runtimeCode irContract) observableSlots))).setStore
-                (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                  nativeContract
-                  (YulTransaction.ofIR tx) state.storage
-                  (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-                    (Compiler.runtimeCode irContract) observableSlots))), [])) =
-            nativeYul →
-          nativeResultsMatchOn observableSlots
-            (interpretIR irContract tx state) (.ok nativeYul) →
-          nativeResultsMatchOn observableSlots
-            (interpretIR irContract tx state)
-            (nativeGeneratedCallDispatcherResultOf irContract tx state
-              observableSlots nativeContract))
     (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
     (hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -22018,21 +21872,26 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       (interpretIR irContract tx state)
       (nativeGeneratedCallDispatcherResultOf irContract tx state
         observableSlots nativeContract) := by
-  let dummyNativeState : EvmYul.Yul.State :=
-    (inferInstance : Inhabited EvmYul.Yul.State).default
-  let dummyYul : YulResult :=
-    { success := false
-      returnValue := none
-      finalStorage := state.storage
-      finalMappings := Compiler.Proofs.storageAsMappings state.storage
-      events := state.events }
   rcases
-    nativeGeneratedCallDispatcherResult_selector_hit_ok_matchesIR_of_compile_ok_supported
+    nativeGeneratedCallDispatcherResult_selector_hit_ok_matchesIR_forall_of_compile_ok_supported_finalMatched
       spec selectors hSupported irContract tx state observableSlots nativeContract
-      fn dummyNativeState dummyYul hcompile hLowerRuntime hFind hSelectorRange
-      hSelectorsRange hNoWrap with
+      fn hcompile hLowerRuntime hFind hSelectorRange hSelectorsRange hNoWrap with
     ⟨reservedNames, n0, cases', _hCaseMidN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, _hCaseCont⟩
+      hLowerCases, hCase, hBodyLower, hCaseCont⟩
+  have hFuelBound24 :
+      cases'.length + 24 ≤ nativeRuntimeDispatcherFuel irContract := by
+    dsimp [nativeRuntimeDispatcherFuel]
+    by_cases hUsesMapping : irContract.usesMapping
+    · have hMapping : irContract.usesMapping = true := by
+        simpa using hUsesMapping
+      exact
+        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
+          hcompile hSupported hMapping hLowerCases
+    · have hNoMapping : irContract.usesMapping = false :=
+        Bool.eq_false_iff.2 hUsesMapping
+      exact
+        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
+          hcompile hSupported hNoMapping hLowerCases
   have hProjectRestored
       (final : EvmYul.Yul.State) (nativeYul : YulResult)
       (shared : EvmYul.SharedState EvmYul.OperationType.Yul)
@@ -22101,16 +21960,117 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNativeWithSwitchIds_switchCaseBody_payable_eq
         reservedNames bodyStart fn body' bodyEnd
         (by simpa using hPayable) hBodyLower with
-      ⟨_guardBody, bodyNative, userBodyStart, _hBodyShape, hUserBodyLower⟩
+      ⟨guardBody, bodyNative, userBodyStart, hBodyShape, hUserBodyLower⟩
     rcases hUserBodyBridge nativeContract fn reservedNames n0 cases' body'
         bodyNative bodyStart bodyEnd userBodyStart hLowerRuntime hFind hCase
         hBodyLower hUserBodyLower hguards hArgs with
       ⟨final, nativeYul, shared, store, hBody, hPreserves, hRevive,
         hProject, hMatchExec⟩
+    have hCaseBody :
+        ∀ pre suffix,
+          cases' = pre ++ (tx.functionSelector, body') :: suffix →
+          EvmYul.Yul.exec
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+                1) + suffix.length + 7) (.Block body')
+            (some nativeContract)
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              nativeContract
+              (YulTransaction.ofIR tx)
+              state.storage
+              (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                (Compiler.runtimeCode irContract) observableSlots)
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames n0)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
+            .ok final := by
+      intro pre suffix hCases
+      rw [hBodyShape]
+      have hPrefix :=
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_eq
+          (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
+            suffix.length + 1)
+          guardBody bodyNative nativeContract (YulTransaction.ofIR tx)
+          state.storage
+          (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+            (Compiler.runtimeCode irContract) observableSlots)
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+            reservedNames n0)
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+          (4 + fn.params.length * 32)
+          (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+          (Compiler.Proofs.YulGeneration.Backends.Native.DispatchGuardsSafe_calldata_threshold_lt
+            fn tx hguards)
+          (by
+            have hMul : fn.params.length * 32 ≤ tx.args.length * 32 :=
+              Nat.mul_le_mul_right 32 hArgs
+            exact Nat.add_le_add_left hMul 4)
+      have hFuelEq :
+          suffix.length +
+              (1 + (11 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 23)))) =
+            suffix.length +
+              (1 + (7 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 19)))) := by
+        have hBound23 : cases'.length + 23 ≤
+            nativeRuntimeDispatcherFuel irContract := by
+          omega
+        omega
+      simpa [nativeGeneratedSelectorHitUserBodyFuel, hPayable,
+        Nat.add_assoc, Nat.add_comm, Nat.add_left_comm, hFuelEq] using
+        hPrefix.trans (hBody pre suffix hCases)
+    have hFinalMatched :
+        ∀ matchedName : EvmYul.Identifier,
+          matchedName =
+              Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames n0) →
+            final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+      intro matchedName hMatchedName
+      subst matchedName
+      have hMem := List.mem_of_find?_eq_some hCase
+      rw [List.mem_iff_append] at hMem
+      rcases hMem with ⟨pre, suffix, hCases⟩
+      let switchId :=
+        Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0
+      let selectedState :=
+        Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+          nativeContract
+          (YulTransaction.ofIR tx)
+          state.storage
+          (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+            (Compiler.runtimeCode irContract) observableSlots)
+          switchId
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+      let matchedName : EvmYul.Identifier :=
+        Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName switchId
+      have hInitialMatched :
+          selectedState.reviveJump[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+        have hRaw :=
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_matched
+            nativeContract (YulTransaction.ofIR tx) state.storage
+            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (Compiler.runtimeCode irContract) observableSlots)
+            switchId
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+            matchedName rfl
+        have hReviveSelected :=
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_reviveJump_eq
+            nativeContract (YulTransaction.ofIR tx) state.storage
+            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (Compiler.runtimeCode irContract) observableSlots)
+            switchId
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+        simpa [selectedState, hReviveSelected] using hRaw
+      exact
+        Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchMatchedFlag_of_revived_body_final
+          switchId matchedName
+          bodyNative (some nativeContract) selectedState final
+          (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
+            suffix.length + 10)
+          shared store rfl (hPreserves pre suffix hCases)
+          hInitialMatched (hBody pre suffix hCases) hRevive
     exact
-      hCont nativeContract fn reservedNames n0 cases' body' bodyNative
-        bodyStart bodyEnd userBodyStart hLowerRuntime hFind hCase hBodyLower
-        hUserBodyLower final nativeYul hBody hPreserves
+      hCaseCont final nativeYul hCaseBody hFinalMatched
         (hProjectRestored final nativeYul shared store hRevive hProject)
         (nativeResultsMatchOn_interpretIR_of_execIRFunction_dispatchGuards
           irContract tx state observableSlots fn (.ok nativeYul) hFind
@@ -22119,17 +22079,118 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
     rcases
       Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNativeWithSwitchIds_switchCaseBody_nonpayable_eq
         reservedNames bodyStart fn body' bodyEnd hNonPayable hBodyLower with
-      ⟨_callvalueGuardBody, _calldataGuardBody, bodyNative, userBodyStart,
-        _hBodyShape, hUserBodyLower⟩
+      ⟨callvalueGuardBody, calldataGuardBody, bodyNative, userBodyStart,
+        hBodyShape, hUserBodyLower⟩
     rcases hUserBodyBridge nativeContract fn reservedNames n0 cases' body'
         bodyNative bodyStart bodyEnd userBodyStart hLowerRuntime hFind hCase
         hBodyLower hUserBodyLower hguards hArgs with
       ⟨final, nativeYul, shared, store, hBody, hPreserves, hRevive,
         hProject, hMatchExec⟩
+    have hCaseBody :
+        ∀ pre suffix,
+          cases' = pre ++ (tx.functionSelector, body') :: suffix →
+          EvmYul.Yul.exec
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+                1) + suffix.length + 7) (.Block body')
+            (some nativeContract)
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              nativeContract
+              (YulTransaction.ofIR tx)
+              state.storage
+              (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                (Compiler.runtimeCode irContract) observableSlots)
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames n0)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
+            .ok final := by
+      intro pre suffix hCases
+      rw [hBodyShape]
+      have hPrefix :=
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_eq
+          (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
+            suffix.length + 1)
+          callvalueGuardBody calldataGuardBody bodyNative nativeContract
+          (YulTransaction.ofIR tx) state.storage
+          (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+            (Compiler.runtimeCode irContract) observableSlots)
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+            reservedNames n0)
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+          (4 + fn.params.length * 32)
+          (Compiler.Proofs.YulGeneration.Backends.Native.DispatchGuardsSafe_msgValue_zero_mod_of_nonpayable
+            fn tx hguards hNonPayable)
+          (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+          (Compiler.Proofs.YulGeneration.Backends.Native.DispatchGuardsSafe_calldata_threshold_lt
+            fn tx hguards)
+          (by
+            have hMul : fn.params.length * 32 ≤ tx.args.length * 32 :=
+              Nat.mul_le_mul_right 32 hArgs
+            exact Nat.add_le_add_left hMul 4)
+      have hFuelEq :
+          suffix.length +
+              (1 + (12 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 24)))) =
+            suffix.length +
+              (1 + (7 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 19)))) := by
+        have hBound24 := hFuelBound24
+        omega
+      simpa [nativeGeneratedSelectorHitUserBodyFuel, hNonPayable,
+        Nat.add_assoc, Nat.add_comm, Nat.add_left_comm, hFuelEq] using
+        hPrefix.trans (hBody pre suffix hCases)
+    have hFinalMatched :
+        ∀ matchedName : EvmYul.Identifier,
+          matchedName =
+              Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames n0) →
+            final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+      intro matchedName hMatchedName
+      subst matchedName
+      have hMem := List.mem_of_find?_eq_some hCase
+      rw [List.mem_iff_append] at hMem
+      rcases hMem with ⟨pre, suffix, hCases⟩
+      let switchId :=
+        Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0
+      let selectedState :=
+        Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+          nativeContract
+          (YulTransaction.ofIR tx)
+          state.storage
+          (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+            (Compiler.runtimeCode irContract) observableSlots)
+          switchId
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+      let matchedName : EvmYul.Identifier :=
+        Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName switchId
+      have hInitialMatched :
+          selectedState.reviveJump[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+        have hRaw :=
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_matched
+            nativeContract (YulTransaction.ofIR tx) state.storage
+            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (Compiler.runtimeCode irContract) observableSlots)
+            switchId
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+            matchedName rfl
+        have hReviveSelected :=
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_reviveJump_eq
+            nativeContract (YulTransaction.ofIR tx) state.storage
+            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (Compiler.runtimeCode irContract) observableSlots)
+            switchId
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+        simpa [selectedState, hReviveSelected] using hRaw
+      exact
+        Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchMatchedFlag_of_revived_body_final
+          switchId matchedName
+          bodyNative (some nativeContract) selectedState final
+          (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
+            suffix.length + 10)
+          shared store rfl (hPreserves pre suffix hCases)
+          hInitialMatched (hBody pre suffix hCases) hRevive
     exact
-      hCont nativeContract fn reservedNames n0 cases' body' bodyNative
-        bodyStart bodyEnd userBodyStart hLowerRuntime hFind hCase hBodyLower
-        hUserBodyLower final nativeYul hBody hPreserves
+      hCaseCont final nativeYul hCaseBody hFinalMatched
         (hProjectRestored final nativeYul shared store hRevive hProject)
         (nativeResultsMatchOn_interpretIR_of_execIRFunction_dispatchGuards
           irContract tx state observableSlots fn (.ok nativeYul) hFind
@@ -23354,12 +23415,8 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_bridgedStraightStmts_
 /-- F2 (label-prefix variant of E2): Selected user bodies of shape
 `[.block [], .leave]` supply the named selector-hit success bridge.
 
-CONDITIONAL: takes a body-shape-specific `ExecBridgeAtFuelRevivedLeaveAware`
-and the `LeaveAwareCallDispatcherContinuation` as hypotheses. The body-shape
-ExecBridge for `[.block [], .leave]` is TODO — needs a lift via
-`exec_block_noop_block_head_eq` (peel the `.Block []` head and reduce to the
-existing `ExecBridgeAtFuelRevivedLeaveAware.of_leave_body`). ~80-100 LoC of
-proof engineering. -/
+DIRECT: the body-shape-specific `ExecBridgeAtFuelRevivedLeaveAware` is
+composed with the generated final-matched dispatcher endpoint. -/
 private theorem NativeGeneratedSelectorHitSuccessBridge.of_leave_body_with_label_prefix
     (spec : CompilationModel.CompilationModel) (selectors : List Nat)
     (hSupported : SupportedSpec spec selectors)
@@ -23377,8 +23434,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_leave_body_with_label
       ∀ fn,
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
-        fn.body = [.block [], .leave])
-    (hCont : LeaveAwareCallDispatcherContinuation irContract tx state observableSlots) :
+        fn.body = [.block [], .leave]) :
     NativeGeneratedSelectorHitSuccessBridge irContract tx state
       observableSlots := by
   intro nativeContract fn hLowerRuntime hFind hguards hArgs
@@ -23388,7 +23444,6 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_leave_body_with_label
       hSelectorRange hSelectorsRange hNoWrap
       (NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevivedLeaveAware.of_leave_body_with_label_prefix
         irContract tx state observableSlots hLabelLeave)
-      hCont
       nativeContract fn hLowerRuntime hFind hguards hArgs
 
 /-- F4 (label-prefix variant of E4): Selected user bodies of shape
@@ -23396,8 +23451,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_leave_body_with_label
 
 DIRECT (no `hExecBridge` hypothesis): composes the F4 LeaveAware ExecBridge
 (`of_block_leave_with_label_prefix`) with the
-`revivedLeaveAware_and_continuation` consumer. Only requires the standard
-`LeaveAwareCallDispatcherContinuation` hypothesis. -/
+`revivedLeaveAware_and_continuation` consumer. -/
 private theorem NativeGeneratedSelectorHitSuccessBridge.of_block_leave_with_label_prefix
     (spec : CompilationModel.CompilationModel) (selectors : List Nat)
     (hSupported : SupportedSpec spec selectors)
@@ -23415,8 +23469,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_block_leave_with_labe
       ∀ fn,
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
-        fn.body = [.block [], .block [.leave]])
-    (hCont : LeaveAwareCallDispatcherContinuation irContract tx state observableSlots) :
+        fn.body = [.block [], .block [.leave]]) :
     NativeGeneratedSelectorHitSuccessBridge irContract tx state
       observableSlots := by
   intro nativeContract fn hLowerRuntime hFind hguards hArgs
@@ -23426,7 +23479,6 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_block_leave_with_labe
       hSelectorRange hSelectorsRange hNoWrap
       (NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevivedLeaveAware.of_block_leave_with_label_prefix
         irContract tx state observableSlots hLabelBlockLeave)
-      hCont
       nativeContract fn hLowerRuntime hFind hguards hArgs
 
 /-- F6 (label-prefix variant of E6, degenerate): Selected user bodies of shape
@@ -23454,29 +23506,20 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_nativePreservableStra
     (hBody : ∀ fn,
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
             some fn →
-        fn.body = .block [] :: preStmts ++ [.leave])
-    (hCont : LeaveAwareCallDispatcherContinuation irContract tx state observableSlots) :
+        fn.body = .block [] :: preStmts ++ [.leave]) :
     NativeGeneratedSelectorHitSuccessBridge irContract tx state
       observableSlots :=
   NativeGeneratedSelectorHitSuccessBridge.of_leave_body_with_label_prefix
     spec selectors hSupported irContract tx state observableSlots hcompile
     hSelectorRange hSelectorsRange hNoWrap
     (fun fn hFind => by rw [hBody fn hFind, hOnlyEmpty]; rfl)
-    hCont
 
 /-- E2 (S7 component): Selected user bodies of shape `[.leave]` supply the
 named selector-hit success bridge through the `_revived` Leave-aware chain.
 
 Composes `ExecBridgeAtFuelRevivedLeaveAware.of_leave_body` (which packages
 the exec-only Revived `of_leave_body` with the real `_revived.of_leave_body`
-Preserves bridge) with the `revivedLeaveAware_and_continuation` consumer.
-
-Takes `LeaveAwareCallDispatcherContinuation` as a hypothesis — until a
-parallel `_revived`-aware dispatcher continuation provider lands (mirror of
-`nativeGeneratedCallDispatcherResult_selector_hit_ok_matchesIR_forall_of_compile_ok_supported`),
-the caller must supply this directly. The hypothesis encodes the
-"after-body" dispatcher logic with `_revived` Preserves at the matched-flag
-position. -/
+Preserves bridge) with the `revivedLeaveAware_and_continuation` consumer. -/
 private theorem NativeGeneratedSelectorHitSuccessBridge.of_leave_body
     (spec : CompilationModel.CompilationModel) (selectors : List Nat)
     (hSupported : SupportedSpec spec selectors)
@@ -23494,8 +23537,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_leave_body
       ∀ fn,
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
-        fn.body = [.leave])
-    (hCont : LeaveAwareCallDispatcherContinuation irContract tx state observableSlots) :
+        fn.body = [.leave]) :
     NativeGeneratedSelectorHitSuccessBridge irContract tx state
       observableSlots := by
   intro nativeContract fn hLowerRuntime hFind hguards hArgs
@@ -23505,7 +23547,6 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_leave_body
       hSelectorRange hSelectorsRange hNoWrap
       (NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevivedLeaveAware.of_leave_body
         irContract tx state observableSlots hLeave)
-      hCont
       nativeContract fn hLowerRuntime hFind hguards hArgs
 
 /-- E4 (S7 component): Selected user bodies of shape `[.block [.leave]]`
@@ -23513,8 +23554,7 @@ supply the named selector-hit success bridge through the `_revived`
 Leave-aware chain. Parallels E2 but with the block-wrapped Leave shape.
 
 Composes `ExecBridgeAtFuelRevivedLeaveAware.of_block_leave` with the
-`revivedLeaveAware_and_continuation` consumer, taking
-`LeaveAwareCallDispatcherContinuation` as a hypothesis (same as E2). -/
+`revivedLeaveAware_and_continuation` consumer. -/
 private theorem NativeGeneratedSelectorHitSuccessBridge.of_block_leave
     (spec : CompilationModel.CompilationModel) (selectors : List Nat)
     (hSupported : SupportedSpec spec selectors)
@@ -23532,8 +23572,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_block_leave
       ∀ fn,
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
-        fn.body = [.block [.leave]])
-    (hCont : LeaveAwareCallDispatcherContinuation irContract tx state observableSlots) :
+        fn.body = [.block [.leave]]) :
     NativeGeneratedSelectorHitSuccessBridge irContract tx state
       observableSlots := by
   intro nativeContract fn hLowerRuntime hFind hguards hArgs
@@ -23543,7 +23582,6 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_block_leave
       hSelectorRange hSelectorsRange hNoWrap
       (NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevivedLeaveAware.of_block_leave
         irContract tx state observableSlots hBlockLeave)
-      hCont
       nativeContract fn hLowerRuntime hFind hguards hArgs
 
 /-- E6 (S7 component, degenerate): Selected user bodies of shape
@@ -23554,9 +23592,7 @@ success bridge.
 CURRENTLY LIMITED: only handles `preStmts = []`, where body reduces to
 `[.leave]` and dispatches to E2 (`of_leave_body`). The general case requires
 per-stmt preservation lemmas via the per-`NativePreservableStraightStmt`
-observation framework.
-
-Takes `LeaveAwareCallDispatcherContinuation` as a hypothesis (same as E2/E4). -/
+observation framework. -/
 private theorem NativeGeneratedSelectorHitSuccessBridge.of_nativePreservableStraightStmts_leave
     (spec : CompilationModel.CompilationModel) (selectors : List Nat)
     (hSupported : SupportedSpec spec selectors)
@@ -23577,15 +23613,13 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_nativePreservableStra
     (hBody : ∀ fn,
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
             some fn →
-        fn.body = preStmts ++ [.leave])
-    (hCont : LeaveAwareCallDispatcherContinuation irContract tx state observableSlots) :
+        fn.body = preStmts ++ [.leave]) :
     NativeGeneratedSelectorHitSuccessBridge irContract tx state
       observableSlots :=
   NativeGeneratedSelectorHitSuccessBridge.of_leave_body
     spec selectors hSupported irContract tx state observableSlots hcompile
     hSelectorRange hSelectorsRange hNoWrap
     (fun fn hFind => by rw [hBody fn hFind, hOnlyEmpty, List.nil_append])
-    hCont
 
 /-- Generated `callDispatcher` result theorem from `SupportedSpec + compile`,
 modulo the exact-fuel lowered-user-body proof stated against
@@ -24339,12 +24373,14 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_s
       hThreshold
 
 /-- Public generated `callDispatcher` result theorem from `SupportedSpec +
-compile`, modulo the exact-fuel selected user-body halt bridge.
+compile`, modulo the unified exact-fuel selected user-body result bridge.
 
 Selector miss and generated selector-hit guard failures are discharged
-internally. For `stop`/`return`-style selected bodies, callers provide the
-direct lowered user-body halt execution bridge; the generated prefix, compiled
-IR threshold transport, and broad success bridge stay behind private adapters. -/
+internally. Callers provide either the halt-channel selected-body proof or the
+normal revived execution plus matched-flag preservation proof through
+`NativeGeneratedSelectedUserBodyResultBridgeAtFuel`; the generated prefix,
+compiled IR threshold transport, and broad success bridge stay behind private
+adapters. -/
 theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported
     (spec : CompilationModel.CompilationModel) (selectors : List Nat)
     (hSupported : SupportedSpec spec selectors)
@@ -24358,8 +24394,8 @@ theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported
       ∀ selector, selector ∈ selectors →
         selector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
-    (hUserBodyHalt :
-      NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel irContract tx state
+    (hUserBodyResult :
+      NativeGeneratedSelectedUserBodyResultBridgeAtFuel irContract tx state
         observableSlots) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       nativeResultsMatchOn observableSlots
@@ -24370,27 +24406,19 @@ theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported
       nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_with_selected_user_body_result_threshold
       spec selectors hSupported irContract tx state observableSlots hcompile
       hSelectorRange hSelectorsRange hNoWrap
-      (NativeGeneratedSelectedUserBodyResultBridgeAtFuel.of_halt
-        irContract tx state observableSlots hUserBodyHalt)
+      hUserBodyResult
       (fun fn hFind =>
         generatedFunctionCalldataThreshold_of_compile_ok_supported
           spec selectors hSupported irContract tx hcompile fn hFind) with
     ⟨nativeContract, _hLower, hMatch⟩
   exact ⟨nativeContract, hMatch⟩
 
-/-- Strictly more general variant of
-`compile_preserves_native_evmYulLean_of_compile_ok_supported_generated_callDispatcher`
-that accepts the unified `NativeGeneratedSelectedUserBodyResultBridgeAtFuel`
-(disjunction of HaltExec and ExecOnly+Preserves) instead of just
-`HaltExecBridge`. This is the S8-direction generalization: callers with
-halt-ending bodies supply `of_halt hUserBodyHalt`; callers with Leave-ending
-or falling-through bodies supply the ExecOnly+Preserves disjunct (S5/S6/E2/E4/E6).
+/-- Core generated-callDispatcher preservation theorem over the unified
+selected-body result bridge.
 
-Path to true S8 (drop `hUserBodyHalt` premise entirely): derive the Result
-bridge from `SupportedSpec` + body-shape dispatch by case-analyzing on
-the supported body shapes and applying the appropriate S5/S6/S7 chain. That
-requires the per-stmt observation framework to discharge the non-degenerate
-cases of S5/S6/E6/E7. -/
+Callers with halt-ending bodies supply the halt disjunct; callers with
+normal-return bodies supply the revived exec-only plus matched-preservation
+disjunct. -/
 private theorem compile_preserves_native_evmYulLean_of_compile_ok_supported_generated_callDispatcher_via_result
     (spec : CompilationModel.CompilationModel) (selectors : List Nat)
     (hSupported : SupportedSpec spec selectors)
@@ -24466,8 +24494,8 @@ theorem compile_preserves_native_evmYulLean_of_compile_ok_supported_generated_ca
       ∀ selector, selector ∈ selectors →
         selector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
-    (hUserBodyHalt :
-      NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel irContract tx
+    (hUserBodyResult :
+      NativeGeneratedSelectedUserBodyResultBridgeAtFuel irContract tx
         (FunctionBody.initialIRStateForTx spec tx initialWorld)
         observableSlots)
     (hEnv :
@@ -24481,37 +24509,11 @@ theorem compile_preserves_native_evmYulLean_of_compile_ok_supported_generated_ca
         (Nat.succ (sizeOf (Compiler.emitYul irContract).runtimeCode))
         irContract tx (FunctionBody.initialIRStateForTx spec tx initialWorld)
         observableSlots) := by
-  rcases
-      nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_with_selected_user_body_result_threshold
-        spec selectors hSupported irContract tx
-        (FunctionBody.initialIRStateForTx spec tx initialWorld)
-        observableSlots hcompile hSelectorRange hSelectorsRange hNoWrap
-        (NativeGeneratedSelectedUserBodyResultBridgeAtFuel.of_halt
-          irContract tx (FunctionBody.initialIRStateForTx spec tx initialWorld)
-          observableSlots hUserBodyHalt)
-        (fun fn hFind =>
-          generatedFunctionCalldataThreshold_of_compile_ok_supported
-            spec selectors hSupported irContract tx hcompile fn hFind) with
-    ⟨nativeContract, hLower, hMatch⟩
-  have hEq :
-      nativeGeneratedCallDispatcherResultOf irContract tx
-          (FunctionBody.initialIRStateForTx spec tx initialWorld)
-          observableSlots nativeContract =
-        Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
-          (Nat.succ (sizeOf (Compiler.emitYul irContract).runtimeCode))
-          irContract tx
-          (FunctionBody.initialIRStateForTx spec tx initialWorld)
-          observableSlots :=
-    nativeGeneratedCallDispatcherResultOf_eq_interpretIRRuntimeNative_of_lowerRuntimeContractNative_supported
-      tx (FunctionBody.initialIRStateForTx spec tx initialWorld) observableSlots
-      nativeContract hcompile hSupported hLower hEnv
-  rw [hEq] at hMatch
   exact
-    sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeResultsMatchOn
-      (Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
-        spec selectors hSupported irContract tx initialWorld htxNormalized
-        hcalldataSizeFits hcompile)
-      hMatch
+    compile_preserves_native_evmYulLean_of_compile_ok_supported_generated_callDispatcher_via_result
+      spec selectors hSupported irContract tx initialWorld observableSlots
+      hcompile htxNormalized hcalldataSizeFits hSelectorRange hSelectorsRange
+      hNoWrap hUserBodyResult hEnv
 
 /-- Generated `callDispatcher` result theorem from `SupportedSpec + compile`,
 modulo the selected-body proof and the dispatcher continuation provider.

--- a/Compiler/Proofs/EndToEnd.lean
+++ b/Compiler/Proofs/EndToEnd.lean
@@ -796,7 +796,8 @@ private theorem sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
       sizeOf (Compiler.emitYul irContract).runtimeCode := by
   have hRuntime :
       (Compiler.emitYul irContract).runtimeCode =
-        [Compiler.CodegenCommon.buildSwitch irContract.functions none none] :=
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none] :=
     Compiler.Proofs.YulGeneration.Backends.Native.emitYul_runtimeCode_eq_single_dispatcher_of_noMapping_noInternals_noFallback_noReceive
       irContract hNoMapping
       (Compiler.Proofs.IRGeneration.ContractShape.compile_ok_yields_internalFunctions_nil
@@ -821,7 +822,8 @@ private theorem sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
     sizeOf_buildSwitch_noFallback_noReceive_ge_source_cases_length
       irContract.functions
   rw [hRuntime, hLen]
-  exact hSize
+  refine Nat.le_trans hSize ?_
+  simp [Compiler.CodegenCommon.initFreeMemoryPointer]
 
 private theorem sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
     {spec : CompilationModel.CompilationModel} {selectors : List Nat}
@@ -842,7 +844,8 @@ private theorem sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plu
       sizeOf (Compiler.emitYul irContract).runtimeCode := by
   have hRuntime :
       (Compiler.emitYul irContract).runtimeCode =
-        [Compiler.CodegenCommon.buildSwitch irContract.functions none none] :=
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none] :=
     Compiler.Proofs.YulGeneration.Backends.Native.emitYul_runtimeCode_eq_single_dispatcher_of_noMapping_noInternals_noFallback_noReceive
       irContract hNoMapping
       (Compiler.Proofs.IRGeneration.ContractShape.compile_ok_yields_internalFunctions_nil
@@ -867,7 +870,56 @@ private theorem sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plu
     sizeOf_buildSwitch_noFallback_noReceive_ge_source_cases_length_plus24
       irContract.functions
   rw [hRuntime, hLen]
-  exact hSize
+  simp [Compiler.CodegenCommon.initFreeMemoryPointer] at hSize ⊢
+  omega
+
+private theorem sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus25
+    {spec : CompilationModel.CompilationModel} {selectors : List Nat}
+    {irContract : IRContract}
+    {reservedNames : List String} {n0 : Nat}
+    {cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)} {midN : Nat}
+    (hCompile : CompilationModel.compile spec selectors = .ok irContract)
+    (hSupported : SupportedSpec spec selectors)
+    (hNoMapping : irContract.usesMapping = false)
+    (hLowerCases :
+      Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames n0 + 1)
+        (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+          irContract.functions) = .ok (cases', midN)) :
+    cases'.length + 25 ≤
+      sizeOf (Compiler.emitYul irContract).runtimeCode := by
+  have hRuntime :
+      (Compiler.emitYul irContract).runtimeCode =
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none] :=
+    Compiler.Proofs.YulGeneration.Backends.Native.emitYul_runtimeCode_eq_single_dispatcher_of_noMapping_noInternals_noFallback_noReceive
+      irContract hNoMapping
+      (Compiler.Proofs.IRGeneration.ContractShape.compile_ok_yields_internalFunctions_nil
+        (model := spec) (selectors := selectors) (hSupported := hSupported)
+        (ir := irContract) (hcompile := hCompile))
+      (Compiler.Proofs.IRGeneration.ContractShape.compile_ok_yields_noFallbackEntrypoint
+        spec selectors hSupported irContract hCompile)
+      (Compiler.Proofs.IRGeneration.ContractShape.compile_ok_yields_noReceiveEntrypoint
+        spec selectors hSupported irContract hCompile)
+  have hLen :
+      cases'.length =
+        (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+          irContract.functions).length :=
+    Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds_length_eq
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+        reservedNames n0 + 1)
+      midN
+      (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+        irContract.functions) cases' hLowerCases
+  have hSize :=
+    sizeOf_buildSwitch_noFallback_noReceive_ge_source_cases_length_plus24
+      irContract.functions
+  rw [hRuntime, hLen]
+  simp [Compiler.CodegenCommon.initFreeMemoryPointer] at hSize ⊢
+  omega
 
 private theorem sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
     {spec : CompilationModel.CompilationModel} {selectors : List Nat}
@@ -920,7 +972,8 @@ private theorem sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
   simp only [hMapping, hInternals, hNoFallback, hNoReceive, if_true,
     List.singleton_append, List.append_nil]
   simp only [Compiler.CodegenCommon.mappingSlotFuncAt]
-  simp
+  simp [Compiler.CodegenCommon.initFreeMemoryPointer] at hSize ⊢
+  omega
 
 private theorem sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
     {spec : CompilationModel.CompilationModel} {selectors : List Nat}
@@ -973,7 +1026,62 @@ private theorem sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus2
   simp only [hMapping, hInternals, hNoFallback, hNoReceive, if_true,
     List.singleton_append, List.append_nil]
   simp only [Compiler.CodegenCommon.mappingSlotFuncAt]
-  simp
+  simp [Compiler.CodegenCommon.initFreeMemoryPointer]
+  omega
+
+private theorem sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus25
+    {spec : CompilationModel.CompilationModel} {selectors : List Nat}
+    {irContract : IRContract}
+    {reservedNames : List String} {switchStart : Nat}
+    {cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)} {midN : Nat}
+    (hCompile : CompilationModel.compile spec selectors = .ok irContract)
+    (hSupported : SupportedSpec spec selectors)
+    (hMapping : irContract.usesMapping = true)
+    (hLowerCases :
+      Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames switchStart + 1)
+        (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+          irContract.functions) = .ok (cases', midN)) :
+    cases'.length + 25 ≤
+      sizeOf (Compiler.emitYul irContract).runtimeCode := by
+  have hInternals :
+      irContract.internalFunctions = [] :=
+    Compiler.Proofs.IRGeneration.ContractShape.compile_ok_yields_internalFunctions_nil
+      (model := spec) (selectors := selectors) (hSupported := hSupported)
+      (ir := irContract) (hcompile := hCompile)
+  have hNoFallback :
+      irContract.fallbackEntrypoint = none :=
+    Compiler.Proofs.IRGeneration.ContractShape.compile_ok_yields_noFallbackEntrypoint
+      spec selectors hSupported irContract hCompile
+  have hNoReceive :
+      irContract.receiveEntrypoint = none :=
+    Compiler.Proofs.IRGeneration.ContractShape.compile_ok_yields_noReceiveEntrypoint
+      spec selectors hSupported irContract hCompile
+  have hLen :
+      cases'.length =
+        (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+          irContract.functions).length :=
+    Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds_length_eq
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+        reservedNames switchStart + 1)
+      midN
+      (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+        irContract.functions) cases' hLowerCases
+  have hSize :=
+    sizeOf_buildSwitch_noFallback_noReceive_ge_source_cases_length_plus24
+      irContract.functions
+  rw [hLen]
+  unfold Compiler.emitYul Compiler.CodegenCommon.emitYul
+    Compiler.CodegenCommon.runtimeCode
+  simp only [hMapping, hInternals, hNoFallback, hNoReceive, if_true,
+    List.singleton_append, List.append_nil]
+  simp only [Compiler.CodegenCommon.mappingSlotFuncAt]
+  simp [Compiler.CodegenCommon.initFreeMemoryPointer] at hSize ⊢
+  have hExtra : 1 ≤ sizeOf "mappingSlot" := by decide
+  omega
 
 /-- Projected native dispatcher-exec result equality used by the public native
 EndToEnd theorems.
@@ -1258,7 +1366,11 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_mi
     (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hFunctionSelectorsRange :
-      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size) :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
+    (hEnv :
+      Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+        (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+          .ok ()) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) (midN : Nat),
       Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds
@@ -1288,10 +1400,10 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_mi
       (YulTransaction.ofIR tx) state.storage state.events materializedSlots
       hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange with
-    ⟨reservedNames, n0, cases', midN, hLowerCases, hCont⟩
+    ⟨reservedNames, n0, cases', midN, hLowerCases, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', midN, hLowerCases, ?_⟩
   intro hFuel
-  rcases hCont hFuel with ⟨hExec, hProject⟩
+  rcases hDispatcherContinuation hFuel with ⟨hExec, hProject⟩
   unfold nativeDispatcherExecMatchesIRPositive
   dsimp [nativeContract, materializedSlots] at hExec hProject ⊢
   rw [hExec, hProject]
@@ -1316,7 +1428,10 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_mi
     (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hFunctionSelectorsRange :
-      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size) :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
+    (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+      (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+        .ok ()) :
     ∃ (switchStart : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) (midN : Nat),
       Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds
@@ -1371,7 +1486,10 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_mi
     (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hFunctionSelectorsRange :
-      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size) :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
+    (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+      (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+        .ok ()) :
     ∃ (switchStart : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) (midN : Nat),
       Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds
@@ -1401,14 +1519,488 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_mi
       functions (YulTransaction.ofIR tx) state.storage state.events materializedSlots
       hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange with
-    ⟨switchStart, cases', midN, hLowerCases, hCont⟩
+    ⟨switchStart, cases', midN, hLowerCases, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', midN, hLowerCases, ?_⟩
   intro hFuel
-  rcases hCont hFuel with ⟨hExec, hProject⟩
+  rcases hDispatcherContinuation hFuel with ⟨hExec, hProject⟩
   unfold nativeDispatcherExecMatchesIRPositive
   dsimp [nativeContract, materializedSlots] at hExec hProject ⊢
   rw [hExec, hProject]
   simp [nativeResultsMatchOn,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeResultsMatchOn,
+    Compiler.Proofs.IRGeneration.interpretIR, hFind]
+
+private theorem nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive_atFuel
+    (fuel' : Nat) (irContract : IRContract) (tx : IRTransaction)
+    (state : IRState) (observableSlots : List Nat)
+    (inner : List EvmYul.Yul.Ast.Stmt)
+    (functions : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+    (hLower :
+      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
+          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [.Block inner])
+    (hFind :
+      irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
+        none)
+    (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hFunctionSelectorsRange :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
+    (hEnv :
+      Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+        (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+          .ok ()) :
+    ∃ (reservedNames : List String) (n0 : Nat)
+      (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) (midN : Nat),
+      Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds
+          reservedNames
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+            reservedNames n0 + 1)
+          (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+            irContract.functions) = .ok (cases', midN) ∧
+      (cases'.length + 20 ≤ fuel' →
+        nativeDispatcherExecMatchesIRPositive fuel'
+          irContract tx state observableSlots
+          { dispatcher := .Block
+              [.ExprStmtCall
+                (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+                  (Yul.YulExpr.call "mstore"
+                    [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                     Yul.YulExpr.lit 128])),
+               .Block inner],
+            functions := functions }) := by
+  obtain ⟨body1, reservedNames, n0, cases', midN, hInner, hLowerCases⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_sourceLowered
+      irContract.functions inner hLower
+  refine ⟨reservedNames, n0, cases', midN, hLowerCases, ?_⟩
+  intro hFuel
+  let fuel := fuel' - (cases'.length + 20)
+  have hFuelShape : fuel' = fuel + cases'.length + 20 := by
+    dsimp [fuel]
+    exact (Nat.sub_add_cancel hFuel).symm
+  let nativeContract : EvmYul.Yul.Ast.YulContract :=
+    { dispatcher := .Block
+        [.ExprStmtCall
+          (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+            (Yul.YulExpr.call "mstore"
+              [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+               Yul.YulExpr.lit 128])),
+         .Block inner],
+      functions := functions }
+  let materializedSlots :=
+    Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+      (Compiler.runtimeCode irContract) observableSlots
+  have hSelector :
+      tx.functionSelector =
+        tx.functionSelector % Compiler.Constants.selectorModulus := by
+    exact (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hLowerFind :
+      cases'.find? (fun entry => entry.1 == tx.functionSelector) = none :=
+    Compiler.Proofs.YulGeneration.Backends.Native.lowerSwitchCasesNativeWithSwitchIds_buildSwitch_find?_none_of_find_function
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0 + 1)
+      midN tx.functionSelector irContract.functions cases' hLowerCases hFind
+  have hTagsEq :
+      cases'.map (·.1) =
+        (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+          irContract.functions).map (·.1) :=
+    Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds_tags_eq
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0 + 1)
+      midN
+      (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+        irContract.functions) cases' hLowerCases
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size := by
+    intro tag body hmem
+    have hTagMem : tag ∈ cases'.map (·.1) :=
+      List.mem_map_of_mem (f := Prod.fst) hmem
+    rw [hTagsEq] at hTagMem
+    simp [Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases] at hTagMem
+    rcases hTagMem with ⟨fn, hFn, hTag⟩
+    subst hTag
+    exact hFunctionSelectorsRange fn hFn
+  have hExec :
+      Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+          fuel' nativeContract
+          (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+            nativeContract (YulTransaction.ofIR tx) state.storage
+            materializedSlots) =
+        .error EvmYul.Yul.Exception.Revert := by
+    rw [hFuelShape]
+    have hPeel :=
+      Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+        fuel reservedNames n0 cases' body1 inner functions
+        (YulTransaction.ofIR tx) state.storage materializedSlots hInner
+        (by simpa [YulTransaction.ofIR] using hNoWrap)
+    have hEndpoint :=
+      Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_revert_default_postInitFreeMemory_hasSelectorState_projectResult_eq
+        fuel tx.functionSelector
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0)
+        cases' nativeContract (YulTransaction.ofIR tx) state.storage state.events
+        materializedSlots (by simpa [YulTransaction.ofIR] using hSelector)
+        hLowerFind hSelectorRangeNative hTagsRange
+    dsimp [nativeContract, materializedSlots] at hPeel hEndpoint ⊢
+    rw [hPeel]
+    exact hEndpoint.1
+  unfold nativeDispatcherExecMatchesIRPositive
+  dsimp [nativeContract, materializedSlots] at hExec ⊢
+  rw [hExec]
+  simp [Compiler.Proofs.YulGeneration.Backends.Native.projectResult,
+    nativeResultsMatchOn,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeResultsMatchOn,
+    Compiler.Proofs.IRGeneration.interpretIR, hFind]
+
+private theorem nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive
+    (fuel : Nat) (irContract : IRContract) (tx : IRTransaction)
+    (state : IRState) (observableSlots : List Nat)
+    (inner : List EvmYul.Yul.Ast.Stmt)
+    (functions : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+    (hLower :
+      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
+          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [.Block inner])
+    (hFind :
+      irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
+        none)
+    (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hFunctionSelectorsRange :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
+    (hEnv :
+      Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+        (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+          .ok ()) :
+    ∃ (reservedNames : List String) (n0 : Nat)
+      (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) (midN : Nat),
+      Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds
+          reservedNames
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+            reservedNames n0 + 1)
+          (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+            irContract.functions) = .ok (cases', midN) ∧
+      nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 20)
+        irContract tx state observableSlots
+        { dispatcher := .Block
+            [.ExprStmtCall
+              (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+                (Yul.YulExpr.call "mstore"
+                  [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                   Yul.YulExpr.lit 128])),
+             .Block inner],
+          functions := functions } := by
+  obtain ⟨body1, reservedNames, n0, cases', midN, hInner, hLowerCases⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_sourceLowered
+      irContract.functions inner hLower
+  refine ⟨reservedNames, n0, cases', midN, hLowerCases, ?_⟩
+  let nativeContract : EvmYul.Yul.Ast.YulContract :=
+    { dispatcher := .Block
+        [.ExprStmtCall
+          (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+            (Yul.YulExpr.call "mstore"
+              [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+               Yul.YulExpr.lit 128])),
+         .Block inner],
+      functions := functions }
+  let materializedSlots :=
+    Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+      (Compiler.runtimeCode irContract) observableSlots
+  have hSelector :
+      tx.functionSelector =
+        tx.functionSelector % Compiler.Constants.selectorModulus := by
+    exact (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hLowerFind :
+      cases'.find? (fun entry => entry.1 == tx.functionSelector) = none :=
+    Compiler.Proofs.YulGeneration.Backends.Native.lowerSwitchCasesNativeWithSwitchIds_buildSwitch_find?_none_of_find_function
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0 + 1)
+      midN tx.functionSelector irContract.functions cases' hLowerCases hFind
+  have hTagsEq :
+      cases'.map (·.1) =
+        (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+          irContract.functions).map (·.1) :=
+    Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds_tags_eq
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0 + 1)
+      midN
+      (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+        irContract.functions) cases' hLowerCases
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size := by
+    intro tag body hmem
+    have hTagMem : tag ∈ cases'.map (·.1) :=
+      List.mem_map_of_mem (f := Prod.fst) hmem
+    rw [hTagsEq] at hTagMem
+    simp [Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases] at hTagMem
+    rcases hTagMem with ⟨fn, hFn, hTag⟩
+    subst hTag
+    exact hFunctionSelectorsRange fn hFn
+  have hExec :
+      Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+          (fuel + cases'.length + 20) nativeContract
+          (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+            nativeContract (YulTransaction.ofIR tx) state.storage
+            materializedSlots) =
+        .error EvmYul.Yul.Exception.Revert := by
+    have hPeel :=
+      Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+        fuel reservedNames n0 cases' body1 inner functions
+        (YulTransaction.ofIR tx) state.storage materializedSlots hInner
+        (by simpa [YulTransaction.ofIR] using hNoWrap)
+    have hEndpoint :=
+      Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_revert_default_postInitFreeMemory_hasSelectorState_projectResult_eq
+        fuel tx.functionSelector
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0)
+        cases' nativeContract (YulTransaction.ofIR tx) state.storage state.events
+        materializedSlots (by simpa [YulTransaction.ofIR] using hSelector)
+        hLowerFind hSelectorRangeNative hTagsRange
+    dsimp [nativeContract, materializedSlots] at hPeel hEndpoint ⊢
+    rw [hPeel]
+    exact hEndpoint.1
+  unfold nativeDispatcherExecMatchesIRPositive
+  dsimp [nativeContract, materializedSlots] at hExec ⊢
+  rw [hExec]
+  simp [Compiler.Proofs.YulGeneration.Backends.Native.projectResult,
+    nativeResultsMatchOn,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeResultsMatchOn,
+    Compiler.Proofs.IRGeneration.interpretIR, hFind]
+
+private theorem nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds_atFuel
+    (fuel' : Nat) (reservedNames : List String) (n0 : Nat)
+    (irContract : IRContract) (tx : IRTransaction)
+    (state : IRState) (observableSlots : List Nat)
+    (inner : List EvmYul.Yul.Ast.Stmt) (next : Nat)
+    (functions : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+    (hLower :
+      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+          reservedNames n0
+          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([.Block inner], next))
+    (hFind :
+      irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
+        none)
+    (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hFunctionSelectorsRange :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size) :
+    ∃ (switchStart : Nat)
+      (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) (midN : Nat),
+      Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds
+          reservedNames
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+            reservedNames switchStart + 1)
+          (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+            irContract.functions) = .ok (cases', midN) ∧
+      (cases'.length + 20 ≤ fuel' →
+        nativeDispatcherExecMatchesIRPositive fuel'
+          irContract tx state observableSlots
+          { dispatcher := .Block
+              [.ExprStmtCall
+                (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+                  (Yul.YulExpr.call "mstore"
+                    [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                     Yul.YulExpr.lit 128])),
+               .Block inner],
+            functions := functions }) := by
+  obtain ⟨body1, switchStart, cases', midN, hInner, hLowerCases⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_sourceLowered_withSwitchIds
+      reservedNames n0 irContract.functions inner next hLower
+  refine ⟨switchStart, cases', midN, hLowerCases, ?_⟩
+  intro hFuel
+  let fuel := fuel' - (cases'.length + 20)
+  have hFuelShape : fuel' = fuel + cases'.length + 20 := by
+    dsimp [fuel]
+    exact (Nat.sub_add_cancel hFuel).symm
+  let nativeContract : EvmYul.Yul.Ast.YulContract :=
+    { dispatcher := .Block
+        [.ExprStmtCall
+          (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+            (Yul.YulExpr.call "mstore"
+              [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+               Yul.YulExpr.lit 128])),
+         .Block inner],
+      functions := functions }
+  let materializedSlots :=
+    Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+      (Compiler.runtimeCode irContract) observableSlots
+  have hSelector :
+      tx.functionSelector =
+        tx.functionSelector % Compiler.Constants.selectorModulus := by
+    exact (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hLowerFind :
+      cases'.find? (fun entry => entry.1 == tx.functionSelector) = none :=
+    Compiler.Proofs.YulGeneration.Backends.Native.lowerSwitchCasesNativeWithSwitchIds_buildSwitch_find?_none_of_find_function
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart + 1)
+      midN tx.functionSelector irContract.functions cases' hLowerCases hFind
+  have hTagsEq :
+      cases'.map (·.1) =
+        (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+          irContract.functions).map (·.1) :=
+    Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds_tags_eq
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart + 1)
+      midN
+      (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+        irContract.functions) cases' hLowerCases
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size := by
+    intro tag body hmem
+    have hTagMem : tag ∈ cases'.map (·.1) :=
+      List.mem_map_of_mem (f := Prod.fst) hmem
+    rw [hTagsEq] at hTagMem
+    simp [Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases] at hTagMem
+    rcases hTagMem with ⟨fn, hFn, hTag⟩
+    subst hTag
+    exact hFunctionSelectorsRange fn hFn
+  have hExec :
+      Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+          fuel' nativeContract
+          (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+            nativeContract (YulTransaction.ofIR tx) state.storage
+            materializedSlots) =
+        .error EvmYul.Yul.Exception.Revert := by
+    rw [hFuelShape]
+    have hPeel :=
+      Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+        fuel reservedNames switchStart cases' body1 inner functions
+        (YulTransaction.ofIR tx) state.storage materializedSlots hInner
+        (by simpa [YulTransaction.ofIR] using hNoWrap)
+    have hEndpoint :=
+      Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_revert_default_postInitFreeMemory_hasSelectorState_projectResult_eq
+        fuel tx.functionSelector
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+        cases' nativeContract (YulTransaction.ofIR tx) state.storage state.events
+        materializedSlots (by simpa [YulTransaction.ofIR] using hSelector)
+        hLowerFind hSelectorRangeNative hTagsRange
+    dsimp [nativeContract, materializedSlots] at hPeel hEndpoint ⊢
+    rw [hPeel]
+    exact hEndpoint.1
+  unfold nativeDispatcherExecMatchesIRPositive
+  dsimp [nativeContract, materializedSlots] at hExec ⊢
+  rw [hExec]
+  simp [Compiler.Proofs.YulGeneration.Backends.Native.projectResult,
+    nativeResultsMatchOn,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeResultsMatchOn,
+    Compiler.Proofs.IRGeneration.interpretIR, hFind]
+
+private theorem nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds
+    (fuel : Nat) (reservedNames : List String) (n0 : Nat)
+    (irContract : IRContract) (tx : IRTransaction)
+    (state : IRState) (observableSlots : List Nat)
+    (inner : List EvmYul.Yul.Ast.Stmt) (next : Nat)
+    (functions : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+    (hLower :
+      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+          reservedNames n0
+          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([.Block inner], next))
+    (hFind :
+      irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
+        none)
+    (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hFunctionSelectorsRange :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size) :
+    ∃ (switchStart : Nat)
+      (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) (midN : Nat),
+      Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds
+          reservedNames
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+            reservedNames switchStart + 1)
+          (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+            irContract.functions) = .ok (cases', midN) ∧
+      nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 20)
+        irContract tx state observableSlots
+        { dispatcher := .Block
+            [.ExprStmtCall
+              (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+                (Yul.YulExpr.call "mstore"
+                  [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                   Yul.YulExpr.lit 128])),
+             .Block inner],
+          functions := functions } := by
+  obtain ⟨body1, switchStart, cases', midN, hInner, hLowerCases⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_sourceLowered_withSwitchIds
+      reservedNames n0 irContract.functions inner next hLower
+  refine ⟨switchStart, cases', midN, hLowerCases, ?_⟩
+  let nativeContract : EvmYul.Yul.Ast.YulContract :=
+    { dispatcher := .Block
+        [.ExprStmtCall
+          (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+            (Yul.YulExpr.call "mstore"
+              [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+               Yul.YulExpr.lit 128])),
+         .Block inner],
+      functions := functions }
+  let materializedSlots :=
+    Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+      (Compiler.runtimeCode irContract) observableSlots
+  have hSelector :
+      tx.functionSelector =
+        tx.functionSelector % Compiler.Constants.selectorModulus := by
+    exact (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hLowerFind :
+      cases'.find? (fun entry => entry.1 == tx.functionSelector) = none :=
+    Compiler.Proofs.YulGeneration.Backends.Native.lowerSwitchCasesNativeWithSwitchIds_buildSwitch_find?_none_of_find_function
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart + 1)
+      midN tx.functionSelector irContract.functions cases' hLowerCases hFind
+  have hTagsEq :
+      cases'.map (·.1) =
+        (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+          irContract.functions).map (·.1) :=
+    Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds_tags_eq
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart + 1)
+      midN
+      (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+        irContract.functions) cases' hLowerCases
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size := by
+    intro tag body hmem
+    have hTagMem : tag ∈ cases'.map (·.1) :=
+      List.mem_map_of_mem (f := Prod.fst) hmem
+    rw [hTagsEq] at hTagMem
+    simp [Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases] at hTagMem
+    rcases hTagMem with ⟨fn, hFn, hTag⟩
+    subst hTag
+    exact hFunctionSelectorsRange fn hFn
+  have hExec :
+      Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+          (fuel + cases'.length + 20) nativeContract
+          (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+            nativeContract (YulTransaction.ofIR tx) state.storage
+            materializedSlots) =
+        .error EvmYul.Yul.Exception.Revert := by
+    have hPeel :=
+      Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+        fuel reservedNames switchStart cases' body1 inner functions
+        (YulTransaction.ofIR tx) state.storage materializedSlots hInner
+        (by simpa [YulTransaction.ofIR] using hNoWrap)
+    have hEndpoint :=
+      Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_revert_default_postInitFreeMemory_hasSelectorState_projectResult_eq
+        fuel tx.functionSelector
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+        cases' nativeContract (YulTransaction.ofIR tx) state.storage state.events
+        materializedSlots (by simpa [YulTransaction.ofIR] using hSelector)
+        hLowerFind hSelectorRangeNative hTagsRange
+    dsimp [nativeContract, materializedSlots] at hPeel hEndpoint ⊢
+    rw [hPeel]
+    exact hEndpoint.1
+  unfold nativeDispatcherExecMatchesIRPositive
+  dsimp [nativeContract, materializedSlots] at hExec ⊢
+  rw [hExec]
+  simp [Compiler.Proofs.YulGeneration.Backends.Native.projectResult,
+    nativeResultsMatchOn,
     Compiler.Proofs.YulGeneration.Backends.Native.nativeResultsMatchOn,
     Compiler.Proofs.IRGeneration.interpretIR, hFind]
 
@@ -1475,7 +2067,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       err nativeYul hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange with
     ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hCont⟩
+      hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
     hCase, hBodyLower, ?_⟩
   intro hBody hProject hMatch
@@ -1491,7 +2083,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .error err := by
     simpa [materializedSlots] using hBody
-  rcases hCont hBody' hProject with ⟨hExec, hProject'⟩
+  rcases hDispatcherContinuation hBody' hProject with ⟨hExec, hProject'⟩
   exact nativeDispatcherExecMatchesIRPositive_of_exec_error_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
     (observableSlots := observableSlots)
@@ -1570,7 +2162,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       err nativeYul hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange with
     ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hCont⟩
+      hLowerCases, hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
     hLowerCases, hCase, hBodyLower, ?_⟩
   intro hFuel hBody hProject hMatch
@@ -1587,7 +2179,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .error err := by
     simpa [materializedSlots] using hBody
-  rcases hCont hFuel hBody' hProject with ⟨hExec, hProject'⟩
+  rcases hDispatcherContinuation hFuel hBody' hProject with ⟨hExec, hProject'⟩
   exact nativeDispatcherExecMatchesIRPositive_of_exec_error_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
     (observableSlots := observableSlots)
@@ -1673,7 +2265,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange with
     ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hCont⟩
+      hLowerCases, hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
     hLowerCases, hCase, hBodyLower, ?_⟩
   intro err nativeYul hFuel hBody hProject hMatch
@@ -1690,7 +2282,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .error err := by
     simpa [materializedSlots] using hBody
-  rcases hCont err nativeYul hFuel hBody' hProject with ⟨hExec, hProject'⟩
+  rcases hDispatcherContinuation err nativeYul hFuel hBody' hProject with ⟨hExec, hProject'⟩
   exact nativeDispatcherExecMatchesIRPositive_of_exec_error_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
     (observableSlots := observableSlots)
@@ -1762,7 +2354,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       materializedSlots err nativeYul hLower hSelector hFind hNoWrap
       hSelectorRangeNative hFunctionSelectorsRange with
     ⟨switchStart, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hCont⟩
+      hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', body', bodyStart, bodyEnd,
     hCase, hBodyLower, ?_⟩
   intro hBody hProject hMatch
@@ -1778,7 +2370,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .error err := by
     simpa [materializedSlots] using hBody
-  rcases hCont hBody' hProject with ⟨hExec, hProject'⟩
+  rcases hDispatcherContinuation hBody' hProject with ⟨hExec, hProject'⟩
   exact nativeDispatcherExecMatchesIRPositive_of_exec_error_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
     (observableSlots := observableSlots)
@@ -1858,7 +2450,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       materializedSlots err nativeYul hLower hSelector hFind hNoWrap
       hSelectorRangeNative hFunctionSelectorsRange with
     ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hCont⟩
+      hLowerCases, hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
     hLowerCases, hCase, hBodyLower, ?_⟩
   intro hFuel hBody hProject hMatch
@@ -1875,7 +2467,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .error err := by
     simpa [materializedSlots] using hBody
-  rcases hCont hFuel hBody' hProject with ⟨hExec, hProject'⟩
+  rcases hDispatcherContinuation hFuel hBody' hProject with ⟨hExec, hProject'⟩
   exact nativeDispatcherExecMatchesIRPositive_of_exec_error_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
     (observableSlots := observableSlots)
@@ -1963,7 +2555,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       materializedSlots hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange with
     ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hCont⟩
+      hLowerCases, hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
     hLowerCases, hCase, hBodyLower, ?_⟩
   intro err nativeYul hFuel hBody hProject hMatch
@@ -1980,7 +2572,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .error err := by
     simpa [materializedSlots] using hBody
-  rcases hCont err nativeYul hFuel hBody' hProject with ⟨hExec, hProject'⟩
+  rcases hDispatcherContinuation err nativeYul hFuel hBody' hProject with ⟨hExec, hProject'⟩
   exact nativeDispatcherExecMatchesIRPositive_of_exec_error_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
     (observableSlots := observableSlots)
@@ -2073,7 +2665,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       final nativeYulRaw hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange with
     ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hCont⟩
+      hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
     hCase, hBodyLower, ?_⟩
   intro hBody hPreservesMatched hProject hMatch
@@ -2089,7 +2681,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
+  rcases hDispatcherContinuation hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
     (observableSlots := observableSlots)
@@ -2200,7 +2792,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       hSelector hFind hNoWrap hSelectorRangeNative hFunctionSelectorsRange
       hPayable hguards hArgs with
     ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hCont⟩
+      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart,
     bodyEnd, userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hBody hPreservesMatched hProject hMatch
@@ -2216,7 +2808,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
+  rcases hDispatcherContinuation hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
     (observableSlots := observableSlots)
@@ -2327,7 +2919,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       hSelector hFind hNoWrap hSelectorRangeNative hFunctionSelectorsRange
       hNonPayable hguards hArgs with
     ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hCont⟩
+      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart,
     bodyEnd, userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hBody hPreservesMatched hProject hMatch
@@ -2343,7 +2935,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
+  rcases hDispatcherContinuation hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
     (observableSlots := observableSlots)
@@ -2455,7 +3047,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       hSelector hFind hNoWrap hSelectorRangeNative hFunctionSelectorsRange
       hPayable hguards hArgs with
     ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hCont⟩
+      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart,
     bodyEnd, userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hFuel hBody hPreservesMatched hProject hMatch
@@ -2472,7 +3064,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont hFuel hBody' hPreservesMatched rfl with
+  rcases hDispatcherContinuation hFuel hBody' hPreservesMatched rfl with
     ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
@@ -2585,7 +3177,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       hSelector hFind hNoWrap hSelectorRangeNative hFunctionSelectorsRange
       hNonPayable hguards hArgs with
     ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hCont⟩
+      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart,
     bodyEnd, userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hFuel hBody hPreservesMatched hProject hMatch
@@ -2602,7 +3194,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont hFuel hBody' hPreservesMatched rfl with
+  rcases hDispatcherContinuation hFuel hBody' hPreservesMatched rfl with
     ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
@@ -2706,7 +3298,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       final nativeYulRaw hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange with
     ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hCont⟩
+      hLowerCases, hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
     hLowerCases, hCase, hBodyLower, ?_⟩
   intro hFuel hBody hPreservesMatched hProject hMatch
@@ -2723,7 +3315,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont hFuel hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
+  rcases hDispatcherContinuation hFuel hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
     (observableSlots := observableSlots)
@@ -2824,7 +3416,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange with
     ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hCont⟩
+      hLowerCases, hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
     hLowerCases, hCase, hBodyLower, ?_⟩
   intro final nativeYul hFuel hBody hPreservesMatched hProject hMatch
@@ -2844,7 +3436,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont final nativeYulRaw hFuel hBody' hPreservesMatched rfl with
+  rcases hDispatcherContinuation final nativeYulRaw hFuel hBody' hPreservesMatched rfl with
     ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
@@ -2941,7 +3533,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       materializedSlots final nativeYulRaw hLower hSelector hFind hNoWrap
       hSelectorRangeNative hFunctionSelectorsRange with
     ⟨switchStart, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hCont⟩
+      hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', body', bodyStart, bodyEnd,
     hCase, hBodyLower, ?_⟩
   intro hBody hPreservesMatched hProject hMatch
@@ -2957,7 +3549,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
+  rcases hDispatcherContinuation hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
     (observableSlots := observableSlots)
@@ -3065,7 +3657,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       nativeYulRaw hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange hPayable hguards hArgs with
     ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hCont⟩
+      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hBody hPreservesMatched hProject hMatch
@@ -3081,7 +3673,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
+  rcases hDispatcherContinuation hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
     (observableSlots := observableSlots)
@@ -3189,7 +3781,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       nativeYulRaw hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange hNonPayable hguards hArgs with
     ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hCont⟩
+      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hBody hPreservesMatched hProject hMatch
@@ -3205,7 +3797,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
+  rcases hDispatcherContinuation hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
     (observableSlots := observableSlots)
@@ -3315,7 +3907,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       nativeYulRaw hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange hPayable hguards hArgs with
     ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hCont⟩
+      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hFuel hBody hPreservesMatched hProject hMatch
@@ -3332,7 +3924,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont hFuel hBody' hPreservesMatched rfl with
+  rcases hDispatcherContinuation hFuel hBody' hPreservesMatched rfl with
     ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
@@ -3443,7 +4035,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       nativeYulRaw hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange hNonPayable hguards hArgs with
     ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hCont⟩
+      userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hFuel hBody hPreservesMatched hProject hMatch
@@ -3460,7 +4052,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont hFuel hBody' hPreservesMatched rfl with
+  rcases hDispatcherContinuation hFuel hBody' hPreservesMatched rfl with
     ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
@@ -3565,7 +4157,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       materializedSlots final nativeYulRaw hLower hSelector hFind hNoWrap
       hSelectorRangeNative hFunctionSelectorsRange with
     ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hCont⟩
+      hLowerCases, hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
     hLowerCases, hCase, hBodyLower, ?_⟩
   intro hFuel hBody hPreservesMatched hProject hMatch
@@ -3582,7 +4174,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont hFuel hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
+  rcases hDispatcherContinuation hFuel hBody' hPreservesMatched rfl with ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
     (observableSlots := observableSlots)
@@ -3684,7 +4276,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       materializedSlots hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange with
     ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hCont⟩
+      hLowerCases, hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
     hLowerCases, hCase, hBodyLower, ?_⟩
   intro final nativeYul hFuel hBody hPreservesMatched hProject hMatch
@@ -3704,7 +4296,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont final nativeYulRaw hFuel hBody' hPreservesMatched rfl with
+  rcases hDispatcherContinuation final nativeYulRaw hFuel hBody' hPreservesMatched rfl with
     ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
@@ -3805,7 +4397,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       materializedSlots hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange with
     ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hCont⟩
+      hLowerCases, hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
     hLowerCases, hCase, hBodyLower, ?_⟩
   intro final nativeYul hFuel hBody hFinalMatched hProject hMatch
@@ -3825,7 +4417,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont final nativeYulRaw hFuel hBody' hFinalMatched rfl with
+  rcases hDispatcherContinuation final nativeYulRaw hFuel hBody' hFinalMatched rfl with
     ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
@@ -3926,7 +4518,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
       hLower hSelector hFind hNoWrap hSelectorRangeNative
       hFunctionSelectorsRange with
     ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hCont⟩
+      hLowerCases, hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
     hLowerCases, hCase, hBodyLower, ?_⟩
   intro final nativeYul hFuel hBody hFinalMatched hProject hMatch
@@ -3946,7 +4538,7 @@ private theorem nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hi
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
           .ok final := by
     simpa [materializedSlots] using hBody
-  rcases hCont final nativeYulRaw hFuel hBody' hFinalMatched rfl with
+  rcases hDispatcherContinuation final nativeYulRaw hFuel hBody' hFinalMatched rfl with
     ⟨hExec, _hProjectRaw⟩
   refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
     (contract := irContract) (tx := tx) (state := state)
@@ -3963,12 +4555,40 @@ private abbrev nativeContractOfDispatcher
     functions :=
       (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap) }
 
+/-- Native statement emitted by generated runtime initialization. -/
+private abbrev nativeInitFreeMemoryPointerStmt : EvmYul.Yul.Ast.Stmt :=
+  .ExprStmtCall
+    (Backends.lowerExprNative
+      (Yul.YulExpr.call "mstore"
+        [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+         Yul.YulExpr.lit 128]))
+
+/-- Helper-free generated-runtime contract with the init prefix followed by
+the dispatcher lowering. -/
+private abbrev nativeContractOfInitPrefixedDispatcher
+    (dispatcher : List EvmYul.Yul.Ast.Stmt) :
+    EvmYul.Yul.Ast.YulContract :=
+  { dispatcher := .Block (nativeInitFreeMemoryPointerStmt :: dispatcher)
+    functions :=
+      (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap) }
+
 /-- Native contract value produced by dispatcher lowering when the generated
 runtime also includes the native `mappingSlot` helper. -/
 private abbrev nativeContractOfDispatcherWithMapping
     (dispatcher : List EvmYul.Yul.Ast.Stmt) :
     EvmYul.Yul.Ast.YulContract :=
   { dispatcher := .Block dispatcher
+    functions :=
+      ((∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap).insert
+        "mappingSlot"
+        Compiler.Proofs.YulGeneration.Backends.Native.nativeMappingSlotFunctionDefinition) }
+
+/-- Mapping-helper generated-runtime contract with the init prefix followed by
+the dispatcher lowering. -/
+private abbrev nativeContractOfInitPrefixedDispatcherWithMapping
+    (dispatcher : List EvmYul.Yul.Ast.Stmt) :
+    EvmYul.Yul.Ast.YulContract :=
+  { dispatcher := .Block (nativeInitFreeMemoryPointerStmt :: dispatcher)
     functions :=
       ((∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap).insert
         "mappingSlot"
@@ -5591,6 +6211,13 @@ private theorem mappingSlotFuncAt_bridged_local (scratchBase : Nat) :
   unfold Compiler.CodegenCommon.mappingSlotFuncAt
   exact bridgedStmt_funcDef "mappingSlot" ["baseSlot", "key"] ["slot"] _
 
+private theorem initFreeMemoryPointer_bridged_local :
+    BridgedStmt Compiler.CodegenCommon.initFreeMemoryPointer := by
+  unfold Compiler.CodegenCommon.initFreeMemoryPointer
+  exact bridgedStmt_mstore_of_bridged_args _ _
+    (BridgedExpr.lit Compiler.Constants.freeMemoryPointer)
+    (BridgedExpr.lit 128)
+
 private theorem runtimeCode_bridged_local
     (contract : Compiler.IRContract)
     (hFunctions : ∀ fn, fn ∈ contract.functions → BridgedStmts fn.body)
@@ -5602,16 +6229,21 @@ private theorem runtimeCode_bridged_local
     BridgedStmts (Compiler.CodegenCommon.runtimeCode contract) := by
   unfold Compiler.CodegenCommon.runtimeCode
   cases contract.usesMapping
-  · exact BridgedStmts_snoc hInternals
-      (buildSwitch_bridged_local contract.functions
-        contract.fallbackEntrypoint contract.receiveEntrypoint hFunctions
-        hFallback hReceive)
-  · simp only [ite_true]
-    exact BridgedStmts_cons (mappingSlotFuncAt_bridged_local 0)
-      (BridgedStmts_snoc hInternals
+  · simpa [List.append_assoc] using
+      BridgedStmts_snoc
+        (BridgedStmts_snoc hInternals initFreeMemoryPointer_bridged_local)
         (buildSwitch_bridged_local contract.functions
           contract.fallbackEntrypoint contract.receiveEntrypoint hFunctions
-          hFallback hReceive))
+          hFallback hReceive)
+  · simp only [ite_true]
+    exact BridgedStmts_cons (mappingSlotFuncAt_bridged_local 0)
+      (by
+        simpa [List.append_assoc] using
+          BridgedStmts_snoc
+            (BridgedStmts_snoc hInternals initFreeMemoryPointer_bridged_local)
+            (buildSwitch_bridged_local contract.functions
+              contract.fallbackEntrypoint contract.receiveEntrypoint hFunctions
+              hFallback hReceive))
 
 /-- The selected native-harness switch case for a compiled external function is
 bridged whenever the compiled function body is bridged. This packages the
@@ -6428,7 +7060,8 @@ theorem lowerRuntimeContractNative_of_compile_ok_supported_noMapping
     Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
         (Compiler.emitYul irContract).runtimeCode =
       match Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] with
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] with
       | .ok dispatcher =>
           .ok { dispatcher := .Block dispatcher
                 functions :=
@@ -6458,7 +7091,8 @@ private theorem lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_
         (Compiler.emitYul irContract).runtimeCode = .ok nativeContract) :
     ∃ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher ∧
       nativeContract = nativeContractOfDispatcher dispatcher :=
   Compiler.Proofs.YulGeneration.Backends.Native.lowerRuntimeContractNative_emitYul_noMapping_ok_dispatcher
@@ -6488,7 +7122,8 @@ private theorem lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_
         (Compiler.emitYul irContract).runtimeCode = .ok nativeContract) :
     ∃ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher ∧
       nativeContract = nativeGeneratedDispatcherContractOf dispatcher := by
   rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
@@ -6512,9 +7147,10 @@ theorem lowerRuntimeContractNative_of_compile_ok_supported_mapping_reserved
     Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
         (Compiler.emitYul irContract).runtimeCode =
       match Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
-          (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] with
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] with
       | .ok (dispatcher, _) =>
           .ok { dispatcher := .Block dispatcher
                 functions := ((∅ :
@@ -6736,14 +7372,17 @@ theorem lowerRuntimeContractNative_of_compile_ok_supported_exists
       irContract.functions hBodies
   have hDispatcherNoFunc :
       Compiler.Proofs.YulGeneration.Backends.Native.yulStmtsContainFuncDef
-        [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
           false := by
     simp [Compiler.Proofs.YulGeneration.Backends.Native.yulStmtsContainFuncDef,
-      hSwitchNoFunc]
+      Compiler.Proofs.YulGeneration.Backends.Native.yulStmtContainsFuncDef,
+      Compiler.CodegenCommon.initFreeMemoryPointer, hSwitchNoFunc]
   cases hMapping : irContract.usesMapping
   · rcases
       Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNative_ok_of_yulStmtsContainFuncDef_false
-        [Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none]
         hDispatcherNoFunc with
       ⟨dispatcher, hLowerDispatcher⟩
     refine ⟨nativeContractOfDispatcher dispatcher, ?_⟩
@@ -6754,7 +7393,8 @@ theorem lowerRuntimeContractNative_of_compile_ok_supported_exists
       Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNativeWithSwitchIds_ok_of_yulStmtsContainFuncDef_false
         (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
           (Compiler.emitYul irContract).runtimeCode)
-        0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+        0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none]
         hDispatcherNoFunc with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher⟩
     refine ⟨nativeContractOfDispatcherWithMapping dispatcher, ?_⟩
@@ -6778,7 +7418,8 @@ private theorem lowerRuntimeContractNative_of_compile_ok_supported_mapping_ok_di
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) ∧
       nativeContract = nativeContractOfDispatcherWithMapping dispatcher :=
   Compiler.Proofs.YulGeneration.Backends.Native.lowerRuntimeContractNative_emitYul_mapping_ok_dispatcher_reserved
@@ -6810,7 +7451,8 @@ private theorem lowerRuntimeContractNative_of_compile_ok_supported_mapping_ok_pu
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) ∧
       nativeContract =
         nativeGeneratedDispatcherContractWithMappingOf dispatcher := by
@@ -6838,7 +7480,8 @@ private theorem lowerRuntimeContractNative_of_compile_ok_supported_ok_public_dis
     (irContract.usesMapping = false ∧
       ∃ dispatcher : List EvmYul.Yul.Ast.Stmt,
         Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-            [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+            [Compiler.CodegenCommon.initFreeMemoryPointer,
+              Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
           .ok dispatcher ∧
         nativeContract = nativeGeneratedDispatcherContractOf dispatcher) ∨
     (irContract.usesMapping = true ∧
@@ -6846,7 +7489,8 @@ private theorem lowerRuntimeContractNative_of_compile_ok_supported_ok_public_dis
         Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
             (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
               (Compiler.emitYul irContract).runtimeCode)
-            0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+            0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+              Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
           .ok (dispatcher, nextSwitchId) ∧
         nativeContract =
           nativeGeneratedDispatcherContractWithMappingOf dispatcher) := by
@@ -6877,7 +7521,8 @@ private theorem compile_preserves_native_evmYulLean_of_interpretIRRuntimeNative_
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -6933,7 +7578,8 @@ private theorem compile_preserves_native_evmYulLean_of_interpretIRRuntimeNative_
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -6990,7 +7636,8 @@ private theorem compile_preserves_native_evmYulLean_of_interpretIRRuntimeNative_
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -7049,7 +7696,8 @@ private theorem compile_preserves_native_evmYulLean_of_interpretIRRuntimeNative_
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -7225,6 +7873,190 @@ private theorem lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_o
           simp only [
             Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds_nil,
             Bind.bind, Except.bind, Pure.pure, Except.pure, List.append_nil]
+
+private theorem lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+    (funcs : List IRFunction) (dispatcher : List EvmYul.Yul.Ast.Stmt)
+    (h :
+      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch funcs none none] =
+        .ok dispatcher) :
+    ∃ (inner : List EvmYul.Yul.Ast.Stmt) (nextSwitchId : Nat),
+      dispatcher =
+        [.ExprStmtCall
+          (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+            (Yul.YulExpr.call "mstore"
+              [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                Yul.YulExpr.lit 128])),
+         .Block inner] ∧
+      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+          (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+            [Compiler.CodegenCommon.initFreeMemoryPointer,
+              Compiler.CodegenCommon.buildSwitch funcs none none])
+          0 [Compiler.CodegenCommon.buildSwitch funcs none none] =
+        .ok ([.Block inner], nextSwitchId) := by
+  unfold Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative at h
+  dsimp at h
+  rw [Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds_cons]
+    at h
+  simp [Compiler.CodegenCommon.initFreeMemoryPointer] at h
+  simp only [Bind.bind, Except.bind] at h
+  cases hTail :
+      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+        (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+          [Yul.YulStmt.expr
+            (Yul.YulExpr.call "mstore"
+              [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                Yul.YulExpr.lit 128]),
+            Compiler.CodegenCommon.buildSwitch funcs none none])
+        0 [Compiler.CodegenCommon.buildSwitch funcs none none] with
+  | error err =>
+      rw [hTail] at h
+      simp at h
+  | ok pair =>
+      cases pair with
+      | mk tail next =>
+          rw [hTail] at h
+          simp at h
+          subst h
+          rcases
+            lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+              (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+                [Yul.YulStmt.expr
+                  (Yul.YulExpr.call "mstore"
+                    [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                      Yul.YulExpr.lit 128]),
+                  Compiler.CodegenCommon.buildSwitch funcs none none])
+              0 funcs tail next hTail with
+            ⟨inner, hTailEq, hLowerBlock⟩
+          subst hTailEq
+          refine ⟨inner, next, ?_, ?_⟩
+          · rfl
+          · simpa [Compiler.CodegenCommon.initFreeMemoryPointer] using hLowerBlock
+
+private theorem lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+    (reservedNames : List String) (nextSwitchId : Nat)
+    (funcs : List IRFunction) (dispatcher : List EvmYul.Yul.Ast.Stmt)
+    (finalSwitchId : Nat)
+    (h :
+      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+          reservedNames nextSwitchId
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch funcs none none] =
+        .ok (dispatcher, finalSwitchId)) :
+    ∃ inner,
+      dispatcher =
+        [.ExprStmtCall
+          (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+            (Yul.YulExpr.call "mstore"
+              [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                Yul.YulExpr.lit 128])),
+         .Block inner] ∧
+      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+          reservedNames nextSwitchId
+          [Compiler.CodegenCommon.buildSwitch funcs none none] =
+        .ok ([.Block inner], finalSwitchId) := by
+  rw [Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds_cons]
+    at h
+  simp [Compiler.CodegenCommon.initFreeMemoryPointer] at h
+  simp only [Bind.bind, Except.bind] at h
+  cases hTail :
+      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+        reservedNames nextSwitchId
+        [Compiler.CodegenCommon.buildSwitch funcs none none] with
+  | error err =>
+      rw [hTail] at h
+      simp at h
+  | ok pair =>
+      cases pair with
+      | mk tail next =>
+          rw [hTail] at h
+          simp at h
+          rcases h with ⟨hDispatcher, hFinal⟩
+          subst hDispatcher
+          subst hFinal
+          rcases lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+              reservedNames nextSwitchId funcs tail next hTail with
+            ⟨inner, hTailEq, hLowerBlock⟩
+          subst hTailEq
+          exact ⟨inner, rfl, rfl⟩
+
+private theorem lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_of_tail
+    (reservedNames : List String) (nextSwitchId : Nat)
+    (funcs : List IRFunction) (inner : List EvmYul.Yul.Ast.Stmt)
+    (finalSwitchId : Nat)
+    (hTail :
+      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+          reservedNames nextSwitchId
+          [Compiler.CodegenCommon.buildSwitch funcs none none] =
+        .ok ([.Block inner], finalSwitchId)) :
+      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+          reservedNames nextSwitchId
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch funcs none none] =
+        .ok
+          ([.ExprStmtCall
+            (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+              (Yul.YulExpr.call "mstore"
+                [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                  Yul.YulExpr.lit 128])),
+           .Block inner], finalSwitchId) := by
+  rw [Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds_cons]
+  simp only [Compiler.CodegenCommon.initFreeMemoryPointer,
+    Compiler.Proofs.YulGeneration.Backends.lowerStmtGroupNativeWithSwitchIds_expr]
+  change
+    (do
+      let restAndNext ←
+        Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+          reservedNames nextSwitchId
+          [Compiler.CodegenCommon.buildSwitch funcs none none]
+      match restAndNext with
+      | (rest, next) =>
+          pure
+            ([EvmYul.Yul.Ast.Stmt.ExprStmtCall
+              (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+                (Yul.YulExpr.call "mstore"
+                  [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                    Yul.YulExpr.lit 128]))] ++ rest, next)) =
+      .ok
+        ([.ExprStmtCall
+          (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+            (Yul.YulExpr.call "mstore"
+              [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                Yul.YulExpr.lit 128])),
+         .Block inner], finalSwitchId)
+  rw [hTail]
+  rfl
+
+private theorem lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+    (reservedNames : List String) (nextSwitchId finalSwitchId : Nat)
+    (funcs : List IRFunction)
+    (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
+    (hLowerCases :
+      Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds
+        reservedNames nextSwitchId
+        (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+          funcs) = .ok (cases', finalSwitchId))
+    (hFunctionSelectorsRange :
+      ∀ fn, fn ∈ funcs → fn.selector < EvmYul.UInt256.size) :
+    ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size := by
+  intro tag body hmem
+  have hTagsEq :
+      cases'.map (·.1) =
+        (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+          funcs).map (·.1) :=
+    Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds_tags_eq
+      reservedNames nextSwitchId finalSwitchId
+      (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases funcs)
+      cases' hLowerCases
+  have hTagMem : tag ∈ cases'.map (·.1) :=
+    List.mem_map_of_mem (f := Prod.fst) hmem
+  rw [hTagsEq] at hTagMem
+  simp [Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases]
+    at hTagMem
+  rcases hTagMem with ⟨fnTag, hFnTag, hTag⟩
+  subst hTag
+  exact hFunctionSelectorsRange fnTag hFnTag
 
 private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_match
     {fuel' : Nat} {spec : CompilationModel.CompilationModel}
@@ -7454,7 +8286,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
       Compiler.Proofs.YulGeneration.Backends.BridgedSafeStmts
         spec.fields spec.errors .calldata [] false entry.1.body)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
@@ -7481,7 +8314,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
       Compiler.Proofs.YulGeneration.Backends.BridgedSafeStmts
         spec.fields spec.errors .calldata [] false entry.1.body)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
@@ -7514,7 +8348,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
@@ -7544,7 +8379,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
@@ -7571,7 +8407,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hSupported : SupportedSpec spec selectors)
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
@@ -7593,7 +8430,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hSupported : SupportedSpec spec selectors)
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
@@ -7620,7 +8458,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
@@ -7645,7 +8484,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
@@ -7681,7 +8521,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
     (hMatch : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx state
         observableSlots (nativeContractOfDispatcher dispatcher)) :
@@ -7713,7 +8554,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
     (hProject : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeProjectedDispatcherResultEq fuel' irContract tx state
         observableSlots (nativeContractOfDispatcher dispatcher) nativeYul)
@@ -7751,7 +8593,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx state
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)) :
@@ -7786,7 +8629,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeProjectedDispatcherResultEq fuel' irContract tx state
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)
@@ -7816,7 +8660,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
     (hMatch : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx state
         observableSlots (nativeContractOfDispatcher dispatcher)) :
@@ -7842,7 +8687,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
     (hProject : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeProjectedDispatcherResultEq fuel' irContract tx state
         observableSlots (nativeContractOfDispatcher dispatcher) nativeYul)
@@ -7873,7 +8719,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx state
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)) :
@@ -7901,7 +8748,8 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeProjectedDispatcherResultEq fuel' irContract tx state
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)
@@ -7939,7 +8787,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
         false)
     (hMatch : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx state
         observableSlots (nativeContractOfDispatcher dispatcher)) :
@@ -7969,7 +8817,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
         false)
     (hMatch : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx state
         observableSlots (nativeContractOfDispatcher dispatcher)) :
@@ -8003,7 +8851,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
         false)
     (hProject : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeProjectedDispatcherResultEq fuel' irContract tx state
         observableSlots (nativeContractOfDispatcher dispatcher) nativeYul)
@@ -8036,7 +8884,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
         false)
     (hProject : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeProjectedDispatcherResultEq fuel' irContract tx state
         observableSlots (nativeContractOfDispatcher dispatcher) nativeYul)
@@ -8075,7 +8923,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx state
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)) :
@@ -8107,7 +8955,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx state
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)) :
@@ -8143,7 +8991,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeProjectedDispatcherResultEq fuel' irContract tx state
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)
@@ -8179,7 +9027,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_runtime_d
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeProjectedDispatcherResultEq fuel' irContract tx state
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)
@@ -8208,7 +9056,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
       Compiler.Proofs.YulGeneration.Backends.BridgedSafeStmts
         spec.fields spec.errors .calldata [] false entry.1.body)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -8243,7 +9091,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
       Compiler.Proofs.YulGeneration.Backends.BridgedSafeStmts
         spec.fields spec.errors .calldata [] false entry.1.body)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -8274,7 +9122,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
       Compiler.Proofs.YulGeneration.Backends.BridgedSafeStmts
         spec.fields spec.errors .calldata [] false entry.1.body)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -8312,7 +9160,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
       Compiler.Proofs.YulGeneration.Backends.BridgedSafeStmts
         spec.fields spec.errors .calldata [] false entry.1.body)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -8348,7 +9196,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -8385,7 +9233,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -8419,7 +9267,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -8460,7 +9308,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -8490,7 +9338,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hSupported : SupportedSpec spec selectors)
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -8521,7 +9369,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hSupported : SupportedSpec spec selectors)
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -8548,7 +9396,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hSupported : SupportedSpec spec selectors)
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -8582,7 +9430,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hSupported : SupportedSpec spec selectors)
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -8614,7 +9462,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -8647,7 +9495,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -8682,7 +9530,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_positive_noMa
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -8741,7 +9589,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_positive_noMa
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -8800,7 +9648,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_positive_mapp
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -8862,7 +9710,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_positive_mapp
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -8913,7 +9761,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -8950,7 +9798,7 @@ private theorem nativeIRRuntimeMatchesIR_of_compiled_generated_dispatcherStmts_p
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -8989,7 +9837,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_project_noMap
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -9055,7 +9903,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_project_noMap
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -9119,7 +9967,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_project_mappi
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -9189,7 +10037,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_project_mappi
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -9435,7 +10283,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
       Compiler.Proofs.YulGeneration.Backends.BridgedSafeStmts
         spec.fields spec.errors .calldata [] false entry.1.body)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -9473,7 +10321,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
       Compiler.Proofs.YulGeneration.Backends.BridgedSafeStmts
         spec.fields spec.errors .calldata [] false entry.1.body)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -9508,7 +10356,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
       Compiler.Proofs.YulGeneration.Backends.BridgedSafeStmts
         spec.fields spec.errors .calldata [] false entry.1.body)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -9550,7 +10398,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
       Compiler.Proofs.YulGeneration.Backends.BridgedSafeStmts
         spec.fields spec.errors .calldata [] false entry.1.body)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -9586,7 +10434,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -9624,7 +10472,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -9658,7 +10506,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -9698,7 +10546,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -9726,7 +10574,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
     (hSupported : SupportedSpec spec selectors)
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -9756,7 +10604,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
     (hSupported : SupportedSpec spec selectors)
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -9783,7 +10631,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
     (hSupported : SupportedSpec spec selectors)
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -9816,7 +10664,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
     (hSupported : SupportedSpec spec selectors)
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -9847,7 +10695,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -9880,7 +10728,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -9909,7 +10757,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -9944,7 +10792,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -9984,7 +10832,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
     (hNativeDispatcherExec : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher)) :
@@ -10017,7 +10865,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
     (hProject : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher) nativeYul)
@@ -10054,7 +10902,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)) :
@@ -10089,7 +10937,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)
@@ -10117,7 +10965,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
     (hNativeDispatcherExec : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher)) :
@@ -10141,7 +10989,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
     (hProject : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher) nativeYul)
@@ -10169,7 +11017,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)) :
@@ -10195,7 +11043,7 @@ private theorem layer3_contract_preserves_semantics_native_of_compiled_generated
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)
@@ -10304,8 +11152,9 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_noMapping_stru
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         none)
@@ -10327,24 +11176,40 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_noMapping_stru
       sourceResultMatchesNativeOn observableSlots
         (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
         (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
-          (Nat.succ (fuel + cases'.length + 19)) irContract tx
+          (Nat.succ (fuel + cases'.length + 20)) irContract tx
           (FunctionBody.initialIRStateForTx model tx initialWorld)
           observableSlots) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcher [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_noMapping
       hcompile hSupported hNoMapping]
+    unfold nativeContractOfInitPrefixedDispatcher nativeInitFreeMemoryPointerStmt
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_miss_noFallback_noReceive
-      fuel irContract tx initialState observableSlots inner
+    lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      irContract.functions [nativeInitFreeMemoryPointerStmt, .Block inner]
+      hLowerDispatcher with
+    ⟨inner', nextSwitchId, hDispatcherEq, hLowerBlock⟩
+  simp [nativeInitFreeMemoryPointerStmt] at hDispatcherEq
+  subst inner'
+  rcases
+    nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds
+      fuel
+      (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none])
+      0 irContract tx initialState observableSlots inner nextSwitchId
       (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-      hLowerDispatcher hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
-    ⟨reservedNames, n0, cases', midN, hLowerCases, hNativeDispatcherExec⟩
-  refine ⟨reservedNames, n0, cases', midN, hLowerCases, ?_⟩
+      hLowerBlock hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
+    ⟨n0, cases', midN, hLowerCases, hNativeDispatcherExec⟩
+  refine ⟨
+    (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none]),
+    n0, cases', midN, hLowerCases, ?_⟩
   exact
     sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
       (hSourceIR :=
@@ -10355,7 +11220,9 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_noMapping_stru
         nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_supported
           hcompile hSupported hLowerRuntime hEnv
           (by
-            simpa [nativeContractOfDispatcher] using hNativeDispatcherExec))
+            simpa [nativeContractOfInitPrefixedDispatcher,
+              nativeInitFreeMemoryPointerStmt] using
+              hNativeDispatcherExec))
 
 /-- Supported no-mapping selector-miss source theorem at canonical generated
 runtime fuel. This discharges the native dispatcher-match premise for the
@@ -10374,8 +11241,9 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_noMapping_cano
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         none)
@@ -10396,23 +11264,34 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_noMapping_cano
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcher [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_noMapping
       hcompile hSupported hNoMapping]
+    unfold nativeContractOfInitPrefixedDispatcher nativeInitFreeMemoryPointerStmt
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_miss_noFallback_noReceive_atFuel
-      (nativeRuntimeDispatcherFuel irContract) irContract tx initialState
-      observableSlots inner
+    lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      irContract.functions [nativeInitFreeMemoryPointerStmt, .Block inner]
+      hLowerDispatcher with
+    ⟨inner', nextSwitchId, hDispatcherEq, hLowerBlock⟩
+  simp [nativeInitFreeMemoryPointerStmt] at hDispatcherEq
+  subst inner'
+  rcases
+    nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds_atFuel
+      (nativeRuntimeDispatcherFuel irContract)
+      (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none])
+      0 irContract tx initialState observableSlots inner nextSwitchId
       (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-      hLowerDispatcher hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
-    ⟨reservedNames, n0, cases', midN, hLowerCases, hNativeDispatcherExec⟩
+      hLowerBlock hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
+    ⟨n0, cases', midN, hLowerCases, hNativeDispatcherExec⟩
   have hFuel :
-      cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+      cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
     dsimp [nativeRuntimeDispatcherFuel]
-    exact
-      sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
-        hcompile hSupported hNoMapping hLowerCases
+    have h := sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
+      hcompile hSupported hNoMapping hLowerCases
+    omega
   exact
     sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
       (hSourceIR :=
@@ -10425,10 +11304,11 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_noMapping_cano
           (spec := model) (selectors := selectors) (irContract := irContract)
           (tx := tx) (state := initialState)
           (observableSlots := observableSlots)
-          (nativeContract := nativeContractOfDispatcher [.Block inner])
+          (nativeContract := nativeContractOfInitPrefixedDispatcher [.Block inner])
           hcompile hSupported hLowerRuntime hEnv
           (by
-            simpa [nativeContractOfDispatcher]
+            simpa [nativeContractOfInitPrefixedDispatcher,
+              nativeInitFreeMemoryPointerStmt]
               using hNativeDispatcherExec hFuel))
 
 /-- Direct `callDispatcher` no-mapping selector-miss theorem at canonical
@@ -10452,8 +11332,9 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_miss
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         none)
@@ -10465,28 +11346,39 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_miss
       (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
       (nativeGeneratedCallDispatcherResultOf irContract tx
         (FunctionBody.initialIRStateForTx model tx initialWorld)
-        observableSlots (nativeContractOfDispatcher [.Block inner])) := by
+        observableSlots (nativeContractOfInitPrefixedDispatcher [.Block inner])) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_miss_noFallback_noReceive_atFuel
-      (nativeRuntimeDispatcherFuel irContract) irContract tx initialState
-      observableSlots inner
+    lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      irContract.functions [nativeInitFreeMemoryPointerStmt, .Block inner]
+      hLowerDispatcher with
+    ⟨inner', nextSwitchId, hDispatcherEq, hLowerBlock⟩
+  simp [nativeInitFreeMemoryPointerStmt] at hDispatcherEq
+  subst inner'
+  rcases
+    nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds_atFuel
+      (nativeRuntimeDispatcherFuel irContract)
+      (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none])
+      0 irContract tx initialState observableSlots inner nextSwitchId
       (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-      hLowerDispatcher hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
-    ⟨reservedNames, n0, cases', midN, hLowerCases, hNativeDispatcherExec⟩
+      hLowerBlock hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
+    ⟨n0, cases', midN, hLowerCases, hNativeDispatcherExec⟩
   have hFuel :
-      cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+      cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
     dsimp [nativeRuntimeDispatcherFuel]
-    exact
-      sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
-        hcompile hSupported hNoMapping hLowerCases
+    have h := sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
+      hcompile hSupported hNoMapping hLowerCases
+    omega
   have hGeneratedMatch :
       nativeGeneratedCallDispatcherMatchesIROn irContract tx initialState
-        observableSlots (nativeContractOfDispatcher [.Block inner]) := by
+        observableSlots (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
     apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
     simpa [nativeGeneratedDispatcherExecMatchesIROn,
       nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-      nativeContractOfDispatcher] using hNativeDispatcherExec hFuel
+      nativeContractOfInitPrefixedDispatcher, nativeInitFreeMemoryPointerStmt]
+      using hNativeDispatcherExec hFuel
   exact
     sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeResultsMatchOn
       (hSourceIR :=
@@ -10516,8 +11408,9 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_mapping_struct
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         none)
@@ -10542,7 +11435,7 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_mapping_struct
       sourceResultMatchesNativeOn observableSlots
         (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
         (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
-          (Nat.succ (fuel + cases'.length + 19)) irContract tx
+          (Nat.succ (fuel + cases'.length + 20)) irContract tx
           (FunctionBody.initialIRStateForTx model tx initialWorld)
           observableSlots) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
@@ -10556,14 +11449,24 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_mapping_struct
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcherWithMapping [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_mapping_reserved
       hcompile hSupported hMapping]
+    unfold nativeContractOfInitPrefixedDispatcherWithMapping
+      nativeInitFreeMemoryPointerStmt
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds
+    lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      reservedNames 0 irContract.functions
+      [nativeInitFreeMemoryPointerStmt, .Block inner] nextSwitchId
+      hLowerDispatcher with
+    ⟨inner', hDispatcherEq, hLowerBlock⟩
+  simp [nativeInitFreeMemoryPointerStmt] at hDispatcherEq
+  subst inner'
+  rcases
+    nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds
       fuel reservedNames 0 irContract tx initialState observableSlots inner
-      nextSwitchId functions hLowerDispatcher hFind hSelectorRange hNoWrap
+      nextSwitchId functions hLowerBlock hFind hSelectorRange hNoWrap
       hFunctionSelectorsRange with
     ⟨switchStart, cases', midN, hLowerCases, hNativeDispatcherExec⟩
   refine ⟨switchStart, cases', midN, ?_, ?_⟩
@@ -10578,7 +11481,8 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_mapping_struct
           nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_supported
             hcompile hSupported hLowerRuntime hEnv
             (by
-              simpa [nativeContractOfDispatcherWithMapping, functions]
+              simpa [nativeContractOfInitPrefixedDispatcherWithMapping,
+                nativeInitFreeMemoryPointerStmt, functions]
                 using hNativeDispatcherExec))
 
 /-- Supported mapping-helper selector-miss source theorem at canonical
@@ -10600,8 +11504,9 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_mapping_canoni
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         none)
@@ -10629,22 +11534,32 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_mapping_canoni
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcherWithMapping [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_mapping_reserved
       hcompile hSupported hMapping]
+    unfold nativeContractOfInitPrefixedDispatcherWithMapping
+      nativeInitFreeMemoryPointerStmt
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds_atFuel
+    lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      reservedNames 0 irContract.functions
+      [nativeInitFreeMemoryPointerStmt, .Block inner] nextSwitchId
+      hLowerDispatcher with
+    ⟨inner', hDispatcherEq, hLowerBlock⟩
+  simp [nativeInitFreeMemoryPointerStmt] at hDispatcherEq
+  subst inner'
+  rcases
+    nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds_atFuel
       (nativeRuntimeDispatcherFuel irContract) reservedNames 0 irContract tx
       initialState observableSlots inner nextSwitchId functions
-      hLowerDispatcher hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
+      hLowerBlock hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
     ⟨switchStart, cases', midN, hLowerCases, hNativeDispatcherExec⟩
   have hFuel :
-      cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+      cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
     dsimp [nativeRuntimeDispatcherFuel]
-    exact
-      sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
-        hcompile hSupported hMapping hLowerCases
+    have h := sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
+      hcompile hSupported hMapping hLowerCases
+    omega
   exact
     sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
       (hSourceIR :=
@@ -10657,10 +11572,12 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_mapping_canoni
           (spec := model) (selectors := selectors) (irContract := irContract)
           (tx := tx) (state := initialState)
           (observableSlots := observableSlots)
-          (nativeContract := nativeContractOfDispatcherWithMapping [.Block inner])
+          (nativeContract := nativeContractOfInitPrefixedDispatcherWithMapping
+            [.Block inner])
           hcompile hSupported hLowerRuntime hEnv
           (by
-            simpa [nativeContractOfDispatcherWithMapping, functions]
+            simpa [nativeContractOfInitPrefixedDispatcherWithMapping,
+              nativeInitFreeMemoryPointerStmt, functions]
               using hNativeDispatcherExec hFuel))
 
 /-- Direct `callDispatcher` mapping-helper selector-miss theorem at canonical
@@ -10685,8 +11602,9 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_miss
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         none)
@@ -10698,7 +11616,8 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_miss
       (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
       (nativeGeneratedCallDispatcherResultOf irContract tx
         (FunctionBody.initialIRStateForTx model tx initialWorld)
-        observableSlots (nativeContractOfDispatcherWithMapping [.Block inner])) := by
+        observableSlots
+          (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
   let reservedNames :=
     Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
@@ -10708,24 +11627,34 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_miss
       "mappingSlot"
       Compiler.Proofs.YulGeneration.Backends.Native.nativeMappingSlotFunctionDefinition)
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds_atFuel
+    lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      reservedNames 0 irContract.functions
+      [nativeInitFreeMemoryPointerStmt, .Block inner] nextSwitchId
+      hLowerDispatcher with
+    ⟨inner', hDispatcherEq, hLowerBlock⟩
+  simp [nativeInitFreeMemoryPointerStmt] at hDispatcherEq
+  subst inner'
+  rcases
+    nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds_atFuel
       (nativeRuntimeDispatcherFuel irContract) reservedNames 0 irContract tx
       initialState observableSlots inner nextSwitchId functions
-      hLowerDispatcher hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
+      hLowerBlock hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
     ⟨switchStart, cases', midN, hLowerCases, hNativeDispatcherExec⟩
   have hFuel :
-      cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+      cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
     dsimp [nativeRuntimeDispatcherFuel]
-    exact
-      sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
-        hcompile hSupported hMapping hLowerCases
+    have h := sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
+      hcompile hSupported hMapping hLowerCases
+    omega
   have hGeneratedMatch :
       nativeGeneratedCallDispatcherMatchesIROn irContract tx initialState
-        observableSlots (nativeContractOfDispatcherWithMapping [.Block inner]) := by
+        observableSlots
+          (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
     apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
     simpa [nativeGeneratedDispatcherExecMatchesIROn,
       nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-      nativeContractOfDispatcherWithMapping, functions]
+      nativeContractOfInitPrefixedDispatcherWithMapping,
+      nativeInitFreeMemoryPointerStmt, functions]
       using hNativeDispatcherExec hFuel
   exact
     sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeResultsMatchOn
@@ -10774,7 +11703,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_miss
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
           (Compiler.emitYul irContract).runtimeCode)
         0 irContract.functions dispatcher nextSwitchId hLowerDispatcher with
@@ -10785,22 +11714,24 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_miss
       compile_preserves_native_evmYulLean_callDispatcher_selector_miss_mapping_canonical
         model selectors hSupported irContract tx initialWorld observableSlots
         inner nextSwitchId htxNormalized hcalldataSizeFits hcompile hMapping
-        hLowerBlock hFind hSelectorRange hNoWrap hFunctionSelectorsRange
+        (by simpa [nativeInitFreeMemoryPointerStmt] using hLowerDispatcher)
+        hFind hSelectorRange hNoWrap hFunctionSelectorsRange
   · have hNoMapping : irContract.usesMapping = false := by
       exact Bool.eq_false_iff.2 hUsesMapping
     rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, nextSwitchId, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
     exact
       compile_preserves_native_evmYulLean_callDispatcher_selector_miss_noMapping_canonical
         model selectors hSupported irContract tx initialWorld observableSlots
-        inner htxNormalized hcalldataSizeFits hcompile hNoMapping hLowerBlock
+        inner htxNormalized hcalldataSizeFits hcompile hNoMapping
+        (by simpa [nativeInitFreeMemoryPointerStmt] using hLowerDispatcher)
         hFind hSelectorRange hNoWrap hFunctionSelectorsRange
 
 /-- Native-vs-IR selector-miss theorem for a supported generated runtime.
@@ -10851,31 +11782,33 @@ private theorem nativeGeneratedCallDispatcherResult_selector_miss_matchesIR_of_c
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         reservedNames 0 irContract.functions dispatcher nextSwitchId
         hLowerDispatcher with
       ⟨inner, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
     rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds_atFuel
+      nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds_atFuel
         (nativeRuntimeDispatcherFuel irContract) reservedNames 0 irContract tx
         state observableSlots inner nextSwitchId functions
         (by simpa [reservedNames] using hLowerBlock)
         hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
       ⟨switchStart, cases', midN, hLowerCases, hNativeDispatcherExec⟩
     have hFuel :
-        cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+        cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
       dsimp [nativeRuntimeDispatcherFuel]
-      exact
-        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
-          hcompile hSupported hMapping hLowerCases
+      have h := sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
+        hcompile hSupported hMapping hLowerCases
+      omega
     change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-      observableSlots (nativeContractOfDispatcherWithMapping [.Block inner])
+      observableSlots
+        (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
     apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
     simpa [nativeGeneratedDispatcherExecMatchesIROn,
       nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-      nativeContractOfDispatcherWithMapping, functions]
+      nativeContractOfInitPrefixedDispatcherWithMapping,
+      nativeInitFreeMemoryPointerStmt, functions]
       using hNativeDispatcherExec hFuel
   · have hNoMapping : irContract.usesMapping = false :=
       Bool.eq_false_iff.2 hUsesMapping
@@ -10883,30 +11816,34 @@ private theorem nativeGeneratedCallDispatcherResult_selector_miss_matchesIR_of_c
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, nextSwitchId, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
     rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_miss_noFallback_noReceive_atFuel
-        (nativeRuntimeDispatcherFuel irContract) irContract tx state
-        observableSlots inner
+      nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds_atFuel
+        (nativeRuntimeDispatcherFuel irContract)
+        (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none])
+        0 irContract tx state observableSlots inner nextSwitchId
         (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
         hLowerBlock hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
-      ⟨reservedNames, n0, cases', midN, hLowerCases, hNativeDispatcherExec⟩
+      ⟨n0, cases', midN, hLowerCases, hNativeDispatcherExec⟩
     have hFuel :
-        cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+        cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
       dsimp [nativeRuntimeDispatcherFuel]
-      exact
-        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
-          hcompile hSupported hNoMapping hLowerCases
+      have h := sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
+        hcompile hSupported hNoMapping hLowerCases
+      omega
     change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-      observableSlots (nativeContractOfDispatcher [.Block inner])
+      observableSlots (nativeContractOfInitPrefixedDispatcher [.Block inner])
     apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
     simpa [nativeGeneratedDispatcherExecMatchesIROn,
       nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-      nativeContractOfDispatcher] using hNativeDispatcherExec hFuel
+      nativeContractOfInitPrefixedDispatcher, nativeInitFreeMemoryPointerStmt]
+      using hNativeDispatcherExec hFuel
 
 /-- Selector-miss native-vs-IR theorem with native lowering produced from
 `SupportedSpec + compile`. -/
@@ -10925,7 +11862,10 @@ theorem nativeGeneratedCallDispatcherResult_selector_miss_matchesIR_exists_of_co
     (hSelectorsRange :
       ∀ selector, selector ∈ selectors →
         selector < Compiler.Constants.selectorModulus)
-    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+      (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+        .ok ()) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
         (Compiler.emitYul irContract).runtimeCode = .ok nativeContract ∧
@@ -11007,73 +11947,270 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_nonpayable_nonz
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         reservedNames 0 irContract.functions dispatcher nextSwitchId
         hLowerDispatcher with
       ⟨inner, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
+    obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+        hInner, hLowerCases, hCase, hBodyLower⟩ :=
+      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+        reservedNames 0 irContract.functions inner nextSwitchId
+        tx.functionSelector fn hLowerBlock hFind
     rcases
-      Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_nonpayable_callvalue_revert_withSwitchIds_atFuel_projectResult_eq
-        (nativeRuntimeDispatcherFuel irContract) tx.functionSelector
-        reservedNames 0 irContract.functions fn inner nextSwitchId functions
-        tx state.storage state.events
-        (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-          (Compiler.runtimeCode irContract) observableSlots)
-        (by simpa [reservedNames] using hLowerBlock)
-        hSelector hFind hNoWrap hSelectorRangeNative hFunctionSelectorsRange
-        hNonPayable hNonzero with
-      ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
-        userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, hCont⟩
+      Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNativeWithSwitchIds_switchCaseBody_nonpayable_revert_eq
+        reservedNames bodyStart fn body' bodyEnd hNonPayable hBodyLower with
+      ⟨bodyNative, _userBodyStart, hBodyShape, _hUserBodyLower⟩
+    have hTagsEq :
+        cases'.map (·.1) =
+          (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+            irContract.functions).map (·.1) :=
+      Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds_tags_eq
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames switchStart + 1)
+        midN
+        (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+          irContract.functions) cases' hLowerCases
+    have hTagsRange :
+        ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size := by
+      intro tag body hmem
+      have hTagMem : tag ∈ cases'.map (·.1) :=
+        List.mem_map_of_mem (f := Prod.fst) hmem
+      rw [hTagsEq] at hTagMem
+      simp [Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases]
+        at hTagMem
+      rcases hTagMem with ⟨fnTag, hFnTag, hTag⟩
+      subst hTag
+      exact hFunctionSelectorsRange fnTag hFnTag
     have hFuel :
         cases'.length + 24 ≤ nativeRuntimeDispatcherFuel irContract := by
       dsimp [nativeRuntimeDispatcherFuel]
       exact
         sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
           hcompile hSupported hMapping hLowerCases
-    rcases hCont hFuel with ⟨hExec, _hProject⟩
+    let fuel := nativeRuntimeDispatcherFuel irContract - (cases'.length + 24)
+    have hFuelShape :
+        nativeRuntimeDispatcherFuel irContract = fuel + cases'.length + 24 := by
+      dsimp [fuel]
+      exact (Nat.sub_add_cancel hFuel).symm
+    let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+    have hExec :
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+            (nativeRuntimeDispatcherFuel irContract) contract
+            (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+              (YulTransaction.ofIR tx) state.storage
+              (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                (Compiler.runtimeCode irContract) observableSlots)) =
+          .error EvmYul.Yul.Exception.Revert := by
+      rw [hFuelShape]
+      have hPeel :=
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+          (fuel + 4) reservedNames switchStart cases' body1 inner functions
+          (YulTransaction.ofIR tx) state.storage
+          (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+            (Compiler.runtimeCode irContract) observableSlots)
+          hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+      have hBody :
+          ∀ pre suffix, cases' = pre ++ (tx.functionSelector, body') :: suffix →
+            EvmYul.Yul.exec (((fuel + 4) + 1) + suffix.length + 7)
+              (.Block body') (some contract)
+              ((((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
+                    contract (YulTransaction.ofIR tx) state.storage
+                    (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                      (Compiler.runtimeCode irContract) observableSlots)
+                    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore).insert
+                  (Compiler.Proofs.YulGeneration.Backends.nativeSwitchDiscrTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                  (EvmYul.UInt256.ofNat
+                    ((YulTransaction.ofIR tx).functionSelector %
+                      Compiler.Constants.selectorModulus))).insert
+                (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                (EvmYul.UInt256.ofNat 0)).insert
+                (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                (EvmYul.UInt256.ofNat 1)) =
+            .error EvmYul.Yul.Exception.Revert := by
+        intro pre suffix _hCases
+        rw [hBodyShape]
+        rw [show (((fuel + 4) + 1) + suffix.length + 7) =
+          (fuel + suffix.length) + 12 by omega]
+        exact
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_callvalue_revert_postInitFreeMemory_fuel
+            (fuel + suffix.length) [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            bodyNative contract (YulTransaction.ofIR tx) state.storage
+            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (Compiler.runtimeCode irContract) observableSlots)
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+            (4 + fn.params.length * 32)
+            (by simpa [YulTransaction.ofIR] using hNonzero)
+      have hSwitch :=
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+          (fuel + 4) tx.functionSelector
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+          tx.functionSelector cases'
+          [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+          body' contract (YulTransaction.ofIR tx) state.storage state.events
+          (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+            (Compiler.runtimeCode irContract) observableSlots)
+          EvmYul.Yul.Exception.Revert
+              (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+                (YulTransaction.ofIR tx) state.storage state.events
+                (.error EvmYul.Yul.Exception.Revert))
+            hSelector hCase hSelectorRangeNative hTagsRange hBody rfl
+      have hTotal :
+          fuel + cases'.length + 24 = (fuel + 4) + cases'.length + 20 := by
+        omega
+      rw [hTotal]
+      simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+        nativeInitFreeMemoryPointerStmt,
+        Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
     change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-      observableSlots (nativeContractOfDispatcherWithMapping [.Block inner])
+      observableSlots (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
     apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
     simpa [nativeGeneratedDispatcherExecMatchesIROn,
-      nativeRuntimeDispatcherFuel, nativeContractOfDispatcherWithMapping,
-      functions, hExec] using hIRRevert
+      nativeRuntimeDispatcherFuel, nativeContractOfInitPrefixedDispatcherWithMapping,
+      nativeInitFreeMemoryPointerStmt, functions, hExec, contract] using hIRRevert
   · have hNoMapping : irContract.usesMapping = false :=
       Bool.eq_false_iff.2 hUsesMapping
     rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, nextSwitchId, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
+    let reservedNames :=
+      Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+    obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+        hInner, hLowerCases, hCase, hBodyLower⟩ :=
+      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+        reservedNames 0 irContract.functions inner nextSwitchId
+        tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock) hFind
     rcases
-      Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_nonpayable_callvalue_revert_atFuel_projectResult_eq
-        (nativeRuntimeDispatcherFuel irContract) tx.functionSelector
-        irContract.functions fn inner
-        (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-        tx state.storage state.events
-        (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-          (Compiler.runtimeCode irContract) observableSlots)
-        hLowerBlock hSelector hFind hNoWrap hSelectorRangeNative
-        hFunctionSelectorsRange hNonPayable hNonzero with
-      ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart,
-        bodyEnd, userBodyStart, hLowerCases, hCase, hBodyLower,
-        hUserBodyLower, hCont⟩
+      Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNativeWithSwitchIds_switchCaseBody_nonpayable_revert_eq
+        reservedNames bodyStart fn body' bodyEnd hNonPayable hBodyLower with
+      ⟨bodyNative, _userBodyStart, hBodyShape, _hUserBodyLower⟩
+    have hTagsEq :
+        cases'.map (·.1) =
+          (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+            irContract.functions).map (·.1) :=
+      Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds_tags_eq
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames switchStart + 1)
+        midN
+        (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+          irContract.functions) cases' hLowerCases
+    have hTagsRange :
+        ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size := by
+      intro tag body hmem
+      have hTagMem : tag ∈ cases'.map (·.1) :=
+        List.mem_map_of_mem (f := Prod.fst) hmem
+      rw [hTagsEq] at hTagMem
+      simp [Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases]
+        at hTagMem
+      rcases hTagMem with ⟨fnTag, hFnTag, hTag⟩
+      subst hTag
+      exact hFunctionSelectorsRange fnTag hFnTag
     have hFuel :
         cases'.length + 24 ≤ nativeRuntimeDispatcherFuel irContract := by
       dsimp [nativeRuntimeDispatcherFuel]
       exact
         sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
           hcompile hSupported hNoMapping hLowerCases
-    rcases hCont hFuel with ⟨hExec, _hProject⟩
+    let fuel := nativeRuntimeDispatcherFuel irContract - (cases'.length + 24)
+    have hFuelShape :
+        nativeRuntimeDispatcherFuel irContract = fuel + cases'.length + 24 := by
+      dsimp [fuel]
+      exact (Nat.sub_add_cancel hFuel).symm
+    let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+    have hExec :
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+            (nativeRuntimeDispatcherFuel irContract) contract
+            (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+              (YulTransaction.ofIR tx) state.storage
+              (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                (Compiler.runtimeCode irContract) observableSlots)) =
+          .error EvmYul.Yul.Exception.Revert := by
+      rw [hFuelShape]
+      have hPeel :=
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+          (fuel + 4) reservedNames switchStart cases' body1 inner
+          (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+          (YulTransaction.ofIR tx) state.storage
+          (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+            (Compiler.runtimeCode irContract) observableSlots)
+          hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+      have hBody :
+          ∀ pre suffix, cases' = pre ++ (tx.functionSelector, body') :: suffix →
+            EvmYul.Yul.exec (((fuel + 4) + 1) + suffix.length + 7)
+              (.Block body') (some contract)
+              ((((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
+                    contract (YulTransaction.ofIR tx) state.storage
+                    (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                      (Compiler.runtimeCode irContract) observableSlots)
+                    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore).insert
+                  (Compiler.Proofs.YulGeneration.Backends.nativeSwitchDiscrTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                  (EvmYul.UInt256.ofNat
+                    ((YulTransaction.ofIR tx).functionSelector %
+                      Compiler.Constants.selectorModulus))).insert
+                (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                (EvmYul.UInt256.ofNat 0)).insert
+                (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                (EvmYul.UInt256.ofNat 1)) =
+            .error EvmYul.Yul.Exception.Revert := by
+        intro pre suffix _hCases
+        rw [hBodyShape]
+        rw [show (((fuel + 4) + 1) + suffix.length + 7) =
+          (fuel + suffix.length) + 12 by omega]
+        exact
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_callvalue_revert_postInitFreeMemory_fuel
+            (fuel + suffix.length) [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            bodyNative contract (YulTransaction.ofIR tx) state.storage
+            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (Compiler.runtimeCode irContract) observableSlots)
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+            (4 + fn.params.length * 32)
+            (by simpa [YulTransaction.ofIR] using hNonzero)
+      have hSwitch :=
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+          (fuel + 4) tx.functionSelector
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+          tx.functionSelector cases'
+          [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+          body' contract (YulTransaction.ofIR tx) state.storage state.events
+          (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+            (Compiler.runtimeCode irContract) observableSlots)
+          EvmYul.Yul.Exception.Revert
+          (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+            (YulTransaction.ofIR tx) state.storage state.events
+            (.error EvmYul.Yul.Exception.Revert))
+          hSelector hCase hSelectorRangeNative hTagsRange hBody rfl
+      have hTotal :
+          fuel + cases'.length + 24 = (fuel + 4) + cases'.length + 20 := by
+        omega
+      rw [hTotal]
+      simpa [contract, nativeContractOfInitPrefixedDispatcher,
+        nativeInitFreeMemoryPointerStmt,
+        Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
     change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-      observableSlots (nativeContractOfDispatcher [.Block inner])
+      observableSlots (nativeContractOfInitPrefixedDispatcher [.Block inner])
     apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
     simpa [nativeGeneratedDispatcherExecMatchesIROn,
-      nativeRuntimeDispatcherFuel, nativeContractOfDispatcher, hExec]
+      nativeRuntimeDispatcherFuel, nativeContractOfInitPrefixedDispatcher,
+      nativeInitFreeMemoryPointerStmt, hExec, contract]
       using hIRRevert
 
 /-- Native-vs-IR selector-hit theorem for the generated calldata-size guard.
@@ -11145,26 +12282,30 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_args_short_reve
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         reservedNames 0 irContract.functions dispatcher nextSwitchId
         hLowerDispatcher with
       ⟨inner, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
     by_cases hPayable : fn.payable = true
-    · rcases
-        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_payable_args_short_revert_withSwitchIds_atFuel_projectResult_eq
-          (nativeRuntimeDispatcherFuel irContract) tx.functionSelector
-          reservedNames 0 irContract.functions fn inner nextSwitchId functions
-          tx state.storage state.events
-          (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-            (Compiler.runtimeCode irContract) observableSlots)
-          (by simpa [reservedNames] using hLowerBlock)
-          hSelector hFind hNoWrap hSelectorRangeNative hFunctionSelectorsRange
-          hPayable hguards hArgsShort with
-        ⟨_switchStart, cases', _midN, _body', _bodyNative, _bodyStart,
-          _bodyEnd, _userBodyStart, hLowerCases, _hCase, _hBodyLower,
-          _hUserBodyLower, hCont⟩
+    · obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+          hInner, hLowerCases, hCase, hBodyLower⟩ :=
+        Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+          reservedNames 0 irContract.functions inner nextSwitchId
+          tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+          hFind
+      rcases
+        Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNativeWithSwitchIds_switchCaseBody_payable_revert_eq
+          reservedNames bodyStart fn body' bodyEnd hPayable hBodyLower with
+        ⟨bodyNative, _userBodyStart', hBodyShape, _hUserBodyLower'⟩
+      have hTagsRange :
+          ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+        lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+          reservedNames
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+            reservedNames switchStart + 1)
+          midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
       have hFuel24 :
           cases'.length + 24 ≤ nativeRuntimeDispatcherFuel irContract := by
         dsimp [nativeRuntimeDispatcherFuel]
@@ -11174,70 +12315,257 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_args_short_reve
       have hFuel23 :
           cases'.length + 23 ≤ nativeRuntimeDispatcherFuel irContract := by
         omega
-      rcases hCont hFuel23 with ⟨hExec, _hProject⟩
+      let fuel := nativeRuntimeDispatcherFuel irContract - (cases'.length + 23)
+      have hFuelShape :
+          nativeRuntimeDispatcherFuel irContract = fuel + cases'.length + 23 := by
+        dsimp [fuel]
+        exact (Nat.sub_add_cancel hFuel23).symm
+      let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (nativeRuntimeDispatcherFuel irContract) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) state.storage
+                (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                  (Compiler.runtimeCode irContract) observableSlots)) =
+            .error EvmYul.Yul.Exception.Revert := by
+        rw [hFuelShape]
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            (fuel + 3) reservedNames switchStart cases' body1 inner functions
+            (YulTransaction.ofIR tx) state.storage
+            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (Compiler.runtimeCode irContract) observableSlots)
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hCalldataLt :
+            4 + (YulTransaction.ofIR tx).args.length * 32 <
+              4 + fn.params.length * 32 := by
+          have hArgLt : tx.args.length < fn.params.length := by omega
+          simpa [YulTransaction.ofIR_args] using
+            (by omega :
+              4 + tx.args.length * 32 < 4 + fn.params.length * 32)
+        have hBody :
+            ∀ pre suffix, cases' = pre ++ (tx.functionSelector, body') :: suffix →
+              EvmYul.Yul.exec (((fuel + 3) + 1) + suffix.length + 7)
+                (.Block body') (some contract)
+                ((((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
+                      contract (YulTransaction.ofIR tx) state.storage
+                      (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                        (Compiler.runtimeCode irContract) observableSlots)
+                      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore).insert
+                    (Compiler.Proofs.YulGeneration.Backends.nativeSwitchDiscrTempName
+                      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                    (EvmYul.UInt256.ofNat
+                      ((YulTransaction.ofIR tx).functionSelector %
+                        Compiler.Constants.selectorModulus))).insert
+                  (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                  (EvmYul.UInt256.ofNat 0)).insert
+                  (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                  (EvmYul.UInt256.ofNat 1)) =
+              .error EvmYul.Yul.Exception.Revert := by
+          intro pre suffix _hCases
+          rw [hBodyShape]
+          rw [show (((fuel + 3) + 1) + suffix.length + 7) =
+            (fuel + suffix.length) + 11 by omega]
+          exact
+            Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_calldata_revert_postInitFreeMemory_fuel
+              (fuel + suffix.length) bodyNative contract (YulTransaction.ofIR tx)
+              state.storage
+              (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                (Compiler.runtimeCode irContract) observableSlots)
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (4 + fn.params.length * 32)
+              (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+              (Compiler.Proofs.YulGeneration.Backends.Native.DispatchGuardsSafe_calldata_threshold_lt
+                fn tx hguards)
+              hCalldataLt
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+            (fuel + 3) tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) state.storage state.events
+            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (Compiler.runtimeCode irContract) observableSlots)
+            EvmYul.Yul.Exception.Revert
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+              (YulTransaction.ofIR tx) state.storage state.events
+              (.error EvmYul.Yul.Exception.Revert))
+            hSelector hCase hSelectorRangeNative hTagsRange hBody rfl
+        have hTotal :
+            fuel + cases'.length + 23 = (fuel + 3) + cases'.length + 20 := by
+          omega
+        rw [hTotal]
+        simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+          nativeInitFreeMemoryPointerStmt,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
       change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-        observableSlots (nativeContractOfDispatcherWithMapping [.Block inner])
+        observableSlots (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
       apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
       simpa [nativeGeneratedDispatcherExecMatchesIROn,
-        nativeRuntimeDispatcherFuel, nativeContractOfDispatcherWithMapping,
-        functions, hExec] using hIRRevert
+        nativeRuntimeDispatcherFuel, nativeContractOfInitPrefixedDispatcherWithMapping,
+        nativeInitFreeMemoryPointerStmt, functions, hExec, contract] using hIRRevert
     · have hNonPayable : fn.payable = false := Bool.eq_false_iff.2 hPayable
       have hZero : tx.msgValue % Compiler.Constants.evmModulus = 0 := by
         rcases hValue with hPayable' | hZero
         · rw [hNonPayable] at hPayable'
           simp at hPayable'
         · exact hZero
+      obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+          hInner, hLowerCases, hCase, hBodyLower⟩ :=
+        Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+          reservedNames 0 irContract.functions inner nextSwitchId
+          tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+          hFind
       rcases
-        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_nonpayable_args_short_revert_withSwitchIds_atFuel_projectResult_eq
-          (nativeRuntimeDispatcherFuel irContract) tx.functionSelector
-          reservedNames 0 irContract.functions fn inner nextSwitchId functions
-          tx state.storage state.events
-          (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-            (Compiler.runtimeCode irContract) observableSlots)
-          (by simpa [reservedNames] using hLowerBlock)
-          hSelector hFind hNoWrap hSelectorRangeNative hFunctionSelectorsRange
-          hNonPayable hguards hZero hArgsShort with
-        ⟨_switchStart, cases', _midN, _body', _bodyNative, _bodyStart,
-          _bodyEnd, _userBodyStart, hLowerCases, _hCase, _hBodyLower,
-          _hUserBodyLower, hCont⟩
+        Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNativeWithSwitchIds_switchCaseBody_nonpayable_revert_eq
+          reservedNames bodyStart fn body' bodyEnd hNonPayable hBodyLower with
+        ⟨bodyNative, _userBodyStart', hBodyShape, _hUserBodyLower'⟩
+      have hTagsRange :
+          ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+        lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+          reservedNames
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+            reservedNames switchStart + 1)
+          midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
       have hFuel :
           cases'.length + 24 ≤ nativeRuntimeDispatcherFuel irContract := by
         dsimp [nativeRuntimeDispatcherFuel]
         exact
           sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
             hcompile hSupported hMapping hLowerCases
-      rcases hCont hFuel with ⟨hExec, _hProject⟩
+      let fuel := nativeRuntimeDispatcherFuel irContract - (cases'.length + 24)
+      have hFuelShape :
+          nativeRuntimeDispatcherFuel irContract = fuel + cases'.length + 24 := by
+        dsimp [fuel]
+        exact (Nat.sub_add_cancel hFuel).symm
+      let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (nativeRuntimeDispatcherFuel irContract) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) state.storage
+                (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                  (Compiler.runtimeCode irContract) observableSlots)) =
+            .error EvmYul.Yul.Exception.Revert := by
+        rw [hFuelShape]
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            (fuel + 4) reservedNames switchStart cases' body1 inner functions
+            (YulTransaction.ofIR tx) state.storage
+            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (Compiler.runtimeCode irContract) observableSlots)
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hCalldataLt :
+            4 + (YulTransaction.ofIR tx).args.length * 32 <
+              4 + fn.params.length * 32 := by
+          have hArgLt : tx.args.length < fn.params.length := by omega
+          simpa [YulTransaction.ofIR_args] using
+            (by omega :
+              4 + tx.args.length * 32 < 4 + fn.params.length * 32)
+        have hBody :
+            ∀ pre suffix, cases' = pre ++ (tx.functionSelector, body') :: suffix →
+              EvmYul.Yul.exec (((fuel + 4) + 1) + suffix.length + 7)
+                (.Block body') (some contract)
+                ((((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
+                      contract (YulTransaction.ofIR tx) state.storage
+                      (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                        (Compiler.runtimeCode irContract) observableSlots)
+                      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore).insert
+                    (Compiler.Proofs.YulGeneration.Backends.nativeSwitchDiscrTempName
+                      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                    (EvmYul.UInt256.ofNat
+                      ((YulTransaction.ofIR tx).functionSelector %
+                        Compiler.Constants.selectorModulus))).insert
+                  (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                  (EvmYul.UInt256.ofNat 0)).insert
+                  (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                  (EvmYul.UInt256.ofNat 1)) =
+              .error EvmYul.Yul.Exception.Revert := by
+          intro pre suffix _hCases
+          rw [hBodyShape]
+          rw [show (((fuel + 4) + 1) + suffix.length + 7) =
+            (fuel + suffix.length) + 12 by omega]
+          exact
+            Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_calldata_revert_postInitFreeMemory_fuel
+              (fuel + suffix.length) bodyNative contract (YulTransaction.ofIR tx)
+              state.storage
+              (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                (Compiler.runtimeCode irContract) observableSlots)
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (4 + fn.params.length * 32)
+              (by simpa [YulTransaction.ofIR] using hZero)
+              (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+              (Compiler.Proofs.YulGeneration.Backends.Native.DispatchGuardsSafe_calldata_threshold_lt
+                fn tx hguards)
+              hCalldataLt
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+            (fuel + 4) tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) state.storage state.events
+            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (Compiler.runtimeCode irContract) observableSlots)
+            EvmYul.Yul.Exception.Revert
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+              (YulTransaction.ofIR tx) state.storage state.events
+              (.error EvmYul.Yul.Exception.Revert))
+            hSelector hCase hSelectorRangeNative hTagsRange hBody rfl
+        have hTotal :
+            fuel + cases'.length + 24 = (fuel + 4) + cases'.length + 20 := by
+          omega
+        rw [hTotal]
+        simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+          nativeInitFreeMemoryPointerStmt,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
       change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-        observableSlots (nativeContractOfDispatcherWithMapping [.Block inner])
+        observableSlots (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
       apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
       simpa [nativeGeneratedDispatcherExecMatchesIROn,
-        nativeRuntimeDispatcherFuel, nativeContractOfDispatcherWithMapping,
-        functions, hExec] using hIRRevert
+        nativeRuntimeDispatcherFuel, nativeContractOfInitPrefixedDispatcherWithMapping,
+        nativeInitFreeMemoryPointerStmt, functions, hExec, contract] using hIRRevert
   · have hNoMapping : irContract.usesMapping = false :=
       Bool.eq_false_iff.2 hUsesMapping
     rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, nextSwitchId, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
+    let reservedNames :=
+      Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none]
     by_cases hPayable : fn.payable = true
-    · rcases
-        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_payable_args_short_revert_atFuel_projectResult_eq
-          (nativeRuntimeDispatcherFuel irContract) tx.functionSelector
-          irContract.functions fn inner
-          (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-          tx state.storage state.events
-          (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-            (Compiler.runtimeCode irContract) observableSlots)
-          hLowerBlock hSelector hFind hNoWrap hSelectorRangeNative
-          hFunctionSelectorsRange hPayable hguards hArgsShort with
-        ⟨_reservedNames, _n0, cases', _midN, _body', _bodyNative,
-          _bodyStart, _bodyEnd, _userBodyStart, hLowerCases, _hCase,
-          _hBodyLower, _hUserBodyLower, hCont⟩
+    · obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+          hInner, hLowerCases, hCase, hBodyLower⟩ :=
+        Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+          reservedNames 0 irContract.functions inner nextSwitchId
+          tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+          hFind
+      rcases
+        Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNativeWithSwitchIds_switchCaseBody_payable_revert_eq
+          reservedNames bodyStart fn body' bodyEnd hPayable hBodyLower with
+        ⟨bodyNative, _userBodyStart, hBodyShape, _hUserBodyLower⟩
+      have hTagsRange :
+          ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+        lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+          reservedNames
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+            reservedNames switchStart + 1)
+          midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
       have hFuel24 :
           cases'.length + 24 ≤ nativeRuntimeDispatcherFuel irContract := by
         dsimp [nativeRuntimeDispatcherFuel]
@@ -11247,12 +12575,101 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_args_short_reve
       have hFuel23 :
           cases'.length + 23 ≤ nativeRuntimeDispatcherFuel irContract := by
         omega
-      rcases hCont hFuel23 with ⟨hExec, _hProject⟩
+      let fuel := nativeRuntimeDispatcherFuel irContract - (cases'.length + 23)
+      have hFuelShape :
+          nativeRuntimeDispatcherFuel irContract = fuel + cases'.length + 23 := by
+        dsimp [fuel]
+        exact (Nat.sub_add_cancel hFuel23).symm
+      let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (nativeRuntimeDispatcherFuel irContract) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) state.storage
+                (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                  (Compiler.runtimeCode irContract) observableSlots)) =
+            .error EvmYul.Yul.Exception.Revert := by
+        rw [hFuelShape]
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            (fuel + 3) reservedNames switchStart cases' body1 inner
+            (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+            (YulTransaction.ofIR tx) state.storage
+            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (Compiler.runtimeCode irContract) observableSlots)
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hCalldataLt :
+            4 + (YulTransaction.ofIR tx).args.length * 32 <
+              4 + fn.params.length * 32 := by
+          have hArgLt : tx.args.length < fn.params.length := by omega
+          simpa [YulTransaction.ofIR_args] using
+            (by omega :
+              4 + tx.args.length * 32 < 4 + fn.params.length * 32)
+        have hBody :
+            ∀ pre suffix, cases' = pre ++ (tx.functionSelector, body') :: suffix →
+              EvmYul.Yul.exec (((fuel + 3) + 1) + suffix.length + 7)
+                (.Block body') (some contract)
+                ((((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
+                      contract (YulTransaction.ofIR tx) state.storage
+                      (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                        (Compiler.runtimeCode irContract) observableSlots)
+                      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore).insert
+                    (Compiler.Proofs.YulGeneration.Backends.nativeSwitchDiscrTempName
+                      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                    (EvmYul.UInt256.ofNat
+                      ((YulTransaction.ofIR tx).functionSelector %
+                        Compiler.Constants.selectorModulus))).insert
+                  (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                  (EvmYul.UInt256.ofNat 0)).insert
+                  (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                  (EvmYul.UInt256.ofNat 1)) =
+              .error EvmYul.Yul.Exception.Revert := by
+          intro pre suffix _hCases
+          rw [hBodyShape]
+          rw [show (((fuel + 3) + 1) + suffix.length + 7) =
+            (fuel + suffix.length) + 11 by omega]
+          exact
+            Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_calldata_revert_postInitFreeMemory_fuel
+              (fuel + suffix.length) bodyNative contract (YulTransaction.ofIR tx)
+              state.storage
+              (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                (Compiler.runtimeCode irContract) observableSlots)
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (4 + fn.params.length * 32)
+              (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+              (Compiler.Proofs.YulGeneration.Backends.Native.DispatchGuardsSafe_calldata_threshold_lt
+                fn tx hguards)
+              hCalldataLt
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+            (fuel + 3) tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) state.storage state.events
+            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (Compiler.runtimeCode irContract) observableSlots)
+            EvmYul.Yul.Exception.Revert
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+              (YulTransaction.ofIR tx) state.storage state.events
+              (.error EvmYul.Yul.Exception.Revert))
+            hSelector hCase hSelectorRangeNative hTagsRange hBody rfl
+        have hTotal :
+            fuel + cases'.length + 23 = (fuel + 3) + cases'.length + 20 := by
+          omega
+        rw [hTotal]
+        simpa [contract, nativeContractOfInitPrefixedDispatcher,
+          nativeInitFreeMemoryPointerStmt,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
       change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-        observableSlots (nativeContractOfDispatcher [.Block inner])
+        observableSlots (nativeContractOfInitPrefixedDispatcher [.Block inner])
       apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
       simpa [nativeGeneratedDispatcherExecMatchesIROn,
-        nativeRuntimeDispatcherFuel, nativeContractOfDispatcher, hExec]
+        nativeRuntimeDispatcherFuel, nativeContractOfInitPrefixedDispatcher,
+        nativeInitFreeMemoryPointerStmt, hExec, contract]
         using hIRRevert
     · have hNonPayable : fn.payable = false := Bool.eq_false_iff.2 hPayable
       have hZero : tx.msgValue % Compiler.Constants.evmModulus = 0 := by
@@ -11260,31 +12677,125 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_args_short_reve
         · rw [hNonPayable] at hPayable'
           simp at hPayable'
         · exact hZero
+      obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+          hInner, hLowerCases, hCase, hBodyLower⟩ :=
+        Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+          reservedNames 0 irContract.functions inner nextSwitchId
+          tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+          hFind
       rcases
-        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_nonpayable_args_short_revert_atFuel_projectResult_eq
-          (nativeRuntimeDispatcherFuel irContract) tx.functionSelector
-          irContract.functions fn inner
-          (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-          tx state.storage state.events
-          (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-            (Compiler.runtimeCode irContract) observableSlots)
-          hLowerBlock hSelector hFind hNoWrap hSelectorRangeNative
-          hFunctionSelectorsRange hNonPayable hguards hZero hArgsShort with
-        ⟨_reservedNames, _n0, cases', _midN, _body', _bodyNative,
-          _bodyStart, _bodyEnd, _userBodyStart, hLowerCases, _hCase,
-          _hBodyLower, _hUserBodyLower, hCont⟩
+        Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNativeWithSwitchIds_switchCaseBody_nonpayable_revert_eq
+          reservedNames bodyStart fn body' bodyEnd hNonPayable hBodyLower with
+        ⟨bodyNative, _userBodyStart, hBodyShape, _hUserBodyLower⟩
+      have hTagsRange :
+          ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+        lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+          reservedNames
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+            reservedNames switchStart + 1)
+          midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
       have hFuel :
           cases'.length + 24 ≤ nativeRuntimeDispatcherFuel irContract := by
         dsimp [nativeRuntimeDispatcherFuel]
         exact
           sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
             hcompile hSupported hNoMapping hLowerCases
-      rcases hCont hFuel with ⟨hExec, _hProject⟩
+      let fuel := nativeRuntimeDispatcherFuel irContract - (cases'.length + 24)
+      have hFuelShape :
+          nativeRuntimeDispatcherFuel irContract = fuel + cases'.length + 24 := by
+        dsimp [fuel]
+        exact (Nat.sub_add_cancel hFuel).symm
+      let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (nativeRuntimeDispatcherFuel irContract) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) state.storage
+                (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                  (Compiler.runtimeCode irContract) observableSlots)) =
+            .error EvmYul.Yul.Exception.Revert := by
+        rw [hFuelShape]
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            (fuel + 4) reservedNames switchStart cases' body1 inner
+            (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+            (YulTransaction.ofIR tx) state.storage
+            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (Compiler.runtimeCode irContract) observableSlots)
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hCalldataLt :
+            4 + (YulTransaction.ofIR tx).args.length * 32 <
+              4 + fn.params.length * 32 := by
+          have hArgLt : tx.args.length < fn.params.length := by omega
+          simpa [YulTransaction.ofIR_args] using
+            (by omega :
+              4 + tx.args.length * 32 < 4 + fn.params.length * 32)
+        have hBody :
+            ∀ pre suffix, cases' = pre ++ (tx.functionSelector, body') :: suffix →
+              EvmYul.Yul.exec (((fuel + 4) + 1) + suffix.length + 7)
+                (.Block body') (some contract)
+                ((((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
+                      contract (YulTransaction.ofIR tx) state.storage
+                      (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                        (Compiler.runtimeCode irContract) observableSlots)
+                      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore).insert
+                    (Compiler.Proofs.YulGeneration.Backends.nativeSwitchDiscrTempName
+                      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                    (EvmYul.UInt256.ofNat
+                      ((YulTransaction.ofIR tx).functionSelector %
+                        Compiler.Constants.selectorModulus))).insert
+                  (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                  (EvmYul.UInt256.ofNat 0)).insert
+                  (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart))
+                  (EvmYul.UInt256.ofNat 1)) =
+              .error EvmYul.Yul.Exception.Revert := by
+          intro pre suffix _hCases
+          rw [hBodyShape]
+          rw [show (((fuel + 4) + 1) + suffix.length + 7) =
+            (fuel + suffix.length) + 12 by omega]
+          exact
+            Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_calldata_revert_postInitFreeMemory_fuel
+              (fuel + suffix.length) bodyNative contract (YulTransaction.ofIR tx)
+              state.storage
+              (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                (Compiler.runtimeCode irContract) observableSlots)
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (4 + fn.params.length * 32)
+              (by simpa [YulTransaction.ofIR] using hZero)
+              (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+              (Compiler.Proofs.YulGeneration.Backends.Native.DispatchGuardsSafe_calldata_threshold_lt
+                fn tx hguards)
+              hCalldataLt
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+            (fuel + 4) tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) state.storage state.events
+            (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (Compiler.runtimeCode irContract) observableSlots)
+            EvmYul.Yul.Exception.Revert
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+              (YulTransaction.ofIR tx) state.storage state.events
+              (.error EvmYul.Yul.Exception.Revert))
+            hSelector hCase hSelectorRangeNative hTagsRange hBody rfl
+        have hTotal :
+            fuel + cases'.length + 24 = (fuel + 4) + cases'.length + 20 := by
+          omega
+        rw [hTotal]
+        simpa [contract, nativeContractOfInitPrefixedDispatcher,
+          nativeInitFreeMemoryPointerStmt,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
       change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-        observableSlots (nativeContractOfDispatcher [.Block inner])
+        observableSlots (nativeContractOfInitPrefixedDispatcher [.Block inner])
       apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
       simpa [nativeGeneratedDispatcherExecMatchesIROn,
-        nativeRuntimeDispatcherFuel, nativeContractOfDispatcher, hExec]
+        nativeRuntimeDispatcherFuel, nativeContractOfInitPrefixedDispatcher,
+        nativeInitFreeMemoryPointerStmt, hExec, contract]
         using hIRRevert
 
 /-- Selector-hit non-payable value-guard revert theorem with native lowering
@@ -11477,12 +12988,15 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_of_compile_ok_
     let reservedNames :=
       Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode
+    rcases lowerRuntimeContractNative_of_compile_ok_supported_exists
+        hcompile hSupported with
+      ⟨nativeContract, hLowerRuntime⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_exists_of_compile_ok_supported
-        reservedNames 0 hcompile hSupported with
-      ⟨dispatcher, nextSwitchId, hLowerDispatcher⟩
+      lowerRuntimeContractNative_of_compile_ok_supported_mapping_ok_dispatcher_reserved
+        hcompile hSupported hMapping hLowerRuntime with
+      ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         reservedNames 0 irContract.functions dispatcher nextSwitchId
         hLowerDispatcher with
       ⟨inner, hDispatcher, hLowerBlock⟩
@@ -11491,23 +13005,28 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_of_compile_ok_
       compile_preserves_native_evmYulLean_selector_miss_mapping_canonical
         model selectors hSupported irContract tx initialWorld observableSlots
         inner nextSwitchId htxNormalized hcalldataSizeFits hcompile hMapping
-        (by simpa [reservedNames] using hLowerBlock)
+        (by simpa [reservedNames, nativeInitFreeMemoryPointerStmt] using
+          hLowerDispatcher)
         hFind hSelectorRange hNoWrap hFunctionSelectorsRange hEnv
   · have hNoMapping : irContract.usesMapping = false :=
       Bool.eq_false_iff.2 hUsesMapping
-    rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_exists_of_compile_ok_supported
+    rcases lowerRuntimeContractNative_of_compile_ok_supported_exists
         hcompile hSupported with
-      ⟨dispatcher, hLowerDispatcher⟩
+      ⟨nativeContract, hLowerRuntime⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
+        hcompile hSupported hNoMapping hLowerRuntime with
+      ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
+    rcases
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, nextSwitchId, hDispatcher, hLowerBlock⟩
     subst dispatcher
     exact
       compile_preserves_native_evmYulLean_selector_miss_noMapping_canonical
         model selectors hSupported irContract tx initialWorld observableSlots
-        inner htxNormalized hcalldataSizeFits hcompile hNoMapping hLowerBlock
+        inner htxNormalized hcalldataSizeFits hcompile hNoMapping
+        (by simpa [nativeInitFreeMemoryPointerStmt] using hLowerDispatcher)
         hFind hSelectorRange hNoWrap hFunctionSelectorsRange hEnv
 
 /-- Supported no-mapping selector-hit source theorem at the structural fuel
@@ -11530,8 +13049,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_st
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -11558,9 +13078,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_st
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec ((fuel + 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -11579,7 +13099,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_st
               (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
                 reservedNames n0))
             (EvmYul.UInt256.ofNat 1) stmt
-            (some (nativeContractOfDispatcher [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -11587,13 +13107,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_st
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -11606,46 +13126,158 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_st
         sourceResultMatchesNativeOn observableSlots
           (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
           (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
-            (Nat.succ (fuel + cases'.length + 19)) irContract tx
+            (Nat.succ (fuel + cases'.length + 20)) irContract tx
             (FunctionBody.initialIRStateForTx model tx initialWorld)
             observableSlots)) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcher [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_noMapping
       hcompile hSupported hNoMapping]
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive
-      fuel irContract tx initialState observableSlots inner
-      (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-      fn final nativeYul hLowerDispatcher hFind hSelectorRange hNoWrap
-      hFunctionSelectorsRange with
-    ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hNativeDispatcherExec⟩
-  refine ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
+    lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      irContract.functions [nativeInitFreeMemoryPointerStmt, .Block inner]
+      hLowerDispatcher with
+    ⟨inner', nextSwitchId, hDispatcher, hLowerBlock⟩
+  have hInnerEq : inner = inner' := by
+    simpa [nativeInitFreeMemoryPointerStmt] using hDispatcher
+  subst inner'
+  let reservedNames :=
+    Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+  obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+      hInner, hLowerCases, hCase, hBodyLower⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+      reservedNames 0 irContract.functions inner nextSwitchId
+      tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+      hFind
+  have hSelector :
+      tx.functionSelector =
+        (YulTransaction.ofIR tx).functionSelector %
+          Compiler.Constants.selectorModulus := by
+    simpa [YulTransaction.ofIR] using
+      (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hTagsEq :
+      cases'.map (·.1) =
+        (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+          irContract.functions).map (·.1) :=
+    Compiler.Proofs.YulGeneration.Backends.lowerSwitchCasesNativeWithSwitchIds_tags_eq
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart + 1)
+      midN (Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases
+        irContract.functions) cases' hLowerCases
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size := by
+    intro tag body hmem
+    have hTagMem : tag ∈ cases'.map (·.1) :=
+      List.mem_map_of_mem (f := Prod.fst) hmem
+    rw [hTagsEq] at hTagMem
+    simp [Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases]
+      at hTagMem
+    rcases hTagMem with ⟨fnTag, hFnTag, hTag⟩
+    subst hTag
+    exact hFunctionSelectorsRange fnTag hFnTag
+  refine ⟨reservedNames, switchStart, cases', body', bodyStart, bodyEnd,
     hCase, hBodyLower, ?_⟩
   intro hFresh hBody hStmtPreserves hProject hMatch
   have hNativeDispatcherExec' :
-      nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 19)
+      nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 20)
         irContract tx initialState observableSlots
-        (nativeContractOfDispatcher [.Block inner]) := by
-    refine hNativeDispatcherExec ?_ ?_ ?_ hMatch
-    · simpa [initialState, nativeContractOfDispatcher] using hBody
-    · intro pre suffix hcases
-      exact
-        Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_nativeSwitchFresh_find_hit_matched
-          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
-            reservedNames n0)
-          tx.functionSelector tx.functionSelector body'
+        (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+    let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+    let materializedSlots :=
+      Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+        (Compiler.runtimeCode irContract) observableSlots
+    have hExec :
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+            (fuel + cases'.length + 20) contract
+            (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+              (YulTransaction.ofIR tx) initialState.storage materializedSlots) =
+          .ok final := by
+      have hPeel :=
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+          fuel reservedNames switchStart cases' body1 inner
+          (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+          (YulTransaction.ofIR tx) initialState.storage materializedSlots
+          hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+      have hFinalMatched :
+          ∀ matchedName : EvmYul.Identifier,
+            matchedName =
+                Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                    reservedNames switchStart) →
+              final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+        intro matchedName hMatchedName
+        subst matchedName
+        rcases
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitch_find_hit_split
+            tx.functionSelector cases' tx.functionSelector body' hCase with
+          ⟨pre, suffix, hCases, _hTag, _hPrefix⟩
+        exact
+          (Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_nativeSwitchFresh_find_hit_matched
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            tx.functionSelector tx.functionSelector body'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            cases' (EvmYul.UInt256.ofNat 1)
+            (some contract)
+            (by simpa using hFresh) hCase
+            (by
+              simpa [contract, nativeContractOfInitPrefixedDispatcher] using
+                hStmtPreserves))
+            ((fuel + 1) + suffix.length + 7)
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              contract (YulTransaction.ofIR tx) initialState.storage
+              materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore)
+            final
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+              contract (YulTransaction.ofIR tx) initialState.storage
+              materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)) rfl)
+            (by
+              simpa [initialState, contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcher] using hBody pre suffix hCases)
+      have hSwitch :=
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+          fuel tx.functionSelector
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames switchStart)
+          tx.functionSelector cases'
           [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
-          cases' (EvmYul.UInt256.ofNat 1)
-          (some (nativeContractOfDispatcher [.Block inner]))
-          (by simpa using hFresh) hCase
-          (by simpa [nativeContractOfDispatcher] using hStmtPreserves)
-    · simpa [initialState, nativeContractOfDispatcher] using hProject
+          body' contract (YulTransaction.ofIR tx) initialState.storage
+          initialState.events materializedSlots final
+          (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+            (YulTransaction.ofIR tx) initialState.storage initialState.events
+            (.ok (final, [])))
+          hSelector hCase hSelectorRangeNative hTagsRange
+          (by
+            intro pre suffix hCases
+            simpa [initialState, contract, materializedSlots,
+              nativeContractOfInitPrefixedDispatcher] using
+              hBody pre suffix hCases)
+          hFinalMatched rfl
+      simpa [contract, nativeContractOfInitPrefixedDispatcher,
+        nativeInitFreeMemoryPointerStmt,
+        Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+    refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+      (contract := irContract) (tx := tx) (state := initialState)
+      (observableSlots := observableSlots)
+      (nativeContract := contract) ?_ hMatch
+    simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+      contract, initialState] using hProject
   exact
     sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
       (hSourceIR :=
@@ -11676,8 +13308,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_st
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -11706,9 +13339,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_st
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec (fuel + suffix.length + 10) (.Block bodyNative)
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -11724,7 +13357,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_st
               (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
                 reservedNames n0))
             (EvmYul.UInt256.ofNat 1) bodyNative
-            (some (nativeContractOfDispatcher [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -11732,13 +13365,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_st
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -11751,37 +13384,167 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_st
         sourceResultMatchesNativeOn observableSlots
           (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
           (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
-            (Nat.succ (fuel + cases'.length + 23)) irContract tx
+            (Nat.succ (fuel + cases'.length + 24)) irContract tx
             (FunctionBody.initialIRStateForTx model tx initialWorld)
             observableSlots)) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcher [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_noMapping
       hcompile hSupported hNoMapping]
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_payable_generated_prefix
-      fuel irContract tx initialState observableSlots inner
-      (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-      fn final nativeYul hLowerDispatcher hFind hSelectorRange hNoWrap
-      hFunctionSelectorsRange hPayable hguards hArgs with
-    ⟨reservedNames, n0, cases', _midN, body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, _hLowerCases, hCase, hBodyLower, hUserBodyLower,
-      hNativeDispatcherExec⟩
-  refine ⟨reservedNames, n0, cases', body', bodyNative, bodyStart, bodyEnd,
+    lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      irContract.functions [nativeInitFreeMemoryPointerStmt, .Block inner]
+      hLowerDispatcher with
+    ⟨inner', nextSwitchId, hDispatcher, hLowerBlock⟩
+  have hInnerEq : inner = inner' := by
+    simpa [nativeInitFreeMemoryPointerStmt] using hDispatcher
+  subst inner'
+  let reservedNames :=
+    Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+  obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+      hInner, hLowerCases, hCase, hBodyLower⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+      reservedNames 0 irContract.functions inner nextSwitchId
+      tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+      hFind
+  rcases
+    Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNativeWithSwitchIds_switchCaseBody_payable_eq
+      reservedNames bodyStart fn body' bodyEnd hPayable hBodyLower with
+    ⟨guardBody, bodyNative, userBodyStart, hBodyShape, hUserBodyLower⟩
+  have hSelector :
+      tx.functionSelector =
+        (YulTransaction.ofIR tx).functionSelector %
+          Compiler.Constants.selectorModulus := by
+    simpa [YulTransaction.ofIR] using
+      (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+    lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+        reservedNames switchStart + 1)
+      midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
+  refine ⟨reservedNames, switchStart, cases', body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hBody hPreservesMatched hProject hMatch
   have hNativeDispatcherExec' :
-      nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 23)
+      nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 24)
         irContract tx initialState observableSlots
-        (nativeContractOfDispatcher [.Block inner]) := by
-    refine hNativeDispatcherExec ?_ ?_ ?_ hMatch
-    · simpa [initialState, nativeContractOfDispatcher] using hBody
-    · simpa [nativeContractOfDispatcher] using hPreservesMatched
-    · simpa [initialState, nativeContractOfDispatcher] using hProject
+        (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+    let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+    let materializedSlots :=
+      Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+        (Compiler.runtimeCode irContract) observableSlots
+    have hExec :
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+            (fuel + cases'.length + 24) contract
+            (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+              (YulTransaction.ofIR tx) initialState.storage materializedSlots) =
+          .ok final := by
+      have hPeel :=
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+          (fuel + 4) reservedNames switchStart cases' body1 inner
+          (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+          (YulTransaction.ofIR tx) initialState.storage materializedSlots
+          hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+      have hBodyWhole :
+          ∀ pre suffix, cases' = pre ++ (tx.functionSelector, body') :: suffix →
+            EvmYul.Yul.exec (((fuel + 4) + 1) + suffix.length + 7)
+              (.Block body') (some contract)
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+                contract (YulTransaction.ofIR tx) initialState.storage
+                materializedSlots
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)
+                Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
+              .ok final := by
+        intro pre suffix hCases
+        rw [hBodyShape]
+        have hPrefix :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_postInitFreeMemory_eq
+            (fuel + suffix.length + 1) guardBody bodyNative contract
+            (YulTransaction.ofIR tx) initialState.storage materializedSlots
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+            (4 + fn.params.length * 32)
+            (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+            (Compiler.Proofs.YulGeneration.Backends.Native.DispatchGuardsSafe_calldata_threshold_lt
+              fn tx hguards)
+            (by simp; omega)
+        simpa [initialState, contract, materializedSlots,
+          nativeContractOfInitPrefixedDispatcher, Nat.add_assoc, Nat.add_comm,
+          Nat.add_left_comm] using hPrefix.trans (hBody pre suffix hCases)
+      have hFinalMatched :
+          ∀ matchedName : EvmYul.Identifier,
+            matchedName =
+                Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                    reservedNames switchStart) →
+              final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+        intro matchedName hMatchedName
+        subst matchedName
+        rcases
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitch_find_hit_split
+            tx.functionSelector cases' tx.functionSelector body' hCase with
+          ⟨pre, suffix, hCases, _hTag, _hPrefix⟩
+        exact hPreservesMatched pre suffix hCases
+          (fuel + suffix.length + 10)
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+            contract (YulTransaction.ofIR tx) initialState.storage
+            materializedSlots
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore)
+          final
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+            contract (YulTransaction.ofIR tx) initialState.storage
+            materializedSlots
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+            (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)) rfl)
+          (by
+            simpa [initialState, contract, materializedSlots,
+              nativeContractOfInitPrefixedDispatcher] using
+              hBody pre suffix hCases)
+      have hSwitch :=
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+          (fuel + 4) tx.functionSelector
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+            reservedNames switchStart)
+          tx.functionSelector cases'
+          [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+          body' contract (YulTransaction.ofIR tx) initialState.storage
+          initialState.events materializedSlots final
+          (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+            (YulTransaction.ofIR tx) initialState.storage initialState.events
+            (.ok (final, [])))
+          hSelector hCase hSelectorRangeNative hTagsRange hBodyWhole
+          hFinalMatched rfl
+      have hFuelShape :
+          fuel + cases'.length + 24 = (fuel + 4) + cases'.length + 20 := by
+        omega
+      rw [hFuelShape]
+      simpa [contract, nativeContractOfInitPrefixedDispatcher,
+        nativeInitFreeMemoryPointerStmt,
+        Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+    refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+      (contract := irContract) (tx := tx) (state := initialState)
+      (observableSlots := observableSlots)
+      (nativeContract := contract) ?_ hMatch
+    simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+      contract, initialState] using hProject
   exact
     sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
       (hSourceIR :=
@@ -11808,11 +13571,12 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_st
     (htxNormalized : Function.TxContextNormalized tx)
     (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
     (hcompile : CompilationModel.compile model selectors = Except.ok irContract)
-    (hNoMapping : irContract.usesMapping = false)
-    (hLowerDispatcher :
-      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+      (hNoMapping : irContract.usesMapping = false)
+      (hLowerDispatcher :
+        Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
+            [Compiler.CodegenCommon.initFreeMemoryPointer,
+              Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -11838,15 +13602,15 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_st
           .ok (body', bodyEnd) ∧
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
         reservedNames userBodyStart fn.body = .ok (bodyNative, bodyEnd) ∧
-      ((∀ pre suffix,
-          cases' = pre ++ (tx.functionSelector, body') :: suffix →
-          EvmYul.Yul.exec (fuel + suffix.length + 10) (.Block bodyNative)
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
-              (YulTransaction.ofIR tx)
-              (FunctionBody.initialIRStateForTx model tx initialWorld).storage
-              (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+        ((∀ pre suffix,
+            cases' = pre ++ (tx.functionSelector, body') :: suffix →
+            EvmYul.Yul.exec (fuel + suffix.length + 10) (.Block bodyNative)
+              (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
+                (YulTransaction.ofIR tx)
+                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+                (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                 (Compiler.runtimeCode irContract) observableSlots)
               (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
                 reservedNames n0)
@@ -11855,28 +13619,28 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_st
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord
-            (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
-              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
-                reservedNames n0))
-            (EvmYul.UInt256.ofNat 1) bodyNative
-            (some (nativeContractOfDispatcher [.Block inner]))) →
-        Compiler.Proofs.YulGeneration.Backends.Native.projectResult
-          (YulTransaction.ofIR tx)
-          (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames n0))
+              (EvmYul.UInt256.ofNat 1) bodyNative
+              (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))) →
+          Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+            (YulTransaction.ofIR tx)
+            (FunctionBody.initialIRStateForTx model tx initialWorld).storage
           (FunctionBody.initialIRStateForTx model tx initialWorld).events
           (.ok
-            (((final.reviveJump.overwrite?
-              (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
-                (YulTransaction.ofIR tx)
-                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
-                (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-                  (Compiler.runtimeCode irContract) observableSlots))).setStore
-              (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
-                (YulTransaction.ofIR tx)
-                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
-                (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+              (((final.reviveJump.overwrite?
+                (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+                  (nativeContractOfInitPrefixedDispatcher [.Block inner])
+                  (YulTransaction.ofIR tx)
+                  (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+                  (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+                    (Compiler.runtimeCode irContract) observableSlots))).setStore
+                (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+                  (nativeContractOfInitPrefixedDispatcher [.Block inner])
+                  (YulTransaction.ofIR tx)
+                  (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+                  (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))), [])) =
           nativeYul →
         nativeResultsMatchOn observableSlots
@@ -11884,41 +13648,178 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_st
             (FunctionBody.initialIRStateForTx model tx initialWorld))
           (.ok nativeYul) →
         sourceResultMatchesNativeOn observableSlots
-          (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
-          (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
-            (Nat.succ (fuel + cases'.length + 24)) irContract tx
-            (FunctionBody.initialIRStateForTx model tx initialWorld)
-            observableSlots)) := by
-  let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
-  have hLowerRuntime :
-      Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
-          (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcher [.Block inner]) := by
-    rw [lowerRuntimeContractNative_of_compile_ok_supported_noMapping
-      hcompile hSupported hNoMapping]
-    rw [hLowerDispatcher]
-  rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_nonpayable_generated_prefix
-      fuel irContract tx initialState observableSlots inner
-      (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-      fn final nativeYul hLowerDispatcher hFind hSelectorRange hNoWrap
-      hFunctionSelectorsRange hNonPayable hguards hArgs with
-    ⟨reservedNames, n0, cases', _midN, body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, _hLowerCases, hCase, hBodyLower, hUserBodyLower,
-      hNativeDispatcherExec⟩
-  refine ⟨reservedNames, n0, cases', body', bodyNative, bodyStart, bodyEnd,
-    userBodyStart, hCase, hBodyLower, hUserBodyLower, ?_⟩
-  intro hBody hPreservesMatched hProject hMatch
-  have hNativeDispatcherExec' :
-      nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 24)
-        irContract tx initialState observableSlots
-        (nativeContractOfDispatcher [.Block inner]) := by
-    refine hNativeDispatcherExec ?_ ?_ ?_ hMatch
-    · simpa [initialState, nativeContractOfDispatcher] using hBody
-    · simpa [nativeContractOfDispatcher] using hPreservesMatched
-    · simpa [initialState, nativeContractOfDispatcher] using hProject
-  exact
-    sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
+            (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
+            (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
+              (Nat.succ (fuel + cases'.length + 25)) irContract tx
+              (FunctionBody.initialIRStateForTx model tx initialWorld)
+              observableSlots)) := by
+    let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
+    have hLowerRuntime :
+        Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
+            (Compiler.emitYul irContract).runtimeCode =
+          .ok (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+      rw [lowerRuntimeContractNative_of_compile_ok_supported_noMapping
+        hcompile hSupported hNoMapping]
+      rw [hLowerDispatcher]
+    rcases
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+        irContract.functions [nativeInitFreeMemoryPointerStmt, .Block inner]
+        hLowerDispatcher with
+      ⟨inner', nextSwitchId, hDispatcher, hLowerBlock⟩
+    have hInnerEq : inner = inner' := by
+      simpa [nativeInitFreeMemoryPointerStmt] using hDispatcher
+    subst inner'
+    let reservedNames :=
+      Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+    obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+        hInner, hLowerCases, hCase, hBodyLower⟩ :=
+      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+        reservedNames 0 irContract.functions inner nextSwitchId
+        tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+        hFind
+    rcases
+      Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNativeWithSwitchIds_switchCaseBody_nonpayable_eq
+        reservedNames bodyStart fn body' bodyEnd hNonPayable hBodyLower with
+      ⟨callvalueGuardBody, calldataGuardBody, bodyNative, userBodyStart,
+        hBodyShape, hUserBodyLower⟩
+    have hSelector :
+        tx.functionSelector =
+          (YulTransaction.ofIR tx).functionSelector %
+            Compiler.Constants.selectorModulus := by
+      simpa [YulTransaction.ofIR] using
+        (Nat.mod_eq_of_lt hSelectorRange).symm
+    have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+      exact Nat.lt_trans hSelectorRange (by decide)
+    have hTagsRange :
+        ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+      lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames switchStart + 1)
+        midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
+    refine ⟨reservedNames, switchStart, cases', body', bodyNative, bodyStart, bodyEnd,
+      userBodyStart, hCase, hBodyLower, hUserBodyLower, ?_⟩
+    intro hBody hPreservesMatched hProject hMatch
+    have hNativeDispatcherExec' :
+        nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 25)
+          irContract tx initialState observableSlots
+          (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+      let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+      let materializedSlots :=
+        Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+          (Compiler.runtimeCode irContract) observableSlots
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (fuel + cases'.length + 25) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) initialState.storage materializedSlots) =
+            .ok final := by
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            (fuel + 5) reservedNames switchStart cases' body1 inner
+            (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+            (YulTransaction.ofIR tx) initialState.storage materializedSlots
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hBodyWhole :
+            ∀ pre suffix, cases' = pre ++ (tx.functionSelector, body') :: suffix →
+              EvmYul.Yul.exec (((fuel + 5) + 1) + suffix.length + 7)
+                (.Block body') (some contract)
+                (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+                  contract (YulTransaction.ofIR tx) initialState.storage
+                  materializedSlots
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                    reservedNames switchStart)
+                  Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
+                .ok final := by
+          intro pre suffix hCases
+          rw [hBodyShape]
+          have hPrefix :=
+            Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_postInitFreeMemory_eq
+              (fuel + suffix.length + 1) callvalueGuardBody calldataGuardBody
+              bodyNative contract (YulTransaction.ofIR tx) initialState.storage
+              materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (4 + fn.params.length * 32)
+              (Compiler.Proofs.YulGeneration.Backends.Native.DispatchGuardsSafe_msgValue_zero_mod_of_nonpayable
+                fn tx hguards hNonPayable)
+              (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+              (Compiler.Proofs.YulGeneration.Backends.Native.DispatchGuardsSafe_calldata_threshold_lt
+                fn tx hguards)
+              (by
+                have hMul : fn.params.length * 32 ≤ tx.args.length * 32 :=
+                  Nat.mul_le_mul_right 32 hArgs
+                exact Nat.add_le_add_left hMul 4)
+          simpa [initialState, contract, materializedSlots,
+            nativeContractOfInitPrefixedDispatcher, Nat.add_assoc, Nat.add_comm,
+            Nat.add_left_comm] using hPrefix.trans (hBody pre suffix hCases)
+        have hFinalMatched :
+            ∀ matchedName : EvmYul.Identifier,
+              matchedName =
+                  Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                      reservedNames switchStart) →
+                final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+          intro matchedName hMatchedName
+          subst matchedName
+          rcases
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitch_find_hit_split
+              tx.functionSelector cases' tx.functionSelector body' hCase with
+            ⟨pre, suffix, hCases, _hTag, _hPrefix⟩
+          exact hPreservesMatched pre suffix hCases
+            (fuel + suffix.length + 10)
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              contract (YulTransaction.ofIR tx) initialState.storage
+              materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore)
+            final
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+              contract (YulTransaction.ofIR tx) initialState.storage
+              materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)) rfl)
+            (by
+              simpa [initialState, contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcher] using
+                hBody pre suffix hCases)
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+            (fuel + 5) tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) initialState.storage
+            initialState.events materializedSlots final
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+              (YulTransaction.ofIR tx) initialState.storage initialState.events
+              (.ok (final, [])))
+            hSelector hCase hSelectorRangeNative hTagsRange hBodyWhole
+            hFinalMatched rfl
+        have hFuelShape :
+            fuel + cases'.length + 25 = (fuel + 5) + cases'.length + 20 := by
+          omega
+        rw [hFuelShape]
+        simpa [contract, nativeContractOfInitPrefixedDispatcher,
+          nativeInitFreeMemoryPointerStmt,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+      refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+        (contract := irContract) (tx := tx) (state := initialState)
+        (observableSlots := observableSlots)
+        (nativeContract := contract) ?_ hMatch
+      simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+        contract, initialState] using hProject
+    exact
+      sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
       (hSourceIR :=
         Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
           model selectors hSupported irContract tx initialWorld
@@ -11943,11 +13844,12 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
     (htxNormalized : Function.TxContextNormalized tx)
     (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
     (hcompile : CompilationModel.compile model selectors = Except.ok irContract)
-    (hNoMapping : irContract.usesMapping = false)
-    (hLowerDispatcher :
-      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+      (hNoMapping : irContract.usesMapping = false)
+      (hLowerDispatcher :
+        Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
+            [Compiler.CodegenCommon.initFreeMemoryPointer,
+              Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -11974,11 +13876,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
-                1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+              (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
+                  1) + suffix.length + 7) (.Block body')
+              (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -11993,25 +13895,25 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
                 reservedNames n0) ∉
             Compiler.Proofs.YulGeneration.Backends.nativeStmtWriteNames stmt →
           Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord
-            (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
-              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
-                reservedNames n0))
-            (EvmYul.UInt256.ofNat 1) stmt
-            (some (nativeContractOfDispatcher [.Block inner]))) →
+              (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames n0))
+              (EvmYul.UInt256.ofNat 1) stmt
+              (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
           (FunctionBody.initialIRStateForTx model tx initialWorld).events
           (.ok
-            (((final.reviveJump.overwrite?
-              (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+              (((final.reviveJump.overwrite?
+                (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+                  (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
-              (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+                  (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -12031,46 +13933,153 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcher [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_noMapping
       hcompile hSupported hNoMapping]
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_atFuel
-      (nativeRuntimeDispatcherFuel irContract) irContract tx initialState
-      observableSlots inner
-      (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-      fn final nativeYul hLowerDispatcher hFind hSelectorRange hNoWrap
-      hFunctionSelectorsRange with
-    ⟨reservedNames, n0, cases', _midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      irContract.functions [nativeInitFreeMemoryPointerStmt, .Block inner]
+      hLowerDispatcher with
+    ⟨inner', nextSwitchId, hDispatcher, hLowerBlock⟩
+  have hInnerEq : inner = inner' := by
+    simpa [nativeInitFreeMemoryPointerStmt] using hDispatcher
+  subst inner'
+  let reservedNames :=
+    Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+  obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+      hInner, hLowerCases, hCase, hBodyLower⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+      reservedNames 0 irContract.functions inner nextSwitchId
+      tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+      hFind
   have hFuel :
-      cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+      cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
     dsimp [nativeRuntimeDispatcherFuel]
-    exact
-      sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
+    have hBig :=
+      sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
         hcompile hSupported hNoMapping hLowerCases
-  refine ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
+    omega
+  have hSelector :
+      tx.functionSelector =
+        (YulTransaction.ofIR tx).functionSelector %
+          Compiler.Constants.selectorModulus := by
+    simpa [YulTransaction.ofIR] using
+      (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+    lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+        reservedNames switchStart + 1)
+      midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
+  refine ⟨reservedNames, switchStart, cases', body', bodyStart, bodyEnd,
     hCase, hBodyLower, ?_⟩
   intro hFresh hBody hStmtPreserves hProject hMatch
   have hNativeDispatcherExec' :
       nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
         irContract tx initialState observableSlots
-        (nativeContractOfDispatcher [.Block inner]) := by
-    refine hNativeDispatcherExec hFuel ?_ ?_ ?_ hMatch
-    · simpa [initialState, nativeContractOfDispatcher] using hBody
-    · intro pre suffix hcases
-      exact
-        Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_nativeSwitchFresh_find_hit_matched
+        (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+    let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+    let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+    let materializedSlots :=
+      Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+        (Compiler.runtimeCode irContract) observableSlots
+    have hFuelShape :
+        nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+      dsimp [fuel0]
+      exact (Nat.sub_add_cancel hFuel).symm
+    have hExec :
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+            (nativeRuntimeDispatcherFuel irContract) contract
+            (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+              (YulTransaction.ofIR tx) initialState.storage materializedSlots) =
+          .ok final := by
+      rw [hFuelShape]
+      have hPeel :=
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+          fuel0 reservedNames switchStart cases' body1 inner
+          (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+          (YulTransaction.ofIR tx) initialState.storage materializedSlots
+          hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+      have hFinalMatched :
+          ∀ matchedName : EvmYul.Identifier,
+            matchedName =
+                Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                    reservedNames switchStart) →
+              final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+        intro matchedName hMatchedName
+        subst matchedName
+        rcases
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitch_find_hit_split
+            tx.functionSelector cases' tx.functionSelector body' hCase with
+          ⟨pre, suffix, hCases, _hTag, _hPrefix⟩
+        exact
+          (Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_nativeSwitchFresh_find_hit_matched
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            tx.functionSelector tx.functionSelector body'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            cases' (EvmYul.UInt256.ofNat 1)
+            (some contract)
+            (by simpa using hFresh) hCase
+            (by
+              simpa [contract, nativeContractOfInitPrefixedDispatcher] using
+                hStmtPreserves))
+            ((fuel0 + 1) + suffix.length + 7)
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              contract (YulTransaction.ofIR tx) initialState.storage
+              materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore)
+            final
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+              contract (YulTransaction.ofIR tx) initialState.storage
+              materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)) rfl)
+            (by
+              simpa [initialState, contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcher, fuel0] using
+                hBody pre suffix hCases)
+      have hSwitch :=
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+          fuel0 tx.functionSelector
           (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
-            reservedNames n0)
-          tx.functionSelector tx.functionSelector body'
+            reservedNames switchStart)
+          tx.functionSelector cases'
           [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
-          cases' (EvmYul.UInt256.ofNat 1)
-          (some (nativeContractOfDispatcher [.Block inner]))
-          (by simpa using hFresh) hCase
-          (by simpa [nativeContractOfDispatcher] using hStmtPreserves)
-    · simpa [initialState, nativeContractOfDispatcher] using hProject
+          body' contract (YulTransaction.ofIR tx) initialState.storage
+          initialState.events materializedSlots final
+          (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+            (YulTransaction.ofIR tx) initialState.storage initialState.events
+            (.ok (final, [])))
+          hSelector hCase hSelectorRangeNative hTagsRange
+          (by
+            intro pre suffix hCases
+            simpa [initialState, contract, materializedSlots,
+              nativeContractOfInitPrefixedDispatcher, fuel0] using
+              hBody pre suffix hCases)
+          hFinalMatched rfl
+      simpa [contract, nativeContractOfInitPrefixedDispatcher,
+        nativeInitFreeMemoryPointerStmt,
+        Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+    refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+      (contract := irContract) (tx := tx) (state := initialState)
+      (observableSlots := observableSlots)
+      (nativeContract := contract) ?_ hMatch
+    simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+      contract, initialState] using hProject
   exact
     sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
       (hSourceIR :=
@@ -12080,13 +14089,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
       (hNativeIR :=
         nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_supported
           (fuel' := nativeRuntimeDispatcherFuel irContract)
-          (spec := model) (selectors := selectors) (irContract := irContract)
-          (tx := tx) (state := initialState)
-          (observableSlots := observableSlots)
-          (nativeContract := nativeContractOfDispatcher [.Block inner])
-          hcompile hSupported hLowerRuntime hEnv
-          (by
-            simpa [nativeContractOfDispatcher] using hNativeDispatcherExec'))
+            (spec := model) (selectors := selectors) (irContract := irContract)
+            (tx := tx) (state := initialState)
+            (observableSlots := observableSlots)
+            (nativeContract := nativeContractOfInitPrefixedDispatcher [.Block inner])
+            hcompile hSupported hLowerRuntime hEnv
+            (by
+              simpa [nativeContractOfInitPrefixedDispatcher] using hNativeDispatcherExec'))
 
 /-- Block-preservation variant of
 `compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_canonical`.
@@ -12109,8 +14118,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -12133,11 +14143,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -12153,7 +14163,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
               (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
                 reservedNames n0))
             (EvmYul.UInt256.ofNat 1) body'
-            (some (nativeContractOfDispatcher [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -12161,13 +14171,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -12187,36 +14197,142 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcher [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_noMapping
       hcompile hSupported hNoMapping]
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_atFuel
-      (nativeRuntimeDispatcherFuel irContract) irContract tx initialState
-      observableSlots inner
-      (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-      fn final nativeYul hLowerDispatcher hFind hSelectorRange hNoWrap
-      hFunctionSelectorsRange with
-    ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      irContract.functions [nativeInitFreeMemoryPointerStmt, .Block inner]
+      hLowerDispatcher with
+    ⟨inner', nextSwitchId, hDispatcher, hLowerBlock⟩
+  have hInnerEq : inner = inner' := by
+    simpa [nativeInitFreeMemoryPointerStmt] using hDispatcher
+  subst inner'
+  let reservedNames :=
+    Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+  obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+      hInner, hLowerCases, hCase, hBodyLower⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+      reservedNames 0 irContract.functions inner nextSwitchId
+      tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+      hFind
   have hFuel :
-      cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+      cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
     dsimp [nativeRuntimeDispatcherFuel]
-    exact
-      sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
+    have hBig :=
+      sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
         hcompile hSupported hNoMapping hLowerCases
-  refine ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
+    omega
+  have hSelector :
+      tx.functionSelector =
+        (YulTransaction.ofIR tx).functionSelector %
+          Compiler.Constants.selectorModulus := by
+    simpa [YulTransaction.ofIR] using
+      (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+    lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+        reservedNames switchStart + 1)
+      midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
+  refine ⟨reservedNames, switchStart, cases', body', bodyStart, bodyEnd,
     hCase, hBodyLower, ?_⟩
   intro hBody hPreservesMatched hProject hMatch
   have hNativeDispatcherExec' :
       nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
         irContract tx initialState observableSlots
-        (nativeContractOfDispatcher [.Block inner]) := by
-    refine hNativeDispatcherExec hFuel ?_ ?_ ?_ hMatch
-    · simpa [initialState, nativeContractOfDispatcher] using hBody
-    · simpa [nativeContractOfDispatcher] using hPreservesMatched
-    · simpa [initialState, nativeContractOfDispatcher] using hProject
+        (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+    let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+    let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+    let materializedSlots :=
+      Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+        (Compiler.runtimeCode irContract) observableSlots
+    have hFuelShape :
+        nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+      dsimp [fuel0]
+      exact (Nat.sub_add_cancel hFuel).symm
+    have hExec :
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+            (nativeRuntimeDispatcherFuel irContract) contract
+            (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+              (YulTransaction.ofIR tx) initialState.storage materializedSlots) =
+          .ok final := by
+      rw [hFuelShape]
+      have hPeel :=
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+          fuel0 reservedNames switchStart cases' body1 inner
+          (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+          (YulTransaction.ofIR tx) initialState.storage materializedSlots
+          hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+      have hFinalMatched :
+          ∀ matchedName : EvmYul.Identifier,
+            matchedName =
+                Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                    reservedNames switchStart) →
+              final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+        intro matchedName hMatchedName
+        subst matchedName
+        rcases
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitch_find_hit_split
+            tx.functionSelector cases' tx.functionSelector body' hCase with
+          ⟨pre, suffix, hCases, _hTag, _hPrefix⟩
+        exact hPreservesMatched pre suffix hCases
+          ((fuel0 + 1) + suffix.length + 7)
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+            contract (YulTransaction.ofIR tx) initialState.storage
+            materializedSlots
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore)
+          final
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+            contract (YulTransaction.ofIR tx) initialState.storage
+            materializedSlots
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+            (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)) rfl)
+          (by
+            simpa [initialState, contract, materializedSlots,
+              nativeContractOfInitPrefixedDispatcher, fuel0] using
+              hBody pre suffix hCases)
+      have hSwitch :=
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+          fuel0 tx.functionSelector
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+            reservedNames switchStart)
+          tx.functionSelector cases'
+          [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+          body' contract (YulTransaction.ofIR tx) initialState.storage
+          initialState.events materializedSlots final
+          (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+            (YulTransaction.ofIR tx) initialState.storage initialState.events
+            (.ok (final, [])))
+          hSelector hCase hSelectorRangeNative hTagsRange
+          (by
+            intro pre suffix hCases
+            simpa [initialState, contract, materializedSlots,
+              nativeContractOfInitPrefixedDispatcher, fuel0] using
+              hBody pre suffix hCases)
+          hFinalMatched rfl
+      simpa [contract, nativeContractOfInitPrefixedDispatcher,
+        nativeInitFreeMemoryPointerStmt,
+        Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+    refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+      (contract := irContract) (tx := tx) (state := initialState)
+      (observableSlots := observableSlots)
+      (nativeContract := contract) ?_ hMatch
+    simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+      contract, initialState] using hProject
   exact
     sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
       (hSourceIR :=
@@ -12229,10 +14345,10 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
           (spec := model) (selectors := selectors) (irContract := irContract)
           (tx := tx) (state := initialState)
           (observableSlots := observableSlots)
-          (nativeContract := nativeContractOfDispatcher [.Block inner])
+          (nativeContract := nativeContractOfInitPrefixedDispatcher [.Block inner])
           hcompile hSupported hLowerRuntime hEnv
           (by
-            simpa [nativeContractOfDispatcher] using hNativeDispatcherExec'))
+            simpa [nativeContractOfInitPrefixedDispatcher] using hNativeDispatcherExec'))
 
 /-- Direct `callDispatcher` no-mapping selector-hit success theorem at
 canonical generated-runtime fuel, using the block-preservation obligation for
@@ -12252,15 +14368,20 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
     (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hFunctionSelectorsRange :
-      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size) :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
+    (hEnv :
+      Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+        (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+          .ok ()) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -12273,11 +14394,11 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -12293,7 +14414,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
               (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
                 reservedNames n0))
             (EvmYul.UInt256.ofNat 1) body'
-            (some (nativeContractOfDispatcher [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -12301,13 +14422,13 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -12321,45 +14442,32 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
           (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
           (nativeGeneratedCallDispatcherResultOf irContract tx
             (FunctionBody.initialIRStateForTx model tx initialWorld)
-            observableSlots (nativeContractOfDispatcher [.Block inner]))) := by
+            observableSlots (nativeContractOfInitPrefixedDispatcher [.Block inner]))) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
+  have hLowerRuntime :
+      Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
+          (Compiler.emitYul irContract).runtimeCode =
+        .ok (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+    rw [lowerRuntimeContractNative_of_compile_ok_supported_noMapping
+      hcompile hSupported hNoMapping]
+    rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_atFuel
-      (nativeRuntimeDispatcherFuel irContract) irContract tx initialState
-      observableSlots inner
-      (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-      fn final nativeYul hLowerDispatcher hFind hSelectorRange hNoWrap
-      hFunctionSelectorsRange with
-    ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
-  have hFuel :
-      cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
-    dsimp [nativeRuntimeDispatcherFuel]
-    exact
-      sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
-        hcompile hSupported hNoMapping hLowerCases
+    compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_canonical_preserved
+      model selectors hSupported irContract tx initialWorld observableSlots inner
+      fn final nativeYul htxNormalized hcalldataSizeFits hcompile hNoMapping
+      hLowerDispatcher hFind hSelectorRange hNoWrap hFunctionSelectorsRange
+      hEnv with
+    ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd, hCase, hBodyLower,
+      hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
     hCase, hBodyLower, ?_⟩
   intro hBody hPreservesMatched hProject hMatch
-  have hGeneratedMatch :
-      nativeGeneratedCallDispatcherMatchesIROn irContract tx initialState
-        observableSlots (nativeContractOfDispatcher [.Block inner]) := by
-    apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
-    simpa [nativeGeneratedDispatcherExecMatchesIROn,
-      nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-      nativeContractOfDispatcher] using
-        hNativeDispatcherExec hFuel
-          (by simpa [initialState, nativeContractOfDispatcher] using hBody)
-          (by simpa [nativeContractOfDispatcher] using hPreservesMatched)
-          (by simpa [initialState, nativeContractOfDispatcher] using hProject)
-          hMatch
-  exact
-    sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeResultsMatchOn
-      (hSourceIR :=
-        Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
-          model selectors hSupported irContract tx initialWorld
-          htxNormalized hcalldataSizeFits hcompile)
-      (hNativeIR := hGeneratedMatch)
+  have hSource := hDispatcherContinuation hBody hPreservesMatched hProject hMatch
+  rw [nativeGeneratedCallDispatcherResultOf_eq_interpretIRRuntimeNative_of_lowerRuntimeContractNative_supported
+    tx initialState observableSlots
+    (nativeContractOfInitPrefixedDispatcher [.Block inner])
+    hcompile hSupported hLowerRuntime hEnv]
+  simpa [nativeRuntimeFuel, initialState] using hSource
 
 /-- Direct `callDispatcher` no-mapping selector-hit success theorem at
 canonical generated-runtime fuel, deriving selected-body block preservation from
@@ -12379,15 +14487,20 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
     (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hFunctionSelectorsRange :
-      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size) :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
+    (hEnv :
+      Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+        (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+          .ok ()) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -12404,11 +14517,11 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -12427,7 +14540,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
               (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
                 reservedNames n0))
             (EvmYul.UInt256.ofNat 1) stmt
-            (some (nativeContractOfDispatcher [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -12435,13 +14548,13 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -12455,12 +14568,13 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
           (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
           (nativeGeneratedCallDispatcherResultOf irContract tx
             (FunctionBody.initialIRStateForTx model tx initialWorld)
-            observableSlots (nativeContractOfDispatcher [.Block inner]))) := by
+            observableSlots (nativeContractOfInitPrefixedDispatcher [.Block inner]))) := by
   rcases
     compile_preserves_native_evmYulLean_callDispatcher_selector_hit_ok_noMapping_canonical_preserved
       model selectors hSupported irContract tx initialWorld observableSlots inner
       fn final nativeYul htxNormalized hcalldataSizeFits hcompile hNoMapping
-      hLowerDispatcher hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
+      hLowerDispatcher hFind hSelectorRange hNoWrap hFunctionSelectorsRange
+      hEnv with
     ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd, hCase, hBodyLower,
       hPreserved⟩
   refine ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
@@ -12474,9 +14588,9 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
         tx.functionSelector tx.functionSelector body'
         [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
         cases' (EvmYul.UInt256.ofNat 1)
-        (some (nativeContractOfDispatcher [.Block inner]))
+        (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
         (by simpa using hFresh) hCase
-        (by simpa [nativeContractOfDispatcher] using hStmtPreserves))
+        (by simpa [nativeContractOfInitPrefixedDispatcher] using hStmtPreserves))
     hProject hMatch
 
 /-- Supported mapping-helper selector-hit source theorem at the structural fuel
@@ -12499,8 +14613,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -12530,9 +14645,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec ((fuel + 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -12557,7 +14672,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
                   (Compiler.emitYul irContract).runtimeCode)
                 switchStart))
             (EvmYul.UInt256.ofNat 1) stmt
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -12565,13 +14680,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -12584,7 +14699,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
         sourceResultMatchesNativeOn observableSlots
           (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
           (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
-            (Nat.succ (fuel + cases'.length + 19)) irContract tx
+            (Nat.succ (fuel + cases'.length + 20)) irContract tx
             (FunctionBody.initialIRStateForTx model tx initialWorld)
             observableSlots)) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
@@ -12598,43 +14713,138 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcherWithMapping [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_mapping_reserved
       hcompile hSupported hMapping]
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_withSwitchIds
-      fuel reservedNames 0 irContract tx initialState observableSlots inner
-      nextSwitchId functions fn final nativeYul hLowerDispatcher hFind
-      hSelectorRange hNoWrap hFunctionSelectorsRange with
-    ⟨switchStart, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hNativeDispatcherExec⟩
+    lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      reservedNames 0 irContract.functions
+      [nativeInitFreeMemoryPointerStmt, .Block inner] nextSwitchId
+      (by simpa [reservedNames] using hLowerDispatcher) with
+    ⟨inner', hDispatcher, hLowerBlock⟩
+  have hInnerEq : inner = inner' := by
+    simpa [nativeInitFreeMemoryPointerStmt] using hDispatcher
+  subst inner'
+  obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+      hInner, hLowerCases, hCase, hBodyLower⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+      reservedNames 0 irContract.functions inner nextSwitchId
+      tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+      hFind
+  have hSelector :
+      tx.functionSelector =
+        (YulTransaction.ofIR tx).functionSelector %
+          Compiler.Constants.selectorModulus := by
+    simpa [YulTransaction.ofIR] using
+      (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+    lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+        reservedNames switchStart + 1)
+      midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
   refine ⟨switchStart, cases', body', bodyStart, bodyEnd,
     hCase, ?_, ?_⟩
   · simpa [reservedNames] using hBodyLower
   · intro hFresh hBody hStmtPreserves hProject hMatch
     have hNativeDispatcherExec' :
-        nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 19)
+        nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 20)
           irContract tx initialState observableSlots
-          (nativeContractOfDispatcherWithMapping [.Block inner]) := by
-      refine hNativeDispatcherExec ?_ ?_ ?_ hMatch
-      · simpa [initialState, reservedNames, nativeContractOfDispatcherWithMapping,
-          functions] using hBody
-      · intro pre suffix hcases
-        exact
-          Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_nativeSwitchFresh_find_hit_matched
+          (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
+      let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+      let materializedSlots :=
+        Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+          (Compiler.runtimeCode irContract) observableSlots
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (fuel + cases'.length + 20) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) initialState.storage materializedSlots) =
+            .ok final := by
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            fuel reservedNames switchStart cases' body1 inner functions
+            (YulTransaction.ofIR tx) initialState.storage materializedSlots
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hFinalMatched :
+            ∀ matchedName : EvmYul.Identifier,
+              matchedName =
+                  Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                      reservedNames switchStart) →
+                final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+          intro matchedName hMatchedName
+          subst matchedName
+          rcases
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitch_find_hit_split
+              tx.functionSelector cases' tx.functionSelector body' hCase with
+            ⟨pre, suffix, hCases, _hTag, _hPrefix⟩
+          exact
+            (Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_nativeSwitchFresh_find_hit_matched
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              tx.functionSelector tx.functionSelector body'
+              [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+              cases' (EvmYul.UInt256.ofNat 1)
+              (some contract)
+              (by simpa [reservedNames] using hFresh) hCase
+              (by
+                simpa [reservedNames, contract,
+                  nativeContractOfInitPrefixedDispatcherWithMapping, functions] using
+                  hStmtPreserves))
+              ((fuel + 1) + suffix.length + 7)
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+                contract (YulTransaction.ofIR tx) initialState.storage
+                materializedSlots
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)
+                Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore)
+              final
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+                contract (YulTransaction.ofIR tx) initialState.storage
+                materializedSlots
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)
+                Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+                (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                    reservedNames switchStart)) rfl)
+              (by
+                simpa [initialState, reservedNames, contract, materializedSlots,
+                  nativeContractOfInitPrefixedDispatcherWithMapping, functions] using
+                  hBody pre suffix hCases)
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+            fuel tx.functionSelector
             (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
               reservedNames switchStart)
-            tx.functionSelector tx.functionSelector body'
+            tx.functionSelector cases'
             [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
-            cases' (EvmYul.UInt256.ofNat 1)
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (by simpa [reservedNames] using hFresh) hCase
+            body' contract (YulTransaction.ofIR tx) initialState.storage
+            initialState.events materializedSlots final
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+              (YulTransaction.ofIR tx) initialState.storage initialState.events
+              (.ok (final, [])))
+            hSelector hCase hSelectorRangeNative hTagsRange
             (by
-              simpa [reservedNames, nativeContractOfDispatcherWithMapping, functions]
-                using hStmtPreserves)
-      · simpa [initialState, nativeContractOfDispatcherWithMapping, functions]
-          using hProject
+              intro pre suffix hCases
+              simpa [initialState, reservedNames, contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcherWithMapping, functions] using
+                hBody pre suffix hCases)
+            hFinalMatched rfl
+        simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+          nativeInitFreeMemoryPointerStmt, functions,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+      refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+        (contract := irContract) (tx := tx) (state := initialState)
+        (observableSlots := observableSlots)
+        (nativeContract := contract) ?_ hMatch
+      simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+        contract, initialState, functions] using hProject
     exact
       sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
         (hSourceIR :=
@@ -12645,7 +14855,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
           nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_supported
             hcompile hSupported hLowerRuntime hEnv
             (by
-              simpa [nativeContractOfDispatcherWithMapping, functions]
+              simpa [nativeContractOfInitPrefixedDispatcherWithMapping, functions]
                 using hNativeDispatcherExec'))
 
 /-- Supported mapping-helper selector-hit source theorem for the payable
@@ -12670,8 +14880,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -12703,9 +14914,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec (fuel + suffix.length + 10) (.Block bodyNative)
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -12725,7 +14936,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
                   (Compiler.emitYul irContract).runtimeCode)
                 switchStart))
             (EvmYul.UInt256.ofNat 1) bodyNative
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -12733,13 +14944,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -12752,7 +14963,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
         sourceResultMatchesNativeOn observableSlots
           (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
           (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
-            (Nat.succ (fuel + cases'.length + 23)) irContract tx
+            (Nat.succ (fuel + cases'.length + 24)) irContract tx
             (FunctionBody.initialIRStateForTx model tx initialWorld)
             observableSlots)) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
@@ -12766,34 +14977,159 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcherWithMapping [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_mapping_reserved
       hcompile hSupported hMapping]
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_payable_withSwitchIds_generated_prefix
-      fuel reservedNames 0 irContract tx initialState observableSlots inner
-      nextSwitchId functions fn final nativeYul hLowerDispatcher hFind
-      hSelectorRange hNoWrap hFunctionSelectorsRange hPayable hguards hArgs with
-    ⟨switchStart, cases', _midN, body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, _hLowerCases, hCase, hBodyLower, hUserBodyLower,
-      hNativeDispatcherExec⟩
+    lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      reservedNames 0 irContract.functions
+      [nativeInitFreeMemoryPointerStmt, .Block inner] nextSwitchId
+      (by simpa [reservedNames] using hLowerDispatcher) with
+    ⟨inner', hDispatcher, hLowerBlock⟩
+  have hInnerEq : inner = inner' := by
+    simpa [nativeInitFreeMemoryPointerStmt] using hDispatcher
+  subst inner'
+  obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+      hInner, hLowerCases, hCase, hBodyLower⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+      reservedNames 0 irContract.functions inner nextSwitchId
+      tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+      hFind
+  rcases
+    Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNativeWithSwitchIds_switchCaseBody_payable_eq
+      reservedNames bodyStart fn body' bodyEnd hPayable hBodyLower with
+    ⟨guardBody, bodyNative, userBodyStart, hBodyShape, hUserBodyLower⟩
+  have hSelector :
+      tx.functionSelector =
+        (YulTransaction.ofIR tx).functionSelector %
+          Compiler.Constants.selectorModulus := by
+    simpa [YulTransaction.ofIR] using
+      (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+    lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+        reservedNames switchStart + 1)
+      midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
   refine ⟨switchStart, cases', body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hCase, ?_, ?_, ?_⟩
   · simpa [reservedNames] using hBodyLower
   · simpa [reservedNames] using hUserBodyLower
   · intro hBody hPreservesMatched hProject hMatch
     have hNativeDispatcherExec' :
-        nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 23)
+        nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 24)
           irContract tx initialState observableSlots
-          (nativeContractOfDispatcherWithMapping [.Block inner]) := by
-      refine hNativeDispatcherExec ?_ ?_ ?_ hMatch
-      · simpa [initialState, reservedNames, nativeContractOfDispatcherWithMapping,
-          functions] using hBody
-      · simpa [reservedNames, nativeContractOfDispatcherWithMapping, functions]
-          using hPreservesMatched
-      · simpa [initialState, nativeContractOfDispatcherWithMapping, functions]
-          using hProject
+          (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
+      let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+      let materializedSlots :=
+        Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+          (Compiler.runtimeCode irContract) observableSlots
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (fuel + cases'.length + 24) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) initialState.storage materializedSlots) =
+            .ok final := by
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            (fuel + 4) reservedNames switchStart cases' body1 inner functions
+            (YulTransaction.ofIR tx) initialState.storage materializedSlots
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hBodyWhole :
+            ∀ pre suffix, cases' = pre ++ (tx.functionSelector, body') :: suffix →
+              EvmYul.Yul.exec (((fuel + 4) + 1) + suffix.length + 7)
+                (.Block body') (some contract)
+                (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+                  contract (YulTransaction.ofIR tx) initialState.storage
+                  materializedSlots
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                    reservedNames switchStart)
+                  Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
+                .ok final := by
+          intro pre suffix hCases
+          rw [hBodyShape]
+          have hPrefix :=
+            Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_postInitFreeMemory_eq
+              (fuel + suffix.length + 1) guardBody bodyNative contract
+              (YulTransaction.ofIR tx) initialState.storage materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (4 + fn.params.length * 32)
+              (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+              (Compiler.Proofs.YulGeneration.Backends.Native.DispatchGuardsSafe_calldata_threshold_lt
+                fn tx hguards)
+              (by simp; omega)
+          simpa [initialState, contract, materializedSlots,
+            nativeContractOfInitPrefixedDispatcherWithMapping, functions,
+            Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using
+            hPrefix.trans (hBody pre suffix hCases)
+        have hFinalMatched :
+            ∀ matchedName : EvmYul.Identifier,
+              matchedName =
+                  Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                      reservedNames switchStart) →
+                final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+          intro matchedName hMatchedName
+          subst matchedName
+          rcases
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitch_find_hit_split
+              tx.functionSelector cases' tx.functionSelector body' hCase with
+            ⟨pre, suffix, hCases, _hTag, _hPrefix⟩
+          exact hPreservesMatched pre suffix hCases
+            (fuel + suffix.length + 10)
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              contract (YulTransaction.ofIR tx) initialState.storage
+              materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore)
+            final
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+              contract (YulTransaction.ofIR tx) initialState.storage
+              materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)) rfl)
+            (by
+              simpa [initialState, reservedNames, contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcherWithMapping, functions] using
+                hBody pre suffix hCases)
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+            (fuel + 4) tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) initialState.storage
+            initialState.events materializedSlots final
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+              (YulTransaction.ofIR tx) initialState.storage initialState.events
+              (.ok (final, [])))
+            hSelector hCase hSelectorRangeNative hTagsRange hBodyWhole
+            hFinalMatched rfl
+        have hFuelShape :
+            fuel + cases'.length + 24 = (fuel + 4) + cases'.length + 20 := by
+          omega
+        rw [hFuelShape]
+        simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+          nativeInitFreeMemoryPointerStmt, functions,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+      refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+        (contract := irContract) (tx := tx) (state := initialState)
+        (observableSlots := observableSlots)
+        (nativeContract := contract) ?_ hMatch
+      simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+        contract, initialState, functions] using hProject
     exact
       sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
         (hSourceIR :=
@@ -12804,7 +15140,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
           nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_supported
             hcompile hSupported hLowerRuntime hEnv
             (by
-              simpa [nativeContractOfDispatcherWithMapping, functions]
+              simpa [nativeContractOfInitPrefixedDispatcherWithMapping, functions]
                 using hNativeDispatcherExec'))
 
 /-- Supported mapping-helper selector-hit source theorem for the non-payable
@@ -12828,8 +15164,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -12861,9 +15198,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec (fuel + suffix.length + 10) (.Block bodyNative)
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -12883,7 +15220,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
                   (Compiler.emitYul irContract).runtimeCode)
                 switchStart))
             (EvmYul.UInt256.ofNat 1) bodyNative
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -12891,13 +15228,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -12910,7 +15247,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
         sourceResultMatchesNativeOn observableSlots
           (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
           (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
-            (Nat.succ (fuel + cases'.length + 24)) irContract tx
+            (Nat.succ (fuel + cases'.length + 25)) irContract tx
             (FunctionBody.initialIRStateForTx model tx initialWorld)
             observableSlots)) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
@@ -12924,34 +15261,168 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcherWithMapping [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_mapping_reserved
       hcompile hSupported hMapping]
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_nonpayable_withSwitchIds_generated_prefix
-      fuel reservedNames 0 irContract tx initialState observableSlots inner
-      nextSwitchId functions fn final nativeYul hLowerDispatcher hFind
-      hSelectorRange hNoWrap hFunctionSelectorsRange hNonPayable hguards hArgs with
-    ⟨switchStart, cases', _midN, body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, _hLowerCases, hCase, hBodyLower, hUserBodyLower,
-      hNativeDispatcherExec⟩
+    lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      reservedNames 0 irContract.functions
+      [nativeInitFreeMemoryPointerStmt, .Block inner] nextSwitchId
+      (by simpa [reservedNames] using hLowerDispatcher) with
+    ⟨inner', hDispatcher, hLowerBlock⟩
+  have hInnerEq : inner = inner' := by
+    simpa [nativeInitFreeMemoryPointerStmt] using hDispatcher
+  subst inner'
+  obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+      hInner, hLowerCases, hCase, hBodyLower⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+      reservedNames 0 irContract.functions inner nextSwitchId
+      tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+      hFind
+  rcases
+    Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNativeWithSwitchIds_switchCaseBody_nonpayable_eq
+      reservedNames bodyStart fn body' bodyEnd hNonPayable hBodyLower with
+    ⟨callvalueGuardBody, calldataGuardBody, bodyNative, userBodyStart,
+      hBodyShape, hUserBodyLower⟩
+  have hSelector :
+      tx.functionSelector =
+        (YulTransaction.ofIR tx).functionSelector %
+          Compiler.Constants.selectorModulus := by
+    simpa [YulTransaction.ofIR] using
+      (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+    lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+        reservedNames switchStart + 1)
+      midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
   refine ⟨switchStart, cases', body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hCase, ?_, ?_, ?_⟩
   · simpa [reservedNames] using hBodyLower
   · simpa [reservedNames] using hUserBodyLower
   · intro hBody hPreservesMatched hProject hMatch
     have hNativeDispatcherExec' :
-        nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 24)
+        nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 25)
           irContract tx initialState observableSlots
-          (nativeContractOfDispatcherWithMapping [.Block inner]) := by
-      refine hNativeDispatcherExec ?_ ?_ ?_ hMatch
-      · simpa [initialState, reservedNames, nativeContractOfDispatcherWithMapping,
-          functions] using hBody
-      · simpa [reservedNames, nativeContractOfDispatcherWithMapping, functions]
-          using hPreservesMatched
-      · simpa [initialState, nativeContractOfDispatcherWithMapping, functions]
-          using hProject
+          (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
+      let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+      let materializedSlots :=
+        Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+          (Compiler.runtimeCode irContract) observableSlots
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (fuel + cases'.length + 25) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) initialState.storage materializedSlots) =
+            .ok final := by
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            (fuel + 5) reservedNames switchStart cases' body1 inner functions
+            (YulTransaction.ofIR tx) initialState.storage materializedSlots
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hBodyWhole :
+            ∀ pre suffix, cases' = pre ++ (tx.functionSelector, body') :: suffix →
+              EvmYul.Yul.exec (((fuel + 5) + 1) + suffix.length + 7)
+                (.Block body') (some contract)
+                (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+                  contract (YulTransaction.ofIR tx) initialState.storage
+                  materializedSlots
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                    reservedNames switchStart)
+                  Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
+                .ok final := by
+          intro pre suffix hCases
+          rw [hBodyShape]
+          have hGe :
+              4 + fn.params.length * 32 ≤ 4 + tx.args.length * 32 := by
+            have hMul : fn.params.length * 32 ≤ tx.args.length * 32 :=
+              Nat.mul_le_mul_right 32 hArgs
+            exact Nat.add_le_add_left hMul 4
+          have hPrefix :=
+            Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_postInitFreeMemory_eq
+              (fuel + suffix.length + 1) callvalueGuardBody calldataGuardBody
+              bodyNative contract (YulTransaction.ofIR tx) initialState.storage
+              materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (4 + fn.params.length * 32)
+              (Compiler.Proofs.YulGeneration.Backends.Native.DispatchGuardsSafe_msgValue_zero_mod_of_nonpayable
+                fn tx hguards hNonPayable)
+              (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+              (Compiler.Proofs.YulGeneration.Backends.Native.DispatchGuardsSafe_calldata_threshold_lt
+                fn tx hguards)
+              hGe
+          simpa [initialState, contract, materializedSlots,
+            nativeContractOfInitPrefixedDispatcherWithMapping, functions,
+            Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using
+            hPrefix.trans (hBody pre suffix hCases)
+        have hFinalMatched :
+            ∀ matchedName : EvmYul.Identifier,
+              matchedName =
+                  Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                      reservedNames switchStart) →
+                final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+          intro matchedName hMatchedName
+          subst matchedName
+          rcases
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitch_find_hit_split
+              tx.functionSelector cases' tx.functionSelector body' hCase with
+            ⟨pre, suffix, hCases, _hTag, _hPrefix⟩
+          exact hPreservesMatched pre suffix hCases
+            (fuel + suffix.length + 10)
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              contract (YulTransaction.ofIR tx) initialState.storage
+              materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore)
+            final
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+              contract (YulTransaction.ofIR tx) initialState.storage
+              materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)) rfl)
+            (by
+              simpa [initialState, reservedNames, contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcherWithMapping, functions] using
+                hBody pre suffix hCases)
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+            (fuel + 5) tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) initialState.storage
+            initialState.events materializedSlots final
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+              (YulTransaction.ofIR tx) initialState.storage initialState.events
+              (.ok (final, [])))
+            hSelector hCase hSelectorRangeNative hTagsRange hBodyWhole
+            hFinalMatched rfl
+        have hFuelShape :
+            fuel + cases'.length + 25 = (fuel + 5) + cases'.length + 20 := by
+          omega
+        rw [hFuelShape]
+        simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+          nativeInitFreeMemoryPointerStmt, functions,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+      refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+        (contract := irContract) (tx := tx) (state := initialState)
+        (observableSlots := observableSlots)
+        (nativeContract := contract) ?_ hMatch
+      simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+        contract, initialState, functions] using hProject
     exact
       sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
         (hSourceIR :=
@@ -12962,7 +15433,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_stru
           nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_supported
             hcompile hSupported hLowerRuntime hEnv
             (by
-              simpa [nativeContractOfDispatcherWithMapping, functions]
+              simpa [nativeContractOfInitPrefixedDispatcherWithMapping, functions]
                 using hNativeDispatcherExec'))
 
 /-- Lowered-runtime selector-hit source theorem for the payable generated
@@ -13014,154 +15485,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_lowered_runt
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec (fuel + suffix.length + 10) (.Block bodyNative)
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              nativeContract
-              (YulTransaction.ofIR tx)
-              (FunctionBody.initialIRStateForTx model tx initialWorld).storage
-              (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-                (Compiler.runtimeCode irContract) observableSlots)
-              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
-                reservedNames n0)
-              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
-            .ok final) →
-        (∀ pre suffix,
-          cases' = pre ++ (tx.functionSelector, body') :: suffix →
-          Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord
-            (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
-              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
-                reservedNames n0))
-            (EvmYul.UInt256.ofNat 1) bodyNative
-            (some nativeContract)) →
-        Compiler.Proofs.YulGeneration.Backends.Native.projectResult
-          (YulTransaction.ofIR tx)
-          (FunctionBody.initialIRStateForTx model tx initialWorld).storage
-          (FunctionBody.initialIRStateForTx model tx initialWorld).events
-          (.ok
-            (((final.reviveJump.overwrite?
-              (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                nativeContract
-                (YulTransaction.ofIR tx)
-                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
-                (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-                  (Compiler.runtimeCode irContract) observableSlots))).setStore
-              (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                nativeContract
-                (YulTransaction.ofIR tx)
-                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
-                (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-                  (Compiler.runtimeCode irContract) observableSlots))), [])) =
-          nativeYul →
-        nativeResultsMatchOn observableSlots
-          (interpretIR irContract tx
-            (FunctionBody.initialIRStateForTx model tx initialWorld))
-          (.ok nativeYul) →
-        sourceResultMatchesNativeOn observableSlots
-          (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
-          (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
-            (Nat.succ (fuel + cases'.length + 23)) irContract tx
-            (FunctionBody.initialIRStateForTx model tx initialWorld)
-            observableSlots)) := by
-  by_cases hUsesMapping : irContract.usesMapping
-  · have hMapping : irContract.usesMapping = true := by
-      simpa using hUsesMapping
-    rcases lowerRuntimeContractNative_of_compile_ok_supported_mapping_ok_dispatcher_reserved
-        hcompile hSupported hMapping hLowerRuntime with
-      ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
-    rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
-        (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
-          (Compiler.emitYul irContract).runtimeCode)
-        0 irContract.functions dispatcher nextSwitchId hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
-    subst nativeContract
-    subst dispatcher
-    rcases
-      compile_preserves_native_evmYulLean_selector_hit_ok_mapping_structural_payable_generated_prefix
-        fuel model selectors hSupported irContract tx initialWorld
-        observableSlots inner nextSwitchId fn final nativeYul htxNormalized
-        hcalldataSizeFits hcompile hMapping hLowerBlock hFind hSelectorRange
-        hNoWrap hFunctionSelectorsRange hPayable hguards hArgs hEnv with
-      ⟨switchStart, cases', body', bodyNative, bodyStart, bodyEnd,
-        userBodyStart, hCase, hBodyLower, hUserBodyLower, hCont⟩
-    refine ⟨
-      Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
-        (Compiler.emitYul irContract).runtimeCode,
-      switchStart, cases', body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, hCase, hBodyLower, hUserBodyLower, ?_⟩
-    intro hBody hPreservesMatched hProject hMatch
-    exact hCont hBody hPreservesMatched hProject hMatch
-  · have hNoMapping : irContract.usesMapping = false := by
-      exact Bool.eq_false_iff.2 hUsesMapping
-    rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
-        hcompile hSupported hNoMapping hLowerRuntime with
-      ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
-    rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
-        irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
-    subst nativeContract
-    subst dispatcher
-    rcases
-      compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_structural_payable_generated_prefix
-        fuel model selectors hSupported irContract tx initialWorld
-        observableSlots inner fn final nativeYul htxNormalized
-        hcalldataSizeFits hcompile hNoMapping hLowerBlock hFind hSelectorRange
-        hNoWrap hFunctionSelectorsRange hPayable hguards hArgs hEnv with
-      ⟨reservedNames, n0, cases', body', bodyNative, bodyStart, bodyEnd,
-        userBodyStart, hCase, hBodyLower, hUserBodyLower, hCont⟩
-    exact ⟨reservedNames, n0, cases', body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, hCase, hBodyLower, hUserBodyLower, hCont⟩
-
-/-- Lowered-runtime selector-hit source theorem for the non-payable generated
-prefix path. This hides the mapping-helper/no-mapping split while keeping the
-selected native execution and preservation obligations on the lowered user body
-`fn.body`. -/
-private theorem compile_preserves_native_evmYulLean_selector_hit_ok_lowered_runtime_nonpayable_generated_prefix
-    (fuel : Nat)
-    (model : CompilationModel.CompilationModel) (selectors : List Nat)
-    (hSupported : SupportedSpec model selectors)
-    (irContract : IRContract)
-    (tx : IRTransaction)
-    (initialWorld : Verity.ContractState)
-    (observableSlots : List Nat)
-    (nativeContract : EvmYul.Yul.Ast.YulContract)
-    (fn : IRFunction) (final : EvmYul.Yul.State) (nativeYul : YulResult)
-    (htxNormalized : Function.TxContextNormalized tx)
-    (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
-    (hcompile : CompilationModel.compile model selectors = Except.ok irContract)
-    (hLowerRuntime :
-      Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
-        (Compiler.emitYul irContract).runtimeCode = .ok nativeContract)
-    (hFind :
-      irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
-        some fn)
-    (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
-    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
-    (hFunctionSelectorsRange :
-      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
-    (hNonPayable : fn.payable = false)
-    (hguards : DispatchGuardsSafe fn tx)
-    (hArgs : fn.params.length ≤ tx.args.length)
-    (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
-      (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
-        .ok ()) :
-    ∃ (reservedNames : List String) (n0 : Nat)
-      (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
-      (body' bodyNative : List EvmYul.Yul.Ast.Stmt)
-      (bodyStart bodyEnd userBodyStart : Nat),
-      cases'.find? (fun entry => entry.1 == tx.functionSelector) =
-        some (tx.functionSelector, body') ∧
-      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
-        reservedNames bodyStart
-        (Compiler.Proofs.YulGeneration.Backends.Native.switchCaseBody fn) =
-          .ok (body', bodyEnd) ∧
-      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
-        reservedNames userBodyStart fn.body = .ok (bodyNative, bodyEnd) ∧
-      ((∀ pre suffix,
-          cases' = pre ++ (tx.functionSelector, body') :: suffix →
-          EvmYul.Yul.exec (fuel + suffix.length + 10) (.Block bodyNative)
-            (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -13215,248 +15539,56 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_lowered_runt
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
           (Compiler.emitYul irContract).runtimeCode)
         0 irContract.functions dispatcher nextSwitchId hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, hDispatcher, _hLowerBlock⟩
     subst nativeContract
     subst dispatcher
     rcases
-      compile_preserves_native_evmYulLean_selector_hit_ok_mapping_structural_nonpayable_generated_prefix
+      compile_preserves_native_evmYulLean_selector_hit_ok_mapping_structural_payable_generated_prefix
         fuel model selectors hSupported irContract tx initialWorld
         observableSlots inner nextSwitchId fn final nativeYul htxNormalized
-        hcalldataSizeFits hcompile hMapping hLowerBlock hFind hSelectorRange
-        hNoWrap hFunctionSelectorsRange hNonPayable hguards hArgs hEnv with
+        hcalldataSizeFits hcompile hMapping hLowerDispatcher hFind hSelectorRange
+        hNoWrap hFunctionSelectorsRange hPayable hguards hArgs hEnv with
       ⟨switchStart, cases', body', bodyNative, bodyStart, bodyEnd,
-        userBodyStart, hCase, hBodyLower, hUserBodyLower, hCont⟩
+        userBodyStart, hCase, hBodyLower, hUserBodyLower, hDispatcherContinuation⟩
     refine ⟨
       Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode,
       switchStart, cases', body', bodyNative, bodyStart, bodyEnd,
       userBodyStart, hCase, hBodyLower, hUserBodyLower, ?_⟩
     intro hBody hPreservesMatched hProject hMatch
-    exact hCont hBody hPreservesMatched hProject hMatch
+    exact hDispatcherContinuation hBody hPreservesMatched hProject hMatch
   · have hNoMapping : irContract.usesMapping = false := by
       exact Bool.eq_false_iff.2 hUsesMapping
     rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, _nextSwitchId, hDispatcher, _hLowerBlock⟩
     subst nativeContract
     subst dispatcher
     rcases
-      compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_structural_nonpayable_generated_prefix
+      compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_structural_payable_generated_prefix
         fuel model selectors hSupported irContract tx initialWorld
         observableSlots inner fn final nativeYul htxNormalized
-        hcalldataSizeFits hcompile hNoMapping hLowerBlock hFind hSelectorRange
-        hNoWrap hFunctionSelectorsRange hNonPayable hguards hArgs hEnv with
+        hcalldataSizeFits hcompile hNoMapping hLowerDispatcher hFind hSelectorRange
+        hNoWrap hFunctionSelectorsRange hPayable hguards hArgs hEnv with
       ⟨reservedNames, n0, cases', body', bodyNative, bodyStart, bodyEnd,
-        userBodyStart, hCase, hBodyLower, hUserBodyLower, hCont⟩
+        userBodyStart, hCase, hBodyLower, hUserBodyLower, hDispatcherContinuation⟩
     exact ⟨reservedNames, n0, cases', body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, hCase, hBodyLower, hUserBodyLower, hCont⟩
+      userBodyStart, hCase, hBodyLower, hUserBodyLower, hDispatcherContinuation⟩
 
-/-- Exact-total-fuel lowered-runtime selector-hit source theorem for the
-payable generated prefix path. This hides the mapping-helper/no-mapping split
-while stating the native dispatcher result at the externally supplied `fuel'`. -/
-private theorem compile_preserves_native_evmYulLean_selector_hit_ok_lowered_runtime_payable_generated_prefix_atFuel
-    (fuel' : Nat)
-    (model : CompilationModel.CompilationModel) (selectors : List Nat)
-    (hSupported : SupportedSpec model selectors)
-    (irContract : IRContract)
-    (tx : IRTransaction)
-    (initialWorld : Verity.ContractState)
-    (observableSlots : List Nat)
-    (nativeContract : EvmYul.Yul.Ast.YulContract)
-    (fn : IRFunction) (final : EvmYul.Yul.State) (nativeYul : YulResult)
-    (htxNormalized : Function.TxContextNormalized tx)
-    (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
-    (hcompile : CompilationModel.compile model selectors = Except.ok irContract)
-    (hLowerRuntime :
-      Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
-        (Compiler.emitYul irContract).runtimeCode = .ok nativeContract)
-    (hFind :
-      irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
-        some fn)
-    (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
-    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
-    (hFunctionSelectorsRange :
-      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
-    (hPayable : fn.payable = true)
-    (hguards : DispatchGuardsSafe fn tx)
-    (hArgs : fn.params.length ≤ tx.args.length)
-    (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
-      (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
-        .ok ()) :
-    ∃ (reservedNames : List String) (n0 : Nat)
-      (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
-      (body' bodyNative : List EvmYul.Yul.Ast.Stmt)
-      (bodyStart bodyEnd userBodyStart : Nat),
-      cases'.find? (fun entry => entry.1 == tx.functionSelector) =
-        some (tx.functionSelector, body') ∧
-      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
-        reservedNames bodyStart
-        (Compiler.Proofs.YulGeneration.Backends.Native.switchCaseBody fn) =
-          .ok (body', bodyEnd) ∧
-      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
-        reservedNames userBodyStart fn.body = .ok (bodyNative, bodyEnd) ∧
-      (cases'.length + 23 ≤ fuel' →
-        (∀ pre suffix,
-          cases' = pre ++ (tx.functionSelector, body') :: suffix →
-          EvmYul.Yul.exec ((fuel' - (cases'.length + 23)) +
-              suffix.length + 10) (.Block bodyNative)
-            (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              nativeContract
-              (YulTransaction.ofIR tx)
-              (FunctionBody.initialIRStateForTx model tx initialWorld).storage
-              (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-                (Compiler.runtimeCode irContract) observableSlots)
-              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
-                reservedNames n0)
-              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore) =
-            .ok final) →
-        (∀ pre suffix,
-          cases' = pre ++ (tx.functionSelector, body') :: suffix →
-          Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord
-            (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
-              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
-                reservedNames n0))
-            (EvmYul.UInt256.ofNat 1) bodyNative
-            (some nativeContract)) →
-        Compiler.Proofs.YulGeneration.Backends.Native.projectResult
-          (YulTransaction.ofIR tx)
-          (FunctionBody.initialIRStateForTx model tx initialWorld).storage
-          (FunctionBody.initialIRStateForTx model tx initialWorld).events
-          (.ok
-            (((final.reviveJump.overwrite?
-              (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                nativeContract
-                (YulTransaction.ofIR tx)
-                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
-                (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-                  (Compiler.runtimeCode irContract) observableSlots))).setStore
-              (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                nativeContract
-                (YulTransaction.ofIR tx)
-                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
-                (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
-                  (Compiler.runtimeCode irContract) observableSlots))), [])) =
-          nativeYul →
-        nativeResultsMatchOn observableSlots
-          (interpretIR irContract tx
-            (FunctionBody.initialIRStateForTx model tx initialWorld))
-          (.ok nativeYul) →
-        sourceResultMatchesNativeOn observableSlots
-          (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
-          (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
-            (Nat.succ fuel') irContract tx
-            (FunctionBody.initialIRStateForTx model tx initialWorld)
-            observableSlots)) := by
-  let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
-  by_cases hUsesMapping : irContract.usesMapping
-  · have hMapping : irContract.usesMapping = true := by
-      simpa using hUsesMapping
-    let reservedNames :=
-      Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
-        (Compiler.emitYul irContract).runtimeCode
-    let functions :=
-      ((∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap).insert
-        "mappingSlot"
-        Compiler.Proofs.YulGeneration.Backends.Native.nativeMappingSlotFunctionDefinition)
-    rcases lowerRuntimeContractNative_of_compile_ok_supported_mapping_ok_dispatcher_reserved
-        hcompile hSupported hMapping hLowerRuntime with
-      ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
-    rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
-        reservedNames 0 irContract.functions dispatcher nextSwitchId
-        hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
-    subst nativeContract
-    subst dispatcher
-    rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_payable_withSwitchIds_generated_prefix_atFuel
-        fuel' reservedNames 0 irContract tx initialState observableSlots
-        inner nextSwitchId functions fn final nativeYul hLowerBlock hFind
-        hSelectorRange hNoWrap hFunctionSelectorsRange hPayable hguards hArgs with
-      ⟨switchStart, cases', _midN, body', bodyNative, bodyStart, bodyEnd,
-        userBodyStart, _hLowerCases, hCase, hBodyLower, hUserBodyLower,
-        hNativeDispatcherExec⟩
-    refine ⟨reservedNames, switchStart, cases', body', bodyNative, bodyStart,
-      bodyEnd, userBodyStart, hCase, hBodyLower, hUserBodyLower, ?_⟩
-    intro hFuel hBody hPreservesMatched hProject hMatch
-    have hNativeDispatcherExec' :
-        nativeDispatcherExecMatchesIRPositive fuel'
-          irContract tx initialState observableSlots
-          (nativeContractOfDispatcherWithMapping [.Block inner]) := by
-      refine hNativeDispatcherExec hFuel ?_ ?_ ?_ hMatch
-      · simpa [initialState, reservedNames, nativeContractOfDispatcherWithMapping,
-          functions] using hBody
-      · simpa [reservedNames, nativeContractOfDispatcherWithMapping, functions]
-          using hPreservesMatched
-      · simpa [initialState, nativeContractOfDispatcherWithMapping, functions]
-          using hProject
-    exact
-      sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
-        (hSourceIR :=
-          Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
-            model selectors hSupported irContract tx initialWorld
-            htxNormalized hcalldataSizeFits hcompile)
-        (hNativeIR :=
-          nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_supported
-            (fuel' := fuel') hcompile hSupported hLowerRuntime hEnv
-            (by
-              simpa [nativeContractOfDispatcherWithMapping, functions]
-                using hNativeDispatcherExec'))
-  · have hNoMapping : irContract.usesMapping = false := by
-      exact Bool.eq_false_iff.2 hUsesMapping
-    rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
-        hcompile hSupported hNoMapping hLowerRuntime with
-      ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
-    rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
-        irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
-    subst nativeContract
-    subst dispatcher
-    rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_payable_generated_prefix_atFuel
-        fuel' irContract tx initialState observableSlots inner
-        (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-        fn final nativeYul hLowerBlock hFind hSelectorRange hNoWrap
-        hFunctionSelectorsRange hPayable hguards hArgs with
-      ⟨reservedNames, n0, cases', _midN, body', bodyNative, bodyStart, bodyEnd,
-        userBodyStart, _hLowerCases, hCase, hBodyLower, hUserBodyLower,
-        hNativeDispatcherExec⟩
-    refine ⟨reservedNames, n0, cases', body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, hCase, hBodyLower, hUserBodyLower, ?_⟩
-    intro hFuel hBody hPreservesMatched hProject hMatch
-    have hNativeDispatcherExec' :
-        nativeDispatcherExecMatchesIRPositive fuel'
-          irContract tx initialState observableSlots
-          (nativeContractOfDispatcher [.Block inner]) := by
-      refine hNativeDispatcherExec hFuel ?_ ?_ ?_ hMatch
-      · simpa [initialState, nativeContractOfDispatcher] using hBody
-      · simpa [nativeContractOfDispatcher] using hPreservesMatched
-      · simpa [initialState, nativeContractOfDispatcher] using hProject
-    exact
-      sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
-        (hSourceIR :=
-          Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
-            model selectors hSupported irContract tx initialWorld
-            htxNormalized hcalldataSizeFits hcompile)
-        (hNativeIR :=
-          nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_supported
-            (fuel' := fuel') hcompile hSupported hLowerRuntime hEnv
-            (by simpa [nativeContractOfDispatcher] using hNativeDispatcherExec'))
-
-/-- Exact-total-fuel lowered-runtime selector-hit source theorem for the
-non-payable generated prefix path. -/
-private theorem compile_preserves_native_evmYulLean_selector_hit_ok_lowered_runtime_nonpayable_generated_prefix_atFuel
-    (fuel' : Nat)
+/-- Lowered-runtime selector-hit source theorem for the non-payable generated
+prefix path. This hides the mapping-helper/no-mapping split while keeping the
+selected native execution and preservation obligations on the lowered user body
+`fn.body`. -/
+private theorem compile_preserves_native_evmYulLean_selector_hit_ok_lowered_runtime_nonpayable_generated_prefix
+    (fuel : Nat)
     (model : CompilationModel.CompilationModel) (selectors : List Nat)
     (hSupported : SupportedSpec model selectors)
     (irContract : IRContract)
@@ -13496,13 +15628,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_lowered_runt
           .ok (body', bodyEnd) ∧
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
         reservedNames userBodyStart fn.body = .ok (bodyNative, bodyEnd) ∧
-      (cases'.length + 24 ≤ fuel' →
-        (∀ pre suffix,
+      ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
-          EvmYul.Yul.exec ((fuel' - (cases'.length + 24)) +
-              suffix.length + 10) (.Block bodyNative)
+          EvmYul.Yul.exec (fuel + suffix.length + 10) (.Block bodyNative)
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -13546,106 +15676,59 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_lowered_runt
         sourceResultMatchesNativeOn observableSlots
           (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
           (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
-            (Nat.succ fuel') irContract tx
+            (Nat.succ (fuel + cases'.length + 25)) irContract tx
             (FunctionBody.initialIRStateForTx model tx initialWorld)
             observableSlots)) := by
-  let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
   by_cases hUsesMapping : irContract.usesMapping
   · have hMapping : irContract.usesMapping = true := by
       simpa using hUsesMapping
-    let reservedNames :=
-      Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
-        (Compiler.emitYul irContract).runtimeCode
-    let functions :=
-      ((∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap).insert
-        "mappingSlot"
-        Compiler.Proofs.YulGeneration.Backends.Native.nativeMappingSlotFunctionDefinition)
     rcases lowerRuntimeContractNative_of_compile_ok_supported_mapping_ok_dispatcher_reserved
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
-        reservedNames 0 irContract.functions dispatcher nextSwitchId
-        hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+        (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+          (Compiler.emitYul irContract).runtimeCode)
+        0 irContract.functions dispatcher nextSwitchId hLowerDispatcher with
+      ⟨inner, hDispatcher, _hLowerBlock⟩
     subst nativeContract
     subst dispatcher
     rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_nonpayable_withSwitchIds_generated_prefix_atFuel
-        fuel' reservedNames 0 irContract tx initialState observableSlots
-        inner nextSwitchId functions fn final nativeYul hLowerBlock hFind
-        hSelectorRange hNoWrap hFunctionSelectorsRange hNonPayable hguards
-        hArgs with
-      ⟨switchStart, cases', _midN, body', bodyNative, bodyStart, bodyEnd,
-        userBodyStart, _hLowerCases, hCase, hBodyLower, hUserBodyLower,
-        hNativeDispatcherExec⟩
-    refine ⟨reservedNames, switchStart, cases', body', bodyNative, bodyStart,
-      bodyEnd, userBodyStart, hCase, hBodyLower, hUserBodyLower, ?_⟩
-    intro hFuel hBody hPreservesMatched hProject hMatch
-    have hNativeDispatcherExec' :
-        nativeDispatcherExecMatchesIRPositive fuel'
-          irContract tx initialState observableSlots
-          (nativeContractOfDispatcherWithMapping [.Block inner]) := by
-      refine hNativeDispatcherExec hFuel ?_ ?_ ?_ hMatch
-      · simpa [initialState, reservedNames, nativeContractOfDispatcherWithMapping,
-          functions] using hBody
-      · simpa [reservedNames, nativeContractOfDispatcherWithMapping, functions]
-          using hPreservesMatched
-      · simpa [initialState, nativeContractOfDispatcherWithMapping, functions]
-          using hProject
-    exact
-      sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
-        (hSourceIR :=
-          Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
-            model selectors hSupported irContract tx initialWorld
-            htxNormalized hcalldataSizeFits hcompile)
-        (hNativeIR :=
-          nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_supported
-            (fuel' := fuel') hcompile hSupported hLowerRuntime hEnv
-            (by
-              simpa [nativeContractOfDispatcherWithMapping, functions]
-                using hNativeDispatcherExec'))
+      compile_preserves_native_evmYulLean_selector_hit_ok_mapping_structural_nonpayable_generated_prefix
+        fuel model selectors hSupported irContract tx initialWorld
+        observableSlots inner nextSwitchId fn final nativeYul htxNormalized
+        hcalldataSizeFits hcompile hMapping hLowerDispatcher hFind hSelectorRange
+        hNoWrap hFunctionSelectorsRange hNonPayable hguards hArgs hEnv with
+      ⟨switchStart, cases', body', bodyNative, bodyStart, bodyEnd,
+        userBodyStart, hCase, hBodyLower, hUserBodyLower, hDispatcherContinuation⟩
+    refine ⟨
+      Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        (Compiler.emitYul irContract).runtimeCode,
+      switchStart, cases', body', bodyNative, bodyStart, bodyEnd,
+      userBodyStart, hCase, hBodyLower, hUserBodyLower, ?_⟩
+    intro hBody hPreservesMatched hProject hMatch
+    exact hDispatcherContinuation hBody hPreservesMatched hProject hMatch
   · have hNoMapping : irContract.usesMapping = false := by
       exact Bool.eq_false_iff.2 hUsesMapping
     rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, _nextSwitchId, hDispatcher, _hLowerBlock⟩
     subst nativeContract
     subst dispatcher
     rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_nonpayable_generated_prefix_atFuel
-        fuel' irContract tx initialState observableSlots inner
-        (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-        fn final nativeYul hLowerBlock hFind hSelectorRange hNoWrap
-        hFunctionSelectorsRange hNonPayable hguards hArgs with
-      ⟨reservedNames, n0, cases', _midN, body', bodyNative, bodyStart, bodyEnd,
-        userBodyStart, _hLowerCases, hCase, hBodyLower, hUserBodyLower,
-        hNativeDispatcherExec⟩
-    refine ⟨reservedNames, n0, cases', body', bodyNative, bodyStart, bodyEnd,
-      userBodyStart, hCase, hBodyLower, hUserBodyLower, ?_⟩
-    intro hFuel hBody hPreservesMatched hProject hMatch
-    have hNativeDispatcherExec' :
-        nativeDispatcherExecMatchesIRPositive fuel'
-          irContract tx initialState observableSlots
-          (nativeContractOfDispatcher [.Block inner]) := by
-      refine hNativeDispatcherExec hFuel ?_ ?_ ?_ hMatch
-      · simpa [initialState, nativeContractOfDispatcher] using hBody
-      · simpa [nativeContractOfDispatcher] using hPreservesMatched
-      · simpa [initialState, nativeContractOfDispatcher] using hProject
-    exact
-      sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
-        (hSourceIR :=
-          Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
-            model selectors hSupported irContract tx initialWorld
-            htxNormalized hcalldataSizeFits hcompile)
-        (hNativeIR :=
-          nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_supported
-            (fuel' := fuel') hcompile hSupported hLowerRuntime hEnv
-            (by simpa [nativeContractOfDispatcher] using hNativeDispatcherExec'))
+      compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_structural_nonpayable_generated_prefix
+        fuel model selectors hSupported irContract tx initialWorld
+        observableSlots inner fn final nativeYul htxNormalized
+        hcalldataSizeFits hcompile hNoMapping hLowerDispatcher hFind hSelectorRange
+        hNoWrap hFunctionSelectorsRange hNonPayable hguards hArgs hEnv with
+      ⟨reservedNames, n0, cases', body', bodyNative, bodyStart, bodyEnd,
+        userBodyStart, hCase, hBodyLower, hUserBodyLower, hDispatcherContinuation⟩
+    exact ⟨reservedNames, n0, cases', body', bodyNative, bodyStart, bodyEnd,
+      userBodyStart, hCase, hBodyLower, hUserBodyLower, hDispatcherContinuation⟩
 
 /-- Supported mapping-helper selector-hit source theorem at canonical generated
 runtime fuel for the native selector-hit normal-success path. This is the
@@ -13668,8 +15751,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -13699,11 +15783,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -13728,7 +15812,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
                   (Compiler.emitYul irContract).runtimeCode)
                 switchStart))
             (EvmYul.UInt256.ofNat 1) stmt
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -13736,13 +15820,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -13769,24 +15853,48 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcherWithMapping [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_mapping_reserved
       hcompile hSupported hMapping]
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_withSwitchIds_atFuel
-      (nativeRuntimeDispatcherFuel irContract) reservedNames 0 irContract tx
-      initialState observableSlots inner nextSwitchId functions fn final nativeYul
-      hLowerDispatcher hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
-    ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      reservedNames 0 irContract.functions
+      [nativeInitFreeMemoryPointerStmt, .Block inner] nextSwitchId
+      (by simpa [reservedNames] using hLowerDispatcher) with
+    ⟨inner', hDispatcher, hLowerBlock⟩
+  have hInnerEq : inner = inner' := by
+    simpa [nativeInitFreeMemoryPointerStmt] using hDispatcher
+  subst inner'
+  obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+      hInner, hLowerCases, hCase, hBodyLower⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+      reservedNames 0 irContract.functions inner nextSwitchId
+      tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+      hFind
   have hFuel :
-      cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+      cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
     dsimp [nativeRuntimeDispatcherFuel]
-    exact
-      sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
+    have hBig :=
+      sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
         hcompile hSupported hMapping
         (by simpa [reservedNames] using hLowerCases)
+    omega
+  have hSelector :
+      tx.functionSelector =
+        (YulTransaction.ofIR tx).functionSelector %
+          Compiler.Constants.selectorModulus := by
+    simpa [YulTransaction.ofIR] using
+      (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+    lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+        reservedNames switchStart + 1)
+      midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
   refine ⟨switchStart, cases', body', bodyStart, bodyEnd,
     hCase, ?_, ?_⟩
   · simpa [reservedNames] using hBodyLower
@@ -13794,25 +15902,103 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
     have hNativeDispatcherExec' :
         nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
           irContract tx initialState observableSlots
-          (nativeContractOfDispatcherWithMapping [.Block inner]) := by
-      refine hNativeDispatcherExec hFuel ?_ ?_ ?_ hMatch
-      · simpa [initialState, reservedNames, nativeContractOfDispatcherWithMapping,
-          functions] using hBody
-      · intro pre suffix hcases
-        exact
-          Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_nativeSwitchFresh_find_hit_matched
+          (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
+      let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+      let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+      let materializedSlots :=
+        Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+          (Compiler.runtimeCode irContract) observableSlots
+      have hFuelShape :
+          nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+        dsimp [fuel0]
+        exact (Nat.sub_add_cancel hFuel).symm
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (nativeRuntimeDispatcherFuel irContract) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) initialState.storage materializedSlots) =
+            .ok final := by
+        rw [hFuelShape]
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            fuel0 reservedNames switchStart cases' body1 inner functions
+            (YulTransaction.ofIR tx) initialState.storage materializedSlots
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hFinalMatched :
+            ∀ matchedName : EvmYul.Identifier,
+              matchedName =
+                  Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                      reservedNames switchStart) →
+                final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+          intro matchedName hMatchedName
+          subst matchedName
+          rcases
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitch_find_hit_split
+              tx.functionSelector cases' tx.functionSelector body' hCase with
+            ⟨pre, suffix, hCases, _hTag, _hPrefix⟩
+          exact
+            (Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_nativeSwitchFresh_find_hit_matched
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              tx.functionSelector tx.functionSelector body'
+              [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+              cases' (EvmYul.UInt256.ofNat 1)
+              (some contract)
+              (by simpa [reservedNames] using hFresh) hCase
+              (by
+                simpa [reservedNames, contract,
+                  nativeContractOfInitPrefixedDispatcherWithMapping, functions] using
+                  hStmtPreserves))
+              ((fuel0 + 1) + suffix.length + 7)
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+                contract (YulTransaction.ofIR tx) initialState.storage
+                materializedSlots
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)
+                Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore)
+              final
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+                contract (YulTransaction.ofIR tx) initialState.storage
+                materializedSlots
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)
+                Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+                (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                    reservedNames switchStart)) rfl)
+              (by
+                simpa [initialState, reservedNames, contract, materializedSlots,
+                  nativeContractOfInitPrefixedDispatcherWithMapping, fuel0,
+                  functions] using hBody pre suffix hCases)
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+            fuel0 tx.functionSelector
             (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
               reservedNames switchStart)
-            tx.functionSelector tx.functionSelector body'
+            tx.functionSelector cases'
             [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
-            cases' (EvmYul.UInt256.ofNat 1)
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (by simpa [reservedNames] using hFresh) hCase
+            body' contract (YulTransaction.ofIR tx) initialState.storage
+            initialState.events materializedSlots final
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+              (YulTransaction.ofIR tx) initialState.storage initialState.events
+              (.ok (final, [])))
+            hSelector hCase hSelectorRangeNative hTagsRange
             (by
-              simpa [reservedNames, nativeContractOfDispatcherWithMapping, functions]
-                using hStmtPreserves)
-      · simpa [initialState, nativeContractOfDispatcherWithMapping, functions]
-          using hProject
+              intro pre suffix hCases
+              simpa [initialState, reservedNames, contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcherWithMapping, fuel0,
+                functions] using hBody pre suffix hCases)
+            hFinalMatched rfl
+        simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+          nativeInitFreeMemoryPointerStmt, functions,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+      refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+        (contract := irContract) (tx := tx) (state := initialState)
+        (observableSlots := observableSlots)
+        (nativeContract := contract) ?_ hMatch
+      simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+        contract, initialState, functions] using hProject
     exact
       sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
         (hSourceIR :=
@@ -13825,10 +16011,10 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
             (spec := model) (selectors := selectors) (irContract := irContract)
             (tx := tx) (state := initialState)
             (observableSlots := observableSlots)
-            (nativeContract := nativeContractOfDispatcherWithMapping [.Block inner])
+            (nativeContract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
             hcompile hSupported hLowerRuntime hEnv
             (by
-              simpa [nativeContractOfDispatcherWithMapping, functions]
+              simpa [nativeContractOfInitPrefixedDispatcherWithMapping, functions]
                 using hNativeDispatcherExec'))
 
 /-- Supported no-mapping selector-hit source theorem at the structural fuel
@@ -13851,8 +16037,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -13875,9 +16062,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec ((fuel + 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -13899,35 +16086,98 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
         sourceResultMatchesNativeOn observableSlots
           (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
           (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
-            (Nat.succ (fuel + cases'.length + 19)) irContract tx
+            (Nat.succ (fuel + cases'.length + 20)) irContract tx
             (FunctionBody.initialIRStateForTx model tx initialWorld)
             observableSlots)) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcher [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_noMapping
       hcompile hSupported hNoMapping]
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_error_noFallback_noReceive
-      fuel irContract tx initialState observableSlots inner
-      (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-      fn err nativeYul hLowerDispatcher hFind hSelectorRange hNoWrap
-      hFunctionSelectorsRange with
-    ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hNativeDispatcherExec⟩
-  refine ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
+    lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      irContract.functions [nativeInitFreeMemoryPointerStmt, .Block inner]
+      hLowerDispatcher with
+    ⟨inner', nextSwitchId, hDispatcher, hLowerBlock⟩
+  have hInnerEq : inner = inner' := by
+    simpa [nativeInitFreeMemoryPointerStmt] using hDispatcher
+  subst inner'
+  let reservedNames :=
+    Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+  obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+      hInner, hLowerCases, hCase, hBodyLower⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+      reservedNames 0 irContract.functions inner nextSwitchId
+      tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+      hFind
+  have hSelector :
+      tx.functionSelector =
+        (YulTransaction.ofIR tx).functionSelector %
+          Compiler.Constants.selectorModulus := by
+    simpa [YulTransaction.ofIR] using
+      (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+    lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+        reservedNames switchStart + 1)
+      midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
+  refine ⟨reservedNames, switchStart, cases', body', bodyStart, bodyEnd,
     hCase, hBodyLower, ?_⟩
   intro hBody hProject hMatch
   have hNativeDispatcherExec' :
-      nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 19)
+      nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 20)
         irContract tx initialState observableSlots
-        (nativeContractOfDispatcher [.Block inner]) := by
-    refine hNativeDispatcherExec ?_ ?_ hMatch
-    · simpa [initialState, nativeContractOfDispatcher] using hBody
-    · simpa [initialState] using hProject
+        (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+    let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+    let materializedSlots :=
+      Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+        (Compiler.runtimeCode irContract) observableSlots
+    have hExec :
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+            (fuel + cases'.length + 20) contract
+            (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+              (YulTransaction.ofIR tx) initialState.storage materializedSlots) =
+          .error err := by
+      have hPeel :=
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+          fuel reservedNames switchStart cases' body1 inner
+          (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+          (YulTransaction.ofIR tx) initialState.storage materializedSlots
+          hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+      have hSwitch :=
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+          fuel tx.functionSelector
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+            reservedNames switchStart)
+          tx.functionSelector cases'
+          [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+          body' contract (YulTransaction.ofIR tx) initialState.storage
+          initialState.events materializedSlots err nativeYul
+          hSelector hCase hSelectorRangeNative hTagsRange
+          (by
+            intro pre suffix hCases
+            simpa [initialState, contract, materializedSlots,
+              nativeContractOfInitPrefixedDispatcher] using
+              hBody pre suffix hCases)
+          (by simpa [initialState] using hProject)
+      simpa [contract, nativeContractOfInitPrefixedDispatcher,
+        nativeInitFreeMemoryPointerStmt,
+        Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+    refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+      (contract := irContract) (tx := tx) (state := initialState)
+      (observableSlots := observableSlots)
+      (nativeContract := contract) ?_ hMatch
+    simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+      contract, initialState] using hProject
   exact
     sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
       (hSourceIR :=
@@ -13957,8 +16207,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -13981,11 +16232,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -14014,35 +16265,104 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcher [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_noMapping
       hcompile hSupported hNoMapping]
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_error_noFallback_noReceive_atFuel
-      (nativeRuntimeDispatcherFuel irContract) irContract tx initialState
-      observableSlots inner
-      (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-      fn err nativeYul hLowerDispatcher hFind hSelectorRange hNoWrap
-      hFunctionSelectorsRange with
-    ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      irContract.functions [nativeInitFreeMemoryPointerStmt, .Block inner]
+      hLowerDispatcher with
+    ⟨inner', nextSwitchId, hDispatcher, hLowerBlock⟩
+  have hInnerEq : inner = inner' := by
+    simpa [nativeInitFreeMemoryPointerStmt] using hDispatcher
+  subst inner'
+  let reservedNames :=
+    Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+  obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+      hInner, hLowerCases, hCase, hBodyLower⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+      reservedNames 0 irContract.functions inner nextSwitchId
+      tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+      hFind
   have hFuel :
-      cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+      cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
     dsimp [nativeRuntimeDispatcherFuel]
-    exact
-      sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
+    have hBig :=
+      sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
         hcompile hSupported hNoMapping hLowerCases
-  refine ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
+    omega
+  have hSelector :
+      tx.functionSelector =
+        (YulTransaction.ofIR tx).functionSelector %
+          Compiler.Constants.selectorModulus := by
+    simpa [YulTransaction.ofIR] using
+      (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+    lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+        reservedNames switchStart + 1)
+      midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
+  refine ⟨reservedNames, switchStart, cases', body', bodyStart, bodyEnd,
     hCase, hBodyLower, ?_⟩
   intro hBody hProject hMatch
   have hNativeDispatcherExec' :
       nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
         irContract tx initialState observableSlots
-        (nativeContractOfDispatcher [.Block inner]) := by
-    refine hNativeDispatcherExec hFuel ?_ ?_ hMatch
-    · simpa [initialState, nativeContractOfDispatcher] using hBody
-    · simpa [initialState] using hProject
+        (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+    let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+    let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+    let materializedSlots :=
+      Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+        (Compiler.runtimeCode irContract) observableSlots
+    have hFuelShape :
+        nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+      dsimp [fuel0]
+      exact (Nat.sub_add_cancel hFuel).symm
+    have hExec :
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+            (nativeRuntimeDispatcherFuel irContract) contract
+            (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+              (YulTransaction.ofIR tx) initialState.storage materializedSlots) =
+          .error err := by
+      rw [hFuelShape]
+      have hPeel :=
+        Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+          fuel0 reservedNames switchStart cases' body1 inner
+          (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+          (YulTransaction.ofIR tx) initialState.storage materializedSlots
+          hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+      have hSwitch :=
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+          fuel0 tx.functionSelector
+          (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+            reservedNames switchStart)
+          tx.functionSelector cases'
+          [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+          body' contract (YulTransaction.ofIR tx) initialState.storage
+          initialState.events materializedSlots err nativeYul
+          hSelector hCase hSelectorRangeNative hTagsRange
+          (by
+            intro pre suffix hCases
+            simpa [initialState, contract, materializedSlots,
+              nativeContractOfInitPrefixedDispatcher, fuel0] using
+              hBody pre suffix hCases)
+          (by simpa [initialState] using hProject)
+      simpa [contract, nativeContractOfInitPrefixedDispatcher,
+        nativeInitFreeMemoryPointerStmt,
+        Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+    refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+      (contract := irContract) (tx := tx) (state := initialState)
+      (observableSlots := observableSlots)
+      (nativeContract := contract) ?_ hMatch
+    simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+      contract, initialState] using hProject
   exact
     sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
       (hSourceIR :=
@@ -14055,10 +16375,10 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
           (spec := model) (selectors := selectors) (irContract := irContract)
           (tx := tx) (state := initialState)
           (observableSlots := observableSlots)
-          (nativeContract := nativeContractOfDispatcher [.Block inner])
+          (nativeContract := nativeContractOfInitPrefixedDispatcher [.Block inner])
           hcompile hSupported hLowerRuntime hEnv
           (by
-            simpa [nativeContractOfDispatcher] using hNativeDispatcherExec'))
+            simpa [nativeContractOfInitPrefixedDispatcher] using hNativeDispatcherExec'))
 
 /-- Direct `callDispatcher` no-mapping selector-hit error theorem at canonical
 generated-runtime fuel.
@@ -14081,15 +16401,19 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
     (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hFunctionSelectorsRange :
-      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size) :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
+    (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+      (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+        .ok ()) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -14102,11 +16426,11 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -14129,44 +16453,32 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
           (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
           (nativeGeneratedCallDispatcherResultOf irContract tx
             (FunctionBody.initialIRStateForTx model tx initialWorld)
-            observableSlots (nativeContractOfDispatcher [.Block inner]))) := by
+            observableSlots (nativeContractOfInitPrefixedDispatcher [.Block inner]))) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
+  have hLowerRuntime :
+      Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
+          (Compiler.emitYul irContract).runtimeCode =
+        .ok (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+    rw [lowerRuntimeContractNative_of_compile_ok_supported_noMapping
+      hcompile hSupported hNoMapping]
+    rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_error_noFallback_noReceive_atFuel
-      (nativeRuntimeDispatcherFuel irContract) irContract tx initialState
-      observableSlots inner
-      (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-      fn err nativeYul hLowerDispatcher hFind hSelectorRange hNoWrap
-      hFunctionSelectorsRange with
-    ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
-  have hFuel :
-      cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
-    dsimp [nativeRuntimeDispatcherFuel]
-    exact
-      sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
-        hcompile hSupported hNoMapping hLowerCases
+    compile_preserves_native_evmYulLean_selector_hit_error_noMapping_canonical
+      model selectors hSupported irContract tx initialWorld observableSlots
+      inner fn err nativeYul htxNormalized hcalldataSizeFits hcompile
+      hNoMapping hLowerDispatcher hFind hSelectorRange hNoWrap
+      hFunctionSelectorsRange hEnv with
+    ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
+      hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
     hCase, hBodyLower, ?_⟩
   intro hBody hProject hMatch
-  have hGeneratedMatch :
-      nativeGeneratedCallDispatcherMatchesIROn irContract tx initialState
-        observableSlots (nativeContractOfDispatcher [.Block inner]) := by
-    apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
-    simpa [nativeGeneratedDispatcherExecMatchesIROn,
-      nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-      nativeContractOfDispatcher] using
-        hNativeDispatcherExec hFuel
-          (by simpa [initialState, nativeContractOfDispatcher] using hBody)
-          (by simpa [initialState] using hProject)
-          hMatch
-  exact
-    sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeResultsMatchOn
-      (hSourceIR :=
-        Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
-          model selectors hSupported irContract tx initialWorld
-          htxNormalized hcalldataSizeFits hcompile)
-      (hNativeIR := hGeneratedMatch)
+  have hSource := hDispatcherContinuation hBody hProject hMatch
+  rw [nativeGeneratedCallDispatcherResultOf_eq_interpretIRRuntimeNative_of_lowerRuntimeContractNative_supported
+    tx initialState observableSlots
+    (nativeContractOfInitPrefixedDispatcher [.Block inner])
+    hcompile hSupported hLowerRuntime hEnv]
+  simpa [nativeRuntimeFuel, initialState] using hSource
 
 /-- Supported mapping-helper selector-hit source theorem at the structural fuel
 exposed by the reserved-context native selector-hit error execution lemma. -/
@@ -14188,8 +16500,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_s
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -14213,9 +16526,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_s
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec ((fuel + 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -14239,7 +16552,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_s
         sourceResultMatchesNativeOn observableSlots
           (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
           (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative
-            (Nat.succ (fuel + cases'.length + 19)) irContract tx
+            (Nat.succ (fuel + cases'.length + 20)) irContract tx
             (FunctionBody.initialIRStateForTx model tx initialWorld)
             observableSlots)) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
@@ -14253,29 +16566,88 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_s
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcherWithMapping [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_mapping_reserved
       hcompile hSupported hMapping]
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_error_noFallback_noReceive_withSwitchIds
-      fuel reservedNames 0 irContract tx initialState observableSlots inner
-      nextSwitchId functions fn err nativeYul hLowerDispatcher hFind
-      hSelectorRange hNoWrap hFunctionSelectorsRange with
-    ⟨switchStart, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hNativeDispatcherExec⟩
+    lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      reservedNames 0 irContract.functions
+      [nativeInitFreeMemoryPointerStmt, .Block inner] nextSwitchId
+      (by simpa [reservedNames] using hLowerDispatcher) with
+    ⟨inner', hDispatcher, hLowerBlock⟩
+  have hInnerEq : inner = inner' := by
+    simpa [nativeInitFreeMemoryPointerStmt] using hDispatcher
+  subst inner'
+  obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+      hInner, hLowerCases, hCase, hBodyLower⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+      reservedNames 0 irContract.functions inner nextSwitchId
+      tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+      hFind
+  have hSelector :
+      tx.functionSelector =
+        (YulTransaction.ofIR tx).functionSelector %
+          Compiler.Constants.selectorModulus := by
+    simpa [YulTransaction.ofIR] using
+      (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+    lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+        reservedNames switchStart + 1)
+      midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
   refine ⟨switchStart, cases', body', bodyStart, bodyEnd,
     hCase, ?_, ?_⟩
   · simpa [reservedNames] using hBodyLower
   · intro hBody hProject hMatch
     have hNativeDispatcherExec' :
-        nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 19)
+        nativeDispatcherExecMatchesIRPositive (fuel + cases'.length + 20)
           irContract tx initialState observableSlots
-          (nativeContractOfDispatcherWithMapping [.Block inner]) := by
-      refine hNativeDispatcherExec ?_ ?_ hMatch
-      · simpa [initialState, reservedNames, nativeContractOfDispatcherWithMapping,
-          functions] using hBody
-      · simpa [initialState] using hProject
+          (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
+      let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+      let materializedSlots :=
+        Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+          (Compiler.runtimeCode irContract) observableSlots
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (fuel + cases'.length + 20) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) initialState.storage materializedSlots) =
+            .error err := by
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            fuel reservedNames switchStart cases' body1 inner functions
+            (YulTransaction.ofIR tx) initialState.storage materializedSlots
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+            fuel tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) initialState.storage
+            initialState.events materializedSlots err nativeYul
+            hSelector hCase hSelectorRangeNative hTagsRange
+            (by
+              intro pre suffix hCases
+              simpa [initialState, reservedNames, contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcherWithMapping] using
+                hBody pre suffix hCases)
+            (by simpa [initialState] using hProject)
+        simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+          nativeInitFreeMemoryPointerStmt, functions,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+      refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+        (contract := irContract) (tx := tx) (state := initialState)
+        (observableSlots := observableSlots)
+        (nativeContract := contract) ?_ hMatch
+      simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+        contract, initialState] using hProject
     exact
       sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
         (hSourceIR :=
@@ -14286,7 +16658,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_s
           nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_supported
             hcompile hSupported hLowerRuntime hEnv
             (by
-              simpa [nativeContractOfDispatcherWithMapping, functions]
+              simpa [nativeContractOfInitPrefixedDispatcherWithMapping, functions]
                 using hNativeDispatcherExec'))
 
 /-- Supported mapping-helper selector-hit source theorem at canonical generated
@@ -14310,8 +16682,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_c
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -14335,11 +16708,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_c
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -14377,24 +16750,48 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_c
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcherWithMapping [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_mapping_reserved
       hcompile hSupported hMapping]
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_error_noFallback_noReceive_withSwitchIds_atFuel
-      (nativeRuntimeDispatcherFuel irContract) reservedNames 0 irContract tx
-      initialState observableSlots inner nextSwitchId functions fn err nativeYul
-      hLowerDispatcher hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
-    ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      reservedNames 0 irContract.functions
+      [nativeInitFreeMemoryPointerStmt, .Block inner] nextSwitchId
+      (by simpa [reservedNames] using hLowerDispatcher) with
+    ⟨inner', hDispatcher, hLowerBlock⟩
+  have hInnerEq : inner = inner' := by
+    simpa [nativeInitFreeMemoryPointerStmt] using hDispatcher
+  subst inner'
+  obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+      hInner, hLowerCases, hCase, hBodyLower⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+      reservedNames 0 irContract.functions inner nextSwitchId
+      tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+      hFind
   have hFuel :
-      cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+      cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
     dsimp [nativeRuntimeDispatcherFuel]
-    exact
-      sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
+    have hBig :=
+      sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
         hcompile hSupported hMapping
         (by simpa [reservedNames] using hLowerCases)
+    omega
+  have hSelector :
+      tx.functionSelector =
+        (YulTransaction.ofIR tx).functionSelector %
+          Compiler.Constants.selectorModulus := by
+    simpa [YulTransaction.ofIR] using
+      (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+    lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+        reservedNames switchStart + 1)
+      midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
   refine ⟨switchStart, cases', body', bodyStart, bodyEnd,
     hCase, ?_, ?_⟩
   · simpa [reservedNames] using hBodyLower
@@ -14402,11 +16799,53 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_c
     have hNativeDispatcherExec' :
         nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
           irContract tx initialState observableSlots
-          (nativeContractOfDispatcherWithMapping [.Block inner]) := by
-      refine hNativeDispatcherExec hFuel ?_ ?_ hMatch
-      · simpa [initialState, reservedNames, nativeContractOfDispatcherWithMapping,
-          functions] using hBody
-      · simpa [initialState] using hProject
+          (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
+      let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+      let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+      let materializedSlots :=
+        Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+          (Compiler.runtimeCode irContract) observableSlots
+      have hFuelShape :
+          nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+        dsimp [fuel0]
+        exact (Nat.sub_add_cancel hFuel).symm
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (nativeRuntimeDispatcherFuel irContract) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) initialState.storage materializedSlots) =
+            .error err := by
+        rw [hFuelShape]
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            fuel0 reservedNames switchStart cases' body1 inner functions
+            (YulTransaction.ofIR tx) initialState.storage materializedSlots
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+            fuel0 tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) initialState.storage
+            initialState.events materializedSlots err nativeYul
+            hSelector hCase hSelectorRangeNative hTagsRange
+            (by
+              intro pre suffix hCases
+              simpa [initialState, reservedNames, contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcherWithMapping, fuel0] using
+                hBody pre suffix hCases)
+            (by simpa [initialState] using hProject)
+        simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+          nativeInitFreeMemoryPointerStmt, functions,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+      refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+        (contract := irContract) (tx := tx) (state := initialState)
+        (observableSlots := observableSlots)
+        (nativeContract := contract) ?_ hMatch
+      simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+        contract, initialState] using hProject
     exact
       sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
         (hSourceIR :=
@@ -14419,10 +16858,10 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_c
             (spec := model) (selectors := selectors) (irContract := irContract)
             (tx := tx) (state := initialState)
             (observableSlots := observableSlots)
-            (nativeContract := nativeContractOfDispatcherWithMapping [.Block inner])
+            (nativeContract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
             hcompile hSupported hLowerRuntime hEnv
             (by
-            simpa [nativeContractOfDispatcherWithMapping, functions]
+            simpa [nativeContractOfInitPrefixedDispatcherWithMapping, functions]
               using hNativeDispatcherExec'))
 
 /-- Direct `callDispatcher` mapping selector-hit error theorem at canonical
@@ -14448,15 +16887,19 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
     (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hFunctionSelectorsRange :
-      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size) :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
+    (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+      (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+        .ok ()) :
     ∃ (switchStart : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -14470,11 +16913,11 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -14500,53 +16943,31 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
           (nativeGeneratedCallDispatcherResultOf irContract tx
             (FunctionBody.initialIRStateForTx model tx initialWorld)
             observableSlots
-            (nativeContractOfDispatcherWithMapping [.Block inner]))) := by
+            (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
-  let reservedNames :=
-    Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
-      (Compiler.emitYul irContract).runtimeCode
-  let functions :=
-    ((∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap).insert
-      "mappingSlot"
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeMappingSlotFunctionDefinition)
+  have hLowerRuntime :
+      Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
+          (Compiler.emitYul irContract).runtimeCode =
+        .ok (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
+    rw [lowerRuntimeContractNative_of_compile_ok_supported_mapping_reserved
+      hcompile hSupported hMapping]
+    rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_error_noFallback_noReceive_withSwitchIds_atFuel
-      (nativeRuntimeDispatcherFuel irContract) reservedNames 0 irContract tx
-      initialState observableSlots inner nextSwitchId functions fn err nativeYul
-      hLowerDispatcher hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
-    ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
-  have hFuel :
-      cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
-    dsimp [nativeRuntimeDispatcherFuel]
-    exact
-      sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
-        hcompile hSupported hMapping
-        (by simpa [reservedNames] using hLowerCases)
+    compile_preserves_native_evmYulLean_selector_hit_error_mapping_canonical
+      model selectors hSupported irContract tx initialWorld observableSlots
+      inner nextSwitchId fn err nativeYul htxNormalized hcalldataSizeFits
+      hcompile hMapping hLowerDispatcher hFind hSelectorRange hNoWrap
+      hFunctionSelectorsRange hEnv with
+    ⟨switchStart, cases', body', bodyStart, bodyEnd, hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', body', bodyStart, bodyEnd,
-    hCase, ?_, ?_⟩
-  · simpa [reservedNames] using hBodyLower
-  · intro hBody hProject hMatch
-    have hGeneratedMatch :
-        nativeGeneratedCallDispatcherMatchesIROn irContract tx initialState
-          observableSlots
-          (nativeContractOfDispatcherWithMapping [.Block inner]) := by
-      apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
-      simpa [nativeGeneratedDispatcherExecMatchesIROn,
-        nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-        nativeContractOfDispatcherWithMapping, functions] using
-          hNativeDispatcherExec hFuel
-            (by simpa [initialState, reservedNames,
-                nativeContractOfDispatcherWithMapping, functions] using hBody)
-            (by simpa [initialState] using hProject)
-            hMatch
-    exact
-      sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeResultsMatchOn
-        (hSourceIR :=
-          Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
-            model selectors hSupported irContract tx initialWorld
-            htxNormalized hcalldataSizeFits hcompile)
-        (hNativeIR := hGeneratedMatch)
+    hCase, hBodyLower, ?_⟩
+  intro hBody hProject hMatch
+  have hSource := hDispatcherContinuation hBody hProject hMatch
+  rw [nativeGeneratedCallDispatcherResultOf_eq_interpretIRRuntimeNative_of_lowerRuntimeContractNative_supported
+    tx initialState observableSlots
+    (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
+    hcompile hSupported hLowerRuntime hEnv]
+  simpa [nativeRuntimeFuel, initialState] using hSource
 
 /-- Direct `callDispatcher` selector-hit error theorem from successful
 lowering of the whole emitted runtime.
@@ -14575,7 +16996,10 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hFunctionSelectorsRange :
-      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size) :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
+    (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+      (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+        .ok ()) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -14588,10 +17012,10 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -14623,8 +17047,8 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
-        (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+          (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
           (Compiler.emitYul irContract).runtimeCode)
         0 irContract.functions dispatcher nextSwitchId hLowerDispatcher with
       ⟨inner, hDispatcher, hLowerBlock⟩
@@ -14634,37 +17058,37 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       compile_preserves_native_evmYulLean_callDispatcher_selector_hit_error_mapping_canonical
         model selectors hSupported irContract tx initialWorld observableSlots
         inner nextSwitchId fn err nativeYul htxNormalized hcalldataSizeFits
-        hcompile hMapping hLowerBlock hFind hSelectorRange hNoWrap
-        hFunctionSelectorsRange with
-      ⟨switchStart, cases', body', bodyStart, bodyEnd,
-        hCase, hBodyLower, hCont⟩
+        hcompile hMapping hLowerDispatcher hFind hSelectorRange hNoWrap
+        hFunctionSelectorsRange hEnv with
+    ⟨switchStart, cases', body', bodyStart, bodyEnd,
+      hCase, hBodyLower, hDispatcherContinuation⟩
     refine ⟨
       Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode,
       switchStart, cases', body', bodyStart, bodyEnd, hCase, hBodyLower, ?_⟩
     intro hBody hProject hMatch
-    exact hCont hBody hProject hMatch
+    exact hDispatcherContinuation hBody hProject hMatch
   · have hNoMapping : irContract.usesMapping = false := by
       exact Bool.eq_false_iff.2 hUsesMapping
     rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, nextSwitchId, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
     rcases
       compile_preserves_native_evmYulLean_callDispatcher_selector_hit_error_noMapping_canonical
         model selectors hSupported irContract tx initialWorld observableSlots
         inner fn err nativeYul htxNormalized hcalldataSizeFits hcompile
-        hNoMapping hLowerBlock hFind hSelectorRange hNoWrap
-        hFunctionSelectorsRange with
-      ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-        hCase, hBodyLower, hCont⟩
+        hNoMapping hLowerDispatcher hFind hSelectorRange hNoWrap
+        hFunctionSelectorsRange hEnv with
+    ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
+        hCase, hBodyLower, hDispatcherContinuation⟩
     exact ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hCont⟩
+      hCase, hBodyLower, hDispatcherContinuation⟩
 
 /-- Native-vs-IR selector-hit error theorem for a supported generated runtime.
 
@@ -14704,10 +17128,10 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_error_matchesIR
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -14744,81 +17168,202 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_error_matchesIR
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         reservedNames 0 irContract.functions dispatcher nextSwitchId
         hLowerDispatcher with
       ⟨inner, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
-    rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_error_noFallback_noReceive_withSwitchIds_atFuel
-        (nativeRuntimeDispatcherFuel irContract) reservedNames 0 irContract tx
-        state observableSlots inner nextSwitchId functions fn err nativeYul
-        (by simpa [reservedNames] using hLowerBlock)
-        hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
-      ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-        hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+        hInner, hLowerCases, hCase, hBodyLower⟩ :=
+      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+        reservedNames 0 irContract.functions inner nextSwitchId
+        tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+        hFind
     have hFuel :
-        cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+        cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
       dsimp [nativeRuntimeDispatcherFuel]
-      exact
-        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
+      have hBig :=
+        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
           hcompile hSupported hMapping
           (by simpa [reservedNames] using hLowerCases)
+      omega
+    have hSelector :
+        tx.functionSelector =
+          (YulTransaction.ofIR tx).functionSelector %
+            Compiler.Constants.selectorModulus := by
+      simpa [YulTransaction.ofIR] using
+        (Nat.mod_eq_of_lt hSelectorRange).symm
+    have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+      exact Nat.lt_trans hSelectorRange (by decide)
+    have hTagsRange :
+        ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+      lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames switchStart + 1)
+        midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
     refine ⟨reservedNames, switchStart, cases', body', bodyStart, bodyEnd,
       hCase, ?_, ?_⟩
     · simpa [reservedNames] using hBodyLower
     · intro hBody hProject hMatch
-      change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-        observableSlots (nativeContractOfDispatcherWithMapping [.Block inner])
+      have hNativeDispatcherExec' :
+          nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
+            irContract tx state observableSlots
+            (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
+        let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+        let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+        let materializedSlots :=
+          Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+            (Compiler.runtimeCode irContract) observableSlots
+        have hFuelShape :
+            nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+          dsimp [fuel0]
+          exact (Nat.sub_add_cancel hFuel).symm
+        have hExec :
+            Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+                (nativeRuntimeDispatcherFuel irContract) contract
+                (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                  (YulTransaction.ofIR tx) state.storage materializedSlots) =
+              .error err := by
+          rw [hFuelShape]
+          have hPeel :=
+            Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+              fuel0 reservedNames switchStart cases' body1 inner functions
+              (YulTransaction.ofIR tx) state.storage materializedSlots
+              hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+          have hSwitch :=
+            Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+              fuel0 tx.functionSelector
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              tx.functionSelector cases'
+              [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+              body' contract (YulTransaction.ofIR tx) state.storage
+              state.events materializedSlots err nativeYul
+              hSelector hCase hSelectorRangeNative hTagsRange
+              (by
+                intro pre suffix hCases
+                simpa [reservedNames, contract, materializedSlots,
+                  nativeContractOfInitPrefixedDispatcherWithMapping, fuel0] using
+                  hBody pre suffix hCases)
+              (by simpa using hProject)
+          simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+            nativeInitFreeMemoryPointerStmt, functions,
+            Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+        refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+          (contract := irContract) (tx := tx) (state := state)
+          (observableSlots := observableSlots)
+          (nativeContract := contract) ?_ hMatch
+        simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+          contract] using hProject
       apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
       simpa [nativeGeneratedDispatcherExecMatchesIROn,
         nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-        nativeContractOfDispatcherWithMapping, functions] using
-          hNativeDispatcherExec hFuel
-            (by simpa [reservedNames, nativeContractOfDispatcherWithMapping,
-                functions] using hBody)
-            (by simpa using hProject)
-            hMatch
+        nativeContractOfInitPrefixedDispatcherWithMapping,
+        nativeInitFreeMemoryPointerStmt, functions] using hNativeDispatcherExec'
   · have hNoMapping : irContract.usesMapping = false :=
       Bool.eq_false_iff.2 hUsesMapping
     rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, nextSwitchId, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
-    rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_error_noFallback_noReceive_atFuel
-        (nativeRuntimeDispatcherFuel irContract) irContract tx state
-        observableSlots inner
-        (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-        fn err nativeYul hLowerBlock hFind hSelectorRange hNoWrap
-        hFunctionSelectorsRange with
-      ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-        hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    let reservedNames :=
+      Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+    obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+        hInner, hLowerCases, hCase, hBodyLower⟩ :=
+      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+        reservedNames 0 irContract.functions inner nextSwitchId
+        tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+        hFind
     have hFuel :
-        cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+        cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
       dsimp [nativeRuntimeDispatcherFuel]
-      exact
-        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
+      have hBig :=
+        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
           hcompile hSupported hNoMapping hLowerCases
-    refine ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
+      omega
+    have hSelector :
+        tx.functionSelector =
+          (YulTransaction.ofIR tx).functionSelector %
+            Compiler.Constants.selectorModulus := by
+      simpa [YulTransaction.ofIR] using
+        (Nat.mod_eq_of_lt hSelectorRange).symm
+    have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+      exact Nat.lt_trans hSelectorRange (by decide)
+    have hTagsRange :
+        ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+      lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames switchStart + 1)
+        midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
+    refine ⟨reservedNames, switchStart, cases', body', bodyStart, bodyEnd,
       hCase, hBodyLower, ?_⟩
     intro hBody hProject hMatch
-    change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-      observableSlots (nativeContractOfDispatcher [.Block inner])
+    have hNativeDispatcherExec' :
+        nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
+          irContract tx state observableSlots
+          (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+      let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+      let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+      let materializedSlots :=
+        Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+          (Compiler.runtimeCode irContract) observableSlots
+      have hFuelShape :
+          nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+        dsimp [fuel0]
+        exact (Nat.sub_add_cancel hFuel).symm
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (nativeRuntimeDispatcherFuel irContract) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) state.storage materializedSlots) =
+            .error err := by
+        rw [hFuelShape]
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            fuel0 reservedNames switchStart cases' body1 inner
+            (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+            (YulTransaction.ofIR tx) state.storage materializedSlots
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+            fuel0 tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) state.storage
+            state.events materializedSlots err nativeYul
+            hSelector hCase hSelectorRangeNative hTagsRange
+            (by
+              intro pre suffix hCases
+              simpa [contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcher, fuel0] using
+                hBody pre suffix hCases)
+            (by simpa using hProject)
+        simpa [contract, nativeContractOfInitPrefixedDispatcher,
+          nativeInitFreeMemoryPointerStmt,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+      refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+        (contract := irContract) (tx := tx) (state := state)
+        (observableSlots := observableSlots)
+        (nativeContract := contract) ?_ hMatch
+      simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+        contract] using hProject
     apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
     simpa [nativeGeneratedDispatcherExecMatchesIROn,
       nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-      nativeContractOfDispatcher] using
-        hNativeDispatcherExec hFuel
-          (by simpa [nativeContractOfDispatcher] using hBody)
-          (by simpa using hProject)
-          hMatch
+      nativeContractOfInitPrefixedDispatcher, nativeInitFreeMemoryPointerStmt]
+      using hNativeDispatcherExec'
 
 /-- Artifact-fixed native-vs-IR selector-hit error theorem for a supported
 generated runtime.
@@ -14867,10 +17412,10 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_error_artifact_
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -14907,81 +17452,202 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_error_artifact_
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         reservedNames 0 irContract.functions dispatcher nextSwitchId
         hLowerDispatcher with
       ⟨inner, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
-    rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_error_noFallback_noReceive_withSwitchIds_atFuel_artifact
-        (nativeRuntimeDispatcherFuel irContract) reservedNames 0 irContract tx
-        state observableSlots inner nextSwitchId functions fn
-        (by simpa [reservedNames] using hLowerBlock)
-        hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
-      ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-        hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+        hInner, hLowerCases, hCase, hBodyLower⟩ :=
+      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+        reservedNames 0 irContract.functions inner nextSwitchId
+        tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+        hFind
     have hFuel :
-        cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+        cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
       dsimp [nativeRuntimeDispatcherFuel]
-      exact
-        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
+      have hBig :=
+        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
           hcompile hSupported hMapping
           (by simpa [reservedNames] using hLowerCases)
+      omega
+    have hSelector :
+        tx.functionSelector =
+          (YulTransaction.ofIR tx).functionSelector %
+            Compiler.Constants.selectorModulus := by
+      simpa [YulTransaction.ofIR] using
+        (Nat.mod_eq_of_lt hSelectorRange).symm
+    have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+      exact Nat.lt_trans hSelectorRange (by decide)
+    have hTagsRange :
+        ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+      lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames switchStart + 1)
+        midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
     refine ⟨reservedNames, switchStart, cases', midN, body', bodyStart, bodyEnd,
       by simpa [reservedNames] using hLowerCases, hCase, ?_, ?_⟩
     · simpa [reservedNames] using hBodyLower
     · intro err nativeYul hBody hProject hMatch
-      change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-        observableSlots (nativeContractOfDispatcherWithMapping [.Block inner])
+      have hNativeDispatcherExec' :
+          nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
+            irContract tx state observableSlots
+            (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
+        let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+        let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+        let materializedSlots :=
+          Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+            (Compiler.runtimeCode irContract) observableSlots
+        have hFuelShape :
+            nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+          dsimp [fuel0]
+          exact (Nat.sub_add_cancel hFuel).symm
+        have hExec :
+            Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+                (nativeRuntimeDispatcherFuel irContract) contract
+                (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                  (YulTransaction.ofIR tx) state.storage materializedSlots) =
+              .error err := by
+          rw [hFuelShape]
+          have hPeel :=
+            Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+              fuel0 reservedNames switchStart cases' body1 inner functions
+              (YulTransaction.ofIR tx) state.storage materializedSlots
+              hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+          have hSwitch :=
+            Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+              fuel0 tx.functionSelector
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              tx.functionSelector cases'
+              [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+              body' contract (YulTransaction.ofIR tx) state.storage
+              state.events materializedSlots err nativeYul
+              hSelector hCase hSelectorRangeNative hTagsRange
+              (by
+                intro pre suffix hCases
+                simpa [reservedNames, contract, materializedSlots,
+                  nativeContractOfInitPrefixedDispatcherWithMapping, fuel0] using
+                  hBody pre suffix hCases)
+              (by simpa using hProject)
+          simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+            nativeInitFreeMemoryPointerStmt, functions,
+            Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+        refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+          (contract := irContract) (tx := tx) (state := state)
+          (observableSlots := observableSlots)
+          (nativeContract := contract) ?_ hMatch
+        simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+          contract] using hProject
       apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
       simpa [nativeGeneratedDispatcherExecMatchesIROn,
         nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-        nativeContractOfDispatcherWithMapping, functions] using
-          hNativeDispatcherExec err nativeYul hFuel
-            (by simpa [reservedNames, nativeContractOfDispatcherWithMapping,
-                functions] using hBody)
-            (by simpa using hProject)
-            hMatch
+        nativeContractOfInitPrefixedDispatcherWithMapping,
+        nativeInitFreeMemoryPointerStmt, functions] using hNativeDispatcherExec'
   · have hNoMapping : irContract.usesMapping = false :=
       Bool.eq_false_iff.2 hUsesMapping
     rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, nextSwitchId, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
-    rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_error_noFallback_noReceive_atFuel_artifact
-        (nativeRuntimeDispatcherFuel irContract) irContract tx state
-        observableSlots inner
-        (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-        fn hLowerBlock hFind hSelectorRange hNoWrap
-        hFunctionSelectorsRange with
-      ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-        hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    let reservedNames :=
+      Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+    obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+        hInner, hLowerCases, hCase, hBodyLower⟩ :=
+      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+        reservedNames 0 irContract.functions inner nextSwitchId
+        tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+        hFind
     have hFuel :
-        cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+        cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
       dsimp [nativeRuntimeDispatcherFuel]
-      exact
-        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
+      have hBig :=
+        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
           hcompile hSupported hNoMapping hLowerCases
-    refine ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
+      omega
+    have hSelector :
+        tx.functionSelector =
+          (YulTransaction.ofIR tx).functionSelector %
+            Compiler.Constants.selectorModulus := by
+      simpa [YulTransaction.ofIR] using
+        (Nat.mod_eq_of_lt hSelectorRange).symm
+    have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+      exact Nat.lt_trans hSelectorRange (by decide)
+    have hTagsRange :
+        ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+      lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames switchStart + 1)
+        midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
+    refine ⟨reservedNames, switchStart, cases', midN, body', bodyStart, bodyEnd,
       hLowerCases, hCase, hBodyLower, ?_⟩
     intro err nativeYul hBody hProject hMatch
-    change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-      observableSlots (nativeContractOfDispatcher [.Block inner])
+    have hNativeDispatcherExec' :
+        nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
+          irContract tx state observableSlots
+          (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+      let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+      let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+      let materializedSlots :=
+        Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+          (Compiler.runtimeCode irContract) observableSlots
+      have hFuelShape :
+          nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+        dsimp [fuel0]
+        exact (Nat.sub_add_cancel hFuel).symm
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (nativeRuntimeDispatcherFuel irContract) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) state.storage materializedSlots) =
+            .error err := by
+        rw [hFuelShape]
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            fuel0 reservedNames switchStart cases' body1 inner
+            (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+            (YulTransaction.ofIR tx) state.storage materializedSlots
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+            fuel0 tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) state.storage
+            state.events materializedSlots err nativeYul
+            hSelector hCase hSelectorRangeNative hTagsRange
+            (by
+              intro pre suffix hCases
+              simpa [contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcher, fuel0] using
+                hBody pre suffix hCases)
+            (by simpa using hProject)
+        simpa [contract, nativeContractOfInitPrefixedDispatcher,
+          nativeInitFreeMemoryPointerStmt,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+      refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+        (contract := irContract) (tx := tx) (state := state)
+        (observableSlots := observableSlots)
+        (nativeContract := contract) ?_ hMatch
+      simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+        contract] using hProject
     apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
     simpa [nativeGeneratedDispatcherExecMatchesIROn,
       nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-      nativeContractOfDispatcher] using
-        hNativeDispatcherExec err nativeYul hFuel
-          (by simpa [nativeContractOfDispatcher] using hBody)
-          (by simpa using hProject)
-          hMatch
+      nativeContractOfInitPrefixedDispatcher, nativeInitFreeMemoryPointerStmt]
+      using hNativeDispatcherExec'
 
 /-- Selector-hit error native-vs-IR theorem with native lowering produced from
 `SupportedSpec + compile`.
@@ -15020,10 +17686,10 @@ theorem nativeGeneratedCallDispatcherResult_selector_hit_error_matchesIR_exists_
         ((∀ pre suffix,
             cases' = pre ++ (tx.functionSelector, body') :: suffix →
             EvmYul.Yul.exec
-              (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
-                  1) + suffix.length + 7) (.Block body')
+              (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
+                1) + suffix.length + 7) (.Block body')
               (some nativeContract)
-              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
                 nativeContract
                 (YulTransaction.ofIR tx)
                 state.storage
@@ -15051,9 +17717,9 @@ theorem nativeGeneratedCallDispatcherResult_selector_hit_error_matchesIR_exists_
       fn err nativeYul hcompile hLowerRuntime hFind hSelectorRange
       hSelectorsRange hNoWrap with
     ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hCont⟩
+      hCase, hBodyLower, hDispatcherContinuation⟩
   exact ⟨nativeContract, hLowerRuntime, reservedNames, n0, cases',
-    body', bodyStart, bodyEnd, hCase, hBodyLower, hCont⟩
+    body', bodyStart, bodyEnd, hCase, hBodyLower, hDispatcherContinuation⟩
 
 /-- Native-vs-IR selector-hit success theorem for a supported generated runtime.
 
@@ -15101,10 +17767,10 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_ok_matchesIR_of
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -15161,85 +17827,276 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_ok_matchesIR_of
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         reservedNames 0 irContract.functions dispatcher nextSwitchId
         hLowerDispatcher with
       ⟨inner, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
-    rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_withSwitchIds_atFuel
-        (nativeRuntimeDispatcherFuel irContract) reservedNames 0 irContract tx
-        state observableSlots inner nextSwitchId functions fn final nativeYul
-        (by simpa [reservedNames] using hLowerBlock)
-        hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
-      ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-        hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+        hInner, hLowerCases, hCase, hBodyLower⟩ :=
+      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+        reservedNames 0 irContract.functions inner nextSwitchId
+        tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+        hFind
     have hFuel :
-        cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+        cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
       dsimp [nativeRuntimeDispatcherFuel]
-      exact
-        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
+      have hBig :=
+        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
           hcompile hSupported hMapping
           (by simpa [reservedNames] using hLowerCases)
+      omega
+    have hSelector :
+        tx.functionSelector =
+          (YulTransaction.ofIR tx).functionSelector %
+            Compiler.Constants.selectorModulus := by
+      simpa [YulTransaction.ofIR] using
+        (Nat.mod_eq_of_lt hSelectorRange).symm
+    have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+      exact Nat.lt_trans hSelectorRange (by decide)
+    have hTagsRange :
+        ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+      lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames switchStart + 1)
+        midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
     refine ⟨reservedNames, switchStart, cases', midN, body', bodyStart, bodyEnd,
       by simpa [reservedNames] using hLowerCases, hCase, ?_, ?_⟩
     · simpa [reservedNames] using hBodyLower
     · intro hBody hPreservesMatched hProject hMatch
-      change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-        observableSlots (nativeContractOfDispatcherWithMapping [.Block inner])
+      have hNativeDispatcherExec' :
+          nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
+            irContract tx state observableSlots
+            (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
+        let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+        let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+        let materializedSlots :=
+          Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+            (Compiler.runtimeCode irContract) observableSlots
+        have hFuelShape :
+            nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+          dsimp [fuel0]
+          exact (Nat.sub_add_cancel hFuel).symm
+        have hExec :
+            Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+                (nativeRuntimeDispatcherFuel irContract) contract
+                (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                  (YulTransaction.ofIR tx) state.storage materializedSlots) =
+              .ok final := by
+          rw [hFuelShape]
+          have hPeel :=
+            Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+              fuel0 reservedNames switchStart cases' body1 inner functions
+              (YulTransaction.ofIR tx) state.storage materializedSlots
+              hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+          have hFinalMatched :
+              ∀ matchedName : EvmYul.Identifier,
+                matchedName =
+                    Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                        reservedNames switchStart) →
+                  final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+            intro matchedName hMatchedName
+            subst matchedName
+            rcases
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitch_find_hit_split
+                tx.functionSelector cases' tx.functionSelector body' hCase with
+              ⟨pre, suffix, hCases, _hTag, _hPrefix⟩
+            exact hPreservesMatched pre suffix hCases
+              (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
+                  1) + suffix.length + 7)
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+                contract (YulTransaction.ofIR tx) state.storage materializedSlots
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)
+                Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore)
+              final
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+                contract (YulTransaction.ofIR tx) state.storage materializedSlots
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)
+                Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+                (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                    reservedNames switchStart)) rfl)
+              (by
+                simpa [reservedNames, contract, materializedSlots,
+                  nativeContractOfInitPrefixedDispatcherWithMapping, fuel0] using
+                  hBody pre suffix hCases)
+          have hSwitch :=
+            Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+              fuel0 tx.functionSelector
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              tx.functionSelector cases'
+              [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+              body' contract (YulTransaction.ofIR tx) state.storage
+              state.events materializedSlots final
+              (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+                (YulTransaction.ofIR tx) state.storage state.events
+                (.ok (final, [])))
+              hSelector hCase hSelectorRangeNative hTagsRange
+              (by
+                intro pre suffix hCases
+                simpa [reservedNames, contract, materializedSlots,
+                  nativeContractOfInitPrefixedDispatcherWithMapping, fuel0] using
+                  hBody pre suffix hCases)
+              hFinalMatched rfl
+          simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+            nativeInitFreeMemoryPointerStmt, functions,
+            Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+        refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+          (contract := irContract) (tx := tx) (state := state)
+          (observableSlots := observableSlots)
+          (nativeContract := contract) ?_ hMatch
+        simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+          contract] using hProject
       apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
       simpa [nativeGeneratedDispatcherExecMatchesIROn,
         nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-        nativeContractOfDispatcherWithMapping, functions] using
-          hNativeDispatcherExec hFuel
-            (by simpa [reservedNames, nativeContractOfDispatcherWithMapping,
-                functions] using hBody)
-            (by simpa [reservedNames, nativeContractOfDispatcherWithMapping,
-                functions] using hPreservesMatched)
-            (by simpa [nativeContractOfDispatcherWithMapping, functions]
-                using hProject)
-            hMatch
+        nativeContractOfInitPrefixedDispatcherWithMapping,
+        nativeInitFreeMemoryPointerStmt, functions] using hNativeDispatcherExec'
   · have hNoMapping : irContract.usesMapping = false :=
       Bool.eq_false_iff.2 hUsesMapping
     rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, nextSwitchId, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
-    rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_atFuel
-        (nativeRuntimeDispatcherFuel irContract) irContract tx state
-        observableSlots inner
-        (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-        fn final nativeYul hLowerBlock hFind hSelectorRange hNoWrap
-        hFunctionSelectorsRange with
-      ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-        hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    let reservedNames :=
+      Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+    obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+        hInner, hLowerCases, hCase, hBodyLower⟩ :=
+      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+        reservedNames 0 irContract.functions inner nextSwitchId
+        tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+        hFind
     have hFuel :
-        cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+        cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
       dsimp [nativeRuntimeDispatcherFuel]
-      exact
-        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
+      have hBig :=
+        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
           hcompile hSupported hNoMapping hLowerCases
-    refine ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
+      omega
+    have hSelector :
+        tx.functionSelector =
+          (YulTransaction.ofIR tx).functionSelector %
+            Compiler.Constants.selectorModulus := by
+      simpa [YulTransaction.ofIR] using
+        (Nat.mod_eq_of_lt hSelectorRange).symm
+    have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+      exact Nat.lt_trans hSelectorRange (by decide)
+    have hTagsRange :
+        ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+      lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames switchStart + 1)
+        midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
+    refine ⟨reservedNames, switchStart, cases', midN, body', bodyStart, bodyEnd,
       hLowerCases, hCase, hBodyLower, ?_⟩
     intro hBody hPreservesMatched hProject hMatch
-    change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-      observableSlots (nativeContractOfDispatcher [.Block inner])
+    have hNativeDispatcherExec' :
+        nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
+          irContract tx state observableSlots
+          (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+      let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+      let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+      let materializedSlots :=
+        Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+          (Compiler.runtimeCode irContract) observableSlots
+      have hFuelShape :
+          nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+        dsimp [fuel0]
+        exact (Nat.sub_add_cancel hFuel).symm
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (nativeRuntimeDispatcherFuel irContract) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) state.storage materializedSlots) =
+            .ok final := by
+        rw [hFuelShape]
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            fuel0 reservedNames switchStart cases' body1 inner
+            (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+            (YulTransaction.ofIR tx) state.storage materializedSlots
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hFinalMatched :
+            ∀ matchedName : EvmYul.Identifier,
+              matchedName =
+                  Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                      reservedNames switchStart) →
+                final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+          intro matchedName hMatchedName
+          subst matchedName
+          rcases
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitch_find_hit_split
+              tx.functionSelector cases' tx.functionSelector body' hCase with
+            ⟨pre, suffix, hCases, _hTag, _hPrefix⟩
+          exact hPreservesMatched pre suffix hCases
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
+                1) + suffix.length + 7)
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              contract (YulTransaction.ofIR tx) state.storage materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore)
+            final
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+              contract (YulTransaction.ofIR tx) state.storage materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)) rfl)
+            (by
+              simpa [contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcher, fuel0] using
+                hBody pre suffix hCases)
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+            fuel0 tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) state.storage
+            state.events materializedSlots final
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+              (YulTransaction.ofIR tx) state.storage state.events
+              (.ok (final, [])))
+            hSelector hCase hSelectorRangeNative hTagsRange
+            (by
+              intro pre suffix hCases
+              simpa [contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcher, fuel0] using
+                hBody pre suffix hCases)
+            hFinalMatched rfl
+        simpa [contract, nativeContractOfInitPrefixedDispatcher,
+          nativeInitFreeMemoryPointerStmt,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+      refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+        (contract := irContract) (tx := tx) (state := state)
+        (observableSlots := observableSlots)
+        (nativeContract := contract) ?_ hMatch
+      simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+        contract] using hProject
     apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
     simpa [nativeGeneratedDispatcherExecMatchesIROn,
       nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-      nativeContractOfDispatcher] using
-        hNativeDispatcherExec hFuel
-          (by simpa [nativeContractOfDispatcher] using hBody)
-          (by simpa [nativeContractOfDispatcher] using hPreservesMatched)
-          (by simpa [nativeContractOfDispatcher] using hProject)
-          hMatch
+      nativeContractOfInitPrefixedDispatcher, nativeInitFreeMemoryPointerStmt]
+      using hNativeDispatcherExec'
 
 /-- Native-vs-IR selector-hit success theorem for a supported generated runtime
 with the selected-body result quantified inside the continuation.
@@ -15287,10 +18144,10 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_ok_matchesIR_fo
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -15347,85 +18204,276 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_ok_matchesIR_fo
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         reservedNames 0 irContract.functions dispatcher nextSwitchId
         hLowerDispatcher with
       ⟨inner, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
-    rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_withSwitchIds_atFuel_forall
-        (nativeRuntimeDispatcherFuel irContract) reservedNames 0 irContract tx
-        state observableSlots inner nextSwitchId functions fn
-        (by simpa [reservedNames] using hLowerBlock)
-        hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
-      ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-        hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+        hInner, hLowerCases, hCase, hBodyLower⟩ :=
+      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+        reservedNames 0 irContract.functions inner nextSwitchId
+        tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+        hFind
     have hFuel :
-        cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+        cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
       dsimp [nativeRuntimeDispatcherFuel]
-      exact
-        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
+      have hBig :=
+        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
           hcompile hSupported hMapping
           (by simpa [reservedNames] using hLowerCases)
+      omega
+    have hSelector :
+        tx.functionSelector =
+          (YulTransaction.ofIR tx).functionSelector %
+            Compiler.Constants.selectorModulus := by
+      simpa [YulTransaction.ofIR] using
+        (Nat.mod_eq_of_lt hSelectorRange).symm
+    have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+      exact Nat.lt_trans hSelectorRange (by decide)
+    have hTagsRange :
+        ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+      lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames switchStart + 1)
+        midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
     refine ⟨reservedNames, switchStart, cases', midN, body', bodyStart, bodyEnd,
       by simpa [reservedNames] using hLowerCases, hCase, ?_, ?_⟩
     · simpa [reservedNames] using hBodyLower
     · intro final nativeYul hBody hPreservesMatched hProject hMatch
-      change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-        observableSlots (nativeContractOfDispatcherWithMapping [.Block inner])
+      have hNativeDispatcherExec' :
+          nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
+            irContract tx state observableSlots
+            (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
+        let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+        let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+        let materializedSlots :=
+          Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+            (Compiler.runtimeCode irContract) observableSlots
+        have hFuelShape :
+            nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+          dsimp [fuel0]
+          exact (Nat.sub_add_cancel hFuel).symm
+        have hExec :
+            Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+                (nativeRuntimeDispatcherFuel irContract) contract
+                (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                  (YulTransaction.ofIR tx) state.storage materializedSlots) =
+              .ok final := by
+          rw [hFuelShape]
+          have hPeel :=
+            Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+              fuel0 reservedNames switchStart cases' body1 inner functions
+              (YulTransaction.ofIR tx) state.storage materializedSlots
+              hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+          have hFinalMatched :
+              ∀ matchedName : EvmYul.Identifier,
+                matchedName =
+                    Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                        reservedNames switchStart) →
+                  final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+            intro matchedName hMatchedName
+            subst matchedName
+            rcases
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitch_find_hit_split
+                tx.functionSelector cases' tx.functionSelector body' hCase with
+              ⟨pre, suffix, hCases, _hTag, _hPrefix⟩
+            exact hPreservesMatched pre suffix hCases
+              (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
+                  1) + suffix.length + 7)
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+                contract (YulTransaction.ofIR tx) state.storage materializedSlots
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)
+                Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore)
+              final
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+                contract (YulTransaction.ofIR tx) state.storage materializedSlots
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)
+                Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+                (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                  (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                    reservedNames switchStart)) rfl)
+              (by
+                simpa [reservedNames, contract, materializedSlots,
+                  nativeContractOfInitPrefixedDispatcherWithMapping, fuel0] using
+                  hBody pre suffix hCases)
+          have hSwitch :=
+            Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+              fuel0 tx.functionSelector
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              tx.functionSelector cases'
+              [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+              body' contract (YulTransaction.ofIR tx) state.storage
+              state.events materializedSlots final
+              (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+                (YulTransaction.ofIR tx) state.storage state.events
+                (.ok (final, [])))
+              hSelector hCase hSelectorRangeNative hTagsRange
+              (by
+                intro pre suffix hCases
+                simpa [reservedNames, contract, materializedSlots,
+                  nativeContractOfInitPrefixedDispatcherWithMapping, fuel0] using
+                  hBody pre suffix hCases)
+              hFinalMatched rfl
+          simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+            nativeInitFreeMemoryPointerStmt, functions,
+            Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+        refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+          (contract := irContract) (tx := tx) (state := state)
+          (observableSlots := observableSlots)
+          (nativeContract := contract) ?_ hMatch
+        simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+          contract] using hProject
       apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
       simpa [nativeGeneratedDispatcherExecMatchesIROn,
         nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-        nativeContractOfDispatcherWithMapping, functions] using
-          hNativeDispatcherExec final nativeYul hFuel
-            (by simpa [reservedNames, nativeContractOfDispatcherWithMapping,
-                functions] using hBody)
-            (by simpa [reservedNames, nativeContractOfDispatcherWithMapping,
-                functions] using hPreservesMatched)
-            (by simpa [nativeContractOfDispatcherWithMapping, functions]
-                using hProject)
-            hMatch
+        nativeContractOfInitPrefixedDispatcherWithMapping,
+        nativeInitFreeMemoryPointerStmt, functions] using hNativeDispatcherExec'
   · have hNoMapping : irContract.usesMapping = false :=
       Bool.eq_false_iff.2 hUsesMapping
     rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, nextSwitchId, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
-    rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_atFuel_forall
-        (nativeRuntimeDispatcherFuel irContract) irContract tx state
-        observableSlots inner
-        (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-        fn hLowerBlock hFind hSelectorRange hNoWrap
-        hFunctionSelectorsRange with
-      ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-        hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    let reservedNames :=
+      Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+    obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+        hInner, hLowerCases, hCase, hBodyLower⟩ :=
+      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+        reservedNames 0 irContract.functions inner nextSwitchId
+        tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+        hFind
     have hFuel :
-        cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+        cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
       dsimp [nativeRuntimeDispatcherFuel]
-      exact
-        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
+      have hBig :=
+        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
           hcompile hSupported hNoMapping hLowerCases
-    refine ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
+      omega
+    have hSelector :
+        tx.functionSelector =
+          (YulTransaction.ofIR tx).functionSelector %
+            Compiler.Constants.selectorModulus := by
+      simpa [YulTransaction.ofIR] using
+        (Nat.mod_eq_of_lt hSelectorRange).symm
+    have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+      exact Nat.lt_trans hSelectorRange (by decide)
+    have hTagsRange :
+        ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+      lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames switchStart + 1)
+        midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
+    refine ⟨reservedNames, switchStart, cases', midN, body', bodyStart, bodyEnd,
       hLowerCases, hCase, hBodyLower, ?_⟩
     intro final nativeYul hBody hPreservesMatched hProject hMatch
-    change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-      observableSlots (nativeContractOfDispatcher [.Block inner])
+    have hNativeDispatcherExec' :
+        nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
+          irContract tx state observableSlots
+          (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+      let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+      let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+      let materializedSlots :=
+        Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+          (Compiler.runtimeCode irContract) observableSlots
+      have hFuelShape :
+          nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+        dsimp [fuel0]
+        exact (Nat.sub_add_cancel hFuel).symm
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (nativeRuntimeDispatcherFuel irContract) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) state.storage materializedSlots) =
+            .ok final := by
+        rw [hFuelShape]
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            fuel0 reservedNames switchStart cases' body1 inner
+            (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+            (YulTransaction.ofIR tx) state.storage materializedSlots
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hFinalMatched :
+            ∀ matchedName : EvmYul.Identifier,
+              matchedName =
+                  Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                      reservedNames switchStart) →
+                final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+          intro matchedName hMatchedName
+          subst matchedName
+          rcases
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitch_find_hit_split
+              tx.functionSelector cases' tx.functionSelector body' hCase with
+            ⟨pre, suffix, hCases, _hTag, _hPrefix⟩
+          exact hPreservesMatched pre suffix hCases
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
+                1) + suffix.length + 7)
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              contract (YulTransaction.ofIR tx) state.storage materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore)
+            final
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+              contract (YulTransaction.ofIR tx) state.storage materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)) rfl)
+            (by
+              simpa [contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcher, fuel0] using
+                hBody pre suffix hCases)
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+            fuel0 tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) state.storage
+            state.events materializedSlots final
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+              (YulTransaction.ofIR tx) state.storage state.events
+              (.ok (final, [])))
+            hSelector hCase hSelectorRangeNative hTagsRange
+            (by
+              intro pre suffix hCases
+              simpa [contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcher, fuel0] using
+                hBody pre suffix hCases)
+            hFinalMatched rfl
+        simpa [contract, nativeContractOfInitPrefixedDispatcher,
+          nativeInitFreeMemoryPointerStmt,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+      refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+        (contract := irContract) (tx := tx) (state := state)
+        (observableSlots := observableSlots)
+        (nativeContract := contract) ?_ hMatch
+      simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+        contract] using hProject
     apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
     simpa [nativeGeneratedDispatcherExecMatchesIROn,
       nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-      nativeContractOfDispatcher] using
-        hNativeDispatcherExec final nativeYul hFuel
-          (by simpa [nativeContractOfDispatcher] using hBody)
-          (by simpa [nativeContractOfDispatcher] using hPreservesMatched)
-          (by simpa [nativeContractOfDispatcher] using hProject)
-          hMatch
+      nativeContractOfInitPrefixedDispatcher, nativeInitFreeMemoryPointerStmt]
+      using hNativeDispatcherExec'
 
 /-- Generated dispatcher selector-hit theorem with a direct raw matched-flag endpoint fact. -/
 private theorem nativeGeneratedCallDispatcherResult_selector_hit_ok_matchesIR_forall_of_compile_ok_supported_finalMatched
@@ -15469,10 +18517,10 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_ok_matchesIR_fo
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -15526,85 +18574,208 @@ private theorem nativeGeneratedCallDispatcherResult_selector_hit_ok_matchesIR_fo
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         reservedNames 0 irContract.functions dispatcher nextSwitchId
         hLowerDispatcher with
       ⟨inner, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
-    rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_withSwitchIds_atFuel_forall_finalMatched
-        (nativeRuntimeDispatcherFuel irContract) reservedNames 0 irContract tx
-        state observableSlots inner nextSwitchId functions fn
-        (by simpa [reservedNames] using hLowerBlock)
-        hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
-      ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-        hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+        hInner, hLowerCases, hCase, hBodyLower⟩ :=
+      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+        reservedNames 0 irContract.functions inner nextSwitchId
+        tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+        hFind
     have hFuel :
-        cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+        cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
       dsimp [nativeRuntimeDispatcherFuel]
-      exact
-        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
+      have hBig :=
+        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
           hcompile hSupported hMapping
           (by simpa [reservedNames] using hLowerCases)
+      omega
+    have hSelector :
+        tx.functionSelector =
+          (YulTransaction.ofIR tx).functionSelector %
+            Compiler.Constants.selectorModulus := by
+      simpa [YulTransaction.ofIR] using
+        (Nat.mod_eq_of_lt hSelectorRange).symm
+    have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+      exact Nat.lt_trans hSelectorRange (by decide)
+    have hTagsRange :
+        ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+      lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames switchStart + 1)
+        midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
     refine ⟨reservedNames, switchStart, cases', midN, body', bodyStart, bodyEnd,
       by simpa [reservedNames] using hLowerCases, hCase, ?_, ?_⟩
     · simpa [reservedNames] using hBodyLower
     · intro final nativeYul hBody hFinalMatched hProject hMatch
-      change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-        observableSlots (nativeContractOfDispatcherWithMapping [.Block inner])
+      have hNativeDispatcherExec' :
+          nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
+            irContract tx state observableSlots
+            (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
+        let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+        let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+        let materializedSlots :=
+          Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+            (Compiler.runtimeCode irContract) observableSlots
+        have hFuelShape :
+            nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+          dsimp [fuel0]
+          exact (Nat.sub_add_cancel hFuel).symm
+        have hExec :
+            Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+                (nativeRuntimeDispatcherFuel irContract) contract
+                (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                  (YulTransaction.ofIR tx) state.storage materializedSlots) =
+              .ok final := by
+          rw [hFuelShape]
+          have hPeel :=
+            Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+              fuel0 reservedNames switchStart cases' body1 inner functions
+              (YulTransaction.ofIR tx) state.storage materializedSlots
+              hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+          have hSwitch :=
+            Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+              fuel0 tx.functionSelector
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              tx.functionSelector cases'
+              [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+              body' contract (YulTransaction.ofIR tx) state.storage
+              state.events materializedSlots final
+              (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+                (YulTransaction.ofIR tx) state.storage state.events
+                (.ok (final, [])))
+              hSelector hCase hSelectorRangeNative hTagsRange
+              (by
+                intro pre suffix hCases
+                simpa [reservedNames, contract, materializedSlots,
+                  nativeContractOfInitPrefixedDispatcherWithMapping, fuel0] using
+                  hBody pre suffix hCases)
+              hFinalMatched rfl
+          simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+            nativeInitFreeMemoryPointerStmt, functions,
+            Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+        refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+          (contract := irContract) (tx := tx) (state := state)
+          (observableSlots := observableSlots)
+          (nativeContract := contract) ?_ hMatch
+        simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+          contract] using hProject
       apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
       simpa [nativeGeneratedDispatcherExecMatchesIROn,
         nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-        nativeContractOfDispatcherWithMapping, functions] using
-          hNativeDispatcherExec final nativeYul hFuel
-            (by simpa [reservedNames, nativeContractOfDispatcherWithMapping,
-                functions] using hBody)
-            (by simpa [reservedNames, nativeContractOfDispatcherWithMapping,
-                functions] using hFinalMatched)
-            (by simpa [nativeContractOfDispatcherWithMapping, functions]
-                using hProject)
-            hMatch
+        nativeContractOfInitPrefixedDispatcherWithMapping,
+        nativeInitFreeMemoryPointerStmt, functions] using hNativeDispatcherExec'
   · have hNoMapping : irContract.usesMapping = false :=
       Bool.eq_false_iff.2 hUsesMapping
     rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, nextSwitchId, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
-    rcases
-      nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_atFuel_forall_finalMatched
-        (nativeRuntimeDispatcherFuel irContract) irContract tx state
-        observableSlots inner
-        (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-        fn hLowerBlock hFind hSelectorRange hNoWrap
-        hFunctionSelectorsRange with
-      ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-        hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    let reservedNames :=
+      Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none]
+    obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+        hInner, hLowerCases, hCase, hBodyLower⟩ :=
+      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+        reservedNames 0 irContract.functions inner nextSwitchId
+        tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+        hFind
     have hFuel :
-        cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+        cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
       dsimp [nativeRuntimeDispatcherFuel]
-      exact
-        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length
+      have hBig :=
+        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
           hcompile hSupported hNoMapping hLowerCases
-    refine ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
+      omega
+    have hSelector :
+        tx.functionSelector =
+          (YulTransaction.ofIR tx).functionSelector %
+            Compiler.Constants.selectorModulus := by
+      simpa [YulTransaction.ofIR] using
+        (Nat.mod_eq_of_lt hSelectorRange).symm
+    have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+      exact Nat.lt_trans hSelectorRange (by decide)
+    have hTagsRange :
+        ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+      lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+        reservedNames
+        (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+          reservedNames switchStart + 1)
+        midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
+    refine ⟨reservedNames, switchStart, cases', midN, body', bodyStart, bodyEnd,
       hLowerCases, hCase, hBodyLower, ?_⟩
     intro final nativeYul hBody hFinalMatched hProject hMatch
-    change nativeGeneratedCallDispatcherMatchesIROn irContract tx state
-      observableSlots (nativeContractOfDispatcher [.Block inner])
+    have hNativeDispatcherExec' :
+        nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
+          irContract tx state observableSlots
+          (nativeContractOfInitPrefixedDispatcher [.Block inner]) := by
+      let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+      let contract := nativeContractOfInitPrefixedDispatcher [.Block inner]
+      let materializedSlots :=
+        Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+          (Compiler.runtimeCode irContract) observableSlots
+      have hFuelShape :
+          nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+        dsimp [fuel0]
+        exact (Nat.sub_add_cancel hFuel).symm
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (nativeRuntimeDispatcherFuel irContract) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) state.storage materializedSlots) =
+            .ok final := by
+        rw [hFuelShape]
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            fuel0 reservedNames switchStart cases' body1 inner
+            (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
+            (YulTransaction.ofIR tx) state.storage materializedSlots
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+            fuel0 tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) state.storage
+            state.events materializedSlots final
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+              (YulTransaction.ofIR tx) state.storage state.events
+              (.ok (final, [])))
+            hSelector hCase hSelectorRangeNative hTagsRange
+            (by
+              intro pre suffix hCases
+              simpa [contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcher, fuel0] using
+                hBody pre suffix hCases)
+            hFinalMatched rfl
+        simpa [contract, nativeContractOfInitPrefixedDispatcher,
+          nativeInitFreeMemoryPointerStmt,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+      refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+        (contract := irContract) (tx := tx) (state := state)
+        (observableSlots := observableSlots)
+        (nativeContract := contract) ?_ hMatch
+      simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+        contract] using hProject
     apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
     simpa [nativeGeneratedDispatcherExecMatchesIROn,
       nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-      nativeContractOfDispatcher] using
-        hNativeDispatcherExec final nativeYul hFuel
-          (by simpa [nativeContractOfDispatcher] using hBody)
-          (by simpa [nativeContractOfDispatcher] using hFinalMatched)
-          (by simpa [nativeContractOfDispatcher] using hProject)
-          hMatch
+      nativeContractOfInitPrefixedDispatcher, nativeInitFreeMemoryPointerStmt]
+      using hNativeDispatcherExec'
 
 
 /-- Selector-hit success native-vs-IR theorem with native lowering produced
@@ -15644,10 +18815,10 @@ theorem nativeGeneratedCallDispatcherResult_selector_hit_ok_matchesIR_exists_of_
         ((∀ pre suffix,
             cases' = pre ++ (tx.functionSelector, body') :: suffix →
             EvmYul.Yul.exec
-              (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
-                  1) + suffix.length + 7) (.Block body')
+              (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
+                1) + suffix.length + 7) (.Block body')
               (some nativeContract)
-              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
                 nativeContract
                 (YulTransaction.ofIR tx)
                 state.storage
@@ -15695,9 +18866,9 @@ theorem nativeGeneratedCallDispatcherResult_selector_hit_ok_matchesIR_exists_of_
       fn final nativeYul hcompile hLowerRuntime hFind hSelectorRange
       hSelectorsRange hNoWrap with
     ⟨reservedNames, n0, cases', _midN, body', bodyStart, bodyEnd,
-      _hLowerCases, hCase, hBodyLower, hCont⟩
+      _hLowerCases, hCase, hBodyLower, hDispatcherContinuation⟩
   exact ⟨nativeContract, hLowerRuntime, reservedNames, n0, cases',
-    body', bodyStart, bodyEnd, hCase, hBodyLower, hCont⟩
+    body', bodyStart, bodyEnd, hCase, hBodyLower, hDispatcherContinuation⟩
 
 /-- Selector-hit lowered-artifact theorem for a supported generated runtime.
 
@@ -15741,7 +18912,7 @@ private theorem nativeGeneratedSelectorHitLoweredArtifacts_of_compile_ok_support
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         reservedNames 0 irContract.functions dispatcher nextSwitchId
         hLowerDispatcher with
       ⟨inner, hDispatcher, hLowerBlock⟩
@@ -15763,18 +18934,25 @@ private theorem nativeGeneratedSelectorHitLoweredArtifacts_of_compile_ok_support
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, nextSwitchId, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
+    let reservedNames :=
+      Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none]
     rcases
-      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function
-        irContract.functions inner tx.functionSelector fn hLowerBlock hFind with
-      ⟨_body1, reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
+      Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+        reservedNames 0 irContract.functions inner nextSwitchId
+        tx.functionSelector fn
+        (by simpa [reservedNames] using hLowerBlock)
+        hFind with
+      ⟨_body1, n0, cases', midN, body', bodyStart, bodyEnd,
         _hInner, hLowerCases, hCase, hBodyLower⟩
     exact ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower⟩
+      hCase, by simpa [reservedNames] using hBodyLower⟩
 
 /-- Selector-hit success lowered artifacts for a supported generated runtime,
 including the direct lowered user function body.
@@ -15850,7 +19028,7 @@ private theorem nativeGeneratedSelectorHitSuccessUserBodyLoweredArtifacts_of_com
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         reservedNames 0 irContract.functions dispatcher nextSwitchId
         hLowerDispatcher with
       ⟨inner, hDispatcher, hLowerBlock⟩
@@ -15865,7 +19043,7 @@ private theorem nativeGeneratedSelectorHitSuccessUserBodyLoweredArtifacts_of_com
           hFind hSelectorRange hNoWrap hFunctionSelectorsRange
           (by simpa using hPayable) hguards hArgs with
         ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
-          userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, _hCont⟩
+          userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, _hDispatcherContinuation⟩
       exact ⟨reservedNames, switchStart, cases', midN, body', bodyNative,
         bodyStart, bodyEnd, userBodyStart,
         by simpa [reservedNames] using hLowerCases,
@@ -15881,7 +19059,7 @@ private theorem nativeGeneratedSelectorHitSuccessUserBodyLoweredArtifacts_of_com
           hFind hSelectorRange hNoWrap hFunctionSelectorsRange hNonPayable
           hguards hArgs with
         ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
-          userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, _hCont⟩
+          userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, _hDispatcherContinuation⟩
       exact ⟨reservedNames, switchStart, cases', midN, body', bodyNative,
         bodyStart, bodyEnd, userBodyStart,
         by simpa [reservedNames] using hLowerCases,
@@ -15894,45 +19072,59 @@ private theorem nativeGeneratedSelectorHitSuccessUserBodyLoweredArtifacts_of_com
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, nextSwitchId, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
+    let reservedNames :=
+      Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch irContract.functions none none]
     by_cases hPayable : fn.payable
     · rcases
-        nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_payable_generated_prefix
-          0 irContract tx state observableSlots inner
+        nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_payable_withSwitchIds_generated_prefix
+          0 reservedNames 0 irContract tx state observableSlots inner nextSwitchId
           (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-          fn dummyNativeState dummyYul hLowerBlock hFind hSelectorRange
+          fn dummyNativeState dummyYul
+          (by simpa [reservedNames] using hLowerBlock)
+          hFind hSelectorRange
           hNoWrap hFunctionSelectorsRange (by simpa using hPayable)
           hguards hArgs with
-        ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart,
+        ⟨switchStart, cases', midN, body', bodyNative, bodyStart,
           bodyEnd, userBodyStart, hLowerCases, hCase, hBodyLower,
-          hUserBodyLower, _hCont⟩
-      exact ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart,
-        bodyEnd, userBodyStart, hLowerCases, hCase, hBodyLower,
-        hUserBodyLower⟩
+          hUserBodyLower, _hDispatcherContinuation⟩
+      exact ⟨reservedNames, switchStart, cases', midN, body', bodyNative,
+        bodyStart, bodyEnd, userBodyStart,
+        by simpa [reservedNames] using hLowerCases,
+        hCase,
+        by simpa [reservedNames] using hBodyLower,
+        by simpa [reservedNames] using hUserBodyLower⟩
     · have hNonPayable : fn.payable = false := Bool.eq_false_iff.2 hPayable
       rcases
-        nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_nonpayable_generated_prefix
-          0 irContract tx state observableSlots inner
+        nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_nonpayable_withSwitchIds_generated_prefix
+          0 reservedNames 0 irContract tx state observableSlots inner nextSwitchId
           (∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
-          fn dummyNativeState dummyYul hLowerBlock hFind hSelectorRange
+          fn dummyNativeState dummyYul
+          (by simpa [reservedNames] using hLowerBlock)
+          hFind hSelectorRange
           hNoWrap hFunctionSelectorsRange hNonPayable hguards hArgs with
-        ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart,
+        ⟨switchStart, cases', midN, body', bodyNative, bodyStart,
           bodyEnd, userBodyStart, hLowerCases, hCase, hBodyLower,
-          hUserBodyLower, _hCont⟩
-      exact ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart,
-        bodyEnd, userBodyStart, hLowerCases, hCase, hBodyLower,
-        hUserBodyLower⟩
+          hUserBodyLower, _hDispatcherContinuation⟩
+      exact ⟨reservedNames, switchStart, cases', midN, body', bodyNative,
+        bodyStart, bodyEnd, userBodyStart,
+        by simpa [reservedNames] using hLowerCases,
+        hCase,
+        by simpa [reservedNames] using hBodyLower,
+        by simpa [reservedNames] using hUserBodyLower⟩
 
 /-- Selector-hit success lowered artifacts for a supported generated runtime,
 with native runtime lowering produced directly from `SupportedSpec + compile`.
 
 This packages the full lowering witness with the generated switch-case and
 selected user-body lowering artifacts needed by the remaining native body
-execution bridge. -/
+ExecBridge. -/
 theorem nativeGeneratedSelectorHitSuccessUserBodyLoweredArtifacts_exists_of_compile_ok_supported
     (spec : CompilationModel.CompilationModel) (selectors : List Nat)
     (hSupported : SupportedSpec spec selectors)
@@ -16135,10 +19327,10 @@ private def NativeGeneratedSelectorHitBodyBridge
       (∀ pre suffix,
         cases' = pre ++ (tx.functionSelector, body') :: suffix →
         EvmYul.Yul.exec
-          (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
-              1) + suffix.length + 7) (.Block body')
+          (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
+                1) + suffix.length + 7) (.Block body')
           (some nativeContract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
             nativeContract
             (YulTransaction.ofIR tx)
             state.storage
@@ -16207,10 +19399,10 @@ private def NativeGeneratedSelectorHitUserBodyBridge
       (∀ pre suffix,
         cases' = pre ++ (tx.functionSelector, body') :: suffix →
         EvmYul.Yul.exec
-          (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+          (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
               1) + suffix.length + 10) (.Block bodyNative)
           (some nativeContract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
             nativeContract
             (YulTransaction.ofIR tx)
             state.storage
@@ -16244,9 +19436,9 @@ noncomputable def nativeGeneratedSelectorHitUserBodyFuel
     (irContract : IRContract) (fn : IRFunction)
     (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) : Nat :=
   if fn.payable then
-    nativeRuntimeDispatcherFuel irContract - (cases'.length + 23)
-  else
     nativeRuntimeDispatcherFuel irContract - (cases'.length + 24)
+  else
+    nativeRuntimeDispatcherFuel irContract - (cases'.length + 25)
 
 /-- Exact-fuel user-body selector-hit bridge target.
 
@@ -16283,7 +19475,7 @@ private def NativeGeneratedSelectorHitUserBodyBridgeAtFuel
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
               suffix.length + 10) (.Block bodyNative)
           (some nativeContract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
             nativeContract
             (YulTransaction.ofIR tx)
             state.storage
@@ -16345,7 +19537,7 @@ private def NativeGeneratedSelectorHitUserBodyBridgeAtFuelRestored
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
               suffix.length + 10) (.Block bodyNative)
           (some nativeContract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
             nativeContract
             (YulTransaction.ofIR tx)
             state.storage
@@ -16422,7 +19614,7 @@ private def NativeGeneratedSelectorHitUserBodyBridgeAtFuelRevived
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
               suffix.length + 10) (.Block bodyNative)
           (some nativeContract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
             nativeContract
             (YulTransaction.ofIR tx)
             state.storage
@@ -16492,7 +19684,7 @@ private def NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevived
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
               suffix.length + 10) (.Block bodyNative)
           (some nativeContract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
             nativeContract
             (YulTransaction.ofIR tx)
             state.storage
@@ -16519,7 +19711,7 @@ private def NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevived
         (execIRFunction fn tx.args (applyIRTransactionContext tx state))
         (.ok nativeYul)
 
-/-- Parallel `_revived`-leave-aware variant of
+/-- Parallel `_revived`-LeaveAware variant of
 `NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevived` that uses
 `NativeBlockPreservesWord_revived` in the matched-flag preservation conjunct.
 
@@ -16568,7 +19760,7 @@ private def NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevivedLeaveAware
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
               suffix.length + 10) (.Block bodyNative)
           (some nativeContract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
             nativeContract
             (YulTransaction.ofIR tx)
             state.storage
@@ -16595,7 +19787,7 @@ private def NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevivedLeaveAware
         (execIRFunction fn tx.args (applyIRTransactionContext tx state))
         (.ok nativeYul)
 
-/-- Revived native function-body execution bridge without matched-flag
+/-- Revived native function-body ExecBridge without matched-flag
 preservation.
 
 This separates the semantic part of the future native body-correctness theorem
@@ -16638,7 +19830,7 @@ private def NativeGeneratedSelectorHitUserBodyExecOnlyBridgeAtFuelRevived
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
               suffix.length + 10) (.Block bodyNative)
           (some nativeContract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
             nativeContract
             (YulTransaction.ofIR tx)
             state.storage
@@ -16690,10 +19882,10 @@ private def NativeGeneratedSelectorHitBodyHaltExecBridgeAtFuel
       (∀ pre suffix,
         cases' = pre ++ (tx.functionSelector, body') :: suffix →
         EvmYul.Yul.exec
-          (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
-              1) + suffix.length + 7) (.Block body')
+          (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
+                1) + suffix.length + 7) (.Block body')
           (some nativeContract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
             nativeContract
             (YulTransaction.ofIR tx)
             state.storage
@@ -16744,7 +19936,7 @@ def NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
               suffix.length + 10) (.Block bodyNative)
           (some nativeContract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
             nativeContract
             (YulTransaction.ofIR tx)
             state.storage
@@ -16778,12 +19970,12 @@ private theorem NativeGeneratedSelectorHitBodyHaltExecBridgeAtFuel.of_selected_u
     (hFuelPayable :
       ∀ (fn : IRFunction) (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)),
         fn.payable = true →
-        cases'.length + 23 ≤ nativeRuntimeDispatcherFuel irContract)
+        cases'.length + 24 ≤ nativeRuntimeDispatcherFuel irContract)
     (hFuelNonPayable :
       ∀ (fn : IRFunction) (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)),
         fn.payable = false →
-        cases'.length + 24 ≤ nativeRuntimeDispatcherFuel irContract)
-    (hUserBodyHalt :
+        cases'.length + 25 ≤ nativeRuntimeDispatcherFuel irContract)
+    (hSelectedUserBodyHalt :
       NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel irContract tx state
         observableSlots) :
     NativeGeneratedSelectorHitBodyHaltExecBridgeAtFuel irContract tx state
@@ -16796,7 +19988,7 @@ private theorem NativeGeneratedSelectorHitBodyHaltExecBridgeAtFuel.of_selected_u
         reservedNames bodyStart fn body' bodyEnd
         (by simpa using hPayable) hBodyLower with
       ⟨guardBody, bodyNative, userBodyStart, hBodyShape, hUserBodyLower⟩
-    rcases hUserBodyHalt nativeContract fn reservedNames n0 cases'
+    rcases hSelectedUserBodyHalt nativeContract fn reservedNames n0 cases'
         bodyNative bodyEnd userBodyStart hLowerRuntime hFind hUserBodyLower
         hguards hArgs with
       ⟨haltState, haltValue, nativeYul, hBody, hProject, hMatch⟩
@@ -16804,7 +19996,7 @@ private theorem NativeGeneratedSelectorHitBodyHaltExecBridgeAtFuel.of_selected_u
     intro pre suffix hCases
     rw [hBodyShape]
     have hPrefix :=
-      Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_eq
+      Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_postInitFreeMemory_eq
         (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
           suffix.length + 1)
         guardBody bodyNative nativeContract (YulTransaction.ofIR tx)
@@ -16825,10 +20017,10 @@ private theorem NativeGeneratedSelectorHitBodyHaltExecBridgeAtFuel.of_selected_u
     have hFuelEq :
         suffix.length +
             (1 + (11 + (nativeRuntimeDispatcherFuel irContract -
-              (cases'.length + 23)))) =
-          suffix.length +
-            (1 + (7 + (nativeRuntimeDispatcherFuel irContract -
-              (cases'.length + 19)))) := by
+              (cases'.length + 24)))) =
+suffix.length +
+(1 + (7 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 20)))) := by
       have hBound := hFuelPayable fn cases' (by simpa using hPayable)
       omega
     simpa [nativeGeneratedSelectorHitUserBodyFuel, hPayable,
@@ -16840,7 +20032,7 @@ private theorem NativeGeneratedSelectorHitBodyHaltExecBridgeAtFuel.of_selected_u
         reservedNames bodyStart fn body' bodyEnd hNonPayable hBodyLower with
       ⟨callvalueGuardBody, calldataGuardBody, bodyNative, userBodyStart,
         hBodyShape, hUserBodyLower⟩
-    rcases hUserBodyHalt nativeContract fn reservedNames n0 cases'
+    rcases hSelectedUserBodyHalt nativeContract fn reservedNames n0 cases'
         bodyNative bodyEnd userBodyStart hLowerRuntime hFind hUserBodyLower
         hguards hArgs with
       ⟨haltState, haltValue, nativeYul, hBody, hProject, hMatch⟩
@@ -16848,7 +20040,7 @@ private theorem NativeGeneratedSelectorHitBodyHaltExecBridgeAtFuel.of_selected_u
     intro pre suffix hCases
     rw [hBodyShape]
     have hPrefix :=
-      Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_eq
+      Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_postInitFreeMemory_eq
         (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
           suffix.length + 1)
         callvalueGuardBody calldataGuardBody bodyNative nativeContract
@@ -16871,10 +20063,10 @@ private theorem NativeGeneratedSelectorHitBodyHaltExecBridgeAtFuel.of_selected_u
     have hFuelEq :
         suffix.length +
             (1 + (12 + (nativeRuntimeDispatcherFuel irContract -
-              (cases'.length + 24)))) =
-          suffix.length +
-            (1 + (7 + (nativeRuntimeDispatcherFuel irContract -
-              (cases'.length + 19)))) := by
+              (cases'.length + 25)))) =
+suffix.length +
+(1 + (7 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 20)))) := by
       have hBound := hFuelNonPayable fn cases' (by simpa using hNonPayable)
       omega
     simpa [nativeGeneratedSelectorHitUserBodyFuel, hNonPayable,
@@ -16913,12 +20105,12 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_body_halt_exec_atFuel
       nativeContract fn hcompile hLowerRuntime hFind hSelectorRange
       hSelectorsRange hNoWrap with
     ⟨reservedNames, n0, cases', _midN, body', bodyStart, bodyEnd,
-      _hLowerCases, hCase, hBodyLower, hCont⟩
+      _hLowerCases, hCase, hBodyLower, hDispatcherContinuation⟩
   rcases hHaltBridge nativeContract fn reservedNames n0 cases' body'
       bodyStart bodyEnd hLowerRuntime hFind hCase hBodyLower hguards hArgs with
     ⟨haltState, haltValue, nativeYul, hBody, hProject, hMatchExec⟩
   exact
-    hCont (EvmYul.Yul.Exception.YulHalt haltState haltValue) nativeYul
+    hDispatcherContinuation (EvmYul.Yul.Exception.YulHalt haltState haltValue) nativeYul
       hBody hProject
       (nativeResultsMatchOn_interpretIR_of_execIRFunction_dispatchGuards
         irContract tx state observableSlots fn (.ok nativeYul) hFind hguards
@@ -16944,7 +20136,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ha
       ∀ selector, selector ∈ selectors →
         selector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
-    (hUserBodyHalt :
+    (hSelectedUserBodyHalt :
       NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel irContract tx state
         observableSlots) :
     NativeGeneratedSelectorHitSuccessBridge irContract tx state
@@ -16956,7 +20148,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ha
       nativeContract fn hcompile hLowerRuntime hFind hSelectorRange
       hSelectorsRange hNoWrap with
     ⟨reservedNames, n0, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hCont⟩
+      hLowerCases, hCase, hBodyLower, hDispatcherContinuation⟩
   have hFuelBound24 :
       cases'.length + 24 ≤ nativeRuntimeDispatcherFuel irContract := by
     dsimp [nativeRuntimeDispatcherFuel]
@@ -16971,13 +20163,27 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ha
       exact
         sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
           hcompile hSupported hNoMapping hLowerCases
+  have hFuelBound25 :
+      cases'.length + 25 ≤ nativeRuntimeDispatcherFuel irContract := by
+    dsimp [nativeRuntimeDispatcherFuel]
+    by_cases hUsesMapping : irContract.usesMapping
+    · have hMapping : irContract.usesMapping = true := by
+        simpa using hUsesMapping
+      exact
+        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus25
+          hcompile hSupported hMapping hLowerCases
+    · have hNoMapping : irContract.usesMapping = false :=
+        Bool.eq_false_iff.2 hUsesMapping
+      exact
+        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus25
+          hcompile hSupported hNoMapping hLowerCases
   by_cases hPayable : fn.payable
   · rcases
       Compiler.Proofs.YulGeneration.Backends.Native.lowerStmtsNativeWithSwitchIds_switchCaseBody_payable_eq
         reservedNames bodyStart fn body' bodyEnd
         (by simpa using hPayable) hBodyLower with
       ⟨guardBody, bodyNative, userBodyStart, hBodyShape, hUserBodyLower⟩
-    rcases hUserBodyHalt nativeContract fn reservedNames n0 cases'
+    rcases hSelectedUserBodyHalt nativeContract fn reservedNames n0 cases'
         bodyNative bodyEnd userBodyStart hLowerRuntime hFind hUserBodyLower
         hguards hArgs with
       ⟨haltState, haltValue, nativeYul, hBody, hProject, hMatchExec⟩
@@ -16985,10 +20191,10 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ha
         ∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -17001,7 +20207,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ha
       intro pre suffix hCases
       rw [hBodyShape]
       have hPrefix :=
-        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_eq
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_postInitFreeMemory_eq
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
             suffix.length + 1)
           guardBody bodyNative nativeContract (YulTransaction.ofIR tx)
@@ -17022,10 +20228,10 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ha
       have hFuelEq :
           suffix.length +
               (1 + (11 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 23)))) =
-            suffix.length +
-              (1 + (7 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 19)))) := by
+                (cases'.length + 24)))) =
+suffix.length +
+(1 + (7 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 20)))) := by
         have hBound23 : cases'.length + 23 ≤
             nativeRuntimeDispatcherFuel irContract := by
           omega
@@ -17034,7 +20240,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ha
         Nat.add_assoc, Nat.add_comm, Nat.add_left_comm, hFuelEq] using
         hPrefix.trans (hBody pre suffix)
     exact
-      hCont (EvmYul.Yul.Exception.YulHalt haltState haltValue) nativeYul
+      hDispatcherContinuation (EvmYul.Yul.Exception.YulHalt haltState haltValue) nativeYul
         hCaseBody hProject
         (nativeResultsMatchOn_interpretIR_of_execIRFunction_dispatchGuards
           irContract tx state observableSlots fn (.ok nativeYul) hFind hguards
@@ -17045,7 +20251,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ha
         reservedNames bodyStart fn body' bodyEnd hNonPayable hBodyLower with
       ⟨callvalueGuardBody, calldataGuardBody, bodyNative, userBodyStart,
         hBodyShape, hUserBodyLower⟩
-    rcases hUserBodyHalt nativeContract fn reservedNames n0 cases'
+    rcases hSelectedUserBodyHalt nativeContract fn reservedNames n0 cases'
         bodyNative bodyEnd userBodyStart hLowerRuntime hFind hUserBodyLower
         hguards hArgs with
       ⟨haltState, haltValue, nativeYul, hBody, hProject, hMatchExec⟩
@@ -17053,10 +20259,10 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ha
         ∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -17069,7 +20275,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ha
       intro pre suffix hCases
       rw [hBodyShape]
       have hPrefix :=
-        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_eq
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_postInitFreeMemory_eq
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
             suffix.length + 1)
           callvalueGuardBody calldataGuardBody bodyNative nativeContract
@@ -17092,23 +20298,23 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ha
       have hFuelEq :
           suffix.length +
               (1 + (12 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 24)))) =
-            suffix.length +
-              (1 + (7 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 19)))) := by
-        have hBound24 := hFuelBound24
+                (cases'.length + 25)))) =
+suffix.length +
+(1 + (7 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 20)))) := by
+        have hBound25 := hFuelBound25
         omega
       simpa [nativeGeneratedSelectorHitUserBodyFuel, hNonPayable,
         Nat.add_assoc, Nat.add_comm, Nat.add_left_comm, hFuelEq] using
         hPrefix.trans (hBody pre suffix)
     exact
-      hCont (EvmYul.Yul.Exception.YulHalt haltState haltValue) nativeYul
+      hDispatcherContinuation (EvmYul.Yul.Exception.YulHalt haltState haltValue) nativeYul
         hCaseBody hProject
         (nativeResultsMatchOn_interpretIR_of_execIRFunction_dispatchGuards
           irContract tx state observableSlots fn (.ok nativeYul) hFind hguards
           hArgs hMatchExec)
 
-/-- Direct selected-user-body execution bridge without switch-case lowering
+/-- Direct selected-user-body ExecBridge without switch-case lowering
 artifacts.
 
 This is the narrowest current success-case target for the future native
@@ -17145,7 +20351,7 @@ private def NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
               suffix.length + 10) (.Block bodyNative)
           (some nativeContract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
             nativeContract
             (YulTransaction.ofIR tx)
             state.storage
@@ -17186,7 +20392,7 @@ private theorem nativeResultsMatchOn_execIRFunction_empty_body_markedPrefix
         (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx) state.storage state.events
           (.ok
-            ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract (YulTransaction.ofIR tx) state.storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                 (Compiler.runtimeCode irContract) observableSlots)
@@ -17194,7 +20400,7 @@ private theorem nativeResultsMatchOn_execIRFunction_empty_body_markedPrefix
   simp only [nativeResultsMatchOn,
     Compiler.Proofs.YulGeneration.Backends.Native.nativeResultsMatchOn]
   simp [hBody, applyIRTransactionContext,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_reviveJump_eq]
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_reviveJump_eq]
   constructor
   · intro slot hSlot
     exact
@@ -17210,7 +20416,7 @@ private theorem nativeResultsMatchOn_execIRFunction_empty_body_markedPrefix
             (Compiler.runtimeCode irContract) observableSlots)
           switchId store)
 
-/-- Build the direct selected-user-body execution bridge for contracts whose
+/-- Build the direct selected-user-body ExecBridge for contracts whose
 selected generated function body is empty. -/
 private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_empty_body
     (irContract : IRContract)
@@ -17232,7 +20438,7 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_em
   let switchId :=
     Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0
   let final :=
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
       nativeContract (YulTransaction.ofIR tx) state.storage
       (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
         (Compiler.runtimeCode irContract) observableSlots)
@@ -17244,9 +20450,10 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_em
       (.ok (final.reviveJump, []))
   have hFinalOk : ∃ shared store, final = EvmYul.Yul.State.Ok shared store := by
     simp [final,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
       EvmYul.Yul.State.insert]
   rcases hFinalOk with ⟨shared, store, hFinalOk⟩
   refine ⟨final, nativeYul, shared, store, ?_, ?_, rfl, ?_⟩
@@ -17319,7 +20526,7 @@ private theorem nativeResultsMatchOn_execIRFunction_leave_body_markedPrefix
         (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx) state.storage state.events
           (.ok
-            (((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract (YulTransaction.ofIR tx) state.storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                 (Compiler.runtimeCode irContract) observableSlots)
@@ -17328,9 +20535,10 @@ private theorem nativeResultsMatchOn_execIRFunction_leave_body_markedPrefix
     Compiler.Proofs.YulGeneration.Backends.Native.nativeResultsMatchOn]
   unfold execIRFunction
   simp [hBody, applyIRTransactionContext,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
     EvmYul.Yul.State.insert, EvmYul.Yul.State.setLeave,
     EvmYul.Yul.State.reviveJump]
   constructor
@@ -17369,7 +20577,7 @@ private theorem nativeResultsMatchOn_execIRFunction_label_prefix_leave_body_mark
         (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx) state.storage state.events
           (.ok
-            (((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract (YulTransaction.ofIR tx) state.storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                 (Compiler.runtimeCode irContract) observableSlots)
@@ -17378,9 +20586,10 @@ private theorem nativeResultsMatchOn_execIRFunction_label_prefix_leave_body_mark
     Compiler.Proofs.YulGeneration.Backends.Native.nativeResultsMatchOn]
   unfold execIRFunction
   simp [hBody, applyIRTransactionContext, execIRStmts, execIRStmt,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
     EvmYul.Yul.State.insert, EvmYul.Yul.State.setLeave,
     EvmYul.Yul.State.reviveJump]
   constructor
@@ -17398,7 +20607,7 @@ private theorem nativeResultsMatchOn_execIRFunction_label_prefix_leave_body_mark
             (Compiler.runtimeCode irContract) observableSlots)
           switchId store)
 
-/-- Build the direct selected-user-body execution bridge for contracts whose
+/-- Build the direct selected-user-body ExecBridge for contracts whose
 selected generated function body is exactly `leave`. -/
 private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_leave_body
     (irContract : IRContract)
@@ -17421,7 +20630,7 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_le
   let switchId :=
     Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0
   let initial :=
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
       nativeContract (YulTransaction.ofIR tx) state.storage
       (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
         (Compiler.runtimeCode irContract) observableSlots)
@@ -17435,9 +20644,10 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_le
   have hReviveOk :
       ∃ shared store, final.reviveJump = EvmYul.Yul.State.Ok shared store := by
     simp [final, initial,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
       EvmYul.Yul.State.insert, EvmYul.Yul.State.setLeave,
       EvmYul.Yul.State.reviveJump, EvmYul.Yul.State.revive]
   rcases hReviveOk with ⟨shared, store, hRevive⟩
@@ -17453,7 +20663,7 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_le
         Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
         hBody
 
-/-- F2 ExecOnly: Build the direct selected-user-body execution bridge for
+/-- F2 ExecOnly: Build the direct selected-user-body ExecBridge for
 contracts whose selected generated function body is exactly `[.block [], .leave]`
 (F2's body shape, label-prefix variant of E2). Composes the `_revived`
 machinery: peel the `.Block []` head via `exec_block_label_prefix_leave_ok_add_ten`
@@ -17484,7 +20694,7 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_le
   let switchId :=
     Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0
   let initial :=
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
       nativeContract (YulTransaction.ofIR tx) state.storage
       (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
         (Compiler.runtimeCode irContract) observableSlots)
@@ -17498,9 +20708,10 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_le
   have hReviveOk :
       ∃ shared store, final.reviveJump = EvmYul.Yul.State.Ok shared store := by
     simp [final, initial,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
       EvmYul.Yul.State.insert, EvmYul.Yul.State.setLeave,
       EvmYul.Yul.State.reviveJump, EvmYul.Yul.State.revive]
   rcases hReviveOk with ⟨shared, store, hRevive⟩
@@ -17569,7 +20780,7 @@ private theorem nativeResultsMatchOn_execIRFunction_block_leave_body_markedPrefi
         (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx) state.storage state.events
           (.ok
-            (((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract (YulTransaction.ofIR tx) state.storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                 (Compiler.runtimeCode irContract) observableSlots)
@@ -17578,9 +20789,10 @@ private theorem nativeResultsMatchOn_execIRFunction_block_leave_body_markedPrefi
     Compiler.Proofs.YulGeneration.Backends.Native.nativeResultsMatchOn]
   unfold execIRFunction
   simp [hBody, applyIRTransactionContext, execIRStmts, execIRStmt,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
     EvmYul.Yul.State.insert, EvmYul.Yul.State.setLeave,
     EvmYul.Yul.State.reviveJump]
   constructor
@@ -17618,7 +20830,7 @@ private theorem nativeResultsMatchOn_execIRFunction_label_prefix_block_leave_bod
         (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx) state.storage state.events
           (.ok
-            (((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract (YulTransaction.ofIR tx) state.storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                 (Compiler.runtimeCode irContract) observableSlots)
@@ -17627,9 +20839,10 @@ private theorem nativeResultsMatchOn_execIRFunction_label_prefix_block_leave_bod
     Compiler.Proofs.YulGeneration.Backends.Native.nativeResultsMatchOn]
   unfold execIRFunction
   simp [hBody, applyIRTransactionContext, execIRStmts, execIRStmt,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
     EvmYul.Yul.State.insert, EvmYul.Yul.State.setLeave,
     EvmYul.Yul.State.reviveJump]
   constructor
@@ -17647,7 +20860,7 @@ private theorem nativeResultsMatchOn_execIRFunction_label_prefix_block_leave_bod
             (Compiler.runtimeCode irContract) observableSlots)
           switchId store)
 
-/-- Build the direct selected-user-body execution bridge for contracts whose
+/-- Build the direct selected-user-body ExecBridge for contracts whose
 selected generated function body is exactly `[.block [.leave]]`.
 
 Lowering wraps the `.leave` in a `[.Block ...]` native statement, but the
@@ -17679,7 +20892,7 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_bl
   let switchId :=
     Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0
   let initial :=
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
       nativeContract (YulTransaction.ofIR tx) state.storage
       (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
         (Compiler.runtimeCode irContract) observableSlots)
@@ -17693,9 +20906,10 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_bl
   have hReviveOk :
       ∃ shared store, final.reviveJump = EvmYul.Yul.State.Ok shared store := by
     simp [final, initial,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
       EvmYul.Yul.State.insert, EvmYul.Yul.State.setLeave,
       EvmYul.Yul.State.reviveJump, EvmYul.Yul.State.revive]
   rcases hReviveOk with ⟨shared, store, hRevive⟩
@@ -17711,7 +20925,7 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_bl
         Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
         hBody
 
-/-- F4 ExecOnly: Build the direct selected-user-body execution bridge for
+/-- F4 ExecOnly: Build the direct selected-user-body ExecBridge for
 contracts whose selected generated function body is exactly
 `[.block [], .block [.leave]]` (F4's body shape, label-prefix variant of E4).
 
@@ -17743,7 +20957,7 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_bl
   let switchId :=
     Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0
   let initial :=
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
       nativeContract (YulTransaction.ofIR tx) state.storage
       (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
         (Compiler.runtimeCode irContract) observableSlots)
@@ -17757,9 +20971,10 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_bl
   have hReviveOk :
       ∃ shared store, final.reviveJump = EvmYul.Yul.State.Ok shared store := by
     simp [final, initial,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
       EvmYul.Yul.State.insert, EvmYul.Yul.State.setLeave,
       EvmYul.Yul.State.reviveJump, EvmYul.Yul.State.revive]
   rcases hReviveOk with ⟨shared, store, hRevive⟩
@@ -17799,7 +21014,7 @@ private theorem nativeResultsMatchOn_execIRFunction_block_empty_body_markedPrefi
         (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx) state.storage state.events
           (.ok
-            ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract (YulTransaction.ofIR tx) state.storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                 (Compiler.runtimeCode irContract) observableSlots)
@@ -17808,7 +21023,7 @@ private theorem nativeResultsMatchOn_execIRFunction_block_empty_body_markedPrefi
     Compiler.Proofs.YulGeneration.Backends.Native.nativeResultsMatchOn]
   unfold execIRFunction
   simp [hBody, applyIRTransactionContext, execIRStmts, execIRStmt,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_reviveJump_eq]
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_reviveJump_eq]
   constructor
   · intro slot hSlot
     exact
@@ -17824,7 +21039,7 @@ private theorem nativeResultsMatchOn_execIRFunction_block_empty_body_markedPrefi
             (Compiler.runtimeCode irContract) observableSlots)
           switchId store)
 
-/-- Build the direct selected-user-body execution bridge for contracts whose
+/-- Build the direct selected-user-body ExecBridge for contracts whose
 selected generated function body is exactly `[.block []]`.
 
 Mirrors `.of_empty_body` (no leave flag set) but accounts for the additional
@@ -17855,7 +21070,7 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_bl
   let switchId :=
     Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0
   let final :=
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
       nativeContract (YulTransaction.ofIR tx) state.storage
       (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
         (Compiler.runtimeCode irContract) observableSlots)
@@ -17867,9 +21082,10 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_bl
       (.ok (final.reviveJump, []))
   have hFinalOk : ∃ shared store, final = EvmYul.Yul.State.Ok shared store := by
     simp [final,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
       EvmYul.Yul.State.insert]
   rcases hFinalOk with ⟨shared, store, hFinalOk⟩
   refine ⟨final, nativeYul, shared, store, ?_, ?_, rfl, ?_⟩
@@ -17913,7 +21129,7 @@ private theorem nativeResultsMatchOn_execIRFunction_singleton_comment_body_marke
         (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx) state.storage state.events
           (.ok
-            ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract (YulTransaction.ofIR tx) state.storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                 (Compiler.runtimeCode irContract) observableSlots)
@@ -17922,7 +21138,7 @@ private theorem nativeResultsMatchOn_execIRFunction_singleton_comment_body_marke
     Compiler.Proofs.YulGeneration.Backends.Native.nativeResultsMatchOn]
   unfold execIRFunction
   simp [hBody, applyIRTransactionContext, execIRStmts, execIRStmt,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_reviveJump_eq]
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_reviveJump_eq]
   constructor
   · intro slot hSlot
     exact
@@ -17938,7 +21154,7 @@ private theorem nativeResultsMatchOn_execIRFunction_singleton_comment_body_marke
             (Compiler.runtimeCode irContract) observableSlots)
           switchId store)
 
-/-- Build the direct selected-user-body execution bridge for contracts whose
+/-- Build the direct selected-user-body ExecBridge for contracts whose
 selected generated function body is exactly `[.comment text]` for some
 text.
 
@@ -17973,7 +21189,7 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_si
   let switchId :=
     Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0
   let final :=
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
       nativeContract (YulTransaction.ofIR tx) state.storage
       (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
         (Compiler.runtimeCode irContract) observableSlots)
@@ -17985,9 +21201,10 @@ private theorem NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_si
       (.ok (final.reviveJump, []))
   have hFinalOk : ∃ shared store, final = EvmYul.Yul.State.Ok shared store := by
     simp [final,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
       EvmYul.Yul.State.insert]
   rcases hFinalOk with ⟨shared, store, hFinalOk⟩
   refine ⟨final, nativeYul, shared, store, ?_, ?_, rfl, ?_⟩
@@ -18022,7 +21239,7 @@ private theorem nativeResultsMatchOn_execIRFunction_stop_body_markedPrefix
         (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx) state.storage state.events
           (.error (EvmYul.Yul.Exception.YulHalt
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract (YulTransaction.ofIR tx) state.storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                 (Compiler.runtimeCode irContract) observableSlots)
@@ -18036,7 +21253,7 @@ private theorem nativeResultsMatchOn_execIRFunction_stop_body_markedPrefix
   constructor
   · intro slot hSlot
     exact
-      (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_materializedStorageSlot
+      (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_materializedStorageSlot
         nativeContract (YulTransaction.ofIR tx) state.storage
         (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
           (Compiler.runtimeCode irContract) observableSlots)
@@ -18078,7 +21295,7 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_stop_body
   let switchId :=
     Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0
   let haltState :=
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
       nativeContract (YulTransaction.ofIR tx) state.storage
       (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
         (Compiler.runtimeCode irContract) observableSlots)
@@ -18239,7 +21456,7 @@ private theorem NativeGeneratedSelectedUserBodyResultBridgeAtFuel.of_exec_only_a
   Or.inr ⟨hExec, hPreserves⟩
 
 /-- Project the semantic execution half out of the existing all-in-one selected
-user-body execution bridge. -/
+user-body ExecBridge. -/
 private theorem NativeGeneratedSelectorHitUserBodyExecOnlyBridgeAtFuelRevived.of_exec_bridge
     (irContract : IRContract)
     (tx : IRTransaction)
@@ -18284,7 +21501,7 @@ private theorem NativeGeneratedSelectorHitUserBodyExecOnlyBridgeAtFuelRevived.of
   exact hBody pre suffix
 
 /-- Project the dispatcher-local preservation half out of the existing
-all-in-one selected user-body execution bridge. -/
+all-in-one selected user-body ExecBridge. -/
 private theorem NativeGeneratedSelectorHitUserBodyPreservesBridgeAtFuel.of_exec_bridge
     (irContract : IRContract)
     (tx : IRTransaction)
@@ -20213,7 +23430,7 @@ private theorem NativeGeneratedSelectorHitUserBodyPreservesBridgeAtFuelRevived.o
   rw [hBody fn hFind, hOnlyEmpty, List.nil_append]
 
 /-- Adapter: compose an exec-only Revived bridge with a `_revived` Preserves
-bridge to produce the leave-aware revived exec bridge. Parallel to
+bridge to produce the LeaveAware revived exec bridge. Parallel to
 `NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevived.of_exec_only_and_preserves`
 but uses `_revived` Preserves so it works for Leave-ending bodies. -/
 private theorem NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevivedLeaveAware.of_exec_only_and_revivedPreserves
@@ -20243,7 +23460,7 @@ private theorem NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevivedLeaveAw
       bodyStart bodyEnd userBodyStart hLowerRuntime hFind hCase hBodyLower
       hUserBodyLower pre suffix hCases
 
-/-- One-shot constructor for the leave-aware revived exec bridge for the
+/-- One-shot constructor for the LeaveAware revived exec bridge for the
 `[.leave]` body shape. Composes the existing exec-only `of_leave_body` leaf
 (`NativeGeneratedSelectedUserBodyExecOnlyBridgeAtFuelRevived.of_leave_body`)
 with the `_revived` Preserves bridge `of_leave_body` (shipped in `6cf2a453`). -/
@@ -20268,7 +23485,7 @@ private theorem NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevivedLeaveAw
     (NativeGeneratedSelectorHitUserBodyPreservesBridgeAtFuelRevived.of_leave_body
       irContract tx hLeave)
 
-/-- One-shot constructor for the leave-aware revived exec bridge for the
+/-- One-shot constructor for the LeaveAware revived exec bridge for the
 `[.block [.leave]]` body shape. Composes the existing exec-only
 `of_block_leave` leaf with the `_revived` Preserves bridge `of_block_leave`. -/
 private theorem NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevivedLeaveAware.of_block_leave
@@ -20487,7 +23704,7 @@ private theorem NativeGeneratedSelectorHitUserBodyBridgeAtFuelRevived.of_execIRF
     (tx : IRTransaction)
     (state : IRState)
     (observableSlots : List Nat)
-    (hExecBridge :
+    (hSelectedExecBridge :
       NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevived irContract tx
         state observableSlots)
     (hguards :
@@ -20504,7 +23721,7 @@ private theorem NativeGeneratedSelectorHitUserBodyBridgeAtFuelRevived.of_execIRF
       observableSlots := by
   intro nativeContract fn reservedNames n0 cases' body' bodyNative bodyStart
     bodyEnd userBodyStart hLowerRuntime hFind hCase hBodyLower hUserBodyLower
-  rcases hExecBridge nativeContract fn reservedNames n0 cases' body' bodyNative
+  rcases hSelectedExecBridge nativeContract fn reservedNames n0 cases' body' bodyNative
       bodyStart bodyEnd userBodyStart hLowerRuntime hFind hCase hBodyLower
       hUserBodyLower (hguards fn hFind) (hArgs fn hFind) with
     ⟨final, nativeYul, shared, store, hBody, hPreserves, hRevive, hProject,
@@ -20582,7 +23799,7 @@ private theorem NativeGeneratedSelectorHitUserBodyBridgeAtFuelRestored.of_execIR
     (tx : IRTransaction)
     (state : IRState)
     (observableSlots : List Nat)
-    (hExecBridge :
+    (hSelectedExecBridge :
       NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevived irContract tx
         state observableSlots)
     (hguards :
@@ -20600,7 +23817,7 @@ private theorem NativeGeneratedSelectorHitUserBodyBridgeAtFuelRestored.of_execIR
   NativeGeneratedSelectorHitUserBodyBridgeAtFuelRestored.of_revived
     irContract tx state observableSlots
     (NativeGeneratedSelectorHitUserBodyBridgeAtFuelRevived.of_execIRFunction
-      irContract tx state observableSlots hExecBridge hguards hArgs)
+      irContract tx state observableSlots hSelectedExecBridge hguards hArgs)
 
 /-- Generic matched-flag preservation for a selected generated selector-hit
 body.
@@ -20702,10 +23919,10 @@ private def NativeGeneratedSelectorHitDispatcherContinuation
     (∀ pre suffix,
       cases' = pre ++ (tx.functionSelector, body') :: suffix →
       EvmYul.Yul.exec
-        (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
-            1) + suffix.length + 7) (.Block body')
+        (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
+                1) + suffix.length + 7) (.Block body')
         (some nativeContract)
-        (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+        (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
           nativeContract
           (YulTransaction.ofIR tx)
           state.storage
@@ -20782,7 +23999,7 @@ private def NativeGeneratedSelectorHitUserBodyGeneratedPrefixContinuation
             suffix.length + 10)
           (.Block bodyNative)
           (some nativeContract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
             nativeContract
             (YulTransaction.ofIR tx)
             state.storage
@@ -20832,7 +24049,7 @@ private theorem NativeGeneratedSelectorHitArtifactBridge.of_body_bridge_and_cont
     (hBodyBridge :
       NativeGeneratedSelectorHitBodyBridge irContract tx state
         observableSlots)
-    (hCont :
+    (hDispatcherContinuation :
       ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
         (reservedNames : List String) (n0 : Nat)
         (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -20857,7 +24074,7 @@ private theorem NativeGeneratedSelectorHitArtifactBridge.of_body_bridge_and_cont
       bodyStart bodyEnd hLowerRuntime hFind hCase hBodyLower with
     ⟨final, nativeYul, hBody, hPreserves, hProject, hMatch⟩
   exact
-    hCont nativeContract fn reservedNames n0 cases' body' bodyStart bodyEnd
+    hDispatcherContinuation nativeContract fn reservedNames n0 cases' body' bodyStart bodyEnd
       hLowerRuntime hFind hCase hBodyLower
       final nativeYul hBody hPreserves hProject hMatch
 
@@ -20876,7 +24093,7 @@ private theorem NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_and
     (hUserBodyBridge :
       NativeGeneratedSelectorHitUserBodyBridge irContract tx state
         observableSlots)
-    (hCont :
+    (hDispatcherContinuation :
       ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
         (reservedNames : List String) (n0 : Nat)
         (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -20900,10 +24117,10 @@ private theorem NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_and
             cases' = pre ++ (tx.functionSelector, body') :: suffix →
             EvmYul.Yul.exec
               (((nativeRuntimeDispatcherFuel irContract -
-                    (cases'.length + 19)) + 1) + suffix.length + 10)
+                    (cases'.length + 20)) + 1) + suffix.length + 10)
               (.Block bodyNative)
               (some nativeContract)
-              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
                 nativeContract
                 (YulTransaction.ofIR tx)
                 state.storage
@@ -20946,7 +24163,7 @@ private theorem NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_and
         hBodyLower hUserBodyLower with
       ⟨final, nativeYul, hBody, hPreserves, hProject, hMatch⟩
     exact
-      hCont nativeContract fn reservedNames n0 cases' body' bodyNative
+      hDispatcherContinuation nativeContract fn reservedNames n0 cases' body' bodyNative
         bodyStart bodyEnd userBodyStart hLowerRuntime hFind hCase hBodyLower
         hUserBodyLower final nativeYul hBody hPreserves hProject hMatch
   · have hNonPayable : fn.payable = false := Bool.eq_false_iff.2 hPayable
@@ -20960,7 +24177,7 @@ private theorem NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_and
         hBodyLower hUserBodyLower with
       ⟨final, nativeYul, hBody, hPreserves, hProject, hMatch⟩
     exact
-      hCont nativeContract fn reservedNames n0 cases' body' bodyNative
+      hDispatcherContinuation nativeContract fn reservedNames n0 cases' body' bodyNative
         bodyStart bodyEnd userBodyStart hLowerRuntime hFind hCase hBodyLower
         hUserBodyLower final nativeYul hBody hPreserves hProject hMatch
 
@@ -20980,7 +24197,7 @@ private theorem NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_atF
     (hUserBodyBridge :
       NativeGeneratedSelectorHitUserBodyBridgeAtFuel irContract tx state
         observableSlots)
-    (hCont :
+    (hDispatcherContinuation :
       ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
         (reservedNames : List String) (n0 : Nat)
         (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -21007,7 +24224,7 @@ private theorem NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_atF
                 suffix.length + 10)
               (.Block bodyNative)
               (some nativeContract)
-              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
                 nativeContract
                 (YulTransaction.ofIR tx)
                 state.storage
@@ -21050,7 +24267,7 @@ private theorem NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_atF
         hBodyLower hUserBodyLower with
       ⟨final, nativeYul, hBody, hPreserves, hProject, hMatch⟩
     exact
-      hCont nativeContract fn reservedNames n0 cases' body' bodyNative
+      hDispatcherContinuation nativeContract fn reservedNames n0 cases' body' bodyNative
         bodyStart bodyEnd userBodyStart hLowerRuntime hFind hCase hBodyLower
         hUserBodyLower final nativeYul hBody hPreserves hProject hMatch
   · have hNonPayable : fn.payable = false := Bool.eq_false_iff.2 hPayable
@@ -21064,7 +24281,7 @@ private theorem NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_atF
         hBodyLower hUserBodyLower with
       ⟨final, nativeYul, hBody, hPreserves, hProject, hMatch⟩
     exact
-      hCont nativeContract fn reservedNames n0 cases' body' bodyNative
+      hDispatcherContinuation nativeContract fn reservedNames n0 cases' body' bodyNative
         bodyStart bodyEnd userBodyStart hLowerRuntime hFind hCase hBodyLower
         hUserBodyLower final nativeYul hBody hPreserves hProject hMatch
 
@@ -21085,7 +24302,7 @@ private theorem NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_atF
     (hUserBodyBridge :
       NativeGeneratedSelectorHitUserBodyBridgeAtFuelRestored irContract tx state
         observableSlots)
-    (hCont :
+    (hDispatcherContinuation :
       ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
         (reservedNames : List String) (n0 : Nat)
         (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -21112,7 +24329,7 @@ private theorem NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_atF
                 suffix.length + 10)
               (.Block bodyNative)
               (some nativeContract)
-              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
                 nativeContract
                 (YulTransaction.ofIR tx)
                 state.storage
@@ -21166,7 +24383,7 @@ private theorem NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_atF
         hBodyLower hUserBodyLower with
       ⟨final, nativeYul, hBody, hPreserves, hProject, hMatch⟩
     exact
-      hCont nativeContract fn reservedNames n0 cases' body' bodyNative
+      hDispatcherContinuation nativeContract fn reservedNames n0 cases' body' bodyNative
         bodyStart bodyEnd userBodyStart hLowerRuntime hFind hCase hBodyLower
         hUserBodyLower final nativeYul hBody hPreserves hProject hMatch
   · have hNonPayable : fn.payable = false := Bool.eq_false_iff.2 hPayable
@@ -21180,7 +24397,7 @@ private theorem NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_atF
         hBodyLower hUserBodyLower with
       ⟨final, nativeYul, hBody, hPreserves, hProject, hMatch⟩
     exact
-      hCont nativeContract fn reservedNames n0 cases' body' bodyNative
+      hDispatcherContinuation nativeContract fn reservedNames n0 cases' body' bodyNative
         bodyStart bodyEnd userBodyStart hLowerRuntime hFind hCase hBodyLower
         hUserBodyLower final nativeYul hBody hPreserves hProject hMatch
 
@@ -21220,7 +24437,7 @@ private theorem NativeGeneratedSelectorHitBridge.of_artifact_bridge
       fn dummyNativeState dummyYul hcompile hLowerRuntime hFind hSelectorRange
       hSelectorsRange hNoWrap with
     ⟨reservedNames, n0, cases', _midN, body', bodyStart, bodyEnd,
-      _hLowerCases, hCase, hBodyLower, _hCont⟩
+      _hLowerCases, hCase, hBodyLower, _hDispatcherContinuation⟩
   exact hArtifactBridge nativeContract fn reservedNames n0 cases' body'
     bodyStart bodyEnd hLowerRuntime hFind hCase hBodyLower
 
@@ -21639,7 +24856,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
     (hUserBodyBridge :
       NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevived irContract tx
         state observableSlots)
-    (hCont :
+    (hDispatcherContinuation :
       ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
         (reservedNames : List String) (n0 : Nat)
         (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -21666,7 +24883,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
                 suffix.length + 10)
               (.Block bodyNative)
               (some nativeContract)
-              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
                 nativeContract
                 (YulTransaction.ofIR tx)
                 state.storage
@@ -21808,7 +25025,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       ⟨final, nativeYul, shared, store, hBody, hPreserves, hRevive,
         hProject, hMatchExec⟩
     exact
-      hCont nativeContract fn reservedNames n0 cases' body' bodyNative
+      hDispatcherContinuation nativeContract fn reservedNames n0 cases' body' bodyNative
         bodyStart bodyEnd userBodyStart hLowerRuntime hFind hCase hBodyLower
         hUserBodyLower final nativeYul hBody hPreserves
         (hProjectRestored final nativeYul shared store hRevive hProject)
@@ -21827,7 +25044,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       ⟨final, nativeYul, shared, store, hBody, hPreserves, hRevive,
         hProject, hMatchExec⟩
     exact
-      hCont nativeContract fn reservedNames n0 cases' body' bodyNative
+      hDispatcherContinuation nativeContract fn reservedNames n0 cases' body' bodyNative
         bodyStart bodyEnd userBodyStart hLowerRuntime hFind hCase hBodyLower
         hUserBodyLower final nativeYul hBody hPreserves
         (hProjectRestored final nativeYul shared store hRevive hProject)
@@ -21837,12 +25054,12 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
 
 /-- Leave-aware parallel variant of
 `nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFuel_revived_and_continuation`
-that accepts the `_revived`-leave-aware exec bridge (with `_revived` Preserves
+that accepts the `_revived`-LeaveAware exec bridge (with `_revived` Preserves
 in the matched-flag conjunct) and a continuation that consumes `_revived`
 Preserves at the matching position.
 
 Mechanical mirror: the proof body is identical to the OLD-form consumer; only
-the types of `hUserBodyBridge` and the `hCont`'s Preserves parameter change. -/
+the types of `hUserBodyBridge` and the `hDispatcherContinuation`'s Preserves parameter change. -/
 private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFuel_revivedLeaveAware_and_continuation
     (spec : CompilationModel.CompilationModel) (selectors : List Nat)
     (hSupported : SupportedSpec spec selectors)
@@ -21891,6 +25108,20 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
         Bool.eq_false_iff.2 hUsesMapping
       exact
         sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
+          hcompile hSupported hNoMapping hLowerCases
+  have hFuelBound25 :
+      cases'.length + 25 ≤ nativeRuntimeDispatcherFuel irContract := by
+    dsimp [nativeRuntimeDispatcherFuel]
+    by_cases hUsesMapping : irContract.usesMapping
+    · have hMapping : irContract.usesMapping = true := by
+        simpa using hUsesMapping
+      exact
+        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus25
+          hcompile hSupported hMapping hLowerCases
+    · have hNoMapping : irContract.usesMapping = false :=
+        Bool.eq_false_iff.2 hUsesMapping
+      exact
+        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus25
           hcompile hSupported hNoMapping hLowerCases
   have hProjectRestored
       (final : EvmYul.Yul.State) (nativeYul : YulResult)
@@ -21970,10 +25201,10 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
         ∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -21986,7 +25217,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       intro pre suffix hCases
       rw [hBodyShape]
       have hPrefix :=
-        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_eq
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_postInitFreeMemory_eq
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
             suffix.length + 1)
           guardBody bodyNative nativeContract (YulTransaction.ofIR tx)
@@ -22007,10 +25238,10 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       have hFuelEq :
           suffix.length +
               (1 + (11 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 23)))) =
-            suffix.length +
-              (1 + (7 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 19)))) := by
+                (cases'.length + 24)))) =
+suffix.length +
+(1 + (7 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 20)))) := by
         have hBound23 : cases'.length + 23 ≤
             nativeRuntimeDispatcherFuel irContract := by
           omega
@@ -22033,7 +25264,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       let switchId :=
         Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0
       let selectedState :=
-        Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+        Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
           nativeContract
           (YulTransaction.ofIR tx)
           state.storage
@@ -22046,7 +25277,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       have hInitialMatched :
           selectedState.reviveJump[matchedName]! = EvmYul.UInt256.ofNat 1 := by
         have hRaw :=
-          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_matched
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
             nativeContract (YulTransaction.ofIR tx) state.storage
             (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
               (Compiler.runtimeCode irContract) observableSlots)
@@ -22054,7 +25285,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
             matchedName rfl
         have hReviveSelected :=
-          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_reviveJump_eq
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_reviveJump_eq
             nativeContract (YulTransaction.ofIR tx) state.storage
             (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
               (Compiler.runtimeCode irContract) observableSlots)
@@ -22090,10 +25321,10 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
         ∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -22106,7 +25337,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       intro pre suffix hCases
       rw [hBodyShape]
       have hPrefix :=
-        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_eq
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_postInitFreeMemory_eq
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
             suffix.length + 1)
           callvalueGuardBody calldataGuardBody bodyNative nativeContract
@@ -22129,11 +25360,11 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       have hFuelEq :
           suffix.length +
               (1 + (12 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 24)))) =
-            suffix.length +
-              (1 + (7 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 19)))) := by
-        have hBound24 := hFuelBound24
+                (cases'.length + 25)))) =
+suffix.length +
+(1 + (7 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 20)))) := by
+        have hBound25 := hFuelBound25
         omega
       simpa [nativeGeneratedSelectorHitUserBodyFuel, hNonPayable,
         Nat.add_assoc, Nat.add_comm, Nat.add_left_comm, hFuelEq] using
@@ -22153,7 +25384,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       let switchId :=
         Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId reservedNames n0
       let selectedState :=
-        Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+        Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
           nativeContract
           (YulTransaction.ofIR tx)
           state.storage
@@ -22166,7 +25397,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       have hInitialMatched :
           selectedState.reviveJump[matchedName]! = EvmYul.UInt256.ofNat 1 := by
         have hRaw :=
-          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_matched
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
             nativeContract (YulTransaction.ofIR tx) state.storage
             (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
               (Compiler.runtimeCode irContract) observableSlots)
@@ -22174,7 +25405,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
             Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
             matchedName rfl
         have hReviveSelected :=
-          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_reviveJump_eq
+          Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_reviveJump_eq
             nativeContract (YulTransaction.ofIR tx) state.storage
             (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
               (Compiler.runtimeCode irContract) observableSlots)
@@ -22251,6 +25482,20 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       exact
         sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
           hcompile hSupported hNoMapping hLowerCases
+  have hFuelBound25 :
+      cases'.length + 25 ≤ nativeRuntimeDispatcherFuel irContract := by
+    dsimp [nativeRuntimeDispatcherFuel]
+    by_cases hUsesMapping : irContract.usesMapping
+    · have hMapping : irContract.usesMapping = true := by
+        simpa using hUsesMapping
+      exact
+        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus25
+          hcompile hSupported hMapping hLowerCases
+    · have hNoMapping : irContract.usesMapping = false :=
+        Bool.eq_false_iff.2 hUsesMapping
+      exact
+        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus25
+          hcompile hSupported hNoMapping hLowerCases
   have hProjectRestored
       (final : EvmYul.Yul.State) (nativeYul : YulResult)
       (shared : EvmYul.SharedState EvmYul.OperationType.Yul)
@@ -22329,10 +25574,10 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
         ∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -22345,7 +25590,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       intro pre suffix hCases
       rw [hBodyShape]
       have hPrefix :=
-        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_eq
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_postInitFreeMemory_eq
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
             suffix.length + 1)
           guardBody bodyNative nativeContract (YulTransaction.ofIR tx)
@@ -22366,10 +25611,10 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       have hFuelEq :
           suffix.length +
               (1 + (11 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 23)))) =
-            suffix.length +
-              (1 + (7 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 19)))) := by
+                (cases'.length + 24)))) =
+suffix.length +
+(1 + (7 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 20)))) := by
         have hBound23 : cases'.length + 23 ≤
             nativeRuntimeDispatcherFuel irContract := by
           omega
@@ -22413,10 +25658,10 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
         ∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -22429,7 +25674,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       intro pre suffix hCases
       rw [hBodyShape]
       have hPrefix :=
-        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_eq
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_postInitFreeMemory_eq
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
             suffix.length + 1)
           callvalueGuardBody calldataGuardBody bodyNative nativeContract
@@ -22452,11 +25697,11 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
       have hFuelEq :
           suffix.length +
               (1 + (12 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 24)))) =
-            suffix.length +
-              (1 + (7 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 19)))) := by
-        have hBound24 := hFuelBound24
+                (cases'.length + 25)))) =
+suffix.length +
+(1 + (7 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 20)))) := by
+        have hBound25 := hFuelBound25
         omega
       simpa [nativeGeneratedSelectorHitUserBodyFuel, hNonPayable,
         Nat.add_assoc, Nat.add_comm, Nat.add_left_comm, hFuelEq] using
@@ -22483,7 +25728,7 @@ private theorem nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFu
           irContract tx state observableSlots fn (.ok nativeYul) hFind
           hguards hArgs hMatchExec)
 
-/-- The exact-fuel selected user-body execution bridge plus the generated-prefix
+/-- The exact-fuel selected user-body ExecBridge plus the generated-prefix
 continuation supplies the named success-only selector-hit bridge. -/
 private theorem NativeGeneratedSelectorHitSuccessBridge.of_user_body_exec_bridge_atFuel_revived_and_continuation
     (spec : CompilationModel.CompilationModel) (selectors : List Nat)
@@ -22501,7 +25746,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_user_body_exec_bridge
     (hUserBodyBridge :
       NativeGeneratedSelectorHitUserBodyExecBridgeAtFuelRevived irContract tx
         state observableSlots)
-    (hCont :
+    (hDispatcherContinuation :
       ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
         (reservedNames : List String) (n0 : Nat)
         (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -22528,7 +25773,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_user_body_exec_bridge
                 suffix.length + 10)
               (.Block bodyNative)
               (some nativeContract)
-              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
                 nativeContract
                 (YulTransaction.ofIR tx)
                 state.storage
@@ -22573,10 +25818,10 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_user_body_exec_bridge
   exact
     nativeGeneratedSelectorHit_success_of_user_body_exec_bridge_atFuel_revived_and_continuation
       spec selectors hSupported irContract tx state observableSlots hcompile
-      hSelectorRange hSelectorsRange hNoWrap hUserBodyBridge hCont
+      hSelectorRange hSelectorsRange hNoWrap hUserBodyBridge hDispatcherContinuation
       nativeContract fn hLowerRuntime hFind hguards hArgs
 
-/-- The exact-fuel selected user-body execution bridge supplies the named
+/-- The exact-fuel selected user-body ExecBridge supplies the named
 success-only selector-hit bridge. -/
 private theorem NativeGeneratedSelectorHitSuccessBridge.of_user_body_exec_bridge_atFuel_revived
     (spec : CompilationModel.CompilationModel) (selectors : List Nat)
@@ -22675,6 +25920,20 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ex
       exact
         sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24
           hcompile hSupported hNoMapping hLowerCases
+  have hFuelBound25 :
+      cases'.length + 25 ≤ nativeRuntimeDispatcherFuel irContract := by
+    dsimp [nativeRuntimeDispatcherFuel]
+    by_cases hUsesMapping : irContract.usesMapping
+    · have hMapping : irContract.usesMapping = true := by
+        simpa using hUsesMapping
+      exact
+        sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus25
+          hcompile hSupported hMapping hLowerCases
+    · have hNoMapping : irContract.usesMapping = false :=
+        Bool.eq_false_iff.2 hUsesMapping
+      exact
+        sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus25
+          hcompile hSupported hNoMapping hLowerCases
   have hProjectRestored
       (final : EvmYul.Yul.State) (nativeYul : YulResult)
       (shared : EvmYul.SharedState EvmYul.OperationType.Yul)
@@ -22768,10 +26027,10 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ex
         ∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -22784,7 +26043,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ex
       intro pre suffix hCases
       rw [hBodyShape]
       have hPrefix :=
-        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_eq
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_postInitFreeMemory_eq
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
             suffix.length + 1)
           guardBody bodyNative nativeContract (YulTransaction.ofIR tx)
@@ -22805,10 +26064,10 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ex
       have hFuelEq :
           suffix.length +
               (1 + (11 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 23)))) =
-            suffix.length +
-              (1 + (7 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 19)))) := by
+                (cases'.length + 24)))) =
+suffix.length +
+(1 + (7 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 20)))) := by
         have hBound23 : cases'.length + 23 ≤
             nativeRuntimeDispatcherFuel irContract := by
           omega
@@ -22837,10 +26096,10 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ex
         ∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -22853,7 +26112,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ex
       intro pre suffix hCases
       rw [hBodyShape]
       have hPrefix :=
-        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_eq
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_postInitFreeMemory_eq
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
             suffix.length + 1)
           callvalueGuardBody calldataGuardBody bodyNative nativeContract
@@ -22876,11 +26135,11 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ex
       have hFuelEq :
           suffix.length +
               (1 + (12 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 24)))) =
-            suffix.length +
-              (1 + (7 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 19)))) := by
-        have hBound24 := hFuelBound24
+                (cases'.length + 25)))) =
+suffix.length +
+(1 + (7 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 20)))) := by
+        have hBound25 := hFuelBound25
         omega
       simpa [nativeGeneratedSelectorHitUserBodyFuel, hNonPayable,
         Nat.add_assoc, Nat.add_comm, Nat.add_left_comm, hFuelEq] using
@@ -22953,6 +26212,12 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ex
     dsimp [nativeRuntimeDispatcherFuel]
     exact
       sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
+        hcompile hSupported hMapping hLowerCases
+  have hFuelBound25 :
+      cases'.length + 25 ≤ nativeRuntimeDispatcherFuel irContract := by
+    dsimp [nativeRuntimeDispatcherFuel]
+    exact
+      sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus25
         hcompile hSupported hMapping hLowerCases
   have hProjectRestored
       (final : EvmYul.Yul.State) (nativeYul : YulResult)
@@ -23048,10 +26313,10 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ex
         ∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -23064,7 +26329,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ex
       intro pre suffix hCases
       rw [hBodyShape]
       have hPrefix :=
-        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_eq
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_postInitFreeMemory_eq
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
             suffix.length + 1)
           guardBody bodyNative nativeContract (YulTransaction.ofIR tx)
@@ -23085,10 +26350,10 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ex
       have hFuelEq :
           suffix.length +
               (1 + (11 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 23)))) =
-            suffix.length +
-              (1 + (7 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 19)))) := by
+                (cases'.length + 24)))) =
+suffix.length +
+(1 + (7 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 20)))) := by
         have hBound23 : cases'.length + 23 ≤
             nativeRuntimeDispatcherFuel irContract := by
           omega
@@ -23117,10 +26382,10 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ex
         ∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               state.storage
@@ -23133,7 +26398,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ex
       intro pre suffix hCases
       rw [hBodyShape]
       have hPrefix :=
-        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_eq
+        Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_postInitFreeMemory_eq
           (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
             suffix.length + 1)
           callvalueGuardBody calldataGuardBody bodyNative nativeContract
@@ -23156,11 +26421,11 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_ex
       have hFuelEq :
           suffix.length +
               (1 + (12 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 24)))) =
-            suffix.length +
-              (1 + (7 + (nativeRuntimeDispatcherFuel irContract -
-                (cases'.length + 19)))) := by
-        have hBound24 := hFuelBound24
+                (cases'.length + 25)))) =
+suffix.length +
+(1 + (7 + (nativeRuntimeDispatcherFuel irContract -
+                (cases'.length + 20)))) := by
+        have hBound25 := hFuelBound25
         omega
       simpa [nativeGeneratedSelectorHitUserBodyFuel, hNonPayable,
         Nat.add_assoc, Nat.add_comm, Nat.add_left_comm, hFuelEq] using
@@ -23233,12 +26498,12 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_re
         observableSlots) :
     NativeGeneratedSelectorHitSuccessBridge irContract tx state
       observableSlots := by
-  rcases hUserBodyResult with hUserBodyHalt |
+  rcases hUserBodyResult with hSelectedUserBodyHalt |
       ⟨hUserBodyExec, hUserBodyPreserves⟩
   · exact
       NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_halt_exec_atFuel
         spec selectors hSupported irContract tx state observableSlots hcompile
-        hSelectorRange hSelectorsRange hNoWrap hUserBodyHalt
+        hSelectorRange hSelectorsRange hNoWrap hSelectedUserBodyHalt
   · exact
       NativeGeneratedSelectorHitSuccessBridge.of_selected_user_body_exec_only_and_preserves
         spec selectors hSupported irContract tx state observableSlots hcompile
@@ -23449,7 +26714,7 @@ private theorem NativeGeneratedSelectorHitSuccessBridge.of_leave_body_with_label
 /-- F4 (label-prefix variant of E4): Selected user bodies of shape
 `[.block [], .block [.leave]]` supply the named selector-hit success bridge.
 
-DIRECT (no `hExecBridge` hypothesis): composes the F4 LeaveAware ExecBridge
+DIRECT (no `hSelectedExecBridge` hypothesis): composes the F4 LeaveAware ExecBridge
 (`of_block_leave_with_label_prefix`) with the
 `revivedLeaveAware_and_continuation` consumer. -/
 private theorem NativeGeneratedSelectorHitSuccessBridge.of_block_leave_with_label_prefix
@@ -23651,7 +26916,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
         4 + fn.params.length * 32 < EvmYul.UInt256.size)
-    (hCont :
+    (hDispatcherContinuation :
       ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
         (reservedNames : List String) (n0 : Nat)
         (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -23678,7 +26943,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
                 suffix.length + 10)
               (.Block bodyNative)
               (some nativeContract)
-              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
                 nativeContract
                 (YulTransaction.ofIR tx)
                 state.storage
@@ -23730,13 +26995,13 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
       hSelectorRange hSelectorsRange hNoWrap hThreshold
       (NativeGeneratedSelectorHitSuccessBridge.of_user_body_exec_bridge_atFuel_revived_and_continuation
         spec selectors hSupported irContract tx state observableSlots hcompile
-        hSelectorRange hSelectorsRange hNoWrap hUserBodyBridge hCont)
+        hSelectorRange hSelectorsRange hNoWrap hUserBodyBridge hDispatcherContinuation)
 
 /-- Generated `callDispatcher` result theorem from `SupportedSpec + compile`,
 modulo the exact-fuel lowered-user-body proof stated against
 `execIRFunction`, with generated guard failures already discharged.
 
-This version consumes the selected user-body execution bridge directly; the
+This version consumes the selected user-body ExecBridge directly; the
 generated dispatcher continuation is provided by
 `nativeGeneratedCallDispatcherResult_selector_hit_ok_matchesIR_forall_of_compile_ok_supported`.
 -/
@@ -24537,7 +27802,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
     (hBodyBridge :
       NativeGeneratedSelectorHitBodyBridge irContract tx state
         observableSlots)
-    (hCont :
+    (hDispatcherContinuation :
       ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
         (reservedNames : List String) (n0 : Nat)
         (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -24566,7 +27831,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
       spec selectors hSupported irContract tx state observableSlots hcompile
       hSelectorRange hSelectorsRange hNoWrap
       (NativeGeneratedSelectorHitArtifactBridge.of_body_bridge_and_continuation
-        irContract tx state observableSlots hBodyBridge hCont)
+        irContract tx state observableSlots hBodyBridge hDispatcherContinuation)
 
 /-- Generated `callDispatcher` result theorem from `SupportedSpec + compile`,
 modulo the direct lowered-user-body proof and generated-prefix continuation.
@@ -24590,7 +27855,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
     (hUserBodyBridge :
       NativeGeneratedSelectorHitUserBodyBridge irContract tx state
         observableSlots)
-    (hCont :
+    (hDispatcherContinuation :
       ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
         (reservedNames : List String) (n0 : Nat)
         (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -24614,10 +27879,10 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
             cases' = pre ++ (tx.functionSelector, body') :: suffix →
             EvmYul.Yul.exec
               (((nativeRuntimeDispatcherFuel irContract -
-                    (cases'.length + 19)) + 1) + suffix.length + 10)
+                    (cases'.length + 20)) + 1) + suffix.length + 10)
               (.Block bodyNative)
               (some nativeContract)
-              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
                 nativeContract
                 (YulTransaction.ofIR tx)
                 state.storage
@@ -24657,7 +27922,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
       spec selectors hSupported irContract tx state observableSlots hcompile
       hSelectorRange hSelectorsRange hNoWrap
       (NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_and_continuation
-        irContract tx state observableSlots hUserBodyBridge hCont)
+        irContract tx state observableSlots hUserBodyBridge hDispatcherContinuation)
 
 /-- Generated `callDispatcher` result theorem from `SupportedSpec + compile`,
 modulo the exact-fuel lowered-user-body proof and generated-prefix
@@ -24684,7 +27949,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
     (hUserBodyBridge :
       NativeGeneratedSelectorHitUserBodyBridgeAtFuel irContract tx state
         observableSlots)
-    (hCont :
+    (hDispatcherContinuation :
       ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
         (reservedNames : List String) (n0 : Nat)
         (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -24711,7 +27976,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
                 suffix.length + 10)
               (.Block bodyNative)
               (some nativeContract)
-              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
                 nativeContract
                 (YulTransaction.ofIR tx)
                 state.storage
@@ -24751,7 +28016,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
       spec selectors hSupported irContract tx state observableSlots hcompile
       hSelectorRange hSelectorsRange hNoWrap
       (NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_atFuel_and_continuation
-        irContract tx state observableSlots hUserBodyBridge hCont)
+        irContract tx state observableSlots hUserBodyBridge hDispatcherContinuation)
 
 /-- Generated `callDispatcher` result theorem from `SupportedSpec + compile`,
 modulo the exact-fuel lowered-user-body proof at the restored dispatcher
@@ -24777,7 +28042,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
     (hUserBodyBridge :
       NativeGeneratedSelectorHitUserBodyBridgeAtFuelRestored irContract tx state
         observableSlots)
-    (hCont :
+    (hDispatcherContinuation :
       ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
         (reservedNames : List String) (n0 : Nat)
         (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -24804,7 +28069,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
                 suffix.length + 10)
               (.Block bodyNative)
               (some nativeContract)
-              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
                 nativeContract
                 (YulTransaction.ofIR tx)
                 state.storage
@@ -24855,7 +28120,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
       spec selectors hSupported irContract tx state observableSlots hcompile
       hSelectorRange hSelectorsRange hNoWrap
       (NativeGeneratedSelectorHitArtifactBridge.of_user_body_bridge_atFuel_restored_and_continuation
-        irContract tx state observableSlots hUserBodyBridge hCont)
+        irContract tx state observableSlots hUserBodyBridge hDispatcherContinuation)
 
 /-- Generated `callDispatcher` result theorem from `SupportedSpec + compile`,
 modulo the exact-fuel lowered-user-body proof at the revived body boundary.
@@ -24879,7 +28144,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
     (hUserBodyBridge :
       NativeGeneratedSelectorHitUserBodyBridgeAtFuelRevived irContract tx state
         observableSlots)
-    (hCont :
+    (hDispatcherContinuation :
       ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
         (reservedNames : List String) (n0 : Nat)
         (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -24906,7 +28171,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
                 suffix.length + 10)
               (.Block bodyNative)
               (some nativeContract)
-              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
                 nativeContract
                 (YulTransaction.ofIR tx)
                 state.storage
@@ -24958,7 +28223,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
       hSelectorRange hSelectorsRange hNoWrap
       (NativeGeneratedSelectorHitUserBodyBridgeAtFuelRestored.of_revived
         irContract tx state observableSlots hUserBodyBridge)
-      hCont
+      hDispatcherContinuation
 
 /-- Generated `callDispatcher` result theorem from `SupportedSpec + compile`,
 modulo the exact-fuel lowered-user-body proof stated against
@@ -24994,7 +28259,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
         fn.params.length ≤ tx.args.length)
-    (hCont :
+    (hDispatcherContinuation :
       ∀ (nativeContract : EvmYul.Yul.Ast.YulContract) (fn : IRFunction)
         (reservedNames : List String) (n0 : Nat)
         (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -25021,7 +28286,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
                 suffix.length + 10)
               (.Block bodyNative)
               (some nativeContract)
-              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+              (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
                 nativeContract
                 (YulTransaction.ofIR tx)
                 state.storage
@@ -25073,7 +28338,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_w
       hSelectorRange hSelectorsRange hNoWrap
       (NativeGeneratedSelectorHitUserBodyBridgeAtFuelRestored.of_execIRFunction
         irContract tx state observableSlots hUserBodyBridge hguards hArgs)
-      hCont
+      hDispatcherContinuation
 
 attribute [deprecated nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported
   (since := "2026-05-07")]
@@ -25131,7 +28396,10 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     (hSelectorsRange :
       ∀ selector, selector ∈ selectors →
         selector < Compiler.Constants.selectorModulus)
-    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+      (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+        .ok ()) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -25144,10 +28412,10 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -25178,6 +28446,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     hLowerRuntime hFind hSelectorRange hNoWrap
     (generatedRuntimeFunctionSelectorsRange_of_compile_ok_supported
       hcompile hSupported hSelectorsRange)
+    hEnv
 
 /-- Selector-hit error lowered-runtime wrapper with both the selected
 transaction selector range and generated function selector ranges derived from
@@ -25203,7 +28472,10 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     (hSelectorsRange :
       ∀ selector, selector ∈ selectors →
         selector < Compiler.Constants.selectorModulus)
-    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+      (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+        .ok ()) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -25216,10 +28488,10 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -25250,7 +28522,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     hLowerRuntime hFind
     (selectedGeneratedFunctionSelectorRange_of_compile_ok_supported
       hcompile hSupported hSelectorsRange hFind)
-    hSelectorsRange hNoWrap
+    hSelectorsRange hNoWrap hEnv
 
 /-- Selector-hit error lowered-runtime wrapper deriving calldata no-wrap from
 the transaction calldata-size fit premise. -/
@@ -25274,7 +28546,10 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
         some fn)
     (hSelectorsRange :
       ∀ selector, selector ∈ selectors →
-        selector < Compiler.Constants.selectorModulus) :
+        selector < Compiler.Constants.selectorModulus)
+    (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+      (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+        .ok ()) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -25287,10 +28562,10 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -25320,6 +28595,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     nativeContract fn err nativeYul htxNormalized hcalldataSizeFits hcompile
     hLowerRuntime hFind hSelectorsRange
     (txNoWrap_of_calldataSizeFits hcalldataSizeFits)
+    hEnv
 
 /-- Block-preservation variant of
 `compile_preserves_native_evmYulLean_selector_hit_ok_mapping_canonical`. -/
@@ -25340,8 +28616,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -25365,11 +28642,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -25389,7 +28666,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
                   (Compiler.emitYul irContract).runtimeCode)
                 switchStart))
             (EvmYul.UInt256.ofNat 1) body'
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -25397,13 +28674,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -25430,24 +28707,47 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
   have hLowerRuntime :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
           (Compiler.emitYul irContract).runtimeCode =
-        .ok (nativeContractOfDispatcherWithMapping [.Block inner]) := by
+        .ok (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
     rw [lowerRuntimeContractNative_of_compile_ok_supported_mapping_reserved
       hcompile hSupported hMapping]
     rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_withSwitchIds_atFuel
-      (nativeRuntimeDispatcherFuel irContract) reservedNames 0 irContract tx
-      initialState observableSlots inner nextSwitchId functions fn final nativeYul
-      hLowerDispatcher hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
-    ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
+    lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
+      reservedNames 0 irContract.functions
+      [nativeInitFreeMemoryPointerStmt, .Block inner] nextSwitchId
+      (by simpa [reservedNames] using hLowerDispatcher) with
+    ⟨inner', hDispatcher, hLowerBlock⟩
+  have hInnerEq : inner = inner' := by
+    simpa [nativeInitFreeMemoryPointerStmt] using hDispatcher
+  subst inner'
+  obtain ⟨body1, switchStart, cases', midN, body', bodyStart, bodyEnd,
+      hInner, hLowerCases, hCase, hBodyLower⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_find?_some_of_find_function_withSwitchIds
+      reservedNames 0 irContract.functions inner nextSwitchId
+      tx.functionSelector fn (by simpa [reservedNames] using hLowerBlock)
+      hFind
   have hFuel :
-      cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
+      cases'.length + 20 ≤ nativeRuntimeDispatcherFuel irContract := by
     dsimp [nativeRuntimeDispatcherFuel]
-    exact
-      sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
-        hcompile hSupported hMapping
-        (by simpa [reservedNames] using hLowerCases)
+    have hBig :=
+      sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24
+        hcompile hSupported hMapping hLowerCases
+    omega
+  have hSelector :
+      tx.functionSelector =
+        (YulTransaction.ofIR tx).functionSelector %
+          Compiler.Constants.selectorModulus := by
+    simpa [YulTransaction.ofIR] using
+      (Nat.mod_eq_of_lt hSelectorRange).symm
+  have hSelectorRangeNative : tx.functionSelector < EvmYul.UInt256.size := by
+    exact Nat.lt_trans hSelectorRange (by decide)
+  have hTagsRange :
+      ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size :=
+    lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange
+      reservedNames
+      (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+        reservedNames switchStart + 1)
+      midN irContract.functions cases' hLowerCases hFunctionSelectorsRange
   refine ⟨switchStart, cases', body', bodyStart, bodyEnd,
     hCase, ?_, ?_⟩
   · simpa [reservedNames] using hBodyLower
@@ -25455,14 +28755,91 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
     have hNativeDispatcherExec' :
         nativeDispatcherExecMatchesIRPositive (nativeRuntimeDispatcherFuel irContract)
           irContract tx initialState observableSlots
-          (nativeContractOfDispatcherWithMapping [.Block inner]) := by
-      refine hNativeDispatcherExec hFuel ?_ ?_ ?_ hMatch
-      · simpa [initialState, reservedNames, nativeContractOfDispatcherWithMapping,
-          functions] using hBody
-      · simpa [reservedNames, nativeContractOfDispatcherWithMapping, functions]
-          using hPreservesMatched
-      · simpa [initialState, nativeContractOfDispatcherWithMapping, functions]
-          using hProject
+          (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
+      let fuel0 := nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)
+      let contract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]
+      let materializedSlots :=
+        Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+          (Compiler.runtimeCode irContract) observableSlots
+      have hFuelShape :
+          nativeRuntimeDispatcherFuel irContract = fuel0 + cases'.length + 20 := by
+        dsimp [fuel0]
+        exact (Nat.sub_add_cancel hFuel).symm
+      have hExec :
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+              (nativeRuntimeDispatcherFuel irContract) contract
+              (Compiler.Proofs.YulGeneration.Backends.Native.initialState contract
+                (YulTransaction.ofIR tx) initialState.storage materializedSlots) =
+            .ok final := by
+        rw [hFuelShape]
+        have hPeel :=
+          Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+            fuel0 reservedNames switchStart cases' body1 inner functions
+            (YulTransaction.ofIR tx) initialState.storage materializedSlots
+            hInner (by simpa [YulTransaction.ofIR_args] using hNoWrap)
+        have hFinalMatched :
+            ∀ matchedName : EvmYul.Identifier,
+              matchedName =
+                  Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                    (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                      reservedNames switchStart) →
+                final[matchedName]! = EvmYul.UInt256.ofNat 1 := by
+          intro matchedName hMatchedName
+          subst matchedName
+          rcases
+            Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitch_find_hit_split
+              tx.functionSelector cases' tx.functionSelector body' hCase with
+            ⟨pre, suffix, hCases, _hTag, _hPrefix⟩
+          exact hPreservesMatched pre suffix hCases
+            ((fuel0 + 1) + suffix.length + 7)
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              contract (YulTransaction.ofIR tx) initialState.storage
+              materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore)
+            final
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+              contract (YulTransaction.ofIR tx) initialState.storage
+              materializedSlots
+              (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                reservedNames switchStart)
+              Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
+              (Compiler.Proofs.YulGeneration.Backends.nativeSwitchMatchedTempName
+                (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+                  reservedNames switchStart)) rfl)
+            (by
+              simpa [initialState, reservedNames, contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcherWithMapping, functions,
+                fuel0] using hBody pre suffix hCases)
+        have hSwitch :=
+          Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+            fuel0 tx.functionSelector
+            (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
+              reservedNames switchStart)
+            tx.functionSelector cases'
+            [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
+            body' contract (YulTransaction.ofIR tx) initialState.storage
+            initialState.events materializedSlots final
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+              (YulTransaction.ofIR tx) initialState.storage initialState.events
+              (.ok (final, [])))
+            hSelector hCase hSelectorRangeNative hTagsRange
+            (by
+              intro pre suffix hCases
+              simpa [initialState, reservedNames, contract, materializedSlots,
+                nativeContractOfInitPrefixedDispatcherWithMapping, functions,
+                fuel0] using hBody pre suffix hCases)
+            hFinalMatched rfl
+        simpa [contract, nativeContractOfInitPrefixedDispatcherWithMapping,
+          nativeInitFreeMemoryPointerStmt, functions,
+          Compiler.Proofs.YulGeneration.selectorExpr] using hPeel.trans hSwitch.1
+      refine nativeDispatcherExecMatchesIRPositive_of_project_eq_match
+        (contract := irContract) (tx := tx) (state := initialState)
+        (observableSlots := observableSlots)
+        (nativeContract := contract) ?_ hMatch
+      simpa [nativeProjectedDispatcherResultEq, hExec, materializedSlots,
+        contract, initialState, functions] using hProject
     exact
       sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeIRRuntimeMatchesIR
         (hSourceIR :=
@@ -25475,10 +28852,10 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
             (spec := model) (selectors := selectors) (irContract := irContract)
             (tx := tx) (state := initialState)
             (observableSlots := observableSlots)
-            (nativeContract := nativeContractOfDispatcherWithMapping [.Block inner])
+            (nativeContract := nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
             hcompile hSupported hLowerRuntime hEnv
             (by
-              simpa [nativeContractOfDispatcherWithMapping, functions]
+              simpa [nativeContractOfInitPrefixedDispatcherWithMapping, functions]
                 using hNativeDispatcherExec'))
 
 /-- Direct `callDispatcher` mapping selector-hit success theorem at canonical
@@ -25501,15 +28878,20 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
     (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hFunctionSelectorsRange :
-      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size) :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
+    (hEnv :
+      Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+        (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+          .ok ()) :
     ∃ (switchStart : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -25523,11 +28905,11 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -25547,7 +28929,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
                   (Compiler.emitYul irContract).runtimeCode)
                 switchStart))
             (EvmYul.UInt256.ofNat 1) body'
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -25555,13 +28937,13 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -25576,56 +28958,32 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
           (nativeGeneratedCallDispatcherResultOf irContract tx
             (FunctionBody.initialIRStateForTx model tx initialWorld)
             observableSlots
-            (nativeContractOfDispatcherWithMapping [.Block inner]))) := by
+            (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
-  let reservedNames :=
-    Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
-      (Compiler.emitYul irContract).runtimeCode
-  let functions :=
-    ((∅ : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap).insert
-      "mappingSlot"
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeMappingSlotFunctionDefinition)
+  have hLowerRuntime :
+      Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
+          (Compiler.emitYul irContract).runtimeCode =
+        .ok (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]) := by
+    rw [lowerRuntimeContractNative_of_compile_ok_supported_mapping_reserved
+      hcompile hSupported hMapping]
+    rw [hLowerDispatcher]
   rcases
-    nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_ok_noFallback_noReceive_withSwitchIds_atFuel
-      (nativeRuntimeDispatcherFuel irContract) reservedNames 0 irContract tx
-      initialState observableSlots inner nextSwitchId functions fn final nativeYul
-      hLowerDispatcher hFind hSelectorRange hNoWrap hFunctionSelectorsRange with
-    ⟨switchStart, cases', midN, body', bodyStart, bodyEnd,
-      hLowerCases, hCase, hBodyLower, hNativeDispatcherExec⟩
-  have hFuel :
-      cases'.length + 19 ≤ nativeRuntimeDispatcherFuel irContract := by
-    dsimp [nativeRuntimeDispatcherFuel]
-    exact
-      sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length
-        hcompile hSupported hMapping
-        (by simpa [reservedNames] using hLowerCases)
+    compile_preserves_native_evmYulLean_selector_hit_ok_mapping_canonical_preserved
+      model selectors hSupported irContract tx initialWorld observableSlots inner
+      nextSwitchId fn final nativeYul htxNormalized hcalldataSizeFits hcompile
+      hMapping hLowerDispatcher hFind hSelectorRange hNoWrap
+      hFunctionSelectorsRange hEnv with
+    ⟨switchStart, cases', body', bodyStart, bodyEnd, hCase, hBodyLower,
+      hDispatcherContinuation⟩
   refine ⟨switchStart, cases', body', bodyStart, bodyEnd,
-    hCase, ?_, ?_⟩
-  · simpa [reservedNames] using hBodyLower
-  · intro hBody hPreservesMatched hProject hMatch
-    have hGeneratedMatch :
-        nativeGeneratedCallDispatcherMatchesIROn irContract tx initialState
-          observableSlots
-          (nativeContractOfDispatcherWithMapping [.Block inner]) := by
-      apply nativeGeneratedCallDispatcherMatchesIROn_of_dispatcherExec
-      simpa [nativeGeneratedDispatcherExecMatchesIROn,
-        nativeDispatcherExecMatchesIRPositive, nativeRuntimeDispatcherFuel,
-        nativeContractOfDispatcherWithMapping, functions] using
-          hNativeDispatcherExec hFuel
-            (by simpa [initialState, reservedNames,
-                nativeContractOfDispatcherWithMapping, functions] using hBody)
-            (by simpa [reservedNames, nativeContractOfDispatcherWithMapping,
-                functions] using hPreservesMatched)
-            (by simpa [initialState, nativeContractOfDispatcherWithMapping,
-                functions] using hProject)
-            hMatch
-    exact
-      sourceResultMatchesNativeOn_of_sourceResultMatchesIRResult_of_nativeResultsMatchOn
-        (hSourceIR :=
-          Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
-            model selectors hSupported irContract tx initialWorld
-            htxNormalized hcalldataSizeFits hcompile)
-        (hNativeIR := hGeneratedMatch)
+    hCase, hBodyLower, ?_⟩
+  intro hBody hPreservesMatched hProject hMatch
+  have hSource := hDispatcherContinuation hBody hPreservesMatched hProject hMatch
+  rw [nativeGeneratedCallDispatcherResultOf_eq_interpretIRRuntimeNative_of_lowerRuntimeContractNative_supported
+    tx initialState observableSlots
+    (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
+    hcompile hSupported hLowerRuntime hEnv]
+  simpa [nativeRuntimeFuel, initialState] using hSource
 
 /-- Direct `callDispatcher` selector-hit success theorem from successful
 lowering of the whole emitted runtime, using a block-preservation obligation
@@ -25656,7 +29014,11 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hFunctionSelectorsRange :
-      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size) :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
+    (hEnv :
+      Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+        (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+          .ok ()) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -25669,10 +29031,10 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -25725,7 +29087,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
         hcompile hSupported hMapping hLowerRuntime with
       ⟨dispatcher, nextSwitchId, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
           (Compiler.emitYul irContract).runtimeCode)
         0 irContract.functions dispatcher nextSwitchId hLowerDispatcher with
@@ -25736,37 +29098,37 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       compile_preserves_native_evmYulLean_callDispatcher_selector_hit_ok_mapping_canonical_preserved
         model selectors hSupported irContract tx initialWorld observableSlots
         inner nextSwitchId fn final nativeYul htxNormalized hcalldataSizeFits
-        hcompile hMapping hLowerBlock hFind hSelectorRange hNoWrap
-        hFunctionSelectorsRange with
+        hcompile hMapping (by simpa using hLowerDispatcher) hFind
+        hSelectorRange hNoWrap hFunctionSelectorsRange hEnv with
       ⟨switchStart, cases', body', bodyStart, bodyEnd,
-        hCase, hBodyLower, hCont⟩
+        hCase, hBodyLower, hDispatcherContinuation⟩
     refine ⟨
       Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode,
       switchStart, cases', body', bodyStart, bodyEnd, hCase, hBodyLower, ?_⟩
     intro hBody hPreserves hProject hMatch
-    exact hCont hBody hPreserves hProject hMatch
+    exact hDispatcherContinuation hBody hPreserves hProject hMatch
   · have hNoMapping : irContract.usesMapping = false := by
       exact Bool.eq_false_iff.2 hUsesMapping
     rcases lowerRuntimeContractNative_of_compile_ok_supported_noMapping_ok_dispatcher
         hcompile hSupported hNoMapping hLowerRuntime with
       ⟨dispatcher, hLowerDispatcher, hNativeContract⟩
     rcases
-      lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block
+      lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block
         irContract.functions dispatcher hLowerDispatcher with
-      ⟨inner, hDispatcher, hLowerBlock⟩
+      ⟨inner, nextSwitchId, hDispatcher, hLowerBlock⟩
     subst nativeContract
     subst dispatcher
     rcases
       compile_preserves_native_evmYulLean_callDispatcher_selector_hit_ok_noMapping_canonical_preserved
         model selectors hSupported irContract tx initialWorld observableSlots
         inner fn final nativeYul htxNormalized hcalldataSizeFits hcompile
-        hNoMapping hLowerBlock hFind hSelectorRange hNoWrap
-        hFunctionSelectorsRange with
+        hNoMapping (by simpa using hLowerDispatcher) hFind
+        hSelectorRange hNoWrap hFunctionSelectorsRange hEnv with
       ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-        hCase, hBodyLower, hCont⟩
+        hCase, hBodyLower, hDispatcherContinuation⟩
     exact ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hCont⟩
+      hCase, hBodyLower, hDispatcherContinuation⟩
 
 /-- Direct `callDispatcher` selector-hit success theorem from successful
 lowering of the whole emitted runtime, deriving selected-body block preservation
@@ -25792,7 +29154,11 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hFunctionSelectorsRange :
-      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size) :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
+    (hEnv :
+      Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+        (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+          .ok ()) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -25809,10 +29175,10 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -25866,14 +29232,14 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       model selectors hSupported irContract tx initialWorld observableSlots
       nativeContract fn final nativeYul htxNormalized hcalldataSizeFits
       hcompile hLowerRuntime hFind hSelectorRange hNoWrap
-      hFunctionSelectorsRange with
+      hFunctionSelectorsRange hEnv with
     ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hCont⟩
+      hCase, hBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
     hCase, hBodyLower, ?_⟩
   intro hFresh hBody hStmtPreserves hProject hMatch
   exact
-    hCont hBody
+    hDispatcherContinuation hBody
       (by
         intro pre suffix hcases
         exact
@@ -25912,7 +29278,11 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     (hSelectorsRange :
       ∀ selector, selector ∈ selectors →
         selector < Compiler.Constants.selectorModulus)
-    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hEnv :
+      Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+        (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+          .ok ()) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -25929,10 +29299,10 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -25987,6 +29357,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     hLowerRuntime hFind hSelectorRange hNoWrap
     (generatedRuntimeFunctionSelectorsRange_of_compile_ok_supported
       hcompile hSupported hSelectorsRange)
+    hEnv
 
 /-- Selector-hit success lowered-runtime wrapper with both selector range facts
 derived from the source selector list. The selected-body execution,
@@ -26012,7 +29383,11 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     (hSelectorsRange :
       ∀ selector, selector ∈ selectors →
         selector < Compiler.Constants.selectorModulus)
-    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hEnv :
+      Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+        (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+          .ok ()) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -26029,10 +29404,10 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -26087,7 +29462,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     hLowerRuntime hFind
     (selectedGeneratedFunctionSelectorRange_of_compile_ok_supported
       hcompile hSupported hSelectorsRange hFind)
-    hSelectorsRange hNoWrap
+    hSelectorsRange hNoWrap hEnv
 
 /-- Selector-hit success lowered-runtime wrapper deriving calldata no-wrap from
 the transaction calldata-size fit premise. The selected-body execution,
@@ -26112,7 +29487,11 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
         some fn)
     (hSelectorsRange :
       ∀ selector, selector ∈ selectors →
-        selector < Compiler.Constants.selectorModulus) :
+        selector < Compiler.Constants.selectorModulus)
+    (hEnv :
+      Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+        (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+          .ok ()) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -26129,10 +29508,10 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
             (some nativeContract)
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
               nativeContract
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -26185,7 +29564,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
     model selectors hSupported irContract tx initialWorld observableSlots
     nativeContract fn final nativeYul htxNormalized hcalldataSizeFits hcompile
     hLowerRuntime hFind hSelectorsRange
-    (txNoWrap_of_calldataSizeFits hcalldataSizeFits)
+    (txNoWrap_of_calldataSizeFits hcalldataSizeFits) hEnv
 
 /-- Direct `callDispatcher` mapping selector-hit success theorem at canonical
 generated-runtime fuel, deriving selected-body block preservation from native
@@ -26207,15 +29586,20 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
     (hSelectorRange : tx.functionSelector < Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hFunctionSelectorsRange :
-      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size) :
+      ∀ fn, fn ∈ irContract.functions → fn.selector < EvmYul.UInt256.size)
+    (hEnv :
+      Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+        (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) =
+          .ok ()) :
     ∃ (switchStart : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (body' : List EvmYul.Yul.Ast.Stmt) (bodyStart bodyEnd : Nat),
@@ -26235,11 +29619,11 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -26264,7 +29648,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
                   (Compiler.emitYul irContract).runtimeCode)
                 switchStart))
             (EvmYul.UInt256.ofNat 1) stmt
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -26272,13 +29656,13 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -26293,7 +29677,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
           (nativeGeneratedCallDispatcherResultOf irContract tx
             (FunctionBody.initialIRStateForTx model tx initialWorld)
             observableSlots
-            (nativeContractOfDispatcherWithMapping [.Block inner]))) := by
+            (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))) := by
   let reservedNames :=
     Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
       (Compiler.emitYul irContract).runtimeCode
@@ -26302,7 +29686,7 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
       model selectors hSupported irContract tx initialWorld observableSlots inner
       nextSwitchId fn final nativeYul htxNormalized hcalldataSizeFits hcompile
       hMapping hLowerDispatcher hFind hSelectorRange hNoWrap
-      hFunctionSelectorsRange with
+      hFunctionSelectorsRange hEnv with
     ⟨switchStart, cases', body', bodyStart, bodyEnd, hCase, hBodyLower,
       hPreserved⟩
   refine ⟨switchStart, cases', body', bodyStart, bodyEnd, hCase, hBodyLower, ?_⟩
@@ -26315,10 +29699,10 @@ private theorem compile_preserves_native_evmYulLean_callDispatcher_selector_hit_
         tx.functionSelector tx.functionSelector body'
         [Compiler.Proofs.YulGeneration.Backends.Native.nativeRevertZeroZeroStmt]
         cases' (EvmYul.UInt256.ofNat 1)
-        (some (nativeContractOfDispatcherWithMapping [.Block inner]))
+        (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
         (by simpa [reservedNames] using hFresh) hCase
         (by
-          simpa [reservedNames, nativeContractOfDispatcherWithMapping] using
+          simpa [reservedNames, nativeContractOfInitPrefixedDispatcherWithMapping] using
             hStmtPreserves))
     hProject hMatch
 
@@ -26336,8 +29720,9 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_noMapping_cano
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         none)
@@ -26383,8 +29768,9 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_noMapping_cano
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         none)
@@ -26426,8 +29812,9 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_noMapping_cano
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         none)
@@ -26470,8 +29857,9 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_noMapping_cano
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         none)
@@ -26512,8 +29900,9 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_mapping_canoni
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         none)
@@ -26561,8 +29950,9 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_mapping_canoni
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         none)
@@ -26606,8 +29996,9 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_mapping_canoni
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         none)
@@ -26653,8 +30044,9 @@ private theorem compile_preserves_native_evmYulLean_selector_miss_mapping_canoni
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         none)
@@ -26695,8 +30087,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -26726,11 +30119,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -26778,8 +30171,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -26805,11 +30199,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -26857,8 +30251,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -26887,11 +30282,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -26938,8 +30333,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -26964,11 +30360,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_noMapping
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27017,8 +30413,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_c
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -27049,11 +30446,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_c
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27106,8 +30503,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_c
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -27134,11 +30532,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_c
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27191,8 +30589,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_c
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -27222,11 +30621,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_c
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27277,8 +30676,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_c
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -27304,11 +30704,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_error_mapping_c
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27357,8 +30757,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -27391,11 +30792,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27414,7 +30815,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
               (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
                 reservedNames n0))
             (EvmYul.UInt256.ofNat 1) stmt
-            (some (nativeContractOfDispatcher [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -27422,13 +30823,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27468,8 +30869,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -27498,11 +30900,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27521,7 +30923,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
               (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
                 reservedNames n0))
             (EvmYul.UInt256.ofNat 1) stmt
-            (some (nativeContractOfDispatcher [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -27529,13 +30931,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27575,8 +30977,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -27605,11 +31008,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27625,7 +31028,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
               (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
                 reservedNames n0))
             (EvmYul.UInt256.ofNat 1) body'
-            (some (nativeContractOfDispatcher [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -27633,13 +31036,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27679,8 +31082,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
     (hNoMapping : irContract.usesMapping = false)
     (hLowerDispatcher :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok [.Block inner])
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok [nativeInitFreeMemoryPointerStmt, .Block inner])
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -27705,11 +31109,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcher [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcher [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcher [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27725,7 +31129,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
               (Compiler.Proofs.YulGeneration.Backends.freshNativeSwitchId
                 reservedNames n0))
             (EvmYul.UInt256.ofNat 1) body'
-            (some (nativeContractOfDispatcher [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcher [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -27733,13 +31137,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_noMapping_ca
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcher [.Block inner])
+                (nativeContractOfInitPrefixedDispatcher [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27781,8 +31185,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -27818,11 +31223,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27847,7 +31252,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
                   (Compiler.emitYul irContract).runtimeCode)
                 switchStart))
             (EvmYul.UInt256.ofNat 1) stmt
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -27855,13 +31260,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27904,8 +31309,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -27937,11 +31343,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
         (∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -27966,7 +31372,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
                   (Compiler.emitYul irContract).runtimeCode)
                 switchStart))
             (EvmYul.UInt256.ofNat 1) stmt
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -27974,13 +31380,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -28023,8 +31429,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -28054,11 +31461,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -28078,7 +31485,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
                   (Compiler.emitYul irContract).runtimeCode)
                 switchStart))
             (EvmYul.UInt256.ofNat 1) body'
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -28086,13 +31493,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -28135,8 +31542,9 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
-        .ok ([.Block inner], nextSwitchId))
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+        .ok ([nativeInitFreeMemoryPointerStmt, .Block inner], nextSwitchId))
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
         some fn)
@@ -28162,11 +31570,11 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
       ((∀ pre suffix,
           cases' = pre ++ (tx.functionSelector, body') :: suffix →
           EvmYul.Yul.exec
-            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 19)) +
+            (((nativeRuntimeDispatcherFuel irContract - (cases'.length + 20)) +
                 1) + suffix.length + 7) (.Block body')
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))
-            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
-              (nativeContractOfDispatcherWithMapping [.Block inner])
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))
+            (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+              (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
               (YulTransaction.ofIR tx)
               (FunctionBody.initialIRStateForTx model tx initialWorld).storage
               (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -28186,7 +31594,7 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
                   (Compiler.emitYul irContract).runtimeCode)
                 switchStart))
             (EvmYul.UInt256.ofNat 1) body'
-            (some (nativeContractOfDispatcherWithMapping [.Block inner]))) →
+            (some (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner]))) →
         Compiler.Proofs.YulGeneration.Backends.Native.projectResult
           (YulTransaction.ofIR tx)
           (FunctionBody.initialIRStateForTx model tx initialWorld).storage
@@ -28194,13 +31602,13 @@ private theorem compile_preserves_native_evmYulLean_selector_hit_ok_mapping_cano
           (.ok
             (((final.reviveJump.overwrite?
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
                   (Compiler.runtimeCode irContract) observableSlots))).setStore
               (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-                (nativeContractOfDispatcherWithMapping [.Block inner])
+                (nativeContractOfInitPrefixedDispatcherWithMapping [.Block inner])
                 (YulTransaction.ofIR tx)
                 (FunctionBody.initialIRStateForTx model tx initialWorld).storage
                 (Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -28497,7 +31905,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_dispatcherSt
       Compiler.Proofs.YulGeneration.Backends.BridgedSafeStmts
         spec.fields spec.errors .calldata [] false entry.1.body)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -28535,7 +31943,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_dispatcherSt
       Compiler.Proofs.YulGeneration.Backends.BridgedSafeStmts
         spec.fields spec.errors .calldata [] false entry.1.body)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -28680,7 +32088,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_dispatcherSt
       Compiler.Proofs.YulGeneration.Backends.BridgedSafeStmts
         spec.fields spec.errors .calldata [] false entry.1.body)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -28722,7 +32130,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_dispatcherSt
       Compiler.Proofs.YulGeneration.Backends.BridgedSafeStmts
         spec.fields spec.errors .calldata [] false entry.1.body)
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-      [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher)
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -28758,7 +32166,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_dispatcherSt
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -28796,7 +32204,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_dispatcherSt
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -28830,7 +32238,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_dispatcherSt
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId :
       Compiler.Proofs.YulGeneration.Backends.Native.nativeChainIdRepresentable
@@ -28870,7 +32278,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_dispatcherSt
     (hLowerDispatcher : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
       (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
         (Compiler.emitYul irContract).runtimeCode)
-      0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+      0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId))
     (hChainId : tx.chainId = EvmYul.chainId)
     (hBlobBaseFee : tx.blobBaseFee = EvmYul.MIN_BASE_FEE_PER_BLOB_GAS)
@@ -28910,7 +32318,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
     (hNativeDispatcherExec : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher)) :
@@ -28944,7 +32352,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
     (hProject : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher) nativeYul)
@@ -28982,7 +32390,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)) :
@@ -29018,7 +32426,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)
@@ -29047,7 +32455,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
     (hNativeDispatcherExec : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher)) :
@@ -29072,7 +32480,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       (Compiler.emitYul irContract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
     (hProject : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher) nativeYul)
@@ -29101,7 +32509,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)) :
@@ -29128,7 +32536,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)
@@ -29164,7 +32572,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
         false)
     (hNativeDispatcherExec : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher)) :
@@ -29196,7 +32604,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
         false)
     (hNativeDispatcherExec : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher)) :
@@ -29233,7 +32641,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
         false)
     (hProject : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher) nativeYul)
@@ -29269,7 +32677,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
         false)
     (hProject : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher) nativeYul)
@@ -29310,7 +32718,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)) :
@@ -29344,7 +32752,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)) :
@@ -29383,7 +32791,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)
@@ -29422,7 +32830,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)
@@ -29470,7 +32878,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
         false)
     (hNativeDispatcherExec : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher)) :
@@ -29510,7 +32918,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
         false)
     (hNativeDispatcherExec : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher)) :
@@ -29555,7 +32963,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
         false)
     (hProject : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher) nativeYul)
@@ -29599,7 +33007,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
         false)
     (hProject : ∀ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok dispatcher →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcher dispatcher) nativeYul)
@@ -29648,7 +33056,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)) :
@@ -29690,7 +33098,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeDispatcherExecMatchesIRPositive fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)) :
@@ -29735,7 +33143,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)
@@ -29782,7 +33190,7 @@ private theorem layers2_3_ir_matches_native_evmYulLean_of_generated_lowered_runt
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
             (Compiler.emitYul irContract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer, Compiler.CodegenCommon.buildSwitch irContract.functions none none] =
         .ok (dispatcher, nextSwitchId) →
       nativeProjectedDispatcherResultEq fuel' irContract tx initialState
         observableSlots (nativeContractOfDispatcherWithMapping dispatcher)
@@ -29857,11 +33265,34 @@ This pins down the outer runtime layer that the native dispatcher bridge must
 peel before applying the concrete lowered selector-switch lemmas. -/
 private theorem simpleStorage_runtimeCode_eq_single_dispatcher :
     (Compiler.emitYul simpleStorageIRContract).runtimeCode =
-      [Compiler.CodegenCommon.buildSwitch
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch
         simpleStorageIRContract.functions none none] := by
   dsimp [Compiler.emitYul, Compiler.CodegenCommon.emitYul,
     Compiler.runtimeCode, Compiler.CodegenCommon.runtimeCode,
     simpleStorageIRContract]
+
+private abbrev simpleStorageBuildSwitchSourceCases : List (Nat × List Yul.YulStmt) :=
+  simpleStorageIRContract.functions.map (fun fn =>
+    (fn.selector,
+      Compiler.CodegenCommon.dispatchBody fn.payable s!"{fn.name}()"
+        ([Compiler.CodegenCommon.calldatasizeGuard fn.params.length] ++ fn.body)))
+
+private abbrev simpleStorageBuildSwitchBody : List Yul.YulStmt :=
+  [Yul.YulStmt.let_ "__has_selector"
+    (Yul.YulExpr.call "iszero"
+      [Yul.YulExpr.call "lt"
+        [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit 4]]),
+   Yul.YulStmt.if_ (Yul.YulExpr.call "iszero"
+      [Yul.YulExpr.ident "__has_selector"])
+      (Compiler.CodegenCommon.defaultDispatchCase none none),
+   Yul.YulStmt.if_ (Yul.YulExpr.ident "__has_selector")
+      [Yul.YulStmt.switch
+        (Yul.YulExpr.call "shr"
+          [Yul.YulExpr.lit Compiler.Constants.selectorShift,
+           Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 0]])
+        simpleStorageBuildSwitchSourceCases
+        (some (Compiler.CodegenCommon.defaultDispatchCase none none))]]
 
 private theorem lowerRuntimeContractNative_single_stmt_eq_lowerStmtsNative
     (stmt : Yul.YulStmt)
@@ -29877,6 +33308,16 @@ private theorem lowerRuntimeContractNative_single_stmt_eq_lowerStmtsNative
       | .error err => .error err :=
   Compiler.Proofs.YulGeneration.Backends.Native.lowerRuntimeContractNative_single_stmt_eq_lowerStmtsNative
     stmt hNoFunc
+
+private noncomputable def simpleStorageNativeRuntimeDispatcherStmts :
+    List EvmYul.Yul.Ast.Stmt :=
+  match
+    Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+       Compiler.CodegenCommon.buildSwitch
+        simpleStorageIRContract.functions none none] with
+  | .ok stmts => stmts
+  | .error _ => []
 
 private noncomputable def simpleStorageNativeDispatcherStmts :
     List EvmYul.Yul.Ast.Stmt :=
@@ -29894,20 +33335,14 @@ This exposes the concrete lowered dispatcher block without unfolding the
 computed native witness in later selector-case proofs. -/
 private theorem simpleStorageNativeContract_dispatcher_eq_lowered_stmts :
     Compiler.SimpleStorageNativeWitness.nativeContract.dispatcher =
-      .Block simpleStorageNativeDispatcherStmts := by
-  unfold Compiler.SimpleStorageNativeWitness.nativeContract
-  rw [simpleStorage_runtimeCode_eq_single_dispatcher]
-  rw [lowerRuntimeContractNative_single_stmt_eq_lowerStmtsNative]
-  · cases hLower :
-        Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch
-            simpleStorageIRContract.functions none none] with
-    | ok stmts =>
-        simp [simpleStorageNativeDispatcherStmts, hLower]
-    | error err =>
-        simp [simpleStorageNativeDispatcherStmts, hLower]
-  · intro name params rets body h
-    cases h
+      .Block simpleStorageNativeRuntimeDispatcherStmts := by
+  have hOuter := Compiler.SimpleStorageNativeWitness.lowerRuntimeContractNative_eq
+  obtain ⟨dispatcher, hDispatcher, hContract⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.lowerRuntimeContractNative_emitYul_noMapping_ok_dispatcher
+      simpleStorageIRContract Compiler.SimpleStorageNativeWitness.nativeContract
+      (by rfl) (by rfl) (by rfl) (by rfl) hOuter
+  rw [hContract]
+  simp [simpleStorageNativeRuntimeDispatcherStmts, hDispatcher]
 
 /-- A `.block` head in the native lowering surfaces as a singleton `.Block`
 output when the lowering succeeds.
@@ -29936,19 +33371,21 @@ private theorem simpleStorageNativeDispatcherStmts_lowering_ok :
         [Compiler.CodegenCommon.buildSwitch
           simpleStorageIRContract.functions none none] =
       .ok simpleStorageNativeDispatcherStmts := by
-  have hOuter := Compiler.SimpleStorageNativeWitness.lowerRuntimeContractNative_eq
-  rw [simpleStorage_runtimeCode_eq_single_dispatcher] at hOuter
-  rw [lowerRuntimeContractNative_single_stmt_eq_lowerStmtsNative] at hOuter
-  · cases hL : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
-        [Compiler.CodegenCommon.buildSwitch
-          simpleStorageIRContract.functions none none] with
-    | ok stmts =>
-        simp [simpleStorageNativeDispatcherStmts, hL]
-    | error err =>
-        rw [hL] at hOuter
-        simp at hOuter
-  · intro name params rets body h'
-    cases h'
+  have hOk :
+      (match Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
+          [Compiler.CodegenCommon.buildSwitch
+            simpleStorageIRContract.functions none none] with
+      | .ok _ => true
+      | .error _ => false) = true := by
+    native_decide
+  cases hLower : Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative
+      [Compiler.CodegenCommon.buildSwitch
+        simpleStorageIRContract.functions none none] with
+  | ok lowered =>
+      simp [simpleStorageNativeDispatcherStmts, hLower]
+  | error err =>
+      rw [hLower] at hOk
+      cases hOk
 
 /-- The SimpleStorage native dispatcher statement list is a singleton `.Block`.
 
@@ -29956,26 +33393,335 @@ Reason: `buildSwitch` produces a `Yul.YulStmt.block`, which the native lowering
 maps to `[.Block inner]` for the lowered inner statements. Combined with the
 fact that the lowering succeeds (above), this exposes the inner block shape
 without further computation. -/
-private theorem simpleStorageNativeDispatcherStmts_exists_singleton_block :
-    ∃ inner : List EvmYul.Yul.Ast.Stmt,
-      simpleStorageNativeDispatcherStmts = [.Block inner] := by
-  have hOk := simpleStorageNativeDispatcherStmts_lowering_ok
-  -- buildSwitch produces a YulStmt.block by definition.
-  have hBlock :
-      Compiler.CodegenCommon.buildSwitch
-          simpleStorageIRContract.functions none none =
-        Yul.YulStmt.block _ := rfl
-  rw [hBlock] at hOk
-  exact lowerStmtsNative_single_block_ok_singleton _ _ hOk
+private theorem simpleStorageNativeRuntimeDispatcherStmts_exists_init_block :
+    ∃ (inner : List EvmYul.Yul.Ast.Stmt) (next : Nat),
+      simpleStorageNativeRuntimeDispatcherStmts =
+        [.ExprStmtCall
+          (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+            (Yul.YulExpr.call "mstore"
+              [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+               Yul.YulExpr.lit 128])),
+         .Block inner] ∧
+      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+        (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+           Compiler.CodegenCommon.buildSwitch simpleStorageIRContract.functions none none])
+        0
+        simpleStorageBuildSwitchBody =
+        .ok (inner, next) := by
+  have hOuter := Compiler.SimpleStorageNativeWitness.lowerRuntimeContractNative_eq
+  obtain ⟨dispatcher, hDispatcher, _hContract⟩ :=
+    Compiler.Proofs.YulGeneration.Backends.Native.lowerRuntimeContractNative_emitYul_noMapping_ok_dispatcher
+      simpleStorageIRContract Compiler.SimpleStorageNativeWitness.nativeContract
+      (by rfl) (by rfl) (by rfl) (by rfl) hOuter
+  unfold simpleStorageNativeRuntimeDispatcherStmts
+  rw [hDispatcher]
+  unfold Compiler.Proofs.YulGeneration.Backends.lowerStmtsNative at hDispatcher
+  dsimp at hDispatcher
+  cases hLowerList :
+      Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+        (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+           Compiler.CodegenCommon.buildSwitch simpleStorageIRContract.functions none none])
+        0
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+         Compiler.CodegenCommon.buildSwitch simpleStorageIRContract.functions none none] with
+  | error err =>
+      rw [hLowerList] at hDispatcher
+      simp at hDispatcher
+  | ok pair =>
+      rcases pair with ⟨lowered, finalNext⟩
+      rw [hLowerList] at hDispatcher
+      simp at hDispatcher
+      subst dispatcher
+      rw [Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds_cons] at hLowerList
+      simp [Compiler.CodegenCommon.initFreeMemoryPointer, Bind.bind,
+        Compiler.Proofs.YulGeneration.Backends.lowerStmtGroupNativeWithSwitchIds_expr,
+        Except.bind, Pure.pure, Except.pure] at hLowerList
+      rw [Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds_cons] at hLowerList
+      simp [Compiler.CodegenCommon.buildSwitch,
+        Compiler.Proofs.YulGeneration.Backends.lowerStmtGroupNativeWithSwitchIds_block,
+        simpleStorageBuildSwitchBody, simpleStorageBuildSwitchSourceCases,
+        Bind.bind, Except.bind, Pure.pure, Except.pure] at hLowerList
+      cases hInner :
+          Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+            (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+              [Compiler.CodegenCommon.initFreeMemoryPointer,
+               Compiler.CodegenCommon.buildSwitch simpleStorageIRContract.functions none none])
+            0
+            simpleStorageBuildSwitchBody with
+      | error err =>
+          have hInner' :
+              Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+                (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+                  [Yul.YulStmt.expr
+                    (Yul.YulExpr.call "mstore"
+                      [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                       Yul.YulExpr.lit 128]),
+                   Yul.YulStmt.block
+                    [Yul.YulStmt.let_ "__has_selector"
+                      (Yul.YulExpr.call "iszero"
+                        [Yul.YulExpr.call "lt"
+                          [Yul.YulExpr.call "calldatasize" [],
+                           Yul.YulExpr.lit 4]]),
+                     Yul.YulStmt.if_
+                      (Yul.YulExpr.call "iszero"
+                        [Yul.YulExpr.ident "__has_selector"])
+                      (Compiler.CodegenCommon.defaultDispatchCase none none),
+                     Yul.YulStmt.if_ (Yul.YulExpr.ident "__has_selector")
+                      [Yul.YulStmt.switch
+                        (Yul.YulExpr.call "shr"
+                          [Yul.YulExpr.lit Compiler.Constants.selectorShift,
+                           Yul.YulExpr.call "calldataload"
+                            [Yul.YulExpr.lit 0]])
+                        simpleStorageBuildSwitchSourceCases
+                        (some (Compiler.CodegenCommon.defaultDispatchCase
+                          none none))]]])
+                0
+                [Yul.YulStmt.let_ "__has_selector"
+                  (Yul.YulExpr.call "iszero"
+                    [Yul.YulExpr.call "lt"
+                      [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit 4]]),
+                 Yul.YulStmt.if_
+                  (Yul.YulExpr.call "iszero"
+                    [Yul.YulExpr.ident "__has_selector"])
+                  (Compiler.CodegenCommon.defaultDispatchCase none none),
+                 Yul.YulStmt.if_ (Yul.YulExpr.ident "__has_selector")
+                  [Yul.YulStmt.switch
+                    (Yul.YulExpr.call "shr"
+                      [Yul.YulExpr.lit Compiler.Constants.selectorShift,
+                       Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 0]])
+                    simpleStorageBuildSwitchSourceCases
+                    (some (Compiler.CodegenCommon.defaultDispatchCase
+                      none none))]] =
+                .error err := by
+            simpa [Compiler.CodegenCommon.initFreeMemoryPointer,
+              Compiler.CodegenCommon.buildSwitch, simpleStorageBuildSwitchBody,
+              simpleStorageBuildSwitchSourceCases] using hInner
+          have hBad : (Except.error err : Except AdapterError
+              (List EvmYul.Yul.Ast.Stmt × Nat)) = .ok (lowered, finalNext) := by
+            have hInnerMap :
+                Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+                  (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+                    [Yul.YulStmt.expr
+                      (Yul.YulExpr.call "mstore"
+                        [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                         Yul.YulExpr.lit 128]),
+                     Yul.YulStmt.block
+                      [Yul.YulStmt.let_ "__has_selector"
+                        (Yul.YulExpr.call "iszero"
+                          [Yul.YulExpr.call "lt"
+                            [Yul.YulExpr.call "calldatasize" [],
+                             Yul.YulExpr.lit 4]]),
+                       Yul.YulStmt.if_
+                        (Yul.YulExpr.call "iszero"
+                          [Yul.YulExpr.ident "__has_selector"])
+                        (Compiler.CodegenCommon.defaultDispatchCase none none),
+                       Yul.YulStmt.if_ (Yul.YulExpr.ident "__has_selector")
+                        [Yul.YulStmt.switch
+                          (Yul.YulExpr.call "shr"
+                            [Yul.YulExpr.lit Compiler.Constants.selectorShift,
+                             Yul.YulExpr.call "calldataload"
+                              [Yul.YulExpr.lit 0]])
+                          (List.map
+                            (fun fn =>
+                              (fn.selector,
+                                Compiler.CodegenCommon.dispatchBody fn.payable
+                                  (toString "" ++ toString fn.name ++ toString "()")
+                                  (Compiler.CodegenCommon.calldatasizeGuard
+                                    fn.params.length :: fn.body)))
+                            simpleStorageIRContract.functions)
+                          (some (Compiler.CodegenCommon.defaultDispatchCase
+                            none none))]]])
+                  0
+                  [Yul.YulStmt.let_ "__has_selector"
+                    (Yul.YulExpr.call "iszero"
+                      [Yul.YulExpr.call "lt"
+                        [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit 4]]),
+                   Yul.YulStmt.if_
+                    (Yul.YulExpr.call "iszero"
+                      [Yul.YulExpr.ident "__has_selector"])
+                    (Compiler.CodegenCommon.defaultDispatchCase none none),
+                   Yul.YulStmt.if_ (Yul.YulExpr.ident "__has_selector")
+                    [Yul.YulStmt.switch
+                      (Yul.YulExpr.call "shr"
+                        [Yul.YulExpr.lit Compiler.Constants.selectorShift,
+                         Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 0]])
+                      (List.map
+                        (fun fn =>
+                          (fn.selector,
+                            Compiler.CodegenCommon.dispatchBody fn.payable
+                              (toString "" ++ toString fn.name ++ toString "()")
+                              (Compiler.CodegenCommon.calldatasizeGuard
+                                fn.params.length :: fn.body)))
+                        simpleStorageIRContract.functions)
+                      (some (Compiler.CodegenCommon.defaultDispatchCase
+                        none none))]] =
+                  .error err := by
+              simpa [simpleStorageBuildSwitchSourceCases] using hInner'
+            simpa [hInnerMap] using hLowerList
+          cases hBad
+      | ok innerPair =>
+          rcases innerPair with ⟨inner, innerNext⟩
+          have hInner' :
+              Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+                (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+                  [Yul.YulStmt.expr
+                    (Yul.YulExpr.call "mstore"
+                      [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                       Yul.YulExpr.lit 128]),
+                   Yul.YulStmt.block
+                    [Yul.YulStmt.let_ "__has_selector"
+                      (Yul.YulExpr.call "iszero"
+                        [Yul.YulExpr.call "lt"
+                          [Yul.YulExpr.call "calldatasize" [],
+                           Yul.YulExpr.lit 4]]),
+                     Yul.YulStmt.if_
+                      (Yul.YulExpr.call "iszero"
+                        [Yul.YulExpr.ident "__has_selector"])
+                      (Compiler.CodegenCommon.defaultDispatchCase none none),
+                     Yul.YulStmt.if_ (Yul.YulExpr.ident "__has_selector")
+                      [Yul.YulStmt.switch
+                        (Yul.YulExpr.call "shr"
+                          [Yul.YulExpr.lit Compiler.Constants.selectorShift,
+                           Yul.YulExpr.call "calldataload"
+                            [Yul.YulExpr.lit 0]])
+                        simpleStorageBuildSwitchSourceCases
+                        (some (Compiler.CodegenCommon.defaultDispatchCase
+                          none none))]]])
+                0
+                [Yul.YulStmt.let_ "__has_selector"
+                  (Yul.YulExpr.call "iszero"
+                    [Yul.YulExpr.call "lt"
+                      [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit 4]]),
+                 Yul.YulStmt.if_
+                  (Yul.YulExpr.call "iszero"
+                    [Yul.YulExpr.ident "__has_selector"])
+                  (Compiler.CodegenCommon.defaultDispatchCase none none),
+                 Yul.YulStmt.if_ (Yul.YulExpr.ident "__has_selector")
+                  [Yul.YulStmt.switch
+                    (Yul.YulExpr.call "shr"
+                      [Yul.YulExpr.lit Compiler.Constants.selectorShift,
+                       Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 0]])
+                    simpleStorageBuildSwitchSourceCases
+                    (some (Compiler.CodegenCommon.defaultDispatchCase
+                      none none))]] =
+                .ok (inner, innerNext) := by
+            simpa [Compiler.CodegenCommon.initFreeMemoryPointer,
+              Compiler.CodegenCommon.buildSwitch, simpleStorageBuildSwitchBody,
+              simpleStorageBuildSwitchSourceCases] using hInner
+          have hLowerList' :
+              (Except.ok
+                ([EvmYul.Yul.Ast.Stmt.ExprStmtCall
+                    (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+                      (Yul.YulExpr.call "mstore"
+                        [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                         Yul.YulExpr.lit 128])),
+                  EvmYul.Yul.Ast.Stmt.Block inner],
+                 innerNext) :
+                Except AdapterError (List EvmYul.Yul.Ast.Stmt × Nat)) =
+                (Except.ok (lowered, finalNext) :
+                  Except AdapterError (List EvmYul.Yul.Ast.Stmt × Nat)) := by
+            have hInnerMap :
+                Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+                  (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+                    [Yul.YulStmt.expr
+                      (Yul.YulExpr.call "mstore"
+                        [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                         Yul.YulExpr.lit 128]),
+                     Yul.YulStmt.block
+                      [Yul.YulStmt.let_ "__has_selector"
+                        (Yul.YulExpr.call "iszero"
+                          [Yul.YulExpr.call "lt"
+                            [Yul.YulExpr.call "calldatasize" [],
+                             Yul.YulExpr.lit 4]]),
+                       Yul.YulStmt.if_
+                        (Yul.YulExpr.call "iszero"
+                          [Yul.YulExpr.ident "__has_selector"])
+                        (Compiler.CodegenCommon.defaultDispatchCase none none),
+                       Yul.YulStmt.if_ (Yul.YulExpr.ident "__has_selector")
+                        [Yul.YulStmt.switch
+                          (Yul.YulExpr.call "shr"
+                            [Yul.YulExpr.lit Compiler.Constants.selectorShift,
+                             Yul.YulExpr.call "calldataload"
+                              [Yul.YulExpr.lit 0]])
+                          (List.map
+                            (fun fn =>
+                              (fn.selector,
+                                Compiler.CodegenCommon.dispatchBody fn.payable
+                                  (toString "" ++ toString fn.name ++ toString "()")
+                                  (Compiler.CodegenCommon.calldatasizeGuard
+                                    fn.params.length :: fn.body)))
+                            simpleStorageIRContract.functions)
+                          (some (Compiler.CodegenCommon.defaultDispatchCase
+                            none none))]]])
+                  0
+                  [Yul.YulStmt.let_ "__has_selector"
+                    (Yul.YulExpr.call "iszero"
+                      [Yul.YulExpr.call "lt"
+                        [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit 4]]),
+                   Yul.YulStmt.if_
+                    (Yul.YulExpr.call "iszero"
+                      [Yul.YulExpr.ident "__has_selector"])
+                    (Compiler.CodegenCommon.defaultDispatchCase none none),
+                   Yul.YulStmt.if_ (Yul.YulExpr.ident "__has_selector")
+                    [Yul.YulStmt.switch
+                      (Yul.YulExpr.call "shr"
+                        [Yul.YulExpr.lit Compiler.Constants.selectorShift,
+                         Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 0]])
+                      (List.map
+                        (fun fn =>
+                          (fn.selector,
+                            Compiler.CodegenCommon.dispatchBody fn.payable
+                              (toString "" ++ toString fn.name ++ toString "()")
+                              (Compiler.CodegenCommon.calldatasizeGuard
+                                fn.params.length :: fn.body)))
+                        simpleStorageIRContract.functions)
+                      (some (Compiler.CodegenCommon.defaultDispatchCase
+                        none none))]] =
+                  .ok (inner, innerNext) := by
+              simpa [simpleStorageBuildSwitchSourceCases] using hInner'
+            simpa [hInnerMap] using hLowerList
+          simp at hLowerList'
+          rcases hLowerList' with ⟨hLowered, hNext⟩
+          subst lowered
+          subst finalNext
+          exact ⟨inner, innerNext, by simp, by
+            simpa [simpleStorageBuildSwitchBody, simpleStorageBuildSwitchSourceCases]
+              using hInner⟩
 
 private noncomputable def simpleStorageNativeDispatcherInnerStmts :
     List EvmYul.Yul.Ast.Stmt :=
-  Classical.choose simpleStorageNativeDispatcherStmts_exists_singleton_block
+  Classical.choose simpleStorageNativeRuntimeDispatcherStmts_exists_init_block
 
-private theorem simpleStorageNativeDispatcherStmts_eq_singleton_block :
-    simpleStorageNativeDispatcherStmts =
-      [.Block simpleStorageNativeDispatcherInnerStmts] :=
-  Classical.choose_spec simpleStorageNativeDispatcherStmts_exists_singleton_block
+private noncomputable def simpleStorageNativeDispatcherInnerNext : Nat :=
+  Classical.choose
+    (Classical.choose_spec simpleStorageNativeRuntimeDispatcherStmts_exists_init_block)
+
+private theorem simpleStorageNativeRuntimeDispatcherStmts_eq_init_block :
+    simpleStorageNativeRuntimeDispatcherStmts =
+      [.ExprStmtCall
+        (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+          (Yul.YulExpr.call "mstore"
+            [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+             Yul.YulExpr.lit 128])),
+       .Block simpleStorageNativeDispatcherInnerStmts] :=
+  (Classical.choose_spec
+    (Classical.choose_spec
+      simpleStorageNativeRuntimeDispatcherStmts_exists_init_block)).1
+
+private theorem simpleStorageNativeDispatcherInnerStmts_lowering_ok :
+    Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
+      (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+         Compiler.CodegenCommon.buildSwitch simpleStorageIRContract.functions none none])
+      0
+      simpleStorageBuildSwitchBody =
+      .ok (simpleStorageNativeDispatcherInnerStmts,
+        simpleStorageNativeDispatcherInnerNext) :=
+  (Classical.choose_spec
+    (Classical.choose_spec
+      simpleStorageNativeRuntimeDispatcherStmts_exists_init_block)).2
 
 /-- Transitive form of the SimpleStorage native dispatcher shape: combining
 the lowered-stmts and singleton-block equalities exposes the dispatcher value
@@ -29983,9 +33729,16 @@ as `.Block [.Block <inner>]`, which is the exact shape consumed by the harness
 dispatcher-exec peel lemma. -/
 private theorem simpleStorageNativeContract_dispatcher_eq_singleton_block_inner :
     Compiler.SimpleStorageNativeWitness.nativeContract.dispatcher =
-      .Block [.Block simpleStorageNativeDispatcherInnerStmts] := by
-  rw [simpleStorageNativeContract_dispatcher_eq_lowered_stmts,
-    simpleStorageNativeDispatcherStmts_eq_singleton_block]
+      .Block
+        [.ExprStmtCall
+          (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+            (Yul.YulExpr.call "mstore"
+              [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+               Yul.YulExpr.lit 128])),
+         .Block simpleStorageNativeDispatcherInnerStmts] := by
+  rw [simpleStorageNativeContract_dispatcher_eq_lowered_stmts]
+  congr
+  exact simpleStorageNativeRuntimeDispatcherStmts_eq_init_block
 
 /-- Reify the SimpleStorage native witness contract as a record whose
 dispatcher is the doubly-blocked inner statement list.
@@ -29995,7 +33748,13 @@ equalities so that the harness peel lemmas (which expect a
 `{ dispatcher := .Block body, functions := … }` shape) apply in one rewrite. -/
 private theorem simpleStorageNativeContract_eq_record_inner_block :
     Compiler.SimpleStorageNativeWitness.nativeContract =
-      { dispatcher := .Block [.Block simpleStorageNativeDispatcherInnerStmts]
+      { dispatcher := .Block
+          [.ExprStmtCall
+            (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+              (Yul.YulExpr.call "mstore"
+                [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                 Yul.YulExpr.lit 128])),
+           .Block simpleStorageNativeDispatcherInnerStmts]
         functions :=
           Compiler.SimpleStorageNativeWitness.nativeContract.functions } := by
   have hEta : Compiler.SimpleStorageNativeWitness.nativeContract =
@@ -30016,22 +33775,41 @@ private theorem simpleStorageNativeContract_dispatcherExec_eq_innerBlock_exec
     (peeledFuel : Nat)
     (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (Nat.succ (Nat.succ (Nat.succ peeledFuel)))
+        (Nat.succ (Nat.succ (peeledFuel + 6)))
         Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract
           tx storage observableSlots) =
-      EvmYul.Yul.exec (Nat.succ peeledFuel)
+      EvmYul.Yul.exec (peeledFuel + 5)
         (.Block simpleStorageNativeDispatcherInnerStmts)
         (some Compiler.SimpleStorageNativeWitness.nativeContract)
-        (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState
+        (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
           Compiler.SimpleStorageNativeWitness.nativeContract
-          tx storage observableSlots) := by
+          tx storage observableSlots ∅) := by
   rw [simpleStorageNativeContract_eq_record_inner_block]
   rw [Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_block_dispatcher_eq_exec_block
-    (Nat.succ peeledFuel) [.Block simpleStorageNativeDispatcherInnerStmts]
+    (peeledFuel + 6)
+    [.ExprStmtCall
+      (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+        (Yul.YulExpr.call "mstore"
+          [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+           Yul.YulExpr.lit 128])),
+     .Block simpleStorageNativeDispatcherInnerStmts]
     Compiler.SimpleStorageNativeWitness.nativeContract.functions
     tx storage observableSlots]
+  rw [Compiler.Proofs.YulGeneration.Backends.Native.exec_block_cons_initFreeMemoryPointer_eq
+    peeledFuel [.Block simpleStorageNativeDispatcherInnerStmts]
+    { dispatcher := EvmYul.Yul.Ast.Stmt.Block
+        [EvmYul.Yul.Ast.Stmt.ExprStmtCall
+          (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
+            (Yul.YulExpr.call "mstore"
+              [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+               Yul.YulExpr.lit 128])),
+         EvmYul.Yul.Ast.Stmt.Block simpleStorageNativeDispatcherInnerStmts],
+      functions := Compiler.SimpleStorageNativeWitness.nativeContract.functions }
+    tx storage observableSlots]
+  rw [show peeledFuel + 6 =
+      Nat.succ (Nat.succ (peeledFuel + 4)) by omega]
   rw [Compiler.Proofs.YulGeneration.Backends.Native.exec_singleton_block_eq_exec_block]
 
 /-- A successful lowering of a singleton `[.block stmts]` reveals exactly the
@@ -30135,9 +33913,7 @@ private theorem simpleStorageNativeDispatcherInnerStmts_head_let_exists :
     ∃ (e : EvmYul.Yul.Ast.Expr) (rest : List EvmYul.Yul.Ast.Stmt),
       simpleStorageNativeDispatcherInnerStmts =
         EvmYul.Yul.Ast.Stmt.Let ["__has_selector"] (some e) :: rest := by
-  have hOk := simpleStorageNativeDispatcherStmts_lowering_ok
-  rw [simpleStorageNativeDispatcherStmts_eq_singleton_block] at hOk
-  obtain ⟨next, hInner⟩ := lowerStmtsNative_block_stmts_eq _ _ hOk
+  have hInner := simpleStorageNativeDispatcherInnerStmts_lowering_ok
   -- `buildSwitch ssIRC.functions none none` unfolds (definitionally) to a
   -- 3-statement `YulStmt.block` whose head is `let __has_selector := …`, so
   -- `hInner` is already a `let_`-headed lowering at the source spine.
@@ -30158,9 +33934,7 @@ private theorem simpleStorageNativeDispatcherInnerStmts_let_if_head_exists :
         EvmYul.Yul.Ast.Stmt.Let ["__has_selector"] (some e) ::
           EvmYul.Yul.Ast.Stmt.If c body ::
           rest := by
-  have hOk := simpleStorageNativeDispatcherStmts_lowering_ok
-  rw [simpleStorageNativeDispatcherStmts_eq_singleton_block] at hOk
-  obtain ⟨next, hInner⟩ := lowerStmtsNative_block_stmts_eq _ _ hOk
+  have hInner := simpleStorageNativeDispatcherInnerStmts_lowering_ok
   obtain ⟨rest', hLet, hRestLowering⟩ :=
     lowerStmtsNativeWithSwitchIds_let_head_eq _ _ _ _ _ _ _ hInner
   obtain ⟨body', _midN, rest'', hIf, _, _⟩ :=
@@ -30181,9 +33955,7 @@ private theorem simpleStorageNativeDispatcherInnerStmts_eq_let_if_if :
         [EvmYul.Yul.Ast.Stmt.Let ["__has_selector"] (some e),
          EvmYul.Yul.Ast.Stmt.If c1 body1,
          EvmYul.Yul.Ast.Stmt.If c2 body2] := by
-  have hOk := simpleStorageNativeDispatcherStmts_lowering_ok
-  rw [simpleStorageNativeDispatcherStmts_eq_singleton_block] at hOk
-  obtain ⟨_, hInner⟩ := lowerStmtsNative_block_stmts_eq _ _ hOk
+  have hInner := simpleStorageNativeDispatcherInnerStmts_lowering_ok
   obtain ⟨rest', hLet, hRestLowering⟩ :=
     lowerStmtsNativeWithSwitchIds_let_head_eq _ _ _ _ _ _ _ hInner
   obtain ⟨body1', _, rest'', hIf1, _, hRest1⟩ :=
@@ -30274,12 +34046,12 @@ private theorem simpleStorageNativeContract_dispatcherExec_eq_named_let_if_if_bl
     (peeledFuel : Nat)
     (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (Nat.succ (Nat.succ (Nat.succ peeledFuel)))
+        (Nat.succ (Nat.succ (peeledFuel + 6)))
         Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract
           tx storage observableSlots) =
-      EvmYul.Yul.exec (Nat.succ peeledFuel)
+      EvmYul.Yul.exec (peeledFuel + 5)
         (.Block
           [EvmYul.Yul.Ast.Stmt.Let ["__has_selector"]
               (some simpleStorageNativeDispatcher_letValue),
@@ -30290,9 +34062,9 @@ private theorem simpleStorageNativeContract_dispatcherExec_eq_named_let_if_if_bl
               simpleStorageNativeDispatcher_if2Cond
               simpleStorageNativeDispatcher_if2Body])
         (some Compiler.SimpleStorageNativeWitness.nativeContract)
-        (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState
+        (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
           Compiler.SimpleStorageNativeWitness.nativeContract
-          tx storage observableSlots) := by
+          tx storage observableSlots ∅) := by
   rw [simpleStorageNativeContract_dispatcherExec_eq_innerBlock_exec,
       simpleStorageNativeDispatcherInnerStmts_eq_named_let_if_if]
 
@@ -30313,9 +34085,7 @@ private theorem simpleStorageNativeDispatcherInnerStmts_concrete_let_head :
                   [Yul.YulExpr.call "lt"
                     [Yul.YulExpr.call "calldatasize" [],
                      Yul.YulExpr.lit 4]]))) :: rest := by
-  have hOk := simpleStorageNativeDispatcherStmts_lowering_ok
-  rw [simpleStorageNativeDispatcherStmts_eq_singleton_block] at hOk
-  obtain ⟨_, hInner⟩ := lowerStmtsNative_block_stmts_eq _ _ hOk
+  have hInner := simpleStorageNativeDispatcherInnerStmts_lowering_ok
   obtain ⟨rest', hSplit, _⟩ :=
     lowerStmtsNativeWithSwitchIds_let_head_eq _ _ _ _ _ _ _ hInner
   exact ⟨rest', hSplit⟩
@@ -30347,9 +34117,7 @@ private theorem simpleStorageNativeDispatcherInnerStmts_eq_concrete_let_if_if :
             (Compiler.Proofs.YulGeneration.Backends.lowerExprNative
               (Yul.YulExpr.ident "__has_selector"))
             body2] := by
-  have hOk := simpleStorageNativeDispatcherStmts_lowering_ok
-  rw [simpleStorageNativeDispatcherStmts_eq_singleton_block] at hOk
-  obtain ⟨_, hInner⟩ := lowerStmtsNative_block_stmts_eq _ _ hOk
+  have hInner := simpleStorageNativeDispatcherInnerStmts_lowering_ok
   obtain ⟨rest', hLet, hRestLowering⟩ :=
     lowerStmtsNativeWithSwitchIds_let_head_eq _ _ _ _ _ _ _ hInner
   obtain ⟨body1', _, rest'', hIf1, _, hRest1⟩ :=
@@ -30393,9 +34161,7 @@ private theorem simpleStorageNativeDispatcherInnerStmts_eq_concrete_let_if_switc
                 [Yul.YulExpr.lit Compiler.Constants.selectorShift,
                  Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 0]])
               switchId cases' default']] := by
-  have hOk := simpleStorageNativeDispatcherStmts_lowering_ok
-  rw [simpleStorageNativeDispatcherStmts_eq_singleton_block] at hOk
-  obtain ⟨_, hInner⟩ := lowerStmtsNative_block_stmts_eq _ _ hOk
+  have hInner := simpleStorageNativeDispatcherInnerStmts_lowering_ok
   obtain ⟨_, hLet, hRestLowering⟩ :=
     lowerStmtsNativeWithSwitchIds_let_head_eq _ _ _ _ _ _ _ hInner
   obtain ⟨body1', _, _, hIf1, _, hRest1⟩ :=
@@ -30479,54 +34245,6 @@ private theorem lowerStmtsNativeWithSwitchIds_singleton_switch_revert_default_eq
   exact Backends.Native.lowerStmtsNativeWithSwitchIds_singleton_switch_revert_default_eq_sourceLowered
     reservedNames n0 expr cases inner next h
 
-/-- Strengthened companion of `simpleStorageNativeDispatcherInnerStmts_eq_concrete_let_if_switchSingleton`:
-the lowered default body of the inner switch is pinned to the concrete
-`[nativeRevertZeroZeroStmt]` singleton. The lowered case bodies (and the
-selector-miss `If` body `body1`) remain existential as before. Combines the
-existing concrete decomposition with the new
-`lowerStmtsNativeWithSwitchIds_singleton_switch_revert_default_eq`, exploiting
-the definitional fact that `simpleStorageIRContract` has both `fallback` and
-`receive` set to `none`, so the switch's source-level `defaultCase` is
-`defaultDispatchCase none none = [revert(0,0)]`. -/
-private theorem simpleStorageNativeDispatcherInnerStmts_eq_concrete_let_if_switchSingleton_revert_default :
-    ∃ (body1 : List EvmYul.Yul.Ast.Stmt) (switchId : Nat)
-      (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)),
-      simpleStorageNativeDispatcherInnerStmts =
-        [EvmYul.Yul.Ast.Stmt.Let ["__has_selector"]
-            (some (Backends.lowerExprNative
-              (Yul.YulExpr.call "iszero"
-                [Yul.YulExpr.call "lt"
-                  [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit 4]]))),
-         EvmYul.Yul.Ast.Stmt.If
-            (Backends.lowerExprNative
-              (Yul.YulExpr.call "iszero" [Yul.YulExpr.ident "__has_selector"]))
-            body1,
-         EvmYul.Yul.Ast.Stmt.If
-            (Backends.lowerExprNative (Yul.YulExpr.ident "__has_selector"))
-            [Backends.lowerNativeSwitchBlock
-              (Yul.YulExpr.call "shr"
-                [Yul.YulExpr.lit Compiler.Constants.selectorShift,
-                 Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 0]])
-              switchId cases'
-              [Backends.Native.nativeRevertZeroZeroStmt]]] := by
-  have hOk := simpleStorageNativeDispatcherStmts_lowering_ok
-  rw [simpleStorageNativeDispatcherStmts_eq_singleton_block] at hOk
-  obtain ⟨body1, reservedNames, n0, cases', _, hInner, _⟩ :=
-    Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_sourceLowered
-      simpleStorageIRContract.functions simpleStorageNativeDispatcherInnerStmts hOk
-  exact ⟨body1, Backends.freshNativeSwitchId reservedNames n0, cases', hInner⟩
-
-/-- The source-level switch cases that `buildSwitch` emits for SimpleStorage
-(one entry per source IR function, keyed by selector). Used by the
-`_sourceLowered` companion below as the explicit input to
-`lowerSwitchCasesNativeWithSwitchIds`, anchoring the switch lowering to the
-concrete source-level selector list. -/
-private abbrev simpleStorageBuildSwitchSourceCases : List (Nat × List Yul.YulStmt) :=
-  simpleStorageIRContract.functions.map (fun fn =>
-    (fn.selector,
-      Compiler.CodegenCommon.dispatchBody fn.payable s!"{fn.name}()"
-        ([Compiler.CodegenCommon.calldatasizeGuard fn.params.length] ++ fn.body)))
-
 /-- Source-lowered companion of `_eq_concrete_let_if_switchSingleton_revert_default`:
 additionally exposes the lowering equation for the buildSwitch-emitted source
 case list `simpleStorageBuildSwitchSourceCases` into the lowered `cases'`.
@@ -30555,11 +34273,55 @@ private theorem simpleStorageNativeDispatcherInnerStmts_eq_concrete_let_if_switc
       Backends.lowerSwitchCasesNativeWithSwitchIds reservedNames
         (Backends.freshNativeSwitchId reservedNames n0 + 1)
         simpleStorageBuildSwitchSourceCases = .ok (cases', midN) := by
-  have hOk := simpleStorageNativeDispatcherStmts_lowering_ok
-  rw [simpleStorageNativeDispatcherStmts_eq_singleton_block] at hOk
-  simpa [simpleStorageBuildSwitchSourceCases] using
-    (Backends.Native.buildSwitch_noFallback_noReceive_lowered_inner_sourceLowered
-      simpleStorageIRContract.functions simpleStorageNativeDispatcherInnerStmts hOk)
+  have hInner := simpleStorageNativeDispatcherInnerStmts_lowering_ok
+  obtain ⟨rest', hLet, hRestLowering⟩ :=
+    lowerStmtsNativeWithSwitchIds_let_head_eq _ _ _ _ _ _ _ hInner
+  obtain ⟨body1, body1Next, rest'', hIf1, _, hRest1⟩ :=
+    lowerStmtsNativeWithSwitchIds_if_head_eq _ _ _ _ _ _ _ hRestLowering
+  obtain ⟨body2, _body2Next, rest''', hIf2, hBody2, hRest2⟩ :=
+    lowerStmtsNativeWithSwitchIds_if_head_eq _ _ _ _ _ _ _ hRest1
+  rw [Backends.lowerStmtsNativeWithSwitchIds_nil,
+      Except.ok.injEq, Prod.mk.injEq] at hRest2
+  obtain ⟨hNil, _⟩ := hRest2
+  subst hNil
+  obtain ⟨cases', midN, hSwitch, hLowerCases⟩ :=
+    lowerStmtsNativeWithSwitchIds_singleton_switch_revert_default_eq_sourceLowered
+      _ _ _ _ _ _ hBody2
+  rw [hSwitch] at hIf2
+  rw [hIf2] at hIf1
+  rw [hIf1] at hLet
+  let reservedNames : List String :=
+    Backends.yulStmtsIdentifierNames
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+       Compiler.CodegenCommon.buildSwitch simpleStorageIRContract.functions none none]
+  refine ⟨body1, reservedNames, body1Next, cases', midN, ?_, ?_⟩
+  · simpa [reservedNames] using hLet
+  · simpa [reservedNames, simpleStorageBuildSwitchSourceCases] using hLowerCases
+
+private theorem simpleStorageNativeDispatcherInnerStmts_eq_concrete_let_if_switchSingleton_revert_default :
+    ∃ (body1 : List EvmYul.Yul.Ast.Stmt) (switchId : Nat)
+      (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)),
+      simpleStorageNativeDispatcherInnerStmts =
+        [EvmYul.Yul.Ast.Stmt.Let ["__has_selector"]
+            (some (Backends.lowerExprNative
+              (Yul.YulExpr.call "iszero"
+                [Yul.YulExpr.call "lt"
+                  [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit 4]]))),
+         EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative
+              (Yul.YulExpr.call "iszero" [Yul.YulExpr.ident "__has_selector"]))
+            body1,
+         EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative (Yul.YulExpr.ident "__has_selector"))
+            [Backends.lowerNativeSwitchBlock
+              (Yul.YulExpr.call "shr"
+                [Yul.YulExpr.lit Compiler.Constants.selectorShift,
+                 Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 0]])
+              switchId cases'
+              [Backends.Native.nativeRevertZeroZeroStmt]]] := by
+  obtain ⟨body1, reservedNames, n0, cases', _, hInner, _⟩ :=
+    simpleStorageNativeDispatcherInnerStmts_eq_concrete_let_if_switchSingleton_revert_default_sourceLowered
+  exact ⟨body1, Backends.freshNativeSwitchId reservedNames n0, cases', hInner⟩
 
 /-- The `Classical.choose`-pinned let RHS of the SimpleStorage native dispatcher
 equals the lowered `iszero(lt(calldatasize(), 4))` Yul expression that
@@ -30701,9 +34463,7 @@ selector-miss exec proofs invoke `exec_revert_zero_zero_error` directly. -/
 private theorem simpleStorageNativeDispatcher_if1Body_eq :
     simpleStorageNativeDispatcher_if1Body =
       [Backends.Native.nativeRevertZeroZeroStmt] := by
-  have hOk := simpleStorageNativeDispatcherStmts_lowering_ok
-  rw [simpleStorageNativeDispatcherStmts_eq_singleton_block] at hOk
-  obtain ⟨_, hInner⟩ := lowerStmtsNative_block_stmts_eq _ _ hOk
+  have hInner := simpleStorageNativeDispatcherInnerStmts_lowering_ok
   obtain ⟨rest', hLet, hRestLowering⟩ :=
     lowerStmtsNativeWithSwitchIds_let_head_eq _ _ _ _ _ _ _ hInner
   obtain ⟨body1', _, rest'', hIf1, hBody1, hRest1⟩ :=
@@ -30782,8 +34542,8 @@ private theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativ
       EvmYul.Yul.exec (fuel + 12)
           (.Block simpleStorageNativeDispatcherInnerStmts)
           (some contract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState
-            contract tx storage observableSlots) =
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
+            contract tx storage observableSlots ∅) =
         EvmYul.Yul.exec (fuel + 8)
           (.Block
             [Backends.lowerNativeSwitchBlock
@@ -30792,8 +34552,8 @@ private theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativ
                  Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 0]])
               switchId cases' default'])
           (some contract)
-          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState
-            contract tx storage observableSlots).insert "__has_selector"
+          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
+            contract tx storage observableSlots ∅).insert "__has_selector"
             (EvmYul.UInt256.ofNat 1)) := by
   obtain ⟨switchId, cases', default', hIf2Body⟩ :=
     simpleStorageNativeDispatcher_if2Body_eq_lowerSwitchBlock_exists
@@ -30802,8 +34562,8 @@ private theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativ
       simpleStorageNativeDispatcher_letValue_eq,
       simpleStorageNativeDispatcher_if1Cond_eq,
       simpleStorageNativeDispatcher_if2Cond_eq, hIf2Body]
-  exact Backends.Native.exec_block_letSelector_if1Skip_if2Take_initialState_fuel
-    fuel contract tx storage observableSlots "__has_selector"
+  exact Backends.Native.exec_block_letSelector_if1Skip_if2Take_postInitFreeMemory_fuel
+    fuel contract tx storage observableSlots ∅ "__has_selector"
     simpleStorageNativeDispatcher_if1Body
     [Backends.lowerNativeSwitchBlock
       (Yul.YulExpr.call "shr"
@@ -30826,8 +34586,8 @@ private theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativ
       EvmYul.Yul.exec (fuel + 12)
           (.Block simpleStorageNativeDispatcherInnerStmts)
           (some contract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState
-            contract tx storage observableSlots) =
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
+            contract tx storage observableSlots ∅) =
         EvmYul.Yul.exec (fuel + 8)
           (.Block
             [Backends.lowerNativeSwitchBlock
@@ -30837,8 +34597,8 @@ private theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativ
               switchId cases'
               [Backends.Native.nativeRevertZeroZeroStmt]])
           (some contract)
-          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState
-            contract tx storage observableSlots).insert "__has_selector"
+          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
+            contract tx storage observableSlots ∅).insert "__has_selector"
             (EvmYul.UInt256.ofNat 1)) := by
   obtain ⟨switchId, cases', hIf2Body⟩ :=
     simpleStorageNativeDispatcher_if2Body_eq_lowerSwitchBlock_revert_default_exists
@@ -30847,8 +34607,8 @@ private theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativ
       simpleStorageNativeDispatcher_letValue_eq,
       simpleStorageNativeDispatcher_if1Cond_eq,
       simpleStorageNativeDispatcher_if2Cond_eq, hIf2Body]
-  exact Backends.Native.exec_block_letSelector_if1Skip_if2Take_initialState_fuel
-    fuel contract tx storage observableSlots "__has_selector"
+  exact Backends.Native.exec_block_letSelector_if1Skip_if2Take_postInitFreeMemory_fuel
+    fuel contract tx storage observableSlots ∅ "__has_selector"
     simpleStorageNativeDispatcher_if1Body
     [Backends.lowerNativeSwitchBlock
       (Yul.YulExpr.call "shr"
@@ -30873,8 +34633,8 @@ private theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativ
       EvmYul.Yul.exec (fuel + 12)
           (.Block simpleStorageNativeDispatcherInnerStmts)
           (some contract)
-          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState
-            contract tx storage observableSlots) =
+          (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
+            contract tx storage observableSlots ∅) =
         EvmYul.Yul.exec (fuel + 8)
           (.Block
             [Backends.lowerNativeSwitchBlock
@@ -30884,8 +34644,8 @@ private theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativ
               (Backends.freshNativeSwitchId reservedNames n0) cases'
               [Backends.Native.nativeRevertZeroZeroStmt]])
           (some contract)
-          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState
-            contract tx storage observableSlots).insert "__has_selector"
+          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
+            contract tx storage observableSlots ∅).insert "__has_selector"
             (EvmYul.UInt256.ofNat 1)) ∧
       Backends.lowerSwitchCasesNativeWithSwitchIds reservedNames
         (Backends.freshNativeSwitchId reservedNames n0 + 1)
@@ -30897,8 +34657,8 @@ private theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativ
       simpleStorageNativeDispatcher_letValue_eq,
       simpleStorageNativeDispatcher_if1Cond_eq,
       simpleStorageNativeDispatcher_if2Cond_eq, hIf2Body]
-  exact Backends.Native.exec_block_letSelector_if1Skip_if2Take_initialState_fuel
-    fuel contract tx storage observableSlots "__has_selector"
+  exact Backends.Native.exec_block_letSelector_if1Skip_if2Take_postInitFreeMemory_fuel
+    fuel contract tx storage observableSlots ∅ "__has_selector"
     simpleStorageNativeDispatcher_if1Body
     [Backends.lowerNativeSwitchBlock
       (Yul.YulExpr.call "shr"
@@ -30922,7 +34682,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchB
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
       (default' : List EvmYul.Yul.Ast.Stmt),
       Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-          (peeledFuel + 14)
+          (peeledFuel + 15)
           Compiler.SimpleStorageNativeWitness.nativeContract
           (Compiler.Proofs.YulGeneration.Backends.Native.initialState
             Compiler.SimpleStorageNativeWitness.nativeContract
@@ -30935,19 +34695,19 @@ private theorem simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchB
                  Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 0]])
               switchId cases' default'])
           (some Compiler.SimpleStorageNativeWitness.nativeContract)
-          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState
+          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
             Compiler.SimpleStorageNativeWitness.nativeContract
-            tx storage observableSlots).insert "__has_selector"
+            tx storage observableSlots ∅).insert "__has_selector"
             (EvmYul.UInt256.ofNat 1)) := by
   obtain ⟨switchId, cases', default', hExec⟩ :=
     exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativeSwitchBlock_exec
       peeledFuel Compiler.SimpleStorageNativeWitness.nativeContract
       tx storage observableSlots hNoWrap
   refine ⟨switchId, cases', default', ?_⟩
-  have hShape : peeledFuel + 14 =
-      Nat.succ (Nat.succ (Nat.succ (peeledFuel + 11))) := by omega
+  have hShape : peeledFuel + 15 =
+      Nat.succ (Nat.succ ((peeledFuel + 7) + 6)) := by omega
   rw [hShape, simpleStorageNativeContract_dispatcherExec_eq_innerBlock_exec
-        (peeledFuel + 11) tx storage observableSlots]
+        (peeledFuel + 7) tx storage observableSlots]
   exact hExec
 
 /-- Strengthened companion of `simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchBlock_exec`
@@ -30964,7 +34724,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchB
     ∃ (switchId : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)),
       Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-          (peeledFuel + 14)
+          (peeledFuel + 15)
           Compiler.SimpleStorageNativeWitness.nativeContract
           (Compiler.Proofs.YulGeneration.Backends.Native.initialState
             Compiler.SimpleStorageNativeWitness.nativeContract
@@ -30978,19 +34738,19 @@ private theorem simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchB
               switchId cases'
               [Backends.Native.nativeRevertZeroZeroStmt]])
           (some Compiler.SimpleStorageNativeWitness.nativeContract)
-          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState
+          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
             Compiler.SimpleStorageNativeWitness.nativeContract
-            tx storage observableSlots).insert "__has_selector"
+            tx storage observableSlots ∅).insert "__has_selector"
             (EvmYul.UInt256.ofNat 1)) := by
   obtain ⟨switchId, cases', hExec⟩ :=
     exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativeSwitchBlock_revert_default_exec
       peeledFuel Compiler.SimpleStorageNativeWitness.nativeContract
       tx storage observableSlots hNoWrap
   refine ⟨switchId, cases', ?_⟩
-  have hShape : peeledFuel + 14 =
-      Nat.succ (Nat.succ (Nat.succ (peeledFuel + 11))) := by omega
+  have hShape : peeledFuel + 15 =
+      Nat.succ (Nat.succ ((peeledFuel + 7) + 6)) := by omega
   rw [hShape, simpleStorageNativeContract_dispatcherExec_eq_innerBlock_exec
-        (peeledFuel + 11) tx storage observableSlots]
+        (peeledFuel + 7) tx storage observableSlots]
   exact hExec
 
 /-- Source-lowered companion of `_dispatcherExec_eq_lowerNativeSwitchBlock_revert_default_exec`:
@@ -31008,7 +34768,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchB
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) (midN : Nat),
       Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-          (peeledFuel + 14)
+          (peeledFuel + 15)
           Compiler.SimpleStorageNativeWitness.nativeContract
           (Compiler.Proofs.YulGeneration.Backends.Native.initialState
             Compiler.SimpleStorageNativeWitness.nativeContract
@@ -31022,9 +34782,9 @@ private theorem simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchB
               (Backends.freshNativeSwitchId reservedNames n0) cases'
               [Backends.Native.nativeRevertZeroZeroStmt]])
           (some Compiler.SimpleStorageNativeWitness.nativeContract)
-          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState
+          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
             Compiler.SimpleStorageNativeWitness.nativeContract
-            tx storage observableSlots).insert "__has_selector"
+            tx storage observableSlots ∅).insert "__has_selector"
             (EvmYul.UInt256.ofNat 1)) ∧
       Backends.lowerSwitchCasesNativeWithSwitchIds reservedNames
         (Backends.freshNativeSwitchId reservedNames n0 + 1)
@@ -31034,10 +34794,10 @@ private theorem simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchB
       peeledFuel Compiler.SimpleStorageNativeWitness.nativeContract
       tx storage observableSlots hNoWrap
   refine ⟨reservedNames, n0, cases', midN, ?_, hLowerCases⟩
-  have hShape : peeledFuel + 14 =
-      Nat.succ (Nat.succ (Nat.succ (peeledFuel + 11))) := by omega
+  have hShape : peeledFuel + 15 =
+      Nat.succ (Nat.succ ((peeledFuel + 7) + 6)) := by omega
   rw [hShape, simpleStorageNativeContract_dispatcherExec_eq_innerBlock_exec
-        (peeledFuel + 11) tx storage observableSlots]
+        (peeledFuel + 7) tx storage observableSlots]
   exact hExec
 
 /-- Bridge-level selector-miss endpoint, parametric in `cases'` and `switchId`:
@@ -31062,7 +34822,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_selectorMiss_revert_v
       ∀ tag body, (tag, body) ∈ cases' → tag < EvmYul.UInt256.size)
     (hReduction :
       Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-          (fuel + cases'.length + 19)
+          (fuel + cases'.length + 20)
           Compiler.SimpleStorageNativeWitness.nativeContract
           (Compiler.Proofs.YulGeneration.Backends.Native.initialState
             Compiler.SimpleStorageNativeWitness.nativeContract
@@ -31076,22 +34836,22 @@ private theorem simpleStorageNativeContract_dispatcherExec_selectorMiss_revert_v
               switchId cases'
               [Backends.Native.nativeRevertZeroZeroStmt]])
           (some Compiler.SimpleStorageNativeWitness.nativeContract)
-          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState
+          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
             Compiler.SimpleStorageNativeWitness.nativeContract
-            tx storage observableSlots).insert "__has_selector"
+            tx storage observableSlots ∅).insert "__has_selector"
               (EvmYul.UInt256.ofNat 1))) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (fuel + cases'.length + 19)
+        (fuel + cases'.length + 20)
         Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract
           tx storage observableSlots) =
       .error EvmYul.Yul.Exception.Revert := by
   rw [hReduction]
-  exact Backends.Native.exec_block_lowerNativeSwitchBlock_revert_default_hasSelectorState_error
+  exact (Backends.Native.exec_block_lowerNativeSwitchBlock_revert_default_postInitFreeMemory_hasSelectorState_projectResult_eq
     fuel selector switchId cases'
     Compiler.SimpleStorageNativeWitness.nativeContract
-    tx storage observableSlots hSelector hFind hSelectorRange hTagsRange
+    tx storage [] observableSlots hSelector hFind hSelectorRange hTagsRange).1
 
 /-- The source-level switch cases emitted by `buildSwitch` for SimpleStorage
 project to the concrete two-element selector list `[0x6057361d, 0x2e64cec1]`.
@@ -31288,6 +35048,42 @@ private def simpleStorageLoweredStoreCaseBodyTail3 : List EvmYul.Yul.Ast.Stmt :=
      (.call "sstore" [.lit 0, .ident "value"])),
    .ExprStmtCall (Backends.lowerExprNative (.call "stop" []))]
 
+private theorem nativeSwitchPostInitFreeMemorySharedState_weiValue
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat) :
+    (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+      contract tx storage observableSlots).executionEnv.weiValue =
+      Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 tx.msgValue := by
+  simp [Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
+    Compiler.Proofs.YulGeneration.Backends.Native.initialState,
+    Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
+    YulState.initial, EvmYul.Yul.State.sharedState,
+    Compiler.Proofs.YulGeneration.Backends.StateBridge.mkBlockHeader]
+
+private theorem nativeSwitchPostInitFreeMemorySharedState_calldata_size
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat) :
+    (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+      contract tx storage observableSlots).executionEnv.calldata.size =
+      4 + tx.args.length * 32 := by
+  simp [Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
+    Compiler.Proofs.YulGeneration.Backends.Native.initialState,
+    Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
+    YulState.initial, EvmYul.Yul.State.sharedState,
+    Compiler.Proofs.YulGeneration.Backends.StateBridge.mkBlockHeader,
+    Compiler.Proofs.YulGeneration.Backends.StateBridge.calldataToByteArray_size]
+
+private theorem nativeSwitchPostInitFreeMemorySharedState_perm
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat) :
+    (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+      contract tx storage observableSlots).executionEnv.perm = true := by
+  simp [Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
+    Compiler.Proofs.YulGeneration.Backends.Native.initialState,
+    Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
+    YulState.initial, EvmYul.Yul.State.sharedState,
+    Compiler.Proofs.YulGeneration.Backends.StateBridge.mkBlockHeader]
+
 /-- Closed-form native exec of the direct lowered setter body from the
 generated dispatcher marked-prefix state.
 
@@ -31301,7 +35097,7 @@ private theorem exec_block_store0_calldataload4_stop_markedPrefix_halt
     (store : EvmYul.Yul.VarStore)
     (arg : Nat) (rest : List Nat) (hArgs : tx.args = arg :: rest) :
     let initialWithStore :=
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
         contract tx storage observableSlots switchId store
     let withValue := initialWithStore.insert "value"
       (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
@@ -31327,28 +35123,16 @@ private theorem exec_block_store0_calldataload4_stop_markedPrefix_halt
     EvmYul.Yul.reverse', EvmYul.Yul.cons', EvmYul.Yul.multifill',
     EvmYul.Yul.State.multifill, initialWithStore, withValue, finalState,
     hWord,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
     EvmYul.Yul.State.insert, GetElem?.getElem!, decidableGetElem?,
     GetElem.getElem, EvmYul.Yul.State.store, EvmYul.Yul.State.lookup!]
-  have hPerm :
-      (EvmYul.Yul.State.Ok
-        (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-          contract tx storage observableSlots).sharedState
-        (((store.insert
-          (Backends.nativeSwitchDiscrTempName switchId)
-          (EvmYul.UInt256.ofNat
-            (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
-          (Backends.nativeSwitchMatchedTempName switchId)
-          (EvmYul.UInt256.ofNat 1)).insert "value"
-          (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg))).executionEnv.perm =
-        true := by
+  simp [EvmYul.Yul.primCall, EvmYul.Yul.State.executionEnv]
+  cases withValue.toState.sstore (EvmYul.UInt256.ofNat 0)
+      (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg) <;>
     rfl
-  rw [show fuel + 7 = (fuel + 6) + 1 by omega]
-  rw [Compiler.Proofs.YulGeneration.Backends.Native.primCall_sstore_ok
-    (fuel + 6) _ _ _ hPerm]
-  rfl
 
 /-- 3-statement callvalue-stripped tail of `simpleStorageLoweredRetrieveCaseBody`. -/
 private def simpleStorageLoweredRetrieveCaseBodyTail2 : List EvmYul.Yul.Ast.Stmt :=
@@ -31670,8 +35454,8 @@ private theorem exec_block_simpleStorageLoweredStoreCaseBodyTail2_markedPrefix_h
         (Backends.nativeSwitchMatchedTempName switchId)
         (EvmYul.UInt256.ofNat 1))
     let shared :=
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-        contract tx storage observableSlots).sharedState
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+        contract tx storage observableSlots
     let initialWithStore : EvmYul.Yul.State := .Ok shared markedStore
     let withValue := initialWithStore.insert "value"
       (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
@@ -31686,7 +35470,9 @@ private theorem exec_block_simpleStorageLoweredStoreCaseBodyTail2_markedPrefix_h
   have hWord :
       shared.calldataload (EvmYul.UInt256.ofNat 4) =
         Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg := by
-    simpa [shared, EvmYul.Yul.State.toState] using
+    simpa [shared,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
+      EvmYul.Yul.State.toState] using
       Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataload4_arg0_word
         contract tx storage observableSlots arg rest hArgs
   have hTail3 :
@@ -31695,7 +35481,9 @@ private theorem exec_block_simpleStorageLoweredStoreCaseBodyTail2_markedPrefix_h
           (some contract) initialWithStore =
         .error (EvmYul.Yul.Exception.YulHalt finalState ⟨0⟩) := by
     have hPerm : shared.executionEnv.perm = true := by
-      simp [shared, Compiler.Proofs.YulGeneration.Backends.Native.initialState,
+      simp [shared,
+        Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
+        Compiler.Proofs.YulGeneration.Backends.Native.initialState,
         Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
         YulState.initial, EvmYul.Yul.State.sharedState]
     simpa [initialWithStore, withValue, finalState] using
@@ -31704,12 +35492,11 @@ private theorem exec_block_simpleStorageLoweredStoreCaseBodyTail2_markedPrefix_h
   have hCalldataSize :
       shared.executionEnv.calldata.size = 4 + tx.args.length * 32 := by
     simpa [shared,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
-      EvmYul.Yul.State.sharedState, EvmYul.Yul.State.insert] using
-      (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_calldata_size
-        contract tx storage observableSlots switchId store)
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
+      Compiler.Proofs.YulGeneration.Backends.Native.initialState,
+      Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
+      YulState.initial, EvmYul.Yul.State.sharedState,
+      Compiler.Proofs.YulGeneration.Backends.StateBridge.calldataToByteArray_size]
   have hSize :
       shared.executionEnv.calldata.size < EvmYul.UInt256.size := by
     simpa [hCalldataSize] using hNoWrap
@@ -31814,27 +35601,19 @@ private theorem exec_block_simpleStorageLoweredStoreCaseBodyTail3_halt
 the calldata contains the setter argument. -/
 private theorem exec_block_simpleStorageLoweredStoreCaseBody_halt
     (fuel : Nat) (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (shared : EvmYul.SharedState .Yul)
     (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) (store : EvmYul.Yul.VarStore)
     (arg : Nat) (rest : List Nat) (hArgs : tx.args = arg :: rest)
-    (hWei :
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState.executionEnv.weiValue =
-      (⟨0⟩ : EvmYul.Literal))
-    (hSize :
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState.executionEnv.calldata.size <
-      EvmYul.UInt256.size)
-    (hGe :
-      36 ≤ (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState.executionEnv.calldata.size) :
+    (hPerm : shared.executionEnv.perm = true)
+    (hWord :
+      shared.calldataload (EvmYul.UInt256.ofNat 4) =
+        Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
+    (hWei : shared.executionEnv.weiValue = (⟨0⟩ : EvmYul.Literal))
+    (hSize : shared.executionEnv.calldata.size < EvmYul.UInt256.size)
+    (hGe : 36 ≤ shared.executionEnv.calldata.size) :
     let initialWithStore : EvmYul.Yul.State :=
-      .Ok (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState store
+      .Ok shared store
     let withValue := initialWithStore.insert "value"
       (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
     let finalState := withValue.setState
@@ -31844,20 +35623,12 @@ private theorem exec_block_simpleStorageLoweredStoreCaseBody_halt
         codeOverride initialWithStore =
       .error (EvmYul.Yul.Exception.YulHalt finalState ⟨0⟩) := by
   intro initialWithStore withValue finalState
-  have hTail3 := exec_block_simpleStorageLoweredStoreCaseBodyTail3_halt
-    fuel codeOverride tx storage observableSlots store arg rest hArgs
+  have hTail3 := exec_block_store0_calldataload4_stop_shared_halt
+    fuel codeOverride shared store arg hPerm hWord
   have hTail2 := exec_block_simpleStorageLoweredStoreCaseBodyTail2_lt_strip_error
-    fuel codeOverride
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState
-      store _ hSize hGe hTail3
+    fuel codeOverride shared store _ hSize hGe hTail3
   have hTail := exec_block_simpleStorageLoweredStoreCaseBodyTail_callvalue_strip_error
-    (fuel + 4) codeOverride
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState
-      store _ hWei hTail2
+    (fuel + 4) codeOverride shared store _ hWei hTail2
   exact exec_block_simpleStorageLoweredStoreCaseBody_head_strip_error
     (fuel + 11) codeOverride initialWithStore _ hTail
 
@@ -32201,8 +35972,8 @@ private theorem simpleStorageBuildSwitchSourceCases_lowered_concrete
 /-- Closed-form selector-miss bridge endpoint for SimpleStorage native
 dispatcher. Takes only source-level selector facts (`selector ≠ 0x6057361d`
 and `selector ≠ 0x2e64cec1`, the two SimpleStorage IR selectors) and
-produces the dispatcher exec result `.error Revert` at fuel `fuel + 21`
-(`= fuel + cases'.length + 19` with `cases'.length = 2`). The proof opens the
+produces the dispatcher exec result `.error Revert` at fuel `fuel + 22`
+(`= fuel + cases'.length + 20` with `cases'.length = 2`). The proof opens the
 `_sourceLowered` existential, derives `cases'.find? = none` and `tags-range`
 from the source-cases facts via `_find?_none` / `_tags_eq` chained with
 `simpleStorageBuildSwitchSourceCases_find?_none` and `_tags_lt_uint256_size`,
@@ -32219,7 +35990,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_selectorMiss_revert
     (hSelMissRetrieve : selector ≠ 0x2e64cec1)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (fuel + 21)
+        (fuel + 22)
         Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract
@@ -32246,14 +36017,14 @@ private theorem simpleStorageNativeContract_dispatcherExec_selectorMiss_revert
     simp only [List.mem_cons, List.not_mem_nil, or_false] at hMemTag
     rcases hMemTag with rfl | rfl <;> decide
   have hReduction := hExec
-  rw [show (fuel + 7 + 14 : Nat) = fuel + cases'.length + 19 by rw [hLen],
+  rw [show (fuel + 7 + 15 : Nat) = fuel + cases'.length + 20 by rw [hLen],
       show (fuel + 7 + 8 : Nat) = fuel + cases'.length + 13 by rw [hLen]]
     at hReduction
   have h := simpleStorageNativeContract_dispatcherExec_selectorMiss_revert_via_reduction
     fuel selector (Backends.freshNativeSwitchId reservedNames n0) cases'
     tx storage observableSlots hSelector hSelectorRange hFind hTagsRange
     hReduction
-  rw [show fuel + cases'.length + 19 = fuel + 21 by rw [hLen]] at h
+  rw [show fuel + cases'.length + 20 = fuel + 22 by rw [hLen]] at h
   exact h
 
 /-- Post-`__has_selector := 1` switch-prefix state at a hit, with the matched
@@ -32262,18 +36033,17 @@ lowered native switch's hit branch. -/
 private def simpleStorageDispatcherHitBodyInputState
     (switchId : Nat) (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) : EvmYul.Yul.State :=
-  ((((.Ok (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+  ((((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
             Compiler.SimpleStorageNativeWitness.nativeContract
-            tx storage observableSlots).sharedState
-            ((∅ : EvmYul.Yul.VarStore).insert "__has_selector"
-              (EvmYul.UInt256.ofNat 1)) : EvmYul.Yul.State).insert
+            tx storage observableSlots ∅).insert "__has_selector"
+              (EvmYul.UInt256.ofNat 1)).insert
           (Backends.nativeSwitchDiscrTempName switchId)
           (EvmYul.UInt256.ofNat
             (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
         (Backends.nativeSwitchMatchedTempName switchId)
         (EvmYul.UInt256.ofNat 0)).insert
       (Backends.nativeSwitchMatchedTempName switchId)
-      (EvmYul.UInt256.ofNat 1))
+      (EvmYul.UInt256.ofNat 1)
 
 /-- Hit-case dual of `_selectorMiss_revert_via_reduction` for the
 SimpleStorage `store(uint256)` selector: composes the harness-level
@@ -32296,7 +36066,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_via_re
           observableSlots) = .error err)
     (hReduction :
       Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-          (fuel + cases'.length + 19)
+          (fuel + cases'.length + 20)
           Compiler.SimpleStorageNativeWitness.nativeContract
           (Compiler.Proofs.YulGeneration.Backends.Native.initialState
             Compiler.SimpleStorageNativeWitness.nativeContract
@@ -32307,28 +36077,33 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_via_re
               Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 0]])
             switchId cases' [Backends.Native.nativeRevertZeroZeroStmt]])
           (some Compiler.SimpleStorageNativeWitness.nativeContract)
-          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState
+          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
             Compiler.SimpleStorageNativeWitness.nativeContract
-            tx storage observableSlots).insert "__has_selector"
+            tx storage observableSlots ∅).insert "__has_selector"
               (EvmYul.UInt256.ofNat 1))) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (fuel + cases'.length + 19)
+        (fuel + cases'.length + 20)
         Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract
           tx storage observableSlots) = .error err := by
   rw [hReduction]
-  refine Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_hasSelectorState_error
+  refine (Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
     fuel 0x6057361d switchId 0x6057361d cases'
     [Backends.Native.nativeRevertZeroZeroStmt] storeBody'
     Compiler.SimpleStorageNativeWitness.nativeContract
-    tx storage observableSlots err hSelector ?_ ?_ ?_ ?_
+    tx storage [] observableSlots err
+    (Backends.Native.projectResult tx storage [] (.error err))
+    hSelector ?_ ?_ ?_ ?_ rfl).1
   · rw [hCases]; rfl
   · norm_num [EvmYul.UInt256.size]
   · intro tag body hMem; rw [hCases] at hMem
     simp only [List.mem_cons, Prod.mk.injEq, List.not_mem_nil, or_false] at hMem
     rcases hMem with ⟨rfl, _⟩ | ⟨rfl, _⟩ <;> decide
-  · simpa [simpleStorageDispatcherHitBodyInputState] using hBody
+  · simpa [simpleStorageDispatcherHitBodyInputState,
+      Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+      Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+      Backends.Native.nativeSwitchHasSelectorStore] using hBody
 
 private def simpleStorageLoweredHitCasesShape
     (reservedNames : List String) (n0 midN : Nat)
@@ -32352,7 +36127,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_error
             (Backends.freshNativeSwitchId reservedNames n0) tx storage observableSlots) =
           .error err) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (fuel + 21) Compiler.SimpleStorageNativeWitness.nativeContract
+        (fuel + 22) Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract tx storage observableSlots) =
       .error err := by
@@ -32364,7 +36139,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_error
   subst hCases
   have hBody' := hBody reservedNames n0 midN storeBody' retrieveBody' hLowerCases
   have hReduction := hExec
-  rw [show (fuel + 7 + 14 : Nat) = fuel + 2 + 19 from by omega,
+  rw [show (fuel + 7 + 15 : Nat) = fuel + 2 + 20 from by omega,
       show (fuel + 7 + 8 : Nat) = fuel + 2 + 13 from by omega,
       show (2 : Nat) = ([(0x6057361d, storeBody'), (0x2e64cec1, retrieveBody')] :
         List (Nat × List EvmYul.Yul.Ast.Stmt)).length from rfl] at hReduction
@@ -32374,7 +36149,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_error
     storeBody' retrieveBody' tx storage observableSlots err
     hSelector rfl ?_ hReduction
   · rw [show fuel + ([(0x6057361d, storeBody'), (0x2e64cec1, retrieveBody')] :
-        List (Nat × List EvmYul.Yul.Ast.Stmt)).length + 19 = fuel + 21 from rfl] at h
+        List (Nat × List EvmYul.Yul.Ast.Stmt)).length + 20 = fuel + 22 from rfl] at h
     exact h
   · rintro (_ | ⟨⟨_, _⟩, rest⟩) suffix hDecomp
     · simp only [List.nil_append, List.cons.injEq] at hDecomp
@@ -32421,7 +36196,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_concre
             tx storage observableSlots) =
           .error err) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (fuel + 21) Compiler.SimpleStorageNativeWitness.nativeContract
+        (fuel + 22) Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract tx storage
           observableSlots) =
@@ -32446,7 +36221,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_concre
             tx storage observableSlots) =
           .error err) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (fuel + 21) Compiler.SimpleStorageNativeWitness.nativeContract
+        (fuel + 22) Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract tx storage
           observableSlots) =
@@ -32479,7 +36254,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_concre
             tx storage observableSlots) =
           .error err) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (fuel + 21) Compiler.SimpleStorageNativeWitness.nativeContract
+        (fuel + 22) Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract tx storage
           observableSlots) =
@@ -32518,7 +36293,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_via
           observableSlots) = .error err)
     (hReduction :
       Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-          (fuel + cases'.length + 19)
+          (fuel + cases'.length + 20)
           Compiler.SimpleStorageNativeWitness.nativeContract
           (Compiler.Proofs.YulGeneration.Backends.Native.initialState
             Compiler.SimpleStorageNativeWitness.nativeContract
@@ -32529,28 +36304,33 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_via
               Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 0]])
             switchId cases' [Backends.Native.nativeRevertZeroZeroStmt]])
           (some Compiler.SimpleStorageNativeWitness.nativeContract)
-          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState
+          ((Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState
             Compiler.SimpleStorageNativeWitness.nativeContract
-            tx storage observableSlots).insert "__has_selector"
+            tx storage observableSlots ∅).insert "__has_selector"
               (EvmYul.UInt256.ofNat 1))) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (fuel + cases'.length + 19)
+        (fuel + cases'.length + 20)
         Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract
           tx storage observableSlots) = .error err := by
   rw [hReduction]
-  refine Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_hasSelectorState_error
+  refine (Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
     fuel 0x2e64cec1 switchId 0x2e64cec1 cases'
     [Backends.Native.nativeRevertZeroZeroStmt] retrieveBody'
     Compiler.SimpleStorageNativeWitness.nativeContract
-    tx storage observableSlots err hSelector ?_ ?_ ?_ ?_
+    tx storage [] observableSlots err
+    (Backends.Native.projectResult tx storage [] (.error err))
+    hSelector ?_ ?_ ?_ ?_ rfl).1
   · rw [hCases]; rfl
   · norm_num [EvmYul.UInt256.size]
   · intro tag body hMem; rw [hCases] at hMem
     simp only [List.mem_cons, Prod.mk.injEq, List.not_mem_nil, or_false] at hMem
     rcases hMem with ⟨rfl, _⟩ | ⟨rfl, _⟩ <;> decide
-  · simpa [simpleStorageDispatcherHitBodyInputState] using hBody
+  · simpa [simpleStorageDispatcherHitBodyInputState,
+      Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+      Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+      Backends.Native.nativeSwitchHasSelectorStore] using hBody
 
 private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error
     (fuel : Nat) (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
@@ -32566,7 +36346,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error
             (Backends.freshNativeSwitchId reservedNames n0) tx storage observableSlots) =
           .error err) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (fuel + 21) Compiler.SimpleStorageNativeWitness.nativeContract
+        (fuel + 22) Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract tx storage observableSlots) =
       .error err := by
@@ -32578,7 +36358,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error
   subst hCases
   have hBody' := hBody reservedNames n0 midN storeBody' retrieveBody' hLowerCases
   have hReduction := hExec
-  rw [show (fuel + 7 + 14 : Nat) = fuel + 2 + 19 from by omega,
+  rw [show (fuel + 7 + 15 : Nat) = fuel + 2 + 20 from by omega,
       show (fuel + 7 + 8 : Nat) = fuel + 2 + 13 from by omega,
       show (2 : Nat) = ([(0x6057361d, storeBody'), (0x2e64cec1, retrieveBody')] :
         List (Nat × List EvmYul.Yul.Ast.Stmt)).length from rfl] at hReduction
@@ -32588,7 +36368,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error
     storeBody' retrieveBody' tx storage observableSlots err
     hSelector rfl ?_ hReduction
   · rw [show fuel + ([(0x6057361d, storeBody'), (0x2e64cec1, retrieveBody')] :
-        List (Nat × List EvmYul.Yul.Ast.Stmt)).length + 19 = fuel + 21 from rfl] at h
+        List (Nat × List EvmYul.Yul.Ast.Stmt)).length + 20 = fuel + 22 from rfl] at h
     exact h
   · rintro (_ | ⟨⟨_, _⟩, rest⟩) suffix hDecomp
     · exfalso
@@ -32614,7 +36394,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_con
             tx storage observableSlots) =
           .error err) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (fuel + 21) Compiler.SimpleStorageNativeWitness.nativeContract
+        (fuel + 22) Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract tx storage
           observableSlots) =
@@ -32639,7 +36419,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_con
             tx storage observableSlots) =
           .error err) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (fuel + 21) Compiler.SimpleStorageNativeWitness.nativeContract
+        (fuel + 22) Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract tx storage
           observableSlots) =
@@ -32666,7 +36446,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_con
             tx storage observableSlots) =
           .error err) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (fuel + 21) Compiler.SimpleStorageNativeWitness.nativeContract
+        (fuel + 22) Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract tx storage
           observableSlots) =
@@ -32675,11 +36455,11 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_con
     fuel tx storage observableSlots err hSelector hNoWrap ?_
   intro reservedNames n0
   have hWei :
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+      (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState.executionEnv.weiValue =
+        observableSlots).executionEnv.weiValue =
       (⟨0⟩ : EvmYul.Literal) := by
-    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_weiValue]
+    rw [nativeSwitchPostInitFreeMemorySharedState_weiValue]
     apply congrArg EvmYul.UInt256.mk
     apply Fin.ext
     simpa [Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256,
@@ -32713,7 +36493,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_con
             tx storage observableSlots) =
           .error err) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
-        (fuel + 25) Compiler.SimpleStorageNativeWitness.nativeContract
+        (fuel + 26) Compiler.SimpleStorageNativeWitness.nativeContract
         (Compiler.Proofs.YulGeneration.Backends.Native.initialState
           Compiler.SimpleStorageNativeWitness.nativeContract tx storage
           observableSlots) =
@@ -32723,17 +36503,17 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_con
   intro reservedNames n0
   have hT3 := hTail3 reservedNames n0
   have hSize :
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+      (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState.executionEnv.calldata.size <
+        observableSlots).executionEnv.calldata.size <
       EvmYul.UInt256.size := by
-    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataSize]
+    rw [nativeSwitchPostInitFreeMemorySharedState_calldata_size]
     exact hNoWrap
   have hGe :
-      4 ≤ (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+      4 ≤ (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState.executionEnv.calldata.size := by
-    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataSize]
+        observableSlots).executionEnv.calldata.size := by
+    rw [nativeSwitchPostInitFreeMemorySharedState_calldata_size]
     exact Nat.le_add_right 4 _
   show EvmYul.Yul.exec ((fuel + 4) + 6)
     (.Block simpleStorageLoweredRetrieveCaseBodyTail2)
@@ -32743,20 +36523,20 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_con
     fuel _ _ _ err hSize hGe hT3
 
 private noncomputable def simpleStorageNativeDispatcherFuel : Nat :=
-  sizeOf [Compiler.CodegenCommon.buildSwitch
-    simpleStorageIRContract.functions none none]
+  sizeOf [Compiler.CodegenCommon.initFreeMemoryPointer,
+    Compiler.CodegenCommon.buildSwitch simpleStorageIRContract.functions none none]
 
 /-- Lower bound on the SimpleStorage native dispatcher fuel constant for
 the retrieve-hit and store-hit bridges, which use the `_concrete_tail3`
-chain that produces dispatcher exec at `fuel + 25`. -/
-private theorem simpleStorageNativeDispatcherFuel_ge_25 :
-    simpleStorageNativeDispatcherFuel ≥ 25 := by
+chain that produces dispatcher exec at `fuel + 26`. -/
+private theorem simpleStorageNativeDispatcherFuel_ge_26 :
+    simpleStorageNativeDispatcherFuel ≥ 26 := by
   unfold simpleStorageNativeDispatcherFuel
   decide
 
-private theorem simpleStorageNativeDispatcherFuel_ge_21 :
-    simpleStorageNativeDispatcherFuel ≥ 21 := by
-  exact Nat.le_trans (by decide) simpleStorageNativeDispatcherFuel_ge_25
+private theorem simpleStorageNativeDispatcherFuel_ge_22 :
+    simpleStorageNativeDispatcherFuel ≥ 22 := by
+  exact Nat.le_trans (by decide) simpleStorageNativeDispatcherFuel_ge_26
 
 /-- Native dispatcher exec at exactly `simpleStorageNativeDispatcherFuel`
 reduces to `.error Revert` for the selector-miss class. -/
@@ -32778,11 +36558,11 @@ private theorem simpleStorageNativeContract_dispatcherExec_selectorMiss_revert_a
           observableSlots) =
       .error EvmYul.Yul.Exception.Revert := by
   have hReshape : simpleStorageNativeDispatcherFuel =
-      (simpleStorageNativeDispatcherFuel - 21) + 21 :=
-    (Nat.sub_add_cancel simpleStorageNativeDispatcherFuel_ge_21).symm
+      (simpleStorageNativeDispatcherFuel - 22) + 22 :=
+    (Nat.sub_add_cancel simpleStorageNativeDispatcherFuel_ge_22).symm
   rw [hReshape]
   exact simpleStorageNativeContract_dispatcherExec_selectorMiss_revert
-    (simpleStorageNativeDispatcherFuel - 21)
+    (simpleStorageNativeDispatcherFuel - 22)
     (tx.functionSelector % Compiler.Constants.selectorModulus)
     tx storage observableSlots
     rfl hSelectorRange hSelMissStore hSelMissRetrieve hNoWrap
@@ -32947,9 +36727,9 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFu
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hMsgValue : tx.msgValue % EvmYul.UInt256.size = 0) :
-    let shared := (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState
+    let shared :=
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage observableSlots
     let p := shared.sload (EvmYul.UInt256.ofNat 0)
     let shared1 : EvmYul.SharedState .Yul := { shared with toState := p.1 }
     let shared2 : EvmYul.SharedState .Yul :=
@@ -32971,13 +36751,14 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFu
         .error (EvmYul.Yul.Exception.YulHalt (.Ok shared3 store) ⟨1⟩) := by
   -- Bring the let-bound names from the goal into the local context.
   intro shared p shared1 shared2 shared3
-  -- Reshape dispatcher fuel to `g + 25` where `g := dispatcherFuel - 25`.
-  set g := simpleStorageNativeDispatcherFuel - 25 with hg_def
-  have hReshape : simpleStorageNativeDispatcherFuel = g + 25 :=
-    (Nat.sub_add_cancel simpleStorageNativeDispatcherFuel_ge_25).symm
+  -- Reshape dispatcher fuel to `g + 26` where `g := dispatcherFuel - 26`.
+  set g := simpleStorageNativeDispatcherFuel - 26 with hg_def
+  have hReshape : simpleStorageNativeDispatcherFuel = g + 26 :=
+    by simpa [g] using
+      (Nat.sub_add_cancel simpleStorageNativeDispatcherFuel_ge_26).symm
   rw [hReshape]
   -- Open the `_sourceLowered` existential at `peeledFuel := g + 11`, so the
-  -- dispatcher LHS lands at `(g + 11) + 14 = g + 25`.
+  -- dispatcher LHS lands at `(g + 11) + 14 = g + 26`.
   obtain ⟨reservedNames, n0, cases', midN, hExec, hLowerCases⟩ :=
     simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchBlock_revert_default_exec_sourceLowered
       (g + 11) tx storage observableSlots hNoWrap
@@ -33007,39 +36788,39 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFu
   refine ⟨store_body, ?_⟩
   -- Discharge the body-level closed form via `_RetrieveCaseBody_halt`.
   have hWei :
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+      (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState.executionEnv.weiValue =
+        observableSlots).executionEnv.weiValue =
       (⟨0⟩ : EvmYul.Literal) := by
-    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_weiValue]
+    rw [nativeSwitchPostInitFreeMemorySharedState_weiValue]
     apply congrArg EvmYul.UInt256.mk
     apply Fin.ext
     simpa [Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256,
       EvmYul.UInt256.ofNat, Fin.ofNat] using hMsgValue
   have hSize :
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+      (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState.executionEnv.calldata.size <
+        observableSlots).executionEnv.calldata.size <
       EvmYul.UInt256.size := by
-    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataSize]
+    rw [nativeSwitchPostInitFreeMemorySharedState_calldata_size]
     exact hNoWrap
   have hGe :
-      4 ≤ (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+      4 ≤ (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState.executionEnv.calldata.size := by
-    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataSize]
+        observableSlots).executionEnv.calldata.size := by
+    rw [nativeSwitchPostInitFreeMemorySharedState_calldata_size]
     exact Nat.le_add_right 4 _
   have hBodyHalt :=
     exec_block_simpleStorageLoweredRetrieveCaseBody_halt g
       (some Compiler.SimpleStorageNativeWitness.nativeContract)
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+      (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState
+        observableSlots)
       store_body hWei hSize hGe
   -- Reshape `hExec` into the form expected by `_via_reduction`'s
   -- `hReduction` parameter.
   have hReduction := hExec
-  rw [show (g + 11 + 14 : Nat) = (g + 4) + 2 + 19 from by omega,
+  rw [show (g + 11 + 15 : Nat) = (g + 4) + 2 + 20 from by omega,
       show (g + 11 + 8 : Nat) = (g + 4) + 2 + 13 from by omega,
       show (2 : Nat) = ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
         (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
@@ -33084,12 +36865,12 @@ private theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFu
     tx storage observableSlots
     (EvmYul.Yul.Exception.YulHalt (.Ok shared3 store_body) ⟨1⟩)
     hSelector rfl hBodyExec hReduction
-  -- `h` has dispatcher fuel `(g + 4) + cases'.length + 19`. Reshape to `g + 25`.
+  -- `h` has dispatcher fuel `(g + 4) + cases'.length + 19`. Reshape to `g + 26`.
   have hLen :
       ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
         (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
         List (Nat × List EvmYul.Yul.Ast.Stmt)).length = 2 := rfl
-  rw [hLen, show (g + 4) + 2 + 19 = g + 25 from by omega] at h
+  rw [hLen, show (g + 4) + 2 + 20 = g + 26 from by omega] at h
   exact h
 
 /-- Native dispatcher exec at exactly `simpleStorageNativeDispatcherFuel`
@@ -33111,17 +36892,18 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_halt_atFuel
         .error (EvmYul.Yul.Exception.YulHalt haltState ⟨0⟩) ∧
       haltState =
         let initialWithStore : EvmYul.Yul.State :=
-          .Ok (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+          .Ok (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
             Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-            observableSlots).sharedState store_body
+            observableSlots) store_body
         let withValue := initialWithStore.insert "value"
           (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
         withValue.setState
           (withValue.toState.sstore (EvmYul.UInt256.ofNat 0)
             (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)) := by
-  set g := simpleStorageNativeDispatcherFuel - 25 with hg_def
-  have hReshape : simpleStorageNativeDispatcherFuel = g + 25 :=
-    (Nat.sub_add_cancel simpleStorageNativeDispatcherFuel_ge_25).symm
+  set g := simpleStorageNativeDispatcherFuel - 26 with hg_def
+  have hReshape : simpleStorageNativeDispatcherFuel = g + 26 :=
+    by simpa [g] using
+      (Nat.sub_add_cancel simpleStorageNativeDispatcherFuel_ge_26).symm
   rw [hReshape]
   obtain ⟨reservedNames, n0, cases', midN, hExec, hLowerCases⟩ :=
     simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchBlock_revert_default_exec_sourceLowered
@@ -33146,9 +36928,9 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_halt_atFuel
       (Backends.nativeSwitchMatchedTempName switchId)
       (EvmYul.UInt256.ofNat 1)
   let initialWithStore : EvmYul.Yul.State :=
-    .Ok (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+    .Ok (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
       Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-      observableSlots).sharedState store_body
+      observableSlots) store_body
   let withValue := initialWithStore.insert "value"
     (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
   let finalState := withValue.setState
@@ -33156,36 +36938,55 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_halt_atFuel
       (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg))
   refine ⟨store_body, finalState, ?_, ?_⟩
   · have hWei :
-        (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
           Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-          observableSlots).sharedState.executionEnv.weiValue =
+          observableSlots).executionEnv.weiValue =
         (⟨0⟩ : EvmYul.Literal) := by
-      rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_weiValue]
+      rw [nativeSwitchPostInitFreeMemorySharedState_weiValue]
       apply congrArg EvmYul.UInt256.mk
       apply Fin.ext
       simpa [Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256,
         EvmYul.UInt256.ofNat, Fin.ofNat] using hMsgValue
     have hSize :
-        (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
           Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-          observableSlots).sharedState.executionEnv.calldata.size <
+          observableSlots).executionEnv.calldata.size <
         EvmYul.UInt256.size := by
-      rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataSize]
+      rw [nativeSwitchPostInitFreeMemorySharedState_calldata_size]
       exact hNoWrap
     have hGe :
-        36 ≤ (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        36 ≤ (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
           Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-          observableSlots).sharedState.executionEnv.calldata.size := by
-      rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataSize]
+          observableSlots).executionEnv.calldata.size := by
+      rw [nativeSwitchPostInitFreeMemorySharedState_calldata_size]
       rw [hArgs]
       simp
       omega
+    have hPerm :
+        (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+          Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+          observableSlots).executionEnv.perm = true :=
+      nativeSwitchPostInitFreeMemorySharedState_perm
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage observableSlots
+    have hWord :
+        (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+          Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+          observableSlots).calldataload (EvmYul.UInt256.ofNat 4) =
+          Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg := by
+      simpa [Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
+        EvmYul.Yul.State.toState] using
+        Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataload4_arg0_word
+          Compiler.SimpleStorageNativeWitness.nativeContract tx storage observableSlots
+          arg rest hArgs
     have hBodyHalt :=
       exec_block_simpleStorageLoweredStoreCaseBody_halt g
         (some Compiler.SimpleStorageNativeWitness.nativeContract)
-        tx storage observableSlots store_body arg rest hArgs hWei hSize hGe
+        (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+          Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+          observableSlots)
+        tx storage observableSlots store_body arg rest hArgs hPerm hWord hWei hSize hGe
     have hReduction := hExec
-    rw [show (g + 11 + 14 : Nat) = (g + 4) + 2 + 19 from by omega,
+    rw [show (g + 11 + 15 : Nat) = (g + 4) + 2 + 20 from by omega,
         show (g + 11 + 8 : Nat) = (g + 4) + 2 + 13 from by omega,
         show (2 : Nat) = ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
           (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
@@ -33230,7 +37031,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_halt_atFuel
         ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
           (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
           List (Nat × List EvmYul.Yul.Ast.Stmt)).length = 2 := rfl
-    rw [hLen, show (g + 4) + 2 + 19 = g + 25 from by omega] at h
+    rw [hLen, show (g + 4) + 2 + 20 = g + 26 from by omega] at h
     exact h
   · rfl
 
@@ -33249,9 +37050,10 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_short_revert
           Compiler.SimpleStorageNativeWitness.nativeContract tx storage
           observableSlots) =
       .error EvmYul.Yul.Exception.Revert := by
-  set g := simpleStorageNativeDispatcherFuel - 25 with hg_def
-  have hReshape : simpleStorageNativeDispatcherFuel = g + 25 :=
-    (Nat.sub_add_cancel simpleStorageNativeDispatcherFuel_ge_25).symm
+  set g := simpleStorageNativeDispatcherFuel - 26 with hg_def
+  have hReshape : simpleStorageNativeDispatcherFuel = g + 26 :=
+    by simpa [g] using
+      (Nat.sub_add_cancel simpleStorageNativeDispatcherFuel_ge_26).symm
   rw [hReshape]
   obtain ⟨reservedNames, n0, cases', midN, hExec, hLowerCases⟩ :=
     simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchBlock_revert_default_exec_sourceLowered
@@ -33276,34 +37078,34 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_short_revert
       (Backends.nativeSwitchMatchedTempName switchId)
       (EvmYul.UInt256.ofNat 1)
   have hWei :
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+      (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState.executionEnv.weiValue =
+        observableSlots).executionEnv.weiValue =
       (⟨0⟩ : EvmYul.Literal) := by
-    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_weiValue]
+    rw [nativeSwitchPostInitFreeMemorySharedState_weiValue]
     apply congrArg EvmYul.UInt256.mk
     apply Fin.ext
     simpa [Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256,
       EvmYul.UInt256.ofNat, Fin.ofNat] using hMsgValue
   have hSizeEq :
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+      (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState.executionEnv.calldata.size = 4 := by
-    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataSize]
+        observableSlots).executionEnv.calldata.size = 4 := by
+    rw [nativeSwitchPostInitFreeMemorySharedState_calldata_size]
     simp [hArgs]
   have hTail2 :=
     exec_block_simpleStorageLoweredStoreCaseBodyTail2_short_revert
       g (some Compiler.SimpleStorageNativeWitness.nativeContract)
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+      (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState
+        observableSlots)
       store_body hSizeEq
   have hTail :=
     exec_block_simpleStorageLoweredStoreCaseBodyTail_callvalue_strip_error
       (g + 4) (some Compiler.SimpleStorageNativeWitness.nativeContract)
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+      (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage
-        observableSlots).sharedState
+        observableSlots)
       store_body _ hWei hTail2
   have hBodyRevert :
       EvmYul.Yul.exec (g + 13) (.Block simpleStorageLoweredStoreCaseBody)
@@ -33314,7 +37116,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_short_revert
     exact exec_block_simpleStorageLoweredStoreCaseBody_head_strip_error
       (g + 11) _ _ _ hTail
   have hReduction := hExec
-  rw [show (g + 11 + 14 : Nat) = (g + 4) + 2 + 19 from by omega,
+  rw [show (g + 11 + 15 : Nat) = (g + 4) + 2 + 20 from by omega,
       show (g + 11 + 8 : Nat) = (g + 4) + 2 + 13 from by omega,
       show (2 : Nat) = ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
         (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
@@ -33357,7 +37159,7 @@ private theorem simpleStorageNativeContract_dispatcherExec_storeHit_short_revert
       ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
         (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
         List (Nat × List EvmYul.Yul.Ast.Stmt)).length = 2 := rfl
-  rw [hLen, show (g + 4) + 2 + 19 = g + 25 from by omega] at h
+  rw [hLen, show (g + 4) + 2 + 20 = g + 26 from by omega] at h
   exact h
 
 /-- Projected native storage after the generated `store(uint256)` body agrees
@@ -33564,7 +37366,7 @@ private theorem nativeResultsMatchOn_execIRFunction_store0_calldataload4_stop_ma
       Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
         (Compiler.runtimeCode irContract) observableSlots
     let initialWithStore :=
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
         nativeContract yulTx state.storage slots switchId store
     let withValue := initialWithStore.insert "value"
       (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
@@ -33607,17 +37409,19 @@ private theorem nativeResultsMatchOn_execIRFunction_store0_calldataload4_stop_ma
       unfold EvmYul.UInt256.ofNat
       simp [Id.run, Fin.ofNat, evmModulus, EvmYul.UInt256.size]
     simpa [finalState, withValue, initialWithStore, markedStore,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
       Compiler.Proofs.abstractStoreStorageOrMapping,
       Compiler.Proofs.IRGeneration.IRStorageWord.ofNat, hArgMod] using
       hNative.symm
   · simp [finalState, withValue, initialWithStore,
       Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
       Compiler.Proofs.YulGeneration.Backends.Native.initialState,
       Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
       YulState.initial, EvmYul.Yul.State.sharedState,
@@ -33679,7 +37483,7 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_store0_ca
     Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
       (Compiler.runtimeCode irContract) observableSlots
   let initialWithStore :=
-    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
       nativeContract yulTx state.storage slots switchId
       Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchHasSelectorStore
   let withValue := initialWithStore.insert "value"
@@ -33783,11 +37587,150 @@ override), and `evmReturn(0, 32)` (toMachineState override) starting from a
 shared state with empty memory. The native projected return value is the
 `Nat`-normalized form of the loaded slot-zero word; storage and logs are
 read off the halt's `sharedState` directly. -/
+private theorem array_extract_append_left {α} (a b : Array α) :
+    (a ++ b).extract 0 a.size = a := by
+  apply Array.ext
+  · simp
+  · intro i hi1 hi2
+    simp
+
+private theorem byteArray_readWithPadding_prefix
+    (source suffix : ByteArray) (hSize : source.size = 32) :
+    (⟨source.data ++ suffix.data⟩ : ByteArray).readWithPadding 0 32 = source := by
+  have hSizeData : source.data.size = 32 := by
+    simpa [ByteArray.size] using hSize
+  have hSourceNonempty : source.data ≠ #[] := by
+    intro h
+    have : source.data.size = 0 := by simp [h]
+    omega
+  unfold ByteArray.readWithPadding ByteArray.readWithoutPadding
+  have hSmall : ¬ 32 ≥ 2 ^ 64 := by norm_num
+  simp only [hSmall, ↓reduceIte]
+  have hAddr : ¬ 0 ≥ (⟨source.data ++ suffix.data⟩ : ByteArray).size := by
+    simp [ByteArray.size, hSourceNonempty]
+  simp only [hAddr, ↓reduceIte]
+  have hMin : min 32 (⟨source.data ++ suffix.data⟩ : ByteArray).size = 32 := by
+    simp [ByteArray.size, hSizeData]
+  simp only [hMin]
+  apply ByteArray.ext
+  simp [ByteArray.data_extract, ByteArray.data_append, ByteArray.size,
+    ffi.ByteArray.zeroes] at hSizeData ⊢
+  rw [show source.data.extract 0 32 = source.data by
+    rw [show (32 : Nat) = source.data.size by omega]
+    exact array_extract_append_left source.data #[]]
+  simp [hSizeData]
+  rw [USize.toNat_sub, USize.toNat_add, USize.toNat_ofNat,
+    USize.toNat_ofNat, USize.toNat_ofNat]
+  rcases System.Platform.numBits_eq with hbits | hbits
+  · rw [hbits]
+    omega
+  · rw [hbits]
+    omega
+
+private theorem byteArray_write_zero_32_readWithPadding_eq_of_size
+    (source dest : ByteArray) (hSize : source.size = 32)
+    (hDest : 32 ≤ dest.size) :
+    (source.write 0 dest 0 32).readWithPadding 0 32 = source := by
+  unfold ByteArray.write
+  simp only [Nat.reduceEqDiff, ↓reduceIte]
+  have hSourceAddr : ¬ 0 ≥ source.size := by omega
+  simp only [hSourceAddr, ↓reduceIte]
+  have hPractical : min 32 (source.size - 0) = 32 := by omega
+  have hEnd : min dest.size (0 + 32) = 32 := by omega
+  have hSourcePaddingLength : 32 - (0 + 32) = 0 := by omega
+  have hDestPaddingLength : 0 - dest.size = 0 := by simp
+  simp only [hPractical, hEnd, hSourcePaddingLength, hDestPaddingLength]
+  have hCopy :
+      (source ++ ffi.ByteArray.zeroes { toBitVec := 0 }).copySlice 0
+        (dest ++ ffi.ByteArray.zeroes { toBitVec := 0 }) 0 (32 + 0) =
+        (⟨source.data ++ (dest.extract 32 dest.size).data⟩ : ByteArray) := by
+    apply ByteArray.ext
+    rw [ByteArray.data_copySlice]
+    simp [ByteArray.data_append, ByteArray.data_extract, ByteArray.size,
+      ffi.ByteArray.zeroes] at hSize hDest ⊢
+    rw [show (32 : Nat) = source.data.size by omega]
+    simp
+  have hPrefix :=
+    byteArray_readWithPadding_prefix source (dest.extract 32 dest.size) hSize
+  rw [← hCopy] at hPrefix
+  simpa using hPrefix
+
+private theorem byteArray_write_empty_64_32_size_ge_32
+    (source : ByteArray) (hSize : source.size = 32) :
+    32 ≤ (source.write 0 ByteArray.empty 64 32).size := by
+  unfold ByteArray.write
+  simp only [Nat.reduceEqDiff, ↓reduceIte]
+  have hSourceAddr : ¬ 0 ≥ source.size := by omega
+  simp only [hSourceAddr, ↓reduceIte]
+  have hPractical : min 32 (source.size - 0) = 32 := by omega
+  have hEnd : min ByteArray.empty.size (64 + 32) = 0 := by simp
+  have hSourcePaddingLength : 0 - (64 + 32) = 0 := by omega
+  have hDestPaddingLength : 64 - ByteArray.empty.size = 64 := by simp
+  simp only [hPractical, hEnd, hSourcePaddingLength, hDestPaddingLength]
+  simp [ByteArray.size, ByteArray.data_copySlice, ByteArray.data_append,
+    ffi.ByteArray.zeroes] at hSize ⊢
+  rw [hSize, USize.toNat_ofNat]
+  rcases System.Platform.numBits_eq with hbits | hbits
+  · rw [hbits]
+    norm_num
+  · rw [hbits]
+    norm_num
+
+private theorem nativeSwitchPostInitFreeMemorySharedState_memory_size_ge_32
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat) :
+    32 ≤ (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+      contract tx storage observableSlots).memory.size := by
+  simp [Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
+    Compiler.Proofs.YulGeneration.Backends.Native.initialState,
+    Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
+    Compiler.Proofs.YulGeneration.Backends.StateBridge.mkBlockHeader,
+    Compiler.Constants.freeMemoryPointer, YulState.initial,
+    EvmYul.Yul.State.sharedState, EvmYul.MachineState.mstore,
+    EvmYul.MachineState.writeWord, EvmYul.writeBytes]
+  exact byteArray_write_empty_64_32_size_ge_32
+    (EvmYul.UInt256.ofNat 128).toByteArray
+    (Compiler.Proofs.YulGeneration.Backends.Native.uint256_toByteArray_size
+      (EvmYul.UInt256.ofNat 128))
+
+private theorem nativeSwitchPostInitFreeMemorySharedState_accountMap
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat) :
+    (Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+      contract tx storage observableSlots).accountMap =
+      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        contract tx storage observableSlots).sharedState.accountMap := by
+  rfl
+
+private theorem mstore0_then_return32_hReturn_eq_toByteArray
+    (sharedState : EvmYul.SharedState .Yul)
+    (store : EvmYul.Yul.VarStore)
+    (value : EvmYul.UInt256)
+    (hMemorySize : 32 ≤ sharedState.memory.size) :
+    let state : EvmYul.Yul.State := .Ok sharedState store
+    let stored :=
+      state.setMachineState
+        (state.toMachineState.mstore (EvmYul.UInt256.ofNat 0) value)
+    let returned :=
+      stored.setMachineState
+        (stored.toMachineState.evmReturn
+          (EvmYul.UInt256.ofNat 0) (EvmYul.UInt256.ofNat 32))
+    returned.sharedState.H_return = value.toByteArray := by
+  dsimp
+  simp only [EvmYul.Yul.State.toMachineState, EvmYul.Yul.State.setMachineState,
+    EvmYul.Yul.State.sharedState]
+  simp only [EvmYul.MachineState.mstore, EvmYul.MachineState.writeWord,
+    EvmYul.writeBytes, EvmYul.MachineState.evmReturn]
+  exact byteArray_write_zero_32_readWithPadding_eq_of_size value.toByteArray
+    sharedState.memory
+    (Compiler.Proofs.YulGeneration.Backends.Native.uint256_toByteArray_size value)
+    hMemorySize
+
 private theorem projectResult_retrieveHit_eq
     (tx : YulTransaction) (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (shared : EvmYul.SharedState .Yul) (store : EvmYul.Yul.VarStore)
-    (hMemory : shared.memory = ByteArray.empty) :
+    (hMemorySize : 32 ≤ shared.memory.size) :
     let p := shared.sload (EvmYul.UInt256.ofNat 0)
     let shared1 : EvmYul.SharedState .Yul := { shared with toState := p.1 }
     let shared2 : EvmYul.SharedState .Yul :=
@@ -33817,8 +37760,6 @@ private theorem projectResult_retrieveHit_eq
             Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
               (EvmYul.Yul.State.Ok shared3 store) } := by
   intro p shared1 shared2 shared3
-  -- shared1 inherits memory from shared because only `toState` was overridden.
-  have hMemory1 : shared1.memory = ByteArray.empty := hMemory
   -- The harness helpers describe the result via `setMachineState` chains;
   -- those equal the structural overrides used in `shared3`.
   have hSize :
@@ -33830,8 +37771,8 @@ private theorem projectResult_retrieveHit_eq
   have hH_return :
       (EvmYul.Yul.State.Ok shared3 store).sharedState.H_return = p.2.toByteArray := by
     have h :=
-      Compiler.Proofs.YulGeneration.Backends.Native.mstore0_then_return32_emptyMemory_hReturn_eq_toByteArray
-        shared1 store p.2 hMemory1
+      mstore0_then_return32_hReturn_eq_toByteArray shared1 store p.2
+        (by simpa [shared1] using hMemorySize)
     simpa [shared3, shared2, EvmYul.Yul.State.setMachineState,
       EvmYul.Yul.State.toMachineState, EvmYul.Yul.State.sharedState] using h
   have hHaltNotZero : (⟨1⟩ : EvmYul.Yul.Ast.Literal) ≠ ⟨0⟩ := by
@@ -33853,8 +37794,7 @@ private theorem projectResult_literalReturnHit_eq
     (tx : YulTransaction) (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (shared : EvmYul.SharedState .Yul) (store : EvmYul.Yul.VarStore)
-    (value : Nat)
-    (hMemory : shared.memory = ByteArray.empty) :
+    (value : Nat) (hMemorySize : 32 ≤ shared.memory.size) :
     let shared1 : EvmYul.SharedState .Yul :=
       { shared with
         toMachineState :=
@@ -33893,8 +37833,8 @@ private theorem projectResult_literalReturnHit_eq
       (EvmYul.Yul.State.Ok shared2 store).sharedState.H_return =
         (EvmYul.UInt256.ofNat value).toByteArray := by
     have h :=
-      Compiler.Proofs.YulGeneration.Backends.Native.mstore0_then_return32_emptyMemory_hReturn_eq_toByteArray
-        shared store (EvmYul.UInt256.ofNat value) hMemory
+      mstore0_then_return32_hReturn_eq_toByteArray shared store
+        (EvmYul.UInt256.ofNat value) hMemorySize
     simpa [shared2, shared1, EvmYul.Yul.State.setMachineState,
       EvmYul.Yul.State.toMachineState, EvmYul.Yul.State.sharedState] using h
   have hHaltNotZero : (⟨1⟩ : EvmYul.Yul.Ast.Literal) ≠ ⟨0⟩ := by
@@ -33941,8 +37881,8 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_sload0_return32_mark
         (Backends.nativeSwitchMatchedTempName switchId)
         (EvmYul.UInt256.ofNat 1))
     let shared :=
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-        nativeContract yulTx state.storage slots).sharedState
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+        nativeContract yulTx state.storage slots
     let p := shared.sload (EvmYul.UInt256.ofNat 0)
     let shared1 : EvmYul.SharedState .Yul := { shared with toState := p.1 }
     let shared2 : EvmYul.SharedState .Yul :=
@@ -33983,13 +37923,13 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_sload0_return32_mark
             state.events ++
               Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
                 (EvmYul.Yul.State.Ok shared3 markedStore) } := by
-    have hMemory : shared.memory = ByteArray.empty := by
-      simp [shared, Compiler.Proofs.YulGeneration.Backends.Native.initialState,
-        Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
-        YulState.initial, EvmYul.Yul.State.sharedState]
+    have hMemorySize : 32 ≤ shared.memory.size := by
+      simpa [shared] using
+        nativeSwitchPostInitFreeMemorySharedState_memory_size_ge_32
+          nativeContract yulTx state.storage slots
     simpa [yulTx, shared, p, shared1, shared2, shared3] using
       projectResult_retrieveHit_eq yulTx state.storage state.events
-        shared markedStore hMemory
+        shared markedStore hMemorySize
   have hSlotZero : 0 ∈ slots := by
     simp [slots, Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots]
   have hp :
@@ -34447,7 +38387,7 @@ private theorem nativeResultsMatchOn_execIRFunction_oneParam_store0_value_stop_m
       Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
         (Compiler.runtimeCode irContract) observableSlots
     let initialWithStore :=
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
         nativeContract yulTx state.storage slots switchId store
     let withValue := initialWithStore.insert "value"
       (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
@@ -34490,17 +38430,19 @@ private theorem nativeResultsMatchOn_execIRFunction_oneParam_store0_value_stop_m
       unfold EvmYul.UInt256.ofNat
       simp [Id.run, Fin.ofNat, evmModulus, EvmYul.UInt256.size]
     simpa [finalState, withValue, initialWithStore, markedStore,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
       Compiler.Proofs.abstractStoreStorageOrMapping,
       Compiler.Proofs.IRGeneration.IRStorageWord.ofNat, hArgMod] using
       hNative.symm
   · simp [finalState, withValue, initialWithStore,
       Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStorePrefixStateForId,
-      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreInitialState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState,
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState,
       Compiler.Proofs.YulGeneration.Backends.Native.initialState,
       Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
       YulState.initial, EvmYul.Yul.State.sharedState,
@@ -34587,8 +38529,8 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_oneParam_
       (Backends.nativeSwitchMatchedTempName switchId)
       (EvmYul.UInt256.ofNat 1))
   let shared :=
-    (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-      nativeContract yulTx state.storage slots).sharedState
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+      nativeContract yulTx state.storage slots
   let initialWithStore : EvmYul.Yul.State := .Ok shared markedStore
   let withValue := initialWithStore.insert "value"
     (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
@@ -34975,8 +38917,8 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_lit_return32_markedP
         (Backends.nativeSwitchMatchedTempName switchId)
         (EvmYul.UInt256.ofNat 1))
     let shared :=
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-        nativeContract yulTx state.storage slots).sharedState
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+        nativeContract yulTx state.storage slots
     let shared1 : EvmYul.SharedState .Yul :=
       { shared with
         toMachineState :=
@@ -35016,13 +38958,13 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_lit_return32_markedP
             state.events ++
               Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
                 (EvmYul.Yul.State.Ok shared2 markedStore) } := by
-    have hMemory : shared.memory = ByteArray.empty := by
-      simp [shared, Compiler.Proofs.YulGeneration.Backends.Native.initialState,
-        Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
-        YulState.initial, EvmYul.Yul.State.sharedState]
+    have hMemorySize : 32 ≤ shared.memory.size := by
+      simpa [shared] using
+        nativeSwitchPostInitFreeMemorySharedState_memory_size_ge_32
+          nativeContract yulTx state.storage slots
     simpa [yulTx, shared, shared1, shared2] using
       projectResult_literalReturnHit_eq yulTx state.storage state.events
-        shared markedStore value hMemory
+        shared markedStore value hMemorySize
   have hValueNat : (EvmYul.UInt256.ofNat value).toNat = value := by
     have hValueRange' : value < Verity.Core.UINT256_MODULUS := by
       simpa [EvmYul.UInt256.size, Verity.Core.UINT256_MODULUS] using hValueRange
@@ -35049,7 +38991,9 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_lit_return32_markedP
         shared2.accountMap =
           (Compiler.Proofs.YulGeneration.Backends.Native.initialState
             nativeContract yulTx state.storage slots).sharedState.accountMap := by
-      simp [shared2, shared1, shared]
+      simpa [shared2, shared1, shared] using
+        nativeSwitchPostInitFreeMemorySharedState_accountMap
+          nativeContract yulTx state.storage slots
     have hNative :=
       Compiler.Proofs.YulGeneration.Backends.Native.initialState_materializedStorageSlot
         nativeContract yulTx state.storage slots slot hslot'
@@ -35099,8 +39043,8 @@ private theorem nativeResultsMatchOn_execIRFunction_zeroParam_mstore0_lit_return
         (Backends.nativeSwitchMatchedTempName switchId)
         (EvmYul.UInt256.ofNat 1))
     let shared :=
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-        nativeContract yulTx state.storage slots).sharedState
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+        nativeContract yulTx state.storage slots
     let shared1 : EvmYul.SharedState .Yul :=
       { shared with
         toMachineState :=
@@ -35140,13 +39084,13 @@ private theorem nativeResultsMatchOn_execIRFunction_zeroParam_mstore0_lit_return
             state.events ++
               Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
                 (EvmYul.Yul.State.Ok shared2 markedStore) } := by
-    have hMemory : shared.memory = ByteArray.empty := by
-      simp [shared, Compiler.Proofs.YulGeneration.Backends.Native.initialState,
-        Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
-        YulState.initial, EvmYul.Yul.State.sharedState]
+    have hMemorySize : 32 ≤ shared.memory.size := by
+      simpa [shared] using
+        nativeSwitchPostInitFreeMemorySharedState_memory_size_ge_32
+          nativeContract yulTx state.storage slots
     simpa [yulTx, shared, shared1, shared2] using
       projectResult_literalReturnHit_eq yulTx state.storage state.events
-        shared markedStore value hMemory
+        shared markedStore value hMemorySize
   have hValueNat : (EvmYul.UInt256.ofNat value).toNat = value := by
     have hValueRange' : value < Verity.Core.UINT256_MODULUS := by
       simpa [EvmYul.UInt256.size, Verity.Core.UINT256_MODULUS] using hValueRange
@@ -35173,7 +39117,9 @@ private theorem nativeResultsMatchOn_execIRFunction_zeroParam_mstore0_lit_return
         shared2.accountMap =
           (Compiler.Proofs.YulGeneration.Backends.Native.initialState
             nativeContract yulTx state.storage slots).sharedState.accountMap := by
-      simp [shared2, shared1, shared]
+      simpa [shared2, shared1, shared] using
+        nativeSwitchPostInitFreeMemorySharedState_accountMap
+          nativeContract yulTx state.storage slots
     have hNative :=
       Compiler.Proofs.YulGeneration.Backends.Native.initialState_materializedStorageSlot
         nativeContract yulTx state.storage slots slot hslot'
@@ -35221,8 +39167,8 @@ private theorem nativeResultsMatchOn_execIRFunction_zeroParam_mstore0_sload0_ret
         (Backends.nativeSwitchMatchedTempName switchId)
         (EvmYul.UInt256.ofNat 1))
     let shared :=
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-        nativeContract yulTx state.storage slots).sharedState
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+        nativeContract yulTx state.storage slots
     let p := shared.sload (EvmYul.UInt256.ofNat 0)
     let shared1 : EvmYul.SharedState .Yul := { shared with toState := p.1 }
     let shared2 : EvmYul.SharedState .Yul :=
@@ -35263,13 +39209,13 @@ private theorem nativeResultsMatchOn_execIRFunction_zeroParam_mstore0_sload0_ret
             state.events ++
               Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
                 (EvmYul.Yul.State.Ok shared3 markedStore) } := by
-    have hMemory : shared.memory = ByteArray.empty := by
-      simp [shared, Compiler.Proofs.YulGeneration.Backends.Native.initialState,
-        Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
-        YulState.initial, EvmYul.Yul.State.sharedState]
+    have hMemorySize : 32 ≤ shared.memory.size := by
+      simpa [shared] using
+        nativeSwitchPostInitFreeMemorySharedState_memory_size_ge_32
+          nativeContract yulTx state.storage slots
     simpa [yulTx, shared, p, shared1, shared2, shared3] using
       projectResult_retrieveHit_eq yulTx state.storage state.events
-        shared markedStore hMemory
+        shared markedStore hMemorySize
   have hSlotZero : 0 ∈ slots := by
     simp [slots, Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots]
   have hp :
@@ -35345,8 +39291,8 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_calldataload_aligned
         (Backends.nativeSwitchMatchedTempName switchId)
         (EvmYul.UInt256.ofNat 1))
     let shared :=
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-        nativeContract yulTx state.storage slots).sharedState
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+        nativeContract yulTx state.storage slots
     let value := Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg
     let shared1 : EvmYul.SharedState .Yul :=
       { shared with
@@ -35388,14 +39334,14 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_calldataload_aligned
             state.events ++
               Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
                 (EvmYul.Yul.State.Ok shared2 markedStore) } := by
-    have hMemory : shared.memory = ByteArray.empty := by
-      simp [shared, Compiler.Proofs.YulGeneration.Backends.Native.initialState,
-        Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
-        YulState.initial, EvmYul.Yul.State.sharedState]
+    have hMemorySize : 32 ≤ shared.memory.size := by
+      simpa [shared] using
+        nativeSwitchPostInitFreeMemorySharedState_memory_size_ge_32
+          nativeContract yulTx state.storage slots
     simpa [yulTx, shared, value, shared1, shared2,
       Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256] using
       projectResult_literalReturnHit_eq yulTx state.storage state.events
-        shared markedStore arg hMemory
+        shared markedStore arg hMemorySize
   have hValueNat :
       value.toNat = arg % Compiler.Constants.evmModulus := by
     simp [value,
@@ -35422,7 +39368,9 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_calldataload_aligned
         shared2.accountMap =
           (Compiler.Proofs.YulGeneration.Backends.Native.initialState
             nativeContract yulTx state.storage slots).sharedState.accountMap := by
-      simp [shared2, shared1, shared]
+      simpa [shared2, shared1, shared] using
+        nativeSwitchPostInitFreeMemorySharedState_accountMap
+          nativeContract yulTx state.storage slots
     have hNative :=
       Compiler.Proofs.YulGeneration.Backends.Native.initialState_materializedStorageSlot
         nativeContract yulTx state.storage slots slot hslot'
@@ -35470,8 +39418,8 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_calldataload4_return
         (Backends.nativeSwitchMatchedTempName switchId)
         (EvmYul.UInt256.ofNat 1))
     let shared :=
-      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-        nativeContract yulTx state.storage slots).sharedState
+      Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+        nativeContract yulTx state.storage slots
     let value := Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg
     let shared1 : EvmYul.SharedState .Yul :=
       { shared with
@@ -35511,14 +39459,14 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_calldataload4_return
             state.events ++
               Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
                 (EvmYul.Yul.State.Ok shared2 markedStore) } := by
-    have hMemory : shared.memory = ByteArray.empty := by
-      simp [shared, Compiler.Proofs.YulGeneration.Backends.Native.initialState,
-        Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
-        YulState.initial, EvmYul.Yul.State.sharedState]
+    have hMemorySize : 32 ≤ shared.memory.size := by
+      simpa [shared] using
+        nativeSwitchPostInitFreeMemorySharedState_memory_size_ge_32
+          nativeContract yulTx state.storage slots
     simpa [yulTx, shared, value, shared1, shared2,
       Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256] using
       projectResult_literalReturnHit_eq yulTx state.storage state.events
-        shared markedStore arg hMemory
+        shared markedStore arg hMemorySize
   have hValueNat :
       value.toNat = arg % Compiler.Constants.evmModulus := by
     simp [value,
@@ -35545,7 +39493,9 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_calldataload4_return
         shared2.accountMap =
           (Compiler.Proofs.YulGeneration.Backends.Native.initialState
             nativeContract yulTx state.storage slots).sharedState.accountMap := by
-      simp [shared2, shared1, shared]
+      simpa [shared2, shared1, shared] using
+        nativeSwitchPostInitFreeMemorySharedState_accountMap
+          nativeContract yulTx state.storage slots
     have hNative :=
       Compiler.Proofs.YulGeneration.Backends.Native.initialState_materializedStorageSlot
         nativeContract yulTx state.storage slots slot hslot'
@@ -35614,8 +39564,8 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_s
       (Backends.nativeSwitchMatchedTempName switchId)
       (EvmYul.UInt256.ofNat 1))
   let shared :=
-    (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-      nativeContract yulTx state.storage slots).sharedState
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+      nativeContract yulTx state.storage slots
   let p := shared.sload (EvmYul.UInt256.ofNat 0)
   let shared1 : EvmYul.SharedState .Yul := { shared with toState := p.1 }
   let shared2 : EvmYul.SharedState .Yul :=
@@ -35650,7 +39600,8 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_s
         nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
             suffix.length + 10 =
           nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
-            suffix.length + 1 + 9 by omega]
+            suffix.length + 1 + 9 by
+        rw [show (10 : Nat) = 1 + 9 by rfl]]
     simpa [shared, p, shared1, shared2, shared3, haltState] using hExec
   · simpa [switchId, yulTx, slots, markedStore, shared, p, shared1, shared2,
       shared3, haltState, nativeYul] using
@@ -35727,8 +39678,8 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_zeroParam
       (Backends.nativeSwitchMatchedTempName switchId)
       (EvmYul.UInt256.ofNat 1))
   let shared :=
-    (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-      nativeContract yulTx state.storage slots).sharedState
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+      nativeContract yulTx state.storage slots
   let p := shared.sload (EvmYul.UInt256.ofNat 0)
   let shared1 : EvmYul.SharedState .Yul := { shared with toState := p.1 }
   let shared2 : EvmYul.SharedState .Yul :=
@@ -35748,12 +39699,19 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_zeroParam
   refine ⟨haltState, ⟨1⟩, nativeYul, ?_, rfl, ?_⟩
   · intro _pre suffix
     have hSize : shared.executionEnv.calldata.size < EvmYul.UInt256.size := by
-      simpa [shared, yulTx,
-        Compiler.Proofs.YulGeneration.Backends.StateBridge.calldataToByteArray_size]
-        using hNoWrap
+      rw [show shared.executionEnv.calldata.size =
+          4 + yulTx.args.length * 32 by
+        simpa [shared] using
+          nativeSwitchPostInitFreeMemorySharedState_calldata_size
+            nativeContract yulTx state.storage slots]
+      simpa [yulTx, YulTransaction.ofIR_args] using hNoWrap
     have hGe : 4 ≤ shared.executionEnv.calldata.size := by
-      simp [shared, yulTx,
-        Compiler.Proofs.YulGeneration.Backends.StateBridge.calldataToByteArray_size]
+      rw [show shared.executionEnv.calldata.size =
+          4 + yulTx.args.length * 32 by
+        simpa [shared] using
+          nativeSwitchPostInitFreeMemorySharedState_calldata_size
+            nativeContract yulTx state.storage slots]
+      exact Nat.le_add_right 4 _
     have hExec :=
       exec_block_loweredZeroParamSload0ReturnCaseBody_closed
         (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
@@ -35822,8 +39780,8 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_l
       (Backends.nativeSwitchMatchedTempName switchId)
       (EvmYul.UInt256.ofNat 1))
   let shared :=
-    (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-      nativeContract yulTx state.storage slots).sharedState
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+      nativeContract yulTx state.storage slots
   let shared1 : EvmYul.SharedState .Yul :=
     { shared with
       toMachineState :=
@@ -35850,7 +39808,8 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_l
         nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
             suffix.length + 10 =
           nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
-            suffix.length + 2 + 8 by omega]
+            suffix.length + 2 + 8 by
+        rw [show (10 : Nat) = 2 + 8 by rfl]]
     simpa [shared, shared1, shared2, haltState] using hExec
   · simpa [switchId, yulTx, slots, markedStore, shared, shared1, shared2,
       haltState, nativeYul] using
@@ -35928,8 +39887,8 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_zeroParam
       (Backends.nativeSwitchMatchedTempName switchId)
       (EvmYul.UInt256.ofNat 1))
   let shared :=
-    (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-      nativeContract yulTx state.storage slots).sharedState
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+      nativeContract yulTx state.storage slots
   let shared1 : EvmYul.SharedState .Yul :=
     { shared with
       toMachineState :=
@@ -35948,12 +39907,19 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_zeroParam
   refine ⟨haltState, ⟨1⟩, nativeYul, ?_, rfl, ?_⟩
   · intro _pre suffix
     have hSize : shared.executionEnv.calldata.size < EvmYul.UInt256.size := by
-      simpa [shared, yulTx,
-        Compiler.Proofs.YulGeneration.Backends.StateBridge.calldataToByteArray_size]
-        using hNoWrap
+      rw [show shared.executionEnv.calldata.size =
+          4 + yulTx.args.length * 32 by
+        simpa [shared] using
+          nativeSwitchPostInitFreeMemorySharedState_calldata_size
+            nativeContract yulTx state.storage slots]
+      simpa [yulTx, YulTransaction.ofIR_args] using hNoWrap
     have hGe : 4 ≤ shared.executionEnv.calldata.size := by
-      simp [shared, yulTx,
-        Compiler.Proofs.YulGeneration.Backends.StateBridge.calldataToByteArray_size]
+      rw [show shared.executionEnv.calldata.size =
+          4 + yulTx.args.length * 32 by
+        simpa [shared] using
+          nativeSwitchPostInitFreeMemorySharedState_calldata_size
+            nativeContract yulTx state.storage slots]
+      exact Nat.le_add_right 4 _
     have hExec :=
       exec_block_loweredZeroParamLiteralReturnCaseBody_closed
         (nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
@@ -36024,8 +39990,8 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_c
       (Backends.nativeSwitchMatchedTempName switchId)
       (EvmYul.UInt256.ofNat 1))
   let shared :=
-    (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-      nativeContract yulTx state.storage slots).sharedState
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+      nativeContract yulTx state.storage slots
   let value := Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg
   let shared1 : EvmYul.SharedState .Yul :=
     { shared with
@@ -36057,7 +40023,8 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_c
         nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
             suffix.length + 10 =
           nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
-            suffix.length + 1 + 9 by omega]
+            suffix.length + 1 + 9 by
+        rw [show (10 : Nat) = 1 + 9 by rfl]]
     simpa [shared, value, shared1, shared2, haltState] using hExec
   · simpa [switchId, yulTx, slots, markedStore, shared, value, shared1, shared2,
       haltState, nativeYul] using
@@ -36126,8 +40093,8 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_c
       (Backends.nativeSwitchMatchedTempName switchId)
       (EvmYul.UInt256.ofNat 1))
   let shared :=
-    (Compiler.Proofs.YulGeneration.Backends.Native.initialState
-      nativeContract yulTx state.storage slots).sharedState
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
+      nativeContract yulTx state.storage slots
   let value := Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg
   let shared1 : EvmYul.SharedState .Yul :=
     { shared with
@@ -36159,7 +40126,8 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_c
         nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
             suffix.length + 10 =
           nativeGeneratedSelectorHitUserBodyFuel irContract fn cases' +
-            suffix.length + 1 + 9 by omega]
+            suffix.length + 1 + 9 by
+        rw [show (10 : Nat) = 1 + 9 by rfl]]
     simpa [shared, value, shared1, shared2, haltState] using hExec
   · simpa [switchId, yulTx, slots, markedStore, shared, value, shared1, shared2,
       haltState, nativeYul] using
@@ -37176,9 +41144,9 @@ private theorem simpleStorageNativeRetrieveHitMatchBridge_proved
     Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
       (Compiler.runtimeCode simpleStorageIRContract) observableSlots
   let shared :=
-    (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+    Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemorySharedState
       Compiler.SimpleStorageNativeWitness.nativeContract yulTx
-      initialState.storage slots).sharedState
+      initialState.storage slots
   let p := shared.sload (EvmYul.UInt256.ofNat 0)
   let shared1 : EvmYul.SharedState .Yul := { shared with toState := p.1 }
   let shared2 : EvmYul.SharedState .Yul :=
@@ -37226,13 +41194,14 @@ private theorem simpleStorageNativeRetrieveHitMatchBridge_proved
           initialState.events ++
             Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
               (EvmYul.Yul.State.Ok shared3 store) } := by
-    have hMemory : shared.memory = ByteArray.empty := by
-      simp [shared, Compiler.Proofs.YulGeneration.Backends.Native.initialState,
-        Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
-        YulState.initial, EvmYul.Yul.State.sharedState]
+    have hMemorySize : 32 ≤ shared.memory.size := by
+      simpa [shared] using
+        nativeSwitchPostInitFreeMemorySharedState_memory_size_ge_32
+          Compiler.SimpleStorageNativeWitness.nativeContract yulTx
+          initialState.storage slots
     simpa [yulTx, shared, p, shared1, shared2, shared3] using
       projectResult_retrieveHit_eq yulTx initialState.storage initialState.events
-        shared store hMemory
+        shared store hMemorySize
   have hLogs :
       Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
         (EvmYul.Yul.State.Ok shared3 store) = [] := by
@@ -37612,7 +41581,7 @@ expose the public surface this file needs.
   is hypothesis-free).
 - 36 of 36 builtins are bridged, including `mappingSlot` via the shared
   keccak-faithful `abstractMappingSlot` derivation.
-- 0 bridge lemmas use `sorry`; all builtin bridge equivalences are proven.
+- All bridge lemmas are complete; all builtin bridge equivalences are proven.
 - The external-call/function-table family remains outside `BridgedSafeStmts`
   and needs separate simulation work before it can be admitted into the
   safe-body EndToEnd wrapper.

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -850,8 +850,79 @@ theorem lowerRuntimeContractNativeAux_single_stmt_eq_lowerStmtsNativeWithSwitchI
         simp [Bind.bind, Except.bind]
   · exact hNoFunc
 
+/-- A non-`funcDef` runtime statement list lowers exactly through statement
+lowering, preserving the caller's native function table. -/
+theorem lowerRuntimeContractNativeAux_nonFunc_eq_lowerStmtsNativeWithSwitchIds
+    (reservedNames : List String)
+    (stmts : List YulStmt)
+    (dispatcherAcc : List EvmYul.Yul.Ast.Stmt)
+    (functions : Backends.NativeFunctionMap)
+    (nextSwitchId : Nat)
+    (hNoFunc : ∀ stmt, stmt ∈ stmts → ∀ name params rets body,
+      stmt ≠ YulStmt.funcDef name params rets body) :
+    Backends.lowerRuntimeContractNativeAux reservedNames stmts
+        dispatcherAcc functions nextSwitchId =
+      match Backends.lowerStmtsNativeWithSwitchIds reservedNames nextSwitchId stmts with
+      | .ok (dispatcher, nextSwitchId) =>
+          .ok (dispatcherAcc.reverse ++ dispatcher, functions, nextSwitchId)
+      | .error err => .error err := by
+  induction stmts generalizing dispatcherAcc nextSwitchId with
+  | nil =>
+      simp [Backends.lowerRuntimeContractNativeAux, Pure.pure, Except.pure]
+  | cons stmt rest ih =>
+      rw [Backends.lowerRuntimeContractNativeAux_stmt_cons]
+      · rw [Backends.lowerStmtsNativeWithSwitchIds_cons]
+        cases hLower :
+            Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId stmt with
+        | error err =>
+            simp [Bind.bind, Except.bind]
+        | ok pair =>
+            cases pair with
+            | mk lowered nextSwitchId' =>
+                simp [Bind.bind, Except.bind, Pure.pure, Except.pure]
+                rw [ih]
+                · cases hRest :
+                    Backends.lowerStmtsNativeWithSwitchIds reservedNames
+                      nextSwitchId' rest with
+                  | error err =>
+                      simp
+                  | ok pair =>
+                      cases pair with
+                      | mk restLowered finalSwitchId =>
+                          simp [List.reverse_append, List.append_assoc]
+                · intro stmt hmem
+                  exact hNoFunc stmt (by simp [hmem])
+      · exact hNoFunc stmt (by simp)
+
+/-- A non-`funcDef` runtime statement list lowers exactly through statement
+lowering, with an empty native function table. -/
+theorem lowerRuntimeContractNative_nonFunc_eq_lowerStmtsNative
+    (stmts : List YulStmt)
+    (hNoFunc : ∀ stmt, stmt ∈ stmts → ∀ name params rets body,
+      stmt ≠ YulStmt.funcDef name params rets body) :
+    Backends.lowerRuntimeContractNative stmts =
+      match Backends.lowerStmtsNative stmts with
+      | .ok dispatcher =>
+          .ok { dispatcher := .Block dispatcher
+                functions := (∅ : Backends.NativeFunctionMap) }
+      | .error err => .error err := by
+  unfold Backends.lowerRuntimeContractNative
+  unfold Backends.lowerStmtsNative
+  dsimp
+  rw [lowerRuntimeContractNativeAux_nonFunc_eq_lowerStmtsNativeWithSwitchIds
+    (Backends.yulStmtsIdentifierNames stmts) stmts [] (∅ : Backends.NativeFunctionMap)
+    0 hNoFunc]
+  cases hLower :
+      Backends.lowerStmtsNativeWithSwitchIds
+        (Backends.yulStmtsIdentifierNames stmts) 0 stmts with
+  | error err =>
+      simp [hLower, Bind.bind, Except.bind, Pure.pure, Except.pure]
+  | ok pair =>
+      cases pair
+      simp [hLower, Bind.bind, Except.bind, Pure.pure, Except.pure]
+
 /-- Helper-free, no-fallback/no-receive emitted runtimes are exactly the
-single generated dispatcher shell. -/
+generated dispatcher shell prefixed by free-memory-pointer initialization. -/
 theorem emitYul_runtimeCode_eq_single_dispatcher_of_noMapping_noInternals_noFallback_noReceive
     (contract : IRContract)
     (hNoMapping : contract.usesMapping = false)
@@ -859,7 +930,8 @@ theorem emitYul_runtimeCode_eq_single_dispatcher_of_noMapping_noInternals_noFall
     (hNoFallback : contract.fallbackEntrypoint = none)
     (hNoReceive : contract.receiveEntrypoint = none) :
     (Compiler.emitYul contract).runtimeCode =
-      [Compiler.CodegenCommon.buildSwitch contract.functions none none] := by
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch contract.functions none none] := by
   simp [Compiler.emitYul, Compiler.CodegenCommon.emitYul,
     Compiler.CodegenCommon.runtimeCode, hNoMapping, hInternals, hNoFallback,
     hNoReceive]
@@ -874,18 +946,27 @@ theorem lowerRuntimeContractNative_emitYul_noMapping_noInternals_noFallback_noRe
     (hNoReceive : contract.receiveEntrypoint = none) :
     Backends.lowerRuntimeContractNative (Compiler.emitYul contract).runtimeCode =
       match Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch contract.functions none none] with
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch contract.functions none none] with
       | .ok dispatcher =>
           .ok { dispatcher := .Block dispatcher
                 functions := (∅ : Backends.NativeFunctionMap) }
       | .error err => .error err := by
   rw [emitYul_runtimeCode_eq_single_dispatcher_of_noMapping_noInternals_noFallback_noReceive
     contract hNoMapping hInternals hNoFallback hNoReceive]
-  exact lowerRuntimeContractNative_single_stmt_eq_lowerStmtsNative
-    (Compiler.CodegenCommon.buildSwitch contract.functions none none)
+  exact lowerRuntimeContractNative_nonFunc_eq_lowerStmtsNative
+    [Compiler.CodegenCommon.initFreeMemoryPointer,
+      Compiler.CodegenCommon.buildSwitch contract.functions none none]
     (by
-      intro name params rets body h
-      simp [Compiler.CodegenCommon.buildSwitch] at h)
+      intro stmt hmem name params rets body h
+      simp only [List.mem_cons, List.mem_singleton] at hmem
+      rcases hmem with hInit | hSwitch
+      · subst hInit
+        simp [Compiler.CodegenCommon.initFreeMemoryPointer] at h
+      · rcases hSwitch with hSwitch | hNil
+        · subst hSwitch
+          simp [Compiler.CodegenCommon.buildSwitch] at h
+        · cases hNil)
 
 /-- If helper-free emitted runtime lowering succeeds, the successful contract is
 exactly the native dispatcher shell produced by lowering the generated
@@ -902,7 +983,8 @@ theorem lowerRuntimeContractNative_emitYul_noMapping_ok_dispatcher
         .ok nativeContract) :
     ∃ dispatcher : List EvmYul.Yul.Ast.Stmt,
       Backends.lowerStmtsNative
-          [Compiler.CodegenCommon.buildSwitch contract.functions none none] =
+          [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch contract.functions none none] =
         .ok dispatcher ∧
       nativeContract =
         { dispatcher := .Block dispatcher
@@ -911,7 +993,8 @@ theorem lowerRuntimeContractNative_emitYul_noMapping_ok_dispatcher
     contract hNoMapping hInternals hNoFallback hNoReceive] at hLower
   cases hDispatcher :
       Backends.lowerStmtsNative
-        [Compiler.CodegenCommon.buildSwitch contract.functions none none] with
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch contract.functions none none] with
   | ok dispatcher =>
       rw [hDispatcher] at hLower
       simp only [Except.ok.injEq] at hLower
@@ -1991,12 +2074,19 @@ theorem generatedRuntimeDispatcherHasNoFuncDefs_runtimeCode_noFallback_noReceive
   simp [hNoFallback, hNoReceive]
   rw [← List.append_assoc]
   change generatedRuntimeDispatcherHasNoFuncDefs
-      (runtimePrefix ++ [Compiler.CodegenCommon.buildSwitch contract.functions none none]) =
+      (runtimePrefix ++ [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch contract.functions none none]) =
     true
   rw [generatedRuntimeDispatcherHasNoFuncDefs_funcDef_prefix_append runtimePrefix
-    [Compiler.CodegenCommon.buildSwitch contract.functions none none] hPrefix]
-  exact generatedRuntimeDispatcherHasNoFuncDefs_buildSwitch_noFallback_noReceive
-    contract.functions hBodies
+    [Compiler.CodegenCommon.initFreeMemoryPointer,
+      Compiler.CodegenCommon.buildSwitch contract.functions none none] hPrefix]
+  rw [generatedRuntimeDispatcherHasNoFuncDefs_nonFunc_cons]
+  · simp [Compiler.CodegenCommon.initFreeMemoryPointer,
+      yulStmtContainsFuncDef,
+      generatedRuntimeDispatcherHasNoFuncDefs_buildSwitch_noFallback_noReceive
+        contract.functions hBodies]
+  · intro name params rets body h
+    simp [Compiler.CodegenCommon.initFreeMemoryPointer] at h
 
 theorem generatedRuntimeDispatcherHasNoFuncDefs_emitYul_runtimeCode_noFallback_noReceive
     (contract : IRContract)
@@ -2036,6 +2126,27 @@ theorem generatedRuntimeFunctionNamesUnique_buildSwitch_append
   cases fallback <;> cases receive <;>
     simp [Compiler.CodegenCommon.buildSwitch] at h
 
+theorem generatedRuntimeFunctionNamesUnique_initFreeMemoryPointer_buildSwitch_append
+    (funcPrefix : List YulStmt)
+    (funcs : List IRFunction)
+    (fallback : Option IREntrypoint)
+    (receive : Option IREntrypoint) :
+    generatedRuntimeFunctionNamesUnique
+      (funcPrefix ++ [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch funcs fallback receive]) =
+      generatedRuntimeFunctionNamesUnique funcPrefix := by
+  apply generatedRuntimeFunctionNamesUnique_append_nonFunc_suffix
+  intro stmt hmem name params rets body h
+  simp only [List.mem_cons, List.mem_singleton] at hmem
+  rcases hmem with hInit | hSwitch
+  · subst hInit
+    simp [Compiler.CodegenCommon.initFreeMemoryPointer] at h
+  · rcases hSwitch with hSwitch | hNil
+    · subst hSwitch
+      cases fallback <;> cases receive <;>
+        simp [Compiler.CodegenCommon.buildSwitch] at h
+    · cases hNil
+
 theorem generatedRuntimeFunctionNamesUnique_runtimeCode
     (contract : IRContract)
     (hPrefixUnique : generatedRuntimeFunctionNamesUnique
@@ -2047,9 +2158,10 @@ theorem generatedRuntimeFunctionNamesUnique_runtimeCode
       contract.internalFunctions
   rw [Compiler.runtimeCode, Compiler.CodegenCommon.runtimeCode]
   change generatedRuntimeFunctionNamesUnique
-      (runtimePrefix ++ [Compiler.CodegenCommon.buildSwitch contract.functions
+      (runtimePrefix ++ [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch contract.functions
         contract.fallbackEntrypoint contract.receiveEntrypoint]) = true
-  rw [generatedRuntimeFunctionNamesUnique_buildSwitch_append]
+  rw [generatedRuntimeFunctionNamesUnique_initFreeMemoryPointer_buildSwitch_append]
   exact hPrefixUnique
 
 theorem generatedRuntimeFunctionNamesUnique_emitYul_runtimeCode
@@ -2147,7 +2259,8 @@ theorem lowerRuntimeContractNative_emitYul_mapping_noInternals_noFallback_noRece
       match Backends.lowerStmtsNativeWithSwitchIds
           (Backends.yulStmtsIdentifierNames
             (Compiler.emitYul contract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch contract.functions none none] with
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch contract.functions none none] with
       | .ok (dispatcher, _) =>
           .ok { dispatcher := .Block dispatcher
                 functions := ((∅ : Backends.NativeFunctionMap).insert
@@ -2161,9 +2274,34 @@ theorem lowerRuntimeContractNative_emitYul_mapping_noInternals_noFallback_noRece
   simp only [Compiler.CodegenCommon.mappingSlotFuncAt]
   rw [Backends.lowerRuntimeContractNativeAux_funcDef_cons_empty_of_lowerFunctionDefinition
     (definition := nativeMappingSlotFunctionDefinition)]
-  · rw [lowerRuntimeContractNativeAux_single_stmt_eq_lowerStmtsNativeWithSwitchIds]
-    intro name params rets body h
-    simp [Compiler.CodegenCommon.buildSwitch] at h
+  · rw [lowerRuntimeContractNativeAux_nonFunc_eq_lowerStmtsNativeWithSwitchIds]
+    · cases hLower :
+        Backends.lowerStmtsNativeWithSwitchIds
+        (Backends.yulStmtsIdentifierNames
+          [YulStmt.funcDef "mappingSlot" ["baseSlot", "key"] ["slot"]
+              [YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.ident "key"]),
+                YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 32, YulExpr.ident "baseSlot"]),
+                YulStmt.assign "slot" (YulExpr.call "keccak256" [YulExpr.lit 0, YulExpr.lit 64])],
+            Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch contract.functions none none])
+        0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch contract.functions none none] with
+      | error err =>
+          simp [hLower, Functor.map, Except.map, Bind.bind, Except.bind,
+            Pure.pure, Except.pure]
+      | ok pair =>
+          cases pair
+          simp [hLower, Functor.map, Except.map, Bind.bind, Except.bind,
+            Pure.pure, Except.pure]
+    · intro stmt hmem name params rets body h
+      simp only [List.mem_cons, List.mem_singleton] at hmem
+      rcases hmem with hInit | hSwitch
+      · subst hInit
+        simp [Compiler.CodegenCommon.initFreeMemoryPointer] at h
+      · rcases hSwitch with hSwitch | hNil
+        · subst hSwitch
+          simp [Compiler.CodegenCommon.buildSwitch] at h
+        · cases hNil
   · exact lowerFunctionDefinitionNativeWithReserved_mappingSlotFuncAt_zero_body _
 
 /-- If mapping-helper emitted runtime lowering succeeds, the successful
@@ -2183,7 +2321,8 @@ theorem lowerRuntimeContractNative_emitYul_mapping_ok_dispatcher_reserved
       Backends.lowerStmtsNativeWithSwitchIds
           (Backends.yulStmtsIdentifierNames
             (Compiler.emitYul contract).runtimeCode)
-          0 [Compiler.CodegenCommon.buildSwitch contract.functions none none] =
+          0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+            Compiler.CodegenCommon.buildSwitch contract.functions none none] =
         .ok (dispatcher, nextSwitchId) ∧
       nativeContract =
         { dispatcher := .Block dispatcher
@@ -2194,7 +2333,8 @@ theorem lowerRuntimeContractNative_emitYul_mapping_ok_dispatcher_reserved
   cases hDispatcher :
       Backends.lowerStmtsNativeWithSwitchIds
         (Backends.yulStmtsIdentifierNames (Compiler.emitYul contract).runtimeCode)
-        0 [Compiler.CodegenCommon.buildSwitch contract.functions none none] with
+        0 [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch contract.functions none none] with
   | ok pair =>
       rcases pair with ⟨dispatcher, nextSwitchId⟩
       rw [hDispatcher] at hLower
@@ -2250,6 +2390,19 @@ theorem generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_buildSwitch
     (Compiler.CodegenCommon.buildSwitch funcs fallback receive) [] hNoFunc]
   rfl
 
+theorem generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_initFreeMemoryPointer_buildSwitch
+    (funcs : List IRFunction)
+    (fallback : Option IREntrypoint)
+    (receive : Option IREntrypoint) :
+    generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch funcs fallback receive] = true := by
+  rw [generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_nonFunc_cons]
+  · exact generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_buildSwitch
+      funcs fallback receive
+  · intro name params rets body h
+    simp [Compiler.CodegenCommon.initFreeMemoryPointer] at h
+
 theorem generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_runtimeCode
     (contract : IRContract)
     (hInternalBodies : ∀ name params rets body,
@@ -2272,24 +2425,28 @@ theorem generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_runtimeCode
       contract.internalFunctions hInternalBodies
   have hSwitch :
       generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs
-        [Compiler.CodegenCommon.buildSwitch contract.functions
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch contract.functions
           contract.fallbackEntrypoint contract.receiveEntrypoint] = true :=
-    generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_buildSwitch
+    generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_initFreeMemoryPointer_buildSwitch
       contract.functions contract.fallbackEntrypoint contract.receiveEntrypoint
   rw [Compiler.runtimeCode, Compiler.CodegenCommon.runtimeCode]
   change generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs
       (mapping ++ contract.internalFunctions ++
-        [Compiler.CodegenCommon.buildSwitch contract.functions
+        [Compiler.CodegenCommon.initFreeMemoryPointer,
+          Compiler.CodegenCommon.buildSwitch contract.functions
           contract.fallbackEntrypoint contract.receiveEntrypoint]) = true
   rw [List.append_assoc]
   exact generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_append
     mapping (contract.internalFunctions ++
-      [Compiler.CodegenCommon.buildSwitch contract.functions
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch contract.functions
         contract.fallbackEntrypoint contract.receiveEntrypoint])
     hMapping
     (generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_append
       contract.internalFunctions
-      [Compiler.CodegenCommon.buildSwitch contract.functions
+      [Compiler.CodegenCommon.initFreeMemoryPointer,
+        Compiler.CodegenCommon.buildSwitch contract.functions
         contract.fallbackEntrypoint contract.receiveEntrypoint]
       hInternals hSwitch)
 
@@ -7731,6 +7888,188 @@ def nativeSwitchInitialOkState
     EvmYul.Yul.State :=
   .Ok (initialState contract tx storage observableSlots).sharedState ∅
 
+def nativeSwitchPostInitFreeMemorySharedState
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat) :
+    EvmYul.SharedState .Yul :=
+  { (initialState contract tx storage observableSlots).sharedState with
+    toMachineState :=
+      (initialState contract tx storage observableSlots).sharedState.toMachineState.mstore
+        (EvmYul.UInt256.ofNat Compiler.Constants.freeMemoryPointer)
+        (EvmYul.UInt256.ofNat 128) }
+
+def nativeSwitchPostInitFreeMemoryState
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat)
+    (store : EvmYul.Yul.VarStore) :
+    EvmYul.Yul.State :=
+  .Ok (nativeSwitchPostInitFreeMemorySharedState contract tx storage observableSlots)
+    store
+
+/-- Execute the exact generated `initFreeMemoryPointer` native statement from
+    a generated-runtime dispatcher initial state. This is deliberately narrow:
+    it records only the concrete memory update performed by
+    `mstore(freeMemoryPointer, 128)`. -/
+theorem exec_initFreeMemoryPointer_head_ok
+    (fuel : Nat)
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat) :
+    EvmYul.Yul.exec (fuel + 6)
+      (.ExprStmtCall
+        (Backends.lowerExprNative
+          (Yul.YulExpr.call "mstore"
+            [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+              Yul.YulExpr.lit 128])))
+      (some contract)
+      (nativeSwitchInitialOkState contract tx storage observableSlots) =
+    .ok (nativeSwitchPostInitFreeMemoryState contract tx storage
+      observableSlots ∅) := by
+  simpa [nativeSwitchInitialOkState] using
+    (exec_lowerExprNative_mstore_lit_lit_ok_fuel
+      fuel
+      (initialState contract tx storage observableSlots).sharedState
+      (∅ : EvmYul.Yul.VarStore)
+      (some contract)
+      Compiler.Constants.freeMemoryPointer 128)
+
+/-- Peel the exact generated `initFreeMemoryPointer` head from a dispatcher
+    block, exposing the residual dispatcher execution on the concrete
+    post-`mstore(freeMemoryPointer, 128)` state. -/
+theorem exec_block_cons_initFreeMemoryPointer_eq
+    (fuel : Nat)
+    (rest : List EvmYul.Yul.Ast.Stmt)
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat) :
+    EvmYul.Yul.exec (Nat.succ (fuel + 6))
+      (.Block
+        (.ExprStmtCall
+          (Backends.lowerExprNative
+            (Yul.YulExpr.call "mstore"
+              [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+                Yul.YulExpr.lit 128])) :: rest))
+      (some contract)
+      (nativeSwitchInitialOkState contract tx storage observableSlots) =
+    EvmYul.Yul.exec (fuel + 6) (.Block rest) (some contract)
+      (nativeSwitchPostInitFreeMemoryState contract tx storage
+        observableSlots ∅) :=
+  exec_block_cons_ok_eq (fuel + 6)
+    (.ExprStmtCall
+      (Backends.lowerExprNative
+        (Yul.YulExpr.call "mstore"
+          [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+            Yul.YulExpr.lit 128])))
+    rest (some contract)
+    (nativeSwitchInitialOkState contract tx storage observableSlots)
+    (nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots ∅)
+    (exec_initFreeMemoryPointer_head_ok fuel contract tx storage observableSlots)
+
+/-- Post-generated-init variant of
+    `exec_let_lowerExprNative_selectorExpr_initialState_store_ok_fuel`.
+    The `initFreeMemoryPointer` head only writes EVM memory, so the generated
+    selector expression still decodes the same calldata selector while
+    preserving the explicit varstore. -/
+theorem exec_let_lowerExprNative_selectorExpr_postInitFreeMemory_store_ok_fuel
+    (fuel : Nat)
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat)
+    (store : EvmYul.Yul.VarStore)
+    (discrName : EvmYul.Identifier) :
+    EvmYul.Yul.exec (fuel + 11)
+        (.Let [discrName]
+          (some (Backends.lowerExprNative Compiler.Proofs.YulGeneration.selectorExpr)))
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+          store) =
+      .ok ((nativeSwitchPostInitFreeMemoryState contract tx storage
+          observableSlots store).insert discrName
+        (EvmYul.UInt256.ofNat
+          (tx.functionSelector % Compiler.Constants.selectorModulus))) := by
+  have hv :=
+    initialState_selectorExpr_native_uint256 contract tx storage observableSlots
+  have hv224 :
+      EvmYul.UInt256.shiftRight
+        (EvmYul.State.calldataload
+          (EvmYul.SharedState.toState
+            (nativeSwitchPostInitFreeMemorySharedState contract tx storage
+              observableSlots))
+          (EvmYul.UInt256.ofNat 0))
+        (EvmYul.UInt256.ofNat 224) =
+      EvmYul.UInt256.ofNat
+        (tx.functionSelector % Compiler.Constants.selectorModulus) := by
+    simpa [nativeSwitchPostInitFreeMemorySharedState,
+      Compiler.Constants.selectorShift, EvmYul.SharedState.toState,
+      EvmYul.Yul.State.toMachineState] using hv
+  rw [lowerExprNative_selectorExpr]
+  simp [nativeSwitchPostInitFreeMemoryState, EvmYul.Yul.exec,
+    EvmYul.Yul.eval, EvmYul.Yul.evalArgs, EvmYul.Yul.evalTail,
+    EvmYul.Yul.evalPrimCall, EvmYul.Yul.execPrimCall, EvmYul.Yul.reverse',
+    EvmYul.Yul.cons', EvmYul.Yul.head', EvmYul.Yul.multifill',
+    EvmYul.Yul.State.multifill, Compiler.Constants.selectorShift]
+  rw [hv224]
+
+/-- Post-generated-init variant of the `__has_selector` binding. The generated
+    init head only changes memory, leaving calldata size unchanged. -/
+theorem exec_let_lowerExprNative_iszero_lt_calldatasize_4_postInitFreeMemory_store_ok_fuel
+    (fuel : Nat)
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat)
+    (store : EvmYul.Yul.VarStore)
+    (name : EvmYul.Identifier)
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
+    EvmYul.Yul.exec (fuel + 11)
+        (.Let [name]
+          (some (Backends.lowerExprNative
+            (Yul.YulExpr.call "iszero"
+              [Yul.YulExpr.call "lt"
+                [Yul.YulExpr.call "calldatasize" [],
+                 Yul.YulExpr.lit 4]]))))
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+          store) =
+      .ok ((nativeSwitchPostInitFreeMemoryState contract tx storage
+          observableSlots store).insert name (EvmYul.UInt256.ofNat 1)) := by
+  change EvmYul.Yul.exec (fuel + 11)
+        (.Let [name]
+          (some (Backends.lowerExprNative
+            (Yul.YulExpr.call "iszero"
+              [Yul.YulExpr.call "lt"
+                [Yul.YulExpr.call "calldatasize" [],
+                 Yul.YulExpr.lit 4]]))))
+        (some contract)
+        (.Ok (nativeSwitchPostInitFreeMemorySharedState contract tx storage
+          observableSlots) store) =
+      .ok (((.Ok (nativeSwitchPostInitFreeMemorySharedState contract tx storage
+          observableSlots) store : EvmYul.Yul.State).insert name
+        (EvmYul.UInt256.ofNat 1)))
+  rw [exec_let_lowerExprNative_iszero_lt_calldatasize_4_ok_fuel]
+  simp [nativeSwitchPostInitFreeMemoryState,
+    nativeSwitchPostInitFreeMemorySharedState, calldataToByteArray_size,
+    uint256_lt_ofNat_4_eq_zero_of_ge _ (by omega) hNoWrap,
+    uint256_isZero_ofNat_zero]
+
+private theorem nativeSwitchPostInitFreeMemoryState_insert_lookup_self
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (store : EvmYul.Yul.VarStore)
+    (name : EvmYul.Identifier) (value : EvmYul.UInt256) :
+    ((nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+        store).insert name value)[name]! = value := by
+  simp [nativeSwitchPostInitFreeMemoryState, EvmYul.Yul.State.insert,
+    GetElem?.getElem!, decidableGetElem?, GetElem.getElem,
+    EvmYul.Yul.State.store, EvmYul.Yul.State.lookup!]
+
 def nativeSwitchPrefixFinalState
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
@@ -7862,6 +8201,54 @@ theorem exec_nativeSwitchPrefix_selector_initialState_store_ok_fuel
       [.Let [matchedName] (some (.Lit (EvmYul.UInt256.ofNat 0)))]
       (some contract) initState discrState matchedState
   · exact exec_let_lowerExprNative_selectorExpr_initialState_store_ok_fuel
+      fuel contract tx storage observableSlots store discrName
+  · have hFuelTail : fuel + 11 = Nat.succ (fuel + 10) := by omega
+    rw [hFuelTail]
+    apply exec_block_cons_ok (fuel + 10)
+        (.Let [matchedName] (some (.Lit (EvmYul.UInt256.ofNat 0))))
+        [] (some contract) discrState matchedState matchedState
+    · simp [matchedState]
+    · simp [EvmYul.Yul.exec]
+
+/-- Post-generated-init variant of
+    `exec_nativeSwitchPrefix_selector_initialState_store_ok_fuel`. The native
+    switch prefix reads the calldata selector and writes only the two generated
+    switch temporaries, so it can start from the exact state produced by
+    `initFreeMemoryPointer`. -/
+theorem exec_nativeSwitchPrefix_selector_postInitFreeMemory_store_ok_fuel
+    (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (store : EvmYul.Yul.VarStore)
+    (discrName matchedName : EvmYul.Identifier) :
+    EvmYul.Yul.exec (fuel + 12)
+      (.Block (nativeSwitchPrefixStmts discrName matchedName))
+      (some contract)
+      (nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+        store) =
+    .ok (((nativeSwitchPostInitFreeMemoryState contract tx storage
+            observableSlots store).insert discrName
+            (EvmYul.UInt256.ofNat
+              (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+          matchedName (EvmYul.UInt256.ofNat 0)) := by
+  let initState : EvmYul.Yul.State :=
+    nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots store
+  let discrState : EvmYul.Yul.State :=
+    initState.insert discrName
+      (EvmYul.UInt256.ofNat
+        (tx.functionSelector % Compiler.Constants.selectorModulus))
+  let matchedState : EvmYul.Yul.State :=
+    discrState.insert matchedName (EvmYul.UInt256.ofNat 0)
+  change EvmYul.Yul.exec (fuel + 12)
+      (.Block (nativeSwitchPrefixStmts discrName matchedName))
+      (some contract) initState = .ok matchedState
+  have hFuel : fuel + 12 = Nat.succ (fuel + 11) := by omega
+  rw [hFuel, nativeSwitchPrefixStmts]
+  apply exec_block_cons_ok (fuel + 11)
+      (.Let [discrName]
+        (some (Backends.lowerExprNative Compiler.Proofs.YulGeneration.selectorExpr)))
+      [.Let [matchedName] (some (.Lit (EvmYul.UInt256.ofNat 0)))]
+      (some contract) initState discrState matchedState
+  · exact exec_let_lowerExprNative_selectorExpr_postInitFreeMemory_store_ok_fuel
       fuel contract tx storage observableSlots store discrName
   · have hFuelTail : fuel + 11 = Nat.succ (fuel + 10) := by omega
     rw [hFuelTail]
@@ -8276,6 +8663,84 @@ theorem exec_block_letSelector_if1Skip_if2Take_initialState_fuel
         hNoWrap]
   have hLookup := nativeSwitchInitialOkState_insert_lookup_self
     contract tx storage observableSlots selectorName (EvmYul.UInt256.ofNat 1)
+  rw [show fuel + 10 = (fuel + 8) + 2 from rfl,
+      exec_block_singleton_eq (fuel + 8) _ (some contract) _,
+      show fuel + 8 + 1 = (fuel + 7) + 2 from rfl,
+      exec_if_lowerExprNative_ident_one_take_fuel (fuel + 7) if2Body
+        (some contract) _ selectorName hLookup,
+      show fuel + 7 + 1 = fuel + 8 from rfl]
+
+/-- Post-generated-init variant of
+    `exec_block_letSelector_if1Skip_initialState_fuel`. It starts from the
+    explicit state produced by `initFreeMemoryPointer`, preserving the
+    generated memory write while proving the same `__has_selector := 1`
+    transition. -/
+theorem exec_block_letSelector_if1Skip_postInitFreeMemory_fuel
+    (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (store : EvmYul.Yul.VarStore)
+    (selectorName : EvmYul.Identifier) (if1Body tail : List EvmYul.Yul.Ast.Stmt)
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
+    EvmYul.Yul.exec (fuel + 12)
+        (.Block (.Let [selectorName] (some (Backends.lowerExprNative
+            (Yul.YulExpr.call "iszero" [Yul.YulExpr.call "lt"
+              [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit 4]]))) ::
+          .If (Backends.lowerExprNative
+              (Yul.YulExpr.call "iszero" [Yul.YulExpr.ident selectorName]))
+            if1Body ::
+          tail))
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+          store) =
+      EvmYul.Yul.exec (fuel + 10) (.Block tail) (some contract)
+        ((nativeSwitchPostInitFreeMemoryState contract tx storage
+          observableSlots store).insert selectorName (EvmYul.UInt256.ofNat 1)) := by
+  have hLet :=
+    exec_let_lowerExprNative_iszero_lt_calldatasize_4_postInitFreeMemory_store_ok_fuel
+      fuel contract tx storage observableSlots store selectorName hNoWrap
+  have hLookup := nativeSwitchPostInitFreeMemoryState_insert_lookup_self
+    contract tx storage observableSlots store selectorName (EvmYul.UInt256.ofNat 1)
+  have hIfRaw := exec_if_lowerExprNative_iszero_ident_one_skip_fuel
+    (fuel + 1) if1Body (some contract) _ selectorName hLookup
+  have hFuelEq : (fuel + 1) + 9 = fuel + 10 := by omega
+  rw [hFuelEq] at hIfRaw
+  rw [show fuel + 12 = (fuel + 11).succ from rfl,
+      exec_block_cons_ok_eq _ _ _ _ _ _ hLet,
+      show fuel + 11 = (fuel + 10).succ from rfl,
+      exec_block_cons_ok_eq _ _ _ _ _ _ hIfRaw]
+
+/-- Post-generated-init variant of
+    `exec_block_letSelector_if1Skip_if2Take_initialState_fuel`. This is the
+    generated bridge from the init-prefixed runtime into the lazy native switch
+    tail, with the `__has_selector` flag modeled as part of the transition. -/
+theorem exec_block_letSelector_if1Skip_if2Take_postInitFreeMemory_fuel
+    (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (store : EvmYul.Yul.VarStore)
+    (selectorName : EvmYul.Identifier)
+    (if1Body if2Body : List EvmYul.Yul.Ast.Stmt)
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
+    EvmYul.Yul.exec (fuel + 12)
+        (.Block (.Let [selectorName] (some (Backends.lowerExprNative
+            (Yul.YulExpr.call "iszero" [Yul.YulExpr.call "lt"
+              [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit 4]]))) ::
+          .If (Backends.lowerExprNative
+              (Yul.YulExpr.call "iszero" [Yul.YulExpr.ident selectorName]))
+            if1Body ::
+          [.If (Backends.lowerExprNative
+              (Yul.YulExpr.ident selectorName)) if2Body]))
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+          store) =
+      EvmYul.Yul.exec (fuel + 8) (.Block if2Body) (some contract)
+        ((nativeSwitchPostInitFreeMemoryState contract tx storage
+          observableSlots store).insert selectorName (EvmYul.UInt256.ofNat 1)) := by
+  rw [exec_block_letSelector_if1Skip_postInitFreeMemory_fuel fuel contract tx
+        storage observableSlots store selectorName if1Body
+        [.If (Backends.lowerExprNative (Yul.YulExpr.ident selectorName)) if2Body]
+        hNoWrap]
+  have hLookup := nativeSwitchPostInitFreeMemoryState_insert_lookup_self
+    contract tx storage observableSlots store selectorName (EvmYul.UInt256.ofNat 1)
   rw [show fuel + 10 = (fuel + 8) + 2 from rfl,
       exec_block_singleton_eq (fuel + 8) _ (some contract) _,
       show fuel + 8 + 1 = (fuel + 7) + 2 from rfl,
@@ -21694,6 +22159,107 @@ theorem exec_lowerNativeSwitchBlock_storePrefix_tail_error_fuel
         fuel contract tx storage observableSlots store discrName matchedName
   · simpa [prefixState, initState] using hTail
 
+/-- Post-generated-init variant of
+    `exec_lowerNativeSwitchBlock_storePrefix_tail_error_fuel`. This is the
+    exact glue needed after `initFreeMemoryPointer` has updated memory and the
+    generated dispatcher has already bound `__has_selector`. -/
+theorem exec_lowerNativeSwitchBlock_postInitFreeMemory_storePrefix_tail_error_fuel
+    (fuel switchId : Nat)
+    (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
+    (defaultBody : List EvmYul.Yul.Ast.Stmt)
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (store : EvmYul.Yul.VarStore)
+    (err : EvmYul.Yul.Exception)
+    (hTail :
+      EvmYul.Yul.exec (fuel + 10)
+        (.Block (nativeSwitchTailStmts switchId cases defaultBody))
+        (some contract)
+        (((nativeSwitchPostInitFreeMemoryState contract tx storage
+              observableSlots store).insert
+              (Backends.nativeSwitchDiscrTempName switchId)
+              (EvmYul.UInt256.ofNat
+                (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+            (Backends.nativeSwitchMatchedTempName switchId)
+            (EvmYul.UInt256.ofNat 0)) =
+        .error err) :
+    EvmYul.Yul.exec (fuel + 12)
+      (Backends.lowerNativeSwitchBlock
+        Compiler.Proofs.YulGeneration.selectorExpr switchId cases defaultBody)
+      (some contract)
+      (nativeSwitchPostInitFreeMemoryState contract tx storage
+        observableSlots store) =
+    .error err := by
+  let discrName := Backends.nativeSwitchDiscrTempName switchId
+  let matchedName := Backends.nativeSwitchMatchedTempName switchId
+  let initState : EvmYul.Yul.State :=
+    nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots store
+  let prefixState : EvmYul.Yul.State :=
+    (initState.insert discrName
+      (EvmYul.UInt256.ofNat
+        (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+      matchedName (EvmYul.UInt256.ofNat 0)
+  rw [lowerNativeSwitchBlock_selectorExpr_eq_nativeSwitchParts]
+  apply exec_block_append_error (fuel + 10) 0
+    (nativeSwitchPrefixStmts discrName matchedName)
+    (nativeSwitchTailStmts switchId cases defaultBody)
+    (some contract) initState prefixState err
+  · simpa [nativeSwitchPrefixStmts, prefixState, initState, Nat.add_assoc,
+      Nat.add_comm, Nat.add_left_comm] using
+      exec_nativeSwitchPrefix_selector_postInitFreeMemory_store_ok_fuel
+        fuel contract tx storage observableSlots store discrName matchedName
+  · simpa [prefixState, initState, discrName, matchedName] using hTail
+
+/-- Post-generated-init prefix-then-tail-success glue for
+    `lowerNativeSwitchBlock`. This is the success companion to
+    `exec_lowerNativeSwitchBlock_postInitFreeMemory_storePrefix_tail_error_fuel`. -/
+theorem exec_lowerNativeSwitchBlock_postInitFreeMemory_storePrefix_tail_ok_fuel
+    (fuel switchId : Nat)
+    (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
+    (defaultBody : List EvmYul.Yul.Ast.Stmt)
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (store : EvmYul.Yul.VarStore)
+    (final : EvmYul.Yul.State)
+    (hTail :
+      EvmYul.Yul.exec (fuel + 10)
+        (.Block (nativeSwitchTailStmts switchId cases defaultBody))
+        (some contract)
+        (((nativeSwitchPostInitFreeMemoryState contract tx storage
+              observableSlots store).insert
+              (Backends.nativeSwitchDiscrTempName switchId)
+              (EvmYul.UInt256.ofNat
+                (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+            (Backends.nativeSwitchMatchedTempName switchId)
+            (EvmYul.UInt256.ofNat 0)) =
+        .ok final) :
+    EvmYul.Yul.exec (fuel + 12)
+      (Backends.lowerNativeSwitchBlock
+        Compiler.Proofs.YulGeneration.selectorExpr switchId cases defaultBody)
+      (some contract)
+      (nativeSwitchPostInitFreeMemoryState contract tx storage
+        observableSlots store) =
+    .ok final := by
+  let discrName := Backends.nativeSwitchDiscrTempName switchId
+  let matchedName := Backends.nativeSwitchMatchedTempName switchId
+  let initState : EvmYul.Yul.State :=
+    nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots store
+  let prefixState : EvmYul.Yul.State :=
+    (initState.insert discrName
+      (EvmYul.UInt256.ofNat
+        (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+      matchedName (EvmYul.UInt256.ofNat 0)
+  rw [lowerNativeSwitchBlock_selectorExpr_eq_nativeSwitchParts]
+  apply exec_block_append_ok (fuel + 10) 0
+    (nativeSwitchPrefixStmts discrName matchedName)
+    (nativeSwitchTailStmts switchId cases defaultBody)
+    (some contract) initState prefixState final
+  · simpa [nativeSwitchPrefixStmts, prefixState, initState, Nat.add_assoc,
+      Nat.add_comm, Nat.add_left_comm] using
+      exec_nativeSwitchPrefix_selector_postInitFreeMemory_store_ok_fuel
+        fuel contract tx storage observableSlots store discrName matchedName
+  · simpa [prefixState, initState, discrName, matchedName] using hTail
+
 def nativeSwitchStoreInitialState
     (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
     (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
@@ -21718,6 +22284,25 @@ def nativeSwitchStoreMarkedPrefixStateForId
     switchId store).insert
     (Backends.nativeSwitchMatchedTempName switchId) (EvmYul.UInt256.ofNat 1)
 
+def nativeSwitchPostInitFreeMemoryStorePrefixStateForId
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (switchId : Nat) (store : EvmYul.Yul.VarStore) : EvmYul.Yul.State :=
+  ((nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+      store).insert
+      (Backends.nativeSwitchDiscrTempName switchId)
+      (EvmYul.UInt256.ofNat
+        (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+    (Backends.nativeSwitchMatchedTempName switchId) (EvmYul.UInt256.ofNat 0)
+
+def nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (switchId : Nat) (store : EvmYul.Yul.VarStore) : EvmYul.Yul.State :=
+  (nativeSwitchPostInitFreeMemoryStorePrefixStateForId contract tx storage
+    observableSlots switchId store).insert
+    (Backends.nativeSwitchMatchedTempName switchId) (EvmYul.UInt256.ofNat 1)
+
 theorem nativeSwitchStoreMarkedPrefixStateForId_reviveJump_eq
     (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
     (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
@@ -21728,6 +22313,19 @@ theorem nativeSwitchStoreMarkedPrefixStateForId_reviveJump_eq
         switchId store := by
   simp [nativeSwitchStoreMarkedPrefixStateForId,
     nativeSwitchStorePrefixStateForId, nativeSwitchStoreInitialState,
+    EvmYul.Yul.State.insert, EvmYul.Yul.State.reviveJump]
+
+theorem nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_reviveJump_eq
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (switchId : Nat) (store : EvmYul.Yul.VarStore) :
+    (nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+      storage observableSlots switchId store).reviveJump =
+      nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+        storage observableSlots switchId store := by
+  simp [nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+    nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+    nativeSwitchPostInitFreeMemoryState,
     EvmYul.Yul.State.insert, EvmYul.Yul.State.reviveJump]
 
 @[simp] theorem nativeSwitchStoreMarkedPrefixStateForId_weiValue
@@ -21769,6 +22367,58 @@ theorem nativeSwitchStoreMarkedPrefixStateForId_reviveJump_eq
     nativeSwitchStorePrefixStateForId, nativeSwitchStoreInitialState] using
     state_getElem_insert_self_ok
       (initialState contract tx storage observableSlots).sharedState
+      ((store.insert (Backends.nativeSwitchDiscrTempName switchId)
+        (EvmYul.UInt256.ofNat
+          (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+        (Backends.nativeSwitchMatchedTempName switchId)
+        (EvmYul.UInt256.ofNat 0))
+      (Backends.nativeSwitchMatchedTempName switchId) (EvmYul.UInt256.ofNat 1)
+
+@[simp] theorem nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_weiValue
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (switchId : Nat) (store : EvmYul.Yul.VarStore) :
+    (nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+      storage observableSlots switchId store).sharedState.executionEnv.weiValue =
+      natToUInt256 tx.msgValue := by
+  simp [nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+    nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+    nativeSwitchPostInitFreeMemoryState,
+    nativeSwitchPostInitFreeMemorySharedState, initialState,
+    EvmYul.Yul.State.sharedState, EvmYul.Yul.State.insert, YulState.initial,
+    toSharedState, mkBlockHeader]
+
+@[simp] theorem nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_calldata_size
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (switchId : Nat) (store : EvmYul.Yul.VarStore) :
+    (nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+      storage observableSlots switchId store).sharedState.executionEnv.calldata.size =
+      4 + tx.args.length * 32 := by
+  simp [nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+    nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+    nativeSwitchPostInitFreeMemoryState,
+    nativeSwitchPostInitFreeMemorySharedState, initialState,
+    EvmYul.Yul.State.sharedState, EvmYul.Yul.State.insert, YulState.initial,
+    toSharedState, mkBlockHeader, calldataToByteArray_size]
+
+@[simp] theorem nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (switchId : Nat) (store : EvmYul.Yul.VarStore) :
+    ∀ matchedName : EvmYul.Identifier,
+      matchedName = Backends.nativeSwitchMatchedTempName switchId →
+        (nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+          storage observableSlots switchId store)[matchedName]! =
+          EvmYul.UInt256.ofNat 1 := by
+  intro matchedName hMatchedName
+  subst matchedName
+  simpa [nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+    nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+    nativeSwitchPostInitFreeMemoryState] using
+    state_getElem_insert_self_ok
+      (nativeSwitchPostInitFreeMemorySharedState contract tx storage
+        observableSlots)
       ((store.insert (Backends.nativeSwitchDiscrTempName switchId)
         (EvmYul.UInt256.ofNat
           (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
@@ -22007,6 +22657,66 @@ theorem exec_switchCaseBody_payable_prefix_eq
   exact exec_if_lt_calldatasize_skip_markedPrefix_ge_fuel fuel guardBody
     contract tx storage observableSlots switchId store k hSize hKSize hGe
 
+/-- Post-generated-init variant of `exec_switchCaseBody_payable_prefix_eq`. -/
+theorem exec_switchCaseBody_payable_prefix_postInitFreeMemory_eq
+    (fuel : Nat)
+    (guardBody bodyNative : List EvmYul.Yul.Ast.Stmt)
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat)
+    (switchId : Nat)
+    (store : EvmYul.Yul.VarStore)
+    (k : Nat)
+    (hSize : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hKSize : k < EvmYul.UInt256.size)
+    (hGe : k ≤ 4 + tx.args.length * 32) :
+    EvmYul.Yul.exec (fuel + 11)
+        (.Block
+          (EvmYul.Yul.Ast.Stmt.Block [] ::
+           EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative
+              (Yul.YulExpr.call "lt"
+                [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+            guardBody ::
+           bodyNative))
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+          storage observableSlots switchId store) =
+      EvmYul.Yul.exec (fuel + 9) (.Block bodyNative)
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+          storage observableSlots switchId store) := by
+  let state :=
+    nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+      storage observableSlots switchId store
+  have hSize' : state.sharedState.executionEnv.calldata.size <
+      EvmYul.UInt256.size := by
+    simpa [state] using hSize
+  have hGe' : k ≤ state.sharedState.executionEnv.calldata.size := by
+    simpa [state] using hGe
+  have hGuard :
+      EvmYul.Yul.exec (fuel + 9)
+        (.If (Backends.lowerExprNative
+          (Yul.YulExpr.call "lt"
+            [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+          guardBody)
+        (some contract) state =
+      .ok state :=
+    exec_if_lowerExprNative_lt_calldatasize_skip_ge_fuel fuel guardBody
+      (some contract) state.sharedState state.store k hSize' hKSize hGe'
+  have hFuel : fuel + 11 = Nat.succ (Nat.succ (fuel + 9)) := by omega
+  rw [hFuel]
+  rw [exec_block_noop_block_head_eq]
+  simpa [state] using
+    exec_block_cons_ok_eq (fuel + 9)
+      (EvmYul.Yul.Ast.Stmt.If
+        (Backends.lowerExprNative
+          (Yul.YulExpr.call "lt"
+            [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+        guardBody)
+      bodyNative (some contract) state state hGuard
+
 /-- Execute a payable selected switch-case prefix through the failing
 calldata-size guard. The generated label no-op is skipped, then the concrete
 `lt(calldatasize(), k)` guard runs its `revert(0, 0)` body before any user
@@ -22043,6 +22753,64 @@ theorem exec_switchCaseBody_payable_calldata_revert_fuel
   apply exec_block_cons_error (fuel + 9)
   exact exec_if_lt_calldatasize_take_markedPrefix_lt_revert_fuel fuel
     contract tx storage observableSlots switchId store k hSize hKSize hLt
+
+/-- Post-generated-init variant of
+    `exec_switchCaseBody_payable_calldata_revert_fuel`. -/
+theorem exec_switchCaseBody_payable_calldata_revert_postInitFreeMemory_fuel
+    (fuel : Nat)
+    (bodyNative : List EvmYul.Yul.Ast.Stmt)
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat)
+    (switchId : Nat)
+    (store : EvmYul.Yul.VarStore)
+    (k : Nat)
+    (hSize : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hKSize : k < EvmYul.UInt256.size)
+    (hLt : 4 + tx.args.length * 32 < k) :
+    EvmYul.Yul.exec (fuel + 11)
+        (.Block
+          (EvmYul.Yul.Ast.Stmt.Block [] ::
+           EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative
+              (Yul.YulExpr.call "lt"
+                [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+            [nativeRevertZeroZeroStmt] ::
+           bodyNative))
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+          storage observableSlots switchId store) =
+      .error EvmYul.Yul.Exception.Revert := by
+  let state :=
+    nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+      storage observableSlots switchId store
+  have hSize' : state.sharedState.executionEnv.calldata.size <
+      EvmYul.UInt256.size := by
+    simpa [state] using hSize
+  have hLt' : state.sharedState.executionEnv.calldata.size < k := by
+    simpa [state] using hLt
+  have hGuard :
+      EvmYul.Yul.exec (fuel + 9)
+        (.If (Backends.lowerExprNative
+          (Yul.YulExpr.call "lt"
+            [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+          [nativeRevertZeroZeroStmt])
+        (some contract) state =
+      .error EvmYul.Yul.Exception.Revert :=
+    exec_if_lowerExprNative_lt_calldatasize_take_lt_revert_fuel fuel
+      (some contract) state.sharedState state.store k hSize' hKSize hLt'
+  have hFuel : fuel + 11 = Nat.succ (Nat.succ (fuel + 9)) := by omega
+  rw [hFuel]
+  rw [exec_block_noop_block_head_eq]
+  simpa [state] using
+    exec_block_cons_error (fuel + 9)
+      (EvmYul.Yul.Ast.Stmt.If
+        (Backends.lowerExprNative
+          (Yul.YulExpr.call "lt"
+            [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+        [nativeRevertZeroZeroStmt])
+      bodyNative (some contract) state EvmYul.Yul.Exception.Revert hGuard
 
 /-- Execute a non-payable selected switch-case prefix as no-ops and continue
 with the lowered user body. The generated case prefix is the lowered comment
@@ -22126,6 +22894,105 @@ theorem exec_switchCaseBody_nonpayable_prefix_eq
             calldataGuardBody contract tx storage observableSlots switchId
             store k hSize hKSize hGe
 
+/-- Post-generated-init variant of
+    `exec_switchCaseBody_nonpayable_prefix_eq`. -/
+theorem exec_switchCaseBody_nonpayable_prefix_postInitFreeMemory_eq
+    (fuel : Nat)
+    (callvalueGuardBody calldataGuardBody bodyNative :
+      List EvmYul.Yul.Ast.Stmt)
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat)
+    (switchId : Nat)
+    (store : EvmYul.Yul.VarStore)
+    (k : Nat)
+    (hZero : tx.msgValue % evmModulus = 0)
+    (hSize : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hKSize : k < EvmYul.UInt256.size)
+    (hGe : k ≤ 4 + tx.args.length * 32) :
+    EvmYul.Yul.exec (fuel + 12)
+        (.Block
+          (EvmYul.Yul.Ast.Stmt.Block [] ::
+           EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative (Yul.YulExpr.call "callvalue" []))
+            callvalueGuardBody ::
+           EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative
+              (Yul.YulExpr.call "lt"
+                [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+            calldataGuardBody ::
+           bodyNative))
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+          storage observableSlots switchId store) =
+      EvmYul.Yul.exec (fuel + 9) (.Block bodyNative)
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+          storage observableSlots switchId store) := by
+  let state :=
+    nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+      storage observableSlots switchId store
+  have hWei : state.sharedState.executionEnv.weiValue = (⟨0⟩ : EvmYul.Literal) := by
+    simpa [state] using natToUInt256_eq_zero_of_mod_evm tx.msgValue hZero
+  have hCallvalue :
+      EvmYul.Yul.exec (fuel + 10)
+        (.If (Backends.lowerExprNative (Yul.YulExpr.call "callvalue" []))
+          callvalueGuardBody)
+        (some contract) state =
+      .ok state :=
+    exec_if_lowerExprNative_callvalue_skip_zero_fuel (fuel + 4)
+      callvalueGuardBody (some contract) state.sharedState state.store hWei
+  have hSize' : state.sharedState.executionEnv.calldata.size <
+      EvmYul.UInt256.size := by
+    simpa [state] using hSize
+  have hGe' : k ≤ state.sharedState.executionEnv.calldata.size := by
+    simpa [state] using hGe
+  have hCalldata :
+      EvmYul.Yul.exec (fuel + 9)
+        (.If (Backends.lowerExprNative
+          (Yul.YulExpr.call "lt"
+            [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+          calldataGuardBody)
+        (some contract) state =
+      .ok state :=
+    exec_if_lowerExprNative_lt_calldatasize_skip_ge_fuel fuel
+      calldataGuardBody (some contract) state.sharedState state.store k hSize'
+      hKSize hGe'
+  have hFuel : fuel + 12 = Nat.succ (Nat.succ (fuel + 10)) := by omega
+  rw [hFuel]
+  rw [exec_block_noop_block_head_eq]
+  calc
+    EvmYul.Yul.exec (Nat.succ (fuel + 10))
+        (.Block
+          (EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative (Yul.YulExpr.call "callvalue" []))
+            callvalueGuardBody ::
+           EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative
+              (Yul.YulExpr.call "lt"
+                [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+            calldataGuardBody ::
+           bodyNative))
+        (some contract) state =
+      EvmYul.Yul.exec (fuel + 10)
+        (.Block
+          (EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative
+              (Yul.YulExpr.call "lt"
+                [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+            calldataGuardBody ::
+           bodyNative))
+        (some contract) state := by
+          apply exec_block_cons_ok_eq (fuel + 10)
+          exact hCallvalue
+    _ = EvmYul.Yul.exec (fuel + 9) (.Block bodyNative)
+        (some contract) state := by
+          have hTailFuel : fuel + 10 = Nat.succ (fuel + 9) := by omega
+          rw [hTailFuel]
+          apply exec_block_cons_ok_eq (fuel + 9)
+          exact hCalldata
+
 /-- Execute a non-payable selected switch-case prefix through the failing
 callvalue guard. The generated label no-op is skipped, then the concrete
 `callvalue()` guard runs its `revert(0, 0)` body before any calldata guard or
@@ -22163,6 +23030,83 @@ theorem exec_switchCaseBody_nonpayable_callvalue_revert_fuel
   apply exec_block_cons_error (fuel + 10)
   exact exec_if_callvalue_take_markedPrefix_nonzero_revert_fuel (fuel + 2)
     contract tx storage observableSlots switchId store hNonzero
+
+/-- Post-generated-init variant of
+    `exec_switchCaseBody_nonpayable_callvalue_revert_fuel`. -/
+theorem exec_switchCaseBody_nonpayable_callvalue_revert_postInitFreeMemory_fuel
+    (fuel : Nat)
+    (calldataGuardBody bodyNative : List EvmYul.Yul.Ast.Stmt)
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat)
+    (switchId : Nat)
+    (store : EvmYul.Yul.VarStore)
+    (k : Nat)
+    (hNonzero : tx.msgValue % evmModulus ≠ 0) :
+    EvmYul.Yul.exec (fuel + 12)
+        (.Block
+          (EvmYul.Yul.Ast.Stmt.Block [] ::
+           EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative (Yul.YulExpr.call "callvalue" []))
+            [nativeRevertZeroZeroStmt] ::
+           EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative
+              (Yul.YulExpr.call "lt"
+                [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+            calldataGuardBody ::
+           bodyNative))
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+          storage observableSlots switchId store) =
+      .error EvmYul.Yul.Exception.Revert := by
+  let state :=
+    nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+      storage observableSlots switchId store
+  have hGuard :
+      EvmYul.Yul.exec (fuel + 10)
+        (.If (Backends.lowerExprNative (Yul.YulExpr.call "callvalue" []))
+          [nativeRevertZeroZeroStmt])
+        (some contract) state =
+      .error EvmYul.Yul.Exception.Revert := by
+    have hEval :
+        EvmYul.Yul.eval (fuel + 9)
+            (Backends.lowerExprNative (Yul.YulExpr.call "callvalue" []))
+            (some contract) state =
+          .ok (state, natToUInt256 tx.msgValue) := by
+      simpa [state] using
+        (eval_lowerExprNative_callvalue_ok_fuel (fuel + 4)
+          (state.sharedState) (state.store) (some contract))
+    have hBody :
+        EvmYul.Yul.exec (fuel + 9) (.Block [nativeRevertZeroZeroStmt])
+            (some contract) state =
+          .error EvmYul.Yul.Exception.Revert := by
+      have hFuel : fuel + 9 = Nat.succ (fuel + 8) := by omega
+      rw [hFuel]
+      exact exec_block_cons_error (fuel + 8) nativeRevertZeroZeroStmt []
+        (some contract) state EvmYul.Yul.Exception.Revert
+        (exec_revert_zero_zero_error (fuel + 2) state (some contract))
+    have hFuel : fuel + 10 = Nat.succ (fuel + 9) := by omega
+    rw [hFuel]
+    exact exec_if_eval_nonzero_error (fuel + 9)
+      (Backends.lowerExprNative (Yul.YulExpr.call "callvalue" []))
+      [nativeRevertZeroZeroStmt] (some contract) state state
+      (natToUInt256 tx.msgValue) EvmYul.Yul.Exception.Revert
+      hEval (natToUInt256_ne_zero_of_mod_ne tx.msgValue hNonzero) hBody
+  have hFuel : fuel + 12 = Nat.succ (Nat.succ (fuel + 10)) := by omega
+  rw [hFuel]
+  rw [exec_block_noop_block_head_eq]
+  simpa [state] using
+    exec_block_cons_error (fuel + 10)
+      (EvmYul.Yul.Ast.Stmt.If
+        (Backends.lowerExprNative (Yul.YulExpr.call "callvalue" []))
+        [nativeRevertZeroZeroStmt])
+      (EvmYul.Yul.Ast.Stmt.If
+        (Backends.lowerExprNative
+          (Yul.YulExpr.call "lt"
+            [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+        calldataGuardBody :: bodyNative)
+      (some contract) state EvmYul.Yul.Exception.Revert hGuard
 
 /-- Execute a non-payable selected switch-case prefix through the failing
 calldata-size guard after the zero-callvalue guard skips. -/
@@ -22237,6 +23181,103 @@ theorem exec_switchCaseBody_nonpayable_calldata_revert_fuel
           exact exec_if_lt_calldatasize_take_markedPrefix_lt_revert_fuel fuel
             contract tx storage observableSlots switchId store k hSize hKSize
             hLt
+
+/-- Post-generated-init variant of
+    `exec_switchCaseBody_nonpayable_calldata_revert_fuel`. -/
+theorem exec_switchCaseBody_nonpayable_calldata_revert_postInitFreeMemory_fuel
+    (fuel : Nat)
+    (bodyNative : List EvmYul.Yul.Ast.Stmt)
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat)
+    (switchId : Nat)
+    (store : EvmYul.Yul.VarStore)
+    (k : Nat)
+    (hZero : tx.msgValue % evmModulus = 0)
+    (hSize : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hKSize : k < EvmYul.UInt256.size)
+    (hLt : 4 + tx.args.length * 32 < k) :
+    EvmYul.Yul.exec (fuel + 12)
+        (.Block
+          (EvmYul.Yul.Ast.Stmt.Block [] ::
+           EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative (Yul.YulExpr.call "callvalue" []))
+            [nativeRevertZeroZeroStmt] ::
+           EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative
+              (Yul.YulExpr.call "lt"
+                [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+            [nativeRevertZeroZeroStmt] ::
+           bodyNative))
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+          storage observableSlots switchId store) =
+      .error EvmYul.Yul.Exception.Revert := by
+  let state :=
+    nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+      storage observableSlots switchId store
+  have hWei :
+      state.sharedState.executionEnv.weiValue = (⟨0⟩ : EvmYul.Literal) := by
+    dsimp [state]
+    rw [nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_weiValue]
+    exact natToUInt256_eq_zero_of_mod_evm tx.msgValue hZero
+  have hCallvalue :
+      EvmYul.Yul.exec (fuel + 10)
+        (.If (Backends.lowerExprNative (Yul.YulExpr.call "callvalue" []))
+          [nativeRevertZeroZeroStmt])
+        (some contract) state = .ok state := by
+    exact exec_if_lowerExprNative_callvalue_skip_zero_fuel (fuel + 4)
+      [nativeRevertZeroZeroStmt] (some contract) state.sharedState state.store
+      hWei
+  have hSize' : state.sharedState.executionEnv.calldata.size <
+      EvmYul.UInt256.size := by
+    simpa [state] using hSize
+  have hLt' : state.sharedState.executionEnv.calldata.size < k := by
+    simpa [state] using hLt
+  have hCalldata :
+      EvmYul.Yul.exec (fuel + 9)
+        (.If
+          (Backends.lowerExprNative
+            (Yul.YulExpr.call "lt"
+              [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+          [nativeRevertZeroZeroStmt])
+        (some contract) state =
+      .error EvmYul.Yul.Exception.Revert :=
+    exec_if_lowerExprNative_lt_calldatasize_take_lt_revert_fuel fuel
+      (some contract) state.sharedState state.store k hSize' hKSize hLt'
+  have hFuel : fuel + 12 = Nat.succ (Nat.succ (fuel + 10)) := by omega
+  rw [hFuel]
+  rw [exec_block_noop_block_head_eq]
+  calc
+    EvmYul.Yul.exec (Nat.succ (fuel + 10))
+        (.Block
+          (EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative (Yul.YulExpr.call "callvalue" []))
+            [nativeRevertZeroZeroStmt] ::
+           EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative
+              (Yul.YulExpr.call "lt"
+                [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+            [nativeRevertZeroZeroStmt] ::
+           bodyNative))
+        (some contract) state =
+      EvmYul.Yul.exec (fuel + 10)
+        (.Block
+          (EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative
+              (Yul.YulExpr.call "lt"
+                [Yul.YulExpr.call "calldatasize" [], Yul.YulExpr.lit k]))
+            [nativeRevertZeroZeroStmt] ::
+           bodyNative))
+        (some contract) state := by
+          apply exec_block_cons_ok_eq (fuel + 10)
+          exact hCallvalue
+    _ = .error EvmYul.Yul.Exception.Revert := by
+          have hTailFuel : fuel + 10 = Nat.succ (fuel + 9) := by omega
+          rw [hTailFuel]
+          apply exec_block_cons_error (fuel + 9)
+          exact hCalldata
 
 /-- Lowering-aware payable generated-case prefix peel. Starting from the actual
 native lowering result of `switchCaseBody fn`, expose the lowered user body and
@@ -22383,7 +23424,50 @@ theorem nativeSwitchPrefixStoreState_discr_eq
   simp [EvmYul.Yul.State.insert, GetElem?.getElem!, decidableGetElem?,
     GetElem.getElem, EvmYul.Yul.State.store, EvmYul.Yul.State.lookup!]
   rw [Finmap.lookup_insert_of_ne]
-  · rw [Finmap.lookup_insert]; simp
+  · simp [Finmap.lookup_insert]
+  · exact hne
+
+/-- `matched := 0` lookup on the post-`initFreeMemoryPointer` prefix state
+    with arbitrary store. -/
+theorem nativeSwitchPostInitFreeMemoryPrefixStoreState_matched_eq
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (store : EvmYul.Yul.VarStore)
+    (discrName matchedName : EvmYul.Identifier)
+    (discrValue : EvmYul.Literal) :
+    (((nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+              store).insert discrName discrValue).insert
+        matchedName (EvmYul.UInt256.ofNat 0))[matchedName]! =
+      EvmYul.UInt256.ofNat 0 := by
+  simpa [nativeSwitchPostInitFreeMemoryState, EvmYul.Yul.State.insert] using
+    state_getElem_insert_self_ok
+      (nativeSwitchPostInitFreeMemorySharedState contract tx storage
+        observableSlots)
+      (store.insert discrName discrValue)
+      matchedName (EvmYul.UInt256.ofNat 0)
+
+/-- `discr := selector` lookup on the post-`initFreeMemoryPointer` prefix state
+    with arbitrary store. -/
+theorem nativeSwitchPostInitFreeMemoryPrefixStoreState_discr_eq
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (store : EvmYul.Yul.VarStore)
+    (discrName matchedName : EvmYul.Identifier)
+    (selector : Nat) (hne : discrName ≠ matchedName)
+    (hSelector :
+      selector = tx.functionSelector % Compiler.Constants.selectorModulus) :
+    (((nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+              store).insert discrName
+          (EvmYul.UInt256.ofNat
+            (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+        matchedName (EvmYul.UInt256.ofNat 0))[discrName]! =
+      EvmYul.UInt256.ofNat selector := by
+  rw [hSelector]
+  simp [nativeSwitchPostInitFreeMemoryState, EvmYul.Yul.State.insert,
+    GetElem?.getElem!, decidableGetElem?, GetElem.getElem,
+    EvmYul.Yul.State.store, EvmYul.Yul.State.lookup!]
+  rw [Finmap.lookup_insert_of_ne]
+  · simp [Finmap.lookup_insert]
   · exact hne
 
 /-- Store-parametric prefix-then-tail-ok glue for `lowerNativeSwitchBlock`.
@@ -22635,9 +23719,9 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_with_revert_default_store
       (fuel + 1) selector cases (some contract) _ discrName matchedName hFind
       (nativeSwitchPrefixStoreState_matched_eq contract tx storage observableSlots
         store discrName matchedName _)
-      (nativeSwitchPrefixStoreState_discr_eq contract tx storage observableSlots
-        store discrName matchedName selector hne hSelector)
-      hSelectorRange hTagsRange
+        (nativeSwitchPrefixStoreState_discr_eq contract tx storage observableSlots
+          store discrName matchedName selector hne hSelector)
+        hSelectorRange hTagsRange
   exact exec_lowerNativeSwitchBlock_storePrefix_tail_error_fuel
     (fuel + cases.length) switchId cases [nativeRevertZeroZeroStmt]
     contract tx storage observableSlots store EvmYul.Yul.Exception.Revert
@@ -22693,6 +23777,163 @@ theorem exec_lowerNativeSwitchBlock_selector_find_hit_error_store_fuel
     observableSlots store err
     (by simpa [nativeSwitchTailStmts, discrName, matchedName,
         Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hCases)
+
+/-- Post-generated-init selector-hit error execution for the lowered switch
+    block. This is the post-`initFreeMemoryPointer` counterpart of
+    `exec_lowerNativeSwitchBlock_selector_find_hit_error_store_fuel`; the
+    post-init state is part of the modeled transition. -/
+theorem exec_lowerNativeSwitchBlock_selector_find_hit_error_postInitFreeMemory_store_fuel
+    (fuel selector switchId tag : Nat)
+    (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
+    (defaultBody body : List EvmYul.Yul.Ast.Stmt)
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (store : EvmYul.Yul.VarStore)
+    (err : EvmYul.Yul.Exception)
+    (hSelector : selector = tx.functionSelector % Compiler.Constants.selectorModulus)
+    (hFind : cases.find? (fun entry => entry.1 == selector) = some (tag, body))
+    (hSelectorRange : selector < EvmYul.UInt256.size)
+    (hTagsRange :
+      ∀ tag' body', (tag', body') ∈ cases → tag' < EvmYul.UInt256.size)
+    (hBody : ∀ pre suffix, cases = pre ++ (tag, body) :: suffix →
+      EvmYul.Yul.exec ((fuel + 1) + suffix.length + 7) (.Block body)
+        (some contract)
+        ((((nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+                store).insert
+              (Backends.nativeSwitchDiscrTempName switchId)
+              (EvmYul.UInt256.ofNat
+                (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+            (Backends.nativeSwitchMatchedTempName switchId)
+            (EvmYul.UInt256.ofNat 0)).insert
+            (Backends.nativeSwitchMatchedTempName switchId)
+            (EvmYul.UInt256.ofNat 1)) = .error err) :
+    EvmYul.Yul.exec (fuel + cases.length + 12)
+      (Backends.lowerNativeSwitchBlock
+        Compiler.Proofs.YulGeneration.selectorExpr switchId cases defaultBody)
+      (some contract)
+      (nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+        store) =
+    .error err := by
+  let discrName := Backends.nativeSwitchDiscrTempName switchId
+  let matchedName := Backends.nativeSwitchMatchedTempName switchId
+  let prefixState : EvmYul.Yul.State :=
+    ((nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+        store).insert discrName
+        (EvmYul.UInt256.ofNat
+          (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+      matchedName (EvmYul.UInt256.ofNat 0)
+  have hne := nativeSwitchDiscrTempName_ne_matchedTempName switchId
+  have hCases :=
+    exec_nativeSwitchCaseIfs_find_hit_with_default_error_fuel
+      (fuel + 1) selector cases defaultBody tag body (some contract) _
+      discrName matchedName err hFind
+      (by
+        simpa [prefixState, discrName, matchedName] using
+          nativeSwitchPostInitFreeMemoryPrefixStoreState_matched_eq
+            contract tx storage observableSlots store discrName matchedName
+            (EvmYul.UInt256.ofNat
+              (tx.functionSelector % Compiler.Constants.selectorModulus)))
+      (by
+        simpa [prefixState, discrName, matchedName] using
+          nativeSwitchPostInitFreeMemoryPrefixStoreState_discr_eq
+            contract tx storage observableSlots store discrName matchedName
+            selector hne hSelector)
+      hSelectorRange hTagsRange hBody
+  exact exec_lowerNativeSwitchBlock_postInitFreeMemory_storePrefix_tail_error_fuel
+    (fuel + cases.length) switchId cases defaultBody contract tx storage
+    observableSlots store err
+    (by simpa [nativeSwitchTailStmts, discrName, matchedName,
+        Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hCases)
+
+/-- Post-generated-init selector-hit success when the selected body execution
+    and final matched-flag fact are supplied directly. This is the
+    post-`initFreeMemoryPointer` counterpart of
+    `exec_lowerNativeSwitchBlock_selector_find_hit_finalMatched_store_fuel`. -/
+theorem exec_lowerNativeSwitchBlock_selector_find_hit_finalMatched_postInitFreeMemory_store_fuel
+    (fuel selector switchId tag : Nat)
+    (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
+    (defaultBody body : List EvmYul.Yul.Ast.Stmt)
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat)
+    (store : EvmYul.Yul.VarStore)
+    (final : EvmYul.Yul.State)
+    (hSelector : selector = tx.functionSelector % Compiler.Constants.selectorModulus)
+    (hFind : cases.find? (fun entry => entry.1 == selector) = some (tag, body))
+    (hSelectorRange : selector < EvmYul.UInt256.size)
+    (hTagsRange :
+      ∀ tag' body', (tag', body') ∈ cases → tag' < EvmYul.UInt256.size)
+    (hBody : ∀ pre suffix, cases = pre ++ (tag, body) :: suffix →
+      EvmYul.Yul.exec ((fuel + 1) + suffix.length + 7) (.Block body)
+        (some contract) (nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId
+          contract tx storage observableSlots switchId store) = .ok final)
+    (hFinalMatched :
+      ∀ matchedName : EvmYul.Identifier,
+        matchedName = Backends.nativeSwitchMatchedTempName switchId →
+          final[matchedName]! = EvmYul.UInt256.ofNat 1) :
+    EvmYul.Yul.exec (fuel + cases.length + 12)
+      (Backends.lowerNativeSwitchBlock
+        Compiler.Proofs.YulGeneration.selectorExpr switchId cases defaultBody)
+      (some contract)
+      (nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+        store) =
+    .ok final := by
+  let discrName := Backends.nativeSwitchDiscrTempName switchId
+  let matchedName := Backends.nativeSwitchMatchedTempName switchId
+  have hne := nativeSwitchDiscrTempName_ne_matchedTempName switchId
+  have hCasesOnly :
+      EvmYul.Yul.exec (fuel + 1 + cases.length + 9)
+        (.Block (nativeSwitchCaseIfs discrName matchedName cases))
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryStorePrefixStateForId contract tx
+          storage observableSlots switchId store) = .ok final := by
+    exact exec_nativeSwitchCaseIfs_find_hit_fuel
+      (fuel + 1) selector cases tag body (some contract)
+      (nativeSwitchPostInitFreeMemoryStorePrefixStateForId contract tx storage
+        observableSlots switchId store) final discrName matchedName hFind
+      (by
+        simpa [nativeSwitchPostInitFreeMemoryStorePrefixStateForId, discrName,
+          matchedName] using
+          nativeSwitchPostInitFreeMemoryPrefixStoreState_matched_eq
+            contract tx storage observableSlots store discrName matchedName
+            (EvmYul.UInt256.ofNat
+              (tx.functionSelector % Compiler.Constants.selectorModulus)))
+      (by
+        simpa [nativeSwitchPostInitFreeMemoryStorePrefixStateForId, discrName,
+          matchedName] using
+          nativeSwitchPostInitFreeMemoryPrefixStoreState_discr_eq
+            contract tx storage observableSlots store discrName matchedName
+            selector hne hSelector)
+      hSelectorRange hTagsRange
+      (by
+        intro pre suffix hCases
+        simpa [nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+          nativeSwitchPostInitFreeMemoryStorePrefixStateForId, discrName,
+          matchedName, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using
+          hBody pre suffix hCases)
+      (by simpa [matchedName] using hFinalMatched)
+  have hCasesDefault :
+      EvmYul.Yul.exec (fuel + 1 + cases.length + 9)
+        (.Block
+          (nativeSwitchCaseIfs discrName matchedName cases ++
+            nativeSwitchDefaultIf matchedName defaultBody))
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryStorePrefixStateForId contract tx
+          storage observableSlots switchId store) = .ok final := by
+    exact exec_nativeSwitchCaseIfs_with_default_matched_fuel
+      (fuel + 1) cases defaultBody (some contract)
+      (nativeSwitchPostInitFreeMemoryStorePrefixStateForId contract tx storage
+        observableSlots switchId store) final discrName matchedName
+      hCasesOnly
+      (hFinalMatched matchedName rfl)
+  exact exec_lowerNativeSwitchBlock_postInitFreeMemory_storePrefix_tail_ok_fuel
+    (fuel + cases.length) switchId cases defaultBody contract tx storage
+    observableSlots store final (by
+      simpa [nativeSwitchTailStmts, discrName, matchedName, Nat.add_assoc,
+        Nat.add_comm, Nat.add_left_comm,
+        nativeSwitchPostInitFreeMemoryStorePrefixStateForId] using
+        hCasesDefault)
 
 /-- Bridge-shape selector-miss endpoint on the post-`__has_selector := 1`
     state, yielding `.error Revert`. -/
@@ -22978,6 +24219,28 @@ theorem nativeSwitchStoreMarkedPrefixStateForId_materializedStorageSlot
       storage (IRStorageSlot.ofNat slot) := by
   simpa [nativeSwitchStoreMarkedPrefixStateForId,
     nativeSwitchStorePrefixStateForId, nativeSwitchStoreInitialState,
+    EvmYul.Yul.State.insert, projectStorageFromState,
+    EvmYul.Yul.State.sharedState] using
+    (initialState_materializedStorageSlot contract tx storage slots slot hSlot)
+
+theorem nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_materializedStorageSlot
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (slots : List Nat)
+    (switchId : Nat)
+    (store : EvmYul.Yul.VarStore)
+    (slot : Nat)
+    (hSlot : slot ∈ slots) :
+    projectStorageFromState tx
+      (nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+        storage slots switchId store)
+      (IRStorageSlot.ofNat slot) =
+      storage (IRStorageSlot.ofNat slot) := by
+  simpa [nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId,
+    nativeSwitchPostInitFreeMemoryStorePrefixStateForId,
+    nativeSwitchPostInitFreeMemoryState,
+    nativeSwitchPostInitFreeMemorySharedState,
     EvmYul.Yul.State.insert, projectStorageFromState,
     EvmYul.Yul.State.sharedState] using
     (initialState_materializedStorageSlot contract tx storage slots slot hSlot)
@@ -26190,6 +27453,51 @@ theorem exec_lowerNativeSwitchBlock_selector_find_hit_error_store_projectResult_
       simpa [nativeSwitchStoreMarkedPrefixStateForId]
         using hBody pre suffix hCases)
 
+/-- Store-parametric selector-hit projection after the generated
+    `initFreeMemoryPointer` statement has executed. -/
+theorem exec_lowerNativeSwitchBlock_selector_find_hit_error_postInitFreeMemory_store_projectResult_eq
+    (fuel selector switchId tag : Nat)
+    (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
+    (defaultBody body : List EvmYul.Yul.Ast.Stmt)
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (initialEvents : List (List Nat))
+    (observableSlots : List Nat)
+    (store : EvmYul.Yul.VarStore)
+    (err : EvmYul.Yul.Exception)
+    (nativeYul : YulResult)
+    (hSelector : selector = tx.functionSelector % Compiler.Constants.selectorModulus)
+    (hFind : cases.find? (fun entry => entry.1 == selector) = some (tag, body))
+    (hSelectorRange : selector < EvmYul.UInt256.size)
+    (hTagsRange :
+      ∀ tag' body', (tag', body') ∈ cases → tag' < EvmYul.UInt256.size)
+    (hBody : ∀ pre suffix, cases = pre ++ (tag, body) :: suffix →
+      EvmYul.Yul.exec ((fuel + 1) + suffix.length + 7) (.Block body)
+        (some contract)
+        ((((nativeSwitchPostInitFreeMemoryState contract tx storage
+                observableSlots store).insert
+              (Backends.nativeSwitchDiscrTempName switchId)
+              (EvmYul.UInt256.ofNat
+                (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+            (Backends.nativeSwitchMatchedTempName switchId)
+            (EvmYul.UInt256.ofNat 0)).insert
+            (Backends.nativeSwitchMatchedTempName switchId)
+            (EvmYul.UInt256.ofNat 1)) = .error err)
+    (hProject : projectResult tx storage initialEvents (.error err) = nativeYul) :
+    EvmYul.Yul.exec (fuel + cases.length + 12)
+        (Backends.lowerNativeSwitchBlock
+          Compiler.Proofs.YulGeneration.selectorExpr switchId cases defaultBody)
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+          store) =
+      .error err ∧
+    projectResult tx storage initialEvents (.error err) = nativeYul := by
+  refine ⟨?_, hProject⟩
+  exact exec_lowerNativeSwitchBlock_selector_find_hit_error_postInitFreeMemory_store_fuel
+    fuel selector switchId tag cases defaultBody body contract tx storage
+    observableSlots store err hSelector hFind hSelectorRange hTagsRange hBody
+
 /-- Store-parametric selector-hit projection for a payable generated case body,
     with the generated comment and calldata-size guard discharged before the
     selected user body premise. -/
@@ -26633,6 +27941,115 @@ theorem exec_block_lowerNativeSwitchBlock_revert_default_hasSelectorState_projec
   exact exec_block_cons_error (fuel + cases.length + 12) _ [] _ _
     EvmYul.Yul.Exception.Revert hEndpoint
 
+/-- Post-generated-init selector-miss projection on the
+    `__has_selector := 1` state. This is the init-prefixed counterpart of
+    `exec_block_lowerNativeSwitchBlock_revert_default_hasSelectorState_projectResult_eq`. -/
+theorem exec_block_lowerNativeSwitchBlock_revert_default_postInitFreeMemory_hasSelectorState_projectResult_eq
+    (fuel selector switchId : Nat)
+    (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (initialEvents : List (List Nat))
+    (observableSlots : List Nat)
+    (hSelector : selector = tx.functionSelector % Compiler.Constants.selectorModulus)
+    (hFind : cases.find? (fun entry => entry.1 == selector) = none)
+    (hSelectorRange : selector < EvmYul.UInt256.size)
+    (hTagsRange : ∀ tag body, (tag, body) ∈ cases → tag < EvmYul.UInt256.size) :
+    EvmYul.Yul.exec (fuel + cases.length + 13)
+      (.Block [Backends.lowerNativeSwitchBlock
+        Compiler.Proofs.YulGeneration.selectorExpr switchId cases
+        [nativeRevertZeroZeroStmt]])
+      (some contract)
+      ((nativeSwitchPostInitFreeMemoryState contract tx storage
+          observableSlots ∅).insert "__has_selector" (EvmYul.UInt256.ofNat 1)) =
+      .error EvmYul.Yul.Exception.Revert ∧
+    projectResult tx storage initialEvents
+        (.error EvmYul.Yul.Exception.Revert) =
+      { success := false
+        returnValue := none
+        finalStorage := storage
+        finalMappings := Compiler.Proofs.storageAsMappings storage
+        events := initialEvents } := by
+  let store :=
+    (∅ : EvmYul.Yul.VarStore).insert "__has_selector"
+      (EvmYul.UInt256.ofNat 1)
+  have hTail :
+      EvmYul.Yul.exec (fuel + cases.length + 10)
+        (.Block (nativeSwitchTailStmts switchId cases [nativeRevertZeroZeroStmt]))
+        (some contract)
+        (((nativeSwitchPostInitFreeMemoryState contract tx storage
+              observableSlots store).insert
+              (Backends.nativeSwitchDiscrTempName switchId)
+              (EvmYul.UInt256.ofNat
+                (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+            (Backends.nativeSwitchMatchedTempName switchId)
+            (EvmYul.UInt256.ofNat 0)) =
+        .error EvmYul.Yul.Exception.Revert := by
+    let discrName := Backends.nativeSwitchDiscrTempName switchId
+    let matchedName := Backends.nativeSwitchMatchedTempName switchId
+    let prefixState : EvmYul.Yul.State :=
+      (((nativeSwitchPostInitFreeMemoryState contract tx storage
+            observableSlots store).insert discrName
+            (EvmYul.UInt256.ofNat
+              (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+          matchedName (EvmYul.UInt256.ofNat 0))
+    have hne := nativeSwitchDiscrTempName_ne_matchedTempName switchId
+    have hCases :=
+      exec_nativeSwitchCaseIfs_find_none_with_revert_default_fuel
+        (fuel + 1) selector cases (some contract) prefixState discrName
+        matchedName hFind
+        (by
+          simpa [prefixState, discrName, matchedName,
+            nativeSwitchPostInitFreeMemoryState, EvmYul.Yul.State.insert]
+            using
+              state_getElem_insert_self_ok
+                (nativeSwitchPostInitFreeMemorySharedState contract tx storage
+                  observableSlots)
+                ((store.insert discrName
+                  (EvmYul.UInt256.ofNat
+                    (tx.functionSelector % Compiler.Constants.selectorModulus))))
+                matchedName (EvmYul.UInt256.ofNat 0))
+        (by
+          have hDiscr :=
+            state_getElem_insert_self_ok
+              (nativeSwitchPostInitFreeMemorySharedState contract tx storage
+                observableSlots)
+              store discrName
+              (EvmYul.UInt256.ofNat
+                (tx.functionSelector % Compiler.Constants.selectorModulus))
+          have hLookup :=
+            state_getElem_insert_of_ne
+              ((nativeSwitchPostInitFreeMemoryState contract tx storage
+                observableSlots store).insert discrName
+                (EvmYul.UInt256.ofNat
+                  (tx.functionSelector % Compiler.Constants.selectorModulus)))
+              discrName matchedName (EvmYul.UInt256.ofNat 0) hne
+          rw [hLookup]
+          simpa [nativeSwitchPostInitFreeMemoryState, hSelector] using hDiscr)
+        hSelectorRange hTagsRange
+    simpa [nativeSwitchTailStmts, discrName, matchedName, prefixState,
+      Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hCases
+  have hEndpoint :
+      EvmYul.Yul.exec (fuel + cases.length + 12)
+        (Backends.lowerNativeSwitchBlock
+          Compiler.Proofs.YulGeneration.selectorExpr switchId cases
+          [nativeRevertZeroZeroStmt])
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryState contract tx storage
+          observableSlots store) =
+      .error EvmYul.Yul.Exception.Revert :=
+    exec_lowerNativeSwitchBlock_postInitFreeMemory_storePrefix_tail_error_fuel
+      (fuel + cases.length) switchId cases [nativeRevertZeroZeroStmt] contract tx storage
+      observableSlots store EvmYul.Yul.Exception.Revert hTail
+  have hFuelEq : fuel + cases.length + 13 = (fuel + cases.length + 12).succ := by
+    omega
+  refine ⟨?_, by simp⟩
+  rw [hFuelEq]
+  simpa [store, nativeSwitchPostInitFreeMemoryState, EvmYul.Yul.State.insert]
+    using exec_block_cons_error (fuel + cases.length + 12) _ [] _ _
+      EvmYul.Yul.Exception.Revert hEndpoint
+
 /-- Bridge-shape selector-hit error projection on the post-`__has_selector := 1`
     state. This packages a selected body halt/error with its projected result
     after the generated dispatcher-local binding has been installed. -/
@@ -26673,6 +28090,117 @@ theorem exec_block_lowerNativeSwitchBlock_selector_find_hit_hasSelectorState_err
   rw [nativeSwitchInitialOkState_insert_hasSelector_eq, hFuelEq]
   exact ⟨exec_block_cons_error (fuel + cases.length + 12) _ [] _ _ err hEndpoint,
     hProject'⟩
+
+/-- Bridge-shape selector-hit error projection on the post-generated-init
+    `__has_selector := 1` state. This is the init-aware counterpart of
+    `exec_block_lowerNativeSwitchBlock_selector_find_hit_hasSelectorState_error_projectResult_eq`. -/
+theorem exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+    (fuel selector switchId tag : Nat)
+    (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
+    (defaultBody body : List EvmYul.Yul.Ast.Stmt)
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (initialEvents : List (List Nat))
+    (observableSlots : List Nat)
+    (err : EvmYul.Yul.Exception)
+    (nativeYul : YulResult)
+    (hSelector : selector = tx.functionSelector % Compiler.Constants.selectorModulus)
+    (hFind : cases.find? (fun entry => entry.1 == selector) = some (tag, body))
+    (hSelectorRange : selector < EvmYul.UInt256.size)
+    (hTagsRange : ∀ tag' body', (tag', body') ∈ cases → tag' < EvmYul.UInt256.size)
+    (hBody : ∀ pre suffix, cases = pre ++ (tag, body) :: suffix →
+      EvmYul.Yul.exec ((fuel + 1) + suffix.length + 7) (.Block body)
+        (some contract)
+        ((((nativeSwitchPostInitFreeMemoryState contract tx storage
+                observableSlots nativeSwitchHasSelectorStore).insert
+              (Backends.nativeSwitchDiscrTempName switchId)
+              (EvmYul.UInt256.ofNat
+                (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+            (Backends.nativeSwitchMatchedTempName switchId)
+            (EvmYul.UInt256.ofNat 0)).insert
+            (Backends.nativeSwitchMatchedTempName switchId)
+            (EvmYul.UInt256.ofNat 1)) =
+        .error err)
+    (hProject : projectResult tx storage initialEvents (.error err) = nativeYul) :
+    EvmYul.Yul.exec (fuel + cases.length + 13)
+      (.Block [Backends.lowerNativeSwitchBlock
+        Compiler.Proofs.YulGeneration.selectorExpr switchId cases defaultBody])
+      (some contract)
+      ((nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+          ∅).insert "__has_selector" (EvmYul.UInt256.ofNat 1)) =
+        .error err ∧
+    projectResult tx storage initialEvents (.error err) = nativeYul := by
+  rcases exec_lowerNativeSwitchBlock_selector_find_hit_error_postInitFreeMemory_store_projectResult_eq
+      fuel selector switchId tag cases defaultBody body contract tx storage
+      initialEvents observableSlots nativeSwitchHasSelectorStore err nativeYul
+      hSelector hFind hSelectorRange hTagsRange hBody hProject with
+    ⟨hEndpoint, hProject'⟩
+  have hFuelEq : fuel + cases.length + 13 = (fuel + cases.length + 12).succ := by
+    omega
+  rw [hFuelEq]
+  refine ⟨?_, hProject'⟩
+  simpa [nativeSwitchHasSelectorStore, nativeSwitchPostInitFreeMemoryState,
+    EvmYul.Yul.State.insert] using
+    exec_block_cons_error (fuel + cases.length + 12) _ [] _ _ err hEndpoint
+
+/-- Bridge-shape selector-hit success projection on the post-generated-init
+    `__has_selector := 1` state, with the final matched-flag fact supplied
+    directly. This is the init-aware counterpart of
+    `exec_block_lowerNativeSwitchBlock_selector_find_hit_hasSelectorState_ok_projectResult_eq_finalMatched`. -/
+theorem exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
+    (fuel selector switchId tag : Nat)
+    (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
+    (defaultBody body : List EvmYul.Yul.Ast.Stmt)
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (initialEvents : List (List Nat))
+    (observableSlots : List Nat)
+    (final : EvmYul.Yul.State)
+    (nativeYul : YulResult)
+    (hSelector : selector = tx.functionSelector % Compiler.Constants.selectorModulus)
+    (hFind : cases.find? (fun entry => entry.1 == selector) = some (tag, body))
+    (hSelectorRange : selector < EvmYul.UInt256.size)
+    (hTagsRange : ∀ tag' body', (tag', body') ∈ cases → tag' < EvmYul.UInt256.size)
+    (hBody : ∀ pre suffix, cases = pre ++ (tag, body) :: suffix →
+      EvmYul.Yul.exec ((fuel + 1) + suffix.length + 7) (.Block body)
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId contract tx
+          storage observableSlots switchId nativeSwitchHasSelectorStore) =
+        .ok final)
+    (hFinalMatched :
+      ∀ matchedName : EvmYul.Identifier,
+        matchedName = Backends.nativeSwitchMatchedTempName switchId →
+          final[matchedName]! = EvmYul.UInt256.ofNat 1)
+    (hProject : projectResult tx storage initialEvents (.ok (final, [])) = nativeYul) :
+    EvmYul.Yul.exec (fuel + cases.length + 13)
+      (.Block [Backends.lowerNativeSwitchBlock
+        Compiler.Proofs.YulGeneration.selectorExpr switchId cases defaultBody])
+      (some contract)
+      ((nativeSwitchPostInitFreeMemoryState contract tx storage observableSlots
+          ∅).insert "__has_selector" (EvmYul.UInt256.ofNat 1)) =
+        .ok final ∧
+    projectResult tx storage initialEvents (.ok (final, [])) = nativeYul := by
+  have hEndpoint :
+      EvmYul.Yul.exec (fuel + cases.length + 12)
+        (Backends.lowerNativeSwitchBlock
+          Compiler.Proofs.YulGeneration.selectorExpr switchId cases defaultBody)
+        (some contract)
+        (nativeSwitchPostInitFreeMemoryState contract tx storage
+          observableSlots nativeSwitchHasSelectorStore) =
+      .ok final :=
+    exec_lowerNativeSwitchBlock_selector_find_hit_finalMatched_postInitFreeMemory_store_fuel
+      fuel selector switchId tag cases defaultBody body contract tx storage
+      observableSlots nativeSwitchHasSelectorStore final hSelector hFind
+      hSelectorRange hTagsRange hBody hFinalMatched
+  have hFuelEq : fuel + cases.length + 13 =
+      (fuel + cases.length + 12).succ := by
+    omega
+  rw [hFuelEq]
+  refine ⟨?_, hProject⟩
+  simpa [nativeSwitchHasSelectorStore, nativeSwitchPostInitFreeMemoryState,
+    EvmYul.Yul.State.insert] using
+    exec_block_cons_ok (fuel + cases.length + 12) _ [] _ _ final final
+      hEndpoint (by simp [EvmYul.Yul.exec])
 
 /-- Bridge-shape selector-hit error projection for a payable generated case on
     the post-`__has_selector := 1` state, with generated case guards discharged
@@ -27576,18 +29104,18 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
               (some contract)
               ((nativeSwitchInitialOkState contract tx storage observableSlots).insert
                 "__has_selector" (EvmYul.UInt256.ofNat 1)) := by
-            have hExec :=
-              exec_block_letSelector_if1Skip_if2Take_initialState_fuel
-                (fuel + cases'.length + 5) contract tx storage observableSlots
-                "__has_selector" body1
-                [Backends.lowerNativeSwitchBlock
-                  (YulExpr.call "shr"
-                    [YulExpr.lit Compiler.Constants.selectorShift,
-                     YulExpr.call "calldataload" [YulExpr.lit 0]])
-                  (Backends.freshNativeSwitchId reservedNames n0) cases'
-                  [nativeRevertZeroZeroStmt]]
-                hNoWrap
-            simpa only [Nat.add_assoc] using hExec
+              have hExec :=
+                (exec_block_letSelector_if1Skip_if2Take_initialState_fuel
+                  (fuel + cases'.length + 5) contract tx storage observableSlots
+                  "__has_selector" body1
+                  [Backends.lowerNativeSwitchBlock
+                    (YulExpr.call "shr"
+                      [YulExpr.lit Compiler.Constants.selectorShift,
+                       YulExpr.call "calldataload" [YulExpr.lit 0]])
+                    (Backends.freshNativeSwitchId reservedNames n0) cases'
+                    [nativeRevertZeroZeroStmt]]
+                  hNoWrap)
+              simpa only [Nat.add_assoc] using hExec
     rw [hPeel]
     exact exec_block_lowerNativeSwitchBlock_revert_default_hasSelectorState_error
       fuel selector (Backends.freshNativeSwitchId reservedNames n0) cases'
@@ -27779,18 +29307,18 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
                 (some contract)
                 ((nativeSwitchInitialOkState contract tx storage observableSlots).insert
                   "__has_selector" (EvmYul.UInt256.ofNat 1)) := by
-              have hExec :=
-                exec_block_letSelector_if1Skip_if2Take_initialState_fuel
-                  (fuel + cases'.length + 5) contract tx storage observableSlots
-                  "__has_selector" body1
-                  [Backends.lowerNativeSwitchBlock
-                    (YulExpr.call "shr"
-                      [YulExpr.lit Compiler.Constants.selectorShift,
-                       YulExpr.call "calldataload" [YulExpr.lit 0]])
-                    (Backends.freshNativeSwitchId reservedNames n0) cases'
-                    [nativeRevertZeroZeroStmt]]
-                  hNoWrap
-              simpa only [Nat.add_assoc] using hExec
+                have hExec :=
+                  (exec_block_letSelector_if1Skip_if2Take_initialState_fuel
+                    (fuel + cases'.length + 5) contract tx storage observableSlots
+                    "__has_selector" body1
+                    [Backends.lowerNativeSwitchBlock
+                      (YulExpr.call "shr"
+                        [YulExpr.lit Compiler.Constants.selectorShift,
+                         YulExpr.call "calldataload" [YulExpr.lit 0]])
+                      (Backends.freshNativeSwitchId reservedNames n0) cases'
+                      [nativeRevertZeroZeroStmt]]
+                    hNoWrap)
+                simpa only [Nat.add_assoc] using hExec
       exact hPeelStructural
     constructor
     · rw [hPeel]
@@ -27966,18 +29494,18 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
               (some contract)
               ((nativeSwitchInitialOkState contract tx storage observableSlots).insert
                 "__has_selector" (EvmYul.UInt256.ofNat 1)) := by
-            have hExec :=
-              exec_block_letSelector_if1Skip_if2Take_initialState_fuel
-                (fuel + cases'.length + 5) contract tx storage observableSlots
-                "__has_selector" body1
-                [Backends.lowerNativeSwitchBlock
-                  (YulExpr.call "shr"
-                    [YulExpr.lit Compiler.Constants.selectorShift,
-                     YulExpr.call "calldataload" [YulExpr.lit 0]])
-                  (Backends.freshNativeSwitchId reservedNames n0) cases'
-                  [nativeRevertZeroZeroStmt]]
-                hNoWrap
-            simpa only [Nat.add_assoc] using hExec
+              have hExec :=
+                (exec_block_letSelector_if1Skip_if2Take_initialState_fuel
+                  (fuel + cases'.length + 5) contract tx storage observableSlots
+                  "__has_selector" body1
+                  [Backends.lowerNativeSwitchBlock
+                    (YulExpr.call "shr"
+                      [YulExpr.lit Compiler.Constants.selectorShift,
+                       YulExpr.call "calldataload" [YulExpr.lit 0]])
+                    (Backends.freshNativeSwitchId reservedNames n0) cases'
+                    [nativeRevertZeroZeroStmt]]
+                  hNoWrap)
+              simpa only [Nat.add_assoc] using hExec
     rw [hPeel]
     exact exec_block_lowerNativeSwitchBlock_selector_find_hit_hasSelectorState_error_projectResult_eq
       fuel selector (Backends.freshNativeSwitchId reservedNames n0) selector
@@ -28127,6 +29655,158 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_peel
             hNoWrap
         simpa only [Nat.add_assoc] using hExec
 
+/-- Structural dispatcher/prologue peel for generated runtimes whose dispatcher
+    starts with the exact `initFreeMemoryPointer` statement before the lowered
+    `buildSwitch` block. This is the generated-init companion to
+    `contractDispatcherExecResult_buildSwitch_noFallback_noReceive_peel`.
+
+    The post-init state is explicit, and the `__has_selector := 1` transition
+    is modeled as part of the generated prefix rather than recovered later as a
+    raw variable-store fact. -/
+theorem contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
+    (fuel : Nat)
+    (reservedNames : List String) (n0 : Nat)
+    (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
+    (body1 inner : List EvmYul.Yul.Ast.Stmt)
+    (functions : NativeFunctionMap)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat)
+    (hInner :
+      inner =
+        [EvmYul.Yul.Ast.Stmt.Let ["__has_selector"]
+            (some
+              (Backends.lowerExprNative
+                (YulExpr.call "iszero"
+                  [YulExpr.call "lt"
+                    [YulExpr.call "calldatasize" [], YulExpr.lit 4]]))),
+         EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative
+              (YulExpr.call "iszero" [YulExpr.ident "__has_selector"]))
+            body1,
+         EvmYul.Yul.Ast.Stmt.If
+            (Backends.lowerExprNative (YulExpr.ident "__has_selector"))
+            [Backends.lowerNativeSwitchBlock
+              (YulExpr.call "shr"
+                [YulExpr.lit Compiler.Constants.selectorShift,
+                 YulExpr.call "calldataload" [YulExpr.lit 0]])
+              (Backends.freshNativeSwitchId reservedNames n0) cases'
+              [nativeRevertZeroZeroStmt]]])
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
+    let initStmt : EvmYul.Yul.Ast.Stmt :=
+      .ExprStmtCall
+        (Backends.lowerExprNative
+          (Yul.YulExpr.call "mstore"
+            [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
+             Yul.YulExpr.lit 128]))
+    let contract : EvmYul.Yul.Ast.YulContract :=
+      { dispatcher := .Block [initStmt, .Block inner], functions := functions }
+    contractDispatcherExecResult (fuel + cases'.length + 20)
+        contract (initialState contract tx storage observableSlots) =
+      EvmYul.Yul.exec (fuel + cases'.length + 13)
+        (.Block
+          [Backends.lowerNativeSwitchBlock
+            (YulExpr.call "shr"
+              [YulExpr.lit Compiler.Constants.selectorShift,
+               YulExpr.call "calldataload" [YulExpr.lit 0]])
+            (Backends.freshNativeSwitchId reservedNames n0) cases'
+            [nativeRevertZeroZeroStmt]])
+        (some contract)
+        ((nativeSwitchPostInitFreeMemoryState contract tx storage
+          observableSlots ∅).insert "__has_selector"
+          (EvmYul.UInt256.ofNat 1)) := by
+  intro initStmt contract
+  let contract' : EvmYul.Yul.Ast.YulContract :=
+    { dispatcher := .Block [initStmt, .Block inner], functions := functions }
+  have hFuelShape :
+      fuel + cases'.length + 20 =
+        Nat.succ (Nat.succ (fuel + cases'.length + 18)) := by
+    omega
+  have hDispatcherPeel :
+      contractDispatcherExecResult (fuel + cases'.length + 20)
+          contract' (initialState contract' tx storage observableSlots) =
+        EvmYul.Yul.exec (fuel + cases'.length + 17)
+          (.Block inner) (some contract')
+          (nativeSwitchPostInitFreeMemoryState contract' tx storage
+            observableSlots ∅) := by
+    rw [hFuelShape]
+    dsimp [contract']
+    rw [contractDispatcherExecResult_block_dispatcher_eq_exec_block
+      (fuel + cases'.length + 18) [initStmt, .Block inner] functions
+      tx storage observableSlots]
+    rw [show Nat.succ (fuel + cases'.length + 18) =
+        Nat.succ ((fuel + cases'.length + 12) + 6) by omega]
+    rw [exec_block_cons_initFreeMemoryPointer_eq
+      (fuel + cases'.length + 12) [.Block inner] contract'
+      tx storage observableSlots]
+    rw [show (fuel + cases'.length + 12) + 6 =
+        Nat.succ (Nat.succ (fuel + cases'.length + 16)) by omega]
+    rw [exec_singleton_block_eq_exec_block (fuel + cases'.length + 16) inner
+      (some contract')
+      (nativeSwitchPostInitFreeMemoryState contract' tx storage observableSlots ∅)]
+  calc
+    contractDispatcherExecResult (fuel + cases'.length + 20)
+        contract (initialState contract tx storage observableSlots)
+        = EvmYul.Yul.exec (fuel + cases'.length + 17)
+            (.Block inner) (some contract)
+            (nativeSwitchPostInitFreeMemoryState contract tx storage
+              observableSlots ∅) := hDispatcherPeel
+    _ = EvmYul.Yul.exec (fuel + cases'.length + 17)
+          (.Block
+            [EvmYul.Yul.Ast.Stmt.Let ["__has_selector"]
+                (some
+                  (Backends.lowerExprNative
+                    (YulExpr.call "iszero"
+                      [YulExpr.call "lt"
+                        [YulExpr.call "calldatasize" [],
+                         YulExpr.lit 4]]))),
+             EvmYul.Yul.Ast.Stmt.If
+                (Backends.lowerExprNative
+                  (YulExpr.call "iszero" [YulExpr.ident "__has_selector"]))
+                body1,
+             EvmYul.Yul.Ast.Stmt.If
+                (Backends.lowerExprNative (YulExpr.ident "__has_selector"))
+                [Backends.lowerNativeSwitchBlock
+                  (YulExpr.call "shr"
+                    [YulExpr.lit Compiler.Constants.selectorShift,
+                     YulExpr.call "calldataload" [YulExpr.lit 0]])
+                  (Backends.freshNativeSwitchId reservedNames n0) cases'
+                  [nativeRevertZeroZeroStmt]]])
+          (some contract)
+          (nativeSwitchPostInitFreeMemoryState contract tx storage
+            observableSlots ∅) := by
+        exact congrArg
+          (fun body =>
+            EvmYul.Yul.exec (fuel + cases'.length + 17)
+              (.Block body) (some contract)
+              (nativeSwitchPostInitFreeMemoryState contract tx storage
+                observableSlots ∅))
+          hInner
+    _ = EvmYul.Yul.exec (fuel + cases'.length + 13)
+          (.Block
+            [Backends.lowerNativeSwitchBlock
+              (YulExpr.call "shr"
+                [YulExpr.lit Compiler.Constants.selectorShift,
+                 YulExpr.call "calldataload" [YulExpr.lit 0]])
+              (Backends.freshNativeSwitchId reservedNames n0) cases'
+              [nativeRevertZeroZeroStmt]])
+          (some contract)
+          ((nativeSwitchPostInitFreeMemoryState contract tx storage
+            observableSlots ∅).insert "__has_selector"
+            (EvmYul.UInt256.ofNat 1)) := by
+          have hExec :=
+            (exec_block_letSelector_if1Skip_if2Take_postInitFreeMemory_fuel
+              (fuel + cases'.length + 5) contract tx storage observableSlots ∅
+              "__has_selector" body1
+              [Backends.lowerNativeSwitchBlock
+                (YulExpr.call "shr"
+                  [YulExpr.lit Compiler.Constants.selectorShift,
+                   YulExpr.call "calldataload" [YulExpr.lit 0]])
+                (Backends.freshNativeSwitchId reservedNames n0) cases'
+                [nativeRevertZeroZeroStmt]]
+              hNoWrap)
+          simpa only [Nat.add_assoc] using hExec
+
 /-- Generated-prefix variant of
 `contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_error_projectResult_eq`
 for payable functions.
@@ -28190,7 +29870,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
         projectResult (YulTransaction.ofIR tx) storage initialEvents
             (.error err) = nativeYul) := by
   obtain ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hCont⟩ :=
+      hCase, hBodyLower, hDispatcherContinuation⟩ :=
     contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_error_projectResult_eq
       (fuel + 4) selector funcs fn inner functions (YulTransaction.ofIR tx)
       storage initialEvents observableSlots err nativeYul hLower hSelector
@@ -28228,7 +29908,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
       (by simp; omega)
     simpa [Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using
       hPrefix.trans (hUserBody pre suffix hCases)
-  have hResult := hCont hWholeBody hProject
+  have hResult := hDispatcherContinuation hWholeBody hProject
   simpa [Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hResult
 
 /-- Generated-prefix variant of
@@ -28294,7 +29974,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
         projectResult (YulTransaction.ofIR tx) storage initialEvents
             (.error err) = nativeYul) := by
   obtain ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hCont⟩ :=
+      hCase, hBodyLower, hDispatcherContinuation⟩ :=
     contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_error_projectResult_eq
       (fuel + 5) selector funcs fn inner functions (YulTransaction.ofIR tx)
       storage initialEvents observableSlots err nativeYul hLower hSelector
@@ -28336,7 +30016,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
       (by simp; omega)
     simpa [Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using
       hPrefix.trans (hUserBody pre suffix hCases)
-  have hResult := hCont hWholeBody hProject
+  have hResult := hDispatcherContinuation hWholeBody hProject
   simpa [Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hResult
 
 set_option linter.unusedVariables false in
@@ -28392,7 +30072,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
         projectResult (YulTransaction.ofIR tx) storage initialEvents
           (.error EvmYul.Yul.Exception.Revert) := by
   obtain ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hCont⟩ :=
+      hCase, hBodyLower, hDispatcherContinuation⟩ :=
     contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_error_projectResult_eq
       (fuel + 5) selector funcs fn inner functions (YulTransaction.ofIR tx)
       storage initialEvents observableSlots EvmYul.Yul.Exception.Revert
@@ -28425,7 +30105,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
         nativeSwitchHasSelectorStore (4 + fn.params.length * 32)
         (by simpa [YulTransaction.ofIR] using hNonzero)
     simpa [contract, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hExec
-  have hResult := hCont hWholeBody rfl
+  have hResult := hDispatcherContinuation hWholeBody rfl
   refine ⟨reservedNames, n0, cases', body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hCase, hBodyLower, hUserBodyLower, ?_⟩
   simpa [contract, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hResult
@@ -28634,7 +30314,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
         projectResult (YulTransaction.ofIR tx) storage initialEvents
           (.error EvmYul.Yul.Exception.Revert) := by
   obtain ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hCont⟩ :=
+      hCase, hBodyLower, hDispatcherContinuation⟩ :=
     contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_error_projectResult_eq
       (fuel + 4) selector funcs fn inner functions (YulTransaction.ofIR tx)
       storage initialEvents observableSlots EvmYul.Yul.Exception.Revert
@@ -28676,7 +30356,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
         (DispatchGuardsSafe_calldata_threshold_lt fn tx hguards)
         hCalldataLt
     simpa [contract, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hExec
-  have hResult := hCont hWholeBody rfl
+  have hResult := hDispatcherContinuation hWholeBody rfl
   refine ⟨reservedNames, n0, cases', body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hCase, hBodyLower, hUserBodyLower, ?_⟩
   simpa [contract, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hResult
@@ -28732,7 +30412,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
         projectResult (YulTransaction.ofIR tx) storage initialEvents
           (.error EvmYul.Yul.Exception.Revert) := by
   obtain ⟨reservedNames, n0, cases', body', bodyStart, bodyEnd,
-      hCase, hBodyLower, hCont⟩ :=
+      hCase, hBodyLower, hDispatcherContinuation⟩ :=
     contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_error_projectResult_eq
       (fuel + 5) selector funcs fn inner functions (YulTransaction.ofIR tx)
       storage initialEvents observableSlots EvmYul.Yul.Exception.Revert
@@ -28775,7 +30455,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
         (DispatchGuardsSafe_calldata_threshold_lt fn tx hguards)
         hCalldataLt
     simpa [contract, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hExec
-  have hResult := hCont hWholeBody rfl
+  have hResult := hDispatcherContinuation hWholeBody rfl
   refine ⟨reservedNames, n0, cases', body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hCase, hBodyLower, hUserBodyLower, ?_⟩
   simpa [contract, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hResult
@@ -29692,13 +31372,13 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
       initialEvents observableSlots final nativeYul reservedNames bodyStart
       bodyEnd fn hSelector hCase hSelectorRange hTagsRange hBodyLower
       hPayable hguards hNoWrap hArgs
-  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hCont⟩
+  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart,
     bodyEnd, userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower,
     ?_⟩
   intro hUserBody hPreservesUser hProject
   rw [hPeel']
-  have hResult := hCont hUserBody hPreservesUser hProject
+  have hResult := hDispatcherContinuation hUserBody hPreservesUser hProject
   simpa [contract, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hResult
 
 /-- Generated-prefix success variant for non-payable selector hits. The public
@@ -29818,12 +31498,12 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
       initialEvents observableSlots final nativeYul reservedNames bodyStart
       bodyEnd fn hSelector hCase hSelectorRange hTagsRange hBodyLower
       hNonPayable hguards hNoWrap hArgs
-  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hCont⟩
+  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hUserBody hPreservesUser hProject
   rw [hPeel']
-  have hResult := hCont hUserBody hPreservesUser hProject
+  have hResult := hDispatcherContinuation hUserBody hPreservesUser hProject
   simpa [contract, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hResult
 
 /-- Reserved-context generated-prefix success variant for payable selector hits.
@@ -29944,12 +31624,12 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
       initialEvents observableSlots final nativeYul reservedNames bodyStart
       bodyEnd fn hSelector hCase hSelectorRange hTagsRange hBodyLower
       hPayable hguards hNoWrap hArgs
-  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hCont⟩
+  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hUserBody hPreservesUser hProject
   rw [hPeel']
-  have hResult := hCont hUserBody hPreservesUser hProject
+  have hResult := hDispatcherContinuation hUserBody hPreservesUser hProject
   simpa [contract, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hResult
 
 /-- Reserved-context generated-prefix success variant for non-payable selector
@@ -30070,12 +31750,12 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
       initialEvents observableSlots final nativeYul reservedNames bodyStart
       bodyEnd fn hSelector hCase hSelectorRange hTagsRange hBodyLower
       hNonPayable hguards hNoWrap hArgs
-  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hCont⟩
+  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hUserBody hPreservesUser hProject
   rw [hPeel']
-  have hResult := hCont hUserBody hPreservesUser hProject
+  have hResult := hDispatcherContinuation hUserBody hPreservesUser hProject
   simpa [contract, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hResult
 
 /-- Exact-total-fuel companion of
@@ -30208,7 +31888,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
         initialEvents observableSlots final nativeYul reservedNames bodyStart
         bodyEnd fn hSelector hCase hSelectorRange hTagsRange hBodyLower
         hPayable hguards hNoWrap hArgs)
-  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hCont⟩
+  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hFuel hUserBody hPreservesUser hProject
@@ -30261,7 +31941,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
     intro pre suffix hCases
     simpa [fuel, contract, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
       using hUserBody pre suffix hCases
-  have hResult := hCont hUserBody' hPreservesUser hProject
+  have hResult := hDispatcherContinuation hUserBody' hPreservesUser hProject
   simpa [contract, fuel, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
     using hResult
 
@@ -30395,7 +32075,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
         initialEvents observableSlots final nativeYul reservedNames bodyStart
         bodyEnd fn hSelector hCase hSelectorRange hTagsRange hBodyLower
         hNonPayable hguards hNoWrap hArgs)
-  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hCont⟩
+  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨reservedNames, n0, cases', midN, body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hFuel hUserBody hPreservesUser hProject
@@ -30448,7 +32128,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
     intro pre suffix hCases
     simpa [fuel, contract, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
       using hUserBody pre suffix hCases
-  have hResult := hCont hUserBody' hPreservesUser hProject
+  have hResult := hDispatcherContinuation hUserBody' hPreservesUser hProject
   simpa [contract, fuel, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
     using hResult
 
@@ -30583,7 +32263,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
         initialEvents observableSlots final nativeYul reservedNames bodyStart
         bodyEnd fn hSelector hCase hSelectorRange hTagsRange hBodyLower
         hPayable hguards hNoWrap hArgs)
-  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hCont⟩
+  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hFuel hUserBody hPreservesUser hProject
@@ -30636,7 +32316,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
     intro pre suffix hCases
     simpa [fuel, contract, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
       using hUserBody pre suffix hCases
-  have hResult := hCont hUserBody' hPreservesUser hProject
+  have hResult := hDispatcherContinuation hUserBody' hPreservesUser hProject
   simpa [contract, fuel, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
     using hResult
 
@@ -30771,7 +32451,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
         initialEvents observableSlots final nativeYul reservedNames bodyStart
         bodyEnd fn hSelector hCase hSelectorRange hTagsRange hBodyLower
         hNonPayable hguards hNoWrap hArgs)
-  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hCont⟩
+  rcases hBlock with ⟨bodyNative, userBodyStart, hUserBodyLower, hDispatcherContinuation⟩
   refine ⟨switchStart, cases', midN, body', bodyNative, bodyStart, bodyEnd,
     userBodyStart, hLowerCases, hCase, hBodyLower, hUserBodyLower, ?_⟩
   intro hFuel hUserBody hPreservesUser hProject
@@ -30824,7 +32504,7 @@ theorem contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_f
     intro pre suffix hCases
     simpa [fuel, contract, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
       using hUserBody pre suffix hCases
-  have hResult := hCont hUserBody' hPreservesUser hProject
+  have hResult := hDispatcherContinuation hUserBody' hPreservesUser hProject
   simpa [contract, fuel, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
     using hResult
 

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4844,6 +4844,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_revived_nil
   Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_revived_cons
   Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_revived_singleton
+  Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchMatchedFlag_of_revived_body_final
   Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_revived_block
   Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_forall_stmt
   Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_forall_stmt_write_not_mem
@@ -5575,4 +5576,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5289 theorems/lemmas (3601 public, 1688 private, 0 sorry'd)
+-- Total: 5290 theorems/lemmas (3602 public, 1688 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -871,8 +871,10 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.EndToEnd.sizeOf_buildSwitch_noFallback_noReceive_ge_source_cases_length_plus24  -- private
   -- Compiler.Proofs.EndToEnd.sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length  -- private
   -- Compiler.Proofs.EndToEnd.sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus24  -- private
+  -- Compiler.Proofs.EndToEnd.sizeOf_emitYul_runtimeCode_noMapping_ge_lowered_cases_length_plus25  -- private
   -- Compiler.Proofs.EndToEnd.sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length  -- private
   -- Compiler.Proofs.EndToEnd.sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus24  -- private
+  -- Compiler.Proofs.EndToEnd.sizeOf_emitYul_runtimeCode_mapping_ge_lowered_cases_length_plus25  -- private
   -- Compiler.Proofs.EndToEnd.nativeIRRuntimeMatchesIR_of_generated_lowered_dispatcherExec_positive_match  -- private
   -- Compiler.Proofs.EndToEnd.nativeDispatcherExecMatchesIRPositive_of_project_eq_match  -- private
   -- Compiler.Proofs.EndToEnd.nativeIRRuntimeMatchesIR_of_generated_lowered_dispatcherExec_project_eq_match  -- private
@@ -882,6 +884,10 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.EndToEnd.nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_miss_noFallback_noReceive_atFuel  -- private
   -- Compiler.Proofs.EndToEnd.nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds  -- private
   -- Compiler.Proofs.EndToEnd.nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds_atFuel  -- private
+  -- Compiler.Proofs.EndToEnd.nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive_atFuel  -- private
+  -- Compiler.Proofs.EndToEnd.nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive  -- private
+  -- Compiler.Proofs.EndToEnd.nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds_atFuel  -- private
+  -- Compiler.Proofs.EndToEnd.nativeDispatcherExecMatchesIRPositive_of_initFreeMemoryPointer_buildSwitch_selector_miss_noFallback_noReceive_withSwitchIds  -- private
   -- Compiler.Proofs.EndToEnd.nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_error_noFallback_noReceive  -- private
   -- Compiler.Proofs.EndToEnd.nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_error_noFallback_noReceive_atFuel  -- private
   -- Compiler.Proofs.EndToEnd.nativeDispatcherExecMatchesIRPositive_of_buildSwitch_selector_hit_error_noFallback_noReceive_atFuel_artifact  -- private
@@ -970,6 +976,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.EndToEnd.switchCases_bridged_local  -- private
   -- Compiler.Proofs.EndToEnd.buildSwitch_bridged_local  -- private
   -- Compiler.Proofs.EndToEnd.mappingSlotFuncAt_bridged_local  -- private
+  -- Compiler.Proofs.EndToEnd.initFreeMemoryPointer_bridged_local  -- private
   -- Compiler.Proofs.EndToEnd.runtimeCode_bridged_local  -- private
   Compiler.Proofs.EndToEnd.switchCaseBody_bridged_of_body
   Compiler.Proofs.EndToEnd.generatedRuntimeSwitchCaseBodiesBridged_of_compile_ok_supported
@@ -1026,6 +1033,10 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.EndToEnd.compile_preserves_native_evmYulLean_of_interpretIRRuntimeNative_match_mapping_dispatcher_ofIR_globalDefaults  -- private
   -- Compiler.Proofs.EndToEnd.lowerStmtsNative_buildSwitch_noFallback_noReceive_ok_block  -- private
   -- Compiler.Proofs.EndToEnd.lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block  -- private
+  -- Compiler.Proofs.EndToEnd.lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block  -- private
+  -- Compiler.Proofs.EndToEnd.lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_prefixed_block  -- private
+  -- Compiler.Proofs.EndToEnd.lowerStmtsNativeWithSwitchIds_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_ok_of_tail  -- private
+  -- Compiler.Proofs.EndToEnd.lowerSwitchCasesNativeWithSwitchIds_buildSwitch_tags_range_of_functionSelectorsRange  -- private
   -- Compiler.Proofs.EndToEnd.nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_match  -- private
   -- Compiler.Proofs.EndToEnd.nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_body_closure  -- private
   -- Compiler.Proofs.EndToEnd.nativeIRRuntimeMatchesIR_of_compiled_generated_lowered_dispatcherExec_positive_supported  -- private
@@ -1143,8 +1154,6 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.EndToEnd.compile_preserves_native_evmYulLean_selector_hit_ok_mapping_structural_nonpayable_generated_prefix  -- private
   -- Compiler.Proofs.EndToEnd.compile_preserves_native_evmYulLean_selector_hit_ok_lowered_runtime_payable_generated_prefix  -- private
   -- Compiler.Proofs.EndToEnd.compile_preserves_native_evmYulLean_selector_hit_ok_lowered_runtime_nonpayable_generated_prefix  -- private
-  -- Compiler.Proofs.EndToEnd.compile_preserves_native_evmYulLean_selector_hit_ok_lowered_runtime_payable_generated_prefix_atFuel  -- private
-  -- Compiler.Proofs.EndToEnd.compile_preserves_native_evmYulLean_selector_hit_ok_lowered_runtime_nonpayable_generated_prefix_atFuel  -- private
   -- Compiler.Proofs.EndToEnd.compile_preserves_native_evmYulLean_selector_hit_ok_mapping_canonical  -- private
   -- Compiler.Proofs.EndToEnd.compile_preserves_native_evmYulLean_selector_hit_error_noMapping_structural  -- private
   -- Compiler.Proofs.EndToEnd.compile_preserves_native_evmYulLean_selector_hit_error_noMapping_canonical  -- private
@@ -1382,8 +1391,9 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcher_eq_lowered_stmts  -- private
   -- Compiler.Proofs.EndToEnd.lowerStmtsNative_single_block_ok_singleton  -- private
   -- Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcherStmts_lowering_ok  -- private
-  -- Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcherStmts_exists_singleton_block  -- private
-  -- Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcherStmts_eq_singleton_block  -- private
+  -- Compiler.Proofs.EndToEnd.simpleStorageNativeRuntimeDispatcherStmts_exists_init_block  -- private
+  -- Compiler.Proofs.EndToEnd.simpleStorageNativeRuntimeDispatcherStmts_eq_init_block  -- private
+  -- Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcherInnerStmts_lowering_ok  -- private
   -- Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcher_eq_singleton_block_inner  -- private
   -- Compiler.Proofs.EndToEnd.simpleStorageNativeContract_eq_record_inner_block  -- private
   -- Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_eq_innerBlock_exec  -- private
@@ -1402,8 +1412,8 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.EndToEnd.lowerStmtsNativeWithSwitchIds_revert_zero_zero  -- private
   -- Compiler.Proofs.EndToEnd.lowerStmtsNativeWithSwitchIds_singleton_switch_revert_default_eq  -- private
   -- Compiler.Proofs.EndToEnd.lowerStmtsNativeWithSwitchIds_singleton_switch_revert_default_eq_sourceLowered  -- private
-  -- Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcherInnerStmts_eq_concrete_let_if_switchSingleton_revert_default  -- private
   -- Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcherInnerStmts_eq_concrete_let_if_switchSingleton_revert_default_sourceLowered  -- private
+  -- Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcherInnerStmts_eq_concrete_let_if_switchSingleton_revert_default  -- private
   -- Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcher_letValue_eq  -- private
   -- Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcher_if1Cond_eq  -- private
   -- Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcher_if2Cond_eq  -- private
@@ -1425,6 +1435,9 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.EndToEnd.simpleStorageBuildSwitchSourceCases_lowered_shape  -- private
   -- Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredStoreCaseBody_head_strip_error  -- private
   -- Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredRetrieveCaseBody_head_strip_error  -- private
+  -- Compiler.Proofs.EndToEnd.nativeSwitchPostInitFreeMemorySharedState_weiValue  -- private
+  -- Compiler.Proofs.EndToEnd.nativeSwitchPostInitFreeMemorySharedState_calldata_size  -- private
+  -- Compiler.Proofs.EndToEnd.nativeSwitchPostInitFreeMemorySharedState_perm  -- private
   -- Compiler.Proofs.EndToEnd.exec_block_store0_calldataload4_stop_markedPrefix_halt  -- private
   -- Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredStoreCaseBodyTail_callvalue_strip_error  -- private
   -- Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredRetrieveCaseBodyTail_callvalue_strip_error  -- private
@@ -1458,8 +1471,8 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_tail  -- private
   -- Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_tail2  -- private
   -- Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_tail3  -- private
-  -- Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcherFuel_ge_25  -- private
-  -- Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcherFuel_ge_21  -- private
+  -- Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcherFuel_ge_26  -- private
+  -- Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcherFuel_ge_22  -- private
   -- Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_selectorMiss_revert_atFuel  -- private
   -- Compiler.Proofs.EndToEnd.interpretIR_simpleStorage_selectorMiss  -- private
   -- Compiler.Proofs.EndToEnd.interpretIR_simpleStorage_retrieveHit  -- private
@@ -1473,6 +1486,13 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.EndToEnd.NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_store0_calldataload4_stop  -- private
   -- Compiler.Proofs.EndToEnd.NativeGeneratedSelectedUserBodyResultBridgeAtFuel.of_store0_calldataload4_stop  -- private
   -- Compiler.Proofs.EndToEnd.nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_store0_calldataload4_stop  -- private
+  -- Compiler.Proofs.EndToEnd.array_extract_append_left  -- private
+  -- Compiler.Proofs.EndToEnd.byteArray_readWithPadding_prefix  -- private
+  -- Compiler.Proofs.EndToEnd.byteArray_write_zero_32_readWithPadding_eq_of_size  -- private
+  -- Compiler.Proofs.EndToEnd.byteArray_write_empty_64_32_size_ge_32  -- private
+  -- Compiler.Proofs.EndToEnd.nativeSwitchPostInitFreeMemorySharedState_memory_size_ge_32  -- private
+  -- Compiler.Proofs.EndToEnd.nativeSwitchPostInitFreeMemorySharedState_accountMap  -- private
+  -- Compiler.Proofs.EndToEnd.mstore0_then_return32_hReturn_eq_toByteArray  -- private
   -- Compiler.Proofs.EndToEnd.projectResult_retrieveHit_eq  -- private
   -- Compiler.Proofs.EndToEnd.projectResult_literalReturnHit_eq  -- private
   -- Compiler.Proofs.EndToEnd.nativeResultsMatchOn_execIRFunction_mstore0_sload0_return32_markedPrefix  -- private
@@ -4129,6 +4149,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.Native.lowerSwitchCasesNativeWithSwitchIds_buildSwitch_find?_none_of_find_function
   Compiler.Proofs.YulGeneration.Backends.Native.lowerRuntimeContractNative_single_stmt_eq_lowerStmtsNative
   Compiler.Proofs.YulGeneration.Backends.Native.lowerRuntimeContractNativeAux_single_stmt_eq_lowerStmtsNativeWithSwitchIds
+  Compiler.Proofs.YulGeneration.Backends.Native.lowerRuntimeContractNativeAux_nonFunc_eq_lowerStmtsNativeWithSwitchIds
+  Compiler.Proofs.YulGeneration.Backends.Native.lowerRuntimeContractNative_nonFunc_eq_lowerStmtsNative
   Compiler.Proofs.YulGeneration.Backends.Native.emitYul_runtimeCode_eq_single_dispatcher_of_noMapping_noInternals_noFallback_noReceive
   Compiler.Proofs.YulGeneration.Backends.Native.lowerRuntimeContractNative_emitYul_noMapping_noInternals_noFallback_noReceive
   Compiler.Proofs.YulGeneration.Backends.Native.lowerRuntimeContractNative_emitYul_noMapping_ok_dispatcher
@@ -4168,6 +4190,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeDispatcherHasNoFuncDefs_emitYul_runtimeCode_noFallback_noReceive
   Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeFunctionNamesUnique_append_nonFunc_suffix
   Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeFunctionNamesUnique_buildSwitch_append
+  Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeFunctionNamesUnique_initFreeMemoryPointer_buildSwitch_append
   Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeFunctionNamesUnique_runtimeCode
   Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeFunctionNamesUnique_emitYul_runtimeCode
   Compiler.Proofs.YulGeneration.Backends.Native.mappingSlotFuncAt_body_noFuncDefs
@@ -4179,6 +4202,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_append
   Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_internalFunctions
   Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_buildSwitch
+  Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_initFreeMemoryPointer_buildSwitch
   Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_runtimeCode
   Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs_emitYul_runtimeCode
   Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeNativeFragment_emitYul_runtimeCode_noFallback_noReceive
@@ -4611,9 +4635,15 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.Native.exec_block_block_nil_ok_add_ten
   Compiler.Proofs.YulGeneration.Backends.Native.exec_block_stop_halt_add_ten
   Compiler.Proofs.YulGeneration.Backends.Native.exec_block_noop_block_head_eq
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_initFreeMemoryPointer_head_ok
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_block_cons_initFreeMemoryPointer_eq
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_let_lowerExprNative_selectorExpr_postInitFreeMemory_store_ok_fuel
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_let_lowerExprNative_iszero_lt_calldatasize_4_postInitFreeMemory_store_ok_fuel
+  -- Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryState_insert_lookup_self  -- private
   Compiler.Proofs.YulGeneration.Backends.Native.exec_nativeSwitchPrefix_selector_initialState_ok
   Compiler.Proofs.YulGeneration.Backends.Native.exec_nativeSwitchPrefix_selector_initialState_ok_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_nativeSwitchPrefix_selector_initialState_store_ok_fuel
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_nativeSwitchPrefix_selector_postInitFreeMemory_store_ok_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_if_eval_zero
   Compiler.Proofs.YulGeneration.Backends.Native.exec_if_eval_nonzero
   Compiler.Proofs.YulGeneration.Backends.Native.exec_if_eval_nonzero_error
@@ -4633,6 +4663,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.Native.exec_block_singleton_eq
   Compiler.Proofs.YulGeneration.Backends.Native.exec_block_letSelector_if1Skip_initialState_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_block_letSelector_if1Skip_if2Take_initialState_fuel
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_block_letSelector_if1Skip_postInitFreeMemory_fuel
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_block_letSelector_if1Skip_if2Take_postInitFreeMemory_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.eval_nativeSwitchGuardedMatch_ok
   Compiler.Proofs.YulGeneration.Backends.Native.eval_nativeSwitchGuardedMatch_ok_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.eval_nativeSwitchGuardedMatch_hit_ok
@@ -5121,30 +5153,45 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_none_with_default_nonempty_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_none_with_revert_default_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_storePrefix_tail_error_fuel
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_postInitFreeMemory_storePrefix_tail_error_fuel
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_postInitFreeMemory_storePrefix_tail_ok_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_reviveJump_eq
+  Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_reviveJump_eq
   Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_weiValue
   Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_calldata_size
   Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_matched
+  Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_weiValue
+  Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_calldata_size
+  Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_matched
   Compiler.Proofs.YulGeneration.Backends.Native.exec_if_callvalue_skip_markedPrefix_zero_mod_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_if_callvalue_take_markedPrefix_nonzero_revert_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_if_lt_calldatasize_skip_markedPrefix_ge_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_if_lt_calldatasize_take_markedPrefix_lt_revert_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_eq
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_prefix_postInitFreeMemory_eq
   Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_calldata_revert_fuel
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_calldata_revert_postInitFreeMemory_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_eq
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_prefix_postInitFreeMemory_eq
   Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_callvalue_revert_fuel
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_callvalue_revert_postInitFreeMemory_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_calldata_revert_fuel
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_calldata_revert_postInitFreeMemory_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_payable_lowered_prefix_eq
   Compiler.Proofs.YulGeneration.Backends.Native.exec_switchCaseBody_nonpayable_lowered_prefix_eq
   Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchInitialOkState_insert_hasSelector_eq
   Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPrefixStoreState_matched_eq
   Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPrefixStoreState_discr_eq
+  Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryPrefixStoreState_matched_eq
+  Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryPrefixStoreState_discr_eq
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_storePrefix_tail_ok_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_hit_preserved_store_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_hit_finalMatched_store_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_hit_fresh_store_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_none_with_revert_default_store_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_hit_error_store_fuel
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_hit_error_postInitFreeMemory_store_fuel
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_hit_finalMatched_postInitFreeMemory_store_fuel
   Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_revert_default_hasSelectorState_error
   Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_hasSelectorState_error
   Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_hasSelectorState_ok_fresh
@@ -5156,6 +5203,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.Native.initialState_observableStorageSlot
   Compiler.Proofs.YulGeneration.Backends.Native.initialState_materializedStorageSlot
   Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchStoreMarkedPrefixStateForId_materializedStorageSlot
+  Compiler.Proofs.YulGeneration.Backends.Native.nativeSwitchPostInitFreeMemoryStoreMarkedPrefixStateForId_materializedStorageSlot
   Compiler.Proofs.YulGeneration.Backends.Native.initialState_sload_observableSlot_value
   Compiler.Proofs.YulGeneration.Backends.Native.initialState_sload_materializedSlot_value
   Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState_retrieveHit_initialState_materialized
@@ -5271,13 +5319,17 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.Native.projectResult_hardError_events
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_hit_error_projectResult_eq
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_hit_error_store_projectResult_eq
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_hit_error_postInitFreeMemory_store_projectResult_eq
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_hit_error_store_projectResult_eq_payable_generated_prefix
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_hit_error_store_projectResult_eq_nonpayable_generated_prefix
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_hit_ok_store_projectResult_eq_payable_generated_prefix
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_hit_ok_store_projectResult_eq_nonpayable_generated_prefix
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_none_with_revert_default_store_projectResult_eq
   Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_revert_default_hasSelectorState_projectResult_eq
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_revert_default_postInitFreeMemory_hasSelectorState_projectResult_eq
   Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_hasSelectorState_error_projectResult_eq
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_error_projectResult_eq
+  Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_postInitFreeMemory_hasSelectorState_ok_projectResult_eq_finalMatched
   Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_hasSelectorState_error_projectResult_eq_payable_generated_prefix
   Compiler.Proofs.YulGeneration.Backends.Native.exec_block_lowerNativeSwitchBlock_selector_find_hit_hasSelectorState_error_projectResult_eq_nonpayable_generated_prefix
   Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_selector_find_hit_ok_projectResult_eq
@@ -5296,6 +5348,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_none_atFuel_projectResult_eq
   Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_error_projectResult_eq
   Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_buildSwitch_noFallback_noReceive_peel
+  Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_initFreeMemoryPointer_buildSwitch_noFallback_noReceive_peel
   Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_error_payable_generated_prefix_projectResult_eq
   Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_error_nonpayable_generated_prefix_projectResult_eq
   Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult_buildSwitch_noFallback_noReceive_selector_find_some_nonpayable_callvalue_revert_projectResult_eq
@@ -5576,4 +5629,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5290 theorems/lemmas (3602 public, 1688 private, 0 sorry'd)
+-- Total: 5343 theorems/lemmas (3634 public, 1709 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- Removes `LeaveAwareCallDispatcherContinuation` from EndToEnd.
- Removes the leave-aware `hCont` premise from the E2/E4/E6 and F2/F4/F6 success bridge wrappers.
- Reuses the #1890 final-matched generated dispatcher endpoint by deriving the raw matched flag from the narrow checkpoint-aware hook.

Stacked on #1906.

## Verification
- Tiny Lean probe via `lake env lean --stdin` passed on the stacked branch.
- `lake build Compiler.Proofs.EndToEnd`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the generated deploy and runtime prologue to `mstore(0x40, 128)`, which can affect all contracts that rely on free-memory-based ABI encoding/event emission. Risk is moderate because it alters low-level EVM memory initialization but is localized and conventional.
> 
> **Overview**
> Adds an explicit `initFreeMemoryPointer` Yul statement that sets the Solidity free memory pointer (`mstore(0x40, 128)`).
> 
> Injects this initialization into **all** generated outputs: before the runtime dispatcher switch, in the emit-options runtime path, and at the start of deploy code (ahead of value guards/mapping helpers/constructor code).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d478131d3efc05cdd69556e919e3e4272b813cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->