### PR TITLE
Add typed unsafe Yul fragments to CompilationModel

### DIFF
--- a/Compiler/CompilationModel.lean
+++ b/Compiler/CompilationModel.lean
@@ -22,6 +22,7 @@ import Compiler.CompilationModel.MappingWrites
 import Compiler.CompilationModel.ScopeValidation
 import Compiler.CompilationModel.StorageWrites
 import Compiler.CompilationModel.TrustSurface
+import Compiler.CompilationModel.YulImporter
 import Compiler.CompilationModel.UsageAnalysis
 import Compiler.CompilationModel.ValidationCalls
 import Compiler.CompilationModel.ValidationEvents

--- a/Compiler/CompilationModel/Compile.lean
+++ b/Compiler/CompilationModel/Compile.lean
@@ -415,6 +415,11 @@ def compileStmt (fields : List Field) (events : List EventDef := [])
           YulExpr.ident "__returndata_size"
         ])
       ]]
+  | Stmt.rawRevert offset size => do
+      pure [YulStmt.expr (YulExpr.call "revert" [
+        ← compileExpr fields dynamicSource offset,
+        ← compileExpr fields dynamicSource size
+      ])]
   | Stmt.rawLog topics dataOffset dataSize => do
       if topics.length > 4 then
         throw s!"Compilation error: rawLog supports at most 4 topics (log0–log4), got {topics.length}"

--- a/Compiler/CompilationModel/Compile.lean
+++ b/Compiler/CompilationModel/Compile.lean
@@ -49,6 +49,9 @@ open Compiler.Yul
 def unsafeYulToEVMYul (fragment : UnsafeYulFragment) : List YulStmt :=
   fragment.stmts
 
+theorem unsafeYulToEVMYul_eq (fragment : UnsafeYulFragment) :
+    unsafeYulToEVMYul fragment = fragment.stmts := rfl
+
 private def compileAdtStorageWrite (fields : List Field)
     (dynamicSource : DynamicDataSource) (adtTypes : List AdtTypeDef)
     (storageField adtName variantName : String) (args : List Expr) :

--- a/Compiler/CompilationModel/Compile.lean
+++ b/Compiler/CompilationModel/Compile.lean
@@ -428,11 +428,6 @@ def compileStmt (fields : List Field) (events : List EventDef := [])
           YulExpr.ident "__returndata_size"
         ])
       ]]
-  | Stmt.rawRevert offset size => do
-      pure [YulStmt.expr (YulExpr.call "revert" [
-        ← compileExpr fields dynamicSource offset,
-        ← compileExpr fields dynamicSource size
-      ])]
   | Stmt.rawLog topics dataOffset dataSize => do
       if topics.length > 4 then
         throw s!"Compilation error: rawLog supports at most 4 topics (log0–log4), got {topics.length}"
@@ -484,5 +479,18 @@ def compileMatchAdtBranches (fields : List Field) (events : List EventDef)
         inScopeNames adtTypes def_ baseSlot rest
       pure ((variant.tag, fieldBindings ++ bodyStmts) :: restCases)
 end
+
+theorem compileStmt_unsafeYul
+    (fields : List Field) (events : List EventDef := [])
+    (errors : List ErrorDef := [])
+    (dynamicSource : DynamicDataSource := .calldata)
+    (internalRetNames : List String := [])
+    (isInternal : Bool := false)
+    (inScopeNames : List String := [])
+    (adtTypes : List AdtTypeDef := [])
+    (fragment : UnsafeYulFragment) :
+    compileStmt fields events errors dynamicSource internalRetNames isInternal inScopeNames adtTypes
+      (Stmt.unsafeYul fragment) = pure fragment.stmts := by
+  simp [compileStmt, unsafeYulToEVMYul]
 
 end Compiler.CompilationModel

--- a/Compiler/CompilationModel/Compile.lean
+++ b/Compiler/CompilationModel/Compile.lean
@@ -42,6 +42,13 @@ namespace Compiler.CompilationModel
 open Compiler
 open Compiler.Yul
 
+/-- Single bridge from typed unsafe/raw Yul fragments into the EVMYul AST.
+    Proof obligations and trust metadata live on `UnsafeYulFragment`; this
+    function is intentionally the only compiler lowering point for that escape
+    hatch. -/
+def unsafeYulToEVMYul (fragment : UnsafeYulFragment) : List YulStmt :=
+  fragment.stmts
+
 private def compileAdtStorageWrite (fields : List Field)
     (dynamicSource : DynamicDataSource) (adtTypes : List AdtTypeDef)
     (storageField adtName variantName : String) (args : List Expr) :
@@ -269,6 +276,9 @@ def compileStmt (fields : List Field) (events : List EventDef := [])
   | Stmt.unsafeBlock _ body => do
       -- Unsafe block: transparent wrapper, compile inner body directly (#1728, Axis 6 Step 6a)
       compileStmtList fields events errors dynamicSource internalRetNames isInternal inScopeNames adtTypes body
+
+  | Stmt.unsafeYul fragment =>
+      pure (unsafeYulToEVMYul fragment)
 
   | Stmt.emit eventName args => do
       compileEmit fields events dynamicSource eventName args

--- a/Compiler/CompilationModel/LogicalPurity.lean
+++ b/Compiler/CompilationModel/LogicalPurity.lean
@@ -260,6 +260,8 @@ def stmtContainsUnsafeLogicalCallLike : Stmt → Bool
       exprListAnyUnsafeLogicalCallLike args
   | Stmt.ecm _ args =>
       exprListAnyUnsafeLogicalCallLike args
+  | Stmt.unsafeYul _ =>
+      false
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
 

--- a/Compiler/CompilationModel/LogicalPurity.lean
+++ b/Compiler/CompilationModel/LogicalPurity.lean
@@ -225,8 +225,6 @@ def stmtContainsUnsafeLogicalCallLike : Stmt → Bool
       exprContainsUnsafeLogicalCallLike destOffset ||
       exprContainsUnsafeLogicalCallLike sourceOffset ||
       exprContainsUnsafeLogicalCallLike size
-  | Stmt.rawRevert offset size =>
-      exprContainsUnsafeLogicalCallLike offset || exprContainsUnsafeLogicalCallLike size
   | Stmt.revertReturndata | Stmt.stop =>
       false
   | Stmt.setMapping _ key value | Stmt.setMappingWord _ key _ value | Stmt.setMappingPackedWord _ key _ _ value | Stmt.setMappingUint _ key value

--- a/Compiler/CompilationModel/LogicalPurity.lean
+++ b/Compiler/CompilationModel/LogicalPurity.lean
@@ -225,6 +225,8 @@ def stmtContainsUnsafeLogicalCallLike : Stmt → Bool
       exprContainsUnsafeLogicalCallLike destOffset ||
       exprContainsUnsafeLogicalCallLike sourceOffset ||
       exprContainsUnsafeLogicalCallLike size
+  | Stmt.rawRevert offset size =>
+      exprContainsUnsafeLogicalCallLike offset || exprContainsUnsafeLogicalCallLike size
   | Stmt.revertReturndata | Stmt.stop =>
       false
   | Stmt.setMapping _ key value | Stmt.setMappingWord _ key _ value | Stmt.setMappingPackedWord _ key _ _ value | Stmt.setMappingUint _ key value

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -570,6 +570,18 @@ def validateScopedStmtIdentifiers
   | Stmt.returnBytes _ | Stmt.returnStorageWords _
   | Stmt.revertReturndata | Stmt.stop =>
       pure localScope
+  | Stmt.unsafeYul fragment => do
+      let mut scope := localScope
+      for name in fragment.scopeEffects.bindNames do
+        if paramScope.contains name then
+          throw s!"Compilation error: {context} unsafe Yul fragment '{fragment.label}' result '{name}' shadows a parameter"
+        if scope.contains name then
+          throw s!"Compilation error: {context} unsafe Yul fragment '{fragment.label}' redeclares result '{name}' in the same scope"
+        scope := name :: scope
+      for name in fragment.scopeEffects.assignNames do
+        if !scope.contains name then
+          throw s!"Compilation error: {context} unsafe Yul fragment '{fragment.label}' assigns to undeclared local variable '{name}'"
+      pure scope
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
 

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -508,10 +508,6 @@ def validateScopedStmtIdentifiers
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount sourceOffset
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount size
       pure localScope
-  | Stmt.rawRevert offset size => do
-      validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount offset
-      validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount size
-      pure localScope
   | Stmt.ite cond thenBranch elseBranch => do
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount cond
       let _ ← validateScopedStmtListIdentifiers context params paramScope dynamicParams localScope constructorArgCount thenBranch

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -508,6 +508,10 @@ def validateScopedStmtIdentifiers
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount sourceOffset
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount size
       pure localScope
+  | Stmt.rawRevert offset size => do
+      validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount offset
+      validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount size
+      pure localScope
   | Stmt.ite cond thenBranch elseBranch => do
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount cond
       let _ ← validateScopedStmtListIdentifiers context params paramScope dynamicParams localScope constructorArgCount thenBranch

--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -156,150 +156,12 @@ private partial def collectAxiomatizedExprPrimitives : Expr → List String
   | _ =>
       []
 
-private partial def collectLowLevelStmtMechanics : Stmt → List String
-  | .letVar _ value
-  | .assignVar _ value
-  | .setStorage _ value
-  | .setStorageAddr _ value
-  | .setStorageWord _ _ value
-  | .storageArrayPush _ value
-  | .return value
-  | .require value _ =>
-      collectLowLevelExprMechanics value
-  | .setStorageArrayElement _ index value =>
-      collectLowLevelExprMechanics index ++ collectLowLevelExprMechanics value
-  | .storageArrayPop _ =>
-      []
-  | .requireError cond _ args =>
-      collectLowLevelExprMechanics cond ++ args.flatMap collectLowLevelExprMechanics
-  | .revertError _ args =>
-      args.flatMap collectLowLevelExprMechanics
-  | .mstore offset value =>
-      ["mstore"] ++ collectLowLevelExprMechanics offset ++ collectLowLevelExprMechanics value
-  | .tstore offset value =>
-      ["tstore"] ++ collectLowLevelExprMechanics offset ++ collectLowLevelExprMechanics value
-  | .calldatacopy destOffset sourceOffset size =>
-      ["calldatacopy"] ++ collectLowLevelExprMechanics destOffset ++
-        collectLowLevelExprMechanics sourceOffset ++ collectLowLevelExprMechanics size
-  | .returndataCopy destOffset sourceOffset size =>
-      ["returndataCopy"] ++ collectLowLevelExprMechanics destOffset ++ collectLowLevelExprMechanics sourceOffset ++ collectLowLevelExprMechanics size
-  | .revertReturndata =>
-      ["revertReturndata"]
-  | .rawRevert offset size =>
-      ["rawRevert"] ++ collectLowLevelExprMechanics offset ++ collectLowLevelExprMechanics size
-  | .setMapping _ key value
-  | .setMappingWord _ key _ value
-  | .setMappingPackedWord _ key _ _ value
-  | .setMappingUint _ key value
-  | .setStructMember _ key _ value =>
-      collectLowLevelExprMechanics key ++ collectLowLevelExprMechanics value
-  | .setMappingChain _ keys value =>
-      keys.flatMap collectLowLevelExprMechanics ++ collectLowLevelExprMechanics value
-  | .setMapping2 _ key1 key2 value
-  | .setMapping2Word _ key1 key2 _ value
-  | .setStructMember2 _ key1 key2 _ value =>
-      collectLowLevelExprMechanics key1 ++ collectLowLevelExprMechanics key2 ++ collectLowLevelExprMechanics value
-  | .ite cond thenBr elseBr =>
-      collectLowLevelExprMechanics cond ++ thenBr.flatMap collectLowLevelStmtMechanics ++ elseBr.flatMap collectLowLevelStmtMechanics
-  | .forEach _ count body =>
-      collectLowLevelExprMechanics count ++ body.flatMap collectLowLevelStmtMechanics
-  | .unsafeBlock _ body =>
-      body.flatMap collectLowLevelStmtMechanics
-  | .matchAdt _ scrutinee branches =>
-      collectLowLevelExprMechanics scrutinee ++
-        branches.flatMap fun (_, _, body) => body.flatMap collectLowLevelStmtMechanics
-  | .emit _ args
-  | .internalCall _ args
-  | .externalCallBind _ _ args | .tryExternalCallBind _ _ _ args
-  | .returnValues args
-  | .ecm _ args
-  | .internalCallAssign _ _ args =>
-      args.flatMap collectLowLevelExprMechanics
-  | .rawLog topics dataOffset dataSize =>
-      topics.flatMap collectLowLevelExprMechanics ++ collectLowLevelExprMechanics dataOffset ++ collectLowLevelExprMechanics dataSize
-  | .unsafeYul fragment =>
-      fragment.mechanics
-  | .returnArray _
-  | .returnBytes _
-  | .returnStorageWords _
-  | .stop =>
-      []
-
-private partial def collectAxiomatizedStmtPrimitives : Stmt → List String
-  | .letVar _ value
-  | .assignVar _ value
-  | .setStorage _ value
-  | .setStorageAddr _ value
-  | .setStorageWord _ _ value
-  | .storageArrayPush _ value
-  | .return value
-  | .require value _ =>
-      collectAxiomatizedExprPrimitives value
-  | .setStorageArrayElement _ index value =>
-      collectAxiomatizedExprPrimitives index ++ collectAxiomatizedExprPrimitives value
-  | .storageArrayPop _ =>
-      []
-  | .requireError cond _ args =>
-      collectAxiomatizedExprPrimitives cond ++ args.flatMap collectAxiomatizedExprPrimitives
-  | .revertError _ args =>
-      args.flatMap collectAxiomatizedExprPrimitives
-  | .mstore offset value =>
-      collectAxiomatizedExprPrimitives offset ++ collectAxiomatizedExprPrimitives value
-  | .tstore offset value =>
-      collectAxiomatizedExprPrimitives offset ++ collectAxiomatizedExprPrimitives value
-  | .calldatacopy destOffset sourceOffset size
-  | .returndataCopy destOffset sourceOffset size =>
-      collectAxiomatizedExprPrimitives destOffset ++ collectAxiomatizedExprPrimitives sourceOffset ++
-        collectAxiomatizedExprPrimitives size
-  | .setMapping _ key value
-  | .setMappingWord _ key _ value
-  | .setMappingPackedWord _ key _ _ value
-  | .setMappingUint _ key value
-  | .setStructMember _ key _ value =>
-      collectAxiomatizedExprPrimitives key ++ collectAxiomatizedExprPrimitives value
-  | .setMappingChain _ keys value =>
-      keys.flatMap collectAxiomatizedExprPrimitives ++ collectAxiomatizedExprPrimitives value
-  | .setMapping2 _ key1 key2 value
-  | .setMapping2Word _ key1 key2 _ value
-  | .setStructMember2 _ key1 key2 _ value =>
-      collectAxiomatizedExprPrimitives key1 ++ collectAxiomatizedExprPrimitives key2 ++
-        collectAxiomatizedExprPrimitives value
-  | .ite cond thenBr elseBr =>
-      collectAxiomatizedExprPrimitives cond ++ thenBr.flatMap collectAxiomatizedStmtPrimitives ++
-        elseBr.flatMap collectAxiomatizedStmtPrimitives
-  | .forEach _ count body =>
-      collectAxiomatizedExprPrimitives count ++ body.flatMap collectAxiomatizedStmtPrimitives
-  | .unsafeBlock _ body =>
-      body.flatMap collectAxiomatizedStmtPrimitives
-  | .matchAdt _ scrutinee branches =>
-      collectAxiomatizedExprPrimitives scrutinee ++
-        branches.flatMap fun (_, _, body) => body.flatMap collectAxiomatizedStmtPrimitives
-  | .emit _ args
-  | .internalCall _ args
-  | .externalCallBind _ _ args | .tryExternalCallBind _ _ _ args
-  | .returnValues args
-  | .ecm _ args
-  | .internalCallAssign _ _ args =>
-      args.flatMap collectAxiomatizedExprPrimitives
-  | .rawLog topics dataOffset dataSize =>
-      topics.flatMap collectAxiomatizedExprPrimitives ++ collectAxiomatizedExprPrimitives dataOffset ++
-        collectAxiomatizedExprPrimitives dataSize
-  | .rawRevert offset size =>
-      collectAxiomatizedExprPrimitives offset ++ collectAxiomatizedExprPrimitives size
-  | .unsafeYul _ =>
-      []
-  | .returnArray _
-  | .returnBytes _
-  | .returnStorageWords _
-  | .revertReturndata
-  | .stop =>
-      []
-
 private def collectLowLevelMechanicsFromStmts (stmts : List Stmt) : List String :=
   dedupPreserve <|
     Stmt.foldList
       (fun acc _ md =>
-        acc ++ md.lowLevelMechanics ++ md.subexpressions.flatMap collectLowLevelExprMechanics)
+        acc ++ md.lowLevelMechanics.map LowLevelMechanic.toReportString ++
+          md.subexpressions.flatMap collectLowLevelExprMechanics)
       []
       stmts
 
@@ -322,7 +184,7 @@ private def isUnsafeBoundaryMechanic (mechanic : String) : Bool :=
 def collectUnsafeBoundaryMechanicsFromStmts (stmts : List Stmt) : List String :=
   dedupPreserve ((collectLowLevelMechanicsFromStmts stmts).filter isUnsafeBoundaryMechanic)
 
-/-- Like `collectLowLevelStmtMechanics` but skips `unsafeBlock` bodies —
+/-- Like `collectLowLevelMechanicsFromStmts` but skips `unsafeBlock` bodies —
     returns only mechanics that appear *outside* any `unsafe` wrapper. -/
 private partial def collectUnguardedLowLevelStmtMechanics : Stmt → List String
   | .letVar _ value
@@ -353,8 +215,6 @@ private partial def collectUnguardedLowLevelStmtMechanics : Stmt → List String
       ["returndataCopy"] ++ collectLowLevelExprMechanics destOffset ++ collectLowLevelExprMechanics sourceOffset ++ collectLowLevelExprMechanics size
   | .revertReturndata =>
       ["revertReturndata"]
-  | .rawRevert offset size =>
-      ["rawRevert"] ++ collectLowLevelExprMechanics offset ++ collectLowLevelExprMechanics size
   | .setMapping _ key value
   | .setMappingWord _ key _ value
   | .setMappingPackedWord _ key _ _ value
@@ -401,18 +261,6 @@ private def collectUnguardedLowLevelMechanicsFromStmts (stmts : List Stmt) : Lis
     `local_obligations`. -/
 def collectUnguardedUnsafeBoundaryMechanicsFromStmts (stmts : List Stmt) : List String :=
   dedupPreserve ((collectUnguardedLowLevelMechanicsFromStmts stmts).filter isUnsafeBoundaryMechanic)
-
-/-- Collect `unsafe "reason" do` block reason strings from a statement, recursing into branches. -/
-private partial def collectUnsafeBlockReasonsInStmt : Stmt → List String
-  | .unsafeBlock reason body =>
-      [reason] ++ body.flatMap collectUnsafeBlockReasonsInStmt
-  | .ite _ thenBr elseBr =>
-      thenBr.flatMap collectUnsafeBlockReasonsInStmt ++ elseBr.flatMap collectUnsafeBlockReasonsInStmt
-  | .forEach _ _ body =>
-      body.flatMap collectUnsafeBlockReasonsInStmt
-  | .matchAdt _ _ branches =>
-      branches.flatMap fun (_, _, body) => body.flatMap collectUnsafeBlockReasonsInStmt
-  | _ => []
 
 private def collectUnsafeBlockReasonsFromStmts (stmts : List Stmt) : List String :=
   Stmt.foldList (fun acc _ md => acc ++ md.unsafeReasons) [] stmts
@@ -502,76 +350,6 @@ private partial def collectEventEmissionExprMechanics : Expr → List String
   | _ =>
       []
 
-private partial def collectEventEmissionStmtMechanics : Stmt → List String
-  | .letVar _ value
-  | .assignVar _ value
-  | .setStorage _ value
-  | .setStorageAddr _ value
-  | .setStorageWord _ _ value
-  | .storageArrayPush _ value
-  | .return value
-  | .require value _ =>
-      collectEventEmissionExprMechanics value
-  | .setStorageArrayElement _ index value =>
-      collectEventEmissionExprMechanics index ++ collectEventEmissionExprMechanics value
-  | .storageArrayPop _ =>
-      []
-  | .requireError cond _ args =>
-      collectEventEmissionExprMechanics cond ++ args.flatMap collectEventEmissionExprMechanics
-  | .revertError _ args =>
-      args.flatMap collectEventEmissionExprMechanics
-  | .mstore offset value
-  | .tstore offset value =>
-      collectEventEmissionExprMechanics offset ++ collectEventEmissionExprMechanics value
-  | .calldatacopy destOffset sourceOffset size
-  | .returndataCopy destOffset sourceOffset size =>
-      collectEventEmissionExprMechanics destOffset ++ collectEventEmissionExprMechanics sourceOffset ++
-        collectEventEmissionExprMechanics size
-  | .setMapping _ key value
-  | .setMappingWord _ key _ value
-  | .setMappingPackedWord _ key _ _ value
-  | .setMappingUint _ key value
-  | .setStructMember _ key _ value =>
-      collectEventEmissionExprMechanics key ++ collectEventEmissionExprMechanics value
-  | .setMappingChain _ keys value =>
-      keys.flatMap collectEventEmissionExprMechanics ++ collectEventEmissionExprMechanics value
-  | .setMapping2 _ key1 key2 value
-  | .setMapping2Word _ key1 key2 _ value
-  | .setStructMember2 _ key1 key2 _ value =>
-      collectEventEmissionExprMechanics key1 ++ collectEventEmissionExprMechanics key2 ++
-        collectEventEmissionExprMechanics value
-  | .ite cond thenBr elseBr =>
-      collectEventEmissionExprMechanics cond ++
-        thenBr.flatMap collectEventEmissionStmtMechanics ++
-        elseBr.flatMap collectEventEmissionStmtMechanics
-  | .forEach _ count body =>
-      collectEventEmissionExprMechanics count ++ body.flatMap collectEventEmissionStmtMechanics
-  | .unsafeBlock _ body =>
-      body.flatMap collectEventEmissionStmtMechanics
-  | .matchAdt _ scrutinee branches =>
-      collectEventEmissionExprMechanics scrutinee ++
-        branches.flatMap fun (_, _, body) => body.flatMap collectEventEmissionStmtMechanics
-  | .emit _ args
-  | .internalCall _ args
-  | .externalCallBind _ _ args | .tryExternalCallBind _ _ _ args
-  | .returnValues args
-  | .ecm _ args
-  | .internalCallAssign _ _ args =>
-      args.flatMap collectEventEmissionExprMechanics
-  | .rawLog topics dataOffset dataSize =>
-      ["rawLog"] ++ topics.flatMap collectEventEmissionExprMechanics ++
-        collectEventEmissionExprMechanics dataOffset ++ collectEventEmissionExprMechanics dataSize
-  | .rawRevert offset size =>
-      collectEventEmissionExprMechanics offset ++ collectEventEmissionExprMechanics size
-  | .unsafeYul fragment =>
-      if fragment.mechanics.contains "rawLog" then ["rawLog"] else []
-  | .returnArray _
-  | .returnBytes _
-  | .returnStorageWords _
-  | .revertReturndata
-  | .stop =>
-      []
-
 private def collectEventEmissionMechanicsFromStmts (stmts : List Stmt) : List String :=
   dedupPreserve <|
     Stmt.foldList
@@ -579,7 +357,7 @@ private def collectEventEmissionMechanicsFromStmts (stmts : List Stmt) : List St
         let direct :=
           match stmt with
           | .rawLog _ _ _ => ["rawLog"]
-          | .unsafeYul fragment => if fragment.mechanics.contains "rawLog" then ["rawLog"] else []
+          | .unsafeYul fragment => if fragment.mechanics.contains .rawLog then ["rawLog"] else []
           | _ => []
         acc ++ direct ++ md.subexpressions.flatMap collectEventEmissionExprMechanics)
       []
@@ -685,82 +463,6 @@ private partial def collectRuntimeIntrospectionExprMechanics : Expr → List Str
   | _ =>
       []
 
-private partial def collectRuntimeIntrospectionStmtMechanics : Stmt → List String
-  | .letVar _ value
-  | .assignVar _ value
-  | .setStorage _ value
-  | .setStorageAddr _ value
-  | .setStorageWord _ _ value
-  | .storageArrayPush _ value
-  | .return value
-  | .require value _ =>
-      collectRuntimeIntrospectionExprMechanics value
-  | .setStorageArrayElement _ index value =>
-      collectRuntimeIntrospectionExprMechanics index ++ collectRuntimeIntrospectionExprMechanics value
-  | .storageArrayPop _ =>
-      []
-  | .requireError cond _ args =>
-      collectRuntimeIntrospectionExprMechanics cond ++ args.flatMap collectRuntimeIntrospectionExprMechanics
-  | .revertError _ args =>
-      args.flatMap collectRuntimeIntrospectionExprMechanics
-  | .mstore offset value
-  | .tstore offset value =>
-      collectRuntimeIntrospectionExprMechanics offset ++ collectRuntimeIntrospectionExprMechanics value
-  | .calldatacopy destOffset sourceOffset size
-  | .returndataCopy destOffset sourceOffset size =>
-      collectRuntimeIntrospectionExprMechanics destOffset ++
-        collectRuntimeIntrospectionExprMechanics sourceOffset ++
-        collectRuntimeIntrospectionExprMechanics size
-  | .setMapping _ key value
-  | .setMappingWord _ key _ value
-  | .setMappingPackedWord _ key _ _ value
-  | .setMappingUint _ key value
-  | .setStructMember _ key _ value =>
-      collectRuntimeIntrospectionExprMechanics key ++ collectRuntimeIntrospectionExprMechanics value
-  | .setMappingChain _ keys value =>
-      keys.flatMap collectRuntimeIntrospectionExprMechanics ++ collectRuntimeIntrospectionExprMechanics value
-  | .setMapping2 _ key1 key2 value
-  | .setMapping2Word _ key1 key2 _ value
-  | .setStructMember2 _ key1 key2 _ value =>
-      collectRuntimeIntrospectionExprMechanics key1 ++ collectRuntimeIntrospectionExprMechanics key2 ++
-        collectRuntimeIntrospectionExprMechanics value
-  | .ite cond thenBr elseBr =>
-      collectRuntimeIntrospectionExprMechanics cond ++
-        thenBr.flatMap collectRuntimeIntrospectionStmtMechanics ++
-        elseBr.flatMap collectRuntimeIntrospectionStmtMechanics
-  | .forEach _ count body =>
-      collectRuntimeIntrospectionExprMechanics count ++ body.flatMap collectRuntimeIntrospectionStmtMechanics
-  | .unsafeBlock _ body =>
-      body.flatMap collectRuntimeIntrospectionStmtMechanics
-  | .matchAdt _ scrutinee branches =>
-      collectRuntimeIntrospectionExprMechanics scrutinee ++
-        branches.flatMap fun (_, _, body) => body.flatMap collectRuntimeIntrospectionStmtMechanics
-  | .emit _ args
-  | .internalCall _ args
-  | .returnValues args
-  | .ecm _ args
-  | .internalCallAssign _ _ args =>
-      args.flatMap collectRuntimeIntrospectionExprMechanics
-  | .externalCallBind _ _ args | .tryExternalCallBind _ _ _ args =>
-      args.flatMap collectRuntimeIntrospectionExprMechanics
-  | .rawLog topics dataOffset dataSize =>
-      topics.flatMap collectRuntimeIntrospectionExprMechanics ++
-        collectRuntimeIntrospectionExprMechanics dataOffset ++
-        collectRuntimeIntrospectionExprMechanics dataSize
-  | .rawRevert offset size =>
-      collectRuntimeIntrospectionExprMechanics offset ++ collectRuntimeIntrospectionExprMechanics size
-  | .unsafeYul fragment =>
-      fragment.mechanics.filter (fun mechanic =>
-        mechanic == "contractAddress" || mechanic == "chainid" ||
-        mechanic == "selfBalance" || mechanic == "blockNumber" ||
-        mechanic == "blobbasefee")
-  | .returnArray _
-  | .returnBytes _
-  | .returnStorageWords _
-  | .revertReturndata
-  | .stop =>
-      []
-
 private def collectRuntimeIntrospectionMechanicsFromStmts (stmts : List Stmt) : List String :=
   dedupPreserve <|
     Stmt.foldList
@@ -768,10 +470,13 @@ private def collectRuntimeIntrospectionMechanicsFromStmts (stmts : List Stmt) : 
         let direct :=
           match stmt with
           | .unsafeYul fragment =>
-              fragment.mechanics.filter (fun mechanic =>
-                mechanic == "contractAddress" || mechanic == "chainid" ||
-                mechanic == "selfBalance" || mechanic == "blockNumber" ||
-                mechanic == "blobbasefee")
+              fragment.mechanics.filterMap (fun mechanic =>
+                if mechanic == .contractAddress || mechanic == .chainid ||
+                    mechanic == .selfBalance || mechanic == .blockNumber ||
+                    mechanic == .blobbasefee then
+                  some mechanic.toReportString
+                else
+                  none)
           | _ => []
         acc ++ direct ++ md.subexpressions.flatMap collectRuntimeIntrospectionExprMechanics)
       []
@@ -890,91 +595,19 @@ example : collectRuntimeIntrospectionExprMechanics arrayElementWordRuntimeIndexS
 example : collectExternalExprNames arrayElementWordExternalIndexSmoke = ["oracle"] := by
   native_decide
 
-private def rawRevertAxiomatizedArgSmoke : Stmt :=
-  Stmt.rawRevert (Expr.keccak256 (Expr.literal 0) (Expr.literal 64)) (Expr.literal 32)
+private def stmtAxiomatizedArgSmoke : Stmt :=
+  Stmt.mstore (Expr.keccak256 (Expr.literal 0) (Expr.literal 64)) (Expr.literal 32)
 
-private def rawRevertRuntimeArgSmoke : Stmt :=
-  Stmt.rawRevert Expr.blockNumber (Expr.literal 32)
+private def stmtRuntimeArgSmoke : Stmt :=
+  Stmt.mstore Expr.blockNumber (Expr.literal 32)
 
-private def rawRevertExternalArgSmoke : Stmt :=
-  Stmt.rawRevert (Expr.externalCall "oracle" []) (Expr.literal 32)
+private def stmtExternalArgSmoke : Stmt :=
+  Stmt.mstore (Expr.externalCall "oracle" []) (Expr.literal 32)
 
-example : collectAxiomatizedStmtPrimitives rawRevertAxiomatizedArgSmoke = ["keccak256"] := by
+example : collectAxiomatizedPrimitivesFromStmts [stmtAxiomatizedArgSmoke] = ["keccak256"] := by
   native_decide
 
-example : collectRuntimeIntrospectionStmtMechanics rawRevertRuntimeArgSmoke = ["blockNumber"] := by
-  native_decide
-
-private partial def collectExternalStmtNames : Stmt → List String
-  | .letVar _ value
-  | .assignVar _ value
-  | .setStorage _ value
-  | .setStorageAddr _ value
-  | .setStorageWord _ _ value
-  | .storageArrayPush _ value
-  | .return value
-  | .require value _ =>
-      collectExternalExprNames value
-  | .setStorageArrayElement _ index value =>
-      collectExternalExprNames index ++ collectExternalExprNames value
-  | .storageArrayPop _ =>
-      []
-  | .requireError cond _ args =>
-      collectExternalExprNames cond ++ args.flatMap collectExternalExprNames
-  | .revertError _ args =>
-      args.flatMap collectExternalExprNames
-  | .mstore offset value =>
-      collectExternalExprNames offset ++ collectExternalExprNames value
-  | .tstore offset value =>
-      collectExternalExprNames offset ++ collectExternalExprNames value
-  | .calldatacopy destOffset sourceOffset size
-  | .returndataCopy destOffset sourceOffset size =>
-      collectExternalExprNames destOffset ++ collectExternalExprNames sourceOffset ++ collectExternalExprNames size
-  | .setMapping _ key value
-  | .setMappingWord _ key _ value
-  | .setMappingPackedWord _ key _ _ value
-  | .setMappingUint _ key value
-  | .setStructMember _ key _ value =>
-      collectExternalExprNames key ++ collectExternalExprNames value
-  | .setMappingChain _ keys value =>
-      keys.flatMap collectExternalExprNames ++ collectExternalExprNames value
-  | .setMapping2 _ key1 key2 value
-  | .setMapping2Word _ key1 key2 _ value
-  | .setStructMember2 _ key1 key2 _ value =>
-      collectExternalExprNames key1 ++ collectExternalExprNames key2 ++ collectExternalExprNames value
-  | .ite cond thenBr elseBr =>
-      collectExternalExprNames cond ++ thenBr.flatMap collectExternalStmtNames ++ elseBr.flatMap collectExternalStmtNames
-  | .forEach _ count body =>
-      collectExternalExprNames count ++ body.flatMap collectExternalStmtNames
-  | .unsafeBlock _ body =>
-      body.flatMap collectExternalStmtNames
-  | .matchAdt _ scrutinee branches =>
-      collectExternalExprNames scrutinee ++
-        branches.flatMap fun (_, _, body) => body.flatMap collectExternalStmtNames
-  | .emit _ args
-  | .internalCall _ args
-  | .returnValues args
-  | .ecm _ args
-  | .internalCallAssign _ _ args =>
-      args.flatMap collectExternalExprNames
-  | .externalCallBind _ externalName args =>
-      externalName :: args.flatMap collectExternalExprNames
-  | .tryExternalCallBind _ _ externalName args =>
-      externalName :: args.flatMap collectExternalExprNames
-  | .rawLog topics dataOffset dataSize =>
-      topics.flatMap collectExternalExprNames ++ collectExternalExprNames dataOffset ++ collectExternalExprNames dataSize
-  | .rawRevert offset size =>
-      collectExternalExprNames offset ++ collectExternalExprNames size
-  | .unsafeYul _ =>
-      []
-  | .returnArray _
-  | .returnBytes _
-  | .returnStorageWords _
-  | .revertReturndata
-  | .stop =>
-      []
-
-example : collectExternalStmtNames rawRevertExternalArgSmoke = ["oracle"] := by
+example : collectRuntimeIntrospectionMechanicsFromStmts [stmtRuntimeArgSmoke] = ["blockNumber"] := by
   native_decide
 
 private def collectUsedExternalNamesFromStmts (stmts : List Stmt) : List String :=
@@ -1020,17 +653,18 @@ private def collectUsedExternalNamesByStatus
     (fun acc ext => if ext.proofStatus == status then acc ++ [ext.name] else acc)
     []
 
-private partial def collectUsedEcmModulesInStmt : Stmt → List ECM.ExternalCallModule
-  | stmt =>
-      stmt.fold
-        (fun acc s _ =>
-          match s with
-          | .ecm mod _ => acc ++ [mod]
-          | _ => acc)
-        []
+example : collectUsedExternalNamesFromStmts [stmtExternalArgSmoke] = ["oracle"] := by
+  native_decide
 
 private def collectUsedEcmModulesFromStmts (stmts : List Stmt) : List ECM.ExternalCallModule :=
-  dedupEcmModules (stmts.flatMap collectUsedEcmModulesInStmt)
+  dedupEcmModules <|
+    Stmt.foldList
+      (fun acc stmt _ =>
+        match stmt with
+        | .ecm mod _ => acc ++ [mod]
+        | _ => acc)
+      []
+      stmts
 
 /-- Collect ECM modules that are actually referenced by the spec, including
     constructor bodies. This shared view keeps machine-readable reports and
@@ -1070,6 +704,9 @@ def collectLocalObligations (spec : CompilationModel) : List LocalObligation :=
   let functionObligations :=
     spec.functions.flatMap fun fn => collectLocalObligationsFromStmts fn.localObligations fn.body
   dedupLocalObligations (ctorObligations ++ functionObligations)
+
+private def collectUnsafeYulContractsFromStmts (stmts : List Stmt) : List UnsafeYulContract :=
+  Stmt.foldList (fun acc _ md => acc ++ md.unsafeYulContracts) [] stmts
 
 private def collectLocalObligationNamesByStatus
     (spec : CompilationModel)
@@ -1114,6 +751,25 @@ private def ecmModuleJson (entry : ECM.ExternalCallModule) : String :=
     ("module", jsonString entry.name),
     ("status", proofStatusString entry.proofStatus),
     ("axioms", jsonArray (entry.axioms.map jsonString))
+  ]
+
+private def frameSpecJson (frame : FrameSpec) : String :=
+  jsonObject [
+    ("localReads", jsonArray (frame.localReads.map jsonString)),
+    ("localWrites", jsonArray (frame.localWrites.map jsonString)),
+    ("memoryReads", jsonArray (frame.memoryReads.map jsonString)),
+    ("memoryWrites", jsonArray (frame.memoryWrites.map jsonString)),
+    ("storageReads", jsonArray (frame.storageReads.map jsonString)),
+    ("storageWrites", jsonArray (frame.storageWrites.map jsonString)),
+    ("transientReads", jsonArray (frame.transientReads.map jsonString)),
+    ("transientWrites", jsonArray (frame.transientWrites.map jsonString))
+  ]
+
+private def unsafeYulContractJson (contract : UnsafeYulContract) : String :=
+  jsonObject [
+    ("name", jsonString contract.name),
+    ("summary", jsonString contract.summary),
+    ("frame", frameSpecJson contract.frame)
   ]
 
 private def localObligationJson (entry : LocalObligation) : String :=
@@ -1229,6 +885,7 @@ private structure UsageSiteSummary where
   externals : List ExternalFunction
   modules : List ECM.ExternalCallModule
   localObligations : List LocalObligation
+  unsafeYulContracts : List UnsafeYulContract
   unsafeBlocks : List String
 
 private def ecmAxiomsFromModules (modules : List ECM.ExternalCallModule) : List (String × String) :=
@@ -1246,6 +903,7 @@ private def siteHasTrustSurface
     !(collectUsedExternalAssumptionsFromStmts externals stmts).isEmpty ||
     !(collectUsedEcmModulesFromStmts stmts).isEmpty ||
     !(collectLocalObligationsFromStmts localObligations stmts).isEmpty ||
+    !(collectUnsafeYulContractsFromStmts stmts).isEmpty ||
     !(collectUnsafeBlockReasonsFromStmts stmts).isEmpty
 
 private def usageSiteSummary
@@ -1262,6 +920,7 @@ private def usageSiteSummary
   let siteExternals := collectUsedExternalAssumptionsFromStmts spec.externals stmts
   let siteModules := collectUsedEcmModulesFromStmts stmts
   let siteLocalObligations := collectLocalObligationsFromStmts localObligations stmts
+  let siteUnsafeYulContracts := collectUnsafeYulContractsFromStmts stmts
   let siteUnsafeBlocks := collectUnsafeBlockReasonsFromStmts stmts
   { kind := kind
     name := name
@@ -1273,6 +932,7 @@ private def usageSiteSummary
     externals := siteExternals
     modules := siteModules
     localObligations := siteLocalObligations
+    unsafeYulContracts := siteUnsafeYulContracts
     unsafeBlocks := siteUnsafeBlocks }
 
 private def collectUsageSiteSummaries (spec : CompilationModel) : List UsageSiteSummary :=
@@ -1308,6 +968,7 @@ private def usageSitesJson (spec : CompilationModel) : String :=
       ("axiomatizedPrimitives", jsonArray (site.primitives.map jsonString)),
       ("proofStatus", proofStatusJsonForSite site.primitives site.externals site.modules site.localObligations),
       ("localObligations", jsonArray (site.localObligations.map localObligationJson)),
+      ("unsafeYulContracts", jsonArray (site.unsafeYulContracts.map unsafeYulContractJson)),
       ("unsafeBlocks", jsonArray (site.unsafeBlocks.map jsonString)),
       ("hasUncheckedDependencies",
         if hasUncheckedDependenciesForSite site.externals site.modules then "true" else "false"),

--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -217,6 +217,8 @@ private partial def collectLowLevelStmtMechanics : Stmt → List String
       args.flatMap collectLowLevelExprMechanics
   | .rawLog topics dataOffset dataSize =>
       topics.flatMap collectLowLevelExprMechanics ++ collectLowLevelExprMechanics dataOffset ++ collectLowLevelExprMechanics dataSize
+  | .unsafeYul fragment =>
+      fragment.mechanics
   | .returnArray _
   | .returnBytes _
   | .returnStorageWords _
@@ -284,6 +286,8 @@ private partial def collectAxiomatizedStmtPrimitives : Stmt → List String
         collectAxiomatizedExprPrimitives dataSize
   | .rawRevert offset size =>
       collectAxiomatizedExprPrimitives offset ++ collectAxiomatizedExprPrimitives size
+  | .unsafeYul _ =>
+      []
   | .returnArray _
   | .returnBytes _
   | .returnStorageWords _
@@ -292,10 +296,19 @@ private partial def collectAxiomatizedStmtPrimitives : Stmt → List String
       []
 
 private def collectLowLevelMechanicsFromStmts (stmts : List Stmt) : List String :=
-  dedupPreserve (stmts.flatMap collectLowLevelStmtMechanics)
+  dedupPreserve <|
+    Stmt.foldList
+      (fun acc _ md =>
+        acc ++ md.lowLevelMechanics ++ md.subexpressions.flatMap collectLowLevelExprMechanics)
+      []
+      stmts
 
 private def collectAxiomatizedPrimitivesFromStmts (stmts : List Stmt) : List String :=
-  dedupPreserve (stmts.flatMap collectAxiomatizedStmtPrimitives)
+  dedupPreserve <|
+    Stmt.foldList
+      (fun acc _ md => acc ++ md.subexpressions.flatMap collectAxiomatizedExprPrimitives)
+      []
+      stmts
 
 private def isUnsafeBoundaryMechanic (mechanic : String) : Bool :=
   match mechanic with
@@ -372,6 +385,8 @@ private partial def collectUnguardedLowLevelStmtMechanics : Stmt → List String
       args.flatMap collectLowLevelExprMechanics
   | .rawLog topics dataOffset dataSize =>
       topics.flatMap collectLowLevelExprMechanics ++ collectLowLevelExprMechanics dataOffset ++ collectLowLevelExprMechanics dataSize
+  | .unsafeYul _ =>
+      []
   | .returnArray _
   | .returnBytes _
   | .returnStorageWords _
@@ -400,7 +415,7 @@ private partial def collectUnsafeBlockReasonsInStmt : Stmt → List String
   | _ => []
 
 private def collectUnsafeBlockReasonsFromStmts (stmts : List Stmt) : List String :=
-  stmts.flatMap collectUnsafeBlockReasonsInStmt
+  Stmt.foldList (fun acc _ md => acc ++ md.unsafeReasons) [] stmts
 
 /-- Collect all `unsafe "reason" do` block reasons used by a spec. -/
 def collectUnsafeBlockReasons (spec : CompilationModel) : List String :=
@@ -548,6 +563,8 @@ private partial def collectEventEmissionStmtMechanics : Stmt → List String
         collectEventEmissionExprMechanics dataOffset ++ collectEventEmissionExprMechanics dataSize
   | .rawRevert offset size =>
       collectEventEmissionExprMechanics offset ++ collectEventEmissionExprMechanics size
+  | .unsafeYul fragment =>
+      if fragment.mechanics.contains "rawLog" then ["rawLog"] else []
   | .returnArray _
   | .returnBytes _
   | .returnStorageWords _
@@ -556,7 +573,17 @@ private partial def collectEventEmissionStmtMechanics : Stmt → List String
       []
 
 private def collectEventEmissionMechanicsFromStmts (stmts : List Stmt) : List String :=
-  dedupPreserve (stmts.flatMap collectEventEmissionStmtMechanics)
+  dedupPreserve <|
+    Stmt.foldList
+      (fun acc stmt md =>
+        let direct :=
+          match stmt with
+          | .rawLog _ _ _ => ["rawLog"]
+          | .unsafeYul fragment => if fragment.mechanics.contains "rawLog" then ["rawLog"] else []
+          | _ => []
+        acc ++ direct ++ md.subexpressions.flatMap collectEventEmissionExprMechanics)
+      []
+      stmts
 
 /-- Collect not-modeled raw event-emission mechanics used by a spec. -/
 def collectEventEmissionMechanics (spec : CompilationModel) : List String :=
@@ -722,6 +749,11 @@ private partial def collectRuntimeIntrospectionStmtMechanics : Stmt → List Str
         collectRuntimeIntrospectionExprMechanics dataSize
   | .rawRevert offset size =>
       collectRuntimeIntrospectionExprMechanics offset ++ collectRuntimeIntrospectionExprMechanics size
+  | .unsafeYul fragment =>
+      fragment.mechanics.filter (fun mechanic =>
+        mechanic == "contractAddress" || mechanic == "chainid" ||
+        mechanic == "selfBalance" || mechanic == "blockNumber" ||
+        mechanic == "blobbasefee")
   | .returnArray _
   | .returnBytes _
   | .returnStorageWords _
@@ -730,7 +762,20 @@ private partial def collectRuntimeIntrospectionStmtMechanics : Stmt → List Str
       []
 
 private def collectRuntimeIntrospectionMechanicsFromStmts (stmts : List Stmt) : List String :=
-  dedupPreserve (stmts.flatMap collectRuntimeIntrospectionStmtMechanics)
+  dedupPreserve <|
+    Stmt.foldList
+      (fun acc stmt md =>
+        let direct :=
+          match stmt with
+          | .unsafeYul fragment =>
+              fragment.mechanics.filter (fun mechanic =>
+                mechanic == "contractAddress" || mechanic == "chainid" ||
+                mechanic == "selfBalance" || mechanic == "blockNumber" ||
+                mechanic == "blobbasefee")
+          | _ => []
+        acc ++ direct ++ md.subexpressions.flatMap collectRuntimeIntrospectionExprMechanics)
+      []
+      stmts
 
 /-- Collect partially modeled runtime-introspection mechanics used by a spec. -/
 def collectRuntimeIntrospectionMechanics (spec : CompilationModel) : List String :=
@@ -920,6 +965,8 @@ private partial def collectExternalStmtNames : Stmt → List String
       topics.flatMap collectExternalExprNames ++ collectExternalExprNames dataOffset ++ collectExternalExprNames dataSize
   | .rawRevert offset size =>
       collectExternalExprNames offset ++ collectExternalExprNames size
+  | .unsafeYul _ =>
+      []
   | .returnArray _
   | .returnBytes _
   | .returnStorageWords _
@@ -931,7 +978,17 @@ example : collectExternalStmtNames rawRevertExternalArgSmoke = ["oracle"] := by
   native_decide
 
 private def collectUsedExternalNamesFromStmts (stmts : List Stmt) : List String :=
-  dedupPreserve (stmts.flatMap collectExternalStmtNames)
+  dedupPreserve <|
+    Stmt.foldList
+      (fun acc stmt md =>
+        let direct :=
+          match stmt with
+          | .externalCallBind _ externalName _ => [externalName]
+          | .tryExternalCallBind _ _ externalName _ => [externalName]
+          | _ => []
+        acc ++ direct ++ md.subexpressions.flatMap collectExternalExprNames)
+      []
+      stmts
 
 private def collectUsedExternalAssumptionsFromStmts
     (externals : List ExternalFunction)
@@ -964,17 +1021,13 @@ private def collectUsedExternalNamesByStatus
     []
 
 private partial def collectUsedEcmModulesInStmt : Stmt → List ECM.ExternalCallModule
-  | .ecm mod _ => [mod]
-  | .ite _ thenBr elseBr =>
-      thenBr.flatMap collectUsedEcmModulesInStmt ++ elseBr.flatMap collectUsedEcmModulesInStmt
-  | .forEach _ _ body =>
-      body.flatMap collectUsedEcmModulesInStmt
-  | .unsafeBlock _ body =>
-      body.flatMap collectUsedEcmModulesInStmt
-  | .matchAdt _ _ branches =>
-      branches.flatMap fun (_, _, body) => body.flatMap collectUsedEcmModulesInStmt
-  | _ =>
-      []
+  | stmt =>
+      stmt.fold
+        (fun acc s _ =>
+          match s with
+          | .ecm mod _ => acc ++ [mod]
+          | _ => acc)
+        []
 
 private def collectUsedEcmModulesFromStmts (stmts : List Stmt) : List ECM.ExternalCallModule :=
   dedupEcmModules (stmts.flatMap collectUsedEcmModulesInStmt)
@@ -999,8 +1052,9 @@ private def collectUsedEcmModuleNamesByStatus
 
 private def collectLocalObligationsFromStmts
     (obligations : List LocalObligation)
-    (_stmts : List Stmt) : List LocalObligation :=
-  obligations
+    (stmts : List Stmt) : List LocalObligation :=
+  dedupLocalObligations
+    (obligations ++ Stmt.foldList (fun acc _ md => acc ++ md.localObligations) [] stmts)
 
 private def collectConstructorLocalObligations (spec : CompilationModel) : List LocalObligation :=
   match spec.constructor with
@@ -1009,8 +1063,13 @@ private def collectConstructorLocalObligations (spec : CompilationModel) : List 
 
 /-- Collect local proof obligations attached to functions/constructors. -/
 def collectLocalObligations (spec : CompilationModel) : List LocalObligation :=
-  let functionObligations := spec.functions.flatMap (·.localObligations)
-  dedupLocalObligations (collectConstructorLocalObligations spec ++ functionObligations)
+  let ctorObligations :=
+    match spec.constructor with
+    | some ctor => collectLocalObligationsFromStmts ctor.localObligations ctor.body
+    | none => []
+  let functionObligations :=
+    spec.functions.flatMap fun fn => collectLocalObligationsFromStmts fn.localObligations fn.body
+  dedupLocalObligations (ctorObligations ++ functionObligations)
 
 private def collectLocalObligationNamesByStatus
     (spec : CompilationModel)

--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -185,6 +185,8 @@ private partial def collectLowLevelStmtMechanics : Stmt → List String
       ["returndataCopy"] ++ collectLowLevelExprMechanics destOffset ++ collectLowLevelExprMechanics sourceOffset ++ collectLowLevelExprMechanics size
   | .revertReturndata =>
       ["revertReturndata"]
+  | .rawRevert offset size =>
+      ["rawRevert"] ++ collectLowLevelExprMechanics offset ++ collectLowLevelExprMechanics size
   | .setMapping _ key value
   | .setMappingWord _ key _ value
   | .setMappingPackedWord _ key _ _ value
@@ -284,6 +286,7 @@ private partial def collectAxiomatizedStmtPrimitives : Stmt → List String
   | .returnBytes _
   | .returnStorageWords _
   | .revertReturndata
+  | .rawRevert _ _
   | .stop =>
       []
 
@@ -336,6 +339,8 @@ private partial def collectUnguardedLowLevelStmtMechanics : Stmt → List String
       ["returndataCopy"] ++ collectLowLevelExprMechanics destOffset ++ collectLowLevelExprMechanics sourceOffset ++ collectLowLevelExprMechanics size
   | .revertReturndata =>
       ["revertReturndata"]
+  | .rawRevert offset size =>
+      ["rawRevert"] ++ collectLowLevelExprMechanics offset ++ collectLowLevelExprMechanics size
   | .setMapping _ key value
   | .setMappingWord _ key _ value
   | .setMappingPackedWord _ key _ _ value
@@ -544,6 +549,7 @@ private partial def collectEventEmissionStmtMechanics : Stmt → List String
   | .returnBytes _
   | .returnStorageWords _
   | .revertReturndata
+  | .rawRevert _ _
   | .stop =>
       []
 
@@ -562,7 +568,7 @@ def collectEventEmissionMechanics (spec : CompilationModel) : List String :=
 private def isDeniedLowLevelMechanic (mechanic : String) : Bool :=
   match mechanic with
   | "call" | "staticcall" | "delegatecall" | "returndataSize" | "returndataCopy"
-  | "revertReturndata" | "returndataOptionalBoolAt" | "blobbasefee" => true
+  | "revertReturndata" | "rawRevert" | "returndataOptionalBoolAt" | "blobbasefee" => true
   | _ => false
 
 private def collectDeniedLowLevelMechanicsFromMechanics (mechanics : List String) : List String :=
@@ -716,6 +722,7 @@ private partial def collectRuntimeIntrospectionStmtMechanics : Stmt → List Str
   | .returnBytes _
   | .returnStorageWords _
   | .revertReturndata
+  | .rawRevert _ _
   | .stop =>
       []
 
@@ -897,6 +904,7 @@ private partial def collectExternalStmtNames : Stmt → List String
   | .returnBytes _
   | .returnStorageWords _
   | .revertReturndata
+  | .rawRevert _ _
   | .stop =>
       []
 

--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -282,11 +282,12 @@ private partial def collectAxiomatizedStmtPrimitives : Stmt → List String
   | .rawLog topics dataOffset dataSize =>
       topics.flatMap collectAxiomatizedExprPrimitives ++ collectAxiomatizedExprPrimitives dataOffset ++
         collectAxiomatizedExprPrimitives dataSize
+  | .rawRevert offset size =>
+      collectAxiomatizedExprPrimitives offset ++ collectAxiomatizedExprPrimitives size
   | .returnArray _
   | .returnBytes _
   | .returnStorageWords _
   | .revertReturndata
-  | .rawRevert _ _
   | .stop =>
       []
 
@@ -545,11 +546,12 @@ private partial def collectEventEmissionStmtMechanics : Stmt → List String
   | .rawLog topics dataOffset dataSize =>
       ["rawLog"] ++ topics.flatMap collectEventEmissionExprMechanics ++
         collectEventEmissionExprMechanics dataOffset ++ collectEventEmissionExprMechanics dataSize
+  | .rawRevert offset size =>
+      collectEventEmissionExprMechanics offset ++ collectEventEmissionExprMechanics size
   | .returnArray _
   | .returnBytes _
   | .returnStorageWords _
   | .revertReturndata
-  | .rawRevert _ _
   | .stop =>
       []
 
@@ -718,11 +720,12 @@ private partial def collectRuntimeIntrospectionStmtMechanics : Stmt → List Str
       topics.flatMap collectRuntimeIntrospectionExprMechanics ++
         collectRuntimeIntrospectionExprMechanics dataOffset ++
         collectRuntimeIntrospectionExprMechanics dataSize
+  | .rawRevert offset size =>
+      collectRuntimeIntrospectionExprMechanics offset ++ collectRuntimeIntrospectionExprMechanics size
   | .returnArray _
   | .returnBytes _
   | .returnStorageWords _
   | .revertReturndata
-  | .rawRevert _ _
   | .stop =>
       []
 
@@ -842,6 +845,21 @@ example : collectRuntimeIntrospectionExprMechanics arrayElementWordRuntimeIndexS
 example : collectExternalExprNames arrayElementWordExternalIndexSmoke = ["oracle"] := by
   native_decide
 
+private def rawRevertAxiomatizedArgSmoke : Stmt :=
+  Stmt.rawRevert (Expr.keccak256 (Expr.literal 0) (Expr.literal 64)) (Expr.literal 32)
+
+private def rawRevertRuntimeArgSmoke : Stmt :=
+  Stmt.rawRevert Expr.blockNumber (Expr.literal 32)
+
+private def rawRevertExternalArgSmoke : Stmt :=
+  Stmt.rawRevert (Expr.externalCall "oracle" []) (Expr.literal 32)
+
+example : collectAxiomatizedStmtPrimitives rawRevertAxiomatizedArgSmoke = ["keccak256"] := by
+  native_decide
+
+example : collectRuntimeIntrospectionStmtMechanics rawRevertRuntimeArgSmoke = ["blockNumber"] := by
+  native_decide
+
 private partial def collectExternalStmtNames : Stmt → List String
   | .letVar _ value
   | .assignVar _ value
@@ -900,13 +918,17 @@ private partial def collectExternalStmtNames : Stmt → List String
       externalName :: args.flatMap collectExternalExprNames
   | .rawLog topics dataOffset dataSize =>
       topics.flatMap collectExternalExprNames ++ collectExternalExprNames dataOffset ++ collectExternalExprNames dataSize
+  | .rawRevert offset size =>
+      collectExternalExprNames offset ++ collectExternalExprNames size
   | .returnArray _
   | .returnBytes _
   | .returnStorageWords _
   | .revertReturndata
-  | .rawRevert _ _
   | .stop =>
       []
+
+example : collectExternalStmtNames rawRevertExternalArgSmoke = ["oracle"] := by
+  native_decide
 
 private def collectUsedExternalNamesFromStmts (stmts : List Stmt) : List String :=
   dedupPreserve (stmts.flatMap collectExternalStmtNames)

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -291,6 +291,50 @@ structure ExternalFunction where
   linkMode : ForeignLinkMode := .objectLinked
   deriving Repr
 
+structure YulState where
+  vars : List (String × Nat) := []
+  memory : Nat → Nat := fun _ => 0
+  storage : Nat → Nat := fun _ => 0
+  transientStorage : Nat → Nat := fun _ => 0
+  returndata : List Nat := []
+  reverted : Bool := false
+
+structure FrameSpec where
+  localReads : List String := []
+  localWrites : List String := []
+  memoryReads : List String := []
+  memoryWrites : List String := []
+  storageReads : List String := []
+  storageWrites : List String := []
+  transientReads : List String := []
+  transientWrites : List String := []
+  deriving Repr, BEq, Inhabited
+
+/-- Structured refinement contract for localized unsafe Yul boundaries.
+    The predicates give proof code a real target while `summary` remains the
+    stable human-readable report text. -/
+structure UnsafeYulContract where
+  name : String
+  summary : String
+  pre : YulState → Prop
+  post : YulState → YulState → Prop
+  frame : FrameSpec := {}
+
+instance : Repr UnsafeYulContract where
+  reprPrec contract prec :=
+    reprPrec (contract.name, contract.summary, contract.frame) prec
+
+namespace UnsafeYulContract
+
+def rawRevert (name summary : String) : UnsafeYulContract :=
+  { name := name
+    summary := summary
+    pre := fun _ => True
+    post := fun _ after => after.reverted = true
+    frame := { memoryReads := ["revertPayload"] } }
+
+end UnsafeYulContract
+
 structure LocalObligation where
   name : String
   /-- User-supplied summary of the local refinement contract that must hold
@@ -309,12 +353,122 @@ inductive StmtTermination where
   | mayTerminate
   deriving Repr, BEq
 
+/-- Finer control-flow summary for statements and statement lists.
+    This intentionally coexists with `StmtTermination` while callers migrate:
+    the old field answers the coarse "can execution continue?" question, while
+    this summary records which terminal behaviors may occur. -/
+structure ControlFlowSummary where
+  mayFallThrough : Bool := true
+  mayRevert : Bool := false
+  mayReturn : Bool := false
+  mayStop : Bool := false
+  deriving Repr, BEq, Inhabited
+
+namespace ControlFlowSummary
+
+def fallsThrough : ControlFlowSummary := {}
+
+def mayReverting : ControlFlowSummary :=
+  { mayFallThrough := true, mayRevert := true }
+
+def reverts : ControlFlowSummary :=
+  { mayFallThrough := false, mayRevert := true }
+
+def returns : ControlFlowSummary :=
+  { mayFallThrough := false, mayReturn := true }
+
+def stops : ControlFlowSummary :=
+  { mayFallThrough := false, mayStop := true }
+
+def unknown : ControlFlowSummary :=
+  { mayFallThrough := true, mayRevert := true, mayReturn := true, mayStop := true }
+
+def union (a b : ControlFlowSummary) : ControlFlowSummary :=
+  { mayFallThrough := a.mayFallThrough || b.mayFallThrough
+    mayRevert := a.mayRevert || b.mayRevert
+    mayReturn := a.mayReturn || b.mayReturn
+    mayStop := a.mayStop || b.mayStop }
+
+/-- Sequential composition: `b` is reachable only along fall-through paths of `a`. -/
+def seq (a b : ControlFlowSummary) : ControlFlowSummary :=
+  { mayFallThrough := a.mayFallThrough && b.mayFallThrough
+    mayRevert := a.mayRevert || (a.mayFallThrough && b.mayRevert)
+    mayReturn := a.mayReturn || (a.mayFallThrough && b.mayReturn)
+    mayStop := a.mayStop || (a.mayFallThrough && b.mayStop) }
+
+def fromTermination : StmtTermination → ControlFlowSummary
+  | .fallsThrough => fallsThrough
+  | .alwaysTerminates => unknown
+  | .mayTerminate => unknown
+
+end ControlFlowSummary
+
 /-- Scope effects exposed by the generic statement metadata layer. -/
 structure StmtScopeEffects where
   bindNames : List String := []
   assignNames : List String := []
   storageWrites : List String := []
-  deriving Repr
+  deriving Repr, Inhabited
+
+/-- Typed trust-report mechanics emitted by low-level statements and raw Yul fragments.
+    JSON and human-readable reports still render these through `toReportString`,
+    preserving the existing public report format while keeping the model boundary
+    from depending on ad-hoc string literals. -/
+inductive LowLevelMechanic where
+  | call
+  | staticcall
+  | delegatecall
+  | returndataSize
+  | returndataCopy
+  | revertReturndata
+  | rawRevert
+  | returndataOptionalBoolAt
+  | blobbasefee
+  | mload
+  | mstore
+  | calldataload
+  | calldatacopy
+  | extcodesize
+  | tload
+  | tstore
+  | rawLog
+  | contractAddress
+  | chainid
+  | selfBalance
+  | blockNumber
+  | storageWrite
+  deriving Repr, BEq, Inhabited
+
+namespace LowLevelMechanic
+
+def toReportString : LowLevelMechanic → String
+  | .call => "call"
+  | .staticcall => "staticcall"
+  | .delegatecall => "delegatecall"
+  | .returndataSize => "returndataSize"
+  | .returndataCopy => "returndataCopy"
+  | .revertReturndata => "revertReturndata"
+  | .rawRevert => "rawRevert"
+  | .returndataOptionalBoolAt => "returndataOptionalBoolAt"
+  | .blobbasefee => "blobbasefee"
+  | .mload => "mload"
+  | .mstore => "mstore"
+  | .calldataload => "calldataload"
+  | .calldatacopy => "calldatacopy"
+  | .extcodesize => "extcodesize"
+  | .tload => "tload"
+  | .tstore => "tstore"
+  | .rawLog => "rawLog"
+  | .contractAddress => "contractAddress"
+  | .chainid => "chainid"
+  | .selfBalance => "selfBalance"
+  | .blockNumber => "blockNumber"
+  | .storageWrite => "storageWrite"
+
+instance : ToString LowLevelMechanic where
+  toString := toReportString
+
+end LowLevelMechanic
 
 /-- Typed handwritten Yul fragment. This is intentionally not just a string:
     callers provide an EVMYul AST payload plus explicit proof obligations and
@@ -324,13 +478,39 @@ structure UnsafeYulFragment where
   label : String
   stmts : List YulStmt
   obligations : List LocalObligation
-  mechanics : List String := []
+  contracts : List UnsafeYulContract := []
+  mechanics : List LowLevelMechanic := []
   scopeEffects : StmtScopeEffects := {}
   termination : StmtTermination := .mayTerminate
+  controlFlow : ControlFlowSummary := .unknown
   deriving Repr
 
 /-- Backwards-friendly name for explicitly trusted raw Yul fragments. -/
 abbrev RawYul := UnsafeYulFragment
+
+namespace UnsafeYulFragment
+
+/-- Helper constructor for the single Yul `revert(offset, size)` instruction.
+
+    Prefer this through `Stmt.unsafeYul` for one-off raw instruction escapes.
+    Stable typed primitives such as `Stmt.mstore` and `Stmt.calldatacopy`
+    remain first-class statements because Verity has explicit semantics and
+    proof/audit surfaces for them; ad-hoc raw instructions should carry their
+    trust metadata at the `UnsafeYulFragment` boundary instead of growing `Stmt`.
+    Raw memory reverts are intentionally modeled as unsafe Yul fragments rather
+    than first-class `Stmt` constructors. -/
+def rawRevert (offset size : YulExpr) (obligation : LocalObligation)
+    (label : String := obligation.name) : UnsafeYulFragment := {
+  label := label
+  stmts := [YulStmt.expr (YulExpr.call "revert" [offset, size])]
+  obligations := [obligation]
+  contracts := [UnsafeYulContract.rawRevert obligation.name obligation.obligation]
+  mechanics := [.rawRevert]
+  termination := .alwaysTerminates
+  controlFlow := .reverts
+}
+
+end UnsafeYulFragment
 
 /-!
 ### ADT Type Definitions (#1727, Phase 5 Step 5b)
@@ -629,10 +809,6 @@ inductive Stmt
   | returndataCopy (destOffset sourceOffset size : Expr)
   /-- Forward current returndata as revert payload (`returndatacopy` + `revert`). -/
   | revertReturndata
-  /-- Raw low-level revert with caller-specified memory slice.  This models
-      handwritten assembly such as `revert(0, 0)` without forcing callers to
-      encode a Solidity `Error(string)` or custom error. -/
-  | rawRevert (offset size : Expr)
   | stop
   | ite (cond : Expr) (thenBranch : List Stmt) (elseBranch : List Stmt)  -- If/else (#179)
   | forEach (varName : String) (count : Expr) (body : List Stmt)  -- Bounded loop (#179)
@@ -683,9 +859,11 @@ inductive Stmt
 structure StmtMetadata where
   subexpressions : List Expr := []
   termination : StmtTermination := .fallsThrough
-  lowLevelMechanics : List String := []
+  controlFlow : ControlFlowSummary := {}
+  lowLevelMechanics : List LowLevelMechanic := []
   scopeEffects : StmtScopeEffects := {}
   localObligations : List LocalObligation := []
+  unsafeYulContracts : List UnsafeYulContract := []
   unsafeReasons : List String := []
   deriving Repr
 
@@ -723,33 +901,31 @@ def directMetadata : Stmt → StmtMetadata
   | .setStructMember2 field key1 key2 _ value =>
       { subexpressions := [key1, key2, value], scopeEffects := { storageWrites := [field] } }
   | .require cond _ =>
-      { subexpressions := [cond], termination := .mayTerminate }
+      { subexpressions := [cond], termination := .mayTerminate, controlFlow := .mayReverting }
   | .requireError cond _ args =>
-      { subexpressions := cond :: args, termination := .mayTerminate }
+      { subexpressions := cond :: args, termination := .mayTerminate, controlFlow := .mayReverting }
   | .revertError _ args =>
-      { subexpressions := args, termination := .alwaysTerminates }
+      { subexpressions := args, termination := .alwaysTerminates, controlFlow := .reverts }
   | .return value =>
-      { subexpressions := [value], termination := .alwaysTerminates }
+      { subexpressions := [value], termination := .alwaysTerminates, controlFlow := .returns }
   | .returnValues values =>
-      { subexpressions := values, termination := .alwaysTerminates }
+      { subexpressions := values, termination := .alwaysTerminates, controlFlow := .returns }
   | .returnArray _ | .returnBytes _ | .returnStorageWords _ =>
-      { termination := .alwaysTerminates }
+      { termination := .alwaysTerminates, controlFlow := .returns }
   | .mstore offset value =>
-      { subexpressions := [offset, value], lowLevelMechanics := ["mstore"] }
+      { subexpressions := [offset, value], lowLevelMechanics := [.mstore] }
   | .tstore offset value =>
-      { subexpressions := [offset, value], lowLevelMechanics := ["tstore"] }
+      { subexpressions := [offset, value], lowLevelMechanics := [.tstore] }
   | .calldatacopy destOffset sourceOffset size =>
-      { subexpressions := [destOffset, sourceOffset, size], lowLevelMechanics := ["calldatacopy"] }
+      { subexpressions := [destOffset, sourceOffset, size], lowLevelMechanics := [.calldatacopy] }
   | .returndataCopy destOffset sourceOffset size =>
-      { subexpressions := [destOffset, sourceOffset, size], lowLevelMechanics := ["returndataCopy"] }
+      { subexpressions := [destOffset, sourceOffset, size], lowLevelMechanics := [.returndataCopy] }
   | .revertReturndata =>
-      { termination := .alwaysTerminates, lowLevelMechanics := ["revertReturndata"] }
-  | .rawRevert offset size =>
-      { subexpressions := [offset, size], termination := .alwaysTerminates, lowLevelMechanics := ["rawRevert"] }
+      { termination := .alwaysTerminates, controlFlow := .reverts, lowLevelMechanics := [.revertReturndata] }
   | .stop =>
-      { termination := .alwaysTerminates }
+      { termination := .alwaysTerminates, controlFlow := .stops }
   | .ite cond _ _ =>
-      { subexpressions := [cond], termination := .mayTerminate }
+      { subexpressions := [cond], termination := .mayTerminate, controlFlow := .unknown }
   | .forEach varName count _ =>
       { subexpressions := [count], scopeEffects := { bindNames := [varName] } }
   | .emit _ args =>
@@ -770,13 +946,16 @@ def directMetadata : Stmt → StmtMetadata
       { unsafeReasons := [reason] }
   | .unsafeYul fragment =>
       { termination := fragment.termination
+        controlFlow := fragment.controlFlow
         lowLevelMechanics := fragment.mechanics
         scopeEffects := fragment.scopeEffects
         localObligations := fragment.obligations
+        unsafeYulContracts := fragment.contracts
         unsafeReasons := [fragment.label] }
   | .matchAdt _ scrutinee branches =>
       { subexpressions := [scrutinee]
         termination := .mayTerminate
+        controlFlow := .unknown
         scopeEffects := { bindNames := branches.flatMap (fun (_, names, _) => names) } }
 
 partial def fold (f : α → Stmt → StmtMetadata → α) (init : α) (stmt : Stmt) : α :=
@@ -789,17 +968,61 @@ partial def fold (f : α → Stmt → StmtMetadata → α) (init : α) (stmt : S
 partial def foldList (f : α → Stmt → StmtMetadata → α) (init : α) (stmts : List Stmt) : α :=
   stmts.foldl (fun acc stmt => stmt.fold f acc) init
 
+mutual
+partial def controlFlow : Stmt → ControlFlowSummary
+  | .require _ _ | .requireError _ _ _ =>
+      .mayReverting
+  | .revertError _ _ | .revertReturndata =>
+      .reverts
+  | .return _ | .returnValues _ | .returnArray _ | .returnBytes _ | .returnStorageWords _ =>
+      .returns
+  | .stop =>
+      .stops
+  | .ite _ thenBranch elseBranch =>
+      ControlFlowSummary.union (controlFlowList thenBranch) (controlFlowList elseBranch)
+  | .forEach _ _ body =>
+      -- Loops are bounded and may execute zero times, so the loop itself can fall through
+      -- even if some body path returns or reverts.
+      ControlFlowSummary.union .fallsThrough (controlFlowList body)
+  | .unsafeBlock _ body =>
+      controlFlowList body
+  | .matchAdt _ _ branches =>
+      controlFlowBranches branches
+  | .unsafeYul fragment =>
+      fragment.controlFlow
+  | _ =>
+      .fallsThrough
+
+partial def controlFlowList : List Stmt → ControlFlowSummary
+  | [] => .fallsThrough
+  | stmt :: rest =>
+      ControlFlowSummary.seq (controlFlow stmt) (controlFlowList rest)
+
+partial def controlFlowBranches : List (String × List String × List Stmt) → ControlFlowSummary
+  | [] => .fallsThrough
+  | (_, _, body) :: rest =>
+      ControlFlowSummary.union (controlFlowList body) (controlFlowBranches rest)
+end
+
+example : (controlFlowList [Stmt.return (Expr.literal 1), Stmt.stop]).mayStop = false := by
+  native_decide
+
+example : (controlFlow (Stmt.require (Expr.literal 1) "ok")).mayRevert = true := by
+  native_decide
+
 partial def metadataDeep (stmt : Stmt) : StmtMetadata :=
   stmt.fold
     (fun acc _ md =>
       { subexpressions := acc.subexpressions ++ md.subexpressions
         termination := if acc.termination == .alwaysTerminates then .alwaysTerminates else md.termination
+        controlFlow := ControlFlowSummary.union acc.controlFlow md.controlFlow
         lowLevelMechanics := acc.lowLevelMechanics ++ md.lowLevelMechanics
         scopeEffects :=
           { bindNames := acc.scopeEffects.bindNames ++ md.scopeEffects.bindNames
             assignNames := acc.scopeEffects.assignNames ++ md.scopeEffects.assignNames
             storageWrites := acc.scopeEffects.storageWrites ++ md.scopeEffects.storageWrites }
         localObligations := acc.localObligations ++ md.localObligations
+        unsafeYulContracts := acc.unsafeYulContracts ++ md.unsafeYulContracts
         unsafeReasons := acc.unsafeReasons ++ md.unsafeReasons })
     {}
 
@@ -808,12 +1031,14 @@ def metadataListDeep (stmts : List Stmt) : StmtMetadata :=
     (fun acc _ md =>
       { subexpressions := acc.subexpressions ++ md.subexpressions
         termination := if acc.termination == .alwaysTerminates then .alwaysTerminates else md.termination
+        controlFlow := ControlFlowSummary.union acc.controlFlow md.controlFlow
         lowLevelMechanics := acc.lowLevelMechanics ++ md.lowLevelMechanics
         scopeEffects :=
           { bindNames := acc.scopeEffects.bindNames ++ md.scopeEffects.bindNames
             assignNames := acc.scopeEffects.assignNames ++ md.scopeEffects.assignNames
             storageWrites := acc.scopeEffects.storageWrites ++ md.scopeEffects.storageWrites }
         localObligations := acc.localObligations ++ md.localObligations
+        unsafeYulContracts := acc.unsafeYulContracts ++ md.unsafeYulContracts
         unsafeReasons := acc.unsafeReasons ++ md.unsafeReasons })
     {}
     stmts

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -597,6 +597,10 @@ inductive Stmt
   | returndataCopy (destOffset sourceOffset size : Expr)
   /-- Forward current returndata as revert payload (`returndatacopy` + `revert`). -/
   | revertReturndata
+  /-- Raw low-level revert with caller-specified memory slice.  This models
+      handwritten assembly such as `revert(0, 0)` without forcing callers to
+      encode a Solidity `Error(string)` or custom error. -/
+  | rawRevert (offset size : Expr)
   | stop
   | ite (cond : Expr) (thenBranch : List Stmt) (elseBranch : List Stmt)  -- If/else (#179)
   | forEach (varName : String) (count : Expr) (body : List Stmt)  -- Bounded loop (#179)

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -300,6 +300,38 @@ structure LocalObligation where
   proofStatus : Compiler.ProofStatus := .assumed
   deriving Repr
 
+/-- Coarse statement termination classification used by generic statement
+    metadata. `mayTerminate` covers handwritten/raw Yul fragments unless a
+    caller supplies a more precise contract. -/
+inductive StmtTermination where
+  | fallsThrough
+  | alwaysTerminates
+  | mayTerminate
+  deriving Repr, BEq
+
+/-- Scope effects exposed by the generic statement metadata layer. -/
+structure StmtScopeEffects where
+  bindNames : List String := []
+  assignNames : List String := []
+  storageWrites : List String := []
+  deriving Repr
+
+/-- Typed handwritten Yul fragment. This is intentionally not just a string:
+    callers provide an EVMYul AST payload plus explicit proof obligations and
+    trust-surface metadata at the same boundary where the raw fragment enters
+    the compilation model. -/
+structure UnsafeYulFragment where
+  label : String
+  stmts : List YulStmt
+  obligations : List LocalObligation
+  mechanics : List String := []
+  scopeEffects : StmtScopeEffects := {}
+  termination : StmtTermination := .mayTerminate
+  deriving Repr
+
+/-- Backwards-friendly name for explicitly trusted raw Yul fragments. -/
+abbrev RawYul := UnsafeYulFragment
+
 /-!
 ### ADT Type Definitions (#1727, Phase 5 Step 5b)
 
@@ -634,12 +666,159 @@ inductive Stmt
       Marks a region where restricted operations (Step 6b) are permitted.
       The reason string is preserved for trust reporting (Step 6c). -/
   | unsafeBlock (reason : String) (body : List Stmt)
+  /-- Typed handwritten Yul fragment with localized proof obligations and
+      trust-surface metadata. Lowering to EVMYul AST is centralized in
+      `CompilationModel.unsafeYulToEVMYul`. -/
+  | unsafeYul (fragment : UnsafeYulFragment)
   /-- Pattern match on an ADT value: `matchAdt adtName scrutinee branches`.
       Each branch is `(variantName, boundVarNames, body)`.
       Compiles to `YulStmt.switch` on the tag byte. (#1727 Step 5b) -/
   | matchAdt (adtName : String) (scrutinee : Expr)
       (branches : List (String × List String × List Stmt))
   deriving Repr
+
+/-- Common statement metadata. New `Stmt` constructors should be represented
+    here once, then generic traversals and collectors can consume this surface
+    instead of duplicating constructor-by-constructor walks. -/
+structure StmtMetadata where
+  subexpressions : List Expr := []
+  termination : StmtTermination := .fallsThrough
+  lowLevelMechanics : List String := []
+  scopeEffects : StmtScopeEffects := {}
+  localObligations : List LocalObligation := []
+  unsafeReasons : List String := []
+  deriving Repr
+
+namespace Stmt
+
+def childLists : Stmt → List (List Stmt)
+  | .ite _ thenBranch elseBranch => [thenBranch, elseBranch]
+  | .forEach _ _ body => [body]
+  | .unsafeBlock _ body => [body]
+  | .matchAdt _ _ branches => branches.map (fun (_, _, body) => body)
+  | _ => []
+
+def directMetadata : Stmt → StmtMetadata
+  | .letVar name value =>
+      { subexpressions := [value], scopeEffects := { bindNames := [name] } }
+  | .assignVar name value =>
+      { subexpressions := [value], scopeEffects := { assignNames := [name] } }
+  | .setStorage field value | .setStorageAddr field value =>
+      { subexpressions := [value], scopeEffects := { storageWrites := [field] } }
+  | .setStorageWord field _ value =>
+      { subexpressions := [value], scopeEffects := { storageWrites := [field] } }
+  | .storageArrayPush field value =>
+      { subexpressions := [value], scopeEffects := { storageWrites := [field] } }
+  | .storageArrayPop field =>
+      { scopeEffects := { storageWrites := [field] } }
+  | .setStorageArrayElement field index value =>
+      { subexpressions := [index, value], scopeEffects := { storageWrites := [field] } }
+  | .setMapping field key value | .setMappingWord field key _ value
+  | .setMappingPackedWord field key _ _ value | .setMappingUint field key value
+  | .setStructMember field key _ value =>
+      { subexpressions := [key, value], scopeEffects := { storageWrites := [field] } }
+  | .setMappingChain field keys value =>
+      { subexpressions := keys ++ [value], scopeEffects := { storageWrites := [field] } }
+  | .setMapping2 field key1 key2 value | .setMapping2Word field key1 key2 _ value
+  | .setStructMember2 field key1 key2 _ value =>
+      { subexpressions := [key1, key2, value], scopeEffects := { storageWrites := [field] } }
+  | .require cond _ =>
+      { subexpressions := [cond], termination := .mayTerminate }
+  | .requireError cond _ args =>
+      { subexpressions := cond :: args, termination := .mayTerminate }
+  | .revertError _ args =>
+      { subexpressions := args, termination := .alwaysTerminates }
+  | .return value =>
+      { subexpressions := [value], termination := .alwaysTerminates }
+  | .returnValues values =>
+      { subexpressions := values, termination := .alwaysTerminates }
+  | .returnArray _ | .returnBytes _ | .returnStorageWords _ =>
+      { termination := .alwaysTerminates }
+  | .mstore offset value =>
+      { subexpressions := [offset, value], lowLevelMechanics := ["mstore"] }
+  | .tstore offset value =>
+      { subexpressions := [offset, value], lowLevelMechanics := ["tstore"] }
+  | .calldatacopy destOffset sourceOffset size =>
+      { subexpressions := [destOffset, sourceOffset, size], lowLevelMechanics := ["calldatacopy"] }
+  | .returndataCopy destOffset sourceOffset size =>
+      { subexpressions := [destOffset, sourceOffset, size], lowLevelMechanics := ["returndataCopy"] }
+  | .revertReturndata =>
+      { termination := .alwaysTerminates, lowLevelMechanics := ["revertReturndata"] }
+  | .rawRevert offset size =>
+      { subexpressions := [offset, size], termination := .alwaysTerminates, lowLevelMechanics := ["rawRevert"] }
+  | .stop =>
+      { termination := .alwaysTerminates }
+  | .ite cond _ _ =>
+      { subexpressions := [cond], termination := .mayTerminate }
+  | .forEach varName count _ =>
+      { subexpressions := [count], scopeEffects := { bindNames := [varName] } }
+  | .emit _ args =>
+      { subexpressions := args }
+  | .internalCall _ args =>
+      { subexpressions := args }
+  | .internalCallAssign names _ args =>
+      { subexpressions := args, scopeEffects := { bindNames := names } }
+  | .rawLog topics dataOffset dataSize =>
+      { subexpressions := topics ++ [dataOffset, dataSize] }
+  | .externalCallBind resultVars _ args =>
+      { subexpressions := args, scopeEffects := { bindNames := resultVars } }
+  | .tryExternalCallBind successVar resultVars _ args =>
+      { subexpressions := args, scopeEffects := { bindNames := successVar :: resultVars } }
+  | .ecm mod args =>
+      { subexpressions := args, scopeEffects := { bindNames := mod.resultVars } }
+  | .unsafeBlock reason _ =>
+      { unsafeReasons := [reason] }
+  | .unsafeYul fragment =>
+      { termination := fragment.termination
+        lowLevelMechanics := fragment.mechanics
+        scopeEffects := fragment.scopeEffects
+        localObligations := fragment.obligations
+        unsafeReasons := [fragment.label] }
+  | .matchAdt _ scrutinee branches =>
+      { subexpressions := [scrutinee]
+        termination := .mayTerminate
+        scopeEffects := { bindNames := branches.flatMap (fun (_, names, _) => names) } }
+
+partial def fold (f : α → Stmt → StmtMetadata → α) (init : α) (stmt : Stmt) : α :=
+  let md := stmt.directMetadata
+  let acc := f init stmt md
+  stmt.childLists.foldl
+    (fun acc childList => childList.foldl (fun inner child => child.fold f inner) acc)
+    acc
+
+partial def foldList (f : α → Stmt → StmtMetadata → α) (init : α) (stmts : List Stmt) : α :=
+  stmts.foldl (fun acc stmt => stmt.fold f acc) init
+
+partial def metadataDeep (stmt : Stmt) : StmtMetadata :=
+  stmt.fold
+    (fun acc _ md =>
+      { subexpressions := acc.subexpressions ++ md.subexpressions
+        termination := if acc.termination == .alwaysTerminates then .alwaysTerminates else md.termination
+        lowLevelMechanics := acc.lowLevelMechanics ++ md.lowLevelMechanics
+        scopeEffects :=
+          { bindNames := acc.scopeEffects.bindNames ++ md.scopeEffects.bindNames
+            assignNames := acc.scopeEffects.assignNames ++ md.scopeEffects.assignNames
+            storageWrites := acc.scopeEffects.storageWrites ++ md.scopeEffects.storageWrites }
+        localObligations := acc.localObligations ++ md.localObligations
+        unsafeReasons := acc.unsafeReasons ++ md.unsafeReasons })
+    {}
+
+def metadataListDeep (stmts : List Stmt) : StmtMetadata :=
+  foldList
+    (fun acc _ md =>
+      { subexpressions := acc.subexpressions ++ md.subexpressions
+        termination := if acc.termination == .alwaysTerminates then .alwaysTerminates else md.termination
+        lowLevelMechanics := acc.lowLevelMechanics ++ md.lowLevelMechanics
+        scopeEffects :=
+          { bindNames := acc.scopeEffects.bindNames ++ md.scopeEffects.bindNames
+            assignNames := acc.scopeEffects.assignNames ++ md.scopeEffects.assignNames
+            storageWrites := acc.scopeEffects.storageWrites ++ md.scopeEffects.storageWrites }
+        localObligations := acc.localObligations ++ md.localObligations
+        unsafeReasons := acc.unsafeReasons ++ md.unsafeReasons })
+    {}
+    stmts
+
+end Stmt
 
 structure FunctionSpec where
   name : String

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -368,6 +368,10 @@ namespace ControlFlowSummary
 
 def fallsThrough : ControlFlowSummary := {}
 
+/-- Empty control-flow set, used as the identity when unioning alternatives. -/
+def noPaths : ControlFlowSummary :=
+  { mayFallThrough := false, mayRevert := false, mayReturn := false, mayStop := false }
+
 def mayReverting : ControlFlowSummary :=
   { mayFallThrough := true, mayRevert := true }
 
@@ -409,6 +413,93 @@ structure StmtScopeEffects where
   assignNames : List String := []
   storageWrites : List String := []
   deriving Repr, Inhabited
+
+namespace StmtScopeEffects
+
+def merge (a b : StmtScopeEffects) : StmtScopeEffects :=
+  { bindNames := a.bindNames ++ b.bindNames
+    assignNames := a.assignNames ++ b.assignNames
+    storageWrites := a.storageWrites ++ b.storageWrites }
+
+end StmtScopeEffects
+
+mutual
+/-- Conservative scan for storage-like writes inside raw Yul expressions.
+    Transient `tstore` is intentionally classified as a storage write for
+    effect validation because it mutates EVM transaction-local state. -/
+partial def yulExprWritesStorage : YulExpr → Bool
+  | .call func args =>
+      func == "sstore" || func == "tstore" || yulExprListWritesStorage args
+  | _ => false
+
+partial def yulExprListWritesStorage : List YulExpr → Bool
+  | [] => false
+  | expr :: rest =>
+      yulExprWritesStorage expr || yulExprListWritesStorage rest
+end
+
+mutual
+/-- Conservative scope/effect derivation for embedded Yul AST fragments.
+    This is the single source of truth used by both imported-Yul construction
+    and unsafe-Yul validation, so generated declarations and validation checks
+    cannot drift apart. -/
+partial def yulStmtScopeEffects : YulStmt → StmtScopeEffects
+  | .comment _ | .leave =>
+      {}
+  | .let_ name value =>
+      { bindNames := [name]
+        storageWrites := if yulExprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
+  | .letMany names value =>
+      { bindNames := names
+        storageWrites := if yulExprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
+  | .assign name value =>
+      { assignNames := [name]
+        storageWrites := if yulExprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
+  | .expr expr =>
+      { storageWrites := if yulExprWritesStorage expr then ["<raw-yul-storage-write>"] else [] }
+  | .if_ cond body =>
+      let bodyEffects := yulStmtListScopeEffects body
+      { bodyEffects with
+        storageWrites :=
+          (if yulExprWritesStorage cond then ["<raw-yul-storage-write>"] else []) ++
+            bodyEffects.storageWrites }
+  | .for_ init cond post body =>
+      let initEffects := yulStmtListScopeEffects init
+      let postEffects := yulStmtListScopeEffects post
+      let bodyEffects := yulStmtListScopeEffects body
+      { bindNames := initEffects.bindNames ++ postEffects.bindNames ++ bodyEffects.bindNames
+        assignNames := initEffects.assignNames ++ postEffects.assignNames ++ bodyEffects.assignNames
+        storageWrites :=
+          initEffects.storageWrites ++
+          (if yulExprWritesStorage cond then ["<raw-yul-storage-write>"] else []) ++
+          postEffects.storageWrites ++ bodyEffects.storageWrites }
+  | .switch expr cases default =>
+      let casesEffects :=
+        cases.foldl
+          (fun acc (_, body) => StmtScopeEffects.merge acc (yulStmtListScopeEffects body))
+          ({} : StmtScopeEffects)
+      let defaultEffects :=
+        match default with
+        | none => ({} : StmtScopeEffects)
+        | some body => yulStmtListScopeEffects body
+      { bindNames := casesEffects.bindNames ++ defaultEffects.bindNames
+        assignNames := casesEffects.assignNames ++ defaultEffects.assignNames
+        storageWrites :=
+          (if yulExprWritesStorage expr then ["<raw-yul-storage-write>"] else []) ++
+          casesEffects.storageWrites ++ defaultEffects.storageWrites }
+  | .block stmts =>
+      yulStmtListScopeEffects stmts
+  | .funcDef name _params _rets body =>
+      let bodyEffects := yulStmtListScopeEffects body
+      { bindNames := [name]
+        assignNames := []
+        storageWrites := bodyEffects.storageWrites }
+
+partial def yulStmtListScopeEffects : List YulStmt → StmtScopeEffects
+  | [] => {}
+  | stmt :: rest =>
+      StmtScopeEffects.merge (yulStmtScopeEffects stmt) (yulStmtListScopeEffects rest)
+end
 
 /-- Typed trust-report mechanics emitted by low-level statements and raw Yul fragments.
     JSON and human-readable reports still render these through `toReportString`,
@@ -999,7 +1090,7 @@ partial def controlFlowList : List Stmt → ControlFlowSummary
       ControlFlowSummary.seq (controlFlow stmt) (controlFlowList rest)
 
 partial def controlFlowBranches : List (String × List String × List Stmt) → ControlFlowSummary
-  | [] => .fallsThrough
+  | [] => .noPaths
   | (_, _, body) :: rest =>
       ControlFlowSummary.union (controlFlowList body) (controlFlowBranches rest)
 end

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -400,6 +400,12 @@ def seq (a b : ControlFlowSummary) : ControlFlowSummary :=
     mayReturn := a.mayReturn || (a.mayFallThrough && b.mayReturn)
     mayStop := a.mayStop || (a.mayFallThrough && b.mayStop) }
 
+/-- True when every path terminates specifically through a Solidity-style
+return or revert. A raw `stop` also halts execution, but it does not produce the
+return data required by functions that declare return values. -/
+def alwaysReturnsOrReverts (cf : ControlFlowSummary) : Bool :=
+  !cf.mayFallThrough && !cf.mayStop && (cf.mayReturn || cf.mayRevert)
+
 def fromTermination : StmtTermination → ControlFlowSummary
   | .fallsThrough => fallsThrough
   | .alwaysTerminates => unknown

--- a/Compiler/CompilationModel/UsageAnalysis.lean
+++ b/Compiler/CompilationModel/UsageAnalysis.lean
@@ -4,32 +4,7 @@ namespace Compiler.CompilationModel
 
 mutual
 def collectStmtBindNames : Stmt → List String
-  | Stmt.letVar name _ => [name]
-  | Stmt.ite _ thenBranch elseBranch =>
-      collectStmtListBindNames thenBranch ++ collectStmtListBindNames elseBranch
-  | Stmt.forEach varName _ body =>
-      varName :: collectStmtListBindNames body
-  | Stmt.unsafeBlock _ body =>
-      collectStmtListBindNames body
-  | Stmt.matchAdt _ _ branches =>
-      collectMatchBranchBindNames branches
-  | Stmt.internalCallAssign names _ _ => names
-  | Stmt.externalCallBind resultVars _ _ => resultVars
-  | Stmt.tryExternalCallBind successVar resultVars _ _ => successVar :: resultVars
-  | Stmt.ecm mod _ => mod.resultVars
-  -- Statements that never bind new names.
-  | Stmt.assignVar _ _ | Stmt.setStorage _ _ | Stmt.setStorageAddr _ _ | Stmt.setStorageWord _ _ _
-  | Stmt.storageArrayPush _ _ | Stmt.storageArrayPop _ | Stmt.setStorageArrayElement _ _ _
-  | Stmt.return _
-  | Stmt.setMapping _ _ _ | Stmt.setMappingWord _ _ _ _ | Stmt.setMappingPackedWord _ _ _ _ _ | Stmt.setMappingUint _ _ _
-  | Stmt.setMappingChain _ _ _
-  | Stmt.setMapping2 _ _ _ _ | Stmt.setMapping2Word _ _ _ _ _
-  | Stmt.setStructMember _ _ _ _ | Stmt.setStructMember2 _ _ _ _ _
-  | Stmt.require _ _ | Stmt.requireError _ _ _ | Stmt.revertError _ _
-  | Stmt.returnValues _ | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _
-  | Stmt.mstore _ _ | Stmt.tstore _ _ | Stmt.calldatacopy _ _ _ | Stmt.returndataCopy _ _ _ | Stmt.rawRevert _ _ | Stmt.revertReturndata | Stmt.stop
-  | Stmt.emit _ _ | Stmt.internalCall _ _ | Stmt.rawLog _ _ _ =>
-      []
+  | stmt => (stmt.metadataDeep).scopeEffects.bindNames
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -50,28 +25,7 @@ end
 
 mutual
 def collectStmtAssignedNames : Stmt → List String
-  | Stmt.assignVar name _ => [name]
-  | Stmt.ite _ thenBranch elseBranch =>
-      collectStmtListAssignedNames thenBranch ++ collectStmtListAssignedNames elseBranch
-  | Stmt.forEach _ _ body =>
-      collectStmtListAssignedNames body
-  | Stmt.unsafeBlock _ body =>
-      collectStmtListAssignedNames body
-  | Stmt.matchAdt _ _ branches =>
-      collectMatchBranchAssignedNames branches
-  | Stmt.letVar _ _ | Stmt.setStorage _ _ | Stmt.setStorageAddr _ _ | Stmt.setStorageWord _ _ _
-  | Stmt.storageArrayPush _ _ | Stmt.storageArrayPop _ | Stmt.setStorageArrayElement _ _ _
-  | Stmt.return _
-  | Stmt.setMapping _ _ _ | Stmt.setMappingWord _ _ _ _ | Stmt.setMappingPackedWord _ _ _ _ _ | Stmt.setMappingUint _ _ _
-  | Stmt.setMappingChain _ _ _
-  | Stmt.setMapping2 _ _ _ _ | Stmt.setMapping2Word _ _ _ _ _
-  | Stmt.setStructMember _ _ _ _ | Stmt.setStructMember2 _ _ _ _ _
-  | Stmt.require _ _ | Stmt.requireError _ _ _ | Stmt.revertError _ _
-  | Stmt.returnValues _ | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _
-  | Stmt.mstore _ _ | Stmt.tstore _ _ | Stmt.calldatacopy _ _ _ | Stmt.returndataCopy _ _ _ | Stmt.rawRevert _ _ | Stmt.revertReturndata | Stmt.stop
-  | Stmt.emit _ _ | Stmt.internalCall _ _ | Stmt.internalCallAssign _ _ _
-  | Stmt.rawLog _ _ _ | Stmt.externalCallBind _ _ _ | Stmt.tryExternalCallBind _ _ _ _ | Stmt.ecm _ _ =>
-      []
+  | stmt => (stmt.metadataDeep).scopeEffects.assignNames
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -284,6 +238,8 @@ def stmtUsesArrayElementKind (includePlain includeWord : Bool) : Stmt → Bool
       false
   | Stmt.revertReturndata | Stmt.stop =>
       false
+  | Stmt.unsafeYul _ =>
+      false
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -441,6 +397,8 @@ def stmtUsesArrayElement : Stmt → Bool
   | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>
+      false
+  | Stmt.unsafeYul _ =>
       false
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
@@ -650,6 +608,8 @@ def stmtUsesParamDynamicHeadWord : Stmt → Bool
       false
   | Stmt.revertReturndata | Stmt.stop =>
       false
+  | Stmt.unsafeYul _ =>
+      false
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -796,6 +756,8 @@ def stmtUsesMulDiv512 : Stmt → Bool
   | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>
+      false
+  | Stmt.unsafeYul _ =>
       false
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
@@ -973,6 +935,8 @@ def stmtUsesStorageArrayElement : Stmt → Bool
       false
   | Stmt.revertReturndata | Stmt.stop =>
       false
+  | Stmt.unsafeYul _ =>
+      false
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -1128,6 +1092,8 @@ def stmtUsesDynamicBytesEq : Stmt → Bool
   | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>
+      false
+  | Stmt.unsafeYul _ =>
       false
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega

--- a/Compiler/CompilationModel/UsageAnalysis.lean
+++ b/Compiler/CompilationModel/UsageAnalysis.lean
@@ -4,8 +4,19 @@ namespace Compiler.CompilationModel
 
 mutual
 def collectStmtBindNames : Stmt → List String
-  | stmt => (stmt.metadataDeep).scopeEffects.bindNames
-termination_by s => sizeOf s
+  | .letVar name _ => [name]
+  | .internalCallAssign names _ _ => names
+  | .externalCallBind resultVars _ _ => resultVars
+  | .tryExternalCallBind successVar resultVars _ _ => successVar :: resultVars
+  | .ecm mod _ => mod.resultVars
+  | .ite _ thenBranch elseBranch =>
+      collectStmtListBindNames thenBranch ++ collectStmtListBindNames elseBranch
+  | .forEach varName _ body => varName :: collectStmtListBindNames body
+  | .unsafeBlock _ body => collectStmtListBindNames body
+  | .matchAdt _ _ branches => collectMatchBranchBindNames branches
+  | .unsafeYul fragment => fragment.scopeEffects.bindNames
+  | _ => []
+termination_by stmt => sizeOf stmt
 decreasing_by all_goals simp_wf; all_goals omega
 
 def collectStmtListBindNames : List Stmt → List String
@@ -25,8 +36,15 @@ end
 
 mutual
 def collectStmtAssignedNames : Stmt → List String
-  | stmt => (stmt.metadataDeep).scopeEffects.assignNames
-termination_by s => sizeOf s
+  | .assignVar name _ => [name]
+  | .unsafeBlock _ body => collectStmtListAssignedNames body
+  | .ite _ thenBranch elseBranch =>
+      collectStmtListAssignedNames thenBranch ++ collectStmtListAssignedNames elseBranch
+  | .forEach _ _ body => collectStmtListAssignedNames body
+  | .matchAdt _ _ branches => collectMatchBranchAssignedNames branches
+  | .unsafeYul fragment => fragment.scopeEffects.assignNames
+  | _ => []
+termination_by stmt => sizeOf stmt
 decreasing_by all_goals simp_wf; all_goals omega
 
 def collectStmtListAssignedNames : List Stmt → List String
@@ -231,9 +249,6 @@ def stmtUsesArrayElementKind (includePlain includeWord : Bool) : Stmt → Bool
       exprListUsesArrayElementKind includePlain includeWord args
   | Stmt.ecm _ args =>
       exprListUsesArrayElementKind includePlain includeWord args
-  | Stmt.rawRevert offset size =>
-      exprUsesArrayElementKind includePlain includeWord offset ||
-        exprUsesArrayElementKind includePlain includeWord size
   | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>
@@ -392,8 +407,6 @@ def stmtUsesArrayElement : Stmt → Bool
       exprListUsesArrayElement topics || exprUsesArrayElement dataOffset || exprUsesArrayElement dataSize
   | Stmt.externalCallBind _ _ args | Stmt.tryExternalCallBind _ _ _ args | Stmt.ecm _ args =>
       exprListUsesArrayElement args
-  | Stmt.rawRevert offset size =>
-      exprUsesArrayElement offset || exprUsesArrayElement size
   | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>
@@ -602,8 +615,6 @@ def stmtUsesParamDynamicHeadWord : Stmt → Bool
       exprListUsesParamDynamicHeadWord topics ||
         exprUsesParamDynamicHeadWord dataOffset ||
         exprUsesParamDynamicHeadWord dataSize
-  | Stmt.rawRevert offset size =>
-      exprUsesParamDynamicHeadWord offset || exprUsesParamDynamicHeadWord size
   | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>
@@ -751,8 +762,6 @@ def stmtUsesMulDiv512 : Stmt → Bool
   | Stmt.rawLog topics dataOffset dataSize =>
       exprListUsesMulDiv512 topics ||
         exprUsesMulDiv512 dataOffset || exprUsesMulDiv512 dataSize
-  | Stmt.rawRevert offset size =>
-      exprUsesMulDiv512 offset || exprUsesMulDiv512 size
   | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>
@@ -929,8 +938,6 @@ def stmtUsesStorageArrayElement : Stmt → Bool
       exprListUsesStorageArrayElement topics || exprUsesStorageArrayElement dataOffset || exprUsesStorageArrayElement dataSize
   | Stmt.ecm _ args =>
       exprListUsesStorageArrayElement args
-  | Stmt.rawRevert offset size =>
-      exprUsesStorageArrayElement offset || exprUsesStorageArrayElement size
   | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>
@@ -1087,8 +1094,6 @@ def stmtUsesDynamicBytesEq : Stmt → Bool
       exprListUsesDynamicBytesEq args
   | Stmt.rawLog topics dataOffset dataSize =>
       exprListUsesDynamicBytesEq topics || exprUsesDynamicBytesEq dataOffset || exprUsesDynamicBytesEq dataSize
-  | Stmt.rawRevert offset size =>
-      exprUsesDynamicBytesEq offset || exprUsesDynamicBytesEq size
   | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>

--- a/Compiler/CompilationModel/UsageAnalysis.lean
+++ b/Compiler/CompilationModel/UsageAnalysis.lean
@@ -27,7 +27,7 @@ def collectStmtBindNames : Stmt → List String
   | Stmt.setStructMember _ _ _ _ | Stmt.setStructMember2 _ _ _ _ _
   | Stmt.require _ _ | Stmt.requireError _ _ _ | Stmt.revertError _ _
   | Stmt.returnValues _ | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _
-  | Stmt.mstore _ _ | Stmt.tstore _ _ | Stmt.calldatacopy _ _ _ | Stmt.returndataCopy _ _ _ | Stmt.revertReturndata | Stmt.stop
+  | Stmt.mstore _ _ | Stmt.tstore _ _ | Stmt.calldatacopy _ _ _ | Stmt.returndataCopy _ _ _ | Stmt.rawRevert _ _ | Stmt.revertReturndata | Stmt.stop
   | Stmt.emit _ _ | Stmt.internalCall _ _ | Stmt.rawLog _ _ _ =>
       []
 termination_by s => sizeOf s
@@ -68,7 +68,7 @@ def collectStmtAssignedNames : Stmt → List String
   | Stmt.setStructMember _ _ _ _ | Stmt.setStructMember2 _ _ _ _ _
   | Stmt.require _ _ | Stmt.requireError _ _ _ | Stmt.revertError _ _
   | Stmt.returnValues _ | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _
-  | Stmt.mstore _ _ | Stmt.tstore _ _ | Stmt.calldatacopy _ _ _ | Stmt.returndataCopy _ _ _ | Stmt.revertReturndata | Stmt.stop
+  | Stmt.mstore _ _ | Stmt.tstore _ _ | Stmt.calldatacopy _ _ _ | Stmt.returndataCopy _ _ _ | Stmt.rawRevert _ _ | Stmt.revertReturndata | Stmt.stop
   | Stmt.emit _ _ | Stmt.internalCall _ _ | Stmt.internalCallAssign _ _ _
   | Stmt.rawLog _ _ _ | Stmt.externalCallBind _ _ _ | Stmt.tryExternalCallBind _ _ _ _ | Stmt.ecm _ _ =>
       []
@@ -277,7 +277,11 @@ def stmtUsesArrayElementKind (includePlain includeWord : Bool) : Stmt → Bool
       exprListUsesArrayElementKind includePlain includeWord args
   | Stmt.ecm _ args =>
       exprListUsesArrayElementKind includePlain includeWord args
-  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _
+  | Stmt.rawRevert offset size =>
+      exprUsesArrayElementKind includePlain includeWord offset ||
+        exprUsesArrayElementKind includePlain includeWord size
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
+      false
   | Stmt.revertReturndata | Stmt.stop =>
       false
 termination_by s => sizeOf s
@@ -432,7 +436,10 @@ def stmtUsesArrayElement : Stmt → Bool
       exprListUsesArrayElement topics || exprUsesArrayElement dataOffset || exprUsesArrayElement dataSize
   | Stmt.externalCallBind _ _ args | Stmt.tryExternalCallBind _ _ _ args | Stmt.ecm _ args =>
       exprListUsesArrayElement args
-  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _
+  | Stmt.rawRevert offset size =>
+      exprUsesArrayElement offset || exprUsesArrayElement size
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
+      false
   | Stmt.revertReturndata | Stmt.stop =>
       false
 termination_by s => sizeOf s
@@ -637,7 +644,10 @@ def stmtUsesParamDynamicHeadWord : Stmt → Bool
       exprListUsesParamDynamicHeadWord topics ||
         exprUsesParamDynamicHeadWord dataOffset ||
         exprUsesParamDynamicHeadWord dataSize
-  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _
+  | Stmt.rawRevert offset size =>
+      exprUsesParamDynamicHeadWord offset || exprUsesParamDynamicHeadWord size
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
+      false
   | Stmt.revertReturndata | Stmt.stop =>
       false
 termination_by s => sizeOf s
@@ -781,7 +791,10 @@ def stmtUsesMulDiv512 : Stmt → Bool
   | Stmt.rawLog topics dataOffset dataSize =>
       exprListUsesMulDiv512 topics ||
         exprUsesMulDiv512 dataOffset || exprUsesMulDiv512 dataSize
-  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _
+  | Stmt.rawRevert offset size =>
+      exprUsesMulDiv512 offset || exprUsesMulDiv512 size
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
+      false
   | Stmt.revertReturndata | Stmt.stop =>
       false
 termination_by s => sizeOf s
@@ -954,7 +967,10 @@ def stmtUsesStorageArrayElement : Stmt → Bool
       exprListUsesStorageArrayElement topics || exprUsesStorageArrayElement dataOffset || exprUsesStorageArrayElement dataSize
   | Stmt.ecm _ args =>
       exprListUsesStorageArrayElement args
-  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _
+  | Stmt.rawRevert offset size =>
+      exprUsesStorageArrayElement offset || exprUsesStorageArrayElement size
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
+      false
   | Stmt.revertReturndata | Stmt.stop =>
       false
 termination_by s => sizeOf s
@@ -1107,7 +1123,10 @@ def stmtUsesDynamicBytesEq : Stmt → Bool
       exprListUsesDynamicBytesEq args
   | Stmt.rawLog topics dataOffset dataSize =>
       exprListUsesDynamicBytesEq topics || exprUsesDynamicBytesEq dataOffset || exprUsesDynamicBytesEq dataSize
-  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _
+  | Stmt.rawRevert offset size =>
+      exprUsesDynamicBytesEq offset || exprUsesDynamicBytesEq size
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
+      false
   | Stmt.revertReturndata | Stmt.stop =>
       false
 termination_by s => sizeOf s

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -32,6 +32,100 @@ private def firstDuplicateString : List String → Option String
   | name :: rest =>
       if rest.contains name then some name else firstDuplicateString rest
 
+private def missingDeclaredNames (actual declared : List String) : List String :=
+  actual.foldl
+    (fun acc name =>
+      if declared.contains name || acc.contains name then acc else acc ++ [name])
+    []
+
+mutual
+private def yulExprWritesStorage : YulExpr → Bool
+  | .call func args =>
+      func == "sstore" || func == "tstore" || yulExprListWritesStorage args
+  | _ => false
+
+private def yulExprListWritesStorage : List YulExpr → Bool
+  | [] => false
+  | expr :: rest =>
+      yulExprWritesStorage expr || yulExprListWritesStorage rest
+end
+
+private def mergeScopeEffects (a b : StmtScopeEffects) : StmtScopeEffects :=
+  { bindNames := a.bindNames ++ b.bindNames
+    assignNames := a.assignNames ++ b.assignNames
+    storageWrites := a.storageWrites ++ b.storageWrites }
+
+mutual
+private partial def yulStmtActualScopeEffects : YulStmt → StmtScopeEffects
+  | .comment _ | .leave =>
+      {}
+  | .let_ name value =>
+      { bindNames := [name]
+        storageWrites := if yulExprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
+  | .letMany names value =>
+      { bindNames := names
+        storageWrites := if yulExprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
+  | .assign name value =>
+      { assignNames := [name]
+        storageWrites := if yulExprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
+  | .expr expr =>
+      { storageWrites := if yulExprWritesStorage expr then ["<raw-yul-storage-write>"] else [] }
+  | .if_ cond body =>
+      let bodyEffects := yulStmtListActualScopeEffects body
+      { bodyEffects with
+        storageWrites :=
+          (if yulExprWritesStorage cond then ["<raw-yul-storage-write>"] else []) ++
+            bodyEffects.storageWrites }
+  | .for_ init cond post body =>
+      let initEffects := yulStmtListActualScopeEffects init
+      let postEffects := yulStmtListActualScopeEffects post
+      let bodyEffects := yulStmtListActualScopeEffects body
+      { bindNames := initEffects.bindNames ++ postEffects.bindNames ++ bodyEffects.bindNames
+        assignNames := initEffects.assignNames ++ postEffects.assignNames ++ bodyEffects.assignNames
+        storageWrites :=
+          initEffects.storageWrites ++
+          (if yulExprWritesStorage cond then ["<raw-yul-storage-write>"] else []) ++
+          postEffects.storageWrites ++ bodyEffects.storageWrites }
+  | .switch expr cases default =>
+      let casesEffects :=
+        cases.foldl
+          (fun acc (_, body) => mergeScopeEffects acc (yulStmtListActualScopeEffects body))
+          ({} : StmtScopeEffects)
+      let defaultEffects :=
+        match default with
+        | none => ({} : StmtScopeEffects)
+        | some body => yulStmtListActualScopeEffects body
+      { bindNames := casesEffects.bindNames ++ defaultEffects.bindNames
+        assignNames := casesEffects.assignNames ++ defaultEffects.assignNames
+        storageWrites :=
+          (if yulExprWritesStorage expr then ["<raw-yul-storage-write>"] else []) ++
+          casesEffects.storageWrites ++ defaultEffects.storageWrites }
+  | .block stmts =>
+      yulStmtListActualScopeEffects stmts
+  | .funcDef name _params _rets body =>
+      let bodyEffects := yulStmtListActualScopeEffects body
+      { bindNames := [name]
+        assignNames := []
+        storageWrites := bodyEffects.storageWrites }
+
+private partial def yulStmtListActualScopeEffects : List YulStmt → StmtScopeEffects
+  | [] => {}
+  | stmt :: rest =>
+      mergeScopeEffects (yulStmtActualScopeEffects stmt) (yulStmtListActualScopeEffects rest)
+end
+
+private def validateUnsafeYulDeclaredScopeEffects (fragment : UnsafeYulFragment) :
+    Except String Unit := do
+  let actual := yulStmtListActualScopeEffects fragment.stmts
+  let missingBinds := missingDeclaredNames actual.bindNames fragment.scopeEffects.bindNames
+  if !missingBinds.isEmpty then
+    throw s!"Compilation error: unsafe Yul fragment '{fragment.label}' under-declares bound local(s): {String.intercalate ", " missingBinds}"
+  let missingAssigns := missingDeclaredNames actual.assignNames fragment.scopeEffects.assignNames
+  if !missingAssigns.isEmpty then
+    throw s!"Compilation error: unsafe Yul fragment '{fragment.label}' under-declares assigned local(s): {String.intercalate ", " missingAssigns}"
+  if !actual.storageWrites.isEmpty && fragment.scopeEffects.storageWrites.isEmpty then
+    throw s!"Compilation error: unsafe Yul fragment '{fragment.label}' under-declares storage effects for raw Yul storage write(s)."
+
 private def adtPayloadParamNames (params : List Param) : List String :=
   params.flatMap fun param =>
     match param.ty with
@@ -209,40 +303,8 @@ termination_by bs => sizeOf bs
 decreasing_by all_goals simp_wf; all_goals omega
 end
 
-mutual
-  private def stmtListAlwaysReturnsOrReverts : List Stmt → Bool
-    | [] => false
-    | stmt :: rest =>
-        if stmtAlwaysReturnsOrReverts stmt then
-          true
-        else
-          stmtListAlwaysReturnsOrReverts rest
-  termination_by ss => sizeOf ss
-  decreasing_by all_goals simp_wf; all_goals omega
-
-  private def stmtAlwaysReturnsOrReverts : Stmt → Bool
-    | Stmt.return _ | Stmt.returnValues _ | Stmt.returnArray _
-    | Stmt.returnBytes _ | Stmt.returnStorageWords _
-    | Stmt.revertError _ _ | Stmt.revertReturndata | Stmt.rawRevert _ _ =>
-        true
-    | Stmt.ite _ thenBranch elseBranch =>
-        stmtListAlwaysReturnsOrReverts thenBranch && stmtListAlwaysReturnsOrReverts elseBranch
-    | Stmt.unsafeBlock _ body =>
-        stmtListAlwaysReturnsOrReverts body
-    | Stmt.matchAdt _ _ branches =>
-        matchBranchesAllReturnOrRevert branches
-    | _ =>
-        false
-  termination_by s => sizeOf s
-  decreasing_by all_goals simp_wf; all_goals omega
-
-  private def matchBranchesAllReturnOrRevert : List (String × List String × List Stmt) → Bool
-    | [] => true
-    | (_, _, body) :: rest =>
-        stmtListAlwaysReturnsOrReverts body && matchBranchesAllReturnOrRevert rest
-  termination_by bs => sizeOf bs
-  decreasing_by all_goals simp_wf; all_goals omega
-end
+private def stmtListAlwaysReturnsOrReverts (stmts : List Stmt) : Bool :=
+  !(Stmt.controlFlowList stmts).mayFallThrough
 
 def exprReadsStateOrEnv : Expr → Bool
   | Expr.literal _ => false
@@ -440,8 +502,6 @@ def stmtWritesState : Stmt → Bool
       exprWritesState destOffset || exprWritesState sourceOffset || exprWritesState size
   | Stmt.returndataCopy destOffset sourceOffset size =>
       exprWritesState destOffset || exprWritesState sourceOffset || exprWritesState size
-  | Stmt.rawRevert offset size =>
-      exprWritesState offset || exprWritesState size
   | Stmt.revertReturndata =>
       false
   | Stmt.stop =>
@@ -1012,8 +1072,6 @@ def stmtReadsStateOrEnv : Stmt → Bool
   | Stmt.tstore offset value =>
       exprReadsStateOrEnv offset || exprReadsStateOrEnv value
   | Stmt.calldatacopy _ _ _ | Stmt.returndataCopy _ _ _ => true
-  | Stmt.rawRevert offset size =>
-      exprReadsStateOrEnv offset || exprReadsStateOrEnv size
   | Stmt.revertReturndata =>
       true
   | Stmt.stop =>
@@ -1216,9 +1274,6 @@ def stmtWritesStateWithFunctionEffects
       exprWritesStateWithFunctionEffects effects destOffset ||
         exprWritesStateWithFunctionEffects effects sourceOffset ||
         exprWritesStateWithFunctionEffects effects size
-  | Stmt.rawRevert offset size =>
-      exprWritesStateWithFunctionEffects effects offset ||
-        exprWritesStateWithFunctionEffects effects size
   | Stmt.revertReturndata =>
       false
   | Stmt.stop =>
@@ -1396,8 +1451,6 @@ def stmtReadsStateOrEnvWithFunctionEffects
       exprReadsStateOrEnvWithFunctionEffects effects offset ||
         exprReadsStateOrEnvWithFunctionEffects effects value
   | Stmt.calldatacopy _ _ _ | Stmt.returndataCopy _ _ _ => true
-  | Stmt.rawRevert offset size =>
-      exprReadsStateOrEnvWithFunctionEffects effects offset || exprReadsStateOrEnvWithFunctionEffects effects size
   | Stmt.revertReturndata =>
       true
   | Stmt.stop =>
@@ -1512,7 +1565,7 @@ def stmtIsPersistentWrite : Stmt → Bool
   | Stmt.matchAdt _ _ branches =>
       matchBranchesPersistentWrite branches
   | Stmt.unsafeYul fragment =>
-      !fragment.scopeEffects.storageWrites.isEmpty || fragment.mechanics.contains "tstore"
+      !fragment.scopeEffects.storageWrites.isEmpty || fragment.mechanics.contains .tstore
   | _ => false
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
@@ -1549,7 +1602,7 @@ def stmtMayPersistentlyWrite : Stmt → Bool
   | Stmt.matchAdt _ _ branches =>
       matchBranchesMayPersistentlyWrite branches
   | Stmt.unsafeYul fragment =>
-      !fragment.scopeEffects.storageWrites.isEmpty || fragment.mechanics.contains "tstore"
+      !fragment.scopeEffects.storageWrites.isEmpty || fragment.mechanics.contains .tstore
   | s => stmtIsPersistentWrite s
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
@@ -1812,11 +1865,6 @@ def validateNoUnsupportedAdtConstructInStmt : Stmt → Except String Unit
       if exprContainsAdtConstruct destOffset || exprContainsAdtConstruct sourceOffset ||
           exprContainsAdtConstruct size then
         throw "Compilation error: ADT construction cannot be used in copy offsets or sizes."
-  | Stmt.rawRevert offset size =>
-      if exprContainsAdtConstruct offset || exprContainsAdtConstruct size then
-        throw "Compilation error: ADT construction cannot be used in raw revert offsets or sizes."
-      else
-        pure ()
   | Stmt.storageArrayPop _ | Stmt.returnArray _ | Stmt.returnBytes _
   | Stmt.returnStorageWords _ | Stmt.revertReturndata | Stmt.stop =>
       pure ()
@@ -1824,7 +1872,7 @@ def validateNoUnsupportedAdtConstructInStmt : Stmt → Except String Unit
       if fragment.obligations.isEmpty then
         throw s!"Compilation error: unsafe Yul fragment '{fragment.label}' must declare at least one local proof obligation."
       else
-        pure ()
+        validateUnsafeYulDeclaredScopeEffects fragment
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
 

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -223,7 +223,7 @@ mutual
   private def stmtAlwaysReturnsOrReverts : Stmt → Bool
     | Stmt.return _ | Stmt.returnValues _ | Stmt.returnArray _
     | Stmt.returnBytes _ | Stmt.returnStorageWords _
-    | Stmt.revertError _ _ | Stmt.revertReturndata =>
+    | Stmt.revertError _ _ | Stmt.revertReturndata | Stmt.rawRevert _ _ =>
         true
     | Stmt.ite _ thenBranch elseBranch =>
         stmtListAlwaysReturnsOrReverts thenBranch && stmtListAlwaysReturnsOrReverts elseBranch

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -228,7 +228,7 @@ decreasing_by all_goals simp_wf; all_goals omega
 end
 
 private def stmtListAlwaysReturnsOrReverts (stmts : List Stmt) : Bool :=
-  !(Stmt.controlFlowList stmts).mayFallThrough
+  ControlFlowSummary.alwaysReturnsOrReverts (Stmt.controlFlowList stmts)
 
 def exprReadsStateOrEnv : Expr → Bool
   | Expr.literal _ => false

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -428,6 +428,8 @@ def stmtWritesState : Stmt → Bool
       false
   | Stmt.returnBytes _ =>
       false
+  | Stmt.unsafeYul fragment =>
+      !fragment.scopeEffects.storageWrites.isEmpty
   | Stmt.returnStorageWords _ =>
       false
   | Stmt.mstore offset value =>
@@ -1034,6 +1036,8 @@ def stmtReadsStateOrEnv : Stmt → Bool
   | Stmt.matchAdt _ scrutinee branches =>
       exprReadsStateOrEnv scrutinee ||
         matchBranchesReadStateOrEnv branches
+  | Stmt.unsafeYul fragment =>
+      !fragment.mechanics.isEmpty || !fragment.scopeEffects.storageWrites.isEmpty
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -1238,6 +1242,8 @@ def stmtWritesStateWithFunctionEffects
   | Stmt.matchAdt _ scrutinee branches =>
       exprWritesStateWithFunctionEffects effects scrutinee ||
         matchBranchesWriteStateWithFunctionEffects effects branches
+  | Stmt.unsafeYul fragment =>
+      !fragment.scopeEffects.storageWrites.isEmpty
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -1423,6 +1429,8 @@ def stmtReadsStateOrEnvWithFunctionEffects
   | Stmt.matchAdt _ scrutinee branches =>
       exprReadsStateOrEnvWithFunctionEffects effects scrutinee ||
         matchBranchesReadStateOrEnvWithFunctionEffects effects branches
+  | Stmt.unsafeYul fragment =>
+      !fragment.mechanics.isEmpty || !fragment.scopeEffects.storageWrites.isEmpty
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -1503,6 +1511,8 @@ def stmtIsPersistentWrite : Stmt → Bool
       stmtListContainsPersistentWrite body
   | Stmt.matchAdt _ _ branches =>
       matchBranchesPersistentWrite branches
+  | Stmt.unsafeYul fragment =>
+      !fragment.scopeEffects.storageWrites.isEmpty || fragment.mechanics.contains "tstore"
   | _ => false
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
@@ -1538,6 +1548,8 @@ def stmtMayPersistentlyWrite : Stmt → Bool
       stmtListMayPersistentlyWrite body
   | Stmt.matchAdt _ _ branches =>
       matchBranchesMayPersistentlyWrite branches
+  | Stmt.unsafeYul fragment =>
+      !fragment.scopeEffects.storageWrites.isEmpty || fragment.mechanics.contains "tstore"
   | s => stmtIsPersistentWrite s
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
@@ -1635,6 +1647,7 @@ def stmtInternalCEIViolation : Stmt → Bool → Option String
       -- `match adtTag (externalCall ...) { ... setStorage ... }` is correctly flagged
       let scrutineeSeenCall := seenCall || exprMayContainExternalCall scrutinee
       matchBranchesCEIViolation branches scrutineeSeenCall
+  | Stmt.unsafeYul _, _ => none
   | _, _ => none
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
@@ -1807,6 +1820,11 @@ def validateNoUnsupportedAdtConstructInStmt : Stmt → Except String Unit
   | Stmt.storageArrayPop _ | Stmt.returnArray _ | Stmt.returnBytes _
   | Stmt.returnStorageWords _ | Stmt.revertReturndata | Stmt.stop =>
       pure ()
+  | Stmt.unsafeYul fragment =>
+      if fragment.obligations.isEmpty then
+        throw s!"Compilation error: unsafe Yul fragment '{fragment.label}' must declare at least one local proof obligation."
+      else
+        pure ()
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -1829,11 +1847,22 @@ decreasing_by all_goals simp_wf; all_goals omega
 end
 
 def validateFunctionSpec (spec : FunctionSpec) : Except String Unit := do
+  let rawYulObligations :=
+    Stmt.foldList
+      (fun acc _ md => acc ++ md.localObligations)
+      []
+      spec.body
+  if spec.body.any (fun stmt =>
+      stmt.fold (fun acc s _ =>
+        match s with
+        | Stmt.unsafeYul fragment => acc || fragment.obligations.isEmpty
+        | _ => acc) false) then
+    throw s!"Compilation error: function '{spec.name}' contains an unsafe Yul fragment without explicit local proof obligations."
   -- Check for unsafe boundary mechanics outside `unsafe "reason" do` blocks.
   -- Mechanics inside `unsafe` blocks are documented by the reason string and
   -- do not independently require `local_obligations` (#1728, Phase 6 Step 6b).
   let unguardedMechanics := collectUnguardedUnsafeBoundaryMechanicsFromStmts spec.body
-  if !unguardedMechanics.isEmpty && spec.localObligations.isEmpty then
+  if !unguardedMechanics.isEmpty && spec.localObligations.isEmpty && rawYulObligations.isEmpty then
     throw s!"Compilation error: function '{spec.name}' uses low-level/assembly mechanic(s) {String.intercalate ", " unguardedMechanics} outside an unsafe block without any local_obligations entry ({issue1424Ref}). Wrap the low-level code in `unsafe \"reason\" do` or add local_obligations [...] to make the trust boundary explicit."
   if spec.isPayable && (spec.isView || spec.isPure) then
     throw s!"Compilation error: function '{spec.name}' cannot be both payable and view/pure ({issue586Ref})"
@@ -1915,8 +1944,19 @@ def validateConstructorSpec (ctor : Option ConstructorSpec) : Except String Unit
   match ctor with
   | none => pure ()
   | some spec =>
+      let rawYulObligations :=
+        Stmt.foldList
+          (fun acc _ md => acc ++ md.localObligations)
+          []
+          spec.body
+      if spec.body.any (fun stmt =>
+          stmt.fold (fun acc s _ =>
+            match s with
+            | Stmt.unsafeYul fragment => acc || fragment.obligations.isEmpty
+            | _ => acc) false) then
+        throw "Compilation error: constructor contains an unsafe Yul fragment without explicit local proof obligations."
       let unguardedMechanics := collectUnguardedUnsafeBoundaryMechanicsFromStmts spec.body
-      if !unguardedMechanics.isEmpty && spec.localObligations.isEmpty then
+      if !unguardedMechanics.isEmpty && spec.localObligations.isEmpty && rawYulObligations.isEmpty then
         throw s!"Compilation error: constructor uses low-level/assembly mechanic(s) {String.intercalate ", " unguardedMechanics} outside an unsafe block without any local_obligations entry ({issue1424Ref}). Wrap the low-level code in `unsafe \"reason\" do` or add local_obligations [...] to make the trust boundary explicit."
       if spec.body.any stmtContainsUnsafeLogicalCallLike then
         throw s!"Compilation error: constructor uses Expr.logicalAnd/Expr.logicalOr/Expr.ite or arithmetic helpers (mulDivUp/wDivUp/min/max) with call-like operand(s) that would be duplicated in Yul output ({issue748Ref}). Move call-like expressions into Stmt.letVar before combining."

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -438,6 +438,8 @@ def stmtWritesState : Stmt → Bool
       exprWritesState destOffset || exprWritesState sourceOffset || exprWritesState size
   | Stmt.returndataCopy destOffset sourceOffset size =>
       exprWritesState destOffset || exprWritesState sourceOffset || exprWritesState size
+  | Stmt.rawRevert offset size =>
+      exprWritesState offset || exprWritesState size
   | Stmt.revertReturndata =>
       false
   | Stmt.stop =>
@@ -1008,6 +1010,8 @@ def stmtReadsStateOrEnv : Stmt → Bool
   | Stmt.tstore offset value =>
       exprReadsStateOrEnv offset || exprReadsStateOrEnv value
   | Stmt.calldatacopy _ _ _ | Stmt.returndataCopy _ _ _ => true
+  | Stmt.rawRevert offset size =>
+      exprReadsStateOrEnv offset || exprReadsStateOrEnv size
   | Stmt.revertReturndata =>
       true
   | Stmt.stop =>
@@ -1208,6 +1212,9 @@ def stmtWritesStateWithFunctionEffects
       exprWritesStateWithFunctionEffects effects destOffset ||
         exprWritesStateWithFunctionEffects effects sourceOffset ||
         exprWritesStateWithFunctionEffects effects size
+  | Stmt.rawRevert offset size =>
+      exprWritesStateWithFunctionEffects effects offset ||
+        exprWritesStateWithFunctionEffects effects size
   | Stmt.revertReturndata =>
       false
   | Stmt.stop =>
@@ -1383,6 +1390,8 @@ def stmtReadsStateOrEnvWithFunctionEffects
       exprReadsStateOrEnvWithFunctionEffects effects offset ||
         exprReadsStateOrEnvWithFunctionEffects effects value
   | Stmt.calldatacopy _ _ _ | Stmt.returndataCopy _ _ _ => true
+  | Stmt.rawRevert offset size =>
+      exprReadsStateOrEnvWithFunctionEffects effects offset || exprReadsStateOrEnvWithFunctionEffects effects size
   | Stmt.revertReturndata =>
       true
   | Stmt.stop =>
@@ -1790,6 +1799,11 @@ def validateNoUnsupportedAdtConstructInStmt : Stmt → Except String Unit
       if exprContainsAdtConstruct destOffset || exprContainsAdtConstruct sourceOffset ||
           exprContainsAdtConstruct size then
         throw "Compilation error: ADT construction cannot be used in copy offsets or sizes."
+  | Stmt.rawRevert offset size =>
+      if exprContainsAdtConstruct offset || exprContainsAdtConstruct size then
+        throw "Compilation error: ADT construction cannot be used in raw revert offsets or sizes."
+      else
+        pure ()
   | Stmt.storageArrayPop _ | Stmt.returnArray _ | Stmt.returnBytes _
   | Stmt.returnStorageWords _ | Stmt.revertReturndata | Stmt.stop =>
       pure ()

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -38,85 +38,9 @@ private def missingDeclaredNames (actual declared : List String) : List String :
       if declared.contains name || acc.contains name then acc else acc ++ [name])
     []
 
-mutual
-private def yulExprWritesStorage : YulExpr → Bool
-  | .call func args =>
-      func == "sstore" || func == "tstore" || yulExprListWritesStorage args
-  | _ => false
-
-private def yulExprListWritesStorage : List YulExpr → Bool
-  | [] => false
-  | expr :: rest =>
-      yulExprWritesStorage expr || yulExprListWritesStorage rest
-end
-
-private def mergeScopeEffects (a b : StmtScopeEffects) : StmtScopeEffects :=
-  { bindNames := a.bindNames ++ b.bindNames
-    assignNames := a.assignNames ++ b.assignNames
-    storageWrites := a.storageWrites ++ b.storageWrites }
-
-mutual
-private partial def yulStmtActualScopeEffects : YulStmt → StmtScopeEffects
-  | .comment _ | .leave =>
-      {}
-  | .let_ name value =>
-      { bindNames := [name]
-        storageWrites := if yulExprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
-  | .letMany names value =>
-      { bindNames := names
-        storageWrites := if yulExprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
-  | .assign name value =>
-      { assignNames := [name]
-        storageWrites := if yulExprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
-  | .expr expr =>
-      { storageWrites := if yulExprWritesStorage expr then ["<raw-yul-storage-write>"] else [] }
-  | .if_ cond body =>
-      let bodyEffects := yulStmtListActualScopeEffects body
-      { bodyEffects with
-        storageWrites :=
-          (if yulExprWritesStorage cond then ["<raw-yul-storage-write>"] else []) ++
-            bodyEffects.storageWrites }
-  | .for_ init cond post body =>
-      let initEffects := yulStmtListActualScopeEffects init
-      let postEffects := yulStmtListActualScopeEffects post
-      let bodyEffects := yulStmtListActualScopeEffects body
-      { bindNames := initEffects.bindNames ++ postEffects.bindNames ++ bodyEffects.bindNames
-        assignNames := initEffects.assignNames ++ postEffects.assignNames ++ bodyEffects.assignNames
-        storageWrites :=
-          initEffects.storageWrites ++
-          (if yulExprWritesStorage cond then ["<raw-yul-storage-write>"] else []) ++
-          postEffects.storageWrites ++ bodyEffects.storageWrites }
-  | .switch expr cases default =>
-      let casesEffects :=
-        cases.foldl
-          (fun acc (_, body) => mergeScopeEffects acc (yulStmtListActualScopeEffects body))
-          ({} : StmtScopeEffects)
-      let defaultEffects :=
-        match default with
-        | none => ({} : StmtScopeEffects)
-        | some body => yulStmtListActualScopeEffects body
-      { bindNames := casesEffects.bindNames ++ defaultEffects.bindNames
-        assignNames := casesEffects.assignNames ++ defaultEffects.assignNames
-        storageWrites :=
-          (if yulExprWritesStorage expr then ["<raw-yul-storage-write>"] else []) ++
-          casesEffects.storageWrites ++ defaultEffects.storageWrites }
-  | .block stmts =>
-      yulStmtListActualScopeEffects stmts
-  | .funcDef name _params _rets body =>
-      let bodyEffects := yulStmtListActualScopeEffects body
-      { bindNames := [name]
-        assignNames := []
-        storageWrites := bodyEffects.storageWrites }
-
-private partial def yulStmtListActualScopeEffects : List YulStmt → StmtScopeEffects
-  | [] => {}
-  | stmt :: rest =>
-      mergeScopeEffects (yulStmtActualScopeEffects stmt) (yulStmtListActualScopeEffects rest)
-end
-
 private def validateUnsafeYulDeclaredScopeEffects (fragment : UnsafeYulFragment) :
     Except String Unit := do
-  let actual := yulStmtListActualScopeEffects fragment.stmts
+  let actual := yulStmtListScopeEffects fragment.stmts
   let missingBinds := missingDeclaredNames actual.bindNames fragment.scopeEffects.bindNames
   if !missingBinds.isEmpty then
     throw s!"Compilation error: unsafe Yul fragment '{fragment.label}' under-declares bound local(s): {String.intercalate ", " missingBinds}"
@@ -491,7 +415,7 @@ def stmtWritesState : Stmt → Bool
   | Stmt.returnBytes _ =>
       false
   | Stmt.unsafeYul fragment =>
-      !fragment.scopeEffects.storageWrites.isEmpty
+      !fragment.scopeEffects.storageWrites.isEmpty || fragment.mechanics.contains .tstore
   | Stmt.returnStorageWords _ =>
       false
   | Stmt.mstore offset value =>
@@ -1298,7 +1222,7 @@ def stmtWritesStateWithFunctionEffects
       exprWritesStateWithFunctionEffects effects scrutinee ||
         matchBranchesWriteStateWithFunctionEffects effects branches
   | Stmt.unsafeYul fragment =>
-      !fragment.scopeEffects.storageWrites.isEmpty
+      !fragment.scopeEffects.storageWrites.isEmpty || fragment.mechanics.contains .tstore
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
 

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -480,6 +480,8 @@ def stmtWrittenFields : Stmt → List String
       stmtListWrittenFields body
   | Stmt.unsafeBlock _ body =>
       stmtListWrittenFields body
+  | Stmt.unsafeYul fragment =>
+      fragment.scopeEffects.storageWrites
   | Stmt.matchAdt _ _ branches =>
       matchBranchesWrittenFields branches
   | _ => []
@@ -631,6 +633,10 @@ def stmtHasUntrackableWrites : Stmt → Bool
       exprHasUntrackableWrites count || stmtListHasUntrackableWrites body
   | Stmt.unsafeBlock _ body =>
       stmtListHasUntrackableWrites body
+  | Stmt.unsafeYul fragment =>
+      -- Raw Yul storage writes target computed slots that cannot be tied back to
+      -- declared storage fields, so any storage-writing fragment is untrackable.
+      !fragment.scopeEffects.storageWrites.isEmpty || fragment.mechanics.contains .storageWrite
   | Stmt.matchAdt _ scrutinee branches =>
       exprHasUntrackableWrites scrutinee || matchBranchesHasUntrackableWrites branches
   | _ => false
@@ -875,6 +881,10 @@ def stmtContainsExternalCall : Stmt → Bool
         matchBranchesContainExternalCall branches
   | Stmt.internalCall _ args | Stmt.internalCallAssign _ _ args =>
       args.any exprContainsExternalCall
+  | Stmt.unsafeYul fragment =>
+      fragment.mechanics.contains .call ||
+        fragment.mechanics.contains .staticcall ||
+        fragment.mechanics.contains .delegatecall
   | _ => false
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega
@@ -1624,7 +1634,23 @@ def stmtInternalCEIViolation : Stmt → Bool → Option String
       -- `match adtTag (externalCall ...) { ... setStorage ... }` is correctly flagged
       let scrutineeSeenCall := seenCall || exprMayContainExternalCall scrutinee
       matchBranchesCEIViolation branches scrutineeSeenCall
-  | Stmt.unsafeYul _, _ => none
+  | Stmt.unsafeYul fragment, seenCall =>
+      -- A raw Yul fragment whose mechanics include an external interaction must be
+      -- treated like a call for CEI purposes. Flag a violation when a storage write
+      -- happens after a prior external call, or within a fragment that both calls
+      -- out and writes storage.
+      let fragmentCalls :=
+        fragment.mechanics.contains .call ||
+          fragment.mechanics.contains .staticcall ||
+          fragment.mechanics.contains .delegatecall
+      let fragmentWrites :=
+        !fragment.scopeEffects.storageWrites.isEmpty ||
+          fragment.mechanics.contains .storageWrite ||
+          fragment.mechanics.contains .tstore
+      if (seenCall || fragmentCalls) && fragmentWrites then
+        some "raw Yul fragment writes state after an external call"
+      else
+        none
   | _, _ => none
 termination_by s => sizeOf s
 decreasing_by all_goals simp_wf; all_goals omega

--- a/Compiler/CompilationModel/ValidationHelpers.lean
+++ b/Compiler/CompilationModel/ValidationHelpers.lean
@@ -187,7 +187,6 @@ def collectStmtNames : Stmt → List String
       collectExprNames destOffset ++ collectExprNames sourceOffset ++ collectExprNames size
   | Stmt.returndataCopy destOffset sourceOffset size =>
       collectExprNames destOffset ++ collectExprNames sourceOffset ++ collectExprNames size
-  | Stmt.rawRevert offset size => collectExprNames offset ++ collectExprNames size
   | Stmt.revertReturndata => []
   | Stmt.stop => []
   | Stmt.ite cond thenBranch elseBranch =>

--- a/Compiler/CompilationModel/ValidationHelpers.lean
+++ b/Compiler/CompilationModel/ValidationHelpers.lean
@@ -187,6 +187,7 @@ def collectStmtNames : Stmt → List String
       collectExprNames destOffset ++ collectExprNames sourceOffset ++ collectExprNames size
   | Stmt.returndataCopy destOffset sourceOffset size =>
       collectExprNames destOffset ++ collectExprNames sourceOffset ++ collectExprNames size
+  | Stmt.rawRevert offset size => collectExprNames offset ++ collectExprNames size
   | Stmt.revertReturndata => []
   | Stmt.stop => []
   | Stmt.ite cond thenBranch elseBranch =>

--- a/Compiler/CompilationModel/ValidationHelpers.lean
+++ b/Compiler/CompilationModel/ValidationHelpers.lean
@@ -210,6 +210,8 @@ def collectStmtNames : Stmt → List String
       successVar :: resultVars ++ externalName :: collectExprListNames args
   | Stmt.ecm mod args =>
       mod.resultVars ++ collectExprListNames args
+  | Stmt.unsafeYul fragment =>
+      fragment.scopeEffects.bindNames ++ fragment.scopeEffects.assignNames
 termination_by stmt => sizeOf stmt
 decreasing_by
   all_goals simp_wf

--- a/Compiler/CompilationModel/YulImporter.lean
+++ b/Compiler/CompilationModel/YulImporter.lean
@@ -1,0 +1,236 @@
+import Compiler.CompilationModel.Types
+
+namespace Compiler.CompilationModel
+
+open Compiler.Yul
+
+/-- Source location supplied by an external Solidity/Yul AST importer. -/
+structure YulSourceSpan where
+  sourceName : String
+  startLine : Nat
+  startColumn : Nat
+  endLine : Nat
+  endColumn : Nat
+  deriving Repr, BEq, Inhabited
+
+namespace YulSourceSpan
+
+def toReportString (span : YulSourceSpan) : String :=
+  s!"{span.sourceName}:{span.startLine}:{span.startColumn}-{span.endLine}:{span.endColumn}"
+
+end YulSourceSpan
+
+/-- Provenance for Yul entering the compilation model from outside Verity. -/
+inductive ImportedYulDialect where
+  | solidityInlineAssembly
+  | yul
+  | generatedYul
+  deriving Repr, BEq, Inhabited
+
+namespace ImportedYulDialect
+
+def toReportString : ImportedYulDialect → String
+  | .solidityInlineAssembly => "Solidity inline assembly"
+  | .yul => "Yul"
+  | .generatedYul => "generated Yul"
+
+end ImportedYulDialect
+
+/-- Typed boundary for importing already-parsed Solidity inline assembly/Yul AST.
+    Parsing remains outside this module; this boundary converts `Compiler.Yul.YulStmt`
+    into the localized unsafe-Yul statement surface with derived metadata. -/
+structure ImportedYulBlock where
+  label : String
+  dialect : ImportedYulDialect := .solidityInlineAssembly
+  sourceSpan : Option YulSourceSpan := none
+  stmts : List YulStmt
+  obligation : Option String := none
+  proofStatus : Compiler.ProofStatus := .assumed
+  extraMechanics : List LowLevelMechanic := []
+  extraContracts : List UnsafeYulContract := []
+  termination : StmtTermination := .mayTerminate
+  controlFlow : ControlFlowSummary := .unknown
+  deriving Repr
+
+namespace YulImporter
+
+private def uniqueMechanics (xs : List LowLevelMechanic) : List LowLevelMechanic :=
+  xs.eraseDups
+
+private partial def mechanicsOfExpr : YulExpr → List LowLevelMechanic
+  | .call name args =>
+      let here :=
+        match name with
+        | "call" => [.call]
+        | "staticcall" => [.staticcall]
+        | "delegatecall" => [.delegatecall]
+        | "returndatasize" => [.returndataSize]
+        | "returndatacopy" => [.returndataCopy]
+        | "revert" => [.rawRevert]
+        | "mload" => [.mload]
+        | "mstore" => [.mstore]
+        | "calldataload" => [.calldataload]
+        | "calldatacopy" => [.calldatacopy]
+        | "extcodesize" => [.extcodesize]
+        | "tload" => [.tload]
+        | "tstore" => [.tstore, .storageWrite]
+        | "sstore" => [.storageWrite]
+        | "log0" | "log1" | "log2" | "log3" | "log4" => [.rawLog]
+        | "address" => [.contractAddress]
+        | "chainid" => [.chainid]
+        | "selfbalance" => [.selfBalance]
+        | "number" => [.blockNumber]
+        | _ => []
+      here ++ args.flatMap mechanicsOfExpr
+  | _ => []
+
+mutual
+private partial def mechanicsOfStmt : YulStmt → List LowLevelMechanic
+  | .comment _ | .leave => []
+  | .let_ _ value | .letMany _ value | .assign _ value | .expr value =>
+      mechanicsOfExpr value
+  | .if_ cond body =>
+      mechanicsOfExpr cond ++ mechanicsOfStmts body
+  | .for_ init cond post body =>
+      mechanicsOfStmts init ++ mechanicsOfExpr cond ++ mechanicsOfStmts post ++ mechanicsOfStmts body
+  | .switch expr cases default =>
+      mechanicsOfExpr expr ++
+        cases.flatMap (fun (_, body) => mechanicsOfStmts body) ++
+        default.toList.flatMap mechanicsOfStmts
+  | .block stmts =>
+      mechanicsOfStmts stmts
+  | .funcDef _ _ _ body =>
+      mechanicsOfStmts body
+
+private partial def mechanicsOfStmts : List YulStmt → List LowLevelMechanic
+  | [] => []
+  | stmt :: rest => mechanicsOfStmt stmt ++ mechanicsOfStmts rest
+end
+
+private partial def exprWritesStorage : YulExpr → Bool
+  | .call name args =>
+      name == "sstore" || name == "tstore" || args.any exprWritesStorage
+  | _ => false
+
+private def mergeScopeEffects (a b : StmtScopeEffects) : StmtScopeEffects :=
+  { bindNames := a.bindNames ++ b.bindNames
+    assignNames := a.assignNames ++ b.assignNames
+    storageWrites := a.storageWrites ++ b.storageWrites }
+
+mutual
+private partial def scopeEffectsOfStmt : YulStmt → StmtScopeEffects
+  | .comment _ | .leave =>
+      {}
+  | .let_ name value =>
+      { bindNames := [name]
+        storageWrites := if exprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
+  | .letMany names value =>
+      { bindNames := names
+        storageWrites := if exprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
+  | .assign name value =>
+      { assignNames := [name]
+        storageWrites := if exprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
+  | .expr expr =>
+      { storageWrites := if exprWritesStorage expr then ["<raw-yul-storage-write>"] else [] }
+  | .if_ cond body =>
+      let bodyEffects := scopeEffectsOfStmts body
+      { bodyEffects with
+        storageWrites :=
+          (if exprWritesStorage cond then ["<raw-yul-storage-write>"] else []) ++
+            bodyEffects.storageWrites }
+  | .for_ init cond post body =>
+      let initEffects := scopeEffectsOfStmts init
+      let postEffects := scopeEffectsOfStmts post
+      let bodyEffects := scopeEffectsOfStmts body
+      { bindNames := initEffects.bindNames ++ postEffects.bindNames ++ bodyEffects.bindNames
+        assignNames := initEffects.assignNames ++ postEffects.assignNames ++ bodyEffects.assignNames
+        storageWrites :=
+          initEffects.storageWrites ++
+          (if exprWritesStorage cond then ["<raw-yul-storage-write>"] else []) ++
+          postEffects.storageWrites ++ bodyEffects.storageWrites }
+  | .switch expr cases default =>
+      let casesEffects :=
+        cases.foldl
+          (fun acc (_, body) => mergeScopeEffects acc (scopeEffectsOfStmts body))
+          ({} : StmtScopeEffects)
+      let defaultEffects :=
+        match default with
+        | none => ({} : StmtScopeEffects)
+        | some body => scopeEffectsOfStmts body
+      { bindNames := casesEffects.bindNames ++ defaultEffects.bindNames
+        assignNames := casesEffects.assignNames ++ defaultEffects.assignNames
+        storageWrites :=
+          (if exprWritesStorage expr then ["<raw-yul-storage-write>"] else []) ++
+          casesEffects.storageWrites ++ defaultEffects.storageWrites }
+  | .block stmts =>
+      scopeEffectsOfStmts stmts
+  | .funcDef name _ _ body =>
+      let bodyEffects := scopeEffectsOfStmts body
+      { bindNames := [name]
+        storageWrites := bodyEffects.storageWrites }
+
+private partial def scopeEffectsOfStmts : List YulStmt → StmtScopeEffects
+  | [] => {}
+  | stmt :: rest =>
+      mergeScopeEffects (scopeEffectsOfStmt stmt) (scopeEffectsOfStmts rest)
+end
+
+private def controlFlowOfExpr : YulExpr → ControlFlowSummary
+  | .call "revert" _ => .reverts
+  | .call "return" _ => .returns
+  | .call "stop" _ => .stops
+  | _ => .fallsThrough
+
+mutual
+private partial def controlFlowOfStmt : YulStmt → ControlFlowSummary
+  | .comment _ | .let_ _ _ | .letMany _ _ | .assign _ _ | .funcDef _ _ _ _ =>
+      .fallsThrough
+  | .leave =>
+      .returns
+  | .expr expr =>
+      controlFlowOfExpr expr
+  | .if_ cond body =>
+      (controlFlowOfExpr cond).union { (controlFlowOfStmts body) with mayFallThrough := true }
+  | .for_ _ _ _ _ | .switch _ _ _ =>
+      .unknown
+  | .block stmts =>
+      controlFlowOfStmts stmts
+
+private partial def controlFlowOfStmts : List YulStmt → ControlFlowSummary
+  | [] => .fallsThrough
+  | stmt :: rest =>
+      (controlFlowOfStmt stmt).seq (controlFlowOfStmts rest)
+end
+
+private def defaultObligationText (block : ImportedYulBlock) : String :=
+  let source :=
+    match block.sourceSpan with
+    | none => block.dialect.toReportString
+    | some span => s!"{block.dialect.toReportString} at {span.toReportString}"
+  s!"Imported {source} block '{block.label}' must refine the declared Verity state transition."
+
+/-- Convert imported Solidity inline assembly/Yul AST into a localized unsafe-Yul statement. -/
+def importBlock (block : ImportedYulBlock) : Stmt :=
+  let obligationText := block.obligation.getD (defaultObligationText block)
+  let obligation : LocalObligation :=
+    { name := block.label
+      obligation := obligationText
+      proofStatus := block.proofStatus }
+  Stmt.unsafeYul {
+    label := block.label
+    stmts := block.stmts
+    obligations := [obligation]
+    contracts := block.extraContracts
+    mechanics := uniqueMechanics (mechanicsOfStmts block.stmts ++ block.extraMechanics)
+    scopeEffects := scopeEffectsOfStmts block.stmts
+    termination := block.termination
+    controlFlow :=
+      if block.controlFlow == .unknown then
+        controlFlowOfStmts block.stmts
+      else
+        block.controlFlow
+  }
+
+end YulImporter
+
+end Compiler.CompilationModel

--- a/Compiler/CompilationModel/YulImporter.lean
+++ b/Compiler/CompilationModel/YulImporter.lean
@@ -107,74 +107,6 @@ private partial def mechanicsOfStmts : List YulStmt → List LowLevelMechanic
   | stmt :: rest => mechanicsOfStmt stmt ++ mechanicsOfStmts rest
 end
 
-private partial def exprWritesStorage : YulExpr → Bool
-  | .call name args =>
-      name == "sstore" || name == "tstore" || args.any exprWritesStorage
-  | _ => false
-
-private def mergeScopeEffects (a b : StmtScopeEffects) : StmtScopeEffects :=
-  { bindNames := a.bindNames ++ b.bindNames
-    assignNames := a.assignNames ++ b.assignNames
-    storageWrites := a.storageWrites ++ b.storageWrites }
-
-mutual
-private partial def scopeEffectsOfStmt : YulStmt → StmtScopeEffects
-  | .comment _ | .leave =>
-      {}
-  | .let_ name value =>
-      { bindNames := [name]
-        storageWrites := if exprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
-  | .letMany names value =>
-      { bindNames := names
-        storageWrites := if exprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
-  | .assign name value =>
-      { assignNames := [name]
-        storageWrites := if exprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
-  | .expr expr =>
-      { storageWrites := if exprWritesStorage expr then ["<raw-yul-storage-write>"] else [] }
-  | .if_ cond body =>
-      let bodyEffects := scopeEffectsOfStmts body
-      { bodyEffects with
-        storageWrites :=
-          (if exprWritesStorage cond then ["<raw-yul-storage-write>"] else []) ++
-            bodyEffects.storageWrites }
-  | .for_ init cond post body =>
-      let initEffects := scopeEffectsOfStmts init
-      let postEffects := scopeEffectsOfStmts post
-      let bodyEffects := scopeEffectsOfStmts body
-      { bindNames := initEffects.bindNames ++ postEffects.bindNames ++ bodyEffects.bindNames
-        assignNames := initEffects.assignNames ++ postEffects.assignNames ++ bodyEffects.assignNames
-        storageWrites :=
-          initEffects.storageWrites ++
-          (if exprWritesStorage cond then ["<raw-yul-storage-write>"] else []) ++
-          postEffects.storageWrites ++ bodyEffects.storageWrites }
-  | .switch expr cases default =>
-      let casesEffects :=
-        cases.foldl
-          (fun acc (_, body) => mergeScopeEffects acc (scopeEffectsOfStmts body))
-          ({} : StmtScopeEffects)
-      let defaultEffects :=
-        match default with
-        | none => ({} : StmtScopeEffects)
-        | some body => scopeEffectsOfStmts body
-      { bindNames := casesEffects.bindNames ++ defaultEffects.bindNames
-        assignNames := casesEffects.assignNames ++ defaultEffects.assignNames
-        storageWrites :=
-          (if exprWritesStorage expr then ["<raw-yul-storage-write>"] else []) ++
-          casesEffects.storageWrites ++ defaultEffects.storageWrites }
-  | .block stmts =>
-      scopeEffectsOfStmts stmts
-  | .funcDef name _ _ body =>
-      let bodyEffects := scopeEffectsOfStmts body
-      { bindNames := [name]
-        storageWrites := bodyEffects.storageWrites }
-
-private partial def scopeEffectsOfStmts : List YulStmt → StmtScopeEffects
-  | [] => {}
-  | stmt :: rest =>
-      mergeScopeEffects (scopeEffectsOfStmt stmt) (scopeEffectsOfStmts rest)
-end
-
 private def controlFlowOfExpr : YulExpr → ControlFlowSummary
   | .call "revert" _ => .reverts
   | .call "return" _ => .returns
@@ -222,7 +154,7 @@ def importBlock (block : ImportedYulBlock) : Stmt :=
     obligations := [obligation]
     contracts := block.extraContracts
     mechanics := uniqueMechanics (mechanicsOfStmts block.stmts ++ block.extraMechanics)
-    scopeEffects := scopeEffectsOfStmts block.stmts
+    scopeEffects := yulStmtListScopeEffects block.stmts
     termination := block.termination
     controlFlow :=
       if block.controlFlow == .unknown then

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -2922,6 +2922,19 @@ private def matchAdtAllBranchesTerminateSpec : CompilationModel := {
   ]
 }
 
+private def returnValueStopRejectedSpec : CompilationModel := {
+  name := "ReturnValueStopRejected"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "bad"
+      params := []
+      returnType := some FieldType.uint256
+      body := [Stmt.stop]
+    }
+  ]
+}
+
 private def reservedEcmResultVarSpec : CompilationModel := {
   name := "ReservedEcmResultVar"
   fields := [{ name := "value", ty := FieldType.uint256 }]
@@ -5282,6 +5295,10 @@ set_option maxRecDepth 4096 in
   discard <| expectCompile
     "matchAdt with terminating branches"
     matchAdtAllBranchesTerminateSpec
+  expectCompileErrorContains
+    "function with return value rejects stop-only termination"
+    returnValueStopRejectedSpec
+    "not all control-flow paths end in return/revert"
   let envRuntimeYul ← expectCompileToYul "env runtime smoke compiles" envRuntimeSmokeSpec
   expectTrue "env runtime smoke lowers block.number" (contains envRuntimeYul "number()")
   let stringCompiled :=

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -2726,6 +2726,24 @@ private def rawLogTooManyTopicsSpec : CompilationModel := {
   ]
 }
 
+private def rawRevertSmokeSpec : CompilationModel := {
+  name := "RawRevertSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "fail"
+      params := [
+        { name := "offset", ty := ParamType.uint256 },
+        { name := "size", ty := ParamType.uint256 }
+      ]
+      returnType := none
+      body := [
+        Stmt.rawRevert (Expr.param "offset") (Expr.param "size")
+      ]
+    }
+  ]
+}
+
 private def reservedEcmResultVarSpec : CompilationModel := {
   name := "ReservedEcmResultVar"
   fields := [{ name := "value", ty := FieldType.uint256 }]
@@ -5053,6 +5071,17 @@ set_option maxRecDepth 4096 in
     "compiler rawLog rejects more than four topics"
     rawLogTooManyTopicsSpec
     "rawLog supports at most 4 topics"
+  let rawRevertYul ← expectCompileToYul
+    "rawRevert smoke spec"
+    rawRevertSmokeSpec
+  expectTrue "rawRevert preserves the modeled memory slice in rendered Yul"
+    (contains rawRevertYul "revert(offset, size)")
+  let rawRevertTrustReport := emitTrustReportJson [rawRevertSmokeSpec]
+  let rawRevertLowLevelLines := emitLowLevelMechanicsUsageSiteLines [rawRevertSmokeSpec]
+  expectTrue "rawRevert trust report classifies raw memory reverts as denied low-level mechanics"
+    (contains rawRevertTrustReport "\"modeledLowLevelMechanics\"" &&
+      contains rawRevertTrustReport "\"rawRevert\"" &&
+      rawRevertLowLevelLines.any (fun line => contains line "RawRevertSmoke [function:fail]: rawRevert"))
   let envRuntimeYul ← expectCompileToYul "env runtime smoke compiles" envRuntimeSmokeSpec
   expectTrue "env runtime smoke lowers block.number" (contains envRuntimeYul "number()")
   let stringCompiled :=

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -2875,6 +2875,53 @@ private def unsafeYulUnderDeclaredStorageSpec : CompilationModel := {
   ]
 }
 
+private def unsafeYulTstoreMechanicViewRejectedSpec : CompilationModel := {
+  name := "UnsafeYulTstoreMechanicViewRejected"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "bad"
+      params := []
+      returnType := none
+      isView := true
+      body := [
+        Stmt.unsafeYul {
+          label := "declared_tstore_mechanic"
+          stmts := [Compiler.Yul.YulStmt.comment "mechanic-only tstore boundary"]
+          obligations := [unsafeYulScopeObligation "declared_tstore_mechanic_obligation"]
+          mechanics := [.tstore]
+        }
+      ]
+    }
+  ]
+}
+
+private def matchAdtAllBranchesTerminateSpec : CompilationModel := {
+  name := "MatchAdtAllBranchesTerminate"
+  fields := [{ name := "choice", ty := FieldType.adt "Choice" 1 }]
+  «constructor» := none
+  functions := [
+    { name := "pick"
+      params := []
+      returnType := some FieldType.uint256
+      body := [
+        Stmt.matchAdt "Choice" (Expr.adtTag "Choice" "choice") [
+          ("None", [], [Stmt.return (Expr.literal 0)]),
+          ("Some", ["amount"], [Stmt.return (Expr.localVar "amount")])
+        ]
+      ]
+    }
+  ]
+  adtTypes := [
+    { name := "Choice"
+      variants := [
+        { name := "None", tag := 0, fields := [] },
+        { name := "Some", tag := 1, fields := [{ name := "amount", ty := ParamType.uint256 }] }
+      ]
+    }
+  ]
+}
+
 private def reservedEcmResultVarSpec : CompilationModel := {
   name := "ReservedEcmResultVar"
   fields := [{ name := "value", ty := FieldType.uint256 }]
@@ -5228,6 +5275,13 @@ set_option maxRecDepth 4096 in
     "unsafeYul validation rejects under-declared Yul storage writes"
     unsafeYulUnderDeclaredStorageSpec
     "under-declares storage effects"
+  expectCompileErrorContains
+    "unsafeYul tstore mechanic is rejected from view functions"
+    unsafeYulTstoreMechanicViewRejectedSpec
+    "function 'bad' is marked view but writes state"
+  discard <| expectCompile
+    "matchAdt with terminating branches"
+    matchAdtAllBranchesTerminateSpec
   let envRuntimeYul ← expectCompileToYul "env runtime smoke compiles" envRuntimeSmokeSpec
   expectTrue "env runtime smoke lowers block.number" (contains envRuntimeYul "number()")
   let stringCompiled :=

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -75,6 +75,65 @@ example : dischargedEdgeExecutableStillRuns = true := by native_decide
 
 end MacroLocalObligationSmoke
 
+namespace YulImporterSmoke
+
+open Compiler.Yul
+
+private def importedAssemblyStmt : Stmt :=
+  YulImporter.importBlock {
+    label := "sol_inline_assembly"
+    sourceSpan := some {
+      sourceName := "Contract.sol"
+      startLine := 12
+      startColumn := 8
+      endLine := 18
+      endColumn := 5
+    }
+    stmts := [
+      YulStmt.let_ "ptr" (YulExpr.call "mload" [YulExpr.lit 64]),
+      YulStmt.assign "ptr" (YulExpr.call "add" [YulExpr.ident "ptr", YulExpr.lit 32]),
+      YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident "ptr", YulExpr.lit 1]),
+      YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.lit 1]),
+      YulStmt.expr (YulExpr.call "revert" [YulExpr.ident "ptr", YulExpr.lit 32])
+    ]
+  }
+
+def importedAssemblyCarriesDerivedMetadata : Bool :=
+  match importedAssemblyStmt with
+  | Stmt.unsafeYul fragment =>
+      fragment.label == "sol_inline_assembly" &&
+      (match fragment.obligations with
+       | [{ name := "sol_inline_assembly"
+            obligation := "Imported Solidity inline assembly at Contract.sol:12:8-18:5 block 'sol_inline_assembly' must refine the declared Verity state transition."
+            proofStatus := .assumed }] => true
+       | _ => false) &&
+      fragment.mechanics.contains .mload &&
+      fragment.mechanics.contains .mstore &&
+      fragment.mechanics.contains .storageWrite &&
+      fragment.mechanics.contains .rawRevert &&
+      fragment.scopeEffects.bindNames == ["ptr"] &&
+      fragment.scopeEffects.assignNames == ["ptr"] &&
+      !fragment.scopeEffects.storageWrites.isEmpty &&
+      fragment.controlFlow == .reverts
+  | _ => false
+
+example : importedAssemblyCarriesDerivedMetadata = true := by native_decide
+
+def importedAssemblyPassesUnsafeYulValidation : Bool :=
+  let spec : FunctionSpec := {
+    name := "usesImportedAssembly"
+    params := []
+    returnType := none
+    body := [importedAssemblyStmt, Stmt.stop]
+  }
+  match validateFunctionSpec spec with
+  | .ok _ => true
+  | .error _ => false
+
+example : importedAssemblyPassesUnsafeYulValidation = true := by native_decide
+
+end YulImporterSmoke
+
 namespace MacroProxyUpgradeabilitySmoke
 
 open Contracts
@@ -2738,7 +2797,79 @@ private def rawRevertSmokeSpec : CompilationModel := {
       ]
       returnType := none
       body := [
-        Stmt.rawRevert (Expr.param "offset") (Expr.param "size")
+        Stmt.unsafeYul
+          (UnsafeYulFragment.rawRevert
+            (Compiler.Yul.YulExpr.ident "offset")
+            (Compiler.Yul.YulExpr.ident "size")
+            { name := "raw_revert_memory_slice_refinement"
+              obligation := "Caller-provided raw revert memory slice must refine the intended failure payload."
+              proofStatus := .assumed })
+      ]
+    }
+  ]
+}
+
+private def unsafeYulScopeObligation (name : String) : LocalObligation :=
+  { name := name
+    obligation := "Raw Yul scope effects must conservatively describe the Yul payload."
+    proofStatus := .assumed }
+
+private def unsafeYulUnderDeclaredBindSpec : CompilationModel := {
+  name := "UnsafeYulUnderDeclaredBind"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "bad"
+      params := []
+      returnType := none
+      body := [
+        Stmt.unsafeYul {
+          label := "under_declared_bind"
+          stmts := [Compiler.Yul.YulStmt.let_ "tmp" (Compiler.Yul.YulExpr.lit 1)]
+          obligations := [unsafeYulScopeObligation "under_declared_bind_obligation"]
+        }
+      ]
+    }
+  ]
+}
+
+private def unsafeYulUnderDeclaredAssignSpec : CompilationModel := {
+  name := "UnsafeYulUnderDeclaredAssign"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "bad"
+      params := []
+      returnType := none
+      body := [
+        Stmt.letVar "tmp" (Expr.literal 0),
+        Stmt.unsafeYul {
+          label := "under_declared_assign"
+          stmts := [Compiler.Yul.YulStmt.assign "tmp" (Compiler.Yul.YulExpr.lit 1)]
+          obligations := [unsafeYulScopeObligation "under_declared_assign_obligation"]
+        }
+      ]
+    }
+  ]
+}
+
+private def unsafeYulUnderDeclaredStorageSpec : CompilationModel := {
+  name := "UnsafeYulUnderDeclaredStorage"
+  fields := [{ name := "value", ty := FieldType.uint256 }]
+  «constructor» := none
+  functions := [
+    { name := "bad"
+      params := []
+      returnType := none
+      body := [
+        Stmt.unsafeYul {
+          label := "under_declared_storage"
+          stmts := [
+            Compiler.Yul.YulStmt.expr
+              (Compiler.Yul.YulExpr.call "sstore" [Compiler.Yul.YulExpr.lit 0, Compiler.Yul.YulExpr.lit 1])
+          ]
+          obligations := [unsafeYulScopeObligation "under_declared_storage_obligation"]
+        }
       ]
     }
   ]
@@ -5082,6 +5213,21 @@ set_option maxRecDepth 4096 in
     (contains rawRevertTrustReport "\"modeledLowLevelMechanics\"" &&
       contains rawRevertTrustReport "\"rawRevert\"" &&
       rawRevertLowLevelLines.any (fun line => contains line "RawRevertSmoke [function:fail]: rawRevert"))
+  expectTrue "rawRevert trust report includes structured unsafe Yul contract"
+    (contains rawRevertTrustReport "\"unsafeYulContracts\":[{\"name\":\"raw_revert_memory_slice_refinement\"" &&
+      contains rawRevertTrustReport "\"memoryReads\":[\"revertPayload\"]")
+  expectCompileErrorContains
+    "unsafeYul validation rejects under-declared Yul let bindings"
+    unsafeYulUnderDeclaredBindSpec
+    "under-declares bound local(s): tmp"
+  expectCompileErrorContains
+    "unsafeYul validation rejects under-declared Yul assignments"
+    unsafeYulUnderDeclaredAssignSpec
+    "under-declares assigned local(s): tmp"
+  expectCompileErrorContains
+    "unsafeYul validation rejects under-declared Yul storage writes"
+    unsafeYulUnderDeclaredStorageSpec
+    "under-declares storage effects"
   let envRuntimeYul ← expectCompileToYul "env runtime smoke compiles" envRuntimeSmokeSpec
   expectTrue "env runtime smoke lowers block.number" (contains envRuntimeYul "number()")
   let stringCompiled :=

--- a/Compiler/CompileDriverCommon.lean
+++ b/Compiler/CompileDriverCommon.lean
@@ -363,6 +363,8 @@ private partial def collectIntrinsicUsesStmt : Stmt → List IntrinsicUse
   | .storageArrayPop _ | .returnArray _ | .returnBytes _ | .returnStorageWords _
   | .revertReturndata | .stop =>
       []
+  | .unsafeYul _ =>
+      []
 
 private def collectIntrinsicUsesSpec (spec : CompilationModel) : List IntrinsicUse :=
   let ctorUses :=

--- a/Compiler/CompileDriverCommon.lean
+++ b/Compiler/CompileDriverCommon.lean
@@ -285,7 +285,6 @@ private partial def specializeForkStmt
   | .tstore offset value => .tstore (specializeForkExpr targetFork offset) (specializeForkExpr targetFork value)
   | .calldatacopy dest source size => .calldatacopy (specializeForkExpr targetFork dest) (specializeForkExpr targetFork source) (specializeForkExpr targetFork size)
   | .returndataCopy dest source size => .returndataCopy (specializeForkExpr targetFork dest) (specializeForkExpr targetFork source) (specializeForkExpr targetFork size)
-  | .rawRevert offset size => .rawRevert (specializeForkExpr targetFork offset) (specializeForkExpr targetFork size)
   | .ite cond thenBranch elseBranch => .ite (specializeForkExpr targetFork cond) (thenBranch.map (specializeForkStmt targetFork)) (elseBranch.map (specializeForkStmt targetFork))
   | .forEach varName count body => .forEach varName (specializeForkExpr targetFork count) (body.map (specializeForkStmt targetFork))
   | .emit eventName args => .emit eventName (args.map (specializeForkExpr targetFork))
@@ -345,8 +344,6 @@ private partial def collectIntrinsicUsesStmt : Stmt → List IntrinsicUse
   | .calldatacopy destOffset sourceOffset size
   | .returndataCopy destOffset sourceOffset size =>
       [destOffset, sourceOffset, size].flatMap collectIntrinsicUsesExpr
-  | .rawRevert offset size =>
-      collectIntrinsicUsesExpr offset ++ collectIntrinsicUsesExpr size
   | .rawLog topics dataOffset dataSize =>
       topics.flatMap collectIntrinsicUsesExpr ++ collectIntrinsicUsesExpr dataOffset ++
         collectIntrinsicUsesExpr dataSize

--- a/Compiler/CompileDriverCommon.lean
+++ b/Compiler/CompileDriverCommon.lean
@@ -285,6 +285,7 @@ private partial def specializeForkStmt
   | .tstore offset value => .tstore (specializeForkExpr targetFork offset) (specializeForkExpr targetFork value)
   | .calldatacopy dest source size => .calldatacopy (specializeForkExpr targetFork dest) (specializeForkExpr targetFork source) (specializeForkExpr targetFork size)
   | .returndataCopy dest source size => .returndataCopy (specializeForkExpr targetFork dest) (specializeForkExpr targetFork source) (specializeForkExpr targetFork size)
+  | .rawRevert offset size => .rawRevert (specializeForkExpr targetFork offset) (specializeForkExpr targetFork size)
   | .ite cond thenBranch elseBranch => .ite (specializeForkExpr targetFork cond) (thenBranch.map (specializeForkStmt targetFork)) (elseBranch.map (specializeForkStmt targetFork))
   | .forEach varName count body => .forEach varName (specializeForkExpr targetFork count) (body.map (specializeForkStmt targetFork))
   | .emit eventName args => .emit eventName (args.map (specializeForkExpr targetFork))
@@ -344,6 +345,8 @@ private partial def collectIntrinsicUsesStmt : Stmt → List IntrinsicUse
   | .calldatacopy destOffset sourceOffset size
   | .returndataCopy destOffset sourceOffset size =>
       [destOffset, sourceOffset, size].flatMap collectIntrinsicUsesExpr
+  | .rawRevert offset size =>
+      collectIntrinsicUsesExpr offset ++ collectIntrinsicUsesExpr size
   | .rawLog topics dataOffset dataSize =>
       topics.flatMap collectIntrinsicUsesExpr ++ collectIntrinsicUsesExpr dataOffset ++
         collectIntrinsicUsesExpr dataSize

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -632,7 +632,7 @@ private def rawYulTrustSurfaceSpec : CompilationModel := {
               obligation := "Handwritten Yul memory write must refine the high-level memory contract."
               proofStatus := .assumed }
           ]
-          mechanics := ["mstore"]
+          mechanics := [.mstore]
           termination := .fallsThrough
         },
         Stmt.stop

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -612,6 +612,35 @@ private def localObligationTrustSurfaceSpec : CompilationModel := {
   ]
 }
 
+private def rawYulTrustSurfaceSpec : CompilationModel := {
+  name := "RawYulTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "unsafeMemory"
+      params := []
+      returnType := none
+      body := [
+        Stmt.unsafeYul {
+          label := "manual_memory_refinement"
+          stmts := [
+            Compiler.Yul.YulStmt.expr
+              (Compiler.Yul.YulExpr.call "mstore" [Compiler.Yul.YulExpr.lit 0, Compiler.Yul.YulExpr.lit 1])
+          ]
+          obligations := [
+            { name := "manual_memory_refinement"
+              obligation := "Handwritten Yul memory write must refine the high-level memory contract."
+              proofStatus := .assumed }
+          ]
+          mechanics := ["mstore"]
+          termination := .fallsThrough
+        },
+        Stmt.stop
+      ]
+    }
+  ]
+}
+
 private def unsafeBlockTrustSurfaceSpec : CompilationModel := {
   name := "UnsafeBlockTrustSurface"
   fields := []
@@ -1496,6 +1525,24 @@ unsafe def runTests : IO Unit := do
   if !contains localObligationUsageSiteReport "- LocalObligationTrustSurface [function:unsafeEdge]: assumed local obligations: manual_delegatecall_refinement" then
     throw (IO.userError "✗ local-obligation diagnostics localize usage sites")
   IO.println "✓ trust report surfaces local unsafe/refinement obligations"
+
+  let rawYulTrustReport := emitTrustReportJson [rawYulTrustSurfaceSpec]
+  if !contains rawYulTrustReport "\"contract\":\"RawYulTrustSurface\"" then
+    throw (IO.userError "✗ raw Yul trust report emits contract name")
+  if !contains rawYulTrustReport "\"modeledLowLevelMechanics\":[\"mstore\"]" then
+    throw (IO.userError "✗ raw Yul trust report emits fragment low-level mechanics")
+  if !contains rawYulTrustReport "\"localObligations\":[{\"name\":\"manual_memory_refinement\",\"status\":\"assumed\",\"obligation\":\"Handwritten Yul memory write must refine the high-level memory contract.\"}]" then
+    throw (IO.userError "✗ raw Yul trust report emits fragment local obligations")
+  if !contains rawYulTrustReport "\"usageSites\":[{\"kind\":\"function\",\"name\":\"unsafeMemory\"" ||
+      !contains rawYulTrustReport "\"unsafeBlocks\":[\"manual_memory_refinement\"]" then
+    throw (IO.userError "✗ raw Yul trust report localizes fragment usage site")
+  let rawYulOutDir := s!"/tmp/verity-compile-driver-test-{nonce}-raw-yul-out"
+  IO.FS.createDirAll rawYulOutDir
+  compileSpecsWithOptions [rawYulTrustSurfaceSpec] rawYulOutDir false [] {} none none none none
+  let rawYulArtifact ← IO.FS.readFile s!"{rawYulOutDir}/RawYulTrustSurface.yul"
+  if !contains rawYulArtifact "mstore(0, 1)" then
+    throw (IO.userError "✗ raw Yul fragment lowers through the central EVMYul bridge")
+  IO.println "✓ raw Yul fragments lower and surface trust obligations"
 
   let assumptionReport := emitAssumptionReportJson [trustSurfaceSpec, localObligationTrustSurfaceSpec]
   if !contains assumptionReport "\"contract\":\"TrustSurfaceSmoke\"" then

--- a/Compiler/Proofs/IRGeneration/FunctionBody.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody.lean
@@ -8160,7 +8160,7 @@ private theorem compileStmt_ok_any_scope_aux
       | setMappingChain | setStructMember | setStructMember2 | require
       | requireError | revertError | «return» | returnValues | returnArray
       | returnBytes | returnStorageWords | mstore | tstore | calldatacopy
-      | returndataCopy | revertReturndata | stop | emit | internalCall
+      | returndataCopy | revertReturndata | rawRevert | stop | emit | internalCall
       | internalCallAssign | externalCallBind | tryExternalCallBind | ecm | rawLog =>
           simp only [CompilationModel.compileStmt] at hok ⊢; exact hok
     · -- compileStmtList part
@@ -8277,7 +8277,7 @@ private theorem compileStmt_ok_any_scope_with_surface_aux
       | setMappingChain | setStructMember | setStructMember2 | require
       | requireError | revertError | «return» | returnValues | returnArray
       | returnBytes | returnStorageWords | mstore | tstore | calldatacopy
-      | returndataCopy | revertReturndata | stop | emit | internalCall
+      | returndataCopy | revertReturndata | rawRevert | stop | emit | internalCall
       | internalCallAssign | externalCallBind | tryExternalCallBind
       | ecm | rawLog =>
           simp only [CompilationModel.compileStmt] at hok ⊢; exact hok

--- a/Compiler/Proofs/IRGeneration/FunctionBody.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody.lean
@@ -8160,8 +8160,9 @@ private theorem compileStmt_ok_any_scope_aux
       | setMappingChain | setStructMember | setStructMember2 | require
       | requireError | revertError | «return» | returnValues | returnArray
       | returnBytes | returnStorageWords | mstore | tstore | calldatacopy
-      | returndataCopy | revertReturndata | rawRevert | stop | emit | internalCall
-      | internalCallAssign | externalCallBind | tryExternalCallBind | ecm | rawLog =>
+      | returndataCopy | revertReturndata | stop | emit | internalCall
+      | internalCallAssign | externalCallBind | tryExternalCallBind | ecm | rawLog
+      | unsafeYul =>
           simp only [CompilationModel.compileStmt] at hok ⊢; exact hok
     · -- compileStmtList part
       intro stmts scope1 scope2 hlt hok
@@ -8277,9 +8278,9 @@ private theorem compileStmt_ok_any_scope_with_surface_aux
       | setMappingChain | setStructMember | setStructMember2 | require
       | requireError | revertError | «return» | returnValues | returnArray
       | returnBytes | returnStorageWords | mstore | tstore | calldatacopy
-      | returndataCopy | revertReturndata | rawRevert | stop | emit | internalCall
+      | returndataCopy | revertReturndata | stop | emit | internalCall
       | internalCallAssign | externalCallBind | tryExternalCallBind
-      | ecm | rawLog =>
+      | ecm | rawLog | unsafeYul =>
           simp only [CompilationModel.compileStmt] at hok ⊢; exact hok
     · intro stmts scope1 scope2 hlt hok
       cases stmts with

--- a/Compiler/Proofs/IRGeneration/GenericInduction.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction.lean
@@ -1830,11 +1830,11 @@ theorem legacyCompatibleExternalStmtList_of_compileStmt_ok_on_supportedContractS
   | require _ | requireError _ _ | revertError _ _
   | «return» _ | returnValues _ | returnArray _ | returnBytes _
   | returnStorageWords _ | mstore _ _ | tstore _ _ | calldatacopy _ _ _
-  | returndataCopy _ _ _ | revertReturndata | rawRevert _ _ | stop
+  | returndataCopy _ _ _ | revertReturndata | stop
   | ite _ _ _ | forEach _ _ _ | emit _ _
   | internalCall _ _ | internalCallAssign _ _ _ | rawLog _ _ _
   | externalCallBind _ _ _ | tryExternalCallBind _ _ _ _ | ecm _ _
-  | unsafeBlock _ _ | matchAdt _ _ _ =>
+  | unsafeBlock _ _ | unsafeYul _ | matchAdt _ _ _ =>
       exact legacyCompatibleExternalStmtList_of_compileStmt_ok_on_supportedContractSurface
         hnoPacked
         (by simpa [stmtTouchesUnsupportedContractSurfaceExceptMappingWrites] using hsurface)
@@ -3778,10 +3778,10 @@ theorem stmtListScopeCore_prefix_of_compileStmtList_ok_of_stmtListTouchesUnsuppo
       | storageArrayPush _ _ | storageArrayPop _ | setStorageArrayElement _ _ _
       | requireError _ _ _ | revertError _ _ | returnValues _ | returnArray _
       | returnBytes _ | returnStorageWords _ | calldatacopy _ _ _
-      | returndataCopy _ _ _ | revertReturndata | rawRevert _ _
+      | returndataCopy _ _ _ | revertReturndata
       | emit _ _ | internalCall _ _ | internalCallAssign _ _ _
       | rawLog _ _ _ | externalCallBind _ _ _ | tryExternalCallBind _ _ _ _ | ecm _ _
-      | unsafeBlock _ _ | matchAdt _ _ _ =>
+      | unsafeBlock _ _ | unsafeYul _ | matchAdt _ _ _ =>
           simp [stmtTouchesUnsupportedContractSurface] at hstmtSurface
 
 private theorem stmtTouchesUnsupportedContractSurface_of_stmtListTouchesUnsupportedContractSurface_append_cons

--- a/Compiler/Proofs/IRGeneration/GenericInduction.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction.lean
@@ -1830,7 +1830,7 @@ theorem legacyCompatibleExternalStmtList_of_compileStmt_ok_on_supportedContractS
   | require _ | requireError _ _ | revertError _ _
   | «return» _ | returnValues _ | returnArray _ | returnBytes _
   | returnStorageWords _ | mstore _ _ | tstore _ _ | calldatacopy _ _ _
-  | returndataCopy _ _ _ | revertReturndata | stop
+  | returndataCopy _ _ _ | revertReturndata | rawRevert _ _ | stop
   | ite _ _ _ | forEach _ _ _ | emit _ _
   | internalCall _ _ | internalCallAssign _ _ _ | rawLog _ _ _
   | externalCallBind _ _ _ | tryExternalCallBind _ _ _ _ | ecm _ _
@@ -3778,7 +3778,7 @@ theorem stmtListScopeCore_prefix_of_compileStmtList_ok_of_stmtListTouchesUnsuppo
       | storageArrayPush _ _ | storageArrayPop _ | setStorageArrayElement _ _ _
       | requireError _ _ _ | revertError _ _ | returnValues _ | returnArray _
       | returnBytes _ | returnStorageWords _ | calldatacopy _ _ _
-      | returndataCopy _ _ _ | revertReturndata
+      | returndataCopy _ _ _ | revertReturndata | rawRevert _ _
       | emit _ _ | internalCall _ _ | internalCallAssign _ _ _
       | rawLog _ _ _ | externalCallBind _ _ _ | tryExternalCallBind _ _ _ _ | ecm _ _
       | unsafeBlock _ _ | matchAdt _ _ _ =>

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -4548,7 +4548,6 @@ private theorem execStmtWithHelpers_eq_execStmt_of_helperSurfaceClosed_aux
   | .calldatacopy _ _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .returndataCopy _ _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .revertReturndata => simp [execStmtWithHelpers, execStmtWithEvents]
-  | .rawRevert _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .emit _ args =>
       simp only [stmtTouchesUnsupportedHelperSurface] at hsurface
       have hall : args.all (fun expr => exprTouchesUnsupportedHelperSurface expr == false) = true := by
@@ -4562,6 +4561,7 @@ private theorem execStmtWithHelpers_eq_execStmt_of_helperSurfaceClosed_aux
         evalExprListWithHelpers_eq_evalExprList_of_helperSurfaceClosed spec fields fuel state args hall,
         evalExprList_eq_mapM]
   | .rawLog _ _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
+  | .unsafeYul _ => cases hsurface
   | .externalCallBind _ _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .tryExternalCallBind _ _ _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .ecm _ _ => simp [execStmtWithHelpers, execStmtWithEvents]

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -4548,6 +4548,7 @@ private theorem execStmtWithHelpers_eq_execStmt_of_helperSurfaceClosed_aux
   | .calldatacopy _ _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .returndataCopy _ _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .revertReturndata => simp [execStmtWithHelpers, execStmtWithEvents]
+  | .rawRevert _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .emit _ args =>
       simp only [stmtTouchesUnsupportedHelperSurface] at hsurface
       have hall : args.all (fun expr => exprTouchesUnsupportedHelperSurface expr == false) = true := by

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -644,7 +644,7 @@ def stmtTouchesUnsupportedConstructorRawCalldataSurface : Stmt → Bool
   | .setMapping _ key value | .setMappingWord _ key _ value
   | .setMappingPackedWord _ key _ _ value | .setMappingUint _ key value
   | .setStructMember _ key _ value | .setStorageArrayElement _ key value
-  | .mstore key value | .tstore key value =>
+  | .mstore key value | .tstore key value | .rawRevert key value =>
       exprTouchesUnsupportedConstructorRawCalldataSurface key ||
         exprTouchesUnsupportedConstructorRawCalldataSurface value
   | .setMappingChain _ keys value =>
@@ -1169,7 +1169,7 @@ def stmtTouchesUnsupportedEffectSurface : Stmt → Bool
   | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _ | .ecm _ _ => true
   | .letVar _ _ | .assignVar _ _ | .setStorage _ _ | .setStorageAddr _ _
   | .setStorageWord _ _ _
-  | .require _ _ | .return _ | .mstore _ _ | .tstore _ _ | .stop
+  | .require _ _ | .return _ | .mstore _ _ | .tstore _ _ | .rawRevert _ _ | .stop
   | .setMapping _ _ _ | .setMappingWord _ _ _ _
   | .setMappingPackedWord _ _ _ _ _ | .setMapping2 _ _ _ _
   | .setMapping2Word _ _ _ _ _ | .setMappingUint _ _ _ | .setMappingChain _ _ _
@@ -1212,7 +1212,7 @@ def stmtTouchesUnsupportedCoreSurface : Stmt → Bool
   | .setStorageArrayElement _ index value =>
       exprTouchesUnsupportedCoreSurface index ||
         exprTouchesUnsupportedCoreSurface value
-  | .mstore offset value | .tstore offset value =>
+  | .mstore offset value | .tstore offset value | .rawRevert offset value =>
       exprTouchesUnsupportedCoreSurface offset ||
         exprTouchesUnsupportedCoreSurface value
   | .require cond _ | .return cond =>
@@ -1245,7 +1245,7 @@ def stmtTouchesUnsupportedStateSurface : Stmt → Bool
   | .setMappingChain _ _ _
   | .setStructMember _ _ _ _ | .setStructMember2 _ _ _ _ _
   | .storageArrayPush _ _ | .storageArrayPop _ | .setStorageArrayElement _ _ _ => true
-  | .mstore offset value | .tstore offset value =>
+  | .mstore offset value | .tstore offset value | .rawRevert offset value =>
       exprTouchesUnsupportedStateSurface offset ||
         exprTouchesUnsupportedStateSurface value
   | .stop
@@ -1299,7 +1299,8 @@ def stmtTouchesUnsupportedCallSurface : Stmt → Bool
       exprTouchesUnsupportedCallSurface cond
   | .internalCall _ _ | .internalCallAssign _ _ _ => true
   | .calldatacopy _ _ _
-  | .returndataCopy _ _ _ | .revertReturndata | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _
+  | .returndataCopy _ _ _ | .revertReturndata | .rawRevert _ _
+  | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _
   | .ecm _ _ => true
   | .stop | .storageArrayPop _
   | .requireError _ _ _ | .revertError _ _ | .returnValues _ | .returnArray _
@@ -1332,7 +1333,7 @@ def stmtTouchesUnsupportedHelperSurface : Stmt → Bool
         exprTouchesUnsupportedHelperSurface key2 ||
         exprTouchesUnsupportedHelperSurface value
   | .setStorageArrayElement _ index value
-  | .mstore index value | .tstore index value =>
+  | .mstore index value | .tstore index value | .rawRevert index value =>
       exprTouchesUnsupportedHelperSurface index ||
         exprTouchesUnsupportedHelperSurface value
   | .require cond _ | .return cond =>
@@ -1374,7 +1375,7 @@ def stmtTouchesInternalHelperSurface : Stmt → Bool
         exprTouchesInternalHelperSurface key2 ||
         exprTouchesInternalHelperSurface value
   | .setStorageArrayElement _ index value
-  | .mstore index value | .tstore index value =>
+  | .mstore index value | .tstore index value | .rawRevert index value =>
       exprTouchesInternalHelperSurface index ||
         exprTouchesInternalHelperSurface value
   | .require cond _ | .return cond =>
@@ -1439,7 +1440,7 @@ def stmtTouchesExprInternalHelperSurface : Stmt → Bool
         exprTouchesInternalHelperSurface key2 ||
         exprTouchesInternalHelperSurface value
   | .setStorageArrayElement _ index value
-  | .mstore index value | .tstore index value =>
+  | .mstore index value | .tstore index value | .rawRevert index value =>
       exprTouchesInternalHelperSurface index ||
         exprTouchesInternalHelperSurface value
   | .require cond _ | .return cond =>
@@ -1469,6 +1470,7 @@ def stmtTouchesStructuralInternalHelperSurface : Stmt → Bool
   | .letVar _ _ | .assignVar _ _ | .setStorage _ _ | .require _ _
   | .return _ | .internalCall _ _ | .internalCallAssign _ _ _
   | .stop | .setStorageAddr _ _ | .setStorageWord _ _ _ | .mstore _ _ | .tstore _ _
+  | .rawRevert _ _
   | .calldatacopy _ _ _ | .returndataCopy _ _ _
   | .revertReturndata | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _ | .ecm _ _
   | .setMapping _ _ _ | .setMappingWord _ _ _ _
@@ -1501,7 +1503,7 @@ def stmtTouchesUnsupportedForeignSurface : Stmt → Bool
         exprTouchesUnsupportedForeignSurface key2 ||
         exprTouchesUnsupportedForeignSurface value
   | .setStorageArrayElement _ index value
-  | .mstore index value | .tstore index value =>
+  | .mstore index value | .tstore index value | .rawRevert index value =>
       exprTouchesUnsupportedForeignSurface index ||
         exprTouchesUnsupportedForeignSurface value
   | .require cond _ | .return cond =>
@@ -1547,7 +1549,7 @@ def stmtTouchesUnsupportedLowLevelSurface : Stmt → Bool
   | .require cond _ | .return cond =>
       exprTouchesUnsupportedLowLevelSurface cond
   | .calldatacopy _ _ _
-  | .returndataCopy _ _ _ | .revertReturndata => true
+  | .returndataCopy _ _ _ | .revertReturndata | .rawRevert _ _ => true
   | .stop
   | .internalCall _ _ | .internalCallAssign _ _ _ | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _
   | .ecm _ _ | .storageArrayPop _
@@ -1588,7 +1590,7 @@ def stmtTouchesUnsupportedContractSurface (stmt : Stmt) : Bool :=
   | .storageArrayPush _ _ | .storageArrayPop _ | .setStorageArrayElement _ _ _
   | .requireError _ _ _ | .revertError _ _ | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _ | .calldatacopy _ _ _
-  | .returndataCopy _ _ _ | .revertReturndata
+  | .returndataCopy _ _ _ | .revertReturndata | .rawRevert _ _
   | .emit _ _ | .internalCall _ _ | .internalCallAssign _ _ _
   | .rawLog _ _ _ | .externalCallBind _ _ _ | .ecm _ _
   | .tryExternalCallBind _ _ _ _ | .unsafeBlock _ _ | .matchAdt _ _ _ => true
@@ -1883,6 +1885,8 @@ mutual
     | .rawLog topics dataOffset dataSize =>
         exprListInternalHelperCallNames topics ++ exprInternalHelperCallNames dataOffset ++
           exprInternalHelperCallNames dataSize
+    | .rawRevert offset size =>
+        exprInternalHelperCallNames offset ++ exprInternalHelperCallNames size
     | .storageArrayPop _ | .returnArray _ | .returnBytes _ | .returnStorageWords _
     | .revertReturndata | .stop =>
         []
@@ -1949,6 +1953,8 @@ mutual
     | .rawLog topics dataOffset dataSize =>
         exprListInternalHelperCallNames topics ++ exprInternalHelperCallNames dataOffset ++
           exprInternalHelperCallNames dataSize
+    | .rawRevert offset size =>
+        exprInternalHelperCallNames offset ++ exprInternalHelperCallNames size
     | .storageArrayPop _ | .returnArray _ | .returnBytes _ | .returnStorageWords _
     | .revertReturndata | .stop =>
         []
@@ -3435,7 +3441,8 @@ mutual
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.1,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.2.1,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.2.2]
-    | setStorageArrayElement _ index value | mstore index value | tstore index value =>
+    | setStorageArrayElement _ index value | mstore index value | tstore index value
+    | rawRevert index value =>
         simp only [stmtTouchesUnsupportedHelperSurface, Bool.or_eq_false_iff] at hsurface
         simp [stmtTouchesInternalHelperSurface,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.1,
@@ -4444,7 +4451,7 @@ theorem stmtTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
   | storageArrayPop _ | setStorageArrayElement _ _ _ | requireError _ _ _
   | revertError _ _ | returnValues _ | returnArray _ | returnBytes _
   | returnStorageWords _ | calldatacopy _ _ _ | returndataCopy _ _ _
-  | revertReturndata | emit _ _ | internalCall _ _
+  | revertReturndata | rawRevert _ _ | emit _ _ | internalCall _ _
   | internalCallAssign _ _ _ | rawLog _ _ _ | externalCallBind _ _ _ | ecm _ _ =>
       cases hsurface
   | forEach varName count body =>

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -644,7 +644,7 @@ def stmtTouchesUnsupportedConstructorRawCalldataSurface : Stmt → Bool
   | .setMapping _ key value | .setMappingWord _ key _ value
   | .setMappingPackedWord _ key _ _ value | .setMappingUint _ key value
   | .setStructMember _ key _ value | .setStorageArrayElement _ key value
-  | .mstore key value | .tstore key value | .rawRevert key value =>
+  | .mstore key value | .tstore key value  =>
       exprTouchesUnsupportedConstructorRawCalldataSurface key ||
         exprTouchesUnsupportedConstructorRawCalldataSurface value
   | .setMappingChain _ keys value =>
@@ -669,7 +669,7 @@ def stmtTouchesUnsupportedConstructorRawCalldataSurface : Stmt → Bool
   | .returnValues _ | .returnArray _ | .returnBytes _ | .returnStorageWords _
   | .calldatacopy _ _ _ | .returndataCopy _ _ _ | .revertReturndata
   | .rawLog _ _ _ | .ecm _ _ => false
-  | .unsafeBlock _ _ | .matchAdt _ _ _ => true
+  | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _ => true
 
 def stmtListTouchesUnsupportedConstructorRawCalldataSurface : List Stmt → Bool
   | [] => false
@@ -1169,7 +1169,7 @@ def stmtTouchesUnsupportedEffectSurface : Stmt → Bool
   | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _ | .ecm _ _ => true
   | .letVar _ _ | .assignVar _ _ | .setStorage _ _ | .setStorageAddr _ _
   | .setStorageWord _ _ _
-  | .require _ _ | .return _ | .mstore _ _ | .tstore _ _ | .rawRevert _ _ | .stop
+  | .require _ _ | .return _ | .mstore _ _ | .tstore _ _ | .stop
   | .setMapping _ _ _ | .setMappingWord _ _ _ _
   | .setMappingPackedWord _ _ _ _ _ | .setMapping2 _ _ _ _
   | .setMapping2Word _ _ _ _ _ | .setMappingUint _ _ _ | .setMappingChain _ _ _
@@ -1177,7 +1177,7 @@ def stmtTouchesUnsupportedEffectSurface : Stmt → Bool
   | .storageArrayPush _ _ | .storageArrayPop _ | .setStorageArrayElement _ _ _
   | .calldatacopy _ _ _ | .returndataCopy _ _ _ | .revertReturndata
   | .internalCall _ _ | .internalCallAssign _ _ _ => false
-  | .unsafeBlock _ _ | .matchAdt _ _ _ => true
+  | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _ => true
   | .ite _ thenBranch elseBranch =>
       stmtListTouchesUnsupportedEffectSurface thenBranch ||
         stmtListTouchesUnsupportedEffectSurface elseBranch
@@ -1212,7 +1212,7 @@ def stmtTouchesUnsupportedCoreSurface : Stmt → Bool
   | .setStorageArrayElement _ index value =>
       exprTouchesUnsupportedCoreSurface index ||
         exprTouchesUnsupportedCoreSurface value
-  | .mstore offset value | .tstore offset value | .rawRevert offset value =>
+  | .mstore offset value | .tstore offset value  =>
       exprTouchesUnsupportedCoreSurface offset ||
         exprTouchesUnsupportedCoreSurface value
   | .require cond _ | .return cond =>
@@ -1229,7 +1229,7 @@ def stmtTouchesUnsupportedCoreSurface : Stmt → Bool
   | .returndataCopy _ _ _ | .revertReturndata
   | .emit _ _ | .internalCall _ _ | .internalCallAssign _ _ _
   | .rawLog _ _ _ | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _ | .ecm _ _ => false
-  | .unsafeBlock _ _ | .matchAdt _ _ _ => true
+  | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _ => true
 
 /-- State/layout-rich statement surfaces still outside the current whole-contract
 theorem. -/
@@ -1245,7 +1245,7 @@ def stmtTouchesUnsupportedStateSurface : Stmt → Bool
   | .setMappingChain _ _ _
   | .setStructMember _ _ _ _ | .setStructMember2 _ _ _ _ _
   | .storageArrayPush _ _ | .storageArrayPop _ | .setStorageArrayElement _ _ _ => true
-  | .mstore offset value | .tstore offset value | .rawRevert offset value =>
+  | .mstore offset value | .tstore offset value  =>
       exprTouchesUnsupportedStateSurface offset ||
         exprTouchesUnsupportedStateSurface value
   | .stop
@@ -1254,7 +1254,7 @@ def stmtTouchesUnsupportedStateSurface : Stmt → Bool
   | .returndataCopy _ _ _ | .revertReturndata
   | .emit _ _ | .internalCall _ _ | .internalCallAssign _ _ _
   | .rawLog _ _ _ | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _ | .ecm _ _ => false
-  | .unsafeBlock _ _ | .matchAdt _ _ _ => true
+  | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _ => true
   | .ite cond thenBranch elseBranch =>
       exprTouchesUnsupportedStateSurface cond ||
         stmtListTouchesUnsupportedStateSurface thenBranch ||
@@ -1299,14 +1299,14 @@ def stmtTouchesUnsupportedCallSurface : Stmt → Bool
       exprTouchesUnsupportedCallSurface cond
   | .internalCall _ _ | .internalCallAssign _ _ _ => true
   | .calldatacopy _ _ _
-  | .returndataCopy _ _ _ | .revertReturndata | .rawRevert _ _
+  | .returndataCopy _ _ _ | .revertReturndata
   | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _
   | .ecm _ _ => true
   | .stop | .storageArrayPop _
   | .requireError _ _ _ | .revertError _ _ | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _ | .rawLog _ _ _ => false
   | .emit _ args => args.any exprTouchesUnsupportedCallSurface
-  | .unsafeBlock _ _ | .matchAdt _ _ _ => true
+  | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _ => true
   | .ite cond thenBranch elseBranch =>
       exprTouchesUnsupportedCallSurface cond ||
         stmtListTouchesUnsupportedCallSurface thenBranch ||
@@ -1333,7 +1333,7 @@ def stmtTouchesUnsupportedHelperSurface : Stmt → Bool
         exprTouchesUnsupportedHelperSurface key2 ||
         exprTouchesUnsupportedHelperSurface value
   | .setStorageArrayElement _ index value
-  | .mstore index value | .tstore index value | .rawRevert index value =>
+  | .mstore index value | .tstore index value  =>
       exprTouchesUnsupportedHelperSurface index ||
         exprTouchesUnsupportedHelperSurface value
   | .require cond _ | .return cond =>
@@ -1345,7 +1345,7 @@ def stmtTouchesUnsupportedHelperSurface : Stmt → Bool
   | .requireError _ _ _ | .revertError _ _ | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _ | .rawLog _ _ _ => false
   | .emit _ args => exprListTouchesUnsupportedHelperSurface args
-  | .unsafeBlock _ _ | .matchAdt _ _ _ => true
+  | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _ => true
   | .ite cond thenBranch elseBranch =>
       exprTouchesUnsupportedHelperSurface cond ||
         stmtListTouchesUnsupportedHelperSurface thenBranch ||
@@ -1375,7 +1375,7 @@ def stmtTouchesInternalHelperSurface : Stmt → Bool
         exprTouchesInternalHelperSurface key2 ||
         exprTouchesInternalHelperSurface value
   | .setStorageArrayElement _ index value
-  | .mstore index value | .tstore index value | .rawRevert index value =>
+  | .mstore index value | .tstore index value  =>
       exprTouchesInternalHelperSurface index ||
         exprTouchesInternalHelperSurface value
   | .require cond _ | .return cond =>
@@ -1387,7 +1387,7 @@ def stmtTouchesInternalHelperSurface : Stmt → Bool
   | .revertError _ _ | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _ | .emit _ _
   | .rawLog _ _ _ => false
-  | .unsafeBlock _ _ | .matchAdt _ _ _ => true
+  | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _ => true
   | .ite cond thenBranch elseBranch =>
       exprTouchesInternalHelperSurface cond ||
         stmtListTouchesInternalHelperSurface thenBranch ||
@@ -1440,7 +1440,7 @@ def stmtTouchesExprInternalHelperSurface : Stmt → Bool
         exprTouchesInternalHelperSurface key2 ||
         exprTouchesInternalHelperSurface value
   | .setStorageArrayElement _ index value
-  | .mstore index value | .tstore index value | .rawRevert index value =>
+  | .mstore index value | .tstore index value  =>
       exprTouchesInternalHelperSurface index ||
         exprTouchesInternalHelperSurface value
   | .require cond _ | .return cond =>
@@ -1456,7 +1456,7 @@ def stmtTouchesExprInternalHelperSurface : Stmt → Bool
   | .revertError _ _ | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _ | .emit _ _
   | .rawLog _ _ _ => false
-  | .unsafeBlock _ _ | .matchAdt _ _ _ => true
+  | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _ => true
 
 /-- Recursive structural internal-helper transport at the current statement
 head. This isolates `ite` / `forEach` obligations whose proof burden is mainly
@@ -1470,7 +1470,7 @@ def stmtTouchesStructuralInternalHelperSurface : Stmt → Bool
   | .letVar _ _ | .assignVar _ _ | .setStorage _ _ | .require _ _
   | .return _ | .internalCall _ _ | .internalCallAssign _ _ _
   | .stop | .setStorageAddr _ _ | .setStorageWord _ _ _ | .mstore _ _ | .tstore _ _
-  | .rawRevert _ _
+ 
   | .calldatacopy _ _ _ | .returndataCopy _ _ _
   | .revertReturndata | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _ | .ecm _ _
   | .setMapping _ _ _ | .setMappingWord _ _ _ _
@@ -1483,7 +1483,7 @@ def stmtTouchesStructuralInternalHelperSurface : Stmt → Bool
   | .revertError _ _ | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _ | .emit _ _
   | .rawLog _ _ _ => false
-  | .unsafeBlock _ _ | .matchAdt _ _ _ => true
+  | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _ => true
 
 def stmtTouchesUnsupportedForeignSurface : Stmt → Bool
   | .letVar _ value | .assignVar _ value | .setStorage _ value
@@ -1503,7 +1503,7 @@ def stmtTouchesUnsupportedForeignSurface : Stmt → Bool
         exprTouchesUnsupportedForeignSurface key2 ||
         exprTouchesUnsupportedForeignSurface value
   | .setStorageArrayElement _ index value
-  | .mstore index value | .tstore index value | .rawRevert index value =>
+  | .mstore index value | .tstore index value  =>
       exprTouchesUnsupportedForeignSurface index ||
         exprTouchesUnsupportedForeignSurface value
   | .require cond _ | .return cond =>
@@ -1516,7 +1516,7 @@ def stmtTouchesUnsupportedForeignSurface : Stmt → Bool
   | .requireError _ _ _ | .revertError _ _ | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _ | .rawLog _ _ _ => false
   | .emit _ args => args.any exprTouchesUnsupportedForeignSurface
-  | .unsafeBlock _ _ | .matchAdt _ _ _ => true
+  | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _ => true
   | .ite cond thenBranch elseBranch =>
       exprTouchesUnsupportedForeignSurface cond ||
         stmtListTouchesUnsupportedForeignSurface thenBranch ||
@@ -1549,14 +1549,14 @@ def stmtTouchesUnsupportedLowLevelSurface : Stmt → Bool
   | .require cond _ | .return cond =>
       exprTouchesUnsupportedLowLevelSurface cond
   | .calldatacopy _ _ _
-  | .returndataCopy _ _ _ | .revertReturndata | .rawRevert _ _ => true
+  | .returndataCopy _ _ _ | .revertReturndata => true
   | .stop
   | .internalCall _ _ | .internalCallAssign _ _ _ | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _
   | .ecm _ _ | .storageArrayPop _
   | .requireError _ _ _ | .revertError _ _ | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _ | .rawLog _ _ _ => false
   | .emit _ args => args.any exprTouchesUnsupportedLowLevelSurface
-  | .unsafeBlock _ _ | .matchAdt _ _ _ => true
+  | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _ => true
   | .ite cond thenBranch elseBranch =>
       exprTouchesUnsupportedLowLevelSurface cond ||
         stmtListTouchesUnsupportedLowLevelSurface thenBranch ||
@@ -1590,10 +1590,10 @@ def stmtTouchesUnsupportedContractSurface (stmt : Stmt) : Bool :=
   | .storageArrayPush _ _ | .storageArrayPop _ | .setStorageArrayElement _ _ _
   | .requireError _ _ _ | .revertError _ _ | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _ | .calldatacopy _ _ _
-  | .returndataCopy _ _ _ | .revertReturndata | .rawRevert _ _
+  | .returndataCopy _ _ _ | .revertReturndata
   | .emit _ _ | .internalCall _ _ | .internalCallAssign _ _ _
   | .rawLog _ _ _ | .externalCallBind _ _ _ | .ecm _ _
-  | .tryExternalCallBind _ _ _ _ | .unsafeBlock _ _ | .matchAdt _ _ _ => true
+  | .tryExternalCallBind _ _ _ _ | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _ => true
   | .forEach _ (.literal 0) body =>
       stmtListTouchesUnsupportedContractSurface body
   | .forEach _ (.literal _) [] => false
@@ -1885,12 +1885,11 @@ mutual
     | .rawLog topics dataOffset dataSize =>
         exprListInternalHelperCallNames topics ++ exprInternalHelperCallNames dataOffset ++
           exprInternalHelperCallNames dataSize
-    | .rawRevert offset size =>
-        exprInternalHelperCallNames offset ++ exprInternalHelperCallNames size
     | .storageArrayPop _ | .returnArray _ | .returnBytes _ | .returnStorageWords _
     | .revertReturndata | .stop =>
         []
     | .unsafeBlock _ body => stmtListExprHelperCallNames body
+    | .unsafeYul _ => []
     | .matchAdt _ _ branches =>
         matchAdtBranchesExprHelperCallNames branches
   termination_by s => sizeOf s
@@ -1953,12 +1952,11 @@ mutual
     | .rawLog topics dataOffset dataSize =>
         exprListInternalHelperCallNames topics ++ exprInternalHelperCallNames dataOffset ++
           exprInternalHelperCallNames dataSize
-    | .rawRevert offset size =>
-        exprInternalHelperCallNames offset ++ exprInternalHelperCallNames size
     | .storageArrayPop _ | .returnArray _ | .returnBytes _ | .returnStorageWords _
     | .revertReturndata | .stop =>
         []
     | .unsafeBlock _ body => stmtListInternalHelperCallNames body
+    | .unsafeYul _ => []
     | .matchAdt _ _ branches =>
         matchAdtBranchesInternalHelperCallNames branches
   termination_by s => sizeOf s
@@ -3441,8 +3439,7 @@ mutual
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.1,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.2.1,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.2.2]
-    | setStorageArrayElement _ index value | mstore index value | tstore index value
-    | rawRevert index value =>
+    | setStorageArrayElement _ index value | mstore index value | tstore index value =>
         simp only [stmtTouchesUnsupportedHelperSurface, Bool.or_eq_false_iff] at hsurface
         simp [stmtTouchesInternalHelperSurface,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.1,
@@ -3464,7 +3461,7 @@ mutual
         simp [stmtTouchesInternalHelperSurface,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.1,
           stmtListTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.2]
-    | unsafeBlock _ _ | matchAdt _ _ _ =>
+    | unsafeBlock _ _ | unsafeYul _ | matchAdt _ _ _ =>
         simp [stmtTouchesUnsupportedHelperSurface] at hsurface
     | stop | calldatacopy _ _ _ | returndataCopy _ _ _ | revertReturndata
     | externalCallBind _ _ _ | tryExternalCallBind _ _ _ _ | ecm _ _ | storageArrayPop _ | requireError _ _ _
@@ -4443,7 +4440,7 @@ theorem stmtTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
       exact ⟨⟨exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed hsurface.1.1,
         stmtListTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed hsurface.1.2⟩,
         stmtListTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed hsurface.2⟩
-  | tryExternalCallBind _ _ _ _ | unsafeBlock _ _ | matchAdt _ _ _
+  | tryExternalCallBind _ _ _ _ | unsafeBlock _ _ | unsafeYul _ | matchAdt _ _ _
   | setMapping _ _ _ | setMappingWord _ _ _ _
   | setMappingPackedWord _ _ _ _ _ | setMapping2 _ _ _ _
   | setMapping2Word _ _ _ _ _ | setMappingUint _ _ _
@@ -4451,7 +4448,7 @@ theorem stmtTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
   | storageArrayPop _ | setStorageArrayElement _ _ _ | requireError _ _ _
   | revertError _ _ | returnValues _ | returnArray _ | returnBytes _
   | returnStorageWords _ | calldatacopy _ _ _ | returndataCopy _ _ _
-  | revertReturndata | rawRevert _ _ | emit _ _ | internalCall _ _
+  | revertReturndata | emit _ _ | internalCall _ _
   | internalCallAssign _ _ _ | rawLog _ _ _ | externalCallBind _ _ _ | ecm _ _ =>
       cases hsurface
   | forEach varName count body =>

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Verity is complementary to these tools. It is for cases where you need mathemati
 | [Production Solidity Patterns](https://veritylang.com/guides/production-solidity-patterns) | Agent guidance for production ports, reusable Verity features, and oracle/spec boundaries |
 | [docs/VERIFICATION_STATUS.md](docs/VERIFICATION_STATUS.md) | Theorem counts, proof status, test coverage |
 | [docs/INTRINSICS.md](docs/INTRINSICS.md) | Consumer-owned opcode bindings and their trust model |
+| [docs/LOW_LEVEL_YUL.md](docs/LOW_LEVEL_YUL.md) | Policy for typed low-level primitives vs. raw Yul escape hatches |
 | [TRUST_ASSUMPTIONS.md](TRUST_ASSUMPTIONS.md) | What is verified vs. what is trusted |
 | [AXIOMS.md](AXIOMS.md) | Documented axioms (currently 0) |
 | [AUDIT.md](AUDIT.md) | Trust-boundary audit evidence and CI guards |

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -84,6 +84,20 @@ Current theorem totals, property-test coverage, and proof status live in [docs/V
 - **Status**: Surfaced explicitly in `--trust-report`, `--verbose`, and `proofStatus.*.localObligations`.
 - **Mitigation**: `verity-compiler --deny-local-obligations` fails closed on any obligation that remains `assumed` or `unchecked`.
 
+### 10a. Raw Yul Escape Hatch
+- **Role**: Model ad-hoc handwritten Yul through `Stmt.unsafeYul` and
+  `UnsafeYulFragment` when the surface is only a single instruction or otherwise
+  too local to justify a first-class `Stmt` constructor.
+- **Status**: Raw Yul fragments lower through the single
+  `unsafeYulToEVMYul` bridge and carry their own mechanics, termination
+  metadata, and local obligations. Raw memory reverts use
+  `UnsafeYulFragment.rawRevert` through `Stmt.unsafeYul`.
+- **Mitigation**: Keep common typed primitives such as `mstore` and
+  `calldatacopy` first-class only when Verity has stable semantics and they are
+  useful for proofs. Treat other raw Yul as an explicit trust-report surface,
+  and use `--deny-local-obligations` / low-level deny gates for strict builds.
+- **Reference**: See [docs/LOW_LEVEL_YUL.md](docs/LOW_LEVEL_YUL.md).
+
 ### 11. Consumer-Declared Intrinsics
 - **Role**: Let downstream packages bind a source-level Verity function to a
   target EVM opcode or Yul builtin without adding opcode-specific code to

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -166,6 +166,8 @@ constructor := some {
 > **Linear-memory boundary**: Memory-oriented intrinsics (`mload`, `mstore`, `calldatacopy`, `returndataCopy`, `returndataOptionalBoolAt`) compile, but the current proof interpreters still model them only partially. When they appear, surface that boundary with `--trust-report` / `--deny-linear-memory-mechanics`; the remaining gap is tracked under issue `#1411`.
 >
 > **Axiomatized-primitive boundary**: The `keccak256` intrinsic also compiles, but it remains axiomatized in the current proof stack rather than fully modeled end to end. When it appears, archive `--trust-report` and add `--deny-axiomatized-primitives` if the selected contracts must stay inside the proved subset (see issue `#1411`).
+>
+> **Raw Yul boundary**: One-off single-instruction escapes should be modeled as `Stmt.unsafeYul` fragments, not new `Stmt` constructors. For example, raw memory reverts should use `UnsafeYulFragment.rawRevert`. Keep typed primitives such as `mstore` and `calldatacopy` first-class when Verity has stable semantics and proof/audit value for them.
 
 **Statements** cover local variables, storage and mapping writes, `require`, `return`, memory writes, returndata copy and revert bubbling, `stop`, `ite` branching, event emission, internal calls, and a precisely scoped `forEach` fragment. The proved `forEach` cases are zero-bound loops with supported bodies and arbitrary literal-bound empty-body loops; positive literal loops with non-empty bodies remain future proof work.
 

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -397,4 +397,20 @@ When the low-level form is `delegatecall`, the trust report now also isolates it
 
 First-class linear-memory forms (`Expr.mload`, `Stmt.mstore`, `Stmt.calldatacopy`, `Stmt.returndataCopy`, `Expr.returndataOptionalBoolAt`) also compile today, but they are still only partially modeled by the current proof interpreters. When they appear, treat them as an explicit memory/ABI trust boundary, archive `--trust-report`, and use `--deny-linear-memory-mechanics` for proof-strict runs (see issue `#1411`).
 
+One-off raw Yul instructions should use `Stmt.unsafeYul` with an
+`UnsafeYulFragment` helper instead of becoming new first-class statements. Raw
+memory revert is the canonical small helper:
+
+```lean
+Stmt.unsafeYul
+  (UnsafeYulFragment.rawRevert
+    (Compiler.Yul.YulExpr.ident "offset")
+    (Compiler.Yul.YulExpr.ident "size")
+    { name := "raw_revert_memory_slice_refinement"
+      obligation := "Caller-provided raw revert memory slice must refine the intended failure payload."
+      proofStatus := .assumed })
+```
+
+Raw memory reverts should use the explicit raw-Yul fragment boundary.
+
 Prefer ECM wrappers when they fit. For the remaining unavoidable cases, attach a `localObligations` entry at the usage site and discharge it before shipping.

--- a/docs-site/content/trust-model.mdx
+++ b/docs-site/content/trust-model.mdx
@@ -60,6 +60,11 @@ What remains outside the proof envelope is **assumptions**, not axioms:
 
 - **Externally Callable Modules (ECMs)** in `Compiler/Modules/*.lean` carry named assumptions like `erc20_balanceOf_interface`, `evm_ecrecover_precompile`, `keccak256_memory_slice_matches_evm`. These are trust-report metadata, not Lean axioms, they document that the call mechanics depend on the EVM behaving as specified.
 - **`local_obligations`** declared on a constructor or function carry a named refinement obligation at that exact usage site.
+- **Raw Yul fragments** use `Stmt.unsafeYul` with `UnsafeYulFragment`
+  metadata. One-off instruction escapes, such as raw memory reverts, belong here
+  rather than as new first-class statement constructors. Common typed primitives
+  like `Stmt.mstore` and `Stmt.calldatacopy` stay first-class when Verity has
+  stable semantics and proof/audit value for them.
 - **Consumer-declared intrinsics** bind small opcodes or Yul builtins that Verity does not yet model directly. They do not add Verity project axioms; the consumer owns the declared obligation and `min_fork` target. See [Intrinsics](/intrinsics).
 - **Not-modeled features** (parts of low-level call mechanics, linear-memory primitives, raw `rawLog`, dynamic `keccak256` over memory) compile but the proof interpreter does not yet model their full semantics.
 

--- a/docs/INTERPRETER_FEATURE_MATRIX.md
+++ b/docs/INTERPRETER_FEATURE_MATRIX.md
@@ -140,6 +140,13 @@ segment followed by a 32-byte value, use
 32-byte widths. Dynamic `bytes` / `string` packed encoding remains outside the
 current core surface.
 
+One-off raw instruction surfaces should not be added to this statement table by
+default. Use `Stmt.unsafeYul` with a small `UnsafeYulFragment` helper, such as
+`UnsafeYulFragment.rawRevert`, when the feature is just an explicit Yul escape
+hatch. Keep common typed primitives such as `Stmt.mstore` and
+`Stmt.calldatacopy` first-class when they have stable Verity semantics and are
+useful for proofs.
+
 ---
 
 ## Builtin Bridge (Verity vs EVMYulLean)

--- a/docs/LOW_LEVEL_YUL.md
+++ b/docs/LOW_LEVEL_YUL.md
@@ -1,0 +1,32 @@
+# Low-Level Yul Surface
+
+Verity keeps two low-level escape routes separate:
+
+- First-class typed primitives, such as `Stmt.mstore` and
+  `Stmt.calldatacopy`, are kept when they have stable Verity semantics, trust
+  reporting, and proof value.
+- One-off statements that only expose a single Yul instruction should be helper
+  constructors returning `UnsafeYulFragment`, used through `Stmt.unsafeYul`.
+
+Raw Yul is the explicit escape hatch. An `UnsafeYulFragment` carries the EVMYul
+AST payload, low-level mechanics, local obligations, scope effects, and
+termination metadata at the same boundary. This keeps ad-hoc assembly visible
+in trust reports without making every Yul instruction look like a modeled
+Verity statement.
+
+For example, raw memory reverts now use the fragment helper:
+
+```lean
+Stmt.unsafeYul
+  (UnsafeYulFragment.rawRevert
+    (Compiler.Yul.YulExpr.ident "offset")
+    (Compiler.Yul.YulExpr.ident "size")
+    { name := "raw_revert_memory_slice_refinement"
+      obligation := "Caller-provided raw revert memory slice must refine the intended failure payload."
+      proofStatus := .assumed })
+```
+
+Raw memory reverts should use `UnsafeYulFragment.rawRevert`. Typed primitives such as
+`mstore`, `calldatacopy`, and similar common operations should remain
+first-class only when Verity commits to their semantics and they are useful in
+proofs or audits.

--- a/packages/verity-edsl/lakefile.lean
+++ b/packages/verity-edsl/lakefile.lean
@@ -27,5 +27,6 @@ lean_lib «Verity» where
     .one `Verity.Specs.Common,
     .one `Verity.Specs.Common.Sum,
     .one `Verity.Proofs.Stdlib.Math,
-    .one `Verity.Proofs.Stdlib.ListSum
+    .one `Verity.Proofs.Stdlib.ListSum,
+    .one `Verity.Proofs.Stdlib.Automation
   ]


### PR DESCRIPTION
## Summary
- adds a typed `UnsafeYulFragment` / `RawYul` escape hatch to `CompilationModel.Stmt` via `Stmt.unsafeYul`
- removes the dedicated `Stmt.rawRevert` path; one-off low-level instructions now live behind reusable `UnsafeYulFragment` helpers such as `UnsafeYulFragment.rawRevert`
- gives each fragment structured proof/audit metadata: `UnsafeYulContract`s, local obligations, `LowLevelMechanic` enum tags, `ControlFlowSummary`, and declared scope effects
- validates declared scope effects against the embedded Yul AST so fragments cannot silently under-report local binds, assignments, or storage writes
- centralizes lowering through `unsafeYulToEVMYul`, the single bridge from typed raw-Yul fragments to the backend EVMYul AST
- proves exact pass-through with `unsafeYulToEVMYul_eq` and `compileStmt_unsafeYul`
- moves trust/usage collectors toward generic `StmtMetadata`, `Stmt.fold`, and `Stmt.foldList`, reducing constructor-by-constructor duplication
- adds a `YulImporter` path for imported Solidity/Yul AST blocks to become explicit `Stmt.unsafeYul` fragments with generated metadata

## Why
The SPHINCS- verifier models need to mirror Solidity handwritten assembly closely, including exact empty reverts and manually constructed `Error(string)` revert data. Adding a first-class Verity statement for every Yul instruction would grow the trusted surface and duplicate backend AST concepts. The cleaner boundary is a typed raw-Yul fragment: the model author supplies the Yul AST, and Verity requires the proof obligations, trust tags, termination/control-flow summary, and scope effects needed by validation and reports.

## Architecture
- Verity `Stmt` remains separate from backend EVMYul `YulStmt`. The wrapper is intentional: backend Yul does not carry source-level proof obligations, trust metadata, or validation policy.
- `Stmt.unsafeYul fragment` embeds backend Yul AST statements, not raw Yul strings.
- Common stable primitives such as `mstore`, `calldatacopy`, and other semantically modeled operations remain first-class when they have proof/audit value.
- One-off low-level instructions should be helper constructors returning `UnsafeYulFragment`s, not new `Stmt` constructors.
- The lowering proof is intentionally small: `compileStmt_unsafeYul` shows the compiler emits exactly `fragment.stmts`. The larger proof boundary is semantic: each fragment’s `UnsafeYulContract` and local obligations must be discharged by the model proof.

## Verification
- `lake build`
- `lake build Compiler.CompileDriverTest`
- `lake build Compiler.CompilationModel.Compile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler lowering, validation, CEI, and trust-report surfaces for low-level/assembly code; semantic correctness still depends on discharging fragment obligations rather than full interpreter modeling.
> 
> **Overview**
> This PR adds a **typed raw-Yul escape hatch** via `Stmt.unsafeYul` and `UnsafeYulFragment`, replacing ad-hoc paths like dedicated `Stmt.rawRevert` with helpers such as `UnsafeYulFragment.rawRevert`. Fragments carry EVMYul AST, **local obligations**, `LowLevelMechanic` tags, **scope effects**, **control-flow/termination** summaries, and optional **`UnsafeYulContract`** refinements; lowering is centralized in **`unsafeYulToEVMYul`** with a proved **`compileStmt_unsafeYul`** pass-through.
> 
> **Validation and scope** now require non-empty obligations, check declared scope effects against the embedded Yul AST (binds, assigns, storage writes), and integrate fragments into **view/pure**, **CEI**, **untrackable writes**, and **scope validation**. **`YulImporter`** turns imported Solidity/Yul blocks into `Stmt.unsafeYul` with derived metadata.
> 
> **Trust reporting** drops large per-constructor statement walks in favor of **`Stmt.fold` / `StmtMetadata`**, surfaces **`unsafeYulContracts`** in JSON, treats **`rawRevert`** as a denied mechanic, and merges fragment **local obligations** from function/constructor bodies. **`ControlFlowSummary`** drives “all paths return/revert” checks. Docs and tests cover the new boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e503817a53de20ebe6db36aa7bf1e947bca0e03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->