### PR TITLE
Add agent documentation discovery endpoints

### DIFF
--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3943,6 +3943,11 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.compileStmtList_internalCall_bridged
   Compiler.Proofs.YulGeneration.Backends.compileStmt_externalCallBind_bridged
   Compiler.Proofs.YulGeneration.Backends.compileStmtList_externalCallBind_bridged
+  -- Compiler.Proofs.YulGeneration.Backends.compileStmtList_noFuncDefs_of_perStmtBridge  -- private
+  Compiler.Proofs.YulGeneration.Backends.compileStmt_internalCall_noFuncDefs
+  Compiler.Proofs.YulGeneration.Backends.compileStmtList_internalCall_noFuncDefs
+  Compiler.Proofs.YulGeneration.Backends.compileStmt_externalCallBind_noFuncDefs
+  Compiler.Proofs.YulGeneration.Backends.compileStmtList_externalCallBind_noFuncDefs
   Compiler.Proofs.YulGeneration.Backends.compileStmt_ecm_bridged
   Compiler.Proofs.YulGeneration.Backends.compileStmtList_ecm_bridged
   Compiler.Proofs.YulGeneration.Backends.compileStmtList_append_ok_inv
@@ -5457,4 +5462,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5162 theorems/lemmas (3583 public, 1579 private, 0 sorry'd)
+-- Total: 5167 theorems/lemmas (3587 public, 1580 private, 0 sorry'd)

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -38,12 +38,15 @@ npm start
 ```
 docs-site/
 ├── app/api/docs/[...slug]/route.ts  # API for serving markdown
+├── app/llms-full.txt/route.ts       # Full-docs markdown endpoint
+├── agent-discovery.mjs              # Shared agent discovery headers/routes
 ├── content/                         # Documentation pages (MDX)
 │   ├── index.mdx                    # Homepage
 │   ├── examples.mdx                 # Example contracts
 │   ├── core.mdx                     # Core architecture
 │   └── _meta.js                     # Navigation config
 ├── public/llms.txt                  # AI agent index
+├── public/skill.md                  # Operational workflow for agents
 ├── proxy.ts                         # Middleware for AI agent detection
 └── next.config.mjs                  # Next.js config with Nextra
 ```
@@ -61,7 +64,14 @@ The site automatically serves markdown to AI agents through:
 1. **Auto-detection**: Known AI user agents get markdown automatically
 2. **Explicit format**: Any page with `.md` extension or `?format=md` query
 3. **Accept header**: Requests with `Accept: text/markdown`
-4. **API routes**:
+4. **Plain text fallback**: Requests with `Accept: text/plain`
+5. **Discovery endpoints**:
+   - `/llms.txt` and `/.well-known/llms.txt` - Compact agent index
+   - `/llms-full.txt` and `/.well-known/llms-full.txt` - All docs concatenated (Markdown)
+   - `/skill.md` and `/.well-known/skill.md` - Operational workflow for agents working in Verity
+   - `/.well-known/agent-skills` - JSON skill discovery index
+6. **Discovery headers**: Every response advertises `Link`, `X-Llms-Txt`, `X-Llms-Full-Txt`, and `X-Agent-Skill`
+7. **API routes**:
    - `/api/docs/_index` - List all documents (JSON)
    - `/api/docs/_all` - All docs concatenated (Markdown)
    - `/api/docs/[page]` - Single document (Markdown)

--- a/docs-site/agent-discovery.mjs
+++ b/docs-site/agent-discovery.mjs
@@ -1,0 +1,19 @@
+export const AGENT_DISCOVERY_LINKS = [
+  '</llms.txt>; rel="llms-txt"',
+  '</llms-full.txt>; rel="llms-full-txt"',
+  '</skill.md>; rel="agent-skill"',
+].join(", ");
+
+export const AGENT_DISCOVERY_HEADERS = [
+  { key: "Link", value: AGENT_DISCOVERY_LINKS },
+  { key: "X-Llms-Txt", value: "/llms.txt" },
+  { key: "X-Llms-Full-Txt", value: "/llms-full.txt" },
+  { key: "X-Agent-Skill", value: "/skill.md" },
+];
+
+export const AGENT_DISCOVERY_REWRITES = [
+  { source: "/.well-known/llms.txt", destination: "/llms.txt" },
+  { source: "/.well-known/llms-full.txt", destination: "/llms-full.txt" },
+  { source: "/.well-known/skill.md", destination: "/skill.md" },
+  { source: "/.well-known/agent-skills", destination: "/api/agent-skills" },
+];

--- a/docs-site/app/api/agent-skills/route.ts
+++ b/docs-site/app/api/agent-skills/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { agentDiscoveryHeaderRecord } from "@/server/agent-discovery";
+
+export function GET() {
+  return NextResponse.json(
+    {
+      description: "Verity agent skill index",
+      skills: [
+        {
+          name: "verity",
+          url: "/skill.md",
+          description:
+            "Operational guidance for agents adding, porting, proving, and auditing Verity contracts.",
+        },
+      ],
+    },
+    {
+      headers: agentDiscoveryHeaderRecord(),
+    }
+  );
+}

--- a/docs-site/app/api/docs/[...slug]/route.ts
+++ b/docs-site/app/api/docs/[...slug]/route.ts
@@ -1,62 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { readFile, readdir, stat } from "fs/promises";
-import { join } from "path";
-
-// Content directory relative to project root
-const CONTENT_DIR = join(process.cwd(), "content");
-
-/**
- * Strip frontmatter from MDX/markdown content
- * Frontmatter is the YAML block between --- markers at the start
- */
-function stripFrontmatter(content: string): string {
-  const frontmatterRegex = /^---\s*\n[\s\S]*?\n---\s*\n/;
-  return content.replace(frontmatterRegex, "").trim();
-}
-
-/**
- * Extract frontmatter metadata from MDX content
- */
-function extractFrontmatter(content: string): Record<string, string> {
-  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
-  if (!match) return {};
-
-  const frontmatter: Record<string, string> = {};
-  const lines = match[1].split("\n");
-  for (const line of lines) {
-    const [key, ...valueParts] = line.split(":");
-    if (key && valueParts.length) {
-      frontmatter[key.trim()] = valueParts.join(":").trim();
-    }
-  }
-  return frontmatter;
-}
-
-/**
- * List all available documentation files
- */
-async function listDocs(dir: string = CONTENT_DIR, prefix: string = ""): Promise<string[]> {
-  const entries = await readdir(dir, { withFileTypes: true });
-  const docs: string[] = [];
-
-  for (const entry of entries) {
-    // Skip meta files and hidden files
-    if (entry.name.startsWith("_") || entry.name.startsWith(".")) continue;
-
-    const fullPath = join(dir, entry.name);
-    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
-
-    if (entry.isDirectory()) {
-      docs.push(...(await listDocs(fullPath, relativePath)));
-    } else if (entry.name.endsWith(".mdx") || entry.name.endsWith(".md")) {
-      // Convert filename to URL path (remove extension)
-      const urlPath = relativePath.replace(/\.(mdx?|md)$/, "");
-      docs.push(urlPath);
-    }
-  }
-
-  return docs;
-}
+import { agentDiscoveryHeaderRecord } from "@/server/agent-discovery";
+import { buildAllDocsMarkdown, docIndex, readDoc } from "@/server/docs";
 
 /**
  * GET /api/docs/[...slug]
@@ -81,15 +25,15 @@ export async function GET(
   // Special route: list all docs
   if (path === "_index") {
     try {
-      const docs = await listDocs();
-      return NextResponse.json({
-        description: "Verity Documentation Index",
-        docs: docs.map((doc) => ({
-          path: doc,
-          url: `/api/docs/${doc}`,
-          html_url: `/${doc === "index" ? "" : doc}`,
-        })),
-      });
+      return NextResponse.json(
+        {
+          description: "Verity Documentation Index",
+          docs: await docIndex(),
+        },
+        {
+          headers: agentDiscoveryHeaderRecord(),
+        }
+      );
     } catch {
       return NextResponse.json({ error: "Failed to list docs" }, { status: 500 });
     }
@@ -98,50 +42,9 @@ export async function GET(
   // Special route: all docs concatenated
   if (path === "_all") {
     try {
-      const docs = await listDocs();
-      const contents: string[] = [
-        "# Verity - Complete Documentation",
-        "",
-        "> Minimal Lean EDSL for Smart Contracts - All documentation concatenated for AI agent consumption.",
-        "",
-        "---",
-        "",
-      ];
-
-      for (const docPath of docs) {
-        const filePath = join(CONTENT_DIR, `${docPath}.mdx`);
-        try {
-          const content = await readFile(filePath, "utf-8");
-          const frontmatter = extractFrontmatter(content);
-          const markdown = stripFrontmatter(content);
-
-          contents.push(`# ${frontmatter.title || docPath}`);
-          contents.push("");
-          if (frontmatter.description) {
-            contents.push(`> ${frontmatter.description}`);
-            contents.push("");
-          }
-          contents.push(markdown);
-          contents.push("");
-          contents.push("---");
-          contents.push("");
-        } catch {
-          // Try .md extension as fallback
-          try {
-            const mdPath = join(CONTENT_DIR, `${docPath}.md`);
-            const content = await readFile(mdPath, "utf-8");
-            contents.push(stripFrontmatter(content));
-            contents.push("");
-            contents.push("---");
-            contents.push("");
-          } catch {
-            // Skip if file not found
-          }
-        }
-      }
-
-      return new NextResponse(contents.join("\n"), {
+      return new NextResponse(await buildAllDocsMarkdown(), {
         headers: {
+          ...agentDiscoveryHeaderRecord(),
           "Content-Type": "text/markdown; charset=utf-8",
           "Cache-Control": "public, max-age=3600",
           "X-Content-Type-Options": "nosniff",
@@ -155,31 +58,9 @@ export async function GET(
   // Regular doc request - normalize path
   let normalizedPath = path.replace(/\.md$/, ""); // Strip .md extension if present
 
-  // Try to find the file
-  const possiblePaths = [
-    join(CONTENT_DIR, `${normalizedPath}.mdx`),
-    join(CONTENT_DIR, `${normalizedPath}.md`),
-    join(CONTENT_DIR, normalizedPath, "index.mdx"),
-    join(CONTENT_DIR, normalizedPath, "index.md"),
-  ];
+  const doc = await readDoc(normalizedPath);
 
-  let content: string | null = null;
-  let foundPath: string | null = null;
-
-  for (const filePath of possiblePaths) {
-    try {
-      const stats = await stat(filePath);
-      if (stats.isFile()) {
-        content = await readFile(filePath, "utf-8");
-        foundPath = filePath;
-        break;
-      }
-    } catch {
-      // File doesn't exist, try next
-    }
-  }
-
-  if (!content || !foundPath) {
+  if (!doc) {
     return NextResponse.json(
       {
         error: "Document not found",
@@ -190,29 +71,26 @@ export async function GET(
     );
   }
 
-  // Extract metadata and strip frontmatter
-  const frontmatter = extractFrontmatter(content);
-  const markdown = stripFrontmatter(content);
-
   // Build response with optional metadata header
   const includeMetadata = request.nextUrl.searchParams.get("metadata") === "true";
-  let responseContent = markdown;
+  let responseContent = doc.markdown;
 
-  if (includeMetadata && (frontmatter.title || frontmatter.description)) {
+  if (includeMetadata && (doc.metadata.title || doc.metadata.description)) {
     const metaLines = [];
-    if (frontmatter.title) metaLines.push(`# ${frontmatter.title}`);
-    if (frontmatter.description) metaLines.push(`> ${frontmatter.description}`);
+    if (doc.metadata.title) metaLines.push(`# ${doc.metadata.title}`);
+    if (doc.metadata.description) metaLines.push(`> ${doc.metadata.description}`);
     if (metaLines.length) {
-      responseContent = metaLines.join("\n") + "\n\n" + markdown;
+      responseContent = metaLines.join("\n") + "\n\n" + doc.markdown;
     }
   }
 
   return new NextResponse(responseContent, {
     headers: {
+      ...agentDiscoveryHeaderRecord(),
       "Content-Type": "text/markdown; charset=utf-8",
       "Cache-Control": "public, max-age=3600",
       "X-Content-Type-Options": "nosniff",
-      "X-Doc-Title": frontmatter.title || normalizedPath,
+      "X-Doc-Title": doc.metadata.title || normalizedPath,
       "X-Doc-Path": normalizedPath,
     },
   });

--- a/docs-site/app/llms-full.txt/route.ts
+++ b/docs-site/app/llms-full.txt/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { agentDiscoveryHeaderRecord } from "@/server/agent-discovery";
+import { buildAllDocsMarkdown } from "@/server/docs";
+
+export async function GET() {
+  try {
+    return new NextResponse(await buildAllDocsMarkdown(), {
+      headers: {
+        ...agentDiscoveryHeaderRecord(),
+        "Content-Type": "text/markdown; charset=utf-8",
+        "Cache-Control": "public, max-age=3600",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: "Failed to compile docs" }, { status: 500 });
+  }
+}

--- a/docs-site/next.config.mjs
+++ b/docs-site/next.config.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import nextra from "nextra";
 import { bundledLanguages, createHighlighter } from "shiki";
+import { AGENT_DISCOVERY_HEADERS, AGENT_DISCOVERY_REWRITES } from "./agent-discovery.mjs";
 
 const configDir = dirname(fileURLToPath(import.meta.url));
 const isDev = process.env.NODE_ENV !== "production";
@@ -53,6 +54,17 @@ export default withNextra({
   ...(isDev ? { turbopack: { root: configDir } } : {}),
   images: {
     formats: ["image/avif", "image/webp"],
+  },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: AGENT_DISCOVERY_HEADERS,
+      },
+    ];
+  },
+  async rewrites() {
+    return AGENT_DISCOVERY_REWRITES;
   },
   // Redirect legacy URLs to the new IA so old bookmarks / external
   // links don't 404 after the restructure.

--- a/docs-site/proxy.ts
+++ b/docs-site/proxy.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { applyAgentDiscoveryHeaders } from "@/server/agent-discovery";
 
 /**
  * Known LLM/AI user agent patterns
@@ -33,8 +34,9 @@ function isLLMUserAgent(userAgent: string | null): boolean {
  * Routes to raw markdown API when:
  * 1. URL ends with .md extension (e.g., /setup.md)
  * 2. Accept header includes text/markdown
- * 3. Query param ?format=md is present
- * 4. User-Agent is a known LLM (ChatGPT, GPTBot, PerplexityBot, etc.)
+ * 3. Accept header includes text/plain
+ * 4. Query param ?format=md is present
+ * 5. User-Agent is a known LLM (ChatGPT, GPTBot, PerplexityBot, etc.)
  *
  * This allows AI agents to fetch documentation as raw markdown
  * while browsers get the rendered HTML version.
@@ -45,6 +47,7 @@ export function proxy(request: NextRequest) {
   // Skip API routes, static files, and Next.js internals
   if (
     pathname.startsWith("/api/") ||
+    pathname.startsWith("/.well-known/") ||
     pathname.startsWith("/_next/") ||
     pathname.startsWith("/static/") ||
     pathname.startsWith("/_pagefind/") ||
@@ -59,6 +62,7 @@ export function proxy(request: NextRequest) {
   const wantsMarkdown =
     pathname.endsWith(".md") ||
     request.headers.get("Accept")?.includes("text/markdown") ||
+    request.headers.get("Accept")?.includes("text/plain") ||
     request.nextUrl.searchParams.get("format") === "md" ||
     isLLMUserAgent(userAgent);
 
@@ -77,10 +81,10 @@ export function proxy(request: NextRequest) {
     url.searchParams.delete("format");
 
     // Rewrite to the API route (internal redirect, URL doesn't change for client)
-    return NextResponse.rewrite(url);
+    return applyAgentDiscoveryHeaders(NextResponse.rewrite(url));
   }
 
-  return NextResponse.next();
+  return applyAgentDiscoveryHeaders(NextResponse.next());
 }
 
 // Only run proxy on relevant paths

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -1,7 +1,7 @@
 # Verity
 
 > Lean 4 framework for writing smart contracts that compile to EVM bytecode and carry machine-checked correctness proofs.
-> Add `.md` to any docs URL on veritylang.com to get raw markdown (saves tokens). Or fetch `/api/docs/_all` for everything concatenated.
+> Add `.md` to any docs URL on veritylang.com to get raw markdown (saves tokens). Or fetch `/llms-full.txt` for everything concatenated.
 
 ## What it is
 
@@ -58,6 +58,14 @@ The dominant pattern is `_meets_spec`: each EDSL operation has a `_spec` predica
 [lfglabs-dev/verity-benchmark](https://github.com/lfglabs-dev/verity-benchmark) measures AI agent capability at proving contract specs in this framework: 30 tasks across six real-world protocols (Ethereum deposit, Lido VaultHub, Nexus Mutual RAMM, Kleros sortition, Paladin Votes, Damn Vulnerable DeFi). No `sorry`/`admit`/`axiom` placeholders allowed.
 
 ## Documentation index
+
+Agent endpoints:
+- https://veritylang.com/llms.txt, compact agent index
+- https://veritylang.com/llms-full.txt, all docs concatenated as Markdown
+- https://veritylang.com/skill.md, operational agent workflow
+- https://veritylang.com/.well-known/skill.md, operational agent workflow alias
+- https://veritylang.com/api/docs/_index, JSON docs index
+- https://veritylang.com/api/docs/_all, all docs concatenated through the API
 
 Introduction:
 - https://veritylang.com/architecture, single-page system map

--- a/docs-site/public/skill.md
+++ b/docs-site/public/skill.md
@@ -1,0 +1,70 @@
+# Verity Agent Skill
+
+Use this skill when working in the Verity repository or docs. Verity is a Lean 4 framework for writing smart contracts that compile to EVM bytecode with machine-checked correctness proofs.
+
+## First Principles
+
+- Treat Lean files in `Contracts/<Name>/` as the source of truth.
+- Keep specs, EDSL implementation, generated artifacts, and proofs aligned.
+- Do not use `sorry`, `admit`, new `axiom`s, or unchecked assumptions to make proofs pass.
+- Prefer existing Verity primitives and proof patterns before adding abstractions.
+- Read `/llms.txt` first for the compact working model, then fetch `/llms-full.txt` when broader context is needed.
+
+## Add A Contract
+
+1. Scaffold with `python3 scripts/generate_contract.py <Name> --fields ... --functions ...` when the contract shape fits the generator.
+2. Implement storage, specs, and EDSL functions under `Contracts/<Name>/`.
+3. Register compiler integration following the existing contract examples.
+4. Prove each public operation with the `_meets_spec` convention.
+5. Run `lake build`.
+6. If compiler behavior changes, run the relevant Foundry and property tests.
+
+Primary docs:
+
+- `/first-contract.md`
+- `/guides/add-contract.md`
+- `/edsl-api-reference.md`
+- `/proof-techniques.md`
+- `/guides/debugging-proofs.md`
+
+## Port Solidity To Verity
+
+1. Map Solidity state to Verity storage spaces before writing code.
+2. Translate modifiers into explicit guard predicates and `require` checks.
+3. Model external calls, precompiles, or oracle inputs as explicit trust-boundary assumptions unless the repo already has a verified surface.
+4. Use `/guides/production-solidity-patterns.md` for ERC-7201 namespaces, proxy patterns, ECMs, events, and low-level mechanics.
+5. Validate emitted trust, assumption, layout, and layout-compat reports.
+
+Primary docs:
+
+- `/guides/solidity-to-verity.md`
+- `/guides/production-solidity-patterns.md`
+- `/compiler.md`
+- `/trust-model.md`
+
+## Prove Specs
+
+- The default theorem shape is `<operation>_meets_spec`.
+- Most storage-only operations close by unfolding the operation, slot names, and spec, then using `simp`.
+- For guard-protected operations, unfold `bind`, `Contract.run`, and `ContractResult.snd`, then pass the guard hypothesis to `simp`.
+- For list or aggregate invariants, isolate helper lemmas near the proof instead of growing tactic scripts blindly.
+- When stuck, inspect generated goals before changing the spec. A failing proof often means the spec, state shape, or revert path is underspecified.
+
+## Audit Trust
+
+- `lake build` verifies Lean proofs.
+- Use compiler report flags for trust-sensitive changes: `--trust-report`, `--assumption-report`, `--layout-report`, and `--layout-compat-report`.
+- Use deny flags to fail closed in CI or release builds. `--deny-unsafe` is the broad catch-all.
+- Cross-check trust reports against `AXIOMS.md` and `/trust-model.md`.
+
+## Useful Agent URLs
+
+- `/llms.txt`: compact agent index.
+- `/llms-full.txt`: all docs concatenated as Markdown.
+- `/api/docs/_index`: JSON documentation index.
+- `/api/docs/_all`: all docs concatenated through the API.
+- `/<page>.md`: raw Markdown for any docs page.
+- `/.well-known/llms.txt`: discovery alias.
+- `/.well-known/llms-full.txt`: discovery alias.
+- `/.well-known/skill.md`: discovery alias.
+- `/.well-known/agent-skills`: skill discovery index.

--- a/docs-site/server/agent-discovery.ts
+++ b/docs-site/server/agent-discovery.ts
@@ -1,0 +1,14 @@
+import type { NextResponse } from "next/server";
+import { AGENT_DISCOVERY_HEADERS } from "../agent-discovery.mjs";
+
+export function applyAgentDiscoveryHeaders(response: NextResponse): NextResponse {
+  for (const { key, value } of AGENT_DISCOVERY_HEADERS) {
+    response.headers.set(key, value);
+  }
+
+  return response;
+}
+
+export function agentDiscoveryHeaderRecord(): Record<string, string> {
+  return Object.fromEntries(AGENT_DISCOVERY_HEADERS.map(({ key, value }) => [key, value]));
+}

--- a/docs-site/server/docs.ts
+++ b/docs-site/server/docs.ts
@@ -1,0 +1,128 @@
+import { readFile, readdir, stat } from "fs/promises";
+import { join } from "path";
+
+export const CONTENT_DIR = join(process.cwd(), "content");
+
+export type DocMetadata = Record<string, string>;
+
+export type DocEntry = {
+  path: string;
+  url: string;
+  html_url: string;
+  markdown_url: string;
+};
+
+export type ResolvedDoc = {
+  path: string;
+  markdown: string;
+  metadata: DocMetadata;
+};
+
+export function stripFrontmatter(content: string): string {
+  const frontmatterRegex = /^---\s*\n[\s\S]*?\n---\s*\n/;
+  return content.replace(frontmatterRegex, "").trim();
+}
+
+export function extractFrontmatter(content: string): DocMetadata {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match) return {};
+
+  const frontmatter: DocMetadata = {};
+  const lines = match[1].split("\n");
+  for (const line of lines) {
+    const [key, ...valueParts] = line.split(":");
+    if (key && valueParts.length) {
+      frontmatter[key.trim()] = valueParts.join(":").trim();
+    }
+  }
+  return frontmatter;
+}
+
+export async function listDocs(dir: string = CONTENT_DIR, prefix: string = ""): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const docs: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith("_") || entry.name.startsWith(".")) continue;
+
+    const fullPath = join(dir, entry.name);
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+
+    if (entry.isDirectory()) {
+      docs.push(...(await listDocs(fullPath, relativePath)));
+    } else if (entry.name.endsWith(".mdx") || entry.name.endsWith(".md")) {
+      docs.push(relativePath.replace(/\.(mdx?|md)$/, ""));
+    }
+  }
+
+  return docs;
+}
+
+export async function docIndex(): Promise<DocEntry[]> {
+  const docs = await listDocs();
+
+  return docs.map((doc) => ({
+    path: doc,
+    url: `/api/docs/${doc}`,
+    html_url: `/${doc === "index" ? "" : doc}`,
+    markdown_url: `/${doc === "index" ? "index" : doc}.md`,
+  }));
+}
+
+export async function readDoc(docPath: string): Promise<ResolvedDoc | null> {
+  const normalizedPath = docPath.replace(/\.md$/, "");
+  const possiblePaths = [
+    join(CONTENT_DIR, `${normalizedPath}.mdx`),
+    join(CONTENT_DIR, `${normalizedPath}.md`),
+    join(CONTENT_DIR, normalizedPath, "index.mdx"),
+    join(CONTENT_DIR, normalizedPath, "index.md"),
+  ];
+
+  for (const filePath of possiblePaths) {
+    try {
+      const stats = await stat(filePath);
+      if (!stats.isFile()) continue;
+
+      const content = await readFile(filePath, "utf-8");
+      return {
+        path: normalizedPath,
+        markdown: stripFrontmatter(content),
+        metadata: extractFrontmatter(content),
+      };
+    } catch {
+      // Try the next candidate path.
+    }
+  }
+
+  return null;
+}
+
+export async function buildAllDocsMarkdown(): Promise<string> {
+  const docs = await listDocs();
+  const contents: string[] = [
+    "# Verity - Complete Documentation",
+    "",
+    "> Minimal Lean EDSL for Smart Contracts - All documentation concatenated for AI agent consumption.",
+    "",
+    "---",
+    "",
+  ];
+
+  for (const docPath of docs) {
+    const doc = await readDoc(docPath);
+    if (!doc) continue;
+
+    contents.push(`# ${doc.metadata.title || docPath}`);
+    contents.push("");
+    if (doc.metadata.description) {
+      contents.push(`> ${doc.metadata.description}`);
+      contents.push("");
+    }
+    contents.push(doc.markdown);
+    contents.push("");
+    contents.push("---");
+    contents.push("");
+  }
+
+  return contents.join("\n");
+}


### PR DESCRIPTION
## Summary
- add standard agent discovery headers and well-known rewrites for `llms.txt`, full docs markdown, and the Verity agent workflow
- expose `/llms-full.txt` and `/.well-known/llms-full.txt` backed by the existing concatenated docs API
- add `/skill.md` plus `/.well-known/agent-skills` for operational agent guidance when editing Verity contracts and proofs
- refactor docs markdown reading/indexing into shared server helpers used by both single-page and full-doc endpoints
- support `Accept: text/plain` as a markdown negotiation fallback while preserving existing `.md`, `?format=md`, and AI user-agent behavior

## Verification
- `npm run build` in `docs-site`
- local HTTP probes for:
  - `/architecture.md`
  - `/compiler` with `Accept: text/plain`
  - `/.well-known/llms-full.txt`
  - `/.well-known/skill.md`
  - `/.well-known/agent-skills`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new public endpoints/rewrites and injects agent discovery headers site-wide, which could affect caching/routing behavior and response headers for all requests.
> 
> **Overview**
> Adds **agent discovery support** to the docs site: new `/llms-full.txt`, `/skill.md`, and `/.well-known/*` aliases plus a JSON `/.well-known/agent-skills` index, and advertises these via `Link`/`X-*` discovery headers on all routes.
> 
> Refactors the docs markdown API to use shared server utilities (`server/docs.ts`) for indexing, frontmatter parsing, single-doc reads, and full-doc concatenation, and updates the proxy to also negotiate markdown on `Accept: text/plain` while ensuring discovery headers are applied to both rewrites and normal responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98c951e94b5c2287322b9b26459d7ff2a2445972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->