### PR TITLE
Add typed router ABI surface support

### DIFF
--- a/Compiler/ABI.lean
+++ b/Compiler/ABI.lean
@@ -14,6 +14,7 @@ private def abiTypeString : ParamType → String
   | .uint256 => "uint256"
   | .int256 => "int256"
   | .uint8 => "uint8"
+  | .uint16 => "uint16"
   | .address => "address"
   | .bool => "bool"
   | .bytes32 => "bytes32"

--- a/Compiler/CompilationModel/AbiEncoding.lean
+++ b/Compiler/CompilationModel/AbiEncoding.lean
@@ -17,6 +17,8 @@ def encodeStaticCustomErrorArg (errorName : String) (ty : ParamType) (argExpr : 
       pure argExpr
   | ParamType.uint8 =>
       pure (YulExpr.call "and" [argExpr, YulExpr.lit 255])
+  | ParamType.uint16 =>
+      pure (YulExpr.call "and" [argExpr, YulExpr.lit 65535])
   | ParamType.address =>
       pure (YulExpr.call "and" [argExpr, YulExpr.hex addressMask])
   | ParamType.bool =>
@@ -37,7 +39,7 @@ partial def compileUnindexedAbiEncode
     (srcBase dstBase : YulExpr) (stem : String) :
     Except String (List YulStmt × YulExpr) := do
   match ty with
-  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
       let loaded := dynamicWordLoad dynamicSource srcBase
       pure ([
         YulStmt.expr (YulExpr.call "mstore" [dstBase, normalizeEventWord ty loaded])
@@ -298,7 +300,7 @@ def revertWithCustomError (dynamicSource : DynamicDataSource)
   let argsWithHeadOffsets := attachOffsets argsWithSources 4
   let argStores ← argsWithHeadOffsets.zipIdx.mapM fun ((ty, srcExpr, argExpr, headOffset), idx) => do
     match ty with
-    | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+    | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
         let encoded ← encodeStaticCustomErrorArg errorDef.name ty argExpr
         pure [YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit headOffset, encoded])]
     | ParamType.adt _ maxFields =>

--- a/Compiler/CompilationModel/AbiHelpers.lean
+++ b/Compiler/CompilationModel/AbiHelpers.lean
@@ -47,6 +47,7 @@ mutual
     | ParamType.uint256 => "uint256"
     | ParamType.int256 => "int256"
     | ParamType.uint8 => "uint8"
+    | ParamType.uint16 => "uint16"
     | ParamType.address => "address"
     | ParamType.bool => "bool"
     | ParamType.bytes32 => "bytes32"

--- a/Compiler/CompilationModel/AbiTypeLayout.lean
+++ b/Compiler/CompilationModel/AbiTypeLayout.lean
@@ -9,6 +9,7 @@ mutual
     | ParamType.uint256 => false
     | ParamType.int256 => false
     | ParamType.uint8 => false
+    | ParamType.uint16 => false
     | ParamType.address => false
     | ParamType.bool => false
     | ParamType.bytes32 => false
@@ -35,6 +36,7 @@ mutual
     | ParamType.uint256 => 32
     | ParamType.int256 => 32
     | ParamType.uint8 => 32
+    | ParamType.uint16 => 32
     | ParamType.address => 32
     | ParamType.bool => 32
     | ParamType.bytes32 => 32
@@ -69,14 +71,14 @@ mutual
     | ParamType.fixedArray elemTy n =>
         if isDynamicParamType (ParamType.fixedArray elemTy n) then 1 else n * paramParentHeadWords elemTy
     | ParamType.newtypeOf _ baseType => paramParentHeadWords baseType
-    | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address
+    | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address
     | ParamType.bool | ParamType.bytes32 => 1
     | ParamType.adt _ maxFields => 1 + maxFields
 
   /-- Number of 32-byte words in the local head of an ABI value once its dynamic
   tail has been entered. Dynamic children occupy one offset word in that head. -/
   partial def paramLocalHeadWords : ParamType → Nat
-    | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address
+    | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address
     | ParamType.bool | ParamType.bytes32 | ParamType.string | ParamType.bytes
     | ParamType.array _ => 1
     | ParamType.fixedArray elemTy n => n * paramParentHeadWords elemTy

--- a/Compiler/CompilationModel/EventAbiHelpers.lean
+++ b/Compiler/CompilationModel/EventAbiHelpers.lean
@@ -16,6 +16,7 @@ def indexedDynamicArrayElemSupported (elemTy : ParamType) : Bool :=
 def normalizeEventWord (ty : ParamType) (expr : YulExpr) : YulExpr :=
   match ty with
   | ParamType.uint8 => YulExpr.call "and" [expr, YulExpr.lit 255]
+  | ParamType.uint16 => YulExpr.call "and" [expr, YulExpr.lit 65535]
   | ParamType.address => YulExpr.call "and" [expr, YulExpr.hex addressMask]
   | ParamType.bool => yulToBool expr
   | ParamType.newtypeOf _ baseType => normalizeEventWord baseType expr
@@ -24,7 +25,7 @@ def normalizeEventWord (ty : ParamType) (expr : YulExpr) : YulExpr :=
 partial def staticCompositeLeaves (baseName : String) (ty : ParamType) :
     List (ParamType × YulExpr) :=
   match ty with
-  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
       [(ty, YulExpr.ident baseName)]
   | ParamType.fixedArray elemTy n =>
       (List.range n).flatMap fun i =>
@@ -41,7 +42,7 @@ partial def staticCompositeLeaves (baseName : String) (ty : ParamType) :
 partial def staticCompositeLeafTypeOffsets
     (baseOffset : Nat) (ty : ParamType) : List (Nat × ParamType) :=
   match ty with
-  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
       [(baseOffset, ty)]
   | ParamType.fixedArray elemTy n =>
       (List.range n).flatMap fun i =>
@@ -66,7 +67,7 @@ partial def compileIndexedInPlaceEncoding
     (srcBase dstBase : YulExpr) (stem : String) :
     Except String (List YulStmt × YulExpr) := do
   match ty with
-  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
       let loaded := dynamicWordLoad dynamicSource srcBase
       pure ([
         YulStmt.expr (YulExpr.call "mstore" [dstBase, normalizeEventWord ty loaded])

--- a/Compiler/CompilationModel/EventEmission.lean
+++ b/Compiler/CompilationModel/EventEmission.lean
@@ -81,7 +81,7 @@ def eventDynamicArraySource?
 
 def eventParamScalarCompileSupported (ty : ParamType) : Bool :=
   match ty with
-  | .uint256 | .int256 | .uint8 | .address | .bool | .bytes32 => true
+  | .uint256 | .int256 | .uint8 | .uint16 | .address | .bool | .bytes32 => true
   | .string | .tuple _ | .array _ | .fixedArray _ _ | .bytes => false
   | .adt _ _ => false
   | .newtypeOf _ baseType => eventParamScalarCompileSupported baseType

--- a/Compiler/CompilationModel/LayoutCompatibilityReport.lean
+++ b/Compiler/CompilationModel/LayoutCompatibilityReport.lean
@@ -19,6 +19,7 @@ private def jsonOption (render : α → String) : Option α → String
 private def mappingKeyTypeString : MappingKeyType → String
   | .address => "address"
   | .uint256 => "uint256"
+  | .bytes32 => "bytes32"
 
 private def mappingKeyChainString (keys : List MappingKeyType) : String :=
   String.intercalate "=>" (keys.map mappingKeyTypeString)

--- a/Compiler/CompilationModel/LayoutReport.lean
+++ b/Compiler/CompilationModel/LayoutReport.lean
@@ -17,6 +17,14 @@ private def jsonOption (render : α → String) : Option α → String
 private def mappingKeyTypeString : MappingKeyType → String
   | .address => "address"
   | .uint256 => "uint256"
+  | .bytes32 => "bytes32"
+
+private def structMemberTypeString : StructMemberType → String
+  | .uint256 => "uint256"
+  | .uint16 => "uint16"
+  | .address => "address"
+  | .bool => "bool"
+  | .bytes32 => "bytes32"
 
 private def mappingKeysJson (keys : List MappingKeyType) : String :=
   jsonArray (keys.map (fun keyType => jsonString (mappingKeyTypeString keyType)))
@@ -30,6 +38,7 @@ private def packedBitsJson (packed : PackedBits) : String :=
 private def structMemberJson (member : StructMember) : String :=
   jsonObject [
     ("name", jsonString member.name),
+    ("type", jsonString (structMemberTypeString member.ty)),
     ("wordOffset", jsonNat member.wordOffset),
     ("packedBits", jsonOption packedBitsJson member.packed)
   ]

--- a/Compiler/CompilationModel/ParamLoading.lean
+++ b/Compiler/CompilationModel/ParamLoading.lean
@@ -12,7 +12,7 @@ open Compiler
 open Compiler.Yul
 
 def isScalarParamType : ParamType → Bool
-  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 => true
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 => true
   | _ => false
 
 private def dynamicArrayElementStrideWords (elemTy : ParamType) : Nat :=
@@ -108,6 +108,8 @@ def genScalarLoad
       [YulStmt.let_ name load]
   | ParamType.uint8 =>
       [YulStmt.let_ name (YulExpr.call "and" [load, YulExpr.lit 255])]
+  | ParamType.uint16 =>
+      [YulStmt.let_ name (YulExpr.call "and" [load, YulExpr.lit 65535])]
   | ParamType.bytes32 =>
       [YulStmt.let_ name load]
   | ParamType.address =>
@@ -123,7 +125,7 @@ def genStaticTypeLoads
     (loadWord : YulExpr → YulExpr) (name : String) (ty : ParamType) (offset : Nat) :
     List YulStmt :=
   match ty with
-  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
       genScalarLoad loadWord name ty offset
   | ParamType.fixedArray elemTy n =>
       (List.range n).flatMap fun i =>
@@ -147,7 +149,7 @@ def genSingleParamLoad
     (headSize : Nat) (baseOffset : Nat) (name : String) (ty : ParamType) (headOffset : Nat) :
     List YulStmt :=
   match ty with
-  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
     genScalarLoad loadWord name ty headOffset
   | ParamType.tuple elemTypes =>
     if isDynamicParamType ty then
@@ -223,7 +225,7 @@ private def constructorArgAliases (params : List Param) : List YulStmt :=
           YulExpr.ident s!"{param.name}_offset"
         else
           match param.ty with
-          | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+          | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
               YulExpr.ident param.name
           | _ =>
               YulExpr.call "mload" [YulExpr.lit headOffset]

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -13,7 +13,7 @@ def findParamType (params : List Param) (name : String) : Option ParamType :=
 
 partial def staticParamBindingNames (name : String) (ty : ParamType) : List String :=
   match ty with
-  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
       [name]
   | ParamType.fixedArray elemTy n =>
       (List.range n).flatMap (fun i => staticParamBindingNames s!"{name}_{i}" elemTy)
@@ -38,6 +38,7 @@ mutual
     | ParamType.uint256 => false
     | ParamType.int256 => false
     | ParamType.uint8 => false
+    | ParamType.uint16 => false
     | ParamType.address => false
     | ParamType.bool => false
     | ParamType.bytes32 => false
@@ -59,7 +60,7 @@ decreasing_by all_goals simp_wf; all_goals omega
 end
 
 def isScalarParamTypeForScope : ParamType → Bool
-  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 => true
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 => true
   | _ => false
 
 def paramBindingNames (param : Param) : List String :=

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -59,6 +59,7 @@ Support flexible mapping types: single-key, double-key (nested), and uint256 key
 inductive MappingKeyType
   | address    -- mapping(address => ...)
   | uint256    -- mapping(uint256 => ...)
+  | bytes32    -- mapping(bytes32 => ...)
   deriving Repr, BEq
 
 inductive MappingType
@@ -74,12 +75,22 @@ structure PackedBits where
   width : Nat
   deriving Repr, BEq
 
+inductive StructMemberType
+  | uint256
+  | uint16
+  | address
+  | bool
+  | bytes32
+  deriving Repr, BEq
+
 /-- A named member within a struct-valued mapping.
     Each member occupies a specific word within the struct's storage region,
     and may optionally be packed into a subregion of that word. -/
 structure StructMember where
   /-- The member name (used in `Expr.structMember` / `Stmt.setStructMember`). -/
   name : String
+  /-- Solidity surface type of the packed/full-word member. -/
+  ty : StructMemberType := StructMemberType.uint256
   /-- Zero-based word offset from the struct's base slot. -/
   wordOffset : Nat
   /-- Optional packed subfield within the word. When `none`, the member occupies
@@ -159,6 +170,7 @@ inductive ParamType
   | uint256
   | int256
   | uint8
+  | uint16
   | address
   | bool                                   -- Solidity bool (ABI-encoded as 32-byte 0/1)
   | bytes32                                -- Fixed 32-byte value
@@ -181,6 +193,7 @@ def ParamType.toIRType : ParamType → IRType
   | uint256 => IRType.uint256
   | int256 => IRType.uint256
   | uint8 => IRType.uint256
+  | uint16 => IRType.uint256
   | address => IRType.address
   | bool => IRType.uint256
   | bytes32 => IRType.uint256  -- bytes32 is a 256-bit value

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -725,7 +725,7 @@ def validateExternalCallTargetsInConstructor
 
 mutual
 def supportedCustomErrorParamType : ParamType → Bool
-  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 | ParamType.bytes | ParamType.string => true
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 | ParamType.bytes | ParamType.string => true
   | ParamType.array elemTy => supportedCustomErrorParamType elemTy
   | ParamType.fixedArray elemTy _ => supportedCustomErrorParamType elemTy
   | ParamType.tuple elemTys => supportedCustomErrorParamTypes elemTys

--- a/Compiler/CompilationModel/ValidationEvents.lean
+++ b/Compiler/CompilationModel/ValidationEvents.lean
@@ -10,7 +10,7 @@ import Compiler.CompilationModel.ScopeValidation
 namespace Compiler.CompilationModel
 
 def customErrorRequiresDirectParamRef : ParamType → Bool
-  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 => false
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 => false
   | _ => true
 
 def validateDirectParamCustomErrorArg

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -4513,6 +4513,10 @@ verity_contract TypedVerifierRouter where
       outputCount : Uint16 @word 0 packed(176,16),
       active : Bool @word 0 packed(192,8)
     ]) := slot 2
+    routeFlags : MappingStruct2(Bytes32,Bytes32,[
+      enabled : Bool @word 0 packed(0,8),
+      limit : Uint16 @word 0 packed(8,16)
+    ]) := slot 3
 
   struct Circuit where
     verifier : Address,
@@ -4545,6 +4549,14 @@ verity_contract TypedVerifierRouter where
     let active ← structMember "circuits" circuitId "active"
     return Circuit.mk verifierAddr inputCount outputCount active
 
+  function view getCircuitViaMembers (circuitId : Bytes32) : Circuit := do
+    let (verifierAddr, inputCount, outputCount, active) :=
+      structMembers "circuits" circuitId ["verifier", "inputCount", "outputCount", "active"]
+    return Circuit.mk verifierAddr inputCount outputCount active
+
+  function view getRouteFlag (sourceId : Bytes32, targetId : Bytes32) : Tuple [Bool, Uint16] := do
+    return structMembers2 "routeFlags" sourceId targetId ["enabled", "limit"]
+
 def routerSpecUsesBytes32MappingKey : Bool :=
   TypedVerifierRouter.spec.fields.any (fun field =>
     field.name == "circuits" &&
@@ -4573,8 +4585,17 @@ def routerSpecUsesTypedEventsAndReturns : Bool :=
       fn.params.map (fun param => param.ty) == [ParamType.bytes32] &&
       fn.returns == [ParamType.address, ParamType.uint16, ParamType.uint16, ParamType.bool])
 
+def routerStructMembersDestructuringKeepsMemberTypes : Bool :=
+  TypedVerifierRouter.spec.functions.any (fun fn =>
+    fn.name == "getCircuitViaMembers" &&
+      fn.returns == [ParamType.address, ParamType.uint16, ParamType.uint16, ParamType.bool]) &&
+  TypedVerifierRouter.spec.functions.any (fun fn =>
+    fn.name == "getRouteFlag" &&
+      fn.returns == [ParamType.bool, ParamType.uint16])
+
 example : routerSpecUsesBytes32MappingKey = true := by native_decide
 example : routerSpecUsesTypedEventsAndReturns = true := by native_decide
+example : routerStructMembersDestructuringKeepsMemberTypes = true := by native_decide
 
 end MacroSolidityTypeFidelitySmoke
 

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -4499,6 +4499,85 @@ private def erc4626DepositSmokeSpec : CompilationModel := {
   ]
 }
 
+namespace MacroSolidityTypeFidelitySmoke
+
+open Contracts
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_contract TypedVerifierRouter where
+  storage
+    circuits : MappingStruct(Bytes32,[
+      verifier : Address @word 0 packed(0,160),
+      inputCount : Uint16 @word 0 packed(160,16),
+      outputCount : Uint16 @word 0 packed(176,16),
+      active : Bool @word 0 packed(192,8)
+    ]) := slot 2
+
+  struct Circuit where
+    verifier : Address,
+    inputCount : Uint16,
+    outputCount : Uint16,
+    active : Bool
+
+  event_defs
+    event CircuitRegistered(@indexed circuitId : Bytes32, verifier : Address,
+      inputCount : Uint16, outputCount : Uint16)
+    event CircuitActiveSet(@indexed circuitId : Bytes32, active : Bool)
+
+  function setCircuit
+      (circuitId : Bytes32, verifierAddr : Address, inputCount : Uint16,
+       outputCount : Uint16) : Unit := do
+    setStructMember "circuits" circuitId "verifier" verifierAddr
+    setStructMember "circuits" circuitId "inputCount" inputCount
+    setStructMember "circuits" circuitId "outputCount" outputCount
+    setStructMember "circuits" circuitId "active" true
+    emit "CircuitRegistered" [circuitId, addressToWord verifierAddr, inputCount, outputCount]
+
+  function pauseCircuit (circuitId : Bytes32) : Unit := do
+    setStructMember "circuits" circuitId "active" false
+    emit "CircuitActiveSet" [circuitId, false]
+
+  function view getCircuit (circuitId : Bytes32) : Circuit := do
+    let verifierAddr ← structMember "circuits" circuitId "verifier"
+    let inputCount ← structMember "circuits" circuitId "inputCount"
+    let outputCount ← structMember "circuits" circuitId "outputCount"
+    let active ← structMember "circuits" circuitId "active"
+    return Circuit.mk verifierAddr inputCount outputCount active
+
+def routerSpecUsesBytes32MappingKey : Bool :=
+  TypedVerifierRouter.spec.fields.any (fun field =>
+    field.name == "circuits" &&
+      match field.ty with
+      | FieldType.mappingStruct MappingKeyType.bytes32 members =>
+          members.any (fun member =>
+            member.name == "inputCount" &&
+              member.ty == StructMemberType.uint16 &&
+              member.packed == some { offset := 160, width := 16 }) &&
+          members.any (fun member =>
+            member.name == "active" &&
+              member.ty == StructMemberType.bool &&
+              member.packed == some { offset := 192, width := 8 })
+      | _ => false)
+
+def routerSpecUsesTypedEventsAndReturns : Bool :=
+  TypedVerifierRouter.spec.events.any (fun eventDef =>
+    eventDef.name == "CircuitRegistered" &&
+      eventDef.params.map (fun param => param.ty) ==
+        [ParamType.bytes32, ParamType.address, ParamType.uint16, ParamType.uint16]) &&
+  TypedVerifierRouter.spec.events.any (fun eventDef =>
+    eventDef.name == "CircuitActiveSet" &&
+      eventDef.params.map (fun param => param.ty) == [ParamType.bytes32, ParamType.bool]) &&
+  TypedVerifierRouter.spec.functions.any (fun fn =>
+    fn.name == "getCircuit" &&
+      fn.params.map (fun param => param.ty) == [ParamType.bytes32] &&
+      fn.returns == [ParamType.address, ParamType.uint16, ParamType.uint16, ParamType.bool])
+
+example : routerSpecUsesBytes32MappingKey = true := by native_decide
+example : routerSpecUsesTypedEventsAndReturns = true := by native_decide
+
+end MacroSolidityTypeFidelitySmoke
+
 set_option maxRecDepth 4096 in
 #eval! do
   let compiled :=

--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -216,6 +216,29 @@ private theorem legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_uint2
         loadWord sizeExpr headSize baseOffset rest (headOffset + paramHeadSize ParamType.uint256))
       hrest
 
+private theorem legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_int256
+    (loadWord : YulExpr → YulExpr)
+    (sizeExpr : YulExpr)
+    (headSize baseOffset : Nat)
+    (name : String)
+    (rest : List Param)
+    (headOffset : Nat)
+    (hrest :
+      LegacyCompatibleExternalStmtList
+        (CompilationModel.genParamLoadBodyFrom
+          loadWord sizeExpr headSize baseOffset rest
+            (headOffset + paramHeadSize ParamType.int256))) :
+    LegacyCompatibleExternalStmtList
+      (CompilationModel.genParamLoadBodyFrom
+        loadWord sizeExpr headSize baseOffset ({ name := name, ty := ParamType.int256 } :: rest) headOffset) := by
+  simpa [CompilationModel.genParamLoadBodyFrom, CompilationModel.genScalarLoad] using
+    LegacyCompatibleExternalStmtList.let_
+      name
+      (loadWord (YulExpr.lit headOffset))
+      (CompilationModel.genParamLoadBodyFrom
+        loadWord sizeExpr headSize baseOffset rest (headOffset + paramHeadSize ParamType.int256))
+      hrest
+
 private theorem legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_uint8
     (loadWord : YulExpr → YulExpr)
     (sizeExpr : YulExpr)
@@ -308,6 +331,29 @@ private theorem legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_bytes
         loadWord sizeExpr headSize baseOffset rest (headOffset + paramHeadSize ParamType.bytes32))
       hrest
 
+private theorem legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_bool
+    (loadWord : YulExpr → YulExpr)
+    (sizeExpr : YulExpr)
+    (headSize baseOffset : Nat)
+    (name : String)
+    (rest : List Param)
+    (headOffset : Nat)
+    (hrest :
+      LegacyCompatibleExternalStmtList
+        (CompilationModel.genParamLoadBodyFrom
+          loadWord sizeExpr headSize baseOffset rest
+            (headOffset + paramHeadSize ParamType.bool))) :
+    LegacyCompatibleExternalStmtList
+      (CompilationModel.genParamLoadBodyFrom
+        loadWord sizeExpr headSize baseOffset ({ name := name, ty := ParamType.bool } :: rest) headOffset) := by
+  simpa [CompilationModel.genParamLoadBodyFrom, CompilationModel.genScalarLoad] using
+    LegacyCompatibleExternalStmtList.let_
+      name
+      (YulExpr.call "iszero" [YulExpr.call "iszero" [loadWord (YulExpr.lit headOffset)]])
+      (CompilationModel.genParamLoadBodyFrom
+        loadWord sizeExpr headSize baseOffset rest (headOffset + paramHeadSize ParamType.bool))
+      hrest
+
 private theorem legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_scalar
     (loadWord : YulExpr → YulExpr)
     (sizeExpr : YulExpr)
@@ -331,14 +377,8 @@ private theorem legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_scala
         exact legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_uint256
           loadWord sizeExpr headSize baseOffset name rest headOffset hrest
       case int256 =>
-        simpa [CompilationModel.genParamLoadBodyFrom, CompilationModel.genScalarLoad] using
-          LegacyCompatibleExternalStmtList.let_
-            name
-            (loadWord (YulExpr.lit headOffset))
-            (CompilationModel.genParamLoadBodyFrom
-              loadWord sizeExpr headSize baseOffset rest
-                (headOffset + paramHeadSize ParamType.int256))
-            hrest
+        exact legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_int256
+          loadWord sizeExpr headSize baseOffset name rest headOffset hrest
       case uint8 =>
         exact legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_uint8
           loadWord sizeExpr headSize baseOffset name rest headOffset hrest
@@ -352,14 +392,8 @@ private theorem legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_scala
         exact legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_bytes32
           loadWord sizeExpr headSize baseOffset name rest headOffset hrest
       case bool =>
-        simpa [CompilationModel.genParamLoadBodyFrom, CompilationModel.genScalarLoad] using
-          LegacyCompatibleExternalStmtList.let_
-            name
-            (YulExpr.call "iszero" [YulExpr.call "iszero" [loadWord (YulExpr.lit headOffset)]])
-            (CompilationModel.genParamLoadBodyFrom
-              loadWord sizeExpr headSize baseOffset rest
-                (headOffset + paramHeadSize ParamType.bool))
-            hrest
+        exact legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_bool
+          loadWord sizeExpr headSize baseOffset name rest headOffset hrest
 
 private theorem legacyCompatibleExternalStmtList_genParamLoadBodyFrom_of_supported
     (loadWord : YulExpr → YulExpr)

--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -239,6 +239,29 @@ private theorem legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_uint8
         loadWord sizeExpr headSize baseOffset rest (headOffset + paramHeadSize ParamType.uint8))
       hrest
 
+private theorem legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_uint16
+    (loadWord : YulExpr → YulExpr)
+    (sizeExpr : YulExpr)
+    (headSize baseOffset : Nat)
+    (name : String)
+    (rest : List Param)
+    (headOffset : Nat)
+    (hrest :
+      LegacyCompatibleExternalStmtList
+        (CompilationModel.genParamLoadBodyFrom
+          loadWord sizeExpr headSize baseOffset rest
+            (headOffset + paramHeadSize ParamType.uint16))) :
+    LegacyCompatibleExternalStmtList
+      (CompilationModel.genParamLoadBodyFrom
+        loadWord sizeExpr headSize baseOffset ({ name := name, ty := ParamType.uint16 } :: rest) headOffset) := by
+  simpa [CompilationModel.genParamLoadBodyFrom, CompilationModel.genScalarLoad] using
+    LegacyCompatibleExternalStmtList.let_
+      name
+      (YulExpr.call "and" [loadWord (YulExpr.lit headOffset), YulExpr.lit 65535])
+      (CompilationModel.genParamLoadBodyFrom
+        loadWord sizeExpr headSize baseOffset rest (headOffset + paramHeadSize ParamType.uint16))
+      hrest
+
 private theorem legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_address
     (loadWord : YulExpr → YulExpr)
     (sizeExpr : YulExpr)
@@ -318,6 +341,9 @@ private theorem legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_scala
             hrest
       case uint8 =>
         exact legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_uint8
+          loadWord sizeExpr headSize baseOffset name rest headOffset hrest
+      case uint16 =>
+        exact legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_uint16
           loadWord sizeExpr headSize baseOffset name rest headOffset hrest
       case address =>
         exact legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_address

--- a/Compiler/Proofs/IRGeneration/FunctionBody.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody.lean
@@ -944,14 +944,18 @@ private theorem decodeSupportedParamWord_passthrough_lt_evmModulus
 private theorem decodeSupportedParamWord_masked_lt_evmModulus
     {ty : ParamType}
     {word value : Nat}
-    (hmasked : ty = .uint8 ∨ ty = .address)
+    (hmasked : ty = .uint8 ∨ ty = .uint16 ∨ ty = .address)
     (hdecode : SourceSemantics.decodeSupportedParamWord ty word = some value) :
     value < Compiler.Constants.evmModulus := by
-  rcases hmasked with rfl | rfl
+  rcases hmasked with rfl | rfl | rfl
   · have hvalue : value = SourceSemantics.wordNormalize word &&& (SourceSemantics.uint8Modulus - 1) := by
       simpa [SourceSemantics.decodeSupportedParamWord] using hdecode.symm
     cases hvalue
     exact maskedWordNormalize_lt_evmModulus word (SourceSemantics.uint8Modulus - 1)
+  · have hvalue : value = SourceSemantics.wordNormalize word &&& (2^16 - 1) := by
+      simpa [SourceSemantics.decodeSupportedParamWord] using hdecode.symm
+    cases hvalue
+    exact maskedWordNormalize_lt_evmModulus word (2^16 - 1)
   · have hvalue : value = SourceSemantics.wordNormalize word &&& Compiler.Constants.addressMask := by
       simpa [SourceSemantics.decodeSupportedParamWord] using hdecode.symm
     cases hvalue
@@ -978,8 +982,10 @@ theorem decodeSupportedParamWord_lt_evmModulus
       exact decodeSupportedParamWord_passthrough_lt_evmModulus (hpassthrough := .inr (.inl rfl)) hdecode
   | uint8 =>
       exact decodeSupportedParamWord_masked_lt_evmModulus (hmasked := .inl rfl) hdecode
+  | uint16 =>
+      exact decodeSupportedParamWord_masked_lt_evmModulus (hmasked := .inr (.inl rfl)) hdecode
   | address =>
-      exact decodeSupportedParamWord_masked_lt_evmModulus (hmasked := .inr rfl) hdecode
+      exact decodeSupportedParamWord_masked_lt_evmModulus (hmasked := .inr (.inr rfl)) hdecode
   | bool =>
       exact decodeSupportedParamWord_bool_lt_evmModulus hdecode
   | bytes32 =>

--- a/Compiler/Proofs/IRGeneration/GenericInduction.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction.lean
@@ -14446,7 +14446,7 @@ theorem stmtListGenericCore_of_supportedStmtList_of_surface_exceptMappingWrites_
       have hwordOffsetEq : wordOffset = wordOffset0 := by
         rw [hmember] at hmember'
         injection hmember' with hmemberEq
-        injection hmemberEq with _ hEq
+        injection hmemberEq with _ _ hEq
         exact hEq.symm
       subst hwordOffsetEq
       exact stmtListGenericCore_singleton_setStructMemberSingle_of_slotSafety
@@ -14491,7 +14491,7 @@ theorem stmtListGenericCore_of_supportedStmtList_of_surface_exceptMappingWrites_
       have hwordOffsetEq : wordOffset = wordOffset0 := by
         rw [hmember] at hmember'
         injection hmember' with hmemberEq
-        injection hmemberEq with _ hEq
+        injection hmemberEq with _ _ hEq
         exact hEq.symm
       subst hwordOffsetEq
       exact stmtListGenericCore_singleton_setStructMember2Single_of_slotSafety

--- a/Compiler/Proofs/IRGeneration/ParamLoading.lean
+++ b/Compiler/Proofs/IRGeneration/ParamLoading.lean
@@ -127,6 +127,14 @@ theorem exec_genScalarLoad_supported
     simp [genScalarLoad, execIRStmts, execIRStmt, evalIRExpr, evalIRCall, evalIRExprs,
       Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
       Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean, calldataloadWord_aligned, h255]
+  case uint16 =>
+    simp [SourceSemantics.decodeSupportedParamWord, SourceSemantics.wordNormalize] at hdecode
+    subst value
+    have h65535 : (65535 : Nat) % Compiler.Constants.evmModulus = 65535 := by
+      norm_num [Compiler.Constants.evmModulus]
+    simp [genScalarLoad, execIRStmts, execIRStmt, evalIRExpr, evalIRCall, evalIRExprs,
+      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
+      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean, calldataloadWord_aligned, h65535]
   case address =>
     simp [SourceSemantics.decodeSupportedParamWord, SourceSemantics.wordNormalize] at hdecode
     subst value
@@ -169,7 +177,8 @@ private theorem drop_succ_eq_of_drop_eq_cons
 
 private theorem supportedExternalParamType_cases
     {ty : ParamType} (hsupported : SupportedExternalParamType ty) :
-    ty = .uint256 ∨ ty = .int256 ∨ ty = .uint8 ∨ ty = .address ∨ ty = .bytes32 ∨ ty = .bool := by
+    ty = .uint256 ∨ ty = .int256 ∨ ty = .uint8 ∨ ty = .uint16 ∨
+      ty = .address ∨ ty = .bytes32 ∨ ty = .bool := by
   cases ty <;> simp [SupportedExternalParamType] at hsupported ⊢
 
 private theorem execIRStmts_cons_of_execIRStmt_continue
@@ -239,6 +248,31 @@ private theorem exec_genScalarLoad_supported_then_uint8
       (YulStmt.let_ name
         (YulExpr.call "and" [YulExpr.call "calldataload" [YulExpr.lit (4 + 32 * idx)], YulExpr.lit 255])) rest hstmt
 
+private theorem exec_genScalarLoad_supported_then_uint16
+    (state : IRState) (rest : List YulStmt) (name : String) (idx value extraFuel : Nat)
+    (hdecode : SourceSemantics.decodeSupportedParamWord .uint16 (state.calldata.getD idx 0) = some value) :
+    execIRStmts ((genScalarLoad (fun pos => YulExpr.call "calldataload" [pos]) name .uint16 (4 + 32 * idx)).length +
+        rest.length + extraFuel + 1)
+      state
+      (genScalarLoad (fun pos => YulExpr.call "calldataload" [pos]) name .uint16 (4 + 32 * idx) ++ rest) =
+      execIRStmts (rest.length + extraFuel + 1) (state.setVar name value) rest := by
+  have hstmt :
+      execIRStmt (rest.length + extraFuel + 1) state
+        (YulStmt.let_ name
+          (YulExpr.call "and" [YulExpr.call "calldataload" [YulExpr.lit (4 + 32 * idx)], YulExpr.lit 65535])) =
+        .continue (state.setVar name value) := by
+      simp [SourceSemantics.decodeSupportedParamWord, SourceSemantics.wordNormalize] at hdecode
+      subst value
+      have h65535 : (65535 : Nat) % Compiler.Constants.evmModulus = 65535 := by
+        norm_num [Compiler.Constants.evmModulus]
+      simp [execIRStmt, evalIRExpr, evalIRCall, evalIRExprs,
+        Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
+        Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean, calldataloadWord_aligned, h65535]
+  simpa [genScalarLoad, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using
+    execIRStmts_cons_of_execIRStmt_continue_extraFuel extraFuel state (state.setVar name value)
+      (YulStmt.let_ name
+        (YulExpr.call "and" [YulExpr.call "calldataload" [YulExpr.lit (4 + 32 * idx)], YulExpr.lit 65535])) rest hstmt
+
 private theorem exec_genScalarLoad_supported_then_address
     (state : IRState) (rest : List YulStmt) (name : String) (idx value extraFuel : Nat)
     (hdecode : SourceSemantics.decodeSupportedParamWord .address (state.calldata.getD idx 0) = some value) :
@@ -306,12 +340,13 @@ theorem exec_genScalarLoad_supported_then
       state
       (genScalarLoad (fun pos => YulExpr.call "calldataload" [pos]) name ty (4 + 32 * idx) ++ rest) =
       execIRStmts (rest.length + extraFuel + 1) (state.setVar name value) rest := by
-  rcases supportedExternalParamType_cases hsupported with rfl | rfl | rfl | rfl | rfl | rfl
+  rcases supportedExternalParamType_cases hsupported with rfl | rfl | rfl | rfl | rfl | rfl | rfl
   · exact exec_genScalarLoad_supported_then_word_passthrough state rest name .uint256 idx value extraFuel
       (Or.inl rfl) hdecode
   · exact exec_genScalarLoad_supported_then_word_passthrough state rest name .int256 idx value extraFuel
       (Or.inr <| Or.inl rfl) hdecode
   · exact exec_genScalarLoad_supported_then_uint8 state rest name idx value extraFuel hdecode
+  · exact exec_genScalarLoad_supported_then_uint16 state rest name idx value extraFuel hdecode
   · exact exec_genScalarLoad_supported_then_address state rest name idx value extraFuel hdecode
   · exact exec_genScalarLoad_supported_then_word_passthrough state rest name .bytes32 idx value extraFuel
       (Or.inr <| Or.inr rfl) hdecode
@@ -410,7 +445,7 @@ theorem exec_genParamLoadBodyFrom_supported_then
               have htail :
                   (state.setVar param.name value).calldata.drop (idx + 1) = restArgs := by
                 simpa [IRState.setVar] using drop_succ_eq_of_drop_eq_cons hdrop
-              rcases supportedExternalParamType_cases hparam with hty | hty | hty | hty | hty | hty
+              rcases supportedExternalParamType_cases hparam with hty | hty | hty | hty | hty | hty | hty
               ·
                 have hdecode_uint256 :
                     SourceSemantics.decodeSupportedParamWord .uint256 (state.calldata.getD idx 0) =
@@ -472,6 +507,29 @@ theorem exec_genParamLoadBodyFrom_supported_then
                     (name := param.name) (ty := .uint8) (idx := idx) (value := value)
                     (extraFuel := extraFuel)
                     (hsupported := trivial) (hdecode := hdecode_uint8)).trans
+                    (by
+                      simpa [IRState.setVar, htail, applyBindingsToIRState, paramHeadSize,
+                        Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using
+                        ih (state := state.setVar param.name value) (headSize := headSize)
+                          (baseOffset := baseOffset) (idx := idx + 1)
+                          (bindings := restBindings) (rest := rest)
+                          hrestSupported
+                          (by simpa [htail] using hrest))
+              ·
+                have hdecode_uint16 :
+                    SourceSemantics.decodeSupportedParamWord .uint16 (state.calldata.getD idx 0) =
+                      some value := by
+                  simpa [hty] using hdecode'
+                have hoff : 4 + 32 * (idx + 1) = 4 + (32 + 32 * idx) := by omega
+                simpa [Compiler.CompilationModel.genParamLoadBodyFrom, paramHeadSize, IRState.setVar,
+                  Nat.add_assoc, Nat.add_comm, Nat.add_left_comm, applyBindingsToIRState, hty, hoff] using
+                  (exec_genScalarLoad_supported_then (state := state)
+                    (rest := genParamLoadBodyFrom (fun pos => YulExpr.call "calldataload" [pos])
+                      (YulExpr.call "calldatasize" []) headSize baseOffset restParams
+                      (4 + 32 * (idx + 1)) ++ rest)
+                    (name := param.name) (ty := .uint16) (idx := idx) (value := value)
+                    (extraFuel := extraFuel)
+                    (hsupported := trivial) (hdecode := hdecode_uint16)).trans
                     (by
                       simpa [IRState.setVar, htail, applyBindingsToIRState, paramHeadSize,
                         Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using

--- a/Compiler/Proofs/IRGeneration/ParamLoading.lean
+++ b/Compiler/Proofs/IRGeneration/ParamLoading.lean
@@ -101,61 +101,6 @@ theorem supportedScalarHeadSize_eq
   have hlt : ¬ 4 + 32 * idx < 4 := by omega
   simp [Compiler.Proofs.YulGeneration.calldataloadWord, hlt]
 
-theorem exec_genScalarLoad_supported
-    (state : IRState) (name : String) (ty : ParamType) (idx value : Nat)
-    (hsupported : SupportedExternalParamType ty)
-    (hdecode : SourceSemantics.decodeSupportedParamWord ty (state.calldata.getD idx 0) = some value) :
-    execIRStmts ((genScalarLoad (fun pos => YulExpr.call "calldataload" [pos]) name ty (4 + 32 * idx)).length + 1)
-      state
-      (genScalarLoad (fun pos => YulExpr.call "calldataload" [pos]) name ty (4 + 32 * idx)) =
-      .continue (state.setVar name value) := by
-  cases ty <;> try cases hsupported
-  case uint256 | int256 | bytes32 =>
-    have hvalue : value = state.calldata.getD idx 0 % Compiler.Constants.evmModulus := by
-      simpa [SourceSemantics.decodeSupportedParamWord, SourceSemantics.wordNormalize,
-        Verity.Core.UINT256_MODULUS, uint256_modulus_eq_evm] using hdecode.symm
-    cases hvalue
-    simp [genScalarLoad, execIRStmts, execIRStmt, evalIRExpr, evalIRCall, evalIRExprs,
-      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
-      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean, calldataloadWord_aligned]
-  case uint8 =>
-    simp [SourceSemantics.decodeSupportedParamWord, SourceSemantics.wordNormalize,
-      SourceSemantics.uint8Modulus] at hdecode
-    subst value
-    have h255 : (255 : Nat) % Compiler.Constants.evmModulus = 255 := by
-      norm_num [Compiler.Constants.evmModulus]
-    simp [genScalarLoad, execIRStmts, execIRStmt, evalIRExpr, evalIRCall, evalIRExprs,
-      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
-      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean, calldataloadWord_aligned, h255]
-  case uint16 =>
-    simp [SourceSemantics.decodeSupportedParamWord, SourceSemantics.wordNormalize] at hdecode
-    subst value
-    have h65535 : (65535 : Nat) % Compiler.Constants.evmModulus = 65535 := by
-      norm_num [Compiler.Constants.evmModulus]
-    simp [genScalarLoad, execIRStmts, execIRStmt, evalIRExpr, evalIRCall, evalIRExprs,
-      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
-      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean, calldataloadWord_aligned, h65535]
-  case address =>
-    simp [SourceSemantics.decodeSupportedParamWord, SourceSemantics.wordNormalize] at hdecode
-    subst value
-    have hmask : Compiler.Constants.addressMask % Compiler.Constants.evmModulus =
-        Compiler.Constants.addressMask := by
-      have hlt : Compiler.Constants.addressMask < Compiler.Constants.evmModulus := by
-        dsimp [Compiler.Constants.addressMask, Compiler.Constants.evmModulus]
-        omega
-      exact Nat.mod_eq_of_lt hlt
-    simp [genScalarLoad, execIRStmts, execIRStmt, evalIRExpr, evalIRCall, evalIRExprs,
-      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
-      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean, calldataloadWord_aligned, hmask]
-  case bool =>
-    simp only [SourceSemantics.decodeSupportedParamWord, SourceSemantics.wordNormalize,
-      Option.some.injEq] at hdecode
-    subst value
-    simp [genScalarLoad, execIRStmts, execIRStmt, evalIRExpr, evalIRCall, evalIRExprs,
-      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
-      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean, calldataloadWord_aligned]
-    split <;> simp_all
-
 private theorem getD_eq_of_drop_eq_cons
     {xs : List Nat} {idx arg : Nat} {rest : List Nat}
     (hdrop : xs.drop idx = arg :: rest) :

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -61,6 +61,7 @@ def normalizeEventValue (ty : ParamType) (value : Nat) : Nat :=
   let word := wordNormalize value
   match ty with
   | .uint8 => word &&& (uint8Modulus - 1)
+  | .uint16 => word &&& (2^16 - 1)
   | .address => word &&& Compiler.Constants.addressMask
   | .bool => if word = 0 then 0 else 1
   | _ => word
@@ -509,6 +510,7 @@ def decodeSupportedParamWord (ty : ParamType) (word : Nat) : Option Nat :=
   match ty with
   | .uint256 | .int256 | .bytes32 => some word
   | .uint8 => some (word &&& (uint8Modulus - 1))
+  | .uint16 => some (word &&& (2^16 - 1))
   | .address => some (word &&& Compiler.Constants.addressMask)
   | .bool => some (if word = 0 then 0 else 1)
   | _ => none
@@ -2404,7 +2406,7 @@ def bindConstructorArgAliasesFrom
           rawArgs[headWord]? |> Option.map wordNormalize
         else
           match param.ty with
-          | .uint256 | .int256 | .uint8 | .address | .bool | .bytes32 =>
+          | .uint256 | .int256 | .uint8 | .uint16 | .address | .bool | .bytes32 =>
               lookupBinding? bindings param.name
           | _ =>
               rawArgs[headWord]? |> Option.map wordNormalize

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -19,7 +19,7 @@ open Compiler.CompilationModel
 /-- ABI parameter types admitted by the first whole-contract Layer 2 fragment.
 Only single-head-word scalars are included for the initial generic theorem. -/
 def SupportedExternalParamType : ParamType → Prop
-  | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool => True
+  | .uint256 | .int256 | .uint8 | .uint16 | .address | .bytes32 | .bool => True
   | _ => False
 
 /-- Return profiles admitted by the first whole-contract Layer 2 fragment.

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBodyClosure.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBodyClosure.lean
@@ -43,7 +43,7 @@ open Verity.Core.Free
 the `ParamType` constructors whose head word is consumed directly from
 calldata without offset/length bookkeeping. -/
 def IsScalarParamType : ParamType → Prop
-  | .uint256 | .int256 | .uint8 | .address | .bool | .bytes32 => True
+  | .uint256 | .int256 | .uint8 | .uint16 | .address | .bool | .bytes32 => True
   | _ => False
 
 /-- Static ABI parameter types whose leaves are all scalar words. This extends
@@ -64,12 +64,9 @@ theorem isDynamicParamType_false_of_static_scalar
     isDynamicParamType ty = false := by
   induction hStatic with
   | @scalar scalarTy hScalar =>
-      cases scalarTy <;> simp [IsScalarParamType, isDynamicParamType.eq_1,
-        isDynamicParamType.eq_2, isDynamicParamType.eq_3, isDynamicParamType.eq_4,
-        isDynamicParamType.eq_5, isDynamicParamType.eq_6] at hScalar ⊢
+      cases scalarTy <;> simp [IsScalarParamType, isDynamicParamType] at hScalar ⊢
   | fixedArray hElem ih =>
-      rw [isDynamicParamType.eq_10]
-      exact ih
+      simpa [isDynamicParamType] using ih
   | tuple hElems hElems_ih =>
       rw [isDynamicParamType.eq_def]
       suffices hList :
@@ -197,6 +194,12 @@ theorem genScalarLoad_calldataload_bridged
       exact BridgedStmt.straight _
         (BridgedStraightStmt.let_ name _
           (bridgedExpr_and_lit_mask _ (bridgedExpr_calldataload_lit offset) 255))
+  | ParamType.uint16, _ =>
+      simp only [genScalarLoad, List.mem_singleton] at hMem
+      subst hMem
+      exact BridgedStmt.straight _
+        (BridgedStraightStmt.let_ name _
+          (bridgedExpr_and_lit_mask _ (bridgedExpr_calldataload_lit offset) 65535))
   | ParamType.bytes32, _ =>
       simp only [genScalarLoad, List.mem_singleton] at hMem
       subst hMem
@@ -237,12 +240,12 @@ theorem genStaticTypeLoads_calldataload_bridged
       all_goals
         exact genScalarLoad_calldataload_bridged name _ offset (by trivial)
   | @fixedArray elemTy n hElem ih =>
-      rw [genStaticTypeLoads.eq_7]
+      rw [genStaticTypeLoads.eq_8]
       apply BridgedStmts_flatMap
       intro i hi
       exact ih (name := s!"{name}_{i}") (offset := offset + i * paramHeadSize _)
   | @tuple elemTys hElems hElems_ih =>
-      rw [genStaticTypeLoads.eq_8]
+      rw [genStaticTypeLoads.eq_9]
       suffices hGo :
           ∀ (tys : List ParamType) (idx curOffset : Nat),
             (∀ ty ∈ tys, IsStaticScalarParamType ty) →
@@ -326,7 +329,7 @@ private theorem genParamLoadBodyFrom_cons_scalar
       genParamLoadBodyFrom loadWord sizeExpr headSize baseOffset rest
         (headOffset + paramHeadSize param.ty) := by
   match hTy : param.ty, hScalar with
-  | ParamType.uint256, _ | ParamType.int256, _ | ParamType.uint8, _
+  | ParamType.uint256, _ | ParamType.int256, _ | ParamType.uint8, _ | ParamType.uint16, _
   | ParamType.address, _ | ParamType.bool, _ | ParamType.bytes32, _ =>
       simp [genParamLoadBodyFrom, genSingleParamLoad, hTy]
 
@@ -486,7 +489,7 @@ private theorem genStaticTypeLoads_noFuncDefs
       all_goals
         exact genScalarLoad_noFuncDefs loadWord name _ offset
   | @fixedArray elemTy n hElem ih =>
-      rw [genStaticTypeLoads.eq_7]
+      rw [genStaticTypeLoads.eq_8]
       exact Native.yulStmtsContainFuncDef_flatMap_false
         (List.range n)
         (fun i =>
@@ -496,7 +499,7 @@ private theorem genStaticTypeLoads_noFuncDefs
           intro i _hi
           exact ih s!"{name}_{i}" (offset + i * paramHeadSize elemTy))
   | @tuple elemTys hElems hElems_ih =>
-      rw [genStaticTypeLoads.eq_8]
+      rw [genStaticTypeLoads.eq_9]
       exact genStaticTypeLoads_go_noFuncDefs loadWord name elemTys 0 offset
         hElems_ih
 

--- a/Compiler/TypedIRCompiler.lean
+++ b/Compiler/TypedIRCompiler.lean
@@ -52,6 +52,7 @@ private def paramTypeToTy : ParamType → Except String Ty
   | .uint256 => Except.ok Ty.uint256
   | .int256 => Except.ok Ty.uint256
   | .uint8 => Except.ok Ty.uint256
+  | .uint16 => Except.ok Ty.uint256
   | .address => Except.ok Ty.address
   | .bool => Except.ok Ty.bool
   | .bytes32 => Except.ok Ty.uint256

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -99,6 +99,9 @@ class CustomErrorArg (α : Type) where
 instance : CustomErrorArg Uint256 where
   encode value := toString (value : Nat)
 
+instance : CustomErrorArg Uint16 where
+  encode value := toString value.toNat
+
 instance : CustomErrorArg Nat where
   encode value := toString value
 
@@ -251,6 +254,12 @@ end EventArg
 instance : Coe Uint256 EventArg where
   coe value := EventArg.word (pure value)
 
+instance : Coe Uint16 EventArg where
+  coe value := EventArg.word (pure value.toUint256)
+
+instance : Coe Bool EventArg where
+  coe value := EventArg.word (pure (if value then 1 else 0))
+
 instance (α : Type) : CoeTC (Array α) EventArg where
   coe values := EventArg.dynamicArray (pure values.size)
 
@@ -289,6 +298,8 @@ class ExternalResult (α : Type) where
   fromWord : Uint256 → α
 instance : ExternalArg Uint256 where
   toWord value := value
+instance : ExternalArg Uint16 where
+  toWord value := value.toUint256
 instance : ExternalArg Int256 where
   toWord value := value.word
 instance : ExternalArg Address where
@@ -301,6 +312,8 @@ instance : ExternalArg ByteArray where
   toWord bytes := bytes.size
 instance : ExternalResult Uint256 where
   fromWord value := value
+instance : ExternalResult Uint16 where
+  fromWord value := Verity.wordToUint16 value
 instance : ExternalResult Int256 where
   fromWord value := toInt256 value
 instance : ExternalResult Address where
@@ -380,6 +393,14 @@ class StorageWord (α : Type) where
 instance : StorageWord Uint256 where
   fromWord word := word
   toWord word := word
+
+instance : StorageWord Uint16 where
+  fromWord word := Verity.wordToUint16 word
+  toWord value := value.toUint256
+
+instance : StorageWord Bool where
+  fromWord word := word != 0
+  toWord value := Verity.boolToWord value
 
 instance : StorageWord Address where
   fromWord word := Verity.wordToAddress word

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -1262,19 +1262,15 @@ verity_contract NamedStructDynamicRootLeafProjection where
   function goodDynamicLeaf (config : DynamicConfig) : Address := do
     return config.maker
 
-/--
-error: function return types cannot be named structs; return an explicit Tuple [...] instead
--/
-#guard_msgs in
-verity_contract NamedStructReturnRejected where
+verity_contract NamedStructReturnSmoke where
   storage
 
   struct FeeConfig where
     borrowTakerFeeRatio : Uint256,
     lendMakerFeeRatio : Uint256
 
-  function badReturn (feeConfig : FeeConfig) : FeeConfig := do
-    return feeConfig
+  function goodReturn (borrowFee : Uint256, lendFee : Uint256) : FeeConfig := do
+    return FeeConfig.mk borrowFee lendFee
 
 verity_contract CurveCutArraySmoke where
   storage

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1609,6 +1609,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_revertWithMessage  -- private
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_uint256  -- private
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_uint8  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_uint16  -- private
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_address  -- private
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_bytes32  -- private
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_scalar  -- private
@@ -2810,6 +2811,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.ParamLoading.execIRStmts_cons_of_execIRStmt_continue_extraFuel  -- private
   -- Compiler.Proofs.IRGeneration.ParamLoading.exec_genScalarLoad_supported_then_word_passthrough  -- private
   -- Compiler.Proofs.IRGeneration.ParamLoading.exec_genScalarLoad_supported_then_uint8  -- private
+  -- Compiler.Proofs.IRGeneration.ParamLoading.exec_genScalarLoad_supported_then_uint16  -- private
   -- Compiler.Proofs.IRGeneration.ParamLoading.exec_genScalarLoad_supported_then_address  -- private
   -- Compiler.Proofs.IRGeneration.ParamLoading.exec_genScalarLoad_supported_then_bool  -- private
   Compiler.Proofs.IRGeneration.ParamLoading.exec_genScalarLoad_supported_then
@@ -5465,4 +5467,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5167 theorems/lemmas (3587 public, 1580 private, 0 sorry'd)
+-- Total: 5169 theorems/lemmas (3587 public, 1582 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1608,10 +1608,12 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_of_exprStmtExprs  -- private
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_revertWithMessage  -- private
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_uint256  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_int256  -- private
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_uint8  -- private
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_uint16  -- private
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_address  -- private
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_bytes32  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_bool  -- private
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_cons_scalar  -- private
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoadBodyFrom_of_supported  -- private
   -- Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalStmtList_genParamLoads_of_supported  -- private
@@ -2803,7 +2805,6 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.ParamLoading.supportedParamHeadSize_eq_32
   Compiler.Proofs.IRGeneration.ParamLoading.supportedScalarHeadSize_eq
   Compiler.Proofs.IRGeneration.ParamLoading.calldataloadWord_aligned
-  Compiler.Proofs.IRGeneration.ParamLoading.exec_genScalarLoad_supported
   -- Compiler.Proofs.IRGeneration.ParamLoading.getD_eq_of_drop_eq_cons  -- private
   -- Compiler.Proofs.IRGeneration.ParamLoading.drop_succ_eq_of_drop_eq_cons  -- private
   -- Compiler.Proofs.IRGeneration.ParamLoading.supportedExternalParamType_cases  -- private
@@ -5467,4 +5468,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5169 theorems/lemmas (3587 public, 1582 private, 0 sorry'd)
+-- Total: 5170 theorems/lemmas (3586 public, 1584 private, 0 sorry'd)

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -7,6 +7,7 @@
 
 import Verity.Core.Address
 import Verity.Core.Int256
+import Verity.Core.Uint16
 import Verity.Core.Uint256
 import Verity.Core.FiniteSet
 
@@ -16,7 +17,9 @@ open Verity.Core (FiniteAddressSet)
 
 -- Basic Ethereum types
 abbrev Address := Verity.Core.Address
+abbrev Bytes32 := Verity.Core.Uint256
 abbrev Int256 := Verity.Core.Int256
+abbrev Uint16 := Verity.Core.Uint16
 abbrev Uint256 := Verity.Core.Uint256
 
 @[simp] def toInt256 (value : Uint256) : Int256 :=
@@ -35,6 +38,18 @@ abbrev Uint256 := Verity.Core.Uint256
 
 @[simp] def boolToWord (b : Bool) : Uint256 :=
   if b then 1 else 0
+
+@[simp] def uint16ToWord (value : Uint16) : Uint256 :=
+  value.toUint256
+
+@[simp] def wordToUint16 (value : Uint256) : Uint16 :=
+  Verity.Core.Uint16.ofUint256 value
+
+@[simp] def bytes32ToWord (value : Bytes32) : Uint256 :=
+  value
+
+@[simp] def wordToBytes32 (value : Uint256) : Bytes32 :=
+  value
 
 @[simp] def isZeroAddress (a : Address) : Bool :=
   a == zeroAddress

--- a/Verity/Core/Uint16.lean
+++ b/Verity/Core/Uint16.lean
@@ -1,0 +1,85 @@
+/-
+  Core Uint16 type.
+
+  Solidity `uint16` values are ABI-encoded in one 256-bit word but are bounded
+  to 16 bits at the surface. This type preserves that bound in Verity models
+  while exposing explicit word conversion for ABI/storage encoding.
+-/
+
+import Verity.Core.Uint256
+
+namespace Verity.Core
+
+def UINT16_MODULUS : Nat := 2^16
+
+structure Uint16 where
+  val : Nat
+  isLt : val < UINT16_MODULUS
+  deriving DecidableEq
+
+namespace Uint16
+
+def modulus : Nat := UINT16_MODULUS
+
+theorem modulus_pos : 0 < modulus := by
+  have h2 : (0 : Nat) < (2 : Nat) := by decide
+  have h : 0 < (2 : Nat) ^ 16 := Nat.pow_pos h2
+  simp [modulus, UINT16_MODULUS]
+
+def ofNat (n : Nat) : Uint16 :=
+  ⟨n % modulus, Nat.mod_lt _ modulus_pos⟩
+
+def toNat (value : Uint16) : Nat := value.val
+
+def toUint256 (value : Uint16) : Uint256 :=
+  Uint256.ofNat value.val
+
+def ofUint256 (value : Uint256) : Uint16 :=
+  ofNat value.val
+
+instance : OfNat Uint16 n := ⟨ofNat n⟩
+instance : Inhabited Uint16 := ⟨ofNat 0⟩
+instance : Repr Uint16 := ⟨fun u _ => repr u.val⟩
+instance : Coe Uint16 Nat := ⟨Uint16.val⟩
+instance : Coe Uint16 Uint256 := ⟨toUint256⟩
+
+@[simp] theorem val_ofNat (n : Nat) : (ofNat n).val = n % modulus := rfl
+@[simp] theorem toNat_ofNat (n : Nat) : (ofNat n).toNat = n % modulus := rfl
+@[simp] theorem val_zero : (0 : Uint16).val = 0 := by
+  change (ofNat 0).val = 0
+  simp [ofNat]
+
+@[ext] theorem ext {a b : Uint16} (h : a.val = b.val) : a = b := by
+  cases a with
+  | mk a ha =>
+    cases b with
+    | mk b hb =>
+      cases h
+      have : ha = hb := by apply Subsingleton.elim
+      cases this
+      rfl
+
+instance : BEq Uint16 := ⟨fun a b => decide (a = b)⟩
+
+instance : LawfulBEq Uint16 where
+  eq_of_beq {a b} h := by
+    simp only [BEq.beq] at h
+    exact of_decide_eq_true h
+  rfl {a} := by
+    show decide (a = a) = true
+    exact decide_eq_true rfl
+
+@[simp] theorem toUint256_ofNat (n : Nat) :
+    (ofNat n).toUint256 = Uint256.ofNat (n % modulus) := rfl
+
+@[simp] theorem ofUint256_toUint256 (value : Uint16) :
+    ofUint256 value.toUint256 = value := by
+  apply ext
+  have hUint256 : value.val < Uint256.modulus := by
+    exact Nat.lt_trans value.isLt (by native_decide)
+  simp [ofUint256, toUint256, ofNat, modulus, Uint256.val_ofNat,
+    Nat.mod_eq_of_lt hUint256, Nat.mod_eq_of_lt value.isLt]
+
+end Uint16
+
+end Verity.Core

--- a/Verity/Macro/Bridge.lean
+++ b/Verity/Macro/Bridge.lean
@@ -166,7 +166,7 @@ private def mkFieldFrameConjunct (field : StorageFieldDecl) : CommandElabM Term 
       `(∀ k, s'.storageMap $slotLit k = s.storageMap $slotLit k)
   | .mappingUintToUint256 | .mappingStruct .uint256 _ =>
       `(∀ k, s'.storageMapUint $slotLit k = s.storageMapUint $slotLit k)
-  | .mappingChain _ | .mapping2AddressToAddressToUint256 | .mappingStruct2 _ _ _ =>
+  | .mappingStruct .bytes32 _ | .mappingChain _ | .mapping2AddressToAddressToUint256 | .mappingStruct2 _ _ _ =>
       -- These shapes compile to hashed `storage` slots rather than the legacy
       -- storageMap mirrors, so the conservative frame predicate must constrain
       -- the hashed storage surface.

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -44,6 +44,8 @@ syntax "storage_namespace " str : verityStorageItem
 syntax "storage_namespace " "erc7201 " str : verityStorageItem
 syntax ident " @word " num : verityStructMember
 syntax ident " @word " num " packed(" num "," num ")" : verityStructMember
+syntax ident " : " term " @word " num : verityStructMember
+syntax ident " : " term " @word " num " packed(" num "," num ")" : verityStructMember
 syntax "MappingStruct(" term "," "[" sepBy(verityStructMember, ",") "]" ")" : term
 syntax "MappingStruct2(" term "," term "," "[" sepBy(verityStructMember, ",") "]" ")" : term
 syntax ident " : " term : verityParam

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -3510,18 +3510,18 @@ private partial def inferTupleSourceTypes?
         | `(term| structMembers $field:term $key:term $members:term) => do
             let fieldName := ← expectStringOrIdent field
             let memberNames := ← expectStringList members
-            for memberName in memberNames do
-              let _ ← lookupStructMemberDecl fields fieldName memberName false
+            let memberDecls ← memberNames.mapM fun memberName =>
+              lookupStructMemberDecl fields fieldName memberName false
             requireWordLikeType key "structMembers key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key)
-            pure (some (Array.replicate memberNames.size .uint256))
+            pure (some (memberDecls.map (·.ty)))
         | `(term| structMembers2 $field:term $key1:term $key2:term $members:term) => do
             let fieldName := ← expectStringOrIdent field
             let memberNames := ← expectStringList members
-            for memberName in memberNames do
-              let _ ← lookupStructMemberDecl fields fieldName memberName true
+            let memberDecls ← memberNames.mapM fun memberName =>
+              lookupStructMemberDecl fields fieldName memberName true
             requireWordLikeType key1 "structMembers2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key1)
             requireWordLikeType key2 "structMembers2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key2)
-            pure (some (Array.replicate memberNames.size .uint256))
+            pure (some (memberDecls.map (·.ty)))
         | `(term| arrayElement $name:term $index:term) => do
             requireWordLikeType index "arrayElement index"
               (← inferPureExprType fields constDecls immutableDecls externalDecls params locals index)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -22,6 +22,7 @@ inductive ValueType where
   | uint256
   | int256
   | uint8
+  | uint16
   | address
   | bytes32
   | bool
@@ -39,10 +40,12 @@ inductive ValueType where
 inductive MappingKeyType where
   | address
   | uint256
+  | bytes32
   deriving BEq
 
 structure StructMemberDecl where
   name : String
+  ty : ValueType := .uint256
   wordOffset : Nat
   packed : Option (Nat × Nat) := none
   deriving BEq
@@ -207,6 +210,7 @@ private partial def valueTypeSignatureComponent : ValueType → String
   | .uint256 => "scalar_uint256"
   | .int256 => "scalar_int256"
   | .uint8 => "scalar_uint8"
+  | .uint16 => "scalar_uint16"
   | .address => "scalar_address"
   | .bool => "scalar_bool"
   | .bytes32 => "scalar_bytes32"
@@ -383,6 +387,7 @@ private partial def valueTypeFromSyntax
   | `(term| Uint256) => pure .uint256
   | `(term| Int256) => pure .int256
   | `(term| Uint8) => pure .uint8
+  | `(term| Uint16) => pure .uint16
   | `(term| Address) => pure .address
   | `(term| Bytes32) => pure .bytes32
   | `(term| Bool) => pure .bool
@@ -421,16 +426,17 @@ private partial def valueTypeFromSyntax
           | some decl =>
               let maxFields := decl.variants.foldl (fun acc v => max acc v.fields.size) 0
               pure (.adt decl.name maxFields)
-          | none => throwErrorAt ty "unsupported type '{ty}'; expected Uint256, Int256, Uint8, Address, Bytes32, Bool, String, Bytes, Array <type>, FixedArray <type> <size>, Tuple [...], Unit, a user-defined struct, or a user-defined type from the `types` or `inductive` section"
+          | none => throwErrorAt ty "unsupported type '{ty}'; expected Uint256, Int256, Uint8, Uint16, Address, Bytes32, Bool, String, Bytes, Array <type>, FixedArray <type> <size>, Tuple [...], Unit, a user-defined struct, or a user-defined type from the `types` or `inductive` section"
   | _ =>
-      throwErrorAt ty "unsupported type '{ty}'; expected Uint256, Int256, Uint8, Address, Bytes32, Bool, String, Bytes, Array <type>, FixedArray <type> <size>, Tuple [...], Unit, a user-defined struct, or a user-defined type from the `types` or `inductive` section"
+      throwErrorAt ty "unsupported type '{ty}'; expected Uint256, Int256, Uint8, Uint16, Address, Bytes32, Bool, String, Bytes, Array <type>, FixedArray <type> <size>, Tuple [...], Unit, a user-defined struct, or a user-defined type from the `types` or `inductive` section"
 
 private def storageTypeFromSyntax (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl := #[]) (adtDecls : Array AdtDecl := #[]) (ty : Term) : CommandElabM StorageType := do
   let keyTypeFromSyntax (stx : Term) : CommandElabM MappingKeyType := do
     match stx with
     | `(term| Address) => pure .address
     | `(term| Uint256) => pure .uint256
-    | _ => throwErrorAt stx "unsupported mapping key type; expected Address or Uint256"
+    | `(term| Bytes32) => pure .bytes32
+    | _ => throwErrorAt stx "unsupported mapping key type; expected Address, Uint256, or Bytes32"
 
   let structMemberFromSyntax (stx : TSyntax `verityStructMember) : CommandElabM StructMemberDecl := do
     match stx with
@@ -439,9 +445,22 @@ private def storageTypeFromSyntax (newtypes : Array NewtypeDecl) (structDecls : 
           name := toString name.getId
           wordOffset := ← natFromSyntax wordOffset
         }
+    | `(verityStructMember| $name:ident : $memberTy:term @word $wordOffset:num) =>
+        pure {
+          name := toString name.getId
+          ty := ← valueTypeFromSyntax newtypes structDecls adtDecls memberTy
+          wordOffset := ← natFromSyntax wordOffset
+        }
     | `(verityStructMember| $name:ident @word $wordOffset:num packed($offset:num,$width:num)) =>
         pure {
           name := toString name.getId
+          wordOffset := ← natFromSyntax wordOffset
+          packed := some (← natFromSyntax offset, ← natFromSyntax width)
+        }
+    | `(verityStructMember| $name:ident : $memberTy:term @word $wordOffset:num packed($offset:num,$width:num)) =>
+        pure {
+          name := toString name.getId
+          ty := ← valueTypeFromSyntax newtypes structDecls adtDecls memberTy
           wordOffset := ← natFromSyntax wordOffset
           packed := some (← natFromSyntax offset, ← natFromSyntax width)
         }
@@ -493,6 +512,7 @@ private def storageTypeFromSyntax (newtypes : Array NewtypeDecl) (structDecls : 
 private def modelMappingKeyTypeTerm : MappingKeyType → CommandElabM Term
   | .address => `(Compiler.CompilationModel.MappingKeyType.address)
   | .uint256 => `(Compiler.CompilationModel.MappingKeyType.uint256)
+  | .bytes32 => `(Compiler.CompilationModel.MappingKeyType.bytes32)
 
 private def storageTypeMappingKeyTypes? : StorageType → Option (List MappingKeyType)
   | .mappingAddressToUint256 => some [.address]
@@ -507,6 +527,7 @@ private def storageTypeMappingDepth? (ty : StorageType) : Option Nat :=
 private def storageKeyTypeContractTerm : MappingKeyType → CommandElabM Term
   | .address => `(Address)
   | .uint256 => `(Uint256)
+  | .bytes32 => `(Bytes32)
 
 private def modelStructMemberTerm (member : StructMemberDecl) : CommandElabM Term := do
   let packedTerm ←
@@ -514,8 +535,23 @@ private def modelStructMemberTerm (member : StructMemberDecl) : CommandElabM Ter
     | none => `(none)
     | some (offset, width) =>
         `(some { offset := $(natTerm offset), width := $(natTerm width) })
+  let memberTypeTerm ←
+    match member.ty with
+    | .uint256 | .int256 | .uint8 =>
+        `(Compiler.CompilationModel.StructMemberType.uint256)
+    | .uint16 =>
+        `(Compiler.CompilationModel.StructMemberType.uint16)
+    | .address =>
+        `(Compiler.CompilationModel.StructMemberType.address)
+    | .bool =>
+        `(Compiler.CompilationModel.StructMemberType.bool)
+    | .bytes32 =>
+        `(Compiler.CompilationModel.StructMemberType.bytes32)
+    | _ =>
+        throwError "mapping struct member '{member.name}' has unsupported type {repr member.ty}; expected Uint256, Uint16, Address, Bool, or Bytes32"
   `(Compiler.CompilationModel.StructMember.mk
       $(strTerm member.name)
+      $memberTypeTerm
       $(natTerm member.wordOffset)
       $packedTerm)
 
@@ -524,6 +560,7 @@ private def modelFieldTypeTerm (ty : StorageType) : CommandElabM Term :=
   | .scalar .uint256 => `(Compiler.CompilationModel.FieldType.uint256)
   | .scalar .int256 => `(Compiler.CompilationModel.FieldType.uint256)
   | .scalar .uint8 => throwError "storage fields cannot be Uint8; use Uint256 encoding"
+  | .scalar .uint16 => throwError "storage fields cannot be Uint16; use Uint256 encoding"
   | .scalar .address => `(Compiler.CompilationModel.FieldType.address)
   | .scalar .bytes32 => throwError "storage fields cannot be Bytes32; use Uint256 encoding"
   | .scalar .bool => throwError "storage fields cannot be Bool; use Uint256 (0/1) encoding"
@@ -574,6 +611,7 @@ private partial def modelParamTypeTerm (ty : ValueType) : CommandElabM Term :=
   | .uint256 => `(Compiler.CompilationModel.ParamType.uint256)
   | .int256 => `(Compiler.CompilationModel.ParamType.int256)
   | .uint8 => `(Compiler.CompilationModel.ParamType.uint8)
+  | .uint16 => `(Compiler.CompilationModel.ParamType.uint16)
   | .address => `(Compiler.CompilationModel.ParamType.address)
   | .bytes32 => `(Compiler.CompilationModel.ParamType.bytes32)
   | .bool => `(Compiler.CompilationModel.ParamType.bool)
@@ -602,6 +640,7 @@ private def modelReturnTypeTerm (ty : ValueType) : CommandElabM Term :=
   | .uint256 => `(some Compiler.CompilationModel.FieldType.uint256)
   | .int256 => `(none)
   | .uint8 => `(none)
+  | .uint16 => `(none)
   | .address => `(some Compiler.CompilationModel.FieldType.address)
   | .bytes32 => `(none)
   | .bool => `(none)
@@ -620,6 +659,7 @@ private partial def modelReturnsTerm (ty : ValueType) : CommandElabM Term :=
   | .uint256 => `([Compiler.CompilationModel.ParamType.uint256])
   | .int256 => `([Compiler.CompilationModel.ParamType.int256])
   | .uint8 => `([Compiler.CompilationModel.ParamType.uint8])
+  | .uint16 => `([Compiler.CompilationModel.ParamType.uint16])
   | .address => `([Compiler.CompilationModel.ParamType.address])
   | .bytes32 => `([Compiler.CompilationModel.ParamType.bytes32])
   | .bool => `([Compiler.CompilationModel.ParamType.bool])
@@ -645,6 +685,7 @@ private partial def valueTypeFromModelParamType? : Compiler.CompilationModel.Par
   | .uint256 => some .uint256
   | .int256 => some .int256
   | .uint8 => some .uint8
+  | .uint16 => some .uint16
   | .address => some .address
   | .bool => some .bool
   | .bytes32 => some .bytes32
@@ -704,8 +745,9 @@ private partial def contractValueTypeTerm (ty : ValueType) : CommandElabM Term :
   | .uint256 => `(Uint256)
   | .int256 => `(Int256)
   | .uint8 => `(Uint256)
+  | .uint16 => `(Uint16)
   | .address => `(Address)
-  | .bytes32 => `(Uint256)
+  | .bytes32 => `(Bytes32)
   | .bool => `(Bool)
   | .string => `(String)
   | .bytes => `(ByteArray)
@@ -1156,10 +1198,6 @@ private def parseFunction (newtypes : Array NewtypeDecl) (structDecls : Array St
       let mut_ := { mut_ with isPure := pureMod?.isSome }
       let parsedParams ← params.mapM (parseParam newtypes structDecls adtDecls)
       let parsedReturnTy ← valueTypeFromSyntax newtypes structDecls adtDecls retTy
-      match parsedReturnTy with
-      | .struct _ _ =>
-          throwErrorAt retTy "function return types cannot be named structs; return an explicit Tuple [...] instead"
-      | _ => pure ()
       let parsedGuard? ←
         match guard? with
         | some guard => pure (some (← parseInitGuard guard))
@@ -1256,7 +1294,7 @@ def immutableStorageFieldDecl
     ident := immutableSlotIdent imm
     name := immutableHiddenName imm
     ty := match imm.ty with
-      | .uint256 | .int256 | .uint8 | .bytes32 | .bool => .scalar .uint256
+      | .uint256 | .int256 | .uint8 | .uint16 | .bytes32 | .bool => .scalar .uint256
       | .address => .scalar .address
       | _ => .scalar imm.ty
     slotNum := immutableSlotIndex fields idx
@@ -1265,7 +1303,7 @@ def immutableStorageFieldDecl
 
 private def validateImmutableType (imm : ImmutableDecl) : CommandElabM Unit :=
   match imm.ty with
-  | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool => pure ()
+  | .uint256 | .int256 | .uint8 | .uint16 | .address | .bytes32 | .bool => pure ()
   | _ =>
       throwErrorAt imm.ident
         s!"contract immutables currently support only Uint256, Int256, Uint8, Address, Bytes32, and Bool; '{imm.name}' uses unsupported type"
@@ -1299,7 +1337,7 @@ private def rejectExecutableBoundaryAdt
       s!"{context} uses an ADT at the executable contract boundary. ADT storage is supported, but ABI/function boundary ADT lowering is not yet implemented; pass scalar fields explicitly or keep the ADT in storage."
 
 private def externalExecutableWordType? : ValueType → Bool
-  | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool => true
+  | .uint256 | .int256 | .uint8 | .uint16 | .address | .bytes32 | .bool => true
   | .newtype _ baseType => externalExecutableWordType? baseType
   | _ => false
 
@@ -1719,7 +1757,7 @@ private def isSignedWordValueType : ValueType → Bool
   | _ => false
 
 private def isWordLikeValueType : ValueType → Bool
-  | .uint256 | .int256 | .uint8 | .address | .bytes32 => true
+  | .uint256 | .int256 | .uint8 | .uint16 | .address | .bytes32 => true
   | .newtype _ baseType => isWordLikeValueType baseType
   | _ => false
 
@@ -1735,7 +1773,7 @@ private def externalCallDynamicArgSupported (ty : ValueType) : Bool :=
   | _ => false
 
 private partial def staticAbiWordCount? : ValueType → Option Nat
-  | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool => some 1
+  | .uint256 | .int256 | .uint8 | .uint16 | .address | .bytes32 | .bool => some 1
   | .fixedArray elemTy size => do
       let elemWords ← staticAbiWordCount? elemTy
       some (size * elemWords)
@@ -1757,7 +1795,7 @@ private partial def staticAbiWordCount? : ValueType → Option Nat
   | _ => none
 
 private partial def staticAbiLeafNames? : ValueType → Option (List String)
-  | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool => some [""]
+  | .uint256 | .int256 | .uint8 | .uint16 | .address | .bytes32 | .bool => some [""]
   | .fixedArray elemTy size => do
       let elemNames ← staticAbiLeafNames? elemTy
       let mut out : List String := []
@@ -1801,7 +1839,7 @@ private def flattenExternalResultNames
       throwError s!"external result '{baseName}' has a dynamic type; bind dynamic external returns explicitly"
 
 private partial def abiLocalHeadWordCount? : ValueType → Option Nat
-  | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool
+  | .uint256 | .int256 | .uint8 | .uint16 | .address | .bytes32 | .bool
   | .string | .bytes | .array _ => some 1
   | .fixedArray elemTy size => do
       match staticAbiWordCount? elemTy with
@@ -1831,7 +1869,7 @@ private partial def valueTypeUsesDynamicData : ValueType → Bool
   | .struct _ fields => fields.any (fun field => valueTypeUsesDynamicData field.snd)
   | .newtype _ baseType => valueTypeUsesDynamicData baseType
   | .adt _ _ => false  -- ADTs are stored as tag + fixed-width slots, not dynamic
-  | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool | .unit => false
+  | .uint256 | .int256 | .uint8 | .uint16 | .address | .bytes32 | .bool | .unit => false
 
 private partial def abiParentHeadWordCount? (ty : ValueType) : Option Nat :=
   match ty with
@@ -1847,7 +1885,7 @@ private partial def abiParentHeadWordCount? (ty : ValueType) : Option Nat :=
       else
         abiLocalHeadWordCount? ty
   | .newtype _ baseType => abiParentHeadWordCount? baseType
-  | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool => some 1
+  | .uint256 | .int256 | .uint8 | .uint16 | .address | .bytes32 | .bool => some 1
   | .adt _ _ | .unit => none
 
 private def classifyWordArithmeticResultType
@@ -1883,7 +1921,7 @@ private def isNatLiteralTerm (stx : Term) : Bool :=
   | _ => false
 
 private def numericLiteralCompatibleValueType : ValueType → Bool
-  | .uint256 | .int256 | .uint8 => true
+  | .uint256 | .int256 | .uint8 | .uint16 => true
   | .newtype _ baseType => numericLiteralCompatibleValueType baseType
   | _ => false
 
@@ -2554,7 +2592,7 @@ private unsafe def qualifiedSingleBindType
         s!"qualified helper '{qualifiedFunctionDisplayName fnName}' returns multiple values; use tuple destructuring"
 
 private def customErrorRequiresDirectParamRef : ValueType → Bool
-  | .uint256 | .int256 | .uint8 | .address | .bool | .bytes32 => false
+  | .uint256 | .int256 | .uint8 | .uint16 | .address | .bool | .bytes32 => false
   | .newtype _ baseType => customErrorRequiresDirectParamRef baseType
   | _ => true
 
@@ -3153,16 +3191,16 @@ private partial def inferPureExprType
   | `(term| structMember $field:term $key:term $member:term) => do
       let fieldName := ← expectStringOrIdent field
       let memberName := ← expectStringOrIdent member
-      let _ ← lookupStructMemberDecl fields fieldName memberName false
+      let memberDecl ← lookupStructMemberDecl fields fieldName memberName false
       requireWordLikeType key "structMember key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key visitingConstants)
-      pure .uint256
+      pure memberDecl.ty
   | `(term| structMember2 $field:term $key1:term $key2:term $member:term) => do
       let fieldName := ← expectStringOrIdent field
       let memberName := ← expectStringOrIdent member
-      let _ ← lookupStructMemberDecl fields fieldName memberName true
+      let memberDecl ← lookupStructMemberDecl fields fieldName memberName true
       requireWordLikeType key1 "structMember2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key1 visitingConstants)
       requireWordLikeType key2 "structMember2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key2 visitingConstants)
-      pure .uint256
+      pure memberDecl.ty
   | _ =>
       match qualifiedFunctionAppSyntax? stx with
       | some (fnName, _) =>
@@ -3302,16 +3340,16 @@ private partial def inferBindSourceType
   | `(term| structMember $field:term $key:term $member:term) => do
       let fieldName := ← expectStringOrIdent field
       let memberName := ← expectStringOrIdent member
-      let _ ← lookupStructMemberDecl fields fieldName memberName false
+      let memberDecl ← lookupStructMemberDecl fields fieldName memberName false
       requireWordLikeType key "structMember key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key)
-      pure .uint256
+      pure memberDecl.ty
   | `(term| structMember2 $field:term $key1:term $key2:term $member:term) => do
       let fieldName := ← expectStringOrIdent field
       let memberName := ← expectStringOrIdent member
-      let _ ← lookupStructMemberDecl fields fieldName memberName true
+      let memberDecl ← lookupStructMemberDecl fields fieldName memberName true
       requireWordLikeType key1 "structMember2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key1)
       requireWordLikeType key2 "structMember2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key2)
-      pure .uint256
+      pure memberDecl.ty
   | `(term| msgSender) | `(term| Verity.msgSender) =>
       pure .address
   | `(term| msgValue) | `(term| Verity.msgValue) | `(term| selfBalance)
@@ -3435,78 +3473,100 @@ private partial def inferTupleSourceTypes?
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (rhs : Term) : CommandElabM (Option (Array ValueType)) := do
+  let structCtorTypes? : CommandElabM (Option (Array ValueType)) := do
+    match qualifiedFunctionAppSyntax? (stripParens rhs) with
+    | some (name, ctorArgs) =>
+        if name.toString.endsWith ".mk" then
+          pure (some (← ctorArgs.mapM (inferPureExprType fields constDecls immutableDecls externalDecls params locals)))
+        else
+          pure none
+    | none =>
+        match (stripParens rhs).raw with
+        | .node _ `Lean.Parser.Term.app args =>
+            match args.getD 0 Syntax.missing with
+            | .ident _ raw _ _ =>
+                if raw.toString.endsWith ".mk" then
+                  let ctorArgs := (args.getD 1 Syntax.missing).getArgs.map (fun syn => ⟨syn⟩)
+                  pure (some (← ctorArgs.mapM (inferPureExprType fields constDecls immutableDecls externalDecls params locals)))
+                else
+                  pure none
+            | _ => pure none
+        | _ => pure none
   match tupleElemsFromTerm? rhs with
   | some elems =>
       pure <| some (← elems.mapM (inferPureExprType fields constDecls immutableDecls externalDecls params locals))
   | none =>
-      match stripParens rhs with
-      | `(term| $id:ident) =>
-          match params.find? (fun p => p.name == toString id.getId) with
-          | some p =>
-              match p.ty with
-              | .tuple elemTys => pure (some elemTys.toArray)
-              | _ => pure none
-          | none => pure none
-      | `(term| structMembers $field:term $key:term $members:term) => do
-          let fieldName := ← expectStringOrIdent field
-          let memberNames := ← expectStringList members
-          for memberName in memberNames do
-            let _ ← lookupStructMemberDecl fields fieldName memberName false
-          requireWordLikeType key "structMembers key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key)
-          pure (some (Array.replicate memberNames.size .uint256))
-      | `(term| structMembers2 $field:term $key1:term $key2:term $members:term) => do
-          let fieldName := ← expectStringOrIdent field
-          let memberNames := ← expectStringList members
-          for memberName in memberNames do
-            let _ ← lookupStructMemberDecl fields fieldName memberName true
-          requireWordLikeType key1 "structMembers2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key1)
-          requireWordLikeType key2 "structMembers2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key2)
-          pure (some (Array.replicate memberNames.size .uint256))
-      | `(term| arrayElement $name:term $index:term) => do
-          requireWordLikeType index "arrayElement index"
-            (← inferPureExprType fields constDecls immutableDecls externalDecls params locals index)
-          -- verity#1849, G2: `arrayElement (arrayElement <param> <i>).<dynField> <k>`
-          -- never destructures into a tuple — fall through to the scalar
-          -- return path. The compound projection's name isn't a direct param
-          -- ref so `requireDirectParamRef` would throw if invoked here.
-          if (arrayElementDynamicMemberProjection? params name).isSome ||
-              (localArrayElementDynamicMemberProjection? locals name).isSome then
-            pure none
-          else
-            match directParamNameWithType? params name with
-            | none => pure none
-            | some _ =>
-                let sourceTy ← requireDirectParamRef name "arrayElement" params
-                match sourceTy with
-                | .array (.tuple elemTys) =>
-                    let _ ← requireSupportedArrayElementTupleSourceType name "arrayElement tuple destructuring" sourceTy
-                    pure (some elemTys.toArray)
+      match ← structCtorTypes? with
+      | some tys => pure (some tys)
+      | none =>
+        match stripParens rhs with
+        | `(term| $id:ident) =>
+            match params.find? (fun p => p.name == toString id.getId) with
+            | some p =>
+                match p.ty with
+                | .tuple elemTys => pure (some elemTys.toArray)
                 | _ => pure none
-      | `(term| tryExternalCall $name:term $args:term) =>
-          let extName := ← expectStringOrIdent name
-          match stripParens args with
-          | `(term| [ $[$xs],* ]) =>
-              for x in xs do
-                requireWordOrDirectArrayType x s!"tryExternalCall '{extName}' argument"
-                  (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x)
-          | _ => throwErrorAt args "expected list literal [..]"
-          match externalDecls.find? (fun ext => ext.name == extName) with
-          | some ext =>
-              -- tryExternalCall returns (success : Bool, result₁ : T₁, ..., resultₙ : Tₙ)
-              pure (some (#[.bool] ++ ext.returnTys))
-          | none =>
-              -- When called from translation path with empty externalDecls, return none
-              -- to let the tryExternalCallBindStmt? helper handle translation.
-              -- The validation path (with real externalDecls) catches actual errors.
+            | none => pure none
+        | `(term| structMembers $field:term $key:term $members:term) => do
+            let fieldName := ← expectStringOrIdent field
+            let memberNames := ← expectStringList members
+            for memberName in memberNames do
+              let _ ← lookupStructMemberDecl fields fieldName memberName false
+            requireWordLikeType key "structMembers key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key)
+            pure (some (Array.replicate memberNames.size .uint256))
+        | `(term| structMembers2 $field:term $key1:term $key2:term $members:term) => do
+            let fieldName := ← expectStringOrIdent field
+            let memberNames := ← expectStringList members
+            for memberName in memberNames do
+              let _ ← lookupStructMemberDecl fields fieldName memberName true
+            requireWordLikeType key1 "structMembers2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key1)
+            requireWordLikeType key2 "structMembers2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key2)
+            pure (some (Array.replicate memberNames.size .uint256))
+        | `(term| arrayElement $name:term $index:term) => do
+            requireWordLikeType index "arrayElement index"
+              (← inferPureExprType fields constDecls immutableDecls externalDecls params locals index)
+            -- verity#1849, G2: `arrayElement (arrayElement <param> <i>).<dynField> <k>`
+            -- never destructures into a tuple — fall through to the scalar
+            -- return path. The compound projection's name isn't a direct param
+            -- ref so `requireDirectParamRef` would throw if invoked here.
+            if (arrayElementDynamicMemberProjection? params name).isSome ||
+                (localArrayElementDynamicMemberProjection? locals name).isSome then
               pure none
-      | other =>
-          match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals other with
-          | some (fn, _argTerms) =>
-              ensureSupportsInternalHelperSpec rhs fn
-              match fn.returnTy with
-              | .tuple elemTys => pure (some elemTys.toArray)
-              | _ => pure none
-          | none => pure none
+            else
+              match directParamNameWithType? params name with
+              | none => pure none
+              | some _ =>
+                  let sourceTy ← requireDirectParamRef name "arrayElement" params
+                  match sourceTy with
+                  | .array (.tuple elemTys) =>
+                      let _ ← requireSupportedArrayElementTupleSourceType name "arrayElement tuple destructuring" sourceTy
+                      pure (some elemTys.toArray)
+                  | _ => pure none
+        | `(term| tryExternalCall $name:term $args:term) =>
+            let extName := ← expectStringOrIdent name
+            match stripParens args with
+            | `(term| [ $[$xs],* ]) =>
+                for x in xs do
+                  requireWordOrDirectArrayType x s!"tryExternalCall '{extName}' argument"
+                    (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x)
+            | _ => throwErrorAt args "expected list literal [..]"
+            match externalDecls.find? (fun ext => ext.name == extName) with
+            | some ext =>
+                -- tryExternalCall returns (success : Bool, result₁ : T₁, ..., resultₙ : Tₙ)
+                pure (some (#[.bool] ++ ext.returnTys))
+            | none =>
+                -- When called from translation path with empty externalDecls, return none
+                -- to let the tryExternalCallBindStmt? helper handle translation.
+                -- The validation path (with real externalDecls) catches actual errors.
+                pure none
+        | other =>
+            match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals other with
+            | some (fn, _argTerms) =>
+                ensureSupportsInternalHelperSpec rhs fn
+                match fn.returnTy with
+                | .tuple elemTys => pure (some elemTys.toArray)
+                | _ => pure none
+            | none => pure none
 
 private partial def resolveLocalFunctionApp?
     (fields : Array StorageFieldDecl)
@@ -3972,7 +4032,7 @@ partial def translatePureExprWithTypes
         `(Compiler.CompilationModel.Expr.literal 0)
       else if let some imm := immutableDecls.find? (fun imm => declaredNameMatches name imm.name) then
         match imm.ty with
-        | .uint256 | .int256 | .uint8 | .bytes32 | .bool =>
+        | .uint256 | .int256 | .uint8 | .uint16 | .bytes32 | .bool =>
             `(Compiler.CompilationModel.Expr.storage $(strTerm (immutableHiddenName imm)))
         | .address => `(Compiler.CompilationModel.Expr.storageAddr $(strTerm (immutableHiddenName imm)))
         | _ => throwErrorAt stx s!"immutable '{name}' uses unsupported type"
@@ -4691,6 +4751,25 @@ private def tupleLiteralOrStructValueExprs?
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (rhs : Term) : CommandElabM (Option (Array Term)) := do
+  let structCtorValueExprs? : CommandElabM (Option (Array Term)) := do
+    match qualifiedFunctionAppSyntax? (stripParens rhs) with
+    | some (name, ctorArgs) =>
+        if name.toString.endsWith ".mk" then
+          pure (some (← ctorArgs.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)))
+        else
+          pure none
+    | none =>
+        match (stripParens rhs).raw with
+        | .node _ `Lean.Parser.Term.app args =>
+            match args.getD 0 Syntax.missing with
+            | .ident _ raw _ _ =>
+                if raw.toString.endsWith ".mk" then
+                  let ctorArgs := (args.getD 1 Syntax.missing).getArgs.map (fun syn => ⟨syn⟩)
+                  pure (some (← ctorArgs.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)))
+                else
+                  pure none
+            | _ => pure none
+        | _ => pure none
   let structValueExprs? : CommandElabM (Option (Array Term)) := do
     match stripParens rhs with
     | `(term| structMembers $field:term $key:term $members:term) => do
@@ -4721,7 +4800,10 @@ private def tupleLiteralOrStructValueExprs?
   | none =>
       match ← arrayElementTupleElemExprs? fields constDecls immutableDecls params locals rhs with
       | some exprs => pure (some exprs)
-      | none => structValueExprs?
+      | none =>
+          match ← structCtorValueExprs? with
+          | some exprs => pure (some exprs)
+          | none => structValueExprs?
 
 private def tupleValueExprs
     (fields : Array StorageFieldDecl)
@@ -4759,7 +4841,7 @@ private def tupleReturnValueExprs?
 
 private partial def staticInternalHelperBindingNames (name : String) (ty : ValueType) : List String :=
   match ty with
-  | .uint256 | .int256 | .uint8 | .address | .bool | .bytes32 => [name]
+  | .uint256 | .int256 | .uint8 | .uint16 | .address | .bool | .bytes32 => [name]
   | .fixedArray elemTy size =>
       (List.range size).flatMap fun idx =>
         staticInternalHelperBindingNames s!"{name}_{idx}" elemTy
@@ -6934,7 +7016,7 @@ private def immutableInitStmtTerms
     let slotField := immutableStorageFieldDecl fields imm idx
     let valueExpr ← translatePureExpr fields constDecls #[] ctorParams #[] imm.body
     match imm.ty with
-    | .uint256 | .int256 | .uint8 | .bytes32 | .bool =>
+    | .uint256 | .int256 | .uint8 | .uint16 | .bytes32 | .bool =>
         `(Compiler.CompilationModel.Stmt.setStorage $(strTerm slotField.name) $valueExpr)
     | .address =>
         `(Compiler.CompilationModel.Stmt.setStorageAddr $(strTerm slotField.name) $valueExpr)
@@ -7080,6 +7162,7 @@ private def storageSlotInnerTypeTerm (ty : StorageType) : CommandElabM Term := d
     | .scalar .uint256 => `(Uint256)
     | .scalar .int256 => `(Uint256)
     | .scalar .uint8 => throwError "storage field cannot be Uint8; use Uint256 encoding"
+    | .scalar .uint16 => throwError "storage field cannot be Uint16; use Uint256 encoding"
     | .scalar .address => `(Address)
     | .scalar .bytes32 => throwError "storage field cannot be Bytes32; use Uint256 encoding"
     | .scalar .bool => throwError "storage field cannot be Bool; use Uint256 (0/1) encoding"
@@ -7106,12 +7189,9 @@ private def storageSlotInnerTypeTerm (ty : StorageType) : CommandElabM Term := d
     | .mapping2AddressToAddressToUint256 => `(Address → Address → Uint256)
     | .mappingUintToUint256 => `(Uint256 → Uint256)
     | .mappingChain keyTypes => mkStorageMappingTy keyTypes
-    | .mappingStruct .address _ => `(Address → Uint256)
-    | .mappingStruct .uint256 _ => `(Uint256 → Uint256)
-    | .mappingStruct2 .address .address _ => `(Address → Address → Uint256)
-    | .mappingStruct2 .address .uint256 _ => `(Address → Uint256 → Uint256)
-    | .mappingStruct2 .uint256 .address _ => `(Uint256 → Address → Uint256)
-    | .mappingStruct2 .uint256 .uint256 _ => `(Uint256 → Uint256 → Uint256)
+    | .mappingStruct keyType _ => `(($(← storageKeyTypeContractTerm keyType) → Uint256))
+    | .mappingStruct2 outerKey innerKey _ =>
+        `(($(← storageKeyTypeContractTerm outerKey) → $(← storageKeyTypeContractTerm innerKey) → Uint256))
 
 private def mkStorageDefCommand (field : StorageFieldDecl) : CommandElabM Cmd := do
   let storageTy ← storageSlotInnerTypeTerm field.ty
@@ -7365,7 +7445,8 @@ private partial def collectQualifiedFunctionAppsFromSyntax (stx : Syntax) : Arra
   | .node _ `Lean.Parser.Term.app args =>
       match args.getD 0 Syntax.missing with
       | .ident _ _ raw _ =>
-          if isQualifiedFunctionName raw && (nameComponents raw).head? != some "Verity" then
+          if isQualifiedFunctionName raw && (nameComponents raw).head? != some "Verity" &&
+              !raw.toString.endsWith ".mk" then
             fromChildren.push raw
           else
             fromChildren

--- a/artifacts/macro_property_tests/PropertyNamedStructReturnSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyNamedStructReturnSmoke.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyNamedStructReturnSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyNamedStructReturnSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("NamedStructReturnSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `goodReturn` result
+    function testTODO_GoodReturn_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("goodReturn(uint256,uint256)", uint256(1), uint256(1)));
+        require(ok, "goodReturn reverted unexpectedly");
+        require(ret.length >= 64, "goodReturn ABI tuple return payload unexpectedly short");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 649,
+    "core_lines": 664,
     "example_contracts": 14
   },
   "proofs": {


### PR DESCRIPTION
## Summary

Implements the Solidity type-fidelity work requested in #1932 for audit-grade router models:

- adds first-class `Uint16` core type and ABI/macro support;
- adds `bytes32` mapping keys to the compilation model and macro surface;
- allows typed `MappingStruct` members for packed `Uint16`, `Bool`, `Address`, and `Bytes32` fields;
- preserves named struct return metadata through the macro path;
- extends event, ABI, source-semantics, IR, and Yul proof support for `uint16`;
- adds a VerifierRouter-shaped regression covering `MappingStruct(Bytes32, ...)`, typed events, `Uint16` fields, `Bool active`, and `getCircuit(Bytes32) : Circuit`.

This lets the Unlink router model express the Solidity ABI/storage surface directly instead of documenting a `Uint256` word-erasure limitation.

Closes #1932.

## Validation

- `lake build Compiler.CompilationModelFeatureTest Contracts.Smoke`
- `lake build`
- Downstream Unlink benchmark gate passed locally against this branch:
  `lake build Benchmark.Cases.UnlinkXyz.Pool.FormalAudit Benchmark.Cases.UnlinkXyz.Pool.Proofs Benchmark.Cases.UnlinkXyz.Pool.Compile Benchmark.Generated.UnlinkXyz.Pool.Tasks.FormalAuditReady Benchmark.Generated.UnlinkXyz.Pool.Tasks.ArtifactBuilds`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ABI encoding/decoding, macro translation, and proof machinery to add new surface types (`uint16`, `bytes32` mapping keys), which risks subtle ABI/layout regressions despite being mostly additive and well-scoped.
> 
> **Overview**
> Adds first-class `ParamType.uint16` end-to-end (ABI JSON rendering, calldata loading, event/custom-error encoding, typed IR lowering, and source semantics), including proper 16-bit masking and corresponding proof updates.
> 
> Extends the storage/macro surface to support `MappingKeyType.bytes32` and typed `MappingStruct` members via a new `StructMemberType` (e.g., `uint16`, `bool`, `address`, `bytes32`), and propagates those member types through `structMember(s)`/destructuring inference instead of erasing to `uint256`.
> 
> Relaxes macro restrictions to preserve named struct return construction (`.mk`), adds a router-shaped smoke test spec asserting type fidelity, and updates generated Foundry property stubs/verification stats accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bdf36786c5f82944b50a0169908594fb4cb0170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->