### PR TITLE
Add explicit external link modes

### DIFF
--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -7,6 +7,7 @@
 import Compiler.CompilationModel.Compile
 import Compiler.CompilationModel.ParamLoading
 import Compiler.CompilationModel.ScopeValidation
+import Compiler.CompilationModel.TrustSurface
 
 namespace Compiler.CompilationModel
 
@@ -248,6 +249,11 @@ def compileConstructor (fields : List Field) (events : List EventDef) (errors : 
 private def validateCompileInputsBeforeFieldWriteConflict
     (spec : CompilationModel) : Except String Unit := do
   validateIdentifierShapes spec
+  match (collectUsedExternalAssumptions spec).find? (fun ext => ext.linkMode == .external) with
+  | some ext =>
+      throw s!"Compilation error: {spec.name} uses raw linked-helper lowering for external ABI dependency '{ext.name}'. `linked_as := external` dependencies must lower through an ABI-call ECM such as Compiler.Modules.Calls.withReturn so returndata and revert data are preserved."
+  | none =>
+      pure ()
   match firstInvalidSlotAliasRange spec.slotAliasRanges with
   | some (idx, range) =>
       throw s!"Compilation error: slotAliasRanges[{idx}] has invalid source interval {range.sourceStart}..{range.sourceEnd} in {spec.name} ({issue623Ref}). slotAliasRanges require sourceStart <= sourceEnd."

--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -996,6 +996,7 @@ private def assumptionJson (entry : ExternalFunction) : String :=
   jsonObject [
     ("name", jsonString entry.name),
     ("status", proofStatusString entry.proofStatus),
+    ("linkMode", jsonString entry.linkMode.toJsonString),
     ("axioms", jsonArray (entry.axiomNames.map jsonString))
   ]
 
@@ -1040,6 +1041,7 @@ private structure AssumptionReportEntry where
   status : ProofStatus
   detail : String := ""
   assumption : String := ""
+  linkMode : String := ""
   moduleName : String := ""
   axioms : List String := []
 
@@ -1052,6 +1054,7 @@ private def assumptionReportEntryJson (entry : AssumptionReportEntry) : String :
     ("status", proofStatusString entry.status),
     ("detail", jsonString entry.detail),
     ("assumption", jsonString entry.assumption),
+    ("linkMode", jsonString entry.linkMode),
     ("module", jsonString entry.moduleName),
     ("axioms", jsonArray (entry.axioms.map jsonString))
   ]
@@ -1243,6 +1246,7 @@ private def assumptionReportEntriesForSite (site : UsageSiteSummary) : List Assu
         siteName := site.name
         name := ext.name
         status := ext.proofStatus
+        linkMode := ext.linkMode.toJsonString
         axioms := ext.axiomNames })
   let moduleEntries :=
     site.modules.map (fun mod =>
@@ -1371,7 +1375,7 @@ def emitVerboseUsageSiteLines (specs : List CompilationModel) : List String :=
                     if ext.axiomNames.isEmpty then "(no declared axioms)"
                     else String.intercalate ", " ext.axiomNames
                   extAcc ++
-                    [s!"    [linked:{ext.name}][{ext.proofStatus.toJsonString}] {renderedAxioms}"])
+                    [s!"    [linked:{ext.name}][{ext.proofStatus.toJsonString}][{ext.linkMode.toJsonString}] {renderedAxioms}"])
                 []
             let ecmAxiomLines :=
               site.modules.foldl

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -228,6 +228,34 @@ structure ErrorDef where
 Verified external library integration with axiom documentation.
 -/
 
+inductive ForeignLinkMode where
+  /-- The dependency remains an ABI boundary and is called through an adapter
+      that preserves Solidity-compatible returndata and revert behavior. -/
+  | external
+  /-- The dependency is provided as Yul/EVM object code and linked into the
+      generated artifact at compile time. -/
+  | objectLinked
+  /-- The dependency is a small pure helper whose body may be inlined by the
+      frontend/backend. The compiler still treats it as a declared foreign
+      surface for audit visibility. -/
+  | inline
+  /-- The dependency is owned by the compiler runtime rather than by a protocol
+      deployment boundary. -/
+  | compilerRuntime
+  deriving Repr, BEq
+
+def ForeignLinkMode.toJsonString : ForeignLinkMode → String
+  | .external => "external"
+  | .objectLinked => "objectLinked"
+  | .inline => "inline"
+  | .compilerRuntime => "compilerRuntime"
+
+def ForeignLinkMode.humanName : ForeignLinkMode → String
+  | .external => "external ABI boundary"
+  | .objectLinked => "object-linked Yul"
+  | .inline => "inline helper"
+  | .compilerRuntime => "compiler runtime"
+
 structure ExternalFunction where
   name : String
   params : List ParamType
@@ -242,6 +270,11 @@ structure ExternalFunction where
       The actual Lean propositions are stated separately;
       these names are for documentation and audit purposes. -/
   axiomNames : List String
+  /-- How the foreign surface is linked into the generated artifact.  Historical
+      `linked_externals` declarations default to object-linked Yul because the
+      compiler emits a Yul function call and the driver injects matching helper
+      definitions from `--link` libraries. -/
+  linkMode : ForeignLinkMode := .objectLinked
   deriving Repr
 
 structure LocalObligation where

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -253,7 +253,8 @@ def storeEchoModelUsesDeclaredExternal : Bool :=
          returnType := some ParamType.uint256
          returns := [ParamType.uint256]
          proofStatus := Compiler.ProofStatus.assumed
-         axiomNames := [] }] => true
+         axiomNames := []
+         linkMode := Compiler.CompilationModel.ForeignLinkMode.objectLinked }] => true
     | _ => false) &&
     match MacroExternal.storeEcho_modelBody with
     | [Stmt.letVar "echoed" (Expr.externalCall "echo" [Expr.param "next"]),
@@ -272,6 +273,99 @@ def storeEchoExecutableUsesStub : Bool :=
 example : storeEchoExecutableUsesStub = true := by native_decide
 
 end MacroExternalSmoke
+
+namespace MacroExternalLinkModeSmoke
+
+open Contracts
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_contract MacroExternalLinkModes where
+  storage
+    value : Uint256 := slot 0
+  linked_externals
+    external oracleEcho(Uint256) -> (Uint256) linked_as := external
+    external poseidonHash(Uint256, Uint256) -> (Uint256) linked_as := internal_yul
+    external inlineAdd(Uint256, Uint256) -> (Uint256) linked_as := inline
+    external abiRuntime(Uint256) -> (Uint256) linked_as := compiler_runtime
+
+def parsedExternalLinkModes : Bool :=
+  MacroExternalLinkModes.spec.externals.map (fun ext => (ext.name, ext.linkMode.toJsonString)) =
+    [ ("oracleEcho", "external")
+    , ("poseidonHash", "objectLinked")
+    , ("inlineAdd", "inline")
+    , ("abiRuntime", "compilerRuntime")
+    ]
+
+example : parsedExternalLinkModes = true := by native_decide
+
+def linkModeTrustSurfaceSpec : CompilationModel := {
+  name := "LinkModeTrustSurface"
+  fields := []
+  «constructor» := none
+  externals := [
+    { name := "oracleEcho"
+      params := [ParamType.uint256]
+      returnType := some ParamType.uint256
+      returns := [ParamType.uint256]
+      axiomNames := []
+      linkMode := .external },
+    { name := "poseidonHash"
+      params := [ParamType.uint256, ParamType.uint256]
+      returnType := some ParamType.uint256
+      returns := [ParamType.uint256]
+      axiomNames := []
+      linkMode := .objectLinked },
+    { name := "inlineAdd"
+      params := [ParamType.uint256, ParamType.uint256]
+      returnType := some ParamType.uint256
+      returns := [ParamType.uint256]
+      axiomNames := []
+      linkMode := .inline },
+    { name := "abiRuntime"
+      params := [ParamType.uint256]
+      returnType := some ParamType.uint256
+      returns := [ParamType.uint256]
+      axiomNames := []
+      linkMode := .compilerRuntime }
+  ]
+  functions := [
+    { name := "exercise"
+      params := [{ name := "next", ty := ParamType.uint256 }]
+      returnType := some FieldType.uint256
+      body := [
+        Stmt.letVar "a" (Expr.externalCall "oracleEcho" [Expr.param "next"]),
+        Stmt.letVar "b" (Expr.externalCall "poseidonHash" [Expr.param "next", Expr.param "next"]),
+        Stmt.letVar "c" (Expr.externalCall "inlineAdd" [Expr.localVar "b", Expr.param "next"]),
+        Stmt.letVar "d" (Expr.externalCall "abiRuntime" [Expr.localVar "c"]),
+        Stmt.return (Expr.localVar "d")
+      ]
+    }
+  ]
+}
+
+def externalModeRawCallSpec : CompilationModel := {
+  name := "ExternalModeRawCall"
+  fields := []
+  «constructor» := none
+  externals := [
+    { name := "oracleEcho"
+      params := [ParamType.uint256]
+      returnType := some ParamType.uint256
+      returns := [ParamType.uint256]
+      axiomNames := []
+      linkMode := .external }
+  ]
+  functions := [
+    { name := "bad"
+      params := [{ name := "next", ty := ParamType.uint256 }]
+      returnType := some FieldType.uint256
+      body := [Stmt.return (Expr.externalCall "oracleEcho" [Expr.param "next"])]
+    }
+  ]
+}
+
+end MacroExternalLinkModeSmoke
 
 namespace DynamicBytesEqUsageAnalysisSmoke
 
@@ -4996,7 +5090,13 @@ set_option maxRecDepth 4096 in
       contains externalCallWithReturnYul "mstore(add(__ecwr_ptr, 4), asset)" &&
       contains externalCallWithReturnYul "mstore(64, add(__ecwr_ptr, 64))" &&
       contains externalCallWithReturnYul "staticcall(gas(), target, __ecwr_ptr, 36, __ecwr_ptr, 32)" &&
+      contains externalCallWithReturnYul "returndatacopy(0, 0, __ecwr_rds)" &&
+      contains externalCallWithReturnYul "revert(0, __ecwr_rds)" &&
       contains externalCallWithReturnYul "answer := mload(__ecwr_ptr)")
+  expectCompileErrorContains
+    "external link mode rejects raw linked-helper lowering"
+    MacroExternalLinkModeSmoke.externalModeRawCallSpec
+    "linked_as := external"
   let bubblingValueCallYul ←
     expectCompileToYul "bubbling value call smoke spec" bubblingValueCallSmokeSpec
   expectTrue "bubbling value call ECM lowers to call, not staticcall"
@@ -5323,7 +5423,14 @@ set_option maxRecDepth 4096 in
   let macroExternalTrustReport := emitTrustReportJson [MacroExternalSmoke.MacroExternal.spec]
   expectTrue "macro externals surface in the trust report"
     (contains macroExternalTrustReport "\"linkedExternals\"" &&
-      contains macroExternalTrustReport "\"echo\"")
+      contains macroExternalTrustReport "\"echo\"" &&
+      contains macroExternalTrustReport "\"linkMode\":\"objectLinked\"")
+  let macroLinkModeTrustReport := emitTrustReportJson [MacroExternalLinkModeSmoke.linkModeTrustSurfaceSpec]
+  expectTrue "macro external link modes surface in the trust report"
+    (contains macroLinkModeTrustReport "\"linkMode\":\"external\"" &&
+      contains macroLinkModeTrustReport "\"linkMode\":\"objectLinked\"" &&
+      contains macroLinkModeTrustReport "\"linkMode\":\"inline\"" &&
+      contains macroLinkModeTrustReport "\"linkMode\":\"compilerRuntime\"")
   let macroPowTrustReport := emitTrustReportJson [Contracts.Smoke.Uint256PowSmoke.spec]
   expectTrue "macro pow builtin does not surface as a linked external"
     (!contains macroPowTrustReport builtinExpName)

--- a/Compiler/CompileDriverCommon.lean
+++ b/Compiler/CompileDriverCommon.lean
@@ -157,12 +157,19 @@ private def ensureLayoutCompatible (specs : List CompilationModel) : IO Unit := 
 
 private def writeContract
     (backend : CodegenBackend)
+    (spec : CompilationModel)
     (outDir : String)
     (contract : IRContract)
     (libraryPaths : List String)
     (verbose : Bool)
     (options : YulEmitOptions) : IO Yul.PatchPassReport := do
-  let (yulObj, patchReport) := backend.emitYulWithOptionsReport contract options
+  let (baseYulObj, patchReport) := backend.emitYulWithOptionsReport contract options
+  let linkModeComments :=
+    spec.externals.map fun ext =>
+      YulStmt.comment s!"verity linked external {ext.name} linkMode={ext.linkMode.toJsonString}"
+  let yulObj :=
+    { baseYulObj with
+      runtimeCode := linkModeComments ++ baseYulObj.runtimeCode }
 
   let libraries ← libraryPaths.mapM fun path => do
     if verbose then
@@ -228,7 +235,7 @@ def compileSpecsWithOptions
     match compile spec selectors with
     | .ok contract =>
         let contractLibs := if spec.externals.isEmpty then [] else libraryPaths
-        let patchReport ← writeContract backend outDir contract contractLibs verbose options
+        let patchReport ← writeContract backend spec outDir contract contractLibs verbose options
         match abiOutDir with
         | some dir =>
             Compiler.ABI.writeContractABIFile dir spec

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -1087,6 +1087,7 @@ unsafe def runTests : IO Unit := do
   let patchReportDir := s!"/tmp/verity-compile-driver-test-{nonce}-reports/patch"
   let patchReportPath := s!"{patchReportDir}/patch-report.tsv"
   let missingLib := "/tmp/definitely-missing-library.yul"
+  let linkedLib := s!"/tmp/verity-compile-driver-test-{nonce}-poseidon.yul"
   let earlySuccessfulAbi := s!"{abiDir}/AbiSmoke.abi.json"
 
   IO.FS.createDirAll outDir
@@ -1113,6 +1114,17 @@ unsafe def runTests : IO Unit := do
   if !hasEarlySuccessfulAbi then
     throw (IO.userError s!"✗ expected ABI artifact for early successful contract, missing: {earlySuccessfulAbi}")
   IO.println "✓ ABI artifacts still emitted for contracts compiled before failure"
+
+  IO.FS.writeFile linkedLib
+    "function PoseidonT3_hash(a, b) -> out {\n    out := add(a, b)\n}\n"
+  compileSpecsWithOptions [linkedLibrarySpec] outDir false [linkedLib] {} none none none none
+  expectFileContains
+    "compileSpecsWithOptions emits linked helper and link-mode artifact metadata"
+    s!"{outDir}/LinkedLibrarySmoke.yul"
+    [ "verity linked external PoseidonT3_hash linkMode=objectLinked"
+    , "function PoseidonT3_hash(a, b) -> out"
+    , "let h := PoseidonT3_hash(a, b)"
+    ]
 
   compileSpecsWithOptions [stringAbiSmokeSpec] stringOutDir false [] {} none none none (some stringAbiDir)
   expectFileContains
@@ -1231,6 +1243,8 @@ unsafe def runTests : IO Unit := do
     throw (IO.userError "✗ trust report emits linked external name")
   if !contains trustReport "\"status\":\"assumed\"" then
     throw (IO.userError "✗ trust report emits linked external status")
+  if !contains trustReport "\"linkMode\":\"objectLinked\"" then
+    throw (IO.userError "✗ trust report emits linked external link mode")
   if !contains trustReport "\"axioms\":[\"poseidon_t3_deterministic\"]" then
     throw (IO.userError "✗ trust report emits linked external axioms")
   if !contains trustReport "\"module\":\"testCall\"" || !contains trustReport "\"assumption\":\"test_call_interface\"" then
@@ -1288,7 +1302,7 @@ unsafe def runTests : IO Unit := do
     throw (IO.userError "✗ verbose trust report localizes function usage sites")
   if !contains verboseUsageSiteReport "low-level mechanics: staticcall, returndataSize, returndataCopy" then
     throw (IO.userError "✗ verbose trust report preserves per-function low-level mechanics")
-  if !contains verboseUsageSiteReport "[linked:PoseidonT3_hash][assumed] poseidon_t3_deterministic" then
+  if !contains verboseUsageSiteReport "[linked:PoseidonT3_hash][assumed][objectLinked] poseidon_t3_deterministic" then
     throw (IO.userError "✗ verbose trust report localizes linked external assumptions")
   if !contains verboseUsageSiteReport "[ecm:testCall][assumed] test_call_interface" then
     throw (IO.userError "✗ verbose trust report localizes ECM assumptions")
@@ -1388,11 +1402,13 @@ unsafe def runTests : IO Unit := do
     throw (IO.userError "✗ assumption report emits contract name")
   if !contains assumptionReport "\"category\":\"axiomatizedPrimitive\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"keccak256\",\"status\":\"assumed\",\"detail\":\"\",\"assumption\":\"keccak256_memory_slice_matches_evm\"" then
     throw (IO.userError "✗ assumption report emits primitive assumption entries")
-  if !contains assumptionReport "\"category\":\"linkedExternal\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"PoseidonT3_hash\",\"status\":\"assumed\"" then
+  if !contains assumptionReport "\"category\":\"linkedExternal\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"PoseidonT3_hash\",\"status\":\"assumed\"" ||
+      !contains assumptionReport "\"linkMode\":\"objectLinked\"" then
     throw (IO.userError "✗ assumption report emits linked external entries")
   if !contains assumptionReport "\"category\":\"ecmModule\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"testCall\",\"status\":\"assumed\"" then
     throw (IO.userError "✗ assumption report emits ECM module entries")
-  if !contains assumptionReport "\"category\":\"ecmAxiom\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"test_call_interface\",\"status\":\"assumed\",\"detail\":\"\",\"assumption\":\"\",\"module\":\"testCall\"" then
+  if !contains assumptionReport "\"category\":\"ecmAxiom\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"test_call_interface\",\"status\":\"assumed\"" ||
+      !contains assumptionReport "\"module\":\"testCall\"" then
     throw (IO.userError "✗ assumption report emits ECM axiom entries")
   if !contains assumptionReport "\"category\":\"localObligation\",\"siteKind\":\"function\",\"siteName\":\"unsafeEdge\",\"name\":\"manual_delegatecall_refinement\",\"status\":\"assumed\",\"detail\":\"Caller must separately prove the handwritten assembly path refines the intended state transition.\"" then
     throw (IO.userError "✗ assumption report emits localized local-obligation entries")

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -15,6 +15,7 @@ declare_syntax_cat verityEvent
 declare_syntax_cat verityConstant
 declare_syntax_cat verityImmutable
 declare_syntax_cat verityExternal
+declare_syntax_cat verityExternalLinkMode
 declare_syntax_cat verityLocalObligation
 declare_syntax_cat verityLocalObligations
 declare_syntax_cat verityConstructor
@@ -52,7 +53,15 @@ syntax "@indexed " ident " : " term : verityEventParam
 syntax "event " ident "(" sepBy(verityEventParam, ",") ")" : verityEvent
 syntax ident " : " term:max " := " term:max : verityConstant
 syntax ident " : " term:max " := " term:max : verityImmutable
-syntax "external " ident "(" sepBy(term, ",") ")" (" -> " "(" sepBy(term, ",") ")")? : verityExternal
+syntax "external" : verityExternalLinkMode
+syntax "internal_yul" : verityExternalLinkMode
+syntax "object_linked" : verityExternalLinkMode
+syntax "inline" : verityExternalLinkMode
+syntax "compiler_runtime" : verityExternalLinkMode
+syntax "external " ident "(" sepBy(term, ",") ")" : verityExternal
+syntax "external " ident "(" sepBy(term, ",") ")" " -> " "(" sepBy(term, ",") ")" : verityExternal
+syntax "external " ident "(" sepBy(term, ",") ")" ppSpace "linked_as" " := " verityExternalLinkMode : verityExternal
+syntax "external " ident "(" sepBy(term, ",") ")" " -> " "(" sepBy(term, ",") ")" ppSpace "linked_as" " := " verityExternalLinkMode : verityExternal
 syntax ident " := " ident ppSpace str : verityLocalObligation
 syntax "local_obligations " "[" sepBy(verityLocalObligation, ",") "]" : verityLocalObligations
 syntax "payable" : verityMutability

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -115,6 +115,7 @@ structure ExternalDecl where
   name : String
   params : Array ValueType
   returnTys : Array ValueType
+  linkMode : Compiler.CompilationModel.ForeignLinkMode := .objectLinked
 
 /-- A user-defined semantic newtype declared in the `types` section.
     At the language level the type is distinct from its base type; at the
@@ -958,8 +959,35 @@ private def parseImmutable (newtypes : Array NewtypeDecl) (stx : Syntax) : Comma
       }
   | _ => throwErrorAt stx "invalid immutable declaration"
 
+private def parseExternalLinkMode (stx : Syntax) : CommandElabM Compiler.CompilationModel.ForeignLinkMode := do
+  match stx with
+  | `(verityExternalLinkMode| external) => pure .external
+  | `(verityExternalLinkMode| internal_yul) => pure .objectLinked
+  | `(verityExternalLinkMode| object_linked) => pure .objectLinked
+  | `(verityExternalLinkMode| inline) => pure .inline
+  | `(verityExternalLinkMode| compiler_runtime) => pure .compilerRuntime
+  | _ =>
+      throwErrorAt stx
+        "unsupported linked_as mode; expected external, internal_yul, object_linked, inline, or compiler_runtime"
+
 private def parseExternal (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl) (adtDecls : Array AdtDecl) (stx : Syntax) : CommandElabM ExternalDecl := do
   match stx with
+  | `(verityExternal| external $name:ident ($[$params:term],*) -> ($[$returnTys:term],*) linked_as := $mode:verityExternalLinkMode) =>
+      pure {
+        ident := name
+        name := toString name.getId
+        params := ← params.mapM (valueTypeFromSyntax newtypes structDecls adtDecls)
+        returnTys := ← returnTys.mapM (valueTypeFromSyntax newtypes structDecls adtDecls)
+        linkMode := ← parseExternalLinkMode mode
+      }
+  | `(verityExternal| external $name:ident ($[$params:term],*) linked_as := $mode:verityExternalLinkMode) =>
+      pure {
+        ident := name
+        name := toString name.getId
+        params := ← params.mapM (valueTypeFromSyntax newtypes structDecls adtDecls)
+        returnTys := #[]
+        linkMode := ← parseExternalLinkMode mode
+      }
   | `(verityExternal| external $name:ident ($[$params:term],*) -> ($[$returnTys:term],*)) =>
       pure {
         ident := name
@@ -7168,13 +7196,21 @@ private def mkModelExternalTerm (ext : ExternalDecl) : CommandElabM Term := do
     | [] => `(none)
     | [retTy] => `(some $(← modelParamTypeTerm retTy))
     | _ => `(none)
-  `(Compiler.CompilationModel.ExternalFunction.mk
-      $(strTerm ext.name)
-      [ $[$paramTerms],* ]
-      $returnTypeTerm
-      [ $[$returnTerms],* ]
-      Compiler.ProofStatus.assumed
-      [])
+  let linkModeTerm ←
+    match ext.linkMode with
+    | .external => `(Compiler.CompilationModel.ForeignLinkMode.external)
+    | .objectLinked => `(Compiler.CompilationModel.ForeignLinkMode.objectLinked)
+    | .inline => `(Compiler.CompilationModel.ForeignLinkMode.inline)
+    | .compilerRuntime => `(Compiler.CompilationModel.ForeignLinkMode.compilerRuntime)
+  `( ({
+      name := $(strTerm ext.name)
+      params := [ $[$paramTerms],* ]
+      returnType := $returnTypeTerm
+      «returns» := [ $[$returnTerms],* ]
+      proofStatus := Compiler.ProofStatus.assumed
+      axiomNames := []
+      linkMode := $linkModeTerm
+    } : Compiler.CompilationModel.ExternalFunction) )
 
 private def mkModelLocalObligationTerm (obligation : LocalObligationDecl) : CommandElabM Term := do
   let proofStatusTerm ←

--- a/docs/EXTERNAL_CALL_MODULES.md
+++ b/docs/EXTERNAL_CALL_MODULES.md
@@ -32,6 +32,29 @@ ExternalCallModule (Compiler/ECM.lean)
 Stmt.ecm (mod : ExternalCallModule) (args : List Expr)
 ```
 
+## Foreign Link Modes
+
+Foreign dependencies must declare whether they are a deployed boundary or code
+that becomes part of the generated artifact. Verity records this on every
+`linked_externals` declaration and surfaces it in trust and assumption reports:
+
+| Mode | Syntax | Use case | Artifact meaning |
+|------|--------|----------|------------------|
+| External ABI boundary | `linked_as := external` | Permit2, routers, verifier contracts, oracles | The dependency remains a real call boundary; adapters must preserve ABI return decoding and returndata bubbling. |
+| Object-linked Yul | `linked_as := internal_yul` or `linked_as := object_linked` | Poseidon-style deterministic helpers and imported Yul libraries | Matching helper functions are injected into the runtime artifact from `--link` libraries. |
+| Inline helper | `linked_as := inline` | Small pure helper bodies that a frontend/backend may inline | The helper remains visible as a foreign surface while the implementation is expected to be included at compile time. |
+| Compiler runtime | `linked_as := compiler_runtime` | ABI/runtime helpers owned by the Verity compiler | The helper is part of the compiler-owned runtime surface, not a protocol deployment boundary. |
+
+Omitting `linked_as` preserves the historical behavior and is equivalent to
+`linked_as := internal_yul`.
+
+Contracts compiled through the driver also emit one Yul comment per linked
+external, for example `verity linked external PoseidonT3_hash
+linkMode=objectLinked`, so the generated artifact carries the same mode
+metadata as the trust reports. A dependency declared `linked_as := external`
+must be lowered through an ABI-call ECM such as `Calls.withReturn`; raw
+`externalCall` / `externalCallBind` helper lowering is rejected for that mode.
+
 When the compiler encounters `Stmt.ecm mod args`, it:
 
 1. Validates argument count matches `mod.numArgs`


### PR DESCRIPTION
## Summary
- add ForeignLinkMode to linked external declarations with macro syntax for external, internal_yul/object_linked, inline, and compiler_runtime
- surface linkMode in trust reports, assumption reports, verbose usage-site output, and generated Yul artifact comments
- reject raw linked-helper lowering for linked_as := external so ABI-boundary dependencies use ECM adapters with revert-data bubbling
- document the link-mode model and default object-linked behavior

## Verification
- lake build Compiler.CompileDriverCommon Compiler.CompilationModelFeatureTest Compiler.CompileDriverTest
- lake build
- python3 scripts/check_lean_hygiene.py
- git diff --check

Closes #1904

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `linkMode` dimension to external dependencies and enforces a new compile-time rejection for `linked_as := external` when using raw linked-helper lowering, which can break existing specs and affects external-call correctness (returndata/revert bubbling).
> 
> **Overview**
> Adds `ForeignLinkMode` (defaulting existing declarations to `objectLinked`) to `ExternalFunction`, along with macro syntax `linked_as := external|internal_yul|object_linked|inline|compiler_runtime` and propagation into generated model terms.
> 
> Surfaces `linkMode` in machine-readable trust/assumption reports, verbose usage-site output, and injects per-external Yul comments (`verity linked external … linkMode=…`) in driver-emitted artifacts.
> 
> Tightens compilation validation to **reject raw `externalCall` lowering** when a referenced linked external is marked `linked_as := external`, requiring ABI-call ECM adapters that preserve returndata and revert bubbling; updates/extends feature + driver tests and documents the new modes in `EXTERNAL_CALL_MODULES.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f81567c07fb9d577a4f674db4bd05b3ed28a4c6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->