### PR TITLE
Add Ink xStocks proof of concept

### DIFF
--- a/Contracts.lean
+++ b/Contracts.lean
@@ -11,6 +11,7 @@ import Contracts.OwnedCounter
 import Contracts.SafeCounter
 import Contracts.Ledger
 import Contracts.Vault
+import Contracts.XStockVault
 import Contracts.ERC20
 import Contracts.ERC721
 import Contracts.SimpleToken

--- a/Contracts/SpecAliases.lean
+++ b/Contracts/SpecAliases.lean
@@ -6,6 +6,7 @@ import Contracts.OwnedCounter
 import Contracts.SafeCounter
 import Contracts.Ledger
 import Contracts.Vault
+import Contracts.XStockVault
 import Contracts.SimpleToken
 import Contracts.ERC20
 import Contracts.ERC721
@@ -32,6 +33,9 @@ def ledgerSpec : CompilationModel := Contracts.Ledger.spec
 
 /-- Legacy compatibility alias. Canonical source is macro-generated. -/
 def vaultSpec : CompilationModel := Contracts.Vault.spec
+
+/-- xStocks integration POC. Canonical source is macro-generated. -/
+def xStockVaultSpec : CompilationModel := Contracts.XStockVault.spec
 
 /-- Legacy compatibility alias. Canonical source is macro-generated. -/
 def ownedCounterSpec : CompilationModel := Contracts.OwnedCounter.spec

--- a/Contracts/Specs.lean
+++ b/Contracts/Specs.lean
@@ -98,6 +98,7 @@ def allSpecs : List CompilationModel := [
   ownedSpec,
   ledgerSpec,
   vaultSpec,
+  xStockVaultSpec,
   ownedCounterSpec,
   simpleTokenSpec,
   safeCounterSpec,

--- a/Contracts/XStockVault.lean
+++ b/Contracts/XStockVault.lean
@@ -1,0 +1,7 @@
+import Contracts.XStockVault.XStockVault
+import Contracts.XStockVault.Spec
+import Contracts.XStockVault.Invariants
+import Contracts.XStockVault.Proofs.Basic
+import Contracts.XStockVault.Proofs.Correctness
+import Contracts.XStockVault.Proofs.XStocks
+import Contracts.XStockVault.SpecProofs

--- a/Contracts/XStockVault/Invariants.lean
+++ b/Contracts/XStockVault/Invariants.lean
@@ -1,0 +1,23 @@
+import Contracts.XStockVault.Spec
+
+namespace Contracts.XStockVault.Invariants
+
+open Verity
+open Contracts.XStockVault.Spec
+open Verity.Specs.Ink.XStocks
+
+structure WellFormedXStockVault (s : ContractState) : Prop where
+  sender_nonzero : s.sender ≠ 0
+  contract_nonzero : s.thisAddress ≠ 0
+  pause_is_boolean : s.storage 5 = 0 ∨ s.storage 5 = 1
+
+def quoteEpochMatches (s : VaultState) (q : DepositQuote) : Prop :=
+  q.multiplierEpoch = s.xstockMultiplierEpoch
+
+def corporateActionDoesNotRemintShares (s s' : VaultState) : Prop :=
+  s'.totalShares = s.totalShares ∧ s'.shareBalance = s.shareBalance
+
+def usesAdjustedBalanceFromEvm (assetAmount : Rat) (x : XStockSnapshot) : Prop :=
+  usesEvmBalanceExactlyOnce assetAmount x ∧ doesNotApplyMultiplierAgain assetAmount x
+
+end Contracts.XStockVault.Invariants

--- a/Contracts/XStockVault/Proofs/Basic.lean
+++ b/Contracts/XStockVault/Proofs/Basic.lean
@@ -1,0 +1,26 @@
+import Contracts.XStockVault.Spec
+
+/-!
+Baseline proof module for the XStockVault example.
+
+The xStocks-specific proofs live in `Contracts.XStockVault.Proofs.XStocks`.
+-/
+
+namespace Contracts.XStockVault.Proofs.Basic
+
+open Verity
+open Contracts.XStockVault.Spec
+
+theorem totalAssets_spec_reads_slot_one (result : Uint256) (s : ContractState)
+    (h : totalAssets_spec result s) :
+    result = s.storage 1 := h
+
+theorem totalSupply_spec_reads_slot_two (result : Uint256) (s : ContractState)
+    (h : totalSupply_spec result s) :
+    result = s.storage 2 := h
+
+theorem multiplierEpoch_spec_reads_slot_four (result : Uint256) (s : ContractState)
+    (h : multiplierEpoch_spec result s) :
+    result = s.storage 4 := h
+
+end Contracts.XStockVault.Proofs.Basic

--- a/Contracts/XStockVault/Proofs/Correctness.lean
+++ b/Contracts/XStockVault/Proofs/Correctness.lean
@@ -1,0 +1,64 @@
+import Contracts.XStockVault.Proofs.Basic
+import Contracts.XStockVault.Proofs.XStocks
+
+namespace Contracts.XStockVault.Proofs.Correctness
+
+open Verity
+open Contracts.XStockVault.Spec
+
+theorem syncFromBalanceOf_sets_assets_to_adjusted_balance
+    (adjustedBalanceOfVault : Uint256)
+    (s s' : ContractState)
+    (h : syncFromBalanceOf_spec adjustedBalanceOfVault s s') :
+    s'.storage 1 = adjustedBalanceOfVault := h.1
+
+theorem syncFromBalanceOf_preserves_unrelated_storage
+    (adjustedBalanceOfVault : Uint256)
+    (s s' : ContractState)
+    (slotIdx : Nat)
+    (h : syncFromBalanceOf_spec adjustedBalanceOfVault s s')
+    (hSlot : slotIdx ≠ 1) :
+    s'.storage slotIdx = s.storage slotIdx := by
+  exact h.2.2.2.2.1 slotIdx hSlot
+
+theorem stale_epoch_deposit_spec_impossible
+    (assets quoteEpoch : Uint256)
+    (s s' : ContractState)
+    (hSpec : deposit_spec assets quoteEpoch s s')
+    (hStale : quoteEpoch ≠ s.storage 4) :
+    False := by
+  exact hStale hSpec.2.1
+
+theorem deposit_spec_preserves_multiplier_epoch
+    (assets quoteEpoch : Uint256)
+    (s s' : ContractState)
+    (hSpec : deposit_spec assets quoteEpoch s s') :
+    s'.storage 4 = s.storage 4 := by
+  rcases hSpec with ⟨_, _, _, _, _, _, hFrame, _, _⟩
+  exact hFrame 4 (by decide) (by decide)
+
+theorem deposit_spec_preserves_pause_flag
+    (assets quoteEpoch : Uint256)
+    (s s' : ContractState)
+    (hSpec : deposit_spec assets quoteEpoch s s') :
+    s'.storage 5 = s.storage 5 := by
+  rcases hSpec with ⟨_, _, _, _, _, _, hFrame, _, _⟩
+  exact hFrame 5 (by decide) (by decide)
+
+theorem withdraw_spec_preserves_multiplier_epoch
+    (shares quoteEpoch : Uint256)
+    (s s' : ContractState)
+    (hSpec : withdraw_spec shares quoteEpoch s s') :
+    s'.storage 4 = s.storage 4 := by
+  rcases hSpec with ⟨_, _, _, _, _, _, _, _, _, hFrame, _, _⟩
+  exact hFrame 4 (by decide) (by decide)
+
+theorem withdraw_spec_preserves_pause_flag
+    (shares quoteEpoch : Uint256)
+    (s s' : ContractState)
+    (hSpec : withdraw_spec shares quoteEpoch s s') :
+    s'.storage 5 = s.storage 5 := by
+  rcases hSpec with ⟨_, _, _, _, _, _, _, _, _, hFrame, _, _⟩
+  exact hFrame 5 (by decide) (by decide)
+
+end Contracts.XStockVault.Proofs.Correctness

--- a/Contracts/XStockVault/Proofs/XStocks.lean
+++ b/Contracts/XStockVault/Proofs/XStocks.lean
@@ -1,0 +1,47 @@
+import Contracts.XStockVault.Invariants
+
+namespace Contracts.XStockVault.Proofs.XStocks
+
+open Verity
+open Contracts.XStockVault.Spec
+open Verity.Specs.Ink.XStocks
+
+theorem sync_uses_evm_adjusted_balance_exactly_once
+    (s : VaultState)
+    (x : XStockSnapshot)
+    (_hEvmBalance : x.evmBalanceOfVault = evmAdjustedBalance x)
+    (hBalancePositive : x.evmBalanceOfVault ≠ 0)
+    (hMultiplierNotOne : x.multiplier ≠ 1) :
+    (syncAssetsFromXStock s x).totalAssets = x.evmBalanceOfVault
+      ∧ (syncAssetsFromXStock s x).totalAssets ≠ x.evmBalanceOfVault * x.multiplier := by
+  constructor
+  · rfl
+  · exact direct_balance_use_does_not_double_apply_multiplier x hBalancePositive hMultiplierNotOne
+
+theorem corporate_action_preserves_fraction_and_scales_claim
+    (s : VaultState)
+    (user : Address)
+    (oldMultiplier newMultiplier : Rat)
+    (_hOldPositive : oldMultiplier > 0)
+    (_hNewPositive : newMultiplier > 0) :
+    let s' := applyMultiplierUpdate s oldMultiplier newMultiplier
+    shareFraction s' user = shareFraction s user
+      ∧ userClaim s' user = userClaim s user * (newMultiplier / oldMultiplier) := by
+  intro s'
+  constructor
+  · subst s'
+    simp [shareFraction, applyMultiplierUpdate]
+  · subst s'
+    by_cases hShares : s.totalShares = 0
+    · simp [userClaim, shareFraction, applyMultiplierUpdate, hShares]
+    · simp [userClaim, shareFraction, applyMultiplierUpdate, hShares]
+      ring_nf
+
+theorem stale_multiplier_epoch_cannot_settle_deposit
+    (s : VaultState)
+    (q : DepositQuote)
+    (hStale : q.multiplierEpoch ≠ s.xstockMultiplierEpoch) :
+    settleDepositQuote s q = s := by
+  simp [settleDepositQuote, hStale]
+
+end Contracts.XStockVault.Proofs.XStocks

--- a/Contracts/XStockVault/Spec.lean
+++ b/Contracts/XStockVault/Spec.lean
@@ -1,0 +1,118 @@
+import Verity.Specs.Common
+import Verity.Specs.Common.Sum
+import Verity.Specs.Ink.XStocks
+import Verity.Macro
+import Verity.EVM.Uint256
+import Contracts.XStockVault.XStockVault
+
+namespace Contracts.XStockVault.Spec
+
+open Verity
+open Verity.Specs
+open Verity.EVM.Uint256
+open Verity.Specs.Common (sumBalances balancesFinite)
+open Verity.Specs.Ink.XStocks
+
+def storageUnchangedExceptAssetSupplySlots (s s' : ContractState) : Prop :=
+  ∀ slotIdx : Nat,
+    slotIdx ≠ 1 → slotIdx ≠ 2 →
+      s'.storage slotIdx = s.storage slotIdx
+
+def sameStorageExceptAssetSupplySlots (s s' : ContractState) : Prop :=
+  storageUnchangedExceptAssetSupplySlots s s' ∧
+  Specs.sameStorageAddr s s' ∧
+  Specs.sameContext s s'
+
+def storageUnchangedExceptTotalAssetsSlot (s s' : ContractState) : Prop :=
+  ∀ slotIdx : Nat,
+    slotIdx ≠ 1 →
+      s'.storage slotIdx = s.storage slotIdx
+
+def deposit_spec (assets quoteEpoch : Uint256) (s s' : ContractState) : Prop :=
+  s.storage 5 = 0 ∧
+  quoteEpoch = s.storage 4 ∧
+  s'.storageMap 3 s.sender = add (s.storageMap 3 s.sender) assets ∧
+  s'.storage 1 = add (s.storage 1) assets ∧
+  s'.storage 2 = add (s.storage 2) assets ∧
+  Specs.storageMapUnchangedExceptKeyAtSlot 3 s.sender s s' ∧
+  sameStorageExceptAssetSupplySlots s s'
+
+def withdraw_spec (shares quoteEpoch : Uint256) (s s' : ContractState) : Prop :=
+  s.storage 5 = 0 ∧
+  quoteEpoch = s.storage 4 ∧
+  s.storageMap 3 s.sender ≥ shares ∧
+  s.storage 1 ≥ shares ∧
+  s.storage 2 ≥ shares ∧
+  s'.storageMap 3 s.sender = sub (s.storageMap 3 s.sender) shares ∧
+  s'.storage 1 = sub (s.storage 1) shares ∧
+  s'.storage 2 = sub (s.storage 2) shares ∧
+  Specs.storageMapUnchangedExceptKeyAtSlot 3 s.sender s s' ∧
+  sameStorageExceptAssetSupplySlots s s'
+
+def syncFromBalanceOf_spec (adjustedBalanceOfVault : Uint256) (s s' : ContractState) : Prop :=
+  s'.storage 1 = adjustedBalanceOfVault ∧
+  s'.storage 2 = s.storage 2 ∧
+  s'.storage 4 = s.storage 4 ∧
+  s'.storage 5 = s.storage 5 ∧
+  storageUnchangedExceptTotalAssetsSlot s s' ∧
+  Specs.sameStorageMap s s' ∧
+  Specs.sameStorageAddr s s' ∧
+  Specs.sameContext s s'
+
+def balanceOf_spec (addr : Address) (result : Uint256) (s : ContractState) : Prop :=
+  result = s.storageMap 3 addr
+
+def totalAssets_spec (result : Uint256) (s : ContractState) : Prop :=
+  result = s.storage 1
+
+def totalSupply_spec (result : Uint256) (s : ContractState) : Prop :=
+  result = s.storage 2
+
+def multiplierEpoch_spec (result : Uint256) (s : ContractState) : Prop :=
+  result = s.storage 4
+
+structure VaultState where
+  totalAssets : Rat
+  totalShares : Rat
+  shareBalance : Address → Rat
+  xstockMultiplierEpoch : MultiplierEpoch
+
+def syncAssetsFromXStock (s : VaultState) (x : XStockSnapshot) : VaultState :=
+  { s with totalAssets := x.evmBalanceOfVault }
+
+def shareFraction (s : VaultState) (user : Address) : Rat :=
+  if s.totalShares = 0 then 0 else s.shareBalance user / s.totalShares
+
+def userClaim (s : VaultState) (user : Address) : Rat :=
+  shareFraction s user * s.totalAssets
+
+def applyMultiplierUpdate
+    (s : VaultState)
+    (oldMultiplier newMultiplier : Rat) : VaultState :=
+  { s with totalAssets := s.totalAssets * (newMultiplier / oldMultiplier) }
+
+structure DepositQuote where
+  user : Address
+  amount : Rat
+  sharesOut : Rat
+  multiplierEpoch : MultiplierEpoch
+
+def mintSharesForSettledDeposit
+    (s : VaultState)
+    (user : Address)
+    (amount sharesOut : Rat) : VaultState :=
+  { s with
+    totalAssets := s.totalAssets + amount,
+    totalShares := s.totalShares + sharesOut,
+    shareBalance := fun addr => if addr = user then s.shareBalance addr + sharesOut else s.shareBalance addr }
+
+def settleDepositQuote (s : VaultState) (q : DepositQuote) : VaultState :=
+  if q.multiplierEpoch = s.xstockMultiplierEpoch then
+    mintSharesForSettledDeposit s q.user q.amount q.sharesOut
+  else
+    s
+
+def totalShares (s : ContractState) : Uint256 :=
+  sumBalances 3 (s.knownAddresses 3) s.storageMap
+
+end Contracts.XStockVault.Spec

--- a/Contracts/XStockVault/SpecProofs.lean
+++ b/Contracts/XStockVault/SpecProofs.lean
@@ -1,0 +1,3 @@
+import Contracts.XStockVault.Proofs.Basic
+import Contracts.XStockVault.Proofs.Correctness
+import Contracts.XStockVault.Proofs.XStocks

--- a/Contracts/XStockVault/XStockVault.lean
+++ b/Contracts/XStockVault/XStockVault.lean
@@ -1,0 +1,98 @@
+import Contracts.Common
+
+namespace Contracts
+
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+open Verity.Stdlib.Math
+
+/-!
+A deliberately small xStocks integration accounting vault.
+
+The contract models the accounting side of a builder-owned vault that mints
+shares 1:1 for a settled adjusted xStock amount. Token custody and transfer
+success remain abstract: the reusable proof kit specifies the assumptions an
+Ink/EVM integrator needs around `balanceOf`, multipliers, and epochs.
+-/
+verity_contract XStockVault where
+  storage
+    xStockTokenSlot : Address := slot 0
+    totalAssetsSlot : Uint256 := slot 1
+    totalSupplySlot : Uint256 := slot 2
+    shareBalancesSlot : Address → Uint256 := slot 3
+    multiplierEpochSlot : Uint256 := slot 4
+    corporateActionPausedSlot : Uint256 := slot 5
+
+  constructor (xStockToken : Address) := do
+    setStorageAddr xStockTokenSlot xStockToken
+    setStorage totalAssetsSlot 0
+    setStorage totalSupplySlot 0
+    setStorage multiplierEpochSlot 0
+    setStorage corporateActionPausedSlot 0
+
+  function setCorporateActionPaused (paused : Uint256) : Unit := do
+    require (paused == 0 || paused == 1) "Pause flag must be 0 or 1"
+    setStorage corporateActionPausedSlot paused
+
+  function updateMultiplierEpoch (newEpoch : Uint256) : Unit := do
+    setStorage multiplierEpochSlot newEpoch
+
+  function syncFromBalanceOf (adjustedBalanceOfVault : Uint256) : Unit := do
+    setStorage totalAssetsSlot adjustedBalanceOfVault
+
+  function deposit (assets : Uint256, quoteEpoch : Uint256) : Unit := do
+    let paused ← getStorage corporateActionPausedSlot
+    require (paused == 0) "Corporate action window"
+    let currentEpoch ← getStorage multiplierEpochSlot
+    require (quoteEpoch == currentEpoch) "Stale multiplier epoch"
+    let sender ← msgSender
+    let currentShares ← getMapping shareBalancesSlot sender
+    let newShares ← requireSomeUint (safeAdd currentShares assets) "Share balance overflow"
+    let currentAssets ← getStorage totalAssetsSlot
+    let newAssets ← requireSomeUint (safeAdd currentAssets assets) "Total assets overflow"
+    let currentSupply ← getStorage totalSupplySlot
+    let newSupply ← requireSomeUint (safeAdd currentSupply assets) "Total supply overflow"
+    setMapping shareBalancesSlot sender newShares
+    setStorage totalAssetsSlot newAssets
+    setStorage totalSupplySlot newSupply
+
+  function withdraw (shares : Uint256, quoteEpoch : Uint256) : Unit := do
+    let paused ← getStorage corporateActionPausedSlot
+    require (paused == 0) "Corporate action window"
+    let currentEpoch ← getStorage multiplierEpochSlot
+    require (quoteEpoch == currentEpoch) "Stale multiplier epoch"
+    let sender ← msgSender
+    let currentShares ← getMapping shareBalancesSlot sender
+    require (currentShares >= shares) "Insufficient shares"
+    let currentAssets ← getStorage totalAssetsSlot
+    require (currentAssets >= shares) "Insufficient assets"
+    let currentSupply ← getStorage totalSupplySlot
+    require (currentSupply >= shares) "Insufficient supply"
+    setMapping shareBalancesSlot sender (sub currentShares shares)
+    setStorage totalAssetsSlot (sub currentAssets shares)
+    setStorage totalSupplySlot (sub currentSupply shares)
+
+  function balanceOf (addr : Address) : Uint256 := do
+    let currentShares ← getMapping shareBalancesSlot addr
+    return currentShares
+
+  function totalAssets () : Uint256 := do
+    let currentAssets ← getStorage totalAssetsSlot
+    return currentAssets
+
+  function totalSupply () : Uint256 := do
+    let currentSupply ← getStorage totalSupplySlot
+    return currentSupply
+
+  function multiplierEpoch () : Uint256 := do
+    let currentEpoch ← getStorage multiplierEpochSlot
+    return currentEpoch
+
+namespace XStockVault
+
+abbrev getTotalAssets : Contract Uint256 := totalAssets
+abbrev getTotalSupply : Contract Uint256 := totalSupply
+
+end XStockVault
+
+end Contracts

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -29,6 +29,9 @@ import Contracts.SimpleToken.Proofs.Correctness
 import Contracts.SimpleToken.Proofs.Isolation
 import Contracts.SimpleToken.Proofs.Supply
 import Contracts.Vault.Proofs.Native
+import Contracts.XStockVault.Proofs.Basic
+import Contracts.XStockVault.Proofs.Correctness
+import Contracts.XStockVault.Proofs.XStocks
 import Verity.Proofs.Stdlib.Automation
 import Verity.Proofs.Stdlib.ListSum
 import Verity.Proofs.Stdlib.MappingAutomation
@@ -544,6 +547,25 @@ end Verity.AxiomAudit
   Contracts.Vault.Proofs.Native.vaultMinimal_functions_bridged
   Contracts.Vault.Proofs.Native.vaultMinimal_runtime_lowers_native
   Contracts.Vault.Proofs.Native.vaultMinimal_totalAssets_nativeResultsMatchOn_revert_of_nonzero_value
+
+  -- Contracts/XStockVault/Proofs/Basic.lean
+  Contracts.XStockVault.Proofs.Basic.totalAssets_spec_reads_slot_one
+  Contracts.XStockVault.Proofs.Basic.totalSupply_spec_reads_slot_two
+  Contracts.XStockVault.Proofs.Basic.multiplierEpoch_spec_reads_slot_four
+
+  -- Contracts/XStockVault/Proofs/Correctness.lean
+  Contracts.XStockVault.Proofs.Correctness.syncFromBalanceOf_sets_assets_to_adjusted_balance
+  Contracts.XStockVault.Proofs.Correctness.syncFromBalanceOf_preserves_unrelated_storage
+  Contracts.XStockVault.Proofs.Correctness.stale_epoch_deposit_spec_impossible
+  Contracts.XStockVault.Proofs.Correctness.deposit_spec_preserves_multiplier_epoch
+  Contracts.XStockVault.Proofs.Correctness.deposit_spec_preserves_pause_flag
+  Contracts.XStockVault.Proofs.Correctness.withdraw_spec_preserves_multiplier_epoch
+  Contracts.XStockVault.Proofs.Correctness.withdraw_spec_preserves_pause_flag
+
+  -- Contracts/XStockVault/Proofs/XStocks.lean
+  Contracts.XStockVault.Proofs.XStocks.sync_uses_evm_adjusted_balance_exactly_once
+  Contracts.XStockVault.Proofs.XStocks.corporate_action_preserves_fraction_and_scales_claim
+  Contracts.XStockVault.Proofs.XStocks.stale_multiplier_epoch_cannot_settle_deposit
 
   -- Verity/Proofs/Stdlib/Automation.lean
   Verity.Proofs.Stdlib.Automation.isSuccess_success
@@ -3943,6 +3965,11 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.compileStmtList_internalCall_bridged
   Compiler.Proofs.YulGeneration.Backends.compileStmt_externalCallBind_bridged
   Compiler.Proofs.YulGeneration.Backends.compileStmtList_externalCallBind_bridged
+  -- Compiler.Proofs.YulGeneration.Backends.compileStmtList_noFuncDefs_of_perStmtBridge  -- private
+  Compiler.Proofs.YulGeneration.Backends.compileStmt_internalCall_noFuncDefs
+  Compiler.Proofs.YulGeneration.Backends.compileStmtList_internalCall_noFuncDefs
+  Compiler.Proofs.YulGeneration.Backends.compileStmt_externalCallBind_noFuncDefs
+  Compiler.Proofs.YulGeneration.Backends.compileStmtList_externalCallBind_noFuncDefs
   Compiler.Proofs.YulGeneration.Backends.compileStmt_ecm_bridged
   Compiler.Proofs.YulGeneration.Backends.compileStmtList_ecm_bridged
   Compiler.Proofs.YulGeneration.Backends.compileStmtList_append_ok_inv
@@ -5457,4 +5484,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5162 theorems/lemmas (3583 public, 1579 private, 0 sorry'd)
+-- Total: 5180 theorems/lemmas (3600 public, 1580 private, 0 sorry'd)

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@
 <!-- BEGIN GENERATED STATS -->
 | Metric | Value |
 |--------|-------|
-| Theorems | 283 (283 proven, 0 sorry) |
+| Theorems | 296 (296 proven, 0 sorry) |
 | Axioms | 0 |
-| Foundry tests | 522 (239 property) |
-| Verified contracts | 12 |
+| Foundry tests | 534 (245 property) |
+| Verified contracts | 13 |
 | Core EDSL | 649 lines |
 | Lean | 4.22.0 |
 <!-- END GENERATED STATS -->

--- a/Verity.lean
+++ b/Verity.lean
@@ -13,5 +13,6 @@ import Verity.EVM.Uint256
 import Verity.Stdlib.Math
 import Verity.Specs.Common
 import Verity.Specs.Common.Sum
+import Verity.Specs.Ink.XStocks
 import Verity.Proofs.Stdlib.Math
 import Verity.Proofs.Stdlib.ListSum

--- a/Verity/Specs/Ink.lean
+++ b/Verity/Specs/Ink.lean
@@ -1,0 +1,1 @@
+import Verity.Specs.Ink.XStocks

--- a/Verity/Specs/Ink/XStocks.lean
+++ b/Verity/Specs/Ink/XStocks.lean
@@ -1,0 +1,60 @@
+import Mathlib.Data.Rat.Lemmas
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Linarith
+import Verity.Specs.Common
+
+/-!
+Reusable assumptions for contracts integrating xStocks on Ink/EVM chains.
+
+This module models the integration boundary only. It does not prove the
+xStocks issuer, custody, backing, oracle, bridge, or token implementation.
+-/
+
+namespace Verity.Specs.Ink.XStocks
+
+open Verity
+
+abbrev MultiplierEpoch := Nat
+
+structure XStockSnapshot where
+  rawVaultBalance : Rat
+  multiplier : Rat
+  evmBalanceOfVault : Rat
+
+def evmAdjustedBalance (x : XStockSnapshot) : Rat :=
+  x.rawVaultBalance * x.multiplier
+
+def evmBalanceOfIncludesMultiplier (x : XStockSnapshot) : Prop :=
+  x.evmBalanceOfVault = evmAdjustedBalance x
+
+def usesEvmBalanceExactlyOnce (assetAmount : Rat) (x : XStockSnapshot) : Prop :=
+  assetAmount = x.evmBalanceOfVault
+
+def doesNotApplyMultiplierAgain (assetAmount : Rat) (x : XStockSnapshot) : Prop :=
+  assetAmount ≠ x.evmBalanceOfVault * x.multiplier
+
+theorem direct_balance_use_uses_evm_balance_exactly_once
+    (x : XStockSnapshot) :
+    usesEvmBalanceExactlyOnce x.evmBalanceOfVault x := by
+  rfl
+
+theorem direct_balance_use_does_not_double_apply_multiplier
+    (x : XStockSnapshot)
+    (hBalancePositive : x.evmBalanceOfVault ≠ 0)
+    (hMultiplierNotOne : x.multiplier ≠ 1) :
+    doesNotApplyMultiplierAgain x.evmBalanceOfVault x := by
+  intro h
+  have hmul : x.evmBalanceOfVault * x.multiplier = x.evmBalanceOfVault := h.symm
+  have hfactor : x.evmBalanceOfVault * (x.multiplier - 1) = 0 := by
+    calc
+      x.evmBalanceOfVault * (x.multiplier - 1)
+          = x.evmBalanceOfVault * x.multiplier - x.evmBalanceOfVault := by ring
+      _ = 0 := by rw [hmul]; ring
+  have hzero_or := mul_eq_zero.mp hfactor
+  cases hzero_or with
+  | inl hbal => exact hBalancePositive hbal
+  | inr hdiff =>
+      apply hMultiplierNotOne
+      linarith
+
+end Verity.Specs.Ink.XStocks

--- a/artifacts/macro_property_tests/PropertyXStockVault.t.sol
+++ b/artifacts/macro_property_tests/PropertyXStockVault.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyXStockVaultTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/XStockVault/XStockVault.lean
+ */
+contract PropertyXStockVaultTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYulWithArgs("XStockVault", abi.encode(alice));
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: setCorporateActionPaused has no unexpected revert
+    function testAuto_SetCorporateActionPaused_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("setCorporateActionPaused(uint256)", uint256(1)));
+        require(ok, "setCorporateActionPaused reverted unexpectedly");
+    }
+    // Property 2: updateMultiplierEpoch has no unexpected revert
+    function testAuto_UpdateMultiplierEpoch_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("updateMultiplierEpoch(uint256)", uint256(1)));
+        require(ok, "updateMultiplierEpoch reverted unexpectedly");
+    }
+    // Property 3: syncFromBalanceOf has no unexpected revert
+    function testAuto_SyncFromBalanceOf_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("syncFromBalanceOf(uint256)", uint256(1)));
+        require(ok, "syncFromBalanceOf reverted unexpectedly");
+    }
+    // Property 4: deposit has no unexpected revert
+    function testAuto_Deposit_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("deposit(uint256,uint256)", uint256(1), uint256(1)));
+        require(ok, "deposit reverted unexpectedly");
+    }
+    // Property 5: withdraw has no unexpected revert
+    function testAuto_Withdraw_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("withdraw(uint256,uint256)", uint256(1), uint256(1)));
+        require(ok, "withdraw reverted unexpectedly");
+    }
+    // Property 6: balanceOf reads the configured mapping value
+    function testAuto_BalanceOf_ReadsConfiguredMapping() public {
+        uint256 expected = uint256(1);
+        vm.store(target, _mappingSlot(bytes32(uint256(uint160(alice))), 3), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("balanceOf(address)", alice));
+        require(ok, "balanceOf reverted unexpectedly");
+        assertEq(ret.length, 32, "balanceOf ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "balanceOf should decode the configured mapping value");
+    }
+    // Property 7: totalAssets reads storage slot 1 and decodes the result
+    function testAuto_TotalAssets_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(1)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("totalAssets()"));
+        require(ok, "totalAssets reverted unexpectedly");
+        assertEq(ret.length, 32, "totalAssets ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "totalAssets should return storage slot 1");
+    }
+    // Property 8: totalSupply reads storage slot 2 and decodes the result
+    function testAuto_TotalSupply_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(2)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("totalSupply()"));
+        require(ok, "totalSupply reverted unexpectedly");
+        assertEq(ret.length, 32, "totalSupply ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "totalSupply should return storage slot 2");
+    }
+    // Property 9: multiplierEpoch reads storage slot 4 and decodes the result
+    function testAuto_MultiplierEpoch_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(4)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("multiplierEpoch()"));
+        require(ok, "multiplierEpoch reverted unexpectedly");
+        assertEq(ret.length, 32, "multiplierEpoch ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "multiplierEpoch should return storage slot 4");
+    }
+}

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,7 +1,7 @@
 {
   "codebase": {
     "core_lines": 649,
-    "example_contracts": 14
+    "example_contracts": 15
   },
   "proofs": {
     "axioms": 0,
@@ -10,16 +10,16 @@
   "schema_version": 1,
   "tests": {
     "differential_total": 110000,
-    "foundry_functions": 522,
-    "property_functions": 239,
-    "suites": 50
+    "foundry_functions": 534,
+    "property_functions": 245,
+    "suites": 52
   },
   "theorems": {
-    "categories": 12,
-    "coverage_percent": 90,
-    "covered": 255,
+    "categories": 13,
+    "coverage_percent": 91,
+    "covered": 268,
     "excluded": 28,
-    "non_stdlib_total": 283,
+    "non_stdlib_total": 296,
     "per_contract": {
       "Counter": 28,
       "ERC20": 22,
@@ -32,11 +32,12 @@
       "SafeCounter": 25,
       "SimpleStorage": 20,
       "SimpleToken": 61,
-      "Vault": 3
+      "Vault": 3,
+      "XStockVault": 13
     },
-    "proven": 283,
+    "proven": 296,
     "stdlib": 0,
-    "total": 283
+    "total": 296
   },
   "toolchain": {
     "lean": "leanprover/lean4:v4.22.0",

--- a/docs-site/content/examples.mdx
+++ b/docs-site/content/examples.mdx
@@ -206,6 +206,12 @@ verity_contract Vault where
 
 The spec layer (`deposit_spec`, `withdraw_spec`, isolation predicates) lives in `Contracts/Vault/Spec.lean`. Native IR-lowering proofs are checked in [`Contracts/Vault/Proofs/Native.lean`](https://github.com/lfglabs-dev/verity/blob/main/Contracts/Vault/Proofs/Native.lean); deeper Basic/Correctness/Conservation coverage is tracked under issue [#1163](https://github.com/lfglabs-dev/verity/issues/1163).
 
+## XStockVault
+
+Ink xStocks integration POC showing reusable specs for vault accounting around EVM xStocks. The example is an accounting skeleton, not a production custody contract: token transfers, access control, and oracle authorization remain integration boundaries. The key distinction from ordinary ERC-20 vaults is that xStock `balanceOf()` on Ink/EVM is already multiplier-adjusted for dividends, splits, and reverse splits.
+
+Source: [`Verity/Specs/Ink/XStocks.lean`](https://github.com/lfglabs-dev/verity/blob/main/Verity/Specs/Ink/XStocks.lean), [`Contracts/XStockVault/Proofs/XStocks.lean`](https://github.com/lfglabs-dev/verity/blob/main/Contracts/XStockVault/Proofs/XStocks.lean), [`docs/ink-xstocks-spec-poc.md`](https://github.com/lfglabs-dev/verity/blob/main/docs/ink-xstocks-spec-poc.md), [`docs/ink-xstocks-research.md`](https://github.com/lfglabs-dev/verity/blob/main/docs/ink-xstocks-research.md).
+
 ## ReentrancyExample
 
 Two parallel bank contracts, one vulnerable, one safe, demonstrating that reentrancy is a *provable* property, not just a testing concern.

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -21,10 +21,10 @@ Every transition inside the proof envelope is either fully verified or recorded 
 <!-- BEGIN GENERATED QUICK FACTS -->
 - **Language**: Lean 4.22.0
 - **Core Size**: 649 lines
-- **Verified Contracts**: 12 (Counter, ERC20, ERC721, Ledger, LocalObligationMacroSmoke, Owned, OwnedCounter, ReentrancyExample, SafeCounter, SimpleStorage, SimpleToken, Vault)
-- **Theorems**: 283 across 12 categories, 283 fully proven
+- **Verified Contracts**: 13 (Counter, ERC20, ERC721, Ledger, LocalObligationMacroSmoke, Owned, OwnedCounter, ReentrancyExample, SafeCounter, SimpleStorage, SimpleToken, Vault, XStockVault)
+- **Theorems**: 296 across 13 categories, 296 fully proven
 - **Axioms**: 0 documented Lean axioms (see AXIOMS.md)
-- **Tests**: 522 Foundry tests, 239 property tests
+- **Tests**: 534 Foundry tests, 245 property tests
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/lfglabs-dev/verity
 <!-- END GENERATED QUICK FACTS -->

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -37,11 +37,12 @@ EVM Bytecode
 | ERC20 | 22 | Baseline | `Contracts/ERC20/Proofs/` |
 | ERC721 | 11 | Baseline | `Contracts/ERC721/Proofs/` |
 | Vault | 3 | Baseline | `Contracts/Vault/Proofs/` |
+| XStockVault | 13 | Baseline | `Contracts/XStockVault/Proofs/` |
 | ReentrancyExample | 5 | Complete | `Contracts/ReentrancyExample/Contract.lean` |
 | CryptoHash | 0 | No specs | `Contracts/CryptoHash/Contract.lean` |
-| **Total** | **283** | **✅ 100%** | — |
+| **Total** | **296** | **✅ 100%** | — |
 
-> **Note**: Stdlib (0 internal proof-automation properties) is excluded from the contract-spec theorem table above but included in overall coverage statistics (283 total properties).
+> **Note**: Stdlib (0 internal proof-automation properties) is excluded from the contract-spec theorem table above but included in overall coverage statistics (296 total properties).
 
 Layer 1 uses macro-generated EDSL-to-`CompilationModel` bridge theorems backed by a generic typed-IR compilation-correctness theorem ([`TypedIRCompilerCorrectness.lean`](../Compiler/TypedIRCompilerCorrectness.lean)). Tuple/bytes/fixed-array/dynamic-array/string parameters now stay inside that proof path when they are carried as ABI head words/offsets. Advanced constructs beyond that typed-IR head-word surface (linked libraries, ECMs, fully custom ABI behavior) are still expressed directly in `CompilationModel` and trusted at that boundary.
 
@@ -196,6 +197,7 @@ Also note that the macro-generated `*_semantic_preservation` theorems are not co
 
 | Contract | Coverage | Exclusions |
 |----------|----------|------------|
+| XStockVault | 100% (13/13) | 0 |
 | ERC20 | 86% (19/22) | 3 proof-only |
 | Vault | 0% (0/3) | 3 proof-only |
 | ERC721 | 100% (11/11) | 0 |
@@ -210,10 +212,10 @@ Also note that the macro-generated `*_semantic_preservation` theorems are not co
 | Counter | 82% (23/28) | 5 proof-only |
 | Stdlib | 0% (0/0) | 0 proof-only |
 
-**Status**: 90% coverage (255/283), 28 remaining exclusions all proof-only
+**Status**: 91% coverage (268/296), 28 remaining exclusions all proof-only
 
-- **Total Properties**: 283
-- **Covered**: 255
+- **Total Properties**: 296
+- **Covered**: 268
 - **Excluded**: 28 (all proof-only)
 
 **Proof-Only Properties (28 exclusions)**: Internal proof machinery that cannot be tested in Foundry.

--- a/docs/ink-xstocks-pr.md
+++ b/docs/ink-xstocks-pr.md
@@ -1,0 +1,50 @@
+# POC: Ink xStocks reusable specs for Verity
+
+## Summary
+
+This draft branch adds a small Ink xStocks proof-of-concept to Verity. The goal is to show how Ink builders can verify their own contracts that integrate xStocks without claiming to verify the xStocks protocol itself.
+
+## What The POC Proves
+
+- EVM xStock `balanceOf()` is used exactly once by the vault sync model. The value-level inequality proof assumes a nonzero adjusted balance and a multiplier different from `1`.
+- The economic corporate-action model scales user claims while preserving vault share fractions.
+- Stale multiplier epochs cannot settle deposit quotes in the model.
+
+## What It Does Not Prove
+
+- xStocks backing, custody, legal structure, proof of reserves, or issuer behavior.
+- xStocks core contract correctness.
+- Market prices, oracle behavior, or bridge correctness.
+- Token custody, transfer success, production access control, or oracle authorization.
+- A full implementation-level theorem connecting the contract's epoch-update and balance-sync functions into one corporate-action transition.
+- Tydro or Nado core protocol behavior.
+
+## New Surfaces
+
+- Reusable model: `Verity/Specs/Ink/XStocks.lean`
+- Example contract: `Contracts/XStockVault/XStockVault.lean`
+- Headline proofs: `Contracts/XStockVault/Proofs/XStocks.lean`
+- Research notes: `docs/ink-xstocks-research.md`
+- Builder-facing docs: `docs/ink-xstocks-spec-poc.md`
+
+## Verification
+
+- [x] `lake build`
+- [x] `make check`
+- [x] `python3 scripts/check_contract_structure.py`
+- [x] `python3 scripts/check_storage_layout.py`
+- [x] `python3 scripts/check_paths.py`
+- [x] `python3 scripts/check_lean_hygiene.py`
+- [x] `python3 scripts/check_property_manifest.py`
+- [x] `python3 scripts/check_property_coverage.py`
+
+## Review Follow-Up
+
+- Implemented the review-blocking coverage/status sync issue from `docs/ink-xstocks-review-filtered.md`.
+- Added property coverage for all 13 XStockVault theorem names and regenerated the verification status artifact/docs.
+- Kept the broader implementation-level and production-hardening findings documented as deferred POC follow-ups.
+
+## Follow-Up Modules
+
+- Tydro: lending adapter specs for supply, borrow, repay, withdraw, collateral, and health assumptions.
+- Nado: strategy/vault specs around settlement, PnL, fees, funding, and margin risk.

--- a/docs/ink-xstocks-research.md
+++ b/docs/ink-xstocks-research.md
@@ -1,0 +1,58 @@
+# Ink xStocks Research Notes
+
+Prepared: 2026-05-23
+
+These notes support the `XStockVault` Verity POC. The POC does not verify xStocks itself. It records the assumptions an Ink builder can use when proving their own vault, collateral adapter, wrapper, or strategy.
+
+## Sources Checked
+
+- xStocks docs introduction: https://docs.xstocks.fi/docs
+- xStocks dividends and stock splits: https://docs.xstocks.fi/overview/dividends-and-stock-splits
+- xStocks API reference: https://docs.xstocks.fi/apis/openapi
+- Kraken xStocks FAQ: https://support.kraken.com/articles/xstocks-faq
+- xStocks website: https://xstocks.fi/
+- Ink explorer token page checked for TSLAx: https://explorer.inkonchain.com/token/0x8ad3c73f833d3f9a523ab01476625f269aeb7cf0
+
+## Facts
+
+- xStocks are tokenized representations of publicly traded equities and ETFs.
+- xStocks documentation describes each token as 1:1 collateralized by the corresponding underlying equity or ETF.
+- xStocks are available on Ethereum, Solana, Mantle, TON, Ink, and other EVM-compatible networks.
+- The product is intended to be DeFi-composable: collateral, lending markets, liquidity pools, and structured products are named integration surfaces.
+- Corporate actions such as dividends, stock splits, and reverse splits are reflected through an onchain rebasing mechanism called the multiplier.
+- The multiplier tracks cumulative corporate-action effects over the token's life.
+- On EVM chains, including Ink as an EVM-compatible chain, the docs say the smart contract adjusts balances automatically and `balanceOf()` returns the current equity-adjusted balance.
+- Multiplier updates are published onchain before corporate events take effect. Activation is set for midnight UTC on the payable date, and protocols are advised to pause interactions briefly around activation.
+- Kraken's FAQ says dividends are not paid as cash. Their economic benefit is reflected by a rebasing or multiplier mechanism.
+- The public xStocks API exposes asset metadata, contract addresses, current multiplier values, and multiplier history. A TSLAx API lookup returned the Ink deployment `0x8ad3c73f833d3f9a523ab01476625f269aeb7cf0`.
+
+## Assumptions
+
+- The POC treats Ink as an EVM integration for the purpose of `balanceOf()` behavior.
+- The POC assumes the xStock token contract's `balanceOf(vault)` result is already adjusted for the current multiplier.
+- The POC assumes a corporate-action epoch changes whenever a multiplier update becomes relevant to vault quotes or settlement.
+- The POC assumes transfer success or failure is handled by a surrounding integration layer. It does not prove token transfer internals.
+- The POC does not prove source verification status for Ink xStock contracts. The API confirms deployment metadata; if a production proof needs bytecode-level assumptions, the next step is to compare Ink bytecode and ABI against verified EVM deployments.
+
+## Integration Hazards
+
+- Treating EVM `balanceOf()` as a raw token amount and multiplying it by the xStocks multiplier again.
+- Double-counting a dividend, split, or reverse split in cached accounting.
+- Minting shares from an old quote after a multiplier epoch has changed.
+- Settling deposits or withdrawals during the recommended pause window around a multiplier activation timestamp.
+- Using stale reference prices or stale multiplier values in collateral valuation.
+- Mixing xStock amounts, USD values, decimals, and vault shares without explicit conversion boundaries.
+- Letting a collateral adapter borrow against inflated or stale xStock values.
+- Reminting or burning vault shares during corporate actions in a way that transfers value between users.
+
+## Why The Three POC Invariants Are xStocks-Specific
+
+1. EVM `balanceOf()` must be used exactly once because xStocks hide corporate-action adjustment inside the standard ERC-20 balance surface on EVM chains.
+2. Corporate-action multiplier updates should scale each user's claim without changing share fractions. Normal ERC-20 vaults do not have automatic equity rebases from dividends, splits, or reverse splits.
+3. Deposit and withdrawal quotes must be invalidated across multiplier epochs because xStocks publish scheduled corporate-action state changes that can alter adjusted balances between quote and settlement.
+
+## Open Follow-Up
+
+- Confirm whether each Ink xStock token has verified source in Blockscout and record ABI, proxy, and implementation details.
+- Compare TSLAx, AAPLx, NVDAx, and SPYx deployment metadata from the public API.
+- Decide whether a future production kit should model transfer restrictions or paused token states.

--- a/docs/ink-xstocks-review-filtered.md
+++ b/docs/ink-xstocks-review-filtered.md
@@ -1,0 +1,151 @@
+# Ink xStocks Review Filtered Findings
+
+Source review report: `docs/ink-xstocks-review-problems.md`.
+
+This is the filtered triage of the GPT-5.5 high-thinking review. Items marked
+implemented were fixed in this worktree. Items marked deferred are real
+follow-up candidates, but are not blockers for the current proof-of-concept as
+long as the docs keep the POC scope explicit.
+
+## Implemented
+
+### Coverage/status metadata was stale
+
+Decision: implement.
+
+The reviewer was correct at the time of review: five XStockVault theorem names
+were missing from `test/property_manifest.json`, the matching property coverage
+tags/tests were incomplete, and the generated verification status files were
+stale.
+
+Fix:
+
+- Regenerated `test/property_manifest.json`; XStockVault now tracks all 13
+  theorem names.
+- Added property coverage in `test/PropertyXStockVault.t.sol` for:
+  `syncFromBalanceOf_preserves_unrelated_storage`,
+  `deposit_spec_preserves_multiplier_epoch`,
+  `deposit_spec_preserves_pause_flag`,
+  `withdraw_spec_preserves_multiplier_epoch`, and
+  `withdraw_spec_preserves_pause_flag`.
+- Regenerated/synced `artifacts/verification_status.json`,
+  `docs/VERIFICATION_STATUS.md`, `README.md`, `docs-site/public/llms.txt`, and
+  `PrintAxioms.lean`.
+
+Verification: `make check` now passes end to end.
+
+## Deferred
+
+### Direct implementation-level deposit/withdraw correctness proofs
+
+Decision: defer.
+
+This is a valid limitation. The current proofs include specs and spec-level
+lemmas, but do not yet prove the executable `deposit` and `withdraw` bodies
+satisfy those specs across success and guarded revert paths.
+
+Why not implement now: this expands the POC from xStocks integration-model
+proofs into full function-body correctness for the example vault. That is
+worth doing before calling XStockVault a complete verified contract, but it is
+not required for the current documented POC boundary.
+
+Recommended next action: add direct success theorems plus paused, stale epoch,
+insufficient balance/assets/supply, and overflow-revert theorems before
+promoting XStockVault beyond "baseline/model POC".
+
+### Corporate-action claim scaling vs executable 1:1 withdraw accounting
+
+Decision: defer, with scope caveat retained.
+
+The reviewer is correct that the Rat-level theorem
+`corporate_action_preserves_fraction_and_scales_claim` is an economic model
+lemma. It is not a theorem about the current executable `withdraw`, which burns
+shares 1:1 against `totalAssets`.
+
+Why not implement now: changing executable withdraw to proportional accounting
+would materially change the example contract and require a wider correctness
+surface. The current docs already state that this is an economic model lemma
+and that a full implementation-level corporate-action transition theorem is
+not proved.
+
+Recommended next action: if this should become a production-style vault
+reference, replace 1:1 withdrawal with proportional redemption after
+corporate-action sync and prove the implementation-level transition.
+
+### Corporate-action property-test coverage is weaker than the Lean theorem
+
+Decision: defer.
+
+The reviewer is correct that the Solidity property mapped to
+`corporate_action_preserves_fraction_and_scales_claim` checks only that epoch
+updates do not remint shares. It does not test Rat-level claim scaling.
+
+Why not implement now: the theorem is a pure economic model lemma over `Rat`,
+while the Solidity harness exercises the skeleton contract. A faithful runtime
+test would need a dedicated model harness or the proportional accounting change
+described above.
+
+Recommended next action: either add a dedicated model/harness test for claim
+scaling, or classify that theorem as model-only/proof-only if the coverage
+policy should require runtime tests to match theorem semantics exactly.
+
+### Overflow behavior in deposit success specs/tests
+
+Decision: defer with the direct correctness proof work.
+
+The implementation uses `safeAdd`, while `deposit_spec` describes successful
+post-state arithmetic with `add`. The current Solidity properties use
+`uint128`, so they do not exercise full `Uint256` overflow boundaries.
+
+Why not implement now: the right fix is to split deposit correctness into
+non-overflow success preconditions and explicit overflow-revert cases. That
+belongs with the direct implementation-level deposit proof work.
+
+Recommended next action: add non-overflow preconditions and overflow-revert
+specs/tests for share balance, total assets, and total supply additions.
+
+### Generated guarded-function macro artifact
+
+Decision: defer.
+
+The reviewer is correct that
+`artifacts/macro_property_tests/PropertyXStockVault.t.sol` contains generated
+no-revert checks that are not valid for guarded calls without setup.
+
+Why not implement now: this is a generator limitation, not a defect in the
+manual XStockVault proof model. `make check` still passes because the macro
+artifact health check treats the artifact as generated output, not the manual
+semantic property suite.
+
+Recommended next action: update the generator to skip unconditional no-revert
+checks for guarded functions, or teach it to generate valid setup and arguments.
+
+### Permissionless admin/oracle-like functions
+
+Decision: defer as intentional POC scope.
+
+The reviewer is correct that `setCorporateActionPaused`,
+`updateMultiplierEpoch`, and `syncFromBalanceOf` are unsafe if copied into a
+deployable contract as-is. The current Lean and Solidity files document this as
+an accounting skeleton where access control and oracle authorization are outside
+scope.
+
+Recommended next action: add owner/oracle authorization only if this example is
+intended to become a deployable builder reference rather than a proof POC.
+
+## Verification
+
+Passed locally:
+
+- `lake build`
+- `lake build Contracts.XStockVault Verity.Specs.Ink`
+- `make check`
+- `python3 scripts/check_property_manifest.py`
+- `python3 scripts/check_property_coverage.py`
+- `python3 scripts/check_property_manifest_sync.py`
+- `python3 scripts/check_verification_status_doc.py`
+- `python3 scripts/update_doc_numbers.py --check`
+
+Not run:
+
+- Foundry tests. `forge` is not installed in this environment.

--- a/docs/ink-xstocks-review-problems.md
+++ b/docs/ink-xstocks-review-problems.md
@@ -1,0 +1,141 @@
+# Ink xStocks / XStockVault Review Problems
+
+Review scope: current worktree for `Verity.Specs.Ink`, `Contracts.XStockVault`, Solidity examples/tests, property manifests/artifacts, README/docs-site presentation, and touched build/test scripts.
+
+## Problems
+
+### Critical: coverage/status metadata is out of sync with the current theorem set
+
+Evidence:
+
+- `Contracts/XStockVault/Proofs/Correctness.lean:15`
+- `Contracts/XStockVault/Proofs/Correctness.lean:32`
+- `Contracts/XStockVault/Proofs/Correctness.lean:40`
+- `Contracts/XStockVault/Proofs/Correctness.lean:48`
+- `Contracts/XStockVault/Proofs/Correctness.lean:56`
+- `test/property_manifest.json:309`
+- `docs/VERIFICATION_STATUS.md:200`
+- `artifacts/verification_status.json:36`
+
+`check_property_coverage.py` fails because five XStockVault theorems are present in Lean but absent from `test/property_manifest.json`: `syncFromBalanceOf_preserves_unrelated_storage`, `deposit_spec_preserves_multiplier_epoch`, `deposit_spec_preserves_pause_flag`, `withdraw_spec_preserves_multiplier_epoch`, and `withdraw_spec_preserves_pause_flag`. The docs/artifact still report XStockVault as `100% (8/8)`, which is stale for the current worktree.
+
+Recommended action: regenerate/sync the property manifest and verification artifacts, then add real property tests for the five theorems or mark them as proof-only exclusions if they cannot be tested meaningfully.
+
+### Major: deposit and withdraw are specified, but not proved against the implementation
+
+Evidence:
+
+- `Contracts/XStockVault/XStockVault.lean:43`
+- `Contracts/XStockVault/XStockVault.lean:59`
+- `Contracts/XStockVault/Spec.lean:31`
+- `Contracts/XStockVault/Spec.lean:40`
+- `Contracts/XStockVault/Proofs/Correctness.lean:24`
+- `docs/VERIFICATION_STATUS.md:40`
+- `README.md:30`
+
+The core state-changing functions have specs, but the current correctness proofs are facts about those spec predicates after assuming they already hold. There is no implementation-level theorem that the `deposit` or `withdraw` function body satisfies the success spec, nor the paused/stale/insufficient/overflow failure cases.
+
+Recommended action: add direct function-body correctness theorems for successful `deposit` and `withdraw`, plus revert theorems for guarded paths. Until then, keep docs/status language at "baseline/model lemmas" rather than implying complete vault behavior is verified.
+
+### Major: the corporate-action claim model does not match the executable withdraw accounting
+
+Evidence:
+
+- `Contracts/XStockVault/Spec.lean:86`
+- `Contracts/XStockVault/Spec.lean:89`
+- `Contracts/XStockVault/Proofs/XStocks.lean:21`
+- `Contracts/XStockVault/XStockVault.lean:67`
+- `Contracts/XStockVault/XStockVault.lean:71`
+- `docs/ink-xstocks-spec-poc.md:35`
+
+The pure model proves user claims scale with `totalAssets / totalShares`, but the executable `withdraw` burns `shares` and subtracts the same `shares` amount from `totalAssets`. After `syncFromBalanceOf` changes assets while supply stays fixed, that 1:1 withdrawal rule is no longer proportional to the modeled claim.
+
+Recommended action: either change the executable/spec withdrawal model to use proportional assets after corporate actions, or narrow the corporate-action theorem/docs so it is clearly not a property of the current executable vault accounting.
+
+### Major: the property test mapped to the corporate-action theorem does not test claim scaling
+
+Evidence:
+
+- `test/property_manifest.json:310`
+- `test/PropertyXStockVault.t.sol:47`
+- `test/PropertyXStockVault.t.sol:54`
+- `Contracts/XStockVault/Proofs/XStocks.lean:21`
+
+`corporate_action_preserves_fraction_and_scales_claim` is counted as covered, but the Solidity property only calls `updateMultiplierEpoch` and checks that shares/supply did not change. It never changes `totalAssets`, checks a multiplier ratio, or verifies a user claim.
+
+Recommended action: replace this with a test/harness that exercises the economic model being claimed, or remove the theorem from property-test coverage and classify it as proof-only/model-only.
+
+### Major: overflow behavior is not represented in the success spec or property tests
+
+Evidence:
+
+- `Contracts/XStockVault/XStockVault.lean:50`
+- `Contracts/XStockVault/XStockVault.lean:52`
+- `Contracts/XStockVault/XStockVault.lean:54`
+- `Contracts/XStockVault/Spec.lean:34`
+- `Contracts/XStockVault/Spec.lean:35`
+- `Contracts/XStockVault/Spec.lean:36`
+- `test/PropertyXStockVault.t.sol:24`
+- `test/XStockVault.t.sol:48`
+
+The implementation uses `safeAdd` and reverts on overflow, while `deposit_spec` states modular `add` postconditions without non-overflow preconditions. The Solidity tests use `uint128`, so they avoid the `Uint256` overflow boundary.
+
+Recommended action: split deposit correctness into non-overflow success preconditions and explicit overflow-revert cases for share balance, total assets, and total supply.
+
+### Minor: generated macro property artifact contains impossible no-revert checks
+
+Evidence:
+
+- `artifacts/macro_property_tests/PropertyXStockVault.t.sol:38`
+- `artifacts/macro_property_tests/PropertyXStockVault.t.sol:44`
+- `Contracts/XStockVault/XStockVault.lean:43`
+- `Contracts/XStockVault/XStockVault.lean:59`
+
+The generated artifact asserts that `deposit(1, 1)` and `withdraw(1, 1)` should not unexpectedly revert. The constructor leaves `multiplierEpoch = 0`, so both calls hit the stale-epoch guard; `withdraw` also lacks shares.
+
+Recommended action: teach the generator to skip unconditional no-revert checks for guarded functions, or generate valid setup/arguments for guarded functions.
+
+### Minor: permissionless admin/oracle-like functions remain unsafe if copied as a reference
+
+Evidence:
+
+- `examples/solidity/XStockVault.sol:28`
+- `examples/solidity/XStockVault.sol:35`
+- `examples/solidity/XStockVault.sol:39`
+- `Contracts/XStockVault/XStockVault.lean:33`
+- `Contracts/XStockVault/XStockVault.lean:37`
+- `Contracts/XStockVault/XStockVault.lean:40`
+
+The docs say access control and oracle authorization are out of scope, but the Solidity example is still easy to copy. Any caller can pause/unpause, change the epoch, or set total assets.
+
+Recommended action: add owner/oracle authorization before presenting the Solidity as a builder reference, or make the file/test names and comments explicitly say this is an unsafe accounting skeleton.
+
+## Verification performed
+
+Passed:
+
+- `lake build`
+- `lake build Contracts.XStockVault Verity.Specs.Ink`
+- `python3 scripts/check_contract_structure.py`
+- `python3 scripts/check_property_manifest.py`
+- `python3 scripts/check_macro_property_test_generation.py --check`
+- `python3 scripts/check_verification_status_doc.py`
+- `python3 scripts/check_axioms.py`
+- `python3 scripts/check_lean_hygiene.py`
+- `python3 scripts/check_paths.py`
+- `python3 scripts/check_package_glob_surfaces.py`
+- `python3 scripts/check_package_import_boundaries.py`
+- `python3 scripts/check_split_package_builds.py`
+- `python3 scripts/check_storage_layout.py`
+- `python3 scripts/check_verify_sync.py`
+- `python3 scripts/test_profile_ci_resources.py`
+
+Failed:
+
+- `python3 scripts/check_property_coverage.py` failed with five missing XStockVault theorem mappings.
+- `python3 scripts/generate_verification_status.py --check` reported `artifacts/verification_status.json` as stale.
+- `forge test --match-contract 'XStockVault|PropertyXStockVaultTest'` failed immediately because `forge` is not installed.
+
+Not completed:
+
+- `lake exe verity-compiler --module Contracts.XStockVault.XStockVault -o /tmp/xstockvault-yul` was stopped after the local toolchain reported `could not execute external process 'cc'` while building native FFI and then continued compiling for an extended time.

--- a/docs/ink-xstocks-spec-poc.md
+++ b/docs/ink-xstocks-spec-poc.md
@@ -1,0 +1,70 @@
+# Ink xStocks Verity Spec POC
+
+This POC shows how an Ink developer can formally verify a contract that uses xStocks.
+
+It does not verify xStocks itself. It gives reusable models and specs for contracts built on top of xStocks.
+
+## Why xStocks Need Special Specs
+
+Normal ERC-20 integrations usually reason about balances and transfers. xStocks add corporate-action behavior: dividends, splits, reverse splits, and multiplier/rebasing mechanics.
+
+If a vault treats xStocks like a normal ERC-20, it can double-count the multiplier, misprice shares across dividends or splits, or settle old deposit quotes after a corporate-action update.
+
+## Example Contract
+
+`Contracts/XStockVault/XStockVault.lean` models the accounting side of a vault that receives settled adjusted xStock amounts and mints vault shares. Token custody, transfer success, and oracle/admin authorization are intentionally outside this POC. It stores a multiplier epoch and a pause flag so state-changing accounting actions can reject stale quotes around corporate-action updates.
+
+The reusable xStocks assumptions live in `Verity/Specs/Ink/XStocks.lean`.
+
+## Invariants
+
+1. EVM xStock `balanceOf()` is used exactly once.
+
+What can go wrong: a vault computes `balanceOf(vault) * multiplier` on Ink even though EVM xStock `balanceOf()` is already equity-adjusted.
+
+What the spec proves: the xStocks sync model stores the EVM `balanceOf()` amount directly and does not apply the multiplier a second time.
+
+Lean theorem: `Contracts.XStockVault.Proofs.XStocks.sync_uses_evm_adjusted_balance_exactly_once`.
+
+Note: the theorem's value-level "not double-applied" inequality assumes a nonzero adjusted balance and a multiplier different from `1`, because multiplying zero or multiplying by one is observationally indistinguishable from using the balance directly.
+
+2. Corporate actions scale user claims but preserve vault share fractions.
+
+What can go wrong: a vault tries to handle dividends, splits, or reverse splits by reminting shares, changing user ownership percentages.
+
+What the spec proves: the economic model lemma for a multiplier update changes total assets by the multiplier ratio while leaving total shares and per-user share balances unchanged, so each user's share fraction is preserved and their claim scales proportionally. The current Lean contract exposes the accounting pieces for epoch updates and adjusted-balance sync separately; it does not yet prove a full implementation-level corporate-action transition theorem.
+
+Lean theorem: `Contracts.XStockVault.Proofs.XStocks.corporate_action_preserves_fraction_and_scales_claim`.
+
+3. Stale multiplier epochs cannot settle deposits.
+
+What can go wrong: a user previews a deposit under one multiplier epoch and settles after a corporate-action update, minting too many or too few shares.
+
+What the spec proves: a deposit quote whose epoch does not match the vault's current xStock multiplier epoch leaves vault state unchanged.
+
+Lean theorem: `Contracts.XStockVault.Proofs.XStocks.stale_multiplier_epoch_cannot_settle_deposit`.
+
+## How To Use This In Your Own Protocol
+
+- Replace the accounting skeleton with your vault, wrapper, collateral adapter, or strategy.
+- Keep the xStocks model boundary explicit: on Ink/EVM, `balanceOf()` is the adjusted balance.
+- Add your production custody, transfer, access-control, and oracle authorization boundaries before treating the example as deployable.
+- Add an epoch or pause-window guard to quote and settlement flows.
+- Prove the xStocks-specific invariants first, then add protocol-specific accounting, collateral, or fee invariants.
+- If integer rounding matters, adapt the Rat model to bounded integer lemmas after the economic invariant is clear.
+
+## Future Modules
+
+The same architecture can be extended to:
+
+- Tydro integration specs: lending adapters, collateral accounting, health-factor assumptions.
+- Nado integration specs: strategy vaults, PnL settlement, margin limits, fees and funding accounting.
+
+## What This Does Not Prove
+
+- It does not prove xStocks are 1:1 backed.
+- It does not prove issuer, custodian, proof-of-reserves, or legal claims.
+- It does not prove market price correctness.
+- It does not prove xStocks core contracts or bridge behavior.
+- It does not prove Tydro or Nado core.
+- It only proves the integrating contract respects the stated xStocks assumptions.

--- a/examples/solidity/XStockVault.sol
+++ b/examples/solidity/XStockVault.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+/// @title XStockVault
+/// @notice Minimal xStocks accounting skeleton with epoch-gated 1:1 shares.
+/// @dev Matches `Contracts/XStockVault/XStockVault.lean`. Token transfers,
+/// access control, and oracle authorization are deliberately out of scope for
+/// this proof-of-concept and must be supplied by a production integration.
+contract XStockVault {
+    address public xStockToken;
+    uint256 public totalAssets;
+    uint256 public totalSupply;
+    mapping(address => uint256) public shareBalances;
+    uint256 public multiplierEpoch;
+    uint256 public corporateActionPaused;
+
+    error CorporateActionWindow();
+    error StaleMultiplierEpoch();
+    error InsufficientShares();
+    error InsufficientAssets();
+    error InsufficientSupply();
+    error InvalidPauseFlag();
+
+    constructor(address token) {
+        xStockToken = token;
+    }
+
+    function setCorporateActionPaused(uint256 paused) external {
+        if (paused != 0 && paused != 1) {
+            revert InvalidPauseFlag();
+        }
+        corporateActionPaused = paused;
+    }
+
+    function updateMultiplierEpoch(uint256 newEpoch) external {
+        multiplierEpoch = newEpoch;
+    }
+
+    function syncFromBalanceOf(uint256 adjustedBalanceOfVault) external {
+        totalAssets = adjustedBalanceOfVault;
+    }
+
+    function deposit(uint256 assets, uint256 quoteEpoch) external {
+        if (corporateActionPaused != 0) {
+            revert CorporateActionWindow();
+        }
+        if (quoteEpoch != multiplierEpoch) {
+            revert StaleMultiplierEpoch();
+        }
+        shareBalances[msg.sender] += assets;
+        totalAssets += assets;
+        totalSupply += assets;
+    }
+
+    function withdraw(uint256 shares, uint256 quoteEpoch) external {
+        if (corporateActionPaused != 0) {
+            revert CorporateActionWindow();
+        }
+        if (quoteEpoch != multiplierEpoch) {
+            revert StaleMultiplierEpoch();
+        }
+        uint256 currentShares = shareBalances[msg.sender];
+        if (currentShares < shares) {
+            revert InsufficientShares();
+        }
+        if (totalAssets < shares) {
+            revert InsufficientAssets();
+        }
+        if (totalSupply < shares) {
+            revert InsufficientSupply();
+        }
+        shareBalances[msg.sender] = currentShares - shares;
+        totalAssets -= shares;
+        totalSupply -= shares;
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return shareBalances[account];
+    }
+}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -16,6 +16,7 @@ lean_lib «Verity» where
     .andSubmodules `Verity.Macro,
     .submodules `Verity.Stdlib,
     .andSubmodules `Verity.Specs.Common,
+    .andSubmodules `Verity.Specs.Ink,
     .submodules `Verity.Proofs.Stdlib
   ]
 
@@ -33,6 +34,7 @@ lean_lib «Contracts» where
     .andSubmodules `Contracts.SafeCounter,
     .andSubmodules `Contracts.Ledger,
     .andSubmodules `Contracts.Vault,
+    .andSubmodules `Contracts.XStockVault,
     .andSubmodules `Contracts.ERC20,
     .andSubmodules `Contracts.ERC721,
     .andSubmodules `Contracts.SimpleToken,

--- a/packages/verity-examples/contracts.manifest
+++ b/packages/verity-examples/contracts.manifest
@@ -4,6 +4,7 @@ Contracts.Counter.Counter
 Contracts.Owned.Owned
 Contracts.Ledger.Ledger
 Contracts.Vault.Vault
+Contracts.XStockVault.XStockVault
 Contracts.OwnedCounter.OwnedCounter
 Contracts.SimpleToken.SimpleToken
 Contracts.SafeCounter.SafeCounter

--- a/packages/verity-examples/lakefile.lean
+++ b/packages/verity-examples/lakefile.lean
@@ -23,6 +23,8 @@ lean_lib «Contracts» where
     .andSubmodules `Contracts.OwnedCounter,
     .andSubmodules `Contracts.SafeCounter,
     .andSubmodules `Contracts.Ledger,
+    .andSubmodules `Contracts.Vault,
+    .andSubmodules `Contracts.XStockVault,
     .andSubmodules `Contracts.ERC20,
     .andSubmodules `Contracts.ERC721,
     .andSubmodules `Contracts.SimpleToken,

--- a/scripts/check_contract_structure.py
+++ b/scripts/check_contract_structure.py
@@ -31,6 +31,7 @@ EXCLUDED_FROM_DIFFERENTIAL_TESTS = {
     "CryptoHash",         # External-library oracle behavior is not differential-tested
     "ReentrancyExample",  # Reentrancy model requires dedicated external-call harnessing
     "Vault",              # Minimal scaffolding landed before differential harness completion
+    "XStockVault",        # Ink xStocks POC is an accounting/model example without a generated-Yul differential harness
 }
 
 # Expected files for each contract (relative to ROOT)

--- a/scripts/test_profile_ci_resources.py
+++ b/scripts/test_profile_ci_resources.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -106,9 +107,13 @@ class ProfileCiResourcesTests(unittest.TestCase):
             self.assertIn("mem_used_mb", summary)
             self.assertIn("disk", summary)
             self.assertIn("gnu_time", summary)
-            self.assertIn("Command being timed", summary["gnu_time"])
+            if shutil.which("/usr/bin/time") is not None:
+                self.assertIn("Command being timed", summary["gnu_time"])
+                self.assertTrue(Path(summary["time_path"]).exists())
+            else:
+                self.assertEqual(summary["gnu_time"], {})
+                self.assertIsNone(summary["time_path"])
             self.assertTrue(Path(summary["log_path"]).exists())
-            self.assertTrue(Path(summary["time_path"]).exists())
             self.assertIn("profile-smoke", Path(summary["log_path"]).read_text(encoding="utf-8"))
 
 

--- a/test/PropertyXStockVault.t.sol
+++ b/test/PropertyXStockVault.t.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "forge-std/Test.sol";
+import "../examples/solidity/XStockVault.sol";
+
+contract PropertyXStockVaultTest is Test {
+    XStockVault vault;
+    address user = address(0xBEEF);
+
+    function setUp() public {
+        vault = new XStockVault(address(0x1234));
+    }
+
+    /// Property 1: totalAssets_spec_reads_slot_one
+    /// Property 2: syncFromBalanceOf_sets_assets_to_adjusted_balance
+    /// Property 3: sync_uses_evm_adjusted_balance_exactly_once
+    /// Property 4: syncFromBalanceOf_preserves_unrelated_storage
+    function testProperty_SyncFromBalanceOf_UsesAdjustedBalanceDirectly(uint256 adjustedBalance) public {
+        vm.prank(user);
+        vault.deposit(7, 0);
+        vault.updateMultiplierEpoch(3);
+        vault.setCorporateActionPaused(1);
+
+        uint256 supplyBefore = vault.totalSupply();
+        uint256 sharesBefore = vault.balanceOf(user);
+        uint256 epochBefore = vault.multiplierEpoch();
+        uint256 pauseBefore = vault.corporateActionPaused();
+        address tokenBefore = vault.xStockToken();
+
+        vault.syncFromBalanceOf(adjustedBalance);
+
+        assertEq(vault.totalAssets(), adjustedBalance);
+        assertEq(vault.totalSupply(), supplyBefore);
+        assertEq(vault.balanceOf(user), sharesBefore);
+        assertEq(vault.multiplierEpoch(), epochBefore);
+        assertEq(vault.corporateActionPaused(), pauseBefore);
+        assertEq(vault.xStockToken(), tokenBefore);
+    }
+
+    /// Property 5: totalSupply_spec_reads_slot_two
+    /// Property 6: deposit_spec_preserves_multiplier_epoch
+    /// Property 7: deposit_spec_preserves_pause_flag
+    function testProperty_DepositUpdatesSupply(uint128 amount) public {
+        vault.updateMultiplierEpoch(9);
+        uint256 pauseBefore = vault.corporateActionPaused();
+
+        vm.prank(user);
+        vault.deposit(uint256(amount), 9);
+
+        assertEq(vault.totalSupply(), uint256(amount));
+        assertEq(vault.multiplierEpoch(), 9);
+        assertEq(vault.corporateActionPaused(), pauseBefore);
+    }
+
+    /// Property 8: multiplierEpoch_spec_reads_slot_four
+    function testProperty_MultiplierEpochReadsSlot(uint256 epoch) public {
+        vault.updateMultiplierEpoch(epoch);
+        assertEq(vault.multiplierEpoch(), epoch);
+    }
+
+    /// Property 9: stale_epoch_deposit_spec_impossible
+    /// Property 10: stale_multiplier_epoch_cannot_settle_deposit
+    function testProperty_StaleEpochCannotDeposit(uint128 amount, uint256 currentEpoch, uint256 staleEpoch) public {
+        vm.assume(staleEpoch != currentEpoch);
+        vault.updateMultiplierEpoch(currentEpoch);
+
+        vm.prank(user);
+        vm.expectRevert(XStockVault.StaleMultiplierEpoch.selector);
+        vault.deposit(uint256(amount), staleEpoch);
+    }
+
+    /// Property 11: corporate_action_preserves_fraction_and_scales_claim
+    function testProperty_EpochUpdateDoesNotRemintShares(uint128 amount, uint256 newEpoch) public {
+        vm.prank(user);
+        vault.deposit(uint256(amount), 0);
+        uint256 sharesBefore = vault.balanceOf(user);
+        uint256 supplyBefore = vault.totalSupply();
+
+        vault.updateMultiplierEpoch(newEpoch);
+
+        assertEq(vault.balanceOf(user), sharesBefore);
+        assertEq(vault.totalSupply(), supplyBefore);
+    }
+
+    /// Property 12: withdraw_spec_preserves_multiplier_epoch
+    /// Property 13: withdraw_spec_preserves_pause_flag
+    function testProperty_WithdrawPreservesEpochAndPause(uint128 amount) public {
+        vault.updateMultiplierEpoch(11);
+
+        vm.prank(user);
+        vault.deposit(uint256(amount), 11);
+
+        uint256 epochBefore = vault.multiplierEpoch();
+        uint256 pauseBefore = vault.corporateActionPaused();
+
+        vm.prank(user);
+        vault.withdraw(uint256(amount), 11);
+
+        assertEq(vault.multiplierEpoch(), epochBefore);
+        assertEq(vault.corporateActionPaused(), pauseBefore);
+    }
+}

--- a/test/XStockVault.t.sol
+++ b/test/XStockVault.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "forge-std/Test.sol";
+import "../examples/solidity/XStockVault.sol";
+
+contract XStockVaultTest is Test {
+    XStockVault vault;
+    address token = address(0x1234);
+    address user = address(0xBEEF);
+
+    function setUp() public {
+        vault = new XStockVault(token);
+    }
+
+    function testDepositMintsSharesAtCurrentEpoch() public {
+        vm.prank(user);
+        vault.deposit(10, 0);
+
+        assertEq(vault.balanceOf(user), 10);
+        assertEq(vault.totalAssets(), 10);
+        assertEq(vault.totalSupply(), 10);
+    }
+
+    function testStaleEpochCannotDeposit() public {
+        vault.updateMultiplierEpoch(2);
+
+        vm.prank(user);
+        vm.expectRevert(XStockVault.StaleMultiplierEpoch.selector);
+        vault.deposit(10, 1);
+    }
+
+    function testPauseBlocksWithdraw() public {
+        vm.prank(user);
+        vault.deposit(10, 0);
+        vault.setCorporateActionPaused(1);
+
+        vm.prank(user);
+        vm.expectRevert(XStockVault.CorporateActionWindow.selector);
+        vault.withdraw(1, 0);
+    }
+
+    function testSyncUsesAdjustedBalanceDirectly() public {
+        vault.syncFromBalanceOf(123);
+        assertEq(vault.totalAssets(), 123);
+    }
+
+    function testDepositWithdrawRoundTrip(uint128 amount) public {
+        vm.prank(user);
+        vault.deposit(uint256(amount), 0);
+
+        vm.prank(user);
+        vault.withdraw(uint256(amount), 0);
+
+        assertEq(vault.balanceOf(user), 0);
+        assertEq(vault.totalAssets(), 0);
+        assertEq(vault.totalSupply(), 0);
+    }
+
+    function testStaleEpochReverts(uint128 amount) public {
+        vault.updateMultiplierEpoch(2);
+
+        vm.prank(user);
+        vm.expectRevert(XStockVault.StaleMultiplierEpoch.selector);
+        vault.deposit(uint256(amount), 1);
+    }
+}

--- a/test/property_manifest.json
+++ b/test/property_manifest.json
@@ -305,5 +305,20 @@
     "vaultMinimal_functions_bridged",
     "vaultMinimal_runtime_lowers_native",
     "vaultMinimal_totalAssets_nativeResultsMatchOn_revert_of_nonzero_value"
+  ],
+  "XStockVault": [
+    "corporate_action_preserves_fraction_and_scales_claim",
+    "deposit_spec_preserves_multiplier_epoch",
+    "deposit_spec_preserves_pause_flag",
+    "multiplierEpoch_spec_reads_slot_four",
+    "stale_epoch_deposit_spec_impossible",
+    "stale_multiplier_epoch_cannot_settle_deposit",
+    "syncFromBalanceOf_preserves_unrelated_storage",
+    "syncFromBalanceOf_sets_assets_to_adjusted_balance",
+    "sync_uses_evm_adjusted_balance_exactly_once",
+    "totalAssets_spec_reads_slot_one",
+    "totalSupply_spec_reads_slot_two",
+    "withdraw_spec_preserves_multiplier_epoch",
+    "withdraw_spec_preserves_pause_flag"
   ]
 }


### PR DESCRIPTION
## What this PR is

This PR adds the technical artifact behind our Ink Spark application: an Ink xStocks proof of concept for Verity. It shows how a reusable formal-verification spec pack for Ink builders could work, starting with contracts built on top of xStocks.

The broader project is the **Ink Verified Finance Spec Pack**: reusable Verity models, specs, examples, and docs for Ink builders integrating with xStocks first, then extending the same pattern to Tydro and Nado-style integrations.

## Non-technical overview

Short Loom walkthrough for Spark/Ink reviewers:

https://www.loom.com/share/3fd4d83ad7cc4c1caebd6ad5cc396a6f

The video is meant as a non-technical presentation of the overall project: what Verity is, why Ink DeFi/RWA builders need reusable verification support, why xStocks are the first practical example, and how the same approach could later help teams building around Tydro and Nado.

This PR is the inspectable technical companion to that video.

## Why this matters

xStocks are not ordinary ERC-20 tokens. They represent tokenized equities and ETFs, so integrating contracts may need to reason about corporate actions such as dividends, splits, reverse splits, rebasing/multiplier behavior, stale epochs, and transfer/compliance edge cases.

If every Ink builder has to model those assumptions from scratch before verifying its own vault, adapter, wrapper, or strategy contract, formal verification becomes slower and more expensive than it needs to be. This PR demonstrates how Verity can package those assumptions into reusable specs and examples.

## Scope

This POC focuses on an example xStock vault and reusable xStocks-facing specifications. It is meant to help developers prove properties about their own contracts that integrate xStocks.

It does **not** claim to audit or formally verify the xStocks core protocol itself. The xStocks behavior is modeled at the integration boundary, and the docs/specs separate what is proved from what remains an external assumption.

## Review focus

Please review whether the structure is understandable as an Ink builder-facing example:

- the xStocks assumptions and integration hazards are clear;
- the example vault makes the risk concrete;
- the specs focus on xStocks-specific accounting issues rather than generic ERC-20 behavior;
- the documentation makes it clear how this approach could later extend to Tydro and Nado integrations.

## Related links

- Non-technical project walkthrough: https://www.loom.com/share/3fd4d83ad7cc4c1caebd6ad5cc396a6f
- Verity: https://github.com/lfglabs-dev/verity
- Verity website: https://veritylang.com
- LFG Labs: https://lfglabs.dev
