### PR TITLE
Replace footer bar with inline backlink on homepage

### DIFF
--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -135,14 +135,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           docsRepositoryBase="https://github.com/lfglabs-dev/verity/tree/main/docs-site"
           sidebar={{ defaultMenuCollapseLevel: 1 }}
           toc={{ backToTop: true }}
-          footer={
-            <p className="verity-footer">
-              Built by{' '}
-              <a href="https://lfglabs.dev" target="_blank" rel="noopener">
-                LFG Labs
-              </a>
-            </p>
-          }
         >
           {children}
         </Layout>

--- a/docs-site/app/verity-site.css
+++ b/docs-site/app/verity-site.css
@@ -2495,22 +2495,3 @@ input:focus-visible,
     display: none !important;
   }
 }
-
-/* Subtle backlink to LFG Labs, styled to feel inline with page content */
-.verity-footer {
-  max-width: var(--nextra-content-width, 90rem);
-  margin: 0 auto;
-  padding: 2rem 0;
-  text-align: center;
-  font-size: 0.8125rem;
-  color: var(--verity-color-muted, #6b7c7c);
-}
-.verity-footer a {
-  color: inherit;
-  text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, currentColor 30%, transparent);
-  text-underline-offset: 3px;
-}
-.verity-footer a:hover {
-  color: var(--verity-color-accent, #0a7d7d);
-}

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -80,3 +80,5 @@ import { ReadingList } from '../components/ReadingList'
 **For agents and tooling:** see [/llms.txt](/llms.txt), or add `.md` to any
 page URL for raw markdown.
 </Callout>
+
+Verity is a research project by [LFG Labs](https://lfglabs.dev).


### PR DESCRIPTION
## Summary
- Remove the `footer` prop from nextra Layout — it rendered outside the content area and overlapped the sidebar
- Remove all `.verity-footer` CSS
- Add a simple inline "Verity is a research project by LFG Labs" link at the bottom of the homepage content

## Test plan
- [x] Footer bar no longer appears below the sidebar
- [x] Homepage shows the backlink as regular page content

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/content-only change that removes a custom footer hook and its CSS; main risk is minor layout/regression in docs-site chrome.
> 
> **Overview**
> Removes the custom `footer` passed into Nextra `Layout` and deletes the associated `.verity-footer` styling to avoid footer UI overlapping the sidebar.
> 
> Adds a simple inline attribution link (“Verity is a research project by LFG Labs”) to the bottom of the homepage (`content/index.mdx`) so the backlink appears as normal page content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f184ab4616e612f50a7df3abbf7cbc875ec0922. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->