### PR TITLE
Track forEach counters in body scope to fix nested-loop shadowing

### DIFF
--- a/Compiler/CompilationModel/Compile.lean
+++ b/Compiler/CompilationModel/Compile.lean
@@ -94,6 +94,20 @@ private def compileAdtStorageWrite (fields : List Field)
         compileAdtFieldWrite (YulExpr.lit slot) idx (YulExpr.lit 0)
   pure (payloadBindings ++ tagStores ++ payloadStores ++ clearStores)
 
+/-- Scope visible while compiling a `Stmt.forEach` body. The loop's synthetic
+counters `__forEach_idx`/`__forEach_count` are live across the whole body (Yul
+for-loop init variables are in scope in the body), so they must be tracked while
+compiling it. Otherwise a nested `forEach` re-derives the same names and the inner
+`let` collides with the outer one ("Variable name already taken in this scope").
+This is defeq to the codegen's inline `idxName :: countName :: varName :: inScopeNames`,
+so the generated Yul is unchanged; it exists as a named handle for the proofs. -/
+def forEachBodyScope (inScopeNames : List String) (varName : String)
+    (count : Expr) (body : List Stmt) : List String :=
+  let forUsedNames := varName :: (inScopeNames ++ collectExprNames count ++ collectStmtListNames body)
+  let idxName := pickFreshName "__forEach_idx" forUsedNames
+  let countName := pickFreshName "__forEach_count" (idxName :: forUsedNames)
+  idxName :: countName :: varName :: inScopeNames
+
 -- Compile statement to Yul (using mutual recursion for lists).
 -- When isInternal=true, Stmt.return compiles to `__ret := value; leave` so internal
 -- function execution terminates immediately without exiting the outer EVM call.
@@ -262,10 +276,12 @@ def compileStmt (fields : List Field) (events : List EventDef := [])
       -- semantics where `count` is evaluated once and `varName` holds the last
       -- iteration state after the loop rather than the post-incremented counter.
       let countExpr ← compileExpr fields dynamicSource count
-      let bodyStmts ← compileStmtList fields events errors dynamicSource internalRetNames isInternal (varName :: inScopeNames) adtTypes body
       let forUsedNames := varName :: (inScopeNames ++ collectExprNames count ++ collectStmtListNames body)
       let idxName := pickFreshName "__forEach_idx" forUsedNames
       let countName := pickFreshName "__forEach_count" (idxName :: forUsedNames)
+      -- Compile the body with the synthetic counters in scope (see `forEachBodyScope`),
+      -- so a nested `forEach` cannot re-derive colliding `__forEach_idx`/`__forEach_count`.
+      let bodyStmts ← compileStmtList fields events errors dynamicSource internalRetNames isInternal (forEachBodyScope inScopeNames varName count body) adtTypes body
       let initStmts := [
         YulStmt.let_ idxName (YulExpr.lit 0),
         YulStmt.let_ countName countExpr,

--- a/Compiler/Proofs/IRGeneration/FunctionBody.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody.lean
@@ -8135,10 +8135,12 @@ private theorem compileStmt_ok_any_scope_aux
           | ok countIR =>
             simp only [hcount] at hir ⊢
             cases hbody1 : CompilationModel.compileStmtList
-                fields [] [] .calldata [] false (varName :: scope1) [] body with
+                fields [] [] .calldata [] false
+                (CompilationModel.forEachBodyScope scope1 varName count body) [] body with
             | error e => simp [hbody1] at hir
             | ok bodyIR1 =>
-              rcases ih.2 body (varName :: scope1) (varName :: scope2)
+              rcases ih.2 body (CompilationModel.forEachBodyScope scope1 varName count body)
+                  (CompilationModel.forEachBodyScope scope2 varName count body)
                   (by simp [Stmt.forEach.sizeOf_spec] at hlt; omega) ⟨bodyIR1, hbody1⟩
                 with ⟨bodyIR2, hbody2⟩
               simp only [hbody2]
@@ -8255,10 +8257,12 @@ private theorem compileStmt_ok_any_scope_with_surface_aux
           | ok countIR =>
             simp only [hcount] at hir ⊢
             cases hbody1 : CompilationModel.compileStmtList
-                fields events errors .calldata [] false (varName :: scope1) [] body with
+                fields events errors .calldata [] false
+                (CompilationModel.forEachBodyScope scope1 varName count body) [] body with
             | error e => simp [hbody1] at hir
             | ok bodyIR1 =>
-              rcases ih.2 body (varName :: scope1) (varName :: scope2)
+              rcases ih.2 body (CompilationModel.forEachBodyScope scope1 varName count body)
+                  (CompilationModel.forEachBodyScope scope2 varName count body)
                   (by simp [Stmt.forEach.sizeOf_spec] at hlt; omega) ⟨bodyIR1, hbody1⟩
                 with ⟨bodyIR2, hbody2⟩
               simp only [hbody2]

--- a/Compiler/Proofs/IRGeneration/GenericInduction.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction.lean
@@ -1054,7 +1054,7 @@ theorem legacyCompatibleExternalStmtList_of_compileStmt_ok_on_supportedContractS
               simp only [CompilationModel.compileStmt, bind, Except.bind] at hcompile
               cases hbody :
                   CompilationModel.compileStmtList fields events errors .calldata [] false
-                    (varName :: inScopeNames) [] body with
+                    (CompilationModel.forEachBodyScope inScopeNames varName (Expr.literal 0) body) [] body with
               | error e => simp [CompilationModel.compileExpr, pure, Except.pure, hbody] at hcompile
               | ok loopBodyIR =>
                   simp [CompilationModel.compileExpr, hbody] at hcompile
@@ -3620,12 +3620,13 @@ private theorem stmtListScopeCore_of_unsupportedContractSurface_eq_false
                   simp only [CompilationModel.compileStmt, bind, Except.bind] at hhead
                   cases hbody :
                       CompilationModel.compileStmtList fields [] [] .calldata [] false
-                        (varName :: scope) [] body with
+                        (CompilationModel.forEachBodyScope scope varName (Expr.literal 0) body) [] body with
                   | error e => simp [CompilationModel.compileExpr, pure, Except.pure, hbody] at hhead
                   | ok loopBodyIR =>
                       exact .forEachLiteralZero
                         (stmtListScopeCore_of_unsupportedContractSurface_eq_false
-                          fields (varName :: scope) body loopBodyIR hbodySurface hbody)
+                          fields (CompilationModel.forEachBodyScope scope varName (Expr.literal 0) body)
+                            body loopBodyIR hbodySurface hbody)
                         ihRest
               | succ n =>
                   cases body with
@@ -3756,12 +3757,13 @@ theorem stmtListScopeCore_prefix_of_compileStmtList_ok_of_stmtListTouchesUnsuppo
                   simp only [CompilationModel.compileStmt, bind, Except.bind] at hhead
                   cases hbody :
                       CompilationModel.compileStmtList fields [] [] .calldata [] false
-                        (varName :: scope) [] body with
+                        (CompilationModel.forEachBodyScope scope varName (Expr.literal 0) body) [] body with
                   | error e => simp [CompilationModel.compileExpr, pure, Except.pure, hbody] at hhead
                   | ok loopBodyIR =>
                       exact StmtListScopeCore.forEachLiteralZero
                         (stmtListScopeCore_of_unsupportedContractSurface_eq_false
-                          fields (varName :: scope) body loopBodyIR hbodySurface hbody)
+                          fields (CompilationModel.forEachBodyScope scope varName (Expr.literal 0) body)
+                            body loopBodyIR hbodySurface hbody)
                         (ih hrestSurface htail)
               | succ n =>
                   cases body with
@@ -13708,9 +13710,9 @@ private theorem compiledStmtStep_forEach_literal_zero
   rcases compileStmtList_ok_of_stmtListGenericCore_early
       (fields := fields)
       (scope := varName :: scope)
-      (inScopeNames := varName :: scope)
+      (inScopeNames := CompilationModel.forEachBodyScope scope varName (Expr.literal 0) body)
       hbodyGeneric
-      FunctionBody.scopeNamesIncluded_refl with
+      (fun name hmem => List.mem_cons_of_mem _ (List.mem_cons_of_mem _ hmem)) with
     ⟨bodyIR, hbodyCompile⟩
   refine ⟨forEachZeroCompiledIR scope varName body bodyIR, ?_⟩
   refine

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBodyClosure.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBodyClosure.lean
@@ -4002,7 +4002,7 @@ theorem compileStmt_forEach_with_bridged_body
     (hCount : BridgedSourceExpr count)
     (hBody : ∀ {out : List YulStmt},
       compileStmtList fields events errors dynamicSource internalRetNames
-        isInternal (varName :: inScopeNames) [] body = .ok out →
+        isInternal (forEachBodyScope inScopeNames varName count body) [] body = .ok out →
       BridgedStmts out) :
     ∀ {out : List YulStmt},
       compileStmt fields events errors dynamicSource internalRetNames isInternal
@@ -4015,7 +4015,7 @@ theorem compileStmt_forEach_with_bridged_body
   | ok countExpr =>
       simp [hCExpr] at hOk
       cases hBodyOk : compileStmtList fields events errors dynamicSource
-          internalRetNames isInternal (varName :: inScopeNames) [] body with
+          internalRetNames isInternal (forEachBodyScope inScopeNames varName count body) [] body with
       | error err => simp [hBodyOk] at hOk
       | ok bodyOut =>
           simp [hBodyOk, Pure.pure, Except.pure] at hOk
@@ -4128,7 +4128,7 @@ theorem compileStmt_forEach_with_noFuncDefs_body
     (varName : String) (count : Expr) (body : List Stmt)
     (hBody : ∀ {out : List YulStmt},
       compileStmtList fields events errors dynamicSource internalRetNames
-        isInternal (varName :: inScopeNames) [] body = .ok out →
+        isInternal (forEachBodyScope inScopeNames varName count body) [] body = .ok out →
       Native.yulStmtsContainFuncDef out = false) :
     ∀ {out : List YulStmt},
       compileStmt fields events errors dynamicSource internalRetNames isInternal
@@ -4141,7 +4141,7 @@ theorem compileStmt_forEach_with_noFuncDefs_body
   | ok countExpr =>
       simp [hCExpr] at hOk
       cases hBodyOk : compileStmtList fields events errors dynamicSource
-          internalRetNames isInternal (varName :: inScopeNames) [] body with
+          internalRetNames isInternal (forEachBodyScope inScopeNames varName count body) [] body with
       | error err => simp [hBodyOk] at hOk
       | ok bodyOut =>
           have hBodyNoFunc := hBody hBodyOk
@@ -5595,7 +5595,7 @@ theorem compileStmt_external_forEach_body_with_errors_bridged
         hCount ?_ hOk
       intro bodyOut hBodyOk
       exact compileStmtList_external_body_with_errors_bridged fields events
-        errors dynamicSource internalRetNames body (varName :: inScopeNames)
+        errors dynamicSource internalRetNames body _
         hBody hBodyOk
 
 /-- External forEach-wrapped with-errors source bodies compile to Yul lists
@@ -5673,7 +5673,7 @@ theorem compileStmt_internal_forEach_body_with_errors_bridged
         hCount ?_ hOk
       intro bodyOut hBodyOk
       exact compileStmtList_internal_body_with_errors_bridged fields events
-        errors dynamicSource internalRetNames body (varName :: inScopeNames)
+        errors dynamicSource internalRetNames body _
         hBody hBodyOk
 
 /-- Internal forEach-wrapped with-errors source bodies compile to Yul lists
@@ -5895,7 +5895,7 @@ mutual
         intro bodyOut hBodyOk
         exact compileStmtList_external_recursive_body_with_errors_bridged fields
           events errors dynamicSource internalRetNames hBody
-          (varName :: inScopeNames) hBodyOk
+          _ hBodyOk
 
   theorem compileStmtList_external_recursive_body_with_errors_bridged
       (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
@@ -6012,7 +6012,7 @@ mutual
         intro bodyOut hBodyOk
         exact compileStmtList_internal_recursive_body_with_errors_bridged fields
           events errors dynamicSource internalRetNames hBody
-          (varName :: inScopeNames) hBodyOk
+          _ hBodyOk
 
   theorem compileStmtList_internal_recursive_body_with_errors_bridged
       (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
@@ -7921,7 +7921,7 @@ mutual
         intro bodyOut hBodyOk
         exact compileStmtList_external_recursive_body_with_raw_log_bridged fields
           events errors dynamicSource internalRetNames hBody
-          (varName :: inScopeNames) hBodyOk
+          _ hBodyOk
 
   theorem compileStmtList_external_recursive_body_with_raw_log_bridged
       (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
@@ -8038,7 +8038,7 @@ mutual
         intro bodyOut hBodyOk
         exact compileStmtList_internal_recursive_body_with_raw_log_bridged fields
           events errors dynamicSource internalRetNames hBody
-          (varName :: inScopeNames) hBodyOk
+          _ hBodyOk
 
   theorem compileStmtList_internal_recursive_body_with_raw_log_bridged
       (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
@@ -8111,7 +8111,7 @@ mutual
           dynamicSource internalRetNames false inScopeNames varName count body ?_ hOk
         exact compileStmtList_external_recursive_body_with_raw_log_noFuncDefs
           fields events errors dynamicSource internalRetNames hBody
-          (varName :: inScopeNames)
+          _
 
   theorem compileStmtList_external_recursive_body_with_raw_log_noFuncDefs
       (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
@@ -8181,7 +8181,7 @@ mutual
           dynamicSource internalRetNames true inScopeNames varName count body ?_ hOk
         exact compileStmtList_internal_recursive_body_with_raw_log_noFuncDefs
           fields events errors dynamicSource internalRetNames hBody
-          (varName :: inScopeNames)
+          _
 
   theorem compileStmtList_internal_recursive_body_with_raw_log_noFuncDefs
       (fields : List Field) (events : List EventDef) (errors : List ErrorDef)


### PR DESCRIPTION
## Summary

A `forEach` lowers to a Yul for-loop with two synthetic init variables,
`__forEach_idx` and `__forEach_count`, that stay live across the whole loop body.
The body was compiled with scope `varName :: inScopeNames`, which omits those two
counters. A `forEach` nested inside another `forEach` therefore re-derived the same
`__forEach_idx` / `__forEach_count` (`pickFreshName` saw them as unused), and the
inner `let` collided with the still-live outer binding. solc rejects this with
"Variable name already taken in this scope", so any contract that nests loops fails
to compile.

## What

- Add `CompilationModel.forEachBodyScope`, which extends the body-compile scope with
  the two synthetic counter names. It is definitionally equal to
  `idxName :: countName :: varName :: inScopeNames`, so generated Yul for non-nested
  loops is byte-identical; for nested loops the inner counters are now freshened
  (`__forEach_idx_...`, `__forEach_count_...`) and the output is valid.
- Re-thread the proof side (`FunctionBody`, `GenericInduction`,
  `EvmYulLeanBodyClosure`) through the same handle so the scope-accounting and
  bridged-body theorems continue to hold over the corrected scope.

## Audit docs

No new axioms (AXIOMS.md stays at 0 project-level axioms), no trust-boundary change,
no CI-boundary change. Every invariant recorded in AUDIT.md / TRUST_ASSUMPTIONS.md /
AXIOMS.md is preserved (the proofs are re-threaded, not weakened), so per Non-Negotiable
1 those files need no synchronization. Flagging this explicitly so a maintainer can
object if they read it differently.

## Testing

- `lake build` is green on this branch.
- Downstream evidence: with this commit, solc compiles a contract that nests `forEach`
  loops (Unlink's `UnlinkPool`) cleanly, where the unfixed compiler emitted
  shadowing-invalid Yul that solc rejected.

Opened as draft for review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core statement compilation and many IR-generation proofs; behavior change is localized to nested `forEach` name freshening, but incorrect scope wiring could affect generated Yul or proof soundness.
> 
> **Overview**
> Fixes **nested `forEach`** lowering so inner loops no longer reuse the outer loop’s `__forEach_idx` / `__forEach_count` names, which solc rejected as duplicate bindings in the same Yul scope.
> 
> Adds **`CompilationModel.forEachBodyScope`**, which extends the in-scope name list passed into `compileStmtList` for a loop body with the freshly chosen counter names (plus the loop variable). **`Stmt.forEach` codegen** now compiles the body with that scope instead of only `varName :: inScopeNames`. For a single loop the scope matches the previous inline list, so output stays the same; nested loops get suffixed counter locals and valid Yul.
> 
> **Proof modules** (`FunctionBody`, `GenericInduction`, `EvmYulLeanBodyClosure`) are updated to use the same scope handle in induction and bridged-body theorems so IR-generation proofs still align with the compiler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 825b5a7b5fb807261e6b39c0b2540b558ec517e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->