### PR TITLE
Add requireSomeUintError typed-error overflow guard

### DIFF
--- a/Compiler/MacroCustomErrorFeatureTest.lean
+++ b/Compiler/MacroCustomErrorFeatureTest.lean
@@ -7,6 +7,7 @@ open Compiler.CompilationModel
 open Contracts
 open Verity hiding pure bind
 open Verity.EVM.Uint256
+open Verity.Stdlib.Math
 
 namespace MacroCustomErrorUsageSmoke
 
@@ -67,5 +68,106 @@ def rejectLargeExecutableUsesRuntimeFallback : Bool :=
 example : rejectLargeExecutableUsesRuntimeFallback = true := by native_decide
 
 end MacroCustomErrorUsageSmoke
+
+namespace RequireSomeUintErrorSmoke
+
+verity_contract RequireSomeUintErrorUsage where
+  storage
+    sentinel : Uint256 := slot 0
+
+  errors
+    error AddOverflow ()
+    error SubUnderflow ()
+    error DivByZero ()
+    error MulOverflow (Uint256, Uint256)
+
+  function checkAdd (a : Uint256, b : Uint256) : Uint256 := do
+    let result ← requireSomeUintError (safeAdd a b) AddOverflow()
+    return result
+
+  function checkSub (a : Uint256, b : Uint256) : Uint256 := do
+    let result ← requireSomeUintError (safeSub a b) SubUnderflow()
+    return result
+
+  function checkDiv (a : Uint256, b : Uint256) : Uint256 := do
+    let result ← requireSomeUintError (safeDiv a b) DivByZero()
+    return result
+
+  function checkMul (a : Uint256, b : Uint256) : Uint256 := do
+    let result ← requireSomeUintError (safeMul a b) MulOverflow(a, b)
+    return result
+
+def checkAddLowersToTypedRequireError : Bool :=
+  match RequireSomeUintErrorUsage.checkAdd_modelBody with
+  | [Stmt.requireError
+        (Expr.ge (Expr.add (Expr.param "a") (Expr.param "b")) (Expr.param "a"))
+        "AddOverflow"
+        [],
+      Stmt.letVar "result" (Expr.add (Expr.param "a") (Expr.param "b")),
+      Stmt.return (Expr.localVar "result")] =>
+      true
+  | _ => false
+
+example : checkAddLowersToTypedRequireError = true := by native_decide
+
+def checkSubLowersToTypedRequireError : Bool :=
+  match RequireSomeUintErrorUsage.checkSub_modelBody with
+  | [Stmt.requireError
+        (Expr.ge (Expr.param "a") (Expr.param "b"))
+        "SubUnderflow"
+        [],
+      Stmt.letVar "result" (Expr.sub (Expr.param "a") (Expr.param "b")),
+      Stmt.return (Expr.localVar "result")] =>
+      true
+  | _ => false
+
+example : checkSubLowersToTypedRequireError = true := by native_decide
+
+def checkDivLowersToTypedRequireError : Bool :=
+  match RequireSomeUintErrorUsage.checkDiv_modelBody with
+  | [Stmt.requireError
+        (Expr.logicalNot (Expr.eq (Expr.param "b") (Expr.literal 0)))
+        "DivByZero"
+        [],
+      Stmt.letVar "result" (Expr.div (Expr.param "a") (Expr.param "b")),
+      Stmt.return (Expr.localVar "result")] =>
+      true
+  | _ => false
+
+example : checkDivLowersToTypedRequireError = true := by native_decide
+
+def checkMulLowersToTypedRequireError : Bool :=
+  match RequireSomeUintErrorUsage.checkMul_modelBody with
+  | [Stmt.requireError
+        (Expr.logicalOr
+          (Expr.eq (Expr.param "b") (Expr.literal 0))
+          (Expr.eq
+            (Expr.div (Expr.mul (Expr.param "a") (Expr.param "b")) (Expr.param "b"))
+            (Expr.param "a")))
+        "MulOverflow"
+        [Expr.param "a", Expr.param "b"],
+      Stmt.letVar "result" (Expr.mul (Expr.param "a") (Expr.param "b")),
+      Stmt.return (Expr.localVar "result")] =>
+      true
+  | _ => false
+
+example : checkMulLowersToTypedRequireError = true := by native_decide
+
+def checkAddExecutableReturnsSumWhenSafe : Bool :=
+  match RequireSomeUintErrorUsage.checkAdd 1 2 Verity.defaultState with
+  | .success v _ => v == 3
+  | .revert _ _ => false
+
+example : checkAddExecutableReturnsSumWhenSafe = true := by native_decide
+
+def checkAddExecutableRevertsOnOverflow : Bool :=
+  let maxUint : Uint256 := Verity.Core.Uint256.ofNat Verity.Stdlib.Math.MAX_UINT256
+  match RequireSomeUintErrorUsage.checkAdd maxUint 1 Verity.defaultState with
+  | .revert msg _ => msg == "AddOverflow()"
+  | .success _ _ => false
+
+example : checkAddExecutableRevertsOnOverflow = true := by native_decide
+
+end RequireSomeUintErrorSmoke
 
 end Compiler.MacroCustomErrorFeatureTest

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -56,6 +56,14 @@ macro_rules
           $cond
           $(Lean.quote (toString errorName.getId))
           [ $[$encodedArgs],* ])
+  | `(requireSomeUintError $optExpr:term $errorName:ident($args,*)) => do
+      let requireFn := Lean.mkIdentFrom errorName `_root_.Contracts.requireSomeUintCustomError
+      let encodeFn := Lean.mkIdentFrom errorName `_root_.Contracts.CustomErrorArg.encode
+      let encodedArgs ← args.getElems.mapM fun arg => `(term| $encodeFn:ident $arg)
+      `($requireFn:ident
+          $optExpr
+          $(Lean.quote (toString errorName.getId))
+          [ $[$encodedArgs],* ])
   | `(doElem| let $name:ident := arrayElement $values:term $index:term) => do
       let checked := Lean.mkIdentFrom name `_root_.Contracts.arrayElementChecked
       `(doElem| let $name ← $checked:ident $values $index)
@@ -131,6 +139,21 @@ def revertCustomError (name : String) (args : List String) : Contract Unit :=
 
 def requireCustomError (condition : Bool) (name : String) (args : List String) : Contract Unit :=
   if condition then pure () else revertCustomError name args
+
+/-- Typed-error counterpart to `Verity.Stdlib.Math.requireSomeUint`. When the
+optional value is `some`, the wrapper unwraps it. When `none`, the wrapper
+reverts with the supplied custom error name and ABI-style argument list,
+matching the revert payload emitted by `requireError`. The runtime helper is
+named `requireSomeUintCustomError` rather than `requireSomeUintError` because
+the latter is a reserved EDSL keyword (see `Verity/Macro/Syntax.lean`); the
+fallback `return 0` is unreachable in real execution because the preceding
+revert always returns. -/
+def requireSomeUintCustomError (opt : Option Uint256) (name : String) (args : List String) : Contract Uint256 := do
+  match opt with
+  | some value => return value
+  | none => do
+    let _ ← revertCustomError name args
+    return 0
 
 private def wordToSigned (value : Uint256) : Int :=
   (toInt256 value : Int)

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -115,6 +115,7 @@ macro_rules
 syntax "revert " ident "(" sepBy(term, ",") ")" : doElem
 syntax "revertError " ident "(" sepBy(term, ",") ")" : doElem
 syntax "requireError " term:max ppSpace ident "(" sepBy(term, ",") ")" : doElem
+syntax (name := requireSomeUintErrorTerm) "requireSomeUintError " term:max ppSpace ident "(" sepBy(term, ",") ")" : term
 syntax "ecmBind " term:max ppSpace term:max ppSpace term:max : doElem
 syntax (priority := high) "unsafe " str " do " doSeq : doElem
 syntax "constructor " "(" sepBy(verityParam, ",") ")" (ppSpace verityLocalObligations)? " := " term : verityConstructor

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -3468,6 +3468,20 @@ private partial def inferBindSourceType
           requireWordLikeType b "safe uint helper" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals b)
           pure .uint256
       | _ => throwErrorAt rhs "unsupported requireSomeUint source; expected safeAdd, safeSub, safeMul, or safeDiv"
+  -- Typed-error counterpart to `requireSomeUint`. `requireSomeUintError
+  -- (safeXxx a b) ErrName(args)` validates the same `safeXxx` source shape
+  -- and result type; argument-type validation against the contract's
+  -- `errors` block happens in the do-element walk before the lowering pass.
+  | `(term| requireSomeUintError $optExpr:term $_errorName:ident($_args,*)) =>
+      match stripParens optExpr with
+      | `(term| safeAdd $a:term $b:term)
+      | `(term| safeSub $a:term $b:term)
+      | `(term| safeMul $a:term $b:term)
+      | `(term| safeDiv $a:term $b:term) => do
+          requireWordLikeType a "safe uint helper" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a)
+          requireWordLikeType b "safe uint helper" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals b)
+          pure .uint256
+      | _ => throwErrorAt rhs "unsupported requireSomeUintError source; expected safeAdd, safeSub, safeMul, or safeDiv"
   -- Solidity-0.8 default-revert arithmetic (verity#1752). `addPanic`,
   -- `subPanic`, `mulPanic`, `divPanic` are ergonomic shorthands for the
   -- corresponding `requireSomeUint (safeXxx a b) <fixed Panic-style message>`
@@ -5659,6 +5673,60 @@ private def translateSafeRequireBind
           ])
       | _ =>
           throwErrorAt rhs "unsupported requireSomeUint source; expected safeAdd, safeSub, safeMul, or safeDiv"
+  -- Typed-error counterpart to `requireSomeUint`. The lowering mirrors the
+  -- string-message variant exactly, except the guard becomes a
+  -- `Stmt.requireError` emitting a 4-byte selector revert with the supplied
+  -- error name and argument list.
+  | `(term| requireSomeUintError $optExpr:term $errorName:ident($args,*)) =>
+      let errorNameLit := strTerm (toString errorName.getId)
+      let argExprs ← args.getElems.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+      let optExpr := stripParens optExpr
+      match optExpr with
+      | `(term| safeAdd $a:term $b:term) =>
+          let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
+          let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+          let valueExpr : Term ← `(Compiler.CompilationModel.Expr.add $aExpr $bExpr)
+          let guardExpr : Term ← `(Compiler.CompilationModel.Expr.ge $valueExpr $aExpr)
+          pure (some #[
+            (← `(Compiler.CompilationModel.Stmt.requireError $guardExpr $errorNameLit [ $[$argExprs],* ])),
+            (← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $valueExpr))
+          ])
+      | `(term| safeSub $a:term $b:term) =>
+          let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
+          let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+          let valueExpr : Term ← `(Compiler.CompilationModel.Expr.sub $aExpr $bExpr)
+          let guardExpr : Term ← `(Compiler.CompilationModel.Expr.ge $aExpr $bExpr)
+          pure (some #[
+            (← `(Compiler.CompilationModel.Stmt.requireError $guardExpr $errorNameLit [ $[$argExprs],* ])),
+            (← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $valueExpr))
+          ])
+      | `(term| safeMul $a:term $b:term) =>
+          let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
+          let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+          let valueExpr : Term ← `(Compiler.CompilationModel.Expr.mul $aExpr $bExpr)
+          let zeroExpr : Term ← `(Compiler.CompilationModel.Expr.literal 0)
+          let divisorZeroExpr : Term ← `(Compiler.CompilationModel.Expr.eq $bExpr $zeroExpr)
+          let quotientExpr : Term ← `(Compiler.CompilationModel.Expr.div $valueExpr $bExpr)
+          let noOverflowExpr : Term ← `(Compiler.CompilationModel.Expr.eq $quotientExpr $aExpr)
+          let guardExpr : Term ← `(Compiler.CompilationModel.Expr.logicalOr $divisorZeroExpr $noOverflowExpr)
+          pure (some #[
+            (← `(Compiler.CompilationModel.Stmt.requireError $guardExpr $errorNameLit [ $[$argExprs],* ])),
+            (← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $valueExpr))
+          ])
+      | `(term| safeDiv $a:term $b:term) =>
+          let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
+          let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+          let valueExpr : Term ← `(Compiler.CompilationModel.Expr.div $aExpr $bExpr)
+          let zeroExpr : Term ← `(Compiler.CompilationModel.Expr.literal 0)
+          let guardExpr : Term ←
+            `(Compiler.CompilationModel.Expr.logicalNot
+                (Compiler.CompilationModel.Expr.eq $bExpr $zeroExpr))
+          pure (some #[
+            (← `(Compiler.CompilationModel.Stmt.requireError $guardExpr $errorNameLit [ $[$argExprs],* ])),
+            (← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $valueExpr))
+          ])
+      | _ =>
+          throwErrorAt rhs "unsupported requireSomeUintError source; expected safeAdd, safeSub, safeMul, or safeDiv"
   -- Solidity-0.8 default-revert arithmetic (verity#1752): `let x ← addPanic a b`
   -- lowers to the same IR as
   -- `let x ← requireSomeUint (safeAdd a b) "Panic(0x11): arithmetic overflow"`,
@@ -5857,6 +5925,17 @@ private partial def validateDoElemExprTypes
                       ty := .array elemTy
                       source := .memoryArray }
               | none =>
+                  -- requireSomeUintError is the only bind source that takes
+                  -- a custom-error name; validate the error name against the
+                  -- contract's `errors` block before falling through to the
+                  -- generic bind-source typer.
+                  match stripParens rhs with
+                  | `(term| requireSomeUintError $_optExpr:term $errorName:ident($args,*)) =>
+                      for arg in args.getElems do
+                        let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg
+                      validateCustomErrorCall ownerName (toString errorName.getId)
+                        params errorDecls args.getElems
+                  | _ => pure ()
                   let ty ← inferBindSourceType fields constDecls immutableDecls externalDecls functions params locals rhs
                   requireSupportedLocalBindingType name s!"local binding '{toString name.getId}'" ty
                   pure <| locals.push (mkTypedLocal (toString name.getId) ty)

--- a/docs-site/syntaxes/verity.tmLanguage.json
+++ b/docs-site/syntaxes/verity.tmLanguage.json
@@ -456,7 +456,7 @@
         },
         {
           "name": "support.function.guard.verity",
-          "match": "\\b(require|requireSomeUint|requireError|revert|revertError)\\b"
+          "match": "\\b(require|requireSomeUint|requireSomeUintError|requireError|revert|revertError)\\b"
         },
         {
           "name": "support.function.external-call.verity",


### PR DESCRIPTION
Adds `requireSomeUintError (safeXxx a b) ErrName(args)`: a typed-error counterpart to `requireSomeUint` that lowers to `Stmt.requireError` instead of `Stmt.require`. Same overflow/underflow/divisor guards