### PR TITLE
style(docs-site): replace em dashes with commas across content and metadata

### DIFF
--- a/docs-site/app/[[...mdxPath]]/page.tsx
+++ b/docs-site/app/[[...mdxPath]]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata(props: { params: Promise<{ mdxPath?: stri
     ? {
         title: {
           absolute:
-            'Verity — Formally Verified Smart Contract Compiler (Lean 4)',
+            'Verity, Formally Verified Smart Contract Compiler (Lean 4)',
         },
       }
     : {}

--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -6,9 +6,9 @@ import './verity-site.css'
 import './verity-code.css'
 
 const SITE_URL = 'https://veritylang.com'
-const SITE_TITLE = 'Verity — Formally Verified Smart Contract Compiler (Lean 4)'
+const SITE_TITLE = 'Verity, Formally Verified Smart Contract Compiler (Lean 4)'
 const SITE_DESCRIPTION =
-  'Verity is a formally verified smart contract compiler for Ethereum, written in Lean 4. Write the spec, write the implementation, and prove they agree — every claim is machine-checked at compile time, and the compiler itself is proven to preserve semantics from EDSL to EVM bytecode.'
+  'Verity is a formally verified smart contract compiler for Ethereum, written in Lean 4. Write the spec, write the implementation, and prove they agree. Every claim is machine-checked at compile time, and the compiler itself is proven to preserve semantics from EDSL to EVM bytecode.'
 const SITE_KEYWORDS = [
   'Verity',
   'Verity Lang',
@@ -55,7 +55,7 @@ export const metadata = {
         url: '/og.png',
         width: 1200,
         height: 630,
-        alt: 'Verity — Formally Verified Smart Contract Compiler (Lean 4)',
+        alt: 'Verity, Formally Verified Smart Contract Compiler (Lean 4)',
       },
     ],
   },

--- a/docs-site/content/architecture.mdx
+++ b/docs-site/content/architecture.mdx
@@ -83,8 +83,8 @@ live theorem inventory.
 
 ## Where to next
 
-- [Getting Started](/getting-started) — local setup and your first verification run.
-- [First Contract](/first-contract) — guided spec-to-proof walkthrough.
-- [Compiler & CLI](/compiler) — the pipeline in detail, plus CLI flags.
-- [Trust Model](/trust-model) — what you trust when you trust a Verity contract.
-- [EDSL API Reference](/edsl-api-reference) — canonical primitive reference.
+- [Getting Started](/getting-started), local setup and your first verification run.
+- [First Contract](/first-contract), guided spec-to-proof walkthrough.
+- [Compiler & CLI](/compiler), the pipeline in detail, plus CLI flags.
+- [Trust Model](/trust-model), what you trust when you trust a Verity contract.
+- [EDSL API Reference](/edsl-api-reference), canonical primitive reference.

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -1,6 +1,6 @@
 ---
 title: Compiler & CLI
-description: The Verity compiler — pipeline, CLI usage, and the CompilationModel surface.
+description: The Verity compiler, pipeline, CLI usage, and the CompilationModel surface.
 ---
 
 # Compiler & CLI
@@ -16,8 +16,8 @@ EDSL Contract  →  CompilationModel  →  IR  →  Yul  →  EVM Bytecode
 `CompilationModel` is the declarative surface: storage fields, function bodies, constructor params, events. The compiler infers slots, looks up selectors, lowers expressions/statements to IR, generates Yul, and hands off to `solc` for the final bytecode step.
 
 > Verity has two **distinct** "spec" concepts:
-> 1. **Logical specs** in `Contracts/<Name>/Spec.lean` — `Prop` statements used for proofs.
-> 2. **Compiler specs** in `Compiler/Specs.lean` — `CompilationModel` values used for code generation.
+> 1. **Logical specs** in `Contracts/<Name>/Spec.lean`, `Prop` statements used for proofs.
+> 2. **Compiler specs** in `Compiler/Specs.lean`, `CompilationModel` values used for code generation.
 
 ### Modules
 
@@ -52,10 +52,10 @@ See the [Linking External Libraries](/guides/linking-libraries) guide.
 
 The CLI emits machine-readable audit artifacts alongside Yul/ABI:
 
-- `--trust-report <path>` — proof-boundary and assumption data.
-- `--assumption-report <path>` — flattened assumption inventory grouped by contract and usage site. Direct assembly-shaped primitives without any `local_obligations [...]` fail closed.
-- `--layout-report <path>` — resolved storage-slot metadata, alias writes, reserved-slot policy.
-- `--layout-compat-report <path>` — baseline vs candidate layout compatibility for upgrade reviews. Pair with `--deny-layout-incompatibility` to fail closed on incompatible upgrades.
+- `--trust-report <path>`, proof-boundary and assumption data.
+- `--assumption-report <path>`, flattened assumption inventory grouped by contract and usage site. Direct assembly-shaped primitives without any `local_obligations [...]` fail closed.
+- `--layout-report <path>`, resolved storage-slot metadata, alias writes, reserved-slot policy.
+- `--layout-compat-report <path>`, baseline vs candidate layout compatibility for upgrade reviews. Pair with `--deny-layout-incompatibility` to fail closed on incompatible upgrades.
 
 For proof-strict builds, deny flags lock down the trust surface. Each one fails the build closed when the corresponding category of assumption appears:
 
@@ -223,13 +223,13 @@ Not compiled: `ReentrancyExample` (inline proofs only). `CryptoHash` compiles vi
 
 ## Trust boundary
 
-Three verified layers — EDSL ↔ CompilationModel, CompilationModel ↔ IR, IR ↔ Yul. The `solc` Yul-to-bytecode step and the EVM execution model itself are trusted, not verified. See [Trust Model](/trust-model).
+Three verified layers, EDSL ↔ CompilationModel, CompilationModel ↔ IR, IR ↔ Yul. The `solc` Yul-to-bytecode step and the EVM execution model itself are trusted, not verified. See [Trust Model](/trust-model).
 
 **Layer 2 boundary today**: the generic whole-contract `CompilationModel -> IR` theorem is proved for the current explicit supported fragment. The former exact-state body-simulation axiom has been eliminated; the remaining dispatcher bridge is an explicit theorem hypothesis rather than a Lean axiom, so legacy contract-specific bridge theorems are wrappers above the generic theorem rather than independent assumptions.
 
 ## See also
 
-- [Trust Model](/trust-model) — what the audit artifacts bound.
-- [Verification Status](/verification) — theorem inventory.
-- [Examples](/examples) — the validated contract set with code excerpts.
+- [Trust Model](/trust-model), what the audit artifacts bound.
+- [Verification Status](/verification), theorem inventory.
+- [Examples](/examples), the validated contract set with code excerpts.
 - [Linking External Libraries](/guides/linking-libraries).

--- a/docs-site/content/core.mdx
+++ b/docs-site/content/core.mdx
@@ -63,7 +63,7 @@ inductive ContractResult (α : Type) where
 
 Every contract operation returns either `success` with a value and updated state, or `revert` with an error message and the state at the point of failure.
 
-> **Important**: On revert, the returned state may include mutations from operations that executed *before* the revert. This differs from EVM semantics where REVERT discards all state changes. Contracts must follow the **checks-before-effects pattern** — all `require` guards before any `setStorage`/`setMapping` calls — to ensure the revert state equals the original input state. See [TRUST_ASSUMPTIONS.md](https://github.com/lfglabs-dev/verity/blob/main/TRUST_ASSUMPTIONS.md) and [#254](https://github.com/lfglabs-dev/verity/issues/254) for details.
+> **Important**: On revert, the returned state may include mutations from operations that executed *before* the revert. This differs from EVM semantics where REVERT discards all state changes. Contracts must follow the **checks-before-effects pattern**, all `require` guards before any `setStorage`/`setMapping` calls, to ensure the revert state equals the original input state. See [TRUST_ASSUMPTIONS.md](https://github.com/lfglabs-dev/verity/blob/main/TRUST_ASSUMPTIONS.md) and [#254](https://github.com/lfglabs-dev/verity/issues/254) for details.
 
 ## Contract monad
 
@@ -84,7 +84,7 @@ This gives do-notation with automatic failure propagation. A failed `require` st
 
 ## Primitives
 
-The core types above are operated on by a small surface of EDSL primitives — storage get/set, mapping get/set, context accessors (`msgSender`, `msgValue`, `blockTimestamp`, `contractAddress`), event emission, and the `require` guard. Those are documented in the [EDSL API Reference](/edsl-api-reference); the prose here only covers the *type layer* and the monad, not the operation catalogue.
+The core types above are operated on by a small surface of EDSL primitives, storage get/set, mapping get/set, context accessors (`msgSender`, `msgValue`, `blockTimestamp`, `contractAddress`), event emission, and the `require` guard. Those are documented in the [EDSL API Reference](/edsl-api-reference); the prose here only covers the *type layer* and the monad, not the operation catalogue.
 
 The shape of every primitive is the same: it's a `Contract α` value, which is `ContractState → ContractResult α`. Read-only primitives like `msgSender` and `getStorage` always emit `ContractResult.success`; write primitives like `setStorage` return `success ()` with a modified `ContractState`. `require` is the one operation that may emit `ContractResult.revert`, preserving the original state.
 
@@ -106,11 +106,11 @@ Every storage operation, context accessor, and event function has a full-result 
   (require false msg).run s = ContractResult.revert msg s := rfl
 ```
 
-Older `_fst`/`_snd` projection lemmas also exist, but the full-result forms above are preferred — they prove success, value, and state in one shot. Most simple properties can be proven by `simp only [...]` with the right set of definitions.
+Older `_fst`/`_snd` projection lemmas also exist, but the full-result forms above are preferred, they prove success, value, and state in one shot. Most simple properties can be proven by `simp only [...]` with the right set of definitions.
 
 ## Why ContractResult instead of StateM
 
-A plain `StateM ContractState α` monad cannot model `require` failures — proofs would have to assume guards pass (introducing axioms). `ContractResult` makes success/failure explicit, so proofs reason about both paths with no axioms. The cost is a small amount of extra infrastructure (the `ContractResult` type, custom `bind`, and simp lemmas).
+A plain `StateM ContractState α` monad cannot model `require` failures, proofs would have to assume guards pass (introducing axioms). `ContractResult` makes success/failure explicit, so proofs reason about both paths with no axioms. The cost is a small amount of extra infrastructure (the `ContractResult` type, custom `bind`, and simp lemmas).
 
 ## Type safety
 
@@ -140,13 +140,13 @@ Specs express what a function **did not change**. `Verity/Specs/Common.lean` pro
 
 Three layers, narrowest first:
 
-- **Atomic** — one field at a time: `sameStorage`, `sameStorageAddr`, `sameStorageMap`, `sameStorageMapUint`, `sameStorageMap2`, `sameContext`.
-- **Mixed** (most common in practice) — two storage checks + `sameContext`:
-  - `sameAddrMapContext` — use when only `setStorage` (uint256 slot) writes.
-  - `sameStorageMapContext` — use when only `setStorageAddr` writes.
-  - `sameStorageAddrContext` — use when only `setMapping` writes.
-- **Composite** (strictest) — everything except one storage type: `sameExceptStorage`, `sameExceptStorageAddr`, `sameExceptStorageMap`, `sameExceptStorageMapUint`, `sameExceptStorageMap2`. `sameAllStorage` covers context-only writes. All composites include `sameContext`.
-- **Fine-grained** — for single-entry mapping updates: `storageUnchangedExcept slot`, `storageAddrUnchangedExcept slot`, `storageMapUnchangedExceptKeyAtSlot slot addr`, `storageMapUnchangedExceptKeysAtSlot slot a1 a2` (transfers), `storageMapUintUnchangedExceptSlot`, `storageMapUintUnchangedExceptKey`, `storageMap2UnchangedExceptSlot`.
+- **Atomic**, one field at a time: `sameStorage`, `sameStorageAddr`, `sameStorageMap`, `sameStorageMapUint`, `sameStorageMap2`, `sameContext`.
+- **Mixed** (most common in practice), two storage checks + `sameContext`:
+  - `sameAddrMapContext`, use when only `setStorage` (uint256 slot) writes.
+  - `sameStorageMapContext`, use when only `setStorageAddr` writes.
+  - `sameStorageAddrContext`, use when only `setMapping` writes.
+- **Composite** (strictest), everything except one storage type: `sameExceptStorage`, `sameExceptStorageAddr`, `sameExceptStorageMap`, `sameExceptStorageMapUint`, `sameExceptStorageMap2`. `sameAllStorage` covers context-only writes. All composites include `sameContext`.
+- **Fine-grained**, for single-entry mapping updates: `storageUnchangedExcept slot`, `storageAddrUnchangedExcept slot`, `storageMapUnchangedExceptKeyAtSlot slot addr`, `storageMapUnchangedExceptKeysAtSlot slot a1 a2` (transfers), `storageMapUintUnchangedExceptSlot`, `storageMapUintUnchangedExceptKey`, `storageMap2UnchangedExceptSlot`.
 
 A counter's `increment` writes only the uint256 count slot, so the unchanged-state predicate is `sameAddrMapContext`. An ERC20 `transfer` (two mapping keys) uses `storageMapUnchangedExceptKeysAtSlot balances.slot from to`.
 

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -86,7 +86,7 @@ emitEvent "Transfer" [amount] [fromAddr, toAddr]
 
 ### Wrapping (`Uint256`)
 
-`add`, `sub`, `mul`, `pow`, `div`, `mod` — EVM modular arithmetic. `pow a b` / `a ^ b` compiles to Yul `exp(a, b)`.
+`add`, `sub`, `mul`, `pow`, `div`, `mod`, EVM modular arithmetic. `pow a b` / `a ^ b` compiles to Yul `exp(a, b)`.
 
 ```verity
 let z : Uint256 := add x y
@@ -140,7 +140,7 @@ Each entry lowers into `localObligations`, surfaces in `--trust-report`, and par
 
 ### Same-contract helpers
 
-Call helpers with ordinary function-call syntax — do not write `internalCall` directly (those are post-lowering IR nodes).
+Call helpers with ordinary function-call syntax, do not write `internalCall` directly (those are post-lowering IR nodes).
 
 ```verity
 storeBump x
@@ -203,7 +203,7 @@ immutables
   domainTag    : Bytes32 := 42
 ```
 
-Constants inline into `Expr` trees at compile time; constant bodies cannot reference runtime builtins (`blockTimestamp`, calldata reads, low-level opcodes, etc.) — those are rejected at elaboration. Immutables lower to read-only `__immutable_<name>` slots seeded in the constructor. Supported immutable types: `Uint256`, `Uint8`, `Address`, `Bytes32`, `Bool`.
+Constants inline into `Expr` trees at compile time; constant bodies cannot reference runtime builtins (`blockTimestamp`, calldata reads, low-level opcodes, etc.), those are rejected at elaboration. Immutables lower to read-only `__immutable_<name>` slots seeded in the constructor. Supported immutable types: `Uint256`, `Uint8`, `Address`, `Bytes32`, `Bool`.
 
 Storage, constants, immutables, and functions share one namespace; duplicate or cross-kind reuse is rejected with explicit diagnostics. Generated names (`spec`, `<name>_modelBody`, `<name>_model`, `<name>_bridge`, `<name>_semantic_preservation`) are reserved.
 
@@ -226,7 +226,7 @@ Populates `spec.externals` with assumed foreign signatures. Single-word argument
 rawLog [topic0, add topic1 1] dataOffset dataSize
 ```
 
-Lowers to `Stmt.rawLog`. Supports 0–4 topics (`log0`–`log4`). Classified as not-modeled event emission in the trust report — use `--deny-event-emission` for proof-strict runs.
+Lowers to `Stmt.rawLog`. Supports 0–4 topics (`log0`–`log4`). Classified as not-modeled event emission in the trust report, use `--deny-event-emission` for proof-strict runs.
 
 ### Transient storage (EIP-1153)
 
@@ -247,7 +247,7 @@ returnArray amounts
 
 `arrayElement` is bounds-checked (compiled path reverts on out-of-range; executable fallback mirrors). Supports scalar arrays and ABI-decodable static/nested struct arrays. Dynamic-element arrays (`Array Bytes`, `Array String`) support `arrayLength` only; indexed reads and `returnArray` are rejected for those until offset-aware lowering lands.
 
-`String`/`Bytes` support ABI transport (`returnBytes`, custom-error/event payloads, parameter flow) and direct `==`/`!=` checks. Other word-level operators (`<`, `add`, `logicalAnd`) on `String`/`Bytes` are rejected — applies to function bodies, constructor bodies, constants, and immutable initializers.
+`String`/`Bytes` support ABI transport (`returnBytes`, custom-error/event payloads, parameter flow) and direct `==`/`!=` checks. Other word-level operators (`<`, `add`, `logicalAnd`) on `String`/`Bytes` are rejected, applies to function bodies, constructor bodies, constants, and immutable initializers.
 
 ### Modifiers, structs, ADTs, and namespaced storage
 
@@ -272,7 +272,7 @@ Populates `CompilationModel.errors`; guarded and unconditional custom-error exit
 
 ## External Calls (ECM)
 
-External calls are modeled as **Externally Callable Modules** (ECMs) — statement constructors that ABI-encode arguments, perform a `call` / `staticcall`, validate the return shape, and bind the result word. They carry explicit trust-report metadata; module-level `axioms` apply rather than pure `simp`-style contract lemmas.
+External calls are modeled as **Externally Callable Modules** (ECMs), statement constructors that ABI-encode arguments, perform a `call` / `staticcall`, validate the return shape, and bind the result word. They carry explicit trust-report metadata; module-level `axioms` apply rather than pure `simp`-style contract lemmas.
 
 ### ERC-20 helpers
 

--- a/docs-site/content/examples.mdx
+++ b/docs-site/content/examples.mdx
@@ -1,13 +1,13 @@
 ---
 title: Examples Gallery
-description: Sample contracts, ordered by the pattern each introduces — single-slot storage through full token composition.
+description: Sample contracts, ordered by the pattern each introduces, single-slot storage through full token composition.
 ---
 
 # Examples Gallery
 
 A small set of contracts, each introducing a new pattern. They build on each other: SimpleStorage uses one slot, Counter adds arithmetic, Owned adds access control, SimpleToken combines all three.
 
-Each contract is verified end-to-end against the generic whole-contract Layer 2 theorem in `Compiler/Proofs/IRGeneration/Contract.lean` for the current supported fragment — there are no per-contract bridge axioms.
+Each contract is verified end-to-end against the generic whole-contract Layer 2 theorem in `Compiler/Proofs/IRGeneration/Contract.lean` for the current supported fragment, there are no per-contract bridge axioms.
 
 For the *file layout* and authoring steps these examples follow, see [Add a Contract](/guides/add-contract). For a guided walkthrough that builds one from scratch, see [Your First Contract](/first-contract).
 

--- a/docs-site/content/faq.mdx
+++ b/docs-site/content/faq.mdx
@@ -16,7 +16,7 @@ system and one kernel.
 Coq and Isabelle have older ecosystems and more developed libraries, but their
 metaprogramming stories make embedding a usable contract DSL substantially
 harder. Dafny is a verification-oriented language rather than a proof
-assistant — it relies on SMT for automation, which is fast for shallow
+assistant, it relies on SMT for automation, which is fast for shallow
 properties but opaque when proofs require nonlinear arithmetic, induction
 over storage state, or precise EVM-shaped reasoning. Lean's tradeoff is more
 manual proof, but the proofs are kernel-checked and the trust base is smaller.
@@ -24,7 +24,7 @@ manual proof, but the proofs are kernel-checked and the trust base is smaller.
 ## Why an EDSL, not a new language?
 
 Building a new language means building a new parser, a new type checker, a
-new elaborator, a new editor integration, and a new proof checker — and then
+new elaborator, a new editor integration, and a new proof checker, and then
 re-justifying that all of those are correct. Embedding the language inside
 Lean 4 inherits all of that for free: the same toolchain that elaborates
 contracts also checks the proofs about them.
@@ -32,8 +32,8 @@ contracts also checks the proofs about them.
 The core is intentionally small (`Verity/Core.lean`): six storage spaces plus transient, a
 `Contract` monad, a `require` guard, and a curated set of `@[simp]` lemmas.
 Every primitive is shallow enough that the standard unfolding-then-`simp`
-recipe works for most properties. New surface syntax — `verity_contract`,
-`local_obligations`, `linked_externals`, ECM helpers — is added via macros
+recipe works for most properties. New surface syntax, `verity_contract`,
+`local_obligations`, `linked_externals`, ECM helpers, is added via macros
 that lower to the same core.
 
 ## What's verified vs what's trusted?
@@ -44,7 +44,7 @@ and invariants. Trusted: the Lean kernel, the Yul compiler (`solc`), the EVM
 specification, the deployment toolchain, and the named external assumptions
 listed in `--trust-report` (ECM interface signatures, precompile semantics,
 any `local_obligations`). [`AXIOMS.md`](https://github.com/lfglabs-dev/verity/blob/main/AXIOMS.md)
-itself lists **zero active project-level Lean axioms** today — the residual
+itself lists **zero active project-level Lean axioms** today, the residual
 ones have been eliminated. The full breakdown lives at [`/trust-model`](/trust-model).
 
 ## How is Verity different from Certora, Halmos, or K?
@@ -66,7 +66,7 @@ in the Verity EDSL, not in Solidity.
 
 ## Can I use existing Solidity?
 
-Not directly — Verity contracts are written in the Lean-embedded EDSL. There
+Not directly, Verity contracts are written in the Lean-embedded EDSL. There
 are translation guides that walk through common Solidity patterns and how to
 express them in Verity: see [`/guides/solidity-to-verity`](/guides/solidity-to-verity)
 and [`/guides/production-solidity-patterns`](/guides/production-solidity-patterns)
@@ -85,7 +85,7 @@ create`, `cast`, raw RPC, etc.
 
 ## Is this production-ready?
 
-Verity verifies a precisely-scoped class of contracts today — not a drop-in replacement for general Solidity. Inside the supported fragment, you get strong machine-checked guarantees; outside it, the trust report tells you exactly which assumptions are doing the work. Several features compile but are not yet end-to-end modeled (low-level call mechanics, linear-memory primitives, `rawLog`, `keccak256`); each has a `--deny-*` flag for proof-strict builds. There is no multi-contract interaction model, no reentrancy semantics, and no gas modeling.
+Verity verifies a precisely-scoped class of contracts today, not a drop-in replacement for general Solidity. Inside the supported fragment, you get strong machine-checked guarantees; outside it, the trust report tells you exactly which assumptions are doing the work. Several features compile but are not yet end-to-end modeled (low-level call mechanics, linear-memory primitives, `rawLog`, `keccak256`); each has a `--deny-*` flag for proof-strict builds. There is no multi-contract interaction model, no reentrancy semantics, and no gas modeling.
 
 ## Where can I see verified contracts?
 
@@ -94,4 +94,4 @@ for the live theorem inventory by contract.
 
 ## Can AI agents write Verity proofs?
 
-That question is the explicit purpose of [`verity-benchmark`](https://github.com/lfglabs-dev/verity-benchmark) — a fixed set of 30 proof tasks across six real-world protocols (Ethereum deposit contract, Lido VaultHub, Nexus Mutual RAMM, Kleros sortition, Paladin Votes, Damn Vulnerable DeFi). Each task hands an agent a contract, a spec, and a single theorem to prove, with no placeholders allowed (`sorry`, `admit`, `axiom`). The shallow EDSL surface and the `_meets_spec` proof pattern make this a tractable benchmark for measuring agent capability, not a vibe-check.
+That question is the explicit purpose of [`verity-benchmark`](https://github.com/lfglabs-dev/verity-benchmark), a fixed set of 30 proof tasks across six real-world protocols (Ethereum deposit contract, Lido VaultHub, Nexus Mutual RAMM, Kleros sortition, Paladin Votes, Damn Vulnerable DeFi). Each task hands an agent a contract, a spec, and a single theorem to prove, with no placeholders allowed (`sorry`, `admit`, `axiom`). The shallow EDSL surface and the `_meets_spec` proof pattern make this a tractable benchmark for measuring agent capability, not a vibe-check.

--- a/docs-site/content/first-contract.mdx
+++ b/docs-site/content/first-contract.mdx
@@ -30,13 +30,13 @@ python3 scripts/generate_contract.py TipJar \
 ```
 
 This creates all required files:
-- `Contracts/TipJar/Spec.lean` — formal specification
-- `Contracts/TipJar/Invariants.lean` — state invariants
-- `Contracts/TipJar/SpecProofs.lean` — compilation correctness re-export
-- `Contracts/TipJar/TipJar.lean` — EDSL implementation
-- `Contracts/TipJar/Proofs/Basic.lean` — basic correctness proofs
-- `Contracts/TipJar/Proofs/Correctness.lean` — advanced correctness proofs
-- `test/PropertyTipJar.t.sol` — Foundry tests
+- `Contracts/TipJar/Spec.lean`, formal specification
+- `Contracts/TipJar/Invariants.lean`, state invariants
+- `Contracts/TipJar/SpecProofs.lean`, compilation correctness re-export
+- `Contracts/TipJar/TipJar.lean`, EDSL implementation
+- `Contracts/TipJar/Proofs/Basic.lean`, basic correctness proofs
+- `Contracts/TipJar/Proofs/Correctness.lean`, advanced correctness proofs
+- `test/PropertyTipJar.t.sol`, Foundry tests
 
 Our goal: users deposit a tip (adding to their balance) via `tip(uint256)`, anyone reads a balance via `getBalance(address)`. Balances use EVM modular arithmetic; for Solidity ^0.8 checked behavior, add `require` guards (see `SafeCounter`).
 
@@ -204,11 +204,11 @@ import Contracts.TipJar.Proofs.Basic
 import Contracts.TipJar.Proofs.Correctness
 ```
 
-The scaffold generator prints these exact lines — copy them directly.
+The scaffold generator prints these exact lines, copy them directly.
 
 ## Next steps
 
-- Add access control with `require` + owner pattern — see `Contracts/OwnedCounter/`.
-- Add a `withdraw` with balance checks — see `Contracts/Ledger/`.
+- Add access control with `require` + owner pattern, see `Contracts/OwnedCounter/`.
+- Add a `withdraw` with balance checks, see `Contracts/Ledger/`.
 - Study `SimpleStorage`, `Counter`, `Ledger`, `OwnedCounter` for progressive patterns.
 - [Core Architecture](/core) and [EDSL API Reference](/edsl-api-reference) for the full surface.

--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -60,7 +60,7 @@ cd verity
 lake build                # Downloads dependencies and verifies the current proof set
 ```
 
-The first build downloads Mathlib and compiles everything — expect **20–45 minutes** on first run (Mathlib is large). Subsequent builds are incremental and much faster (seconds to minutes).
+The first build downloads Mathlib and compiles everything, expect **20–45 minutes** on first run (Mathlib is large). Subsequent builds are incremental and much faster (seconds to minutes).
 
 ## Explore a proof
 
@@ -73,9 +73,9 @@ lake exe verity-compiler                            # writes artifacts/yul/Simpl
 
 Three directories to keep in mind:
 
-1. `Contracts/<Name>/<Name>.lean` — EDSL implementation, executable Lean code.
-2. `Contracts/<Name>/Spec.lean`, `Invariants.lean`, `Proofs/` — logical specs (`Prop`) and proofs.
-3. `Compiler/Specs.lean` — `CompilationModel` values that generate IR/Yul.
+1. `Contracts/<Name>/<Name>.lean`, EDSL implementation, executable Lean code.
+2. `Contracts/<Name>/Spec.lean`, `Invariants.lean`, `Proofs/`, logical specs (`Prop`) and proofs.
+3. `Compiler/Specs.lean`, `CompilationModel` values that generate IR/Yul.
 
 ## 4. Run the test suite
 
@@ -116,7 +116,7 @@ See the [Linking Libraries guide](/guides/linking-libraries) for details.
 
 ## What to read next
 
-1. **[Example Contracts](/examples)** — Progressive examples from single-slot storage to token transfers
-2. **[Core Architecture](/core)** — The Contract monad, state model, and design decisions
-3. **[First Contract tutorial](/first-contract)** — Hands-on guide building a TipJar from scratch
-4. **[Compiler reference](/compiler)** — Full CompilationModel DSL documentation
+1. **[Example Contracts](/examples)**, Progressive examples from single-slot storage to token transfers
+2. **[Core Architecture](/core)**, The Contract monad, state model, and design decisions
+3. **[First Contract tutorial](/first-contract)**, Hands-on guide building a TipJar from scratch
+4. **[Compiler reference](/compiler)**, Full CompilationModel DSL documentation

--- a/docs-site/content/glossary.mdx
+++ b/docs-site/content/glossary.mdx
@@ -68,7 +68,7 @@ The executable EDSL body of a contract function, lowered from
 
 ### Invariant
 
-A property that should hold of `ContractState` at every reachable point —
+A property that should hold of `ContractState` at every reachable point ,
 typically conservation, isolation, or well-formedness. Lives in
 `Contracts/<Name>/Invariants.lean` and is proved over the implementation.
 
@@ -134,10 +134,10 @@ conjunctions. Distinct from the *compiler* spec (a `CompilationModel`).
 
 The four-file shape of a Verity contract:
 
-- **Spec** — `Spec.lean`, the `Prop` statement of intended behavior.
-- **Invariant** — `Invariants.lean`, properties that should always hold.
-- **Implementation** — the executable EDSL in `<Name>.lean`.
-- **Proof** — the Lean term in `Proofs/` that ties the implementation to the
+- **Spec**, `Spec.lean`, the `Prop` statement of intended behavior.
+- **Invariant**, `Invariants.lean`, properties that should always hold.
+- **Implementation**, the executable EDSL in `<Name>.lean`.
+- **Proof**, the Lean term in `Proofs/` that ties the implementation to the
   spec.
 
 ### Trust report

--- a/docs-site/content/guides/debugging-proofs.mdx
+++ b/docs-site/content/guides/debugging-proofs.mdx
@@ -81,7 +81,7 @@ theorem good_induction (xs : List α) : xs.length = n := by
 
 ## Type errors
 
-`#check` is the fastest debugger. The error message usually shows expected vs got — read both sides carefully. For `Uint256`/`Nat` mismatches, extract `.val` or coerce with `ofNat`.
+`#check` is the fastest debugger. The error message usually shows expected vs got, read both sides carefully. For `Uint256`/`Nat` mismatches, extract `.val` or coerce with `ofNat`.
 
 ## `.run`, `.fst`, `.snd`
 
@@ -93,7 +93,7 @@ Verity contracts are `ContractState → ContractResult α`. Three projection pat
 | `((op).run s).fst` | Return value `α` | Prove what a getter returns |
 | `((op).run s).snd` | Output state | Prove how state changes |
 
-`.fst` returns `default` on revert — if the operation might revert, add a guard hypothesis or match the full result. Avoid `Contract.runState`/`Contract.runValue` in new proofs.
+`.fst` returns `default` on revert, if the operation might revert, add a guard hypothesis or match the full result. Avoid `Contract.runState`/`Contract.runValue` in new proofs.
 
 ## Storage reasoning
 
@@ -129,7 +129,7 @@ theorem retrieve_meets_spec (s : ContractState) :
   simp [retrieve, storedData, retrieve_spec]
 ```
 
-Single `simp` with operation + slot + spec — no `unfold` needed.
+Single `simp` with operation + slot + spec, no `unfold` needed.
 
 ### Multi-conjunct spec (Counter)
 
@@ -198,6 +198,6 @@ Prefer one-shot `simp [def, slot, spec]`. Use `unfold` only when `simp` can't ex
 
 ## See also
 
-- [First Contract](/first-contract) — the full workflow this guide drops into.
-- [Core Architecture](/core) — types and the `Contract` monad.
-- [EDSL API Reference](/edsl-api-reference) — every primitive with its simp lemma.
+- [First Contract](/first-contract), the full workflow this guide drops into.
+- [Core Architecture](/core), types and the `Contract` monad.
+- [EDSL API Reference](/edsl-api-reference), every primitive with its simp lemma.

--- a/docs-site/content/guides/linking-libraries.mdx
+++ b/docs-site/content/guides/linking-libraries.mdx
@@ -9,10 +9,10 @@ For cryptographic primitives (Poseidon, Groth16, etc.) that are impractical to i
 
 ## How it works
 
-1. **Yul library** — plain function definitions, no `object` wrapper.
-2. **Lean placeholder** — used only by proofs; never appears in compiled Yul.
-3. **`externals` declaration on the `CompilationModel`** — the linker only injects into contracts that declare what they need.
-4. **`--link` flag** — pass `.yul` library files at compile time.
+1. **Yul library**, plain function definitions, no `object` wrapper.
+2. **Lean placeholder**, used only by proofs; never appears in compiled Yul.
+3. **`externals` declaration on the `CompilationModel`**, the linker only injects into contracts that declare what they need.
+4. **`--link` flag**, pass `.yul` library files at compile time.
 
 ## Walkthrough
 
@@ -105,6 +105,6 @@ lake exe verity-compiler-patched --enable-patches --patch-report artifacts/patch
 
 ## Common errors
 
-- `Unresolved external references: <name>` — missing `--link`, or the name doesn't match between `CompilationModel` and the `.yul` file (case-sensitive).
-- `Arity mismatch: <name>: called with N args but library defines M params` — return values don't count as parameters.
-- Contract works with the placeholder but reverts at runtime — usually gas, or the library returns an unexpected shape. Run Foundry tests against the linked Yul.
+- `Unresolved external references: <name>`, missing `--link`, or the name doesn't match between `CompilationModel` and the `.yul` file (case-sensitive).
+- `Arity mismatch: <name>: called with N args but library defines M params`, return values don't count as parameters.
+- Contract works with the placeholder but reverts at runtime, usually gas, or the library returns an unexpected shape. Run Foundry tests against the linked Yul.

--- a/docs-site/content/guides/production-solidity-patterns.mdx
+++ b/docs-site/content/guides/production-solidity-patterns.mdx
@@ -1,6 +1,6 @@
 ---
 title: Production Solidity Patterns
-description: Agent-facing checklist for porting non-trivial Solidity contracts — reusable surfaces, oracle/spec boundaries, and ECM usage.
+description: Agent-facing checklist for porting non-trivial Solidity contracts, reusable surfaces, oracle/spec boundaries, and ECM usage.
 ---
 
 # Production Solidity Translation Patterns

--- a/docs-site/content/guides/solidity-to-verity.mdx
+++ b/docs-site/content/guides/solidity-to-verity.mdx
@@ -1,6 +1,6 @@
 ---
 title: Solidity to Verity
-description: Practical mappings for porting a Solidity contract into the verity_contract surface — first-pass syntax, restructuring patterns, and a worked walkthrough.
+description: Practical mappings for porting a Solidity contract into the verity_contract surface, first-pass syntax, restructuring patterns, and a worked walkthrough.
 ---
 
 # Solidity-to-Verity Translation Guide
@@ -225,7 +225,7 @@ def transfer (to : Address) (amount : Uint256) : Contract Unit := do
   emitEvent "Transfer" [amount] [addressToWord sender, addressToWord to]
 ```
 
-Use `getMapping` / `setMapping` for individual entries — there is no whole-mapping read or function-shaped write in the EDSL. Keep `require` guards before any `setMapping` mutation so the revert state equals the input state.
+Use `getMapping` / `setMapping` for individual entries, there is no whole-mapping read or function-shaped write in the EDSL. Keep `require` guards before any `setMapping` mutation so the revert state equals the input state.
 
 ### Step C: Write the spec shape
 
@@ -252,7 +252,7 @@ Pick the right "unchanged" helper from [`Verity.Specs.Common`](/core#spec-helper
 
 ### Step D: Prove with existing automation
 
-Use the `_meets_spec` convention — single `simp` with the operation, slot names, spec definition, and any guard hypothesis:
+Use the `_meets_spec` convention, single `simp` with the operation, slot names, spec definition, and any guard hypothesis:
 
 ```verity
 theorem transfer_meets_spec (s : ContractState) (to : Address) (amount : Uint256)

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Verity — Formally Verified Smart Contract Compiler (Lean 4)
-description: Verity is a Lean-native language for verified smart contracts. Write the spec, write the implementation, and prove they agree — every claim is machine-checked at compile time, with the compiler itself proven to preserve semantics from EDSL to EVM bytecode.
+title: Verity, Formally Verified Smart Contract Compiler (Lean 4)
+description: Verity is a Lean-native language for verified smart contracts. Write the spec, write the implementation, and prove they agree, every claim is machine-checked at compile time, with the compiler itself proven to preserve semantics from EDSL to EVM bytecode.
 ---
 
 import { Callout } from 'nextra/components'
@@ -17,7 +17,7 @@ A small, audited Lean EDSL with example contracts that compile to EVM artifacts.
 Every claim is machine-checked and every assumption is documented. Compilation
 correctness rides on `Compiler/Proofs/IRGeneration/Contract.lean` (generic
 whole-contract `CompilationModel -> IR` theorem for the current supported
-fragment) — no per-contract bridge axioms. The full three-layer breakdown lives
+fragment), no per-contract bridge axioms. The full three-layer breakdown lives
 on the [Trust Model](/trust-model) page; the live theorem inventory is on
 [Verification Status](/verification).
 </ReportCallout>

--- a/docs-site/content/proof-techniques.mdx
+++ b/docs-site/content/proof-techniques.mdx
@@ -96,6 +96,6 @@ No multi-contract interaction, no reentrancy modeling, no gas modeling. The Comp
 
 ## See also
 
-- [Verification](/verification) — live theorem inventory and proof-status snapshot.
-- [Glossary](/glossary) — definitions of `ContractResult`, `local_obligations`, and other load-bearing terms.
-- [Trust Model](/trust-model) — what the proof techniques here actually buy you.
+- [Verification](/verification), live theorem inventory and proof-status snapshot.
+- [Glossary](/glossary), definitions of `ContractResult`, `local_obligations`, and other load-bearing terms.
+- [Trust Model](/trust-model), what the proof techniques here actually buy you.

--- a/docs-site/content/trust-model.mdx
+++ b/docs-site/content/trust-model.mdx
@@ -7,27 +7,27 @@ description: The canonical home for the Layer 1/2/3 framing, the trust boundary,
 
 What you trust when you trust a Verity contract: the Lean kernel, the Yul
 compiler, the deployment toolchain, the EVM specification itself, and the
-short list of axioms documented in `AXIOMS.md`. Everything else — the EDSL
+short list of axioms documented in `AXIOMS.md`. Everything else, the EDSL
 semantics, the `CompilationModel → IR` transformation, the `IR → Yul`
-preservation, and the per-contract specifications — is machine-checked.
+preservation, and the per-contract specifications, is machine-checked.
 
 ## The three layers
 
 Correctness is organized into three nested boundaries. Each layer states what
 is verified and what is explicitly *not* yet.
 
-### Layer 1 — spec ↔ EDSL
+### Layer 1, spec ↔ EDSL
 
 The frontend bridge. An EDSL implementation written in `Contracts/<Name>/` is
 proven equivalent to its `CompilationModel`, and per-contract proofs in
 `Contracts/<Name>/Proofs/` show that the EDSL satisfies a human-readable
 `Spec.lean`. **What's verified:** functional behavior of every supported
 primitive, success/revert paths via `ContractResult`, storage isolation and
-context preservation. **What's not:** the spec itself is a human artifact —
+context preservation. **What's not:** the spec itself is a human artifact ,
 Layer 1 cannot tell you that the spec is the *right* specification for your
 business problem.
 
-### Layer 2 — EDSL ↔ IR / CompilationModel
+### Layer 2, EDSL ↔ IR / CompilationModel
 
 The compiler middle. The generic whole-contract theorem in
 `Compiler/Proofs/IRGeneration/Contract.lean` proves that
@@ -37,12 +37,12 @@ eliminated; legacy contract-specific bridge theorems now sit above the generic
 compiler theorem as wrappers. **What's verified:** every statement and
 expression constructor in the supported fragment lowers to semantically
 equivalent IR. **What's not:** features marked as "not modeled" in the trust
-report — including parts of low-level call mechanics, linear-memory primitives
+report, including parts of low-level call mechanics, linear-memory primitives
 (`mload`/`mstore`/`calldatacopy`/`returndatacopy`), raw `rawLog` event
 emission, and `keccak256` (still axiomatized end-to-end). Each carries a
 `--deny-*` flag for proof-strict builds.
 
-### Layer 3 — IR ↔ Yul / EVM
+### Layer 3, IR ↔ Yul / EVM
 
 The backend. `IR → Yul` preservation is proved in
 `Compiler/Proofs/YulGeneration/`, with the remaining dispatcher bridge exposed
@@ -58,7 +58,7 @@ outside the proof envelope.
 
 What remains outside the proof envelope is **assumptions**, not axioms:
 
-- **Externally Callable Modules (ECMs)** in `Compiler/Modules/*.lean` carry named assumptions like `erc20_balanceOf_interface`, `evm_ecrecover_precompile`, `keccak256_memory_slice_matches_evm`. These are trust-report metadata, not Lean axioms — they document that the call mechanics depend on the EVM behaving as specified.
+- **Externally Callable Modules (ECMs)** in `Compiler/Modules/*.lean` carry named assumptions like `erc20_balanceOf_interface`, `evm_ecrecover_precompile`, `keccak256_memory_slice_matches_evm`. These are trust-report metadata, not Lean axioms, they document that the call mechanics depend on the EVM behaving as specified.
 - **`local_obligations`** declared on a constructor or function carry a named refinement obligation at that exact usage site.
 - **Not-modeled features** (parts of low-level call mechanics, linear-memory primitives, raw `rawLog`, dynamic `keccak256` over memory) compile but the proof interpreter does not yet model their full semantics.
 
@@ -97,6 +97,6 @@ The compiler exports the per-build view of all of this: `--assumption-report <pa
 
 ## See also
 
-- [Verification](/verification) — live theorem and proof-status inventory.
-- [Proof Techniques](/proof-techniques) — how proofs are structured, and what
+- [Verification](/verification), live theorem and proof-status inventory.
+- [Proof Techniques](/proof-techniques), how proofs are structured, and what
   is currently out of scope.

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -9,20 +9,20 @@ All three pipeline layers (EDSL → CompilationModel → IR → Yul) are complet
 
 ## Per-contract proof coverage
 
-Counts are theorems in each module. Read the actual statements in [`Contracts/<Name>/Proofs/`](https://github.com/lfglabs-dev/verity/tree/main/Contracts) — Lean is the source of truth.
+Counts are theorems in each module. Read the actual statements in [`Contracts/<Name>/Proofs/`](https://github.com/lfglabs-dev/verity/tree/main/Contracts), Lean is the source of truth.
 
 | Contract | Basic | Correctness | Conservation / Supply | Isolation | Native | Total |
 |----------|-------|-------------|----------------------|-----------|--------|-------|
-| SimpleStorage | 13 | 7 | — | — | — | 20 |
-| Counter | 19 | 9 | — | — | — | 28 |
-| SafeCounter | 20 | 8 | — | — | — | 28 |
-| Owned | 19 | 4 | — | — | — | 23 |
-| OwnedCounter | 33 | 6 | — | 14 | — | 53 |
-| Ledger | 24 | 6 | 7 (conservation) | — | — | 37 |
-| SimpleToken | 40 | 10 | 6 (supply) | 12 | — | 68 |
-| ERC20 | 15 | 7 | — | — | 3 | 25 |
-| ERC721 | 6 | 5 | — | — | — | 11 |
-| Vault (ERC-4626) | scaffold | scaffold | scaffold | — | 3 | 3 |
+| SimpleStorage | 13 | 7 |, |, |, | 20 |
+| Counter | 19 | 9 |, |, |, | 28 |
+| SafeCounter | 20 | 8 |, |, |, | 28 |
+| Owned | 19 | 4 |, |, |, | 23 |
+| OwnedCounter | 33 | 6 |, | 14 |, | 53 |
+| Ledger | 24 | 6 | 7 (conservation) |, |, | 37 |
+| SimpleToken | 40 | 10 | 6 (supply) | 12 |, | 68 |
+| ERC20 | 15 | 7 |, |, | 3 | 25 |
+| ERC721 | 6 | 5 |, |, |, | 11 |
+| Vault (ERC-4626) | scaffold | scaffold | scaffold |, | 3 | 3 |
 | ReentrancyExample | 5 inline (vulnerability witness + safety proofs) | | | | | 5 |
 
 The **Native** column counts theorems that pin the IR / Yul lowering to the EVMYulLean-bridged backend (`Contracts/<Name>/Proofs/Native.lean`).
@@ -42,13 +42,13 @@ Reusable proof infrastructure in `Verity/Proofs/Stdlib/`:
 
 ## Compiler proofs
 
-- **Generic whole-contract Layer 2 theorem**: `Compiler/Proofs/IRGeneration/Contract.lean` — `CompilationModel.compile` correctness for the supported fragment.
+- **Generic whole-contract Layer 2 theorem**: `Compiler/Proofs/IRGeneration/Contract.lean`, `CompilationModel.compile` correctness for the supported fragment.
 - **End-to-end**: `Compiler/Proofs/EndToEnd.lean`.
-- **Typed IR**: `Compiler/TypedIRCompilerCorrectness.lean` — 36 supported statement fragments including ABI-head tuples, bytes, fixed/dynamic arrays, and strings as word-typed inputs.
+- **Typed IR**: `Compiler/TypedIRCompilerCorrectness.lean`, 36 supported statement fragments including ABI-head tuples, bytes, fixed/dynamic arrays, and strings as word-typed inputs.
 - **Yul semantics + preservation**: `Compiler/Proofs/YulGeneration/`, with an EVMYulLean-bridged native backend in `Compiler/Proofs/YulGeneration/Backends/`.
 
 ## See also
 
-- [Proof Techniques](/proof-techniques) — guard modeling, unfolding, list-sum reasoning.
-- [Trust Model](/trust-model) — what each theorem rules out, what assumptions remain.
-- [Examples Gallery](/examples) — sources the theorems apply to.
+- [Proof Techniques](/proof-techniques), guard modeling, unfolding, list-sum reasoning.
+- [Trust Model](/trust-model), what each theorem rules out, what assumptions remain.
+- [Examples Gallery](/examples), sources the theorems apply to.

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -60,30 +60,30 @@ The dominant pattern is `_meets_spec`: each EDSL operation has a `_spec` predica
 ## Documentation index
 
 Introduction:
-- https://veritylang.com/architecture — single-page system map
-- https://veritylang.com/trust-model — what is verified vs trusted
+- https://veritylang.com/architecture, single-page system map
+- https://veritylang.com/trust-model, what is verified vs trusted
 
 Tutorials:
-- https://veritylang.com/getting-started — local setup
-- https://veritylang.com/first-contract — guided spec→proof walkthrough (TipJar)
+- https://veritylang.com/getting-started, local setup
+- https://veritylang.com/first-contract, guided spec→proof walkthrough (TipJar)
 
 How-to:
 - https://veritylang.com/guides/add-contract
 - https://veritylang.com/guides/solidity-to-verity
-- https://veritylang.com/guides/production-solidity-patterns — modifiers, ERC-7201 namespaces, ECMs, oracle patterns
-- https://veritylang.com/guides/linking-libraries — `--link` for external Yul (Poseidon, etc.)
+- https://veritylang.com/guides/production-solidity-patterns, modifiers, ERC-7201 namespaces, ECMs, oracle patterns
+- https://veritylang.com/guides/linking-libraries, `--link` for external Yul (Poseidon, etc.)
 - https://veritylang.com/guides/debugging-proofs
 
 Reference:
-- https://veritylang.com/examples — SimpleStorage / Counter / SafeCounter / Owned / OwnedCounter / Ledger / SimpleToken / Vault / ERC721 / ReentrancyExample / CryptoHash / ERC20
-- https://veritylang.com/core — ContractState, Contract monad, spec helpers (`sameAddrMapContext` etc.)
-- https://veritylang.com/edsl-api-reference — every primitive, plus `verity_contract` macro features
-- https://veritylang.com/compiler — pipeline, CLI flags, audit artifacts
-- https://veritylang.com/verification — per-contract theorem inventory
+- https://veritylang.com/examples, SimpleStorage / Counter / SafeCounter / Owned / OwnedCounter / Ledger / SimpleToken / Vault / ERC721 / ReentrancyExample / CryptoHash / ERC20
+- https://veritylang.com/core, ContractState, Contract monad, spec helpers (`sameAddrMapContext` etc.)
+- https://veritylang.com/edsl-api-reference, every primitive, plus `verity_contract` macro features
+- https://veritylang.com/compiler, pipeline, CLI flags, audit artifacts
+- https://veritylang.com/verification, per-contract theorem inventory
 - https://veritylang.com/glossary
 
 Explanation:
-- https://veritylang.com/proof-techniques — guard modeling, unfolding, list-sum reasoning
+- https://veritylang.com/proof-techniques, guard modeling, unfolding, list-sum reasoning
 - https://veritylang.com/faq
 
 ## Working effectively in this codebase


### PR DESCRIPTION
## Summary
Removes em dashes from all user-facing content on veritylang.com (MDX pages, site title, metadata, llms.txt) per stylistic preference. Replaces ` — ` with `, ` and standalone `—` with `,`. Code/CSS comments left untouched.

## Test plan
- [x] `npm run build` succeeds
- [x] `grep -c "—"` on rendered HTML for `/`, `/architecture`, `/first-contract`, `/faq`, `/verification`, `/trust-model` returns 0
- [x] Homepage title and description render without em dashes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to docs-site metadata and MDX prose formatting; main risk is accidental markdown formatting regressions (notably in tables/lists) affecting rendering/SEO snippets.
> 
> **Overview**
> Updates veritylang.com docs-site copy and SEO metadata to remove em dashes, replacing them with commas in page titles/descriptions, OpenGraph/Twitter fields, and MDX content.
> 
> Also adjusts various MDX list/table punctuation to match the new style, which may change markdown rendering in a few spots (e.g., list formatting and the `verification.mdx` table separators).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e9197b54d2fa96d2d39c9e23cb2355562dc51f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->