### PR TITLE
Add ABI frame lowering layers

### DIFF
--- a/Compiler/ABI/Frame.lean
+++ b/Compiler/ABI/Frame.lean
@@ -22,6 +22,8 @@ structure FrameField where
   name : String
   ty : ParamType
   source : FrameSource
+  sourceBase : String := ""
+  tailBytes : Nat := 0
   deriving Repr, BEq
 
 structure FrameLayout where
@@ -60,7 +62,14 @@ def layoutSourcesSupported (l : FrameLayout) : Bool :=
   l.fields.all (fun field => sourceCanMaterializeEarly field.source)
 
 def frameSizeBytes (l : FrameLayout) : Nat :=
-  l.headWords * 32
+  l.fields.foldl (fun acc field => acc + fieldHeadWords field * 32 +
+    (if isDynamicParamType field.ty then field.tailBytes else 0)) 0
+
+def fieldPayloadWords (field : FrameField) : Nat :=
+  fieldHeadWords field + if isDynamicParamType field.ty then (field.tailBytes + 31) / 32 else 0
+
+def frameAllocBytes (l : FrameLayout) : Nat :=
+  l.fields.foldl (fun acc field => acc + fieldPayloadWords field * 32) 0
 
 def ptrName (base : String) : String :=
   "__abi_frame_" ++ base
@@ -72,25 +81,39 @@ def allocateFrame (base : String) (l : FrameLayout) : List YulStmt :=
   [ YulStmt.let_ (ptrName base) (YulExpr.call "mload" [YulExpr.lit 64])
   , YulStmt.expr (YulExpr.call "mstore"
       [ YulExpr.lit 64
-      , YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit (frameSizeBytes l)] ])]
+      , YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit (frameAllocBytes l)] ])]
+
+def sourceBaseName (field : FrameField) : String :=
+  if field.sourceBase.isEmpty then field.name else field.sourceBase
+
+private def sourceByteOffset (field : FrameField) (idx : Nat) : YulExpr :=
+  if idx == 0 then
+    YulExpr.ident (sourceBaseName field)
+  else
+    YulExpr.call "add" [YulExpr.ident (sourceBaseName field), YulExpr.lit (idx * 32)]
+
+private def sourceStorageSlot (field : FrameField) (idx : Nat) : YulExpr :=
+  if idx == 0 then
+    YulExpr.ident (sourceBaseName field)
+  else
+    YulExpr.call "add" [YulExpr.ident (sourceBaseName field), YulExpr.lit idx]
 
 private def materializeSourceWord (field : FrameField) (idx : Nat) : YulExpr :=
-  let name := fieldWordName "src" field idx
   match field.source with
-  | .calldata => YulExpr.call "calldataload" [YulExpr.ident name]
-  | .memory => YulExpr.call "mload" [YulExpr.ident name]
-  | .code => YulExpr.call "mload" [YulExpr.ident name]
-  | .storage => YulExpr.call "sload" [YulExpr.ident name]
+  | .calldata => YulExpr.call "calldataload" [sourceByteOffset field idx]
+  | .memory => YulExpr.call "mload" [sourceByteOffset field idx]
+  | .code => YulExpr.call "mload" [sourceByteOffset field idx]
+  | .storage => YulExpr.call "sload" [sourceStorageSlot field idx]
 
 partial def spillField (base : String) (offsetWords : Nat) (field : FrameField) : List YulStmt :=
-  (List.range (fieldHeadWords field)).map fun idx =>
+  (List.range (fieldPayloadWords field)).map fun idx =>
     YulStmt.expr (YulExpr.call "mstore"
       [ YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit ((offsetWords + idx) * 32)]
       , materializeSourceWord field idx ])
 
 partial def spillFields (base : String) (offsetWords : Nat) : List FrameField → List YulStmt
   | [] => []
-  | field :: rest => spillField base offsetWords field ++ spillFields base (offsetWords + fieldHeadWords field) rest
+  | field :: rest => spillField base offsetWords field ++ spillFields base (offsetWords + fieldPayloadWords field) rest
 
 /-- Materialize a typed ABI frame into memory before lowering calls/logs/returns.
     Large or dynamic payloads are then passed as `(ptr, size)` instead of as a
@@ -100,6 +123,10 @@ def spillPayloadToMemory (base : String) (l : FrameLayout) : List YulStmt :=
 
 def pointerArgs (base : String) (l : FrameLayout) : List YulExpr :=
   [YulExpr.ident (ptrName base), YulExpr.lit (frameSizeBytes l)]
+
+def inlinePayloadToScratch (words : List YulExpr) : List YulStmt :=
+  words.zipIdx.map fun (word, idx) =>
+    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit (idx * 32), word])
 
 private partial def inlineArgsFrom : List FrameField → List YulExpr
   | [] => []
@@ -115,6 +142,13 @@ def loweredArgs (base : String) (l : FrameLayout) : List YulExpr :=
   match l.mode with
   | .pointer => pointerArgs base l
   | .inlineWords => inlineArgs l
+
+def materializePayloadToMemory (base : String) (l : FrameLayout) : List YulStmt × List YulExpr :=
+  match l.mode with
+  | .pointer =>
+      (spillPayloadToMemory base l, pointerArgs base l)
+  | .inlineWords =>
+      (inlinePayloadToScratch (inlineArgs l), [YulExpr.lit 0, YulExpr.lit (frameSizeBytes l)])
 
 def containsDynamicArrayOrBytes (l : FrameLayout) : Bool :=
   l.fields.any fun field =>

--- a/Compiler/ABI/Frame.lean
+++ b/Compiler/ABI/Frame.lean
@@ -101,15 +101,15 @@ def spillPayloadToMemory (base : String) (l : FrameLayout) : List YulStmt :=
 def pointerArgs (base : String) (l : FrameLayout) : List YulExpr :=
   [YulExpr.ident (ptrName base), YulExpr.lit (frameSizeBytes l)]
 
-private partial def inlineArgsFrom (idx : Nat) : List FrameField → List YulExpr
+private partial def inlineArgsFrom : List FrameField → List YulExpr
   | [] => []
   | field :: rest =>
       (List.range (fieldHeadWords field)).map (fun wordIdx =>
-        materializeSourceWord field (idx + wordIdx)) ++
-      inlineArgsFrom (idx + 1) rest
+        materializeSourceWord field wordIdx) ++
+      inlineArgsFrom rest
 
 def inlineArgs (l : FrameLayout) : List YulExpr :=
-  inlineArgsFrom 0 l.fields
+  inlineArgsFrom l.fields
 
 def loweredArgs (base : String) (l : FrameLayout) : List YulExpr :=
   match l.mode with

--- a/Compiler/ABI/Frame.lean
+++ b/Compiler/ABI/Frame.lean
@@ -62,8 +62,12 @@ def fieldSourceSupported (field : FrameField) : Bool :=
   | .memory | .code | .storage => true
   | .calldata => true
 
+def fieldLayoutSupported (field : FrameField) : Bool :=
+  fieldSourceSupported field &&
+    !(field.source == .storage && isDynamicParamType field.ty)
+
 def layoutSourcesSupported (l : FrameLayout) : Bool :=
-  l.fields.all fieldSourceSupported
+  l.fields.all fieldLayoutSupported
 
 def frameSizeBytes (l : FrameLayout) : Nat :=
   l.fields.foldl (fun acc field => acc + fieldHeadWords field * 32 +

--- a/Compiler/ABI/Frame.lean
+++ b/Compiler/ABI/Frame.lean
@@ -69,8 +69,11 @@ def fieldLayoutSupported (field : FrameField) : Bool :=
 def layoutSourcesSupported (l : FrameLayout) : Bool :=
   l.fields.all fieldLayoutSupported
 
+def dynamicTailWords (field : FrameField) : Nat :=
+  1 + (field.tailBytes + 31) / 32
+
 def fieldPayloadWords (field : FrameField) : Nat :=
-  fieldHeadWords field + if isDynamicParamType field.ty then (field.tailBytes + 31) / 32 else 0
+  fieldHeadWords field + if isDynamicParamType field.ty then dynamicTailWords field else 0
 
 def frameSizeBytes (l : FrameLayout) : Nat :=
   l.fields.foldl (fun acc field => acc + fieldPayloadWords field * 32) 0
@@ -147,7 +150,7 @@ private def spillDynamicField (base : String) (headOffsetWords tailOffsetWords :
   let tailOffsetBytes := tailOffsetWords * 32
   let headDest := YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit (headOffsetWords * 32)]
   let head := [YulStmt.expr (YulExpr.call "mstore" [headDest, YulExpr.lit tailOffsetBytes])]
-  let tailWords := (field.tailBytes + 31) / 32
+  let tailWords := dynamicTailWords field
   head ++ (List.range tailWords).map fun idx =>
     let dest := YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit ((tailOffsetWords + idx) * 32)]
     match field.source with
@@ -168,7 +171,7 @@ partial def spillFieldsAbi (base : String) (headOffsetWords tailOffsetWords : Na
       let headWords := fieldHeadWords field
       if isDynamicParamType field.ty then
         spillDynamicField base headOffsetWords tailOffsetWords field ++
-          spillFieldsAbi base (headOffsetWords + headWords) (tailOffsetWords + (field.tailBytes + 31) / 32) rest
+          spillFieldsAbi base (headOffsetWords + headWords) (tailOffsetWords + dynamicTailWords field) rest
       else
         spillStaticField base headOffsetWords field ++
           spillFieldsAbi base (headOffsetWords + headWords) tailOffsetWords rest

--- a/Compiler/ABI/Frame.lean
+++ b/Compiler/ABI/Frame.lean
@@ -64,8 +64,7 @@ def fieldSourceSupported (field : FrameField) : Bool :=
 
 def fieldLayoutSupported (field : FrameField) : Bool :=
   fieldSourceSupported field &&
-    !(field.source == .storage && isDynamicParamType field.ty) &&
-    !(field.source == .code && isDynamicParamType field.ty)
+    !isDynamicParamType field.ty
 
 def layoutSourcesSupported (l : FrameLayout) : Bool :=
   l.fields.all fieldLayoutSupported

--- a/Compiler/ABI/Frame.lean
+++ b/Compiler/ABI/Frame.lean
@@ -1,0 +1,131 @@
+import Compiler.CompilationModel.AbiTypeLayout
+import Compiler.Yul.Ast
+
+namespace Compiler.ABI.Frame
+
+open Compiler.CompilationModel
+open Compiler.Yul
+
+inductive FrameSource
+  | calldata
+  | memory
+  | code
+  | storage
+  deriving Repr, BEq
+
+inductive FramePassMode
+  | inlineWords
+  | pointer
+  deriving Repr, BEq
+
+structure FrameField where
+  name : String
+  ty : ParamType
+  source : FrameSource
+  deriving Repr, BEq
+
+structure FrameLayout where
+  fields : List FrameField
+  headWords : Nat
+  hasDynamic : Bool
+  mode : FramePassMode
+  deriving Repr, BEq
+
+def spillThresholdWords : Nat := 4
+
+def fieldHeadWords (field : FrameField) : Nat :=
+  paramParentHeadWords field.ty
+
+def fieldsHeadWords (fields : List FrameField) : Nat :=
+  fields.foldl (fun acc field => acc + fieldHeadWords field) 0
+
+def fieldsHaveDynamic (fields : List FrameField) : Bool :=
+  fields.any (fun field => isDynamicParamType field.ty)
+
+def shouldPassByPointer (fields : List FrameField) : Bool :=
+  fieldsHaveDynamic fields || spillThresholdWords < fieldsHeadWords fields
+
+def layout (fields : List FrameField) : FrameLayout :=
+  let headWords := fieldsHeadWords fields
+  let hasDynamic := fieldsHaveDynamic fields
+  { fields
+    headWords
+    hasDynamic
+    mode := if hasDynamic || spillThresholdWords < headWords then .pointer else .inlineWords }
+
+def sourceCanMaterializeEarly : FrameSource → Bool
+  | .calldata | .memory | .code | .storage => true
+
+def layoutSourcesSupported (l : FrameLayout) : Bool :=
+  l.fields.all (fun field => sourceCanMaterializeEarly field.source)
+
+def frameSizeBytes (l : FrameLayout) : Nat :=
+  l.headWords * 32
+
+def ptrName (base : String) : String :=
+  "__abi_frame_" ++ base
+
+def fieldWordName (base : String) (field : FrameField) (idx : Nat) : String :=
+  ptrName base ++ "_" ++ field.name ++ "_" ++ toString idx
+
+def allocateFrame (base : String) (l : FrameLayout) : List YulStmt :=
+  [ YulStmt.let_ (ptrName base) (YulExpr.call "mload" [YulExpr.lit 64])
+  , YulStmt.expr (YulExpr.call "mstore"
+      [ YulExpr.lit 64
+      , YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit (frameSizeBytes l)] ])]
+
+private def materializeSourceWord (field : FrameField) (idx : Nat) : YulExpr :=
+  let name := fieldWordName "src" field idx
+  match field.source with
+  | .calldata => YulExpr.call "calldataload" [YulExpr.ident name]
+  | .memory => YulExpr.call "mload" [YulExpr.ident name]
+  | .code => YulExpr.call "mload" [YulExpr.ident name]
+  | .storage => YulExpr.call "sload" [YulExpr.ident name]
+
+partial def spillField (base : String) (offsetWords : Nat) (field : FrameField) : List YulStmt :=
+  (List.range (fieldHeadWords field)).map fun idx =>
+    YulStmt.expr (YulExpr.call "mstore"
+      [ YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit ((offsetWords + idx) * 32)]
+      , materializeSourceWord field idx ])
+
+partial def spillFields (base : String) (offsetWords : Nat) : List FrameField → List YulStmt
+  | [] => []
+  | field :: rest => spillField base offsetWords field ++ spillFields base (offsetWords + fieldHeadWords field) rest
+
+/-- Materialize a typed ABI frame into memory before lowering calls/logs/returns.
+    Large or dynamic payloads are then passed as `(ptr, size)` instead of as a
+    long list of Yul values. -/
+def spillPayloadToMemory (base : String) (l : FrameLayout) : List YulStmt :=
+  allocateFrame base l ++ spillFields base 0 l.fields
+
+def pointerArgs (base : String) (l : FrameLayout) : List YulExpr :=
+  [YulExpr.ident (ptrName base), YulExpr.lit (frameSizeBytes l)]
+
+private partial def inlineArgsFrom (idx : Nat) : List FrameField → List YulExpr
+  | [] => []
+  | field :: rest =>
+      (List.range (fieldHeadWords field)).map (fun wordIdx =>
+        materializeSourceWord field (idx + wordIdx)) ++
+      inlineArgsFrom (idx + 1) rest
+
+def inlineArgs (l : FrameLayout) : List YulExpr :=
+  inlineArgsFrom 0 l.fields
+
+def loweredArgs (base : String) (l : FrameLayout) : List YulExpr :=
+  match l.mode with
+  | .pointer => pointerArgs base l
+  | .inlineWords => inlineArgs l
+
+def containsDynamicArrayOrBytes (l : FrameLayout) : Bool :=
+  l.fields.any fun field =>
+    match field.ty with
+    | .array _ | .bytes | .string => true
+    | _ => isDynamicParamType field.ty
+
+def supportsNestedStructs (l : FrameLayout) : Bool :=
+  l.fields.any fun field =>
+    match field.ty with
+    | .tuple elems => elems.any (fun ty => match ty with | .tuple _ => true | _ => false)
+    | _ => false
+
+end Compiler.ABI.Frame

--- a/Compiler/ABI/Frame.lean
+++ b/Compiler/ABI/Frame.lean
@@ -23,6 +23,7 @@ structure FrameField where
   ty : ParamType
   source : FrameSource
   sourceBase : String := ""
+  sourceOffset : Nat := 0
   tailBytes : Nat := 0
   deriving Repr, BEq
 
@@ -45,7 +46,8 @@ def fieldsHaveDynamic (fields : List FrameField) : Bool :=
   fields.any (fun field => isDynamicParamType field.ty)
 
 def shouldPassByPointer (fields : List FrameField) : Bool :=
-  fieldsHaveDynamic fields || spillThresholdWords < fieldsHeadWords fields
+  fields.any (fun field => field.source == .code) ||
+    fieldsHaveDynamic fields || spillThresholdWords < fieldsHeadWords fields
 
 def layout (fields : List FrameField) : FrameLayout :=
   let headWords := fieldsHeadWords fields
@@ -53,13 +55,15 @@ def layout (fields : List FrameField) : FrameLayout :=
   { fields
     headWords
     hasDynamic
-    mode := if hasDynamic || spillThresholdWords < headWords then .pointer else .inlineWords }
+    mode := if shouldPassByPointer fields then .pointer else .inlineWords }
 
-def sourceCanMaterializeEarly : FrameSource → Bool
-  | .calldata | .memory | .code | .storage => true
+def fieldSourceSupported (field : FrameField) : Bool :=
+  match field.source with
+  | .memory | .code | .storage => true
+  | .calldata => true
 
 def layoutSourcesSupported (l : FrameLayout) : Bool :=
-  l.fields.all (fun field => sourceCanMaterializeEarly field.source)
+  l.fields.all fieldSourceSupported
 
 def frameSizeBytes (l : FrameLayout) : Nat :=
   l.fields.foldl (fun acc field => acc + fieldHeadWords field * 32 +
@@ -87,10 +91,14 @@ def sourceBaseName (field : FrameField) : String :=
   if field.sourceBase.isEmpty then field.name else field.sourceBase
 
 private def sourceByteOffset (field : FrameField) (idx : Nat) : YulExpr :=
-  if idx == 0 then
+  let byteOffset := field.sourceOffset + idx * 32
+  if byteOffset == 0 then
     YulExpr.ident (sourceBaseName field)
   else
-    YulExpr.call "add" [YulExpr.ident (sourceBaseName field), YulExpr.lit (idx * 32)]
+    YulExpr.call "add" [YulExpr.ident (sourceBaseName field), YulExpr.lit byteOffset]
+
+private def sourceCodeOffset (field : FrameField) (idx : Nat) : YulExpr :=
+  YulExpr.lit (field.sourceOffset + idx * 32)
 
 private def sourceStorageSlot (field : FrameField) (idx : Nat) : YulExpr :=
   if idx == 0 then
@@ -98,28 +106,75 @@ private def sourceStorageSlot (field : FrameField) (idx : Nat) : YulExpr :=
   else
     YulExpr.call "add" [YulExpr.ident (sourceBaseName field), YulExpr.lit idx]
 
+private def dynamicTailByteOffset (field : FrameField) (idx : Nat) : YulExpr :=
+  let wordOffset := YulExpr.lit (idx * 32)
+  match field.source with
+  | .calldata =>
+      let base := YulExpr.ident (sourceBaseName field)
+      YulExpr.call "add" [YulExpr.call "add" [base, YulExpr.call "calldataload" [base]], wordOffset]
+  | .memory =>
+      if field.sourceOffset + idx * 32 == 0 then
+        YulExpr.ident (sourceBaseName field)
+      else
+        YulExpr.call "add" [YulExpr.ident (sourceBaseName field), YulExpr.lit (field.sourceOffset + idx * 32)]
+  | .code => YulExpr.lit (field.sourceOffset + idx * 32)
+  | .storage => sourceStorageSlot field idx
+
 private def materializeSourceWord (field : FrameField) (idx : Nat) : YulExpr :=
   match field.source with
   | .calldata => YulExpr.call "calldataload" [sourceByteOffset field idx]
   | .memory => YulExpr.call "mload" [sourceByteOffset field idx]
-  | .code => YulExpr.call "mload" [sourceByteOffset field idx]
+  | .code => YulExpr.call "mload" [YulExpr.lit 0]
   | .storage => YulExpr.call "sload" [sourceStorageSlot field idx]
 
-partial def spillField (base : String) (offsetWords : Nat) (field : FrameField) : List YulStmt :=
-  (List.range (fieldPayloadWords field)).map fun idx =>
-    YulStmt.expr (YulExpr.call "mstore"
-      [ YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit ((offsetWords + idx) * 32)]
-      , materializeSourceWord field idx ])
+private def spillCodeWord (field : FrameField) (dest offset : YulExpr) : YulStmt :=
+  YulStmt.expr (YulExpr.call "extcodecopy"
+    [ YulExpr.ident (sourceBaseName field), dest, offset, YulExpr.lit 32 ])
 
-partial def spillFields (base : String) (offsetWords : Nat) : List FrameField → List YulStmt
+private def spillStaticField (base : String) (headOffsetWords : Nat) (field : FrameField) : List YulStmt :=
+  (List.range (fieldHeadWords field)).map fun idx =>
+    let dest := YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit ((headOffsetWords + idx) * 32)]
+    match field.source with
+    | .code => spillCodeWord field dest (sourceCodeOffset field idx)
+    | _ =>
+        YulStmt.expr (YulExpr.call "mstore"
+          [dest, materializeSourceWord field idx])
+
+private def spillDynamicField (base : String) (headOffsetWords tailOffsetWords : Nat) (field : FrameField) : List YulStmt :=
+  let tailOffsetBytes := tailOffsetWords * 32
+  let headDest := YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit (headOffsetWords * 32)]
+  let head := [YulStmt.expr (YulExpr.call "mstore" [headDest, YulExpr.lit tailOffsetBytes])]
+  let tailWords := (field.tailBytes + 31) / 32
+  head ++ (List.range tailWords).map fun idx =>
+    let dest := YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit ((tailOffsetWords + idx) * 32)]
+    match field.source with
+    | .code => spillCodeWord field dest (dynamicTailByteOffset field idx)
+    | .storage =>
+        YulStmt.expr (YulExpr.call "mstore"
+          [dest, YulExpr.call "sload" [dynamicTailByteOffset field idx]])
+    | .calldata =>
+        YulStmt.expr (YulExpr.call "mstore"
+          [dest, YulExpr.call "calldataload" [dynamicTailByteOffset field idx]])
+    | .memory =>
+        YulStmt.expr (YulExpr.call "mstore"
+          [dest, YulExpr.call "mload" [dynamicTailByteOffset field idx]])
+
+partial def spillFieldsAbi (base : String) (headOffsetWords tailOffsetWords : Nat) : List FrameField → List YulStmt
   | [] => []
-  | field :: rest => spillField base offsetWords field ++ spillFields base (offsetWords + fieldPayloadWords field) rest
+  | field :: rest =>
+      let headWords := fieldHeadWords field
+      if isDynamicParamType field.ty then
+        spillDynamicField base headOffsetWords tailOffsetWords field ++
+          spillFieldsAbi base (headOffsetWords + headWords) (tailOffsetWords + (field.tailBytes + 31) / 32) rest
+      else
+        spillStaticField base headOffsetWords field ++
+          spillFieldsAbi base (headOffsetWords + headWords) tailOffsetWords rest
 
 /-- Materialize a typed ABI frame into memory before lowering calls/logs/returns.
     Large or dynamic payloads are then passed as `(ptr, size)` instead of as a
     long list of Yul values. -/
 def spillPayloadToMemory (base : String) (l : FrameLayout) : List YulStmt :=
-  allocateFrame base l ++ spillFields base 0 l.fields
+  allocateFrame base l ++ spillFieldsAbi base 0 l.headWords l.fields
 
 def pointerArgs (base : String) (l : FrameLayout) : List YulExpr :=
   [YulExpr.ident (ptrName base), YulExpr.lit (frameSizeBytes l)]

--- a/Compiler/ABI/Frame.lean
+++ b/Compiler/ABI/Frame.lean
@@ -64,7 +64,8 @@ def fieldSourceSupported (field : FrameField) : Bool :=
 
 def fieldLayoutSupported (field : FrameField) : Bool :=
   fieldSourceSupported field &&
-    !(field.source == .storage && isDynamicParamType field.ty)
+    !(field.source == .storage && isDynamicParamType field.ty) &&
+    !(field.source == .code && isDynamicParamType field.ty)
 
 def layoutSourcesSupported (l : FrameLayout) : Bool :=
   l.fields.all fieldLayoutSupported
@@ -114,13 +115,13 @@ private def dynamicTailByteOffset (field : FrameField) (idx : Nat) : YulExpr :=
   let wordOffset := YulExpr.lit (idx * 32)
   match field.source with
   | .calldata =>
+      let head := sourceByteOffset field 0
       let base := YulExpr.ident (sourceBaseName field)
-      YulExpr.call "add" [YulExpr.call "add" [base, YulExpr.call "calldataload" [base]], wordOffset]
+      YulExpr.call "add" [YulExpr.call "add" [base, YulExpr.call "calldataload" [head]], wordOffset]
   | .memory =>
-      if field.sourceOffset + idx * 32 == 0 then
-        YulExpr.ident (sourceBaseName field)
-      else
-        YulExpr.call "add" [YulExpr.ident (sourceBaseName field), YulExpr.lit (field.sourceOffset + idx * 32)]
+      let head := sourceByteOffset field 0
+      let base := YulExpr.ident (sourceBaseName field)
+      YulExpr.call "add" [YulExpr.call "add" [base, YulExpr.call "mload" [head]], wordOffset]
   | .code => YulExpr.lit (field.sourceOffset + idx * 32)
   | .storage => sourceStorageSlot field idx
 

--- a/Compiler/ABI/Frame.lean
+++ b/Compiler/ABI/Frame.lean
@@ -70,12 +70,11 @@ def fieldLayoutSupported (field : FrameField) : Bool :=
 def layoutSourcesSupported (l : FrameLayout) : Bool :=
   l.fields.all fieldLayoutSupported
 
-def frameSizeBytes (l : FrameLayout) : Nat :=
-  l.fields.foldl (fun acc field => acc + fieldHeadWords field * 32 +
-    (if isDynamicParamType field.ty then field.tailBytes else 0)) 0
-
 def fieldPayloadWords (field : FrameField) : Nat :=
   fieldHeadWords field + if isDynamicParamType field.ty then (field.tailBytes + 31) / 32 else 0
+
+def frameSizeBytes (l : FrameLayout) : Nat :=
+  l.fields.foldl (fun acc field => acc + fieldPayloadWords field * 32) 0
 
 def frameAllocBytes (l : FrameLayout) : Nat :=
   l.fields.foldl (fun acc field => acc + fieldPayloadWords field * 32) 0

--- a/Compiler/ABI/FrameTest.lean
+++ b/Compiler/ABI/FrameTest.lean
@@ -29,6 +29,12 @@ private def inlineFields : List FrameField :=
 private def dynamicStorageFields : List FrameField :=
   [ { name := "blob", ty := .bytes, source := .storage, tailBytes := 64 } ]
 
+private def dynamicCodeFields : List FrameField :=
+  [ { name := "blob", ty := .bytes, source := .code, tailBytes := 64 } ]
+
+private def dynamicMemoryFields : List FrameField :=
+  [ { name := "payload", ty := .bytes, source := .memory, sourceOffset := 32, tailBytes := 64 } ]
+
 private def calldataLoadName? : YulExpr → Option String
   | .call "calldataload" [.ident name] => some name
   | .call "calldataload" [.call "add" [.ident name, _]] => some name
@@ -52,6 +58,19 @@ private def hasDynamicCalldataTailCopy : List YulStmt → Bool :=
       ]) => true
     | _ => false
 
+private def hasDynamicMemoryTailCopy : List YulStmt → Bool :=
+  fun stmts => stmts.any fun
+    | .expr (.call "mstore" [
+        _,
+        .call "mload" [
+          .call "add" [
+            .call "add" [.ident "payload", .call "mload" [.call "add" [.ident "payload", .lit 32]]],
+            .lit 0
+          ]
+        ]
+      ]) => true
+    | _ => false
+
 #eval! do
   let takeLayout := layout takeFields
   assert "nested struct supported" (supportsNestedStructs takeLayout)
@@ -64,10 +83,14 @@ private def hasDynamicCalldataTailCopy : List YulStmt → Bool :=
   assert "calldata/memory/code/storage sources supported" (layoutSourcesSupported srcLayout)
   assert "dynamic storage tails are not lowered as sequential slots"
     (!layoutSourcesSupported (layout dynamicStorageFields))
+  assert "dynamic code tails are rejected instead of using a fixed offset"
+    (!layoutSourcesSupported (layout dynamicCodeFields))
   assert "dynamic source frame is pointer mode" (srcLayout.mode == FramePassMode.pointer)
   assert "code source spills through extcodecopy" (hasExtcodecopy (spillPayloadToMemory "src" srcLayout))
   assert "dynamic calldata tail follows ABI offset"
     (hasDynamicCalldataTailCopy (spillPayloadToMemory "take" takeLayout))
+  assert "dynamic memory tail follows ABI offset"
+    (hasDynamicMemoryTailCopy (spillPayloadToMemory "mem" (layout dynamicMemoryFields)))
   let inlineNames := (inlineArgs (layout inlineFields)).filterMap calldataLoadName?
   assert "inline source words are indexed per field"
     (inlineNames == ["pair", "pair", "amount"])

--- a/Compiler/ABI/FrameTest.lean
+++ b/Compiler/ABI/FrameTest.lean
@@ -26,6 +26,9 @@ private def inlineFields : List FrameField :=
   [ { name := "pair", ty := .tuple [.uint256, .bytes32], source := .calldata }
   , { name := "amount", ty := .uint256, source := .calldata } ]
 
+private def dynamicStorageFields : List FrameField :=
+  [ { name := "blob", ty := .bytes, source := .storage, tailBytes := 64 } ]
+
 private def calldataLoadName? : YulExpr → Option String
   | .call "calldataload" [.ident name] => some name
   | .call "calldataload" [.call "add" [.ident name, _]] => some name
@@ -59,6 +62,8 @@ private def hasDynamicCalldataTailCopy : List YulStmt → Bool :=
   assert "dynamic tail contributes to allocated words" (frameAllocBytes takeLayout == 288)
   let srcLayout := layout sourceFields
   assert "calldata/memory/code/storage sources supported" (layoutSourcesSupported srcLayout)
+  assert "dynamic storage tails are not lowered as sequential slots"
+    (!layoutSourcesSupported (layout dynamicStorageFields))
   assert "dynamic source frame is pointer mode" (srcLayout.mode == FramePassMode.pointer)
   assert "code source spills through extcodecopy" (hasExtcodecopy (spillPayloadToMemory "src" srcLayout))
   assert "dynamic calldata tail follows ABI offset"

--- a/Compiler/ABI/FrameTest.lean
+++ b/Compiler/ABI/FrameTest.lean
@@ -18,7 +18,7 @@ private def takeFields : List FrameField :=
 
 private def sourceFields : List FrameField :=
   [ { name := "c", ty := .uint256, source := .calldata }
-  , { name := "m", ty := .bytes, source := .memory, tailBytes := 64 }
+  , { name := "m", ty := .bytes32, source := .memory }
   , { name := "x", ty := .bytes32, source := .code }
   , { name := "s", ty := .uint256, source := .storage } ]
 
@@ -28,9 +28,6 @@ private def inlineFields : List FrameField :=
 
 private def dynamicStorageFields : List FrameField :=
   [ { name := "blob", ty := .bytes, source := .storage, tailBytes := 64 } ]
-
-private def dynamicCodeFields : List FrameField :=
-  [ { name := "blob", ty := .bytes, source := .code, tailBytes := 64 } ]
 
 private def dynamicMemoryFields : List FrameField :=
   [ { name := "payload", ty := .bytes, source := .memory, sourceOffset := 32, tailBytes := 64 } ]
@@ -48,54 +45,25 @@ private def hasExtcodecopy : List YulStmt → Bool :=
     | .expr (.call "extcodecopy" _) => true
     | _ => false
 
-private def hasDynamicCalldataTailCopy : List YulStmt → Bool :=
-  fun stmts => stmts.any fun
-    | .expr (.call "mstore" [
-        _,
-        .call "calldataload" [
-          .call "add" [
-            .call "add" [.ident "ratifierData", .call "calldataload" [.ident "ratifierData"]],
-            .lit 0
-          ]
-        ]
-      ]) => true
-    | _ => false
-
-private def hasDynamicMemoryTailCopy : List YulStmt → Bool :=
-  fun stmts => stmts.any fun
-    | .expr (.call "mstore" [
-        _,
-        .call "mload" [
-          .call "add" [
-            .call "add" [.ident "payload", .call "mload" [.call "add" [.ident "payload", .lit 32]]],
-            .lit 0
-          ]
-        ]
-      ]) => true
-    | _ => false
-
 #eval! do
   let takeLayout := layout takeFields
   assert "nested struct supported" (supportsNestedStructs takeLayout)
   assert "dynamic bytes/arrays force pointer mode" (takeLayout.mode == FramePassMode.pointer)
   assert "Take frame passes pointer pair" ((loweredArgs "take" takeLayout).length == 2)
-  assert "Take spills early to memory" ((spillPayloadToMemory "take" takeLayout).length > 2)
   assert "dynamic tail contributes to pointer payload size" (frameSizeBytes takeLayout == 288)
   assert "dynamic tail contributes to allocated words" (frameAllocBytes takeLayout == 288)
   assert "dynamic tail size is padded to full ABI words"
     (frameSizeBytes (layout unpaddedDynamicFields) == 96)
+  assert "dynamic calldata frames are not lowered with static tail sizes"
+    (!layoutSourcesSupported takeLayout)
   let srcLayout := layout sourceFields
   assert "calldata/memory/code/storage sources supported" (layoutSourcesSupported srcLayout)
-  assert "dynamic storage tails are not lowered as sequential slots"
+  assert "dynamic storage tails are rejected"
     (!layoutSourcesSupported (layout dynamicStorageFields))
-  assert "dynamic code tails are rejected instead of using a fixed offset"
-    (!layoutSourcesSupported (layout dynamicCodeFields))
+  assert "dynamic memory tails are rejected until runtime-sized ABI frames exist"
+    (!layoutSourcesSupported (layout dynamicMemoryFields))
   assert "dynamic source frame is pointer mode" (srcLayout.mode == FramePassMode.pointer)
   assert "code source spills through extcodecopy" (hasExtcodecopy (spillPayloadToMemory "src" srcLayout))
-  assert "dynamic calldata tail follows ABI offset"
-    (hasDynamicCalldataTailCopy (spillPayloadToMemory "take" takeLayout))
-  assert "dynamic memory tail follows ABI offset"
-    (hasDynamicMemoryTailCopy (spillPayloadToMemory "mem" (layout dynamicMemoryFields)))
   let inlineNames := (inlineArgs (layout inlineFields)).filterMap calldataLoadName?
   assert "inline source words are indexed per field"
     (inlineNames == ["pair", "pair", "amount"])

--- a/Compiler/ABI/FrameTest.lean
+++ b/Compiler/ABI/FrameTest.lean
@@ -35,6 +35,9 @@ private def dynamicCodeFields : List FrameField :=
 private def dynamicMemoryFields : List FrameField :=
   [ { name := "payload", ty := .bytes, source := .memory, sourceOffset := 32, tailBytes := 64 } ]
 
+private def unpaddedDynamicFields : List FrameField :=
+  [ { name := "payload", ty := .bytes, source := .calldata, tailBytes := 33 } ]
+
 private def calldataLoadName? : YulExpr → Option String
   | .call "calldataload" [.ident name] => some name
   | .call "calldataload" [.call "add" [.ident name, _]] => some name
@@ -79,6 +82,8 @@ private def hasDynamicMemoryTailCopy : List YulStmt → Bool :=
   assert "Take spills early to memory" ((spillPayloadToMemory "take" takeLayout).length > 2)
   assert "dynamic tail contributes to pointer payload size" (frameSizeBytes takeLayout == 288)
   assert "dynamic tail contributes to allocated words" (frameAllocBytes takeLayout == 288)
+  assert "dynamic tail size is padded to full ABI words"
+    (frameSizeBytes (layout unpaddedDynamicFields) == 96)
   let srcLayout := layout sourceFields
   assert "calldata/memory/code/storage sources supported" (layoutSourcesSupported srcLayout)
   assert "dynamic storage tails are not lowered as sequential slots"

--- a/Compiler/ABI/FrameTest.lean
+++ b/Compiler/ABI/FrameTest.lean
@@ -50,10 +50,10 @@ private def hasExtcodecopy : List YulStmt → Bool :=
   assert "nested struct supported" (supportsNestedStructs takeLayout)
   assert "dynamic bytes/arrays force pointer mode" (takeLayout.mode == FramePassMode.pointer)
   assert "Take frame passes pointer pair" ((loweredArgs "take" takeLayout).length == 2)
-  assert "dynamic tail contributes to pointer payload size" (frameSizeBytes takeLayout == 288)
-  assert "dynamic tail contributes to allocated words" (frameAllocBytes takeLayout == 288)
+  assert "dynamic tail contributes to pointer payload size" (frameSizeBytes takeLayout == 320)
+  assert "dynamic tail contributes to allocated words" (frameAllocBytes takeLayout == 320)
   assert "dynamic tail size is padded to full ABI words"
-    (frameSizeBytes (layout unpaddedDynamicFields) == 96)
+    (frameSizeBytes (layout unpaddedDynamicFields) == 128)
   assert "dynamic calldata frames are not lowered with static tail sizes"
     (!layoutSourcesSupported takeLayout)
   let srcLayout := layout sourceFields

--- a/Compiler/ABI/FrameTest.lean
+++ b/Compiler/ABI/FrameTest.lean
@@ -14,11 +14,11 @@ private def assert (label : String) (ok : Bool) : IO Unit := do
 private def takeFields : List FrameField :=
   [ { name := "offer", ty := .tuple [.address, .uint256, .tuple [.bytes32, .uint256]], source := .calldata }
   , { name := "units", ty := .uint256, source := .calldata }
-  , { name := "ratifierData", ty := .bytes, source := .calldata } ]
+  , { name := "ratifierData", ty := .bytes, source := .calldata, tailBytes := 96 } ]
 
 private def sourceFields : List FrameField :=
   [ { name := "c", ty := .uint256, source := .calldata }
-  , { name := "m", ty := .bytes, source := .memory }
+  , { name := "m", ty := .bytes, source := .memory, tailBytes := 64 }
   , { name := "x", ty := .bytes32, source := .code }
   , { name := "s", ty := .uint256, source := .storage } ]
 
@@ -28,6 +28,7 @@ private def inlineFields : List FrameField :=
 
 private def calldataLoadName? : YulExpr → Option String
   | .call "calldataload" [.ident name] => some name
+  | .call "calldataload" [.call "add" [.ident name, _]] => some name
   | _ => none
 
 #eval! do
@@ -36,11 +37,13 @@ private def calldataLoadName? : YulExpr → Option String
   assert "dynamic bytes/arrays force pointer mode" (takeLayout.mode == FramePassMode.pointer)
   assert "Take frame passes pointer pair" ((loweredArgs "take" takeLayout).length == 2)
   assert "Take spills early to memory" ((spillPayloadToMemory "take" takeLayout).length > 2)
+  assert "dynamic tail contributes to pointer payload size" (frameSizeBytes takeLayout == 288)
+  assert "dynamic tail contributes to allocated words" (frameAllocBytes takeLayout == 288)
   let srcLayout := layout sourceFields
   assert "calldata/memory/code/storage sources supported" (layoutSourcesSupported srcLayout)
   assert "dynamic source frame is pointer mode" (srcLayout.mode == FramePassMode.pointer)
   let inlineNames := (inlineArgs (layout inlineFields)).filterMap calldataLoadName?
   assert "inline source words are indexed per field"
-    (inlineNames == ["__abi_frame_src_pair_0", "__abi_frame_src_pair_1", "__abi_frame_src_amount_0"])
+    (inlineNames == ["pair", "pair", "amount"])
 
 end Compiler.ABI.FrameTest

--- a/Compiler/ABI/FrameTest.lean
+++ b/Compiler/ABI/FrameTest.lean
@@ -31,6 +31,24 @@ private def calldataLoadName? : YulExpr → Option String
   | .call "calldataload" [.call "add" [.ident name, _]] => some name
   | _ => none
 
+private def hasExtcodecopy : List YulStmt → Bool :=
+  fun stmts => stmts.any fun
+    | .expr (.call "extcodecopy" _) => true
+    | _ => false
+
+private def hasDynamicCalldataTailCopy : List YulStmt → Bool :=
+  fun stmts => stmts.any fun
+    | .expr (.call "mstore" [
+        _,
+        .call "calldataload" [
+          .call "add" [
+            .call "add" [.ident "ratifierData", .call "calldataload" [.ident "ratifierData"]],
+            .lit 0
+          ]
+        ]
+      ]) => true
+    | _ => false
+
 #eval! do
   let takeLayout := layout takeFields
   assert "nested struct supported" (supportsNestedStructs takeLayout)
@@ -42,6 +60,9 @@ private def calldataLoadName? : YulExpr → Option String
   let srcLayout := layout sourceFields
   assert "calldata/memory/code/storage sources supported" (layoutSourcesSupported srcLayout)
   assert "dynamic source frame is pointer mode" (srcLayout.mode == FramePassMode.pointer)
+  assert "code source spills through extcodecopy" (hasExtcodecopy (spillPayloadToMemory "src" srcLayout))
+  assert "dynamic calldata tail follows ABI offset"
+    (hasDynamicCalldataTailCopy (spillPayloadToMemory "take" takeLayout))
   let inlineNames := (inlineArgs (layout inlineFields)).filterMap calldataLoadName?
   assert "inline source words are indexed per field"
     (inlineNames == ["pair", "pair", "amount"])

--- a/Compiler/ABI/FrameTest.lean
+++ b/Compiler/ABI/FrameTest.lean
@@ -4,6 +4,7 @@ namespace Compiler.ABI.FrameTest
 
 open Compiler.ABI.Frame
 open Compiler.CompilationModel
+open Compiler.Yul
 
 private def assert (label : String) (ok : Bool) : IO Unit := do
   if !ok then
@@ -21,6 +22,14 @@ private def sourceFields : List FrameField :=
   , { name := "x", ty := .bytes32, source := .code }
   , { name := "s", ty := .uint256, source := .storage } ]
 
+private def inlineFields : List FrameField :=
+  [ { name := "pair", ty := .tuple [.uint256, .bytes32], source := .calldata }
+  , { name := "amount", ty := .uint256, source := .calldata } ]
+
+private def calldataLoadName? : YulExpr → Option String
+  | .call "calldataload" [.ident name] => some name
+  | _ => none
+
 #eval! do
   let takeLayout := layout takeFields
   assert "nested struct supported" (supportsNestedStructs takeLayout)
@@ -30,5 +39,8 @@ private def sourceFields : List FrameField :=
   let srcLayout := layout sourceFields
   assert "calldata/memory/code/storage sources supported" (layoutSourcesSupported srcLayout)
   assert "dynamic source frame is pointer mode" (srcLayout.mode == FramePassMode.pointer)
+  let inlineNames := (inlineArgs (layout inlineFields)).filterMap calldataLoadName?
+  assert "inline source words are indexed per field"
+    (inlineNames == ["__abi_frame_src_pair_0", "__abi_frame_src_pair_1", "__abi_frame_src_amount_0"])
 
 end Compiler.ABI.FrameTest

--- a/Compiler/ABI/FrameTest.lean
+++ b/Compiler/ABI/FrameTest.lean
@@ -1,0 +1,34 @@
+import Compiler.ABI.Frame
+
+namespace Compiler.ABI.FrameTest
+
+open Compiler.ABI.Frame
+open Compiler.CompilationModel
+
+private def assert (label : String) (ok : Bool) : IO Unit := do
+  if !ok then
+    throw (IO.userError s!"frame test failed: {label}")
+  IO.println s!"ok: {label}"
+
+private def takeFields : List FrameField :=
+  [ { name := "offer", ty := .tuple [.address, .uint256, .tuple [.bytes32, .uint256]], source := .calldata }
+  , { name := "units", ty := .uint256, source := .calldata }
+  , { name := "ratifierData", ty := .bytes, source := .calldata } ]
+
+private def sourceFields : List FrameField :=
+  [ { name := "c", ty := .uint256, source := .calldata }
+  , { name := "m", ty := .bytes, source := .memory }
+  , { name := "x", ty := .bytes32, source := .code }
+  , { name := "s", ty := .uint256, source := .storage } ]
+
+#eval! do
+  let takeLayout := layout takeFields
+  assert "nested struct supported" (supportsNestedStructs takeLayout)
+  assert "dynamic bytes/arrays force pointer mode" (takeLayout.mode == FramePassMode.pointer)
+  assert "Take frame passes pointer pair" ((loweredArgs "take" takeLayout).length == 2)
+  assert "Take spills early to memory" ((spillPayloadToMemory "take" takeLayout).length > 2)
+  let srcLayout := layout sourceFields
+  assert "calldata/memory/code/storage sources supported" (layoutSourcesSupported srcLayout)
+  assert "dynamic source frame is pointer mode" (srcLayout.mode == FramePassMode.pointer)
+
+end Compiler.ABI.FrameTest

--- a/Compiler/CompilationModel/Compile.lean
+++ b/Compiler/CompilationModel/Compile.lean
@@ -418,9 +418,19 @@ def compileStmt (fields : List Field) (events : List EventDef := [])
           YulStmt.let_ "__return_code_pointer"
             (YulExpr.call "and" [pointerExpr, YulExpr.hex addressMask]),
           YulStmt.let_ "__return_code_offset" (YulExpr.lit 1),
+          YulStmt.let_ "__return_code_extent"
+            (YulExpr.call "extcodesize" [YulExpr.ident "__return_code_pointer"]),
+          YulStmt.if_
+            (YulExpr.call "iszero" [
+              YulExpr.call "gt" [
+                YulExpr.ident "__return_code_extent",
+                YulExpr.ident "__return_code_offset"
+              ]
+            ])
+            [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])],
           YulStmt.let_ "__return_code_size"
             (YulExpr.call "sub" [
-              YulExpr.call "extcodesize" [YulExpr.ident "__return_code_pointer"],
+              YulExpr.ident "__return_code_extent",
               YulExpr.ident "__return_code_offset"
             ]),
           YulStmt.let_ "__return_code_ptr"

--- a/Compiler/CompilationModel/Compile.lean
+++ b/Compiler/CompilationModel/Compile.lean
@@ -409,6 +409,30 @@ def compileStmt (fields : List Field) (events : List EventDef := [])
           YulExpr.call "add" [YulExpr.lit 64, YulExpr.call "mul" [lenIdent, YulExpr.lit 32]]
         ])
       ]
+  | Stmt.returnCodeData pointer => do
+      if isInternal then
+        throw s!"Compilation error: internal functions cannot use returnCodeData"
+      let pointerExpr ← compileExpr fields dynamicSource pointer
+      pure [
+        YulStmt.block [
+          YulStmt.let_ "__return_code_pointer"
+            (YulExpr.call "and" [pointerExpr, YulExpr.hex addressMask]),
+          YulStmt.let_ "__return_code_size"
+            (YulExpr.call "extcodesize" [YulExpr.ident "__return_code_pointer"]),
+          YulStmt.let_ "__return_code_ptr"
+            (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]),
+          YulStmt.expr (YulExpr.call "extcodecopy" [
+            YulExpr.ident "__return_code_pointer",
+            YulExpr.ident "__return_code_ptr",
+            YulExpr.lit 0,
+            YulExpr.ident "__return_code_size"
+          ]),
+          YulStmt.expr (YulExpr.call "return" [
+            YulExpr.ident "__return_code_ptr",
+            YulExpr.ident "__return_code_size"
+          ])
+        ]
+      ]
   | Stmt.mstore offset value => do
       pure [YulStmt.expr (YulExpr.call "mstore" [
         ← compileExpr fields dynamicSource offset,

--- a/Compiler/CompilationModel/Compile.lean
+++ b/Compiler/CompilationModel/Compile.lean
@@ -417,14 +417,18 @@ def compileStmt (fields : List Field) (events : List EventDef := [])
         YulStmt.block [
           YulStmt.let_ "__return_code_pointer"
             (YulExpr.call "and" [pointerExpr, YulExpr.hex addressMask]),
+          YulStmt.let_ "__return_code_offset" (YulExpr.lit 1),
           YulStmt.let_ "__return_code_size"
-            (YulExpr.call "extcodesize" [YulExpr.ident "__return_code_pointer"]),
+            (YulExpr.call "sub" [
+              YulExpr.call "extcodesize" [YulExpr.ident "__return_code_pointer"],
+              YulExpr.ident "__return_code_offset"
+            ]),
           YulStmt.let_ "__return_code_ptr"
             (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]),
           YulStmt.expr (YulExpr.call "extcodecopy" [
             YulExpr.ident "__return_code_pointer",
             YulExpr.ident "__return_code_ptr",
-            YulExpr.lit 0,
+            YulExpr.ident "__return_code_offset",
             YulExpr.ident "__return_code_size"
           ]),
           YulStmt.expr (YulExpr.call "return" [

--- a/Compiler/CompilationModel/LogicalPurity.lean
+++ b/Compiler/CompilationModel/LogicalPurity.lean
@@ -213,6 +213,8 @@ def stmtContainsUnsafeLogicalCallLike : Stmt → Bool
       exprListAnyUnsafeLogicalCallLike args
   | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
       false
+  | Stmt.returnCodeData pointer =>
+      exprContainsUnsafeLogicalCallLike pointer
   | Stmt.mstore offset value =>
       exprContainsUnsafeLogicalCallLike offset || exprContainsUnsafeLogicalCallLike value
   | Stmt.tstore offset value =>

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -563,6 +563,9 @@ def validateScopedStmtIdentifiers
             pure localScope
           else
             throw s!"Compilation error: {context} Stmt.returnArray '{name}' requires parameter '{name}' or local bindings '{name}_data_offset' and '{name}_length'"
+  | Stmt.returnCodeData pointer => do
+      validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount pointer
+      pure localScope
   | Stmt.returnBytes _ | Stmt.returnStorageWords _
   | Stmt.revertReturndata | Stmt.stop =>
       pure localScope

--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -281,6 +281,9 @@ private partial def collectUnguardedLowLevelStmtMechanics : Stmt → List String
   | .returnStorageWords _
   | .stop =>
       []
+  | .returnCodeData pointer =>
+      "runtime introspection: extcodesize/extcodecopy returnCodeData" ::
+        collectLowLevelExprMechanics pointer
 
 private def collectUnguardedLowLevelMechanicsFromStmts (stmts : List Stmt) : List String :=
   dedupPreserve (stmts.flatMap collectUnguardedLowLevelStmtMechanics)

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -951,6 +951,7 @@ inductive Stmt
   | returnArray (name : String)        -- ABI-encode dynamic uint256[] parameter loaded from calldata
   | returnBytes (name : String)        -- ABI-encode dynamic bytes parameter loaded from calldata
   | returnStorageWords (name : String) -- ABI-encode dynamic uint256[] from sload over a dynamic word-array parameter
+  | returnCodeData (pointer : Expr)    -- Return an ABI payload stored as runtime code at `pointer`.
   | mstore (offset value : Expr)
   | tstore (offset value : Expr)
   /-- First-class `calldatacopy(destOffset, sourceOffset, size)` statement. -/
@@ -1060,7 +1061,7 @@ def directMetadata : Stmt → StmtMetadata
       { subexpressions := [value], termination := .alwaysTerminates, controlFlow := .returns }
   | .returnValues values =>
       { subexpressions := values, termination := .alwaysTerminates, controlFlow := .returns }
-  | .returnArray _ | .returnBytes _ | .returnStorageWords _ =>
+  | .returnArray _ | .returnBytes _ | .returnStorageWords _ | .returnCodeData _ =>
       { termination := .alwaysTerminates, controlFlow := .returns }
   | .mstore offset value =>
       { subexpressions := [offset, value], lowLevelMechanics := [.mstore] }
@@ -1124,7 +1125,7 @@ partial def controlFlow : Stmt → ControlFlowSummary
       .mayReverting
   | .revertError _ _ | .revertReturndata =>
       .reverts
-  | .return _ | .returnValues _ | .returnArray _ | .returnBytes _ | .returnStorageWords _ =>
+  | .return _ | .returnValues _ | .returnArray _ | .returnBytes _ | .returnStorageWords _ | .returnCodeData _ =>
       .returns
   | .stop =>
       .stops

--- a/Compiler/CompilationModel/UsageAnalysis.lean
+++ b/Compiler/CompilationModel/UsageAnalysis.lean
@@ -249,7 +249,7 @@ def stmtUsesArrayElementKind (includePlain includeWord : Bool) : Stmt → Bool
       exprListUsesArrayElementKind includePlain includeWord args
   | Stmt.ecm _ args =>
       exprListUsesArrayElementKind includePlain includeWord args
-  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ | Stmt.returnCodeData _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>
       false
@@ -407,7 +407,7 @@ def stmtUsesArrayElement : Stmt → Bool
       exprListUsesArrayElement topics || exprUsesArrayElement dataOffset || exprUsesArrayElement dataSize
   | Stmt.externalCallBind _ _ args | Stmt.tryExternalCallBind _ _ _ args | Stmt.ecm _ args =>
       exprListUsesArrayElement args
-  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ | Stmt.returnCodeData _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>
       false
@@ -615,7 +615,7 @@ def stmtUsesParamDynamicHeadWord : Stmt → Bool
       exprListUsesParamDynamicHeadWord topics ||
         exprUsesParamDynamicHeadWord dataOffset ||
         exprUsesParamDynamicHeadWord dataSize
-  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ | Stmt.returnCodeData _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>
       false
@@ -762,7 +762,7 @@ def stmtUsesMulDiv512 : Stmt → Bool
   | Stmt.rawLog topics dataOffset dataSize =>
       exprListUsesMulDiv512 topics ||
         exprUsesMulDiv512 dataOffset || exprUsesMulDiv512 dataSize
-  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ | Stmt.returnCodeData _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>
       false
@@ -938,7 +938,7 @@ def stmtUsesStorageArrayElement : Stmt → Bool
       exprListUsesStorageArrayElement topics || exprUsesStorageArrayElement dataOffset || exprUsesStorageArrayElement dataSize
   | Stmt.ecm _ args =>
       exprListUsesStorageArrayElement args
-  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ | Stmt.returnCodeData _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>
       false
@@ -1094,7 +1094,7 @@ def stmtUsesDynamicBytesEq : Stmt → Bool
       exprListUsesDynamicBytesEq args
   | Stmt.rawLog topics dataOffset dataSize =>
       exprListUsesDynamicBytesEq topics || exprUsesDynamicBytesEq dataOffset || exprUsesDynamicBytesEq dataSize
-  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ | Stmt.returnCodeData _ =>
       false
   | Stmt.revertReturndata | Stmt.stop =>
       false

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -101,6 +101,10 @@ def validateStmtParamReferences (fnName : String) (params : List Param) :
             throw s!"Compilation error: function '{fnName}' returnStorageWords '{name}' requires an array parameter with single-word static elements, got {repr ty}"
       | none =>
           throw s!"Compilation error: function '{fnName}' returnStorageWords references unknown parameter '{name}'"
+  | Stmt.returnCodeData _pointer =>
+      -- `returnCodeData` may return a pointer computed into a local; the scope-aware
+      -- validator checks the expression once local bindings are available.
+      pure ()
   | Stmt.ite _ thenBranch elseBranch => do
       validateStmtParamReferencesInList fnName params thenBranch
       validateStmtParamReferencesInList fnName params elseBranch
@@ -194,6 +198,13 @@ def validateReturnShapesInStmt (fnName : String) (params : List Param)
         pure ()
       else
         throw s!"Compilation error: function '{fnName}' uses Stmt.returnStorageWords but declared returns are {repr expectedReturns}"
+  | Stmt.returnCodeData _ =>
+      if isInternal then
+        throw s!"Compilation error: internal function '{fnName}' cannot use Stmt.returnCodeData; only static returns via Stmt.return/Stmt.returnValues are supported ({issue625Ref})."
+      else if expectedReturns.isEmpty then
+        throw s!"Compilation error: function '{fnName}' uses Stmt.returnCodeData but declares no return values"
+      else
+        pure ()
   | Stmt.ite _ thenBranch elseBranch => do
       validateReturnShapesInStmtList fnName params expectedReturns isInternal thenBranch
       validateReturnShapesInStmtList fnName params expectedReturns isInternal elseBranch
@@ -418,6 +429,8 @@ def stmtWritesState : Stmt → Bool
       !fragment.scopeEffects.storageWrites.isEmpty || fragment.mechanics.contains .tstore
   | Stmt.returnStorageWords _ =>
       false
+  | Stmt.returnCodeData pointer =>
+      exprWritesState pointer
   | Stmt.mstore offset value =>
       exprWritesState offset || exprWritesState value
   | Stmt.tstore _ _ =>
@@ -1007,6 +1020,8 @@ def stmtReadsStateOrEnv : Stmt → Bool
       false
   | Stmt.returnStorageWords _ =>
       true
+  | Stmt.returnCodeData pointer =>
+      true || exprReadsStateOrEnv pointer
   | Stmt.mstore offset value =>
       exprReadsStateOrEnv offset || exprReadsStateOrEnv value
   | Stmt.tstore offset value =>
@@ -1201,6 +1216,8 @@ def stmtWritesStateWithFunctionEffects
       false
   | Stmt.returnStorageWords _ =>
       false
+  | Stmt.returnCodeData pointer =>
+      exprWritesStateWithFunctionEffects effects pointer
   | Stmt.mstore offset value =>
       exprWritesStateWithFunctionEffects effects offset ||
         exprWritesStateWithFunctionEffects effects value
@@ -1384,6 +1401,8 @@ def stmtReadsStateOrEnvWithFunctionEffects
       false
   | Stmt.returnStorageWords _ =>
       true
+  | Stmt.returnCodeData pointer =>
+      true || exprReadsStateOrEnvWithFunctionEffects effects pointer
   | Stmt.mstore offset value =>
       exprReadsStateOrEnvWithFunctionEffects effects offset ||
         exprReadsStateOrEnvWithFunctionEffects effects value
@@ -1823,7 +1842,7 @@ def validateNoUnsupportedAdtConstructInStmt : Stmt → Except String Unit
           exprContainsAdtConstruct size then
         throw "Compilation error: ADT construction cannot be used in copy offsets or sizes."
   | Stmt.storageArrayPop _ | Stmt.returnArray _ | Stmt.returnBytes _
-  | Stmt.returnStorageWords _ | Stmt.revertReturndata | Stmt.stop =>
+  | Stmt.returnStorageWords _ | Stmt.returnCodeData _ | Stmt.revertReturndata | Stmt.stop =>
       pure ()
   | Stmt.unsafeYul fragment =>
       if fragment.obligations.isEmpty then
@@ -1912,7 +1931,7 @@ def validateFunctionSpec (spec : FunctionSpec) : Except String Unit := do
 mutual
 def validateNoRuntimeReturnsInConstructorStmt : Stmt → Except String Unit
   | Stmt.return _ | Stmt.returnValues _ | Stmt.returnArray _
-  | Stmt.returnBytes _ | Stmt.returnStorageWords _ =>
+  | Stmt.returnBytes _ | Stmt.returnStorageWords _ | Stmt.returnCodeData _ =>
       throw "Compilation error: constructor must not return runtime data directly"
   | Stmt.ite _ thenBranch elseBranch => do
       validateNoRuntimeReturnsInConstructorStmtList thenBranch

--- a/Compiler/CompilationModel/ValidationHelpers.lean
+++ b/Compiler/CompilationModel/ValidationHelpers.lean
@@ -181,6 +181,7 @@ def collectStmtNames : Stmt → List String
   | Stmt.returnArray name => [name]
   | Stmt.returnBytes name => [name]
   | Stmt.returnStorageWords name => [name]
+  | Stmt.returnCodeData pointer => collectExprNames pointer
   | Stmt.mstore offset value => collectExprNames offset ++ collectExprNames value
   | Stmt.tstore offset value => collectExprNames offset ++ collectExprNames value
   | Stmt.calldatacopy destOffset sourceOffset size =>

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -5176,12 +5176,12 @@ def routerSpecUsesTypedEventsAndReturns : Bool :=
   TypedVerifierRouter.spec.functions.any (fun fn =>
     fn.name == "getCircuit" &&
       fn.params.map (fun param => param.ty) == [ParamType.bytes32] &&
-      fn.returns == [ParamType.address, ParamType.uint16, ParamType.uint16, ParamType.bool])
+      fn.returns == [ParamType.tuple [ParamType.address, ParamType.uint16, ParamType.uint16, ParamType.bool]])
 
 def routerStructMembersDestructuringKeepsMemberTypes : Bool :=
   TypedVerifierRouter.spec.functions.any (fun fn =>
     fn.name == "getCircuitViaMembers" &&
-      fn.returns == [ParamType.address, ParamType.uint16, ParamType.uint16, ParamType.bool]) &&
+      fn.returns == [ParamType.tuple [ParamType.address, ParamType.uint16, ParamType.uint16, ParamType.bool]]) &&
   TypedVerifierRouter.spec.functions.any (fun fn =>
     fn.name == "getRouteFlag" &&
       fn.returns == [ParamType.bool, ParamType.uint16])

--- a/Compiler/CompileDriverCommon.lean
+++ b/Compiler/CompileDriverCommon.lean
@@ -281,6 +281,7 @@ private partial def specializeForkStmt
   | .revertError errorName args => .revertError errorName (args.map (specializeForkExpr targetFork))
   | .return value => .return (specializeForkExpr targetFork value)
   | .returnValues values => .returnValues (values.map (specializeForkExpr targetFork))
+  | .returnCodeData pointer => .returnCodeData (specializeForkExpr targetFork pointer)
   | .mstore offset value => .mstore (specializeForkExpr targetFork offset) (specializeForkExpr targetFork value)
   | .tstore offset value => .tstore (specializeForkExpr targetFork offset) (specializeForkExpr targetFork value)
   | .calldatacopy dest source size => .calldatacopy (specializeForkExpr targetFork dest) (specializeForkExpr targetFork source) (specializeForkExpr targetFork size)
@@ -341,6 +342,8 @@ private partial def collectIntrinsicUsesStmt : Stmt → List IntrinsicUse
   | .externalCallBind _ _ args | .tryExternalCallBind _ _ _ args
   | .ecm _ args =>
       args.flatMap collectIntrinsicUsesExpr
+  | .returnCodeData pointer =>
+      collectIntrinsicUsesExpr pointer
   | .calldatacopy destOffset sourceOffset size
   | .returndataCopy destOffset sourceOffset size =>
       [destOffset, sourceOffset, size].flatMap collectIntrinsicUsesExpr

--- a/Compiler/Lowering/StackSafeAbi.lean
+++ b/Compiler/Lowering/StackSafeAbi.lean
@@ -25,9 +25,11 @@ def lowerFrameSpilled (base : String) (fields : List FrameField) : Except String
   pure { prologue, args := loweredArgs base l, layout := l }
 
 def lowerFrameAsMemoryPayload (base : String) (fields : List FrameField) : Except String (List YulStmt × List YulExpr × FrameLayout) := do
-  let lowered ← lowerFrameSpilled base fields
-  let (prologue, args) := materializePayloadToMemory base lowered.layout
-  pure (prologue, args, lowered.layout)
+  let l := layout fields
+  if !layoutSourcesSupported l then
+    throw s!"ABI frame '{base}' uses an unsupported source"
+  let (prologue, args) := materializePayloadToMemory base l
+  pure (prologue, args, l)
 
 def lowerEventWithTopic (base : String) (topic0 : YulExpr) (fields : List FrameField) : Except String (List YulStmt) := do
   let (prologue, payloadArgs, _) ← lowerFrameAsMemoryPayload base fields

--- a/Compiler/Lowering/StackSafeAbi.lean
+++ b/Compiler/Lowering/StackSafeAbi.lean
@@ -1,4 +1,5 @@
 import Compiler.ABI.Frame
+import Compiler.Keccak.Sponge
 
 namespace Compiler.Lowering.StackSafeAbi
 
@@ -12,7 +13,7 @@ structure LoweredFrame where
   deriving Repr
 
 def eventNameTopicWord (eventName : String) : Nat :=
-  UInt64.toNat (hash eventName)
+  KeccakEngine.keccak256_str_nat eventName
 
 def lowerFrameSpilled (base : String) (fields : List FrameField) : Except String LoweredFrame := do
   let l := layout fields

--- a/Compiler/Lowering/StackSafeAbi.lean
+++ b/Compiler/Lowering/StackSafeAbi.lean
@@ -1,0 +1,56 @@
+import Compiler.ABI.Frame
+
+namespace Compiler.Lowering.StackSafeAbi
+
+open Compiler.ABI.Frame
+open Compiler.Yul
+
+structure LoweredFrame where
+  prologue : List YulStmt
+  args : List YulExpr
+  layout : FrameLayout
+  deriving Repr
+
+def lowerFrameSpilled (base : String) (fields : List FrameField) : Except String LoweredFrame := do
+  let l := layout fields
+  if !layoutSourcesSupported l then
+    throw s!"ABI frame '{base}' uses an unsupported source"
+  let prologue :=
+    match l.mode with
+    | .pointer => spillPayloadToMemory base l
+    | .inlineWords => []
+  pure { prologue, args := loweredArgs base l, layout := l }
+
+def lowerEvent (eventName : String) (fields : List FrameField) : Except String (List YulStmt) := do
+  let lowered ← lowerFrameSpilled eventName fields
+  match lowered.layout.mode with
+  | .pointer =>
+      pure (lowered.prologue ++
+        [YulStmt.expr (YulExpr.call "log1" (lowered.args ++ [YulExpr.call "keccak256" [YulExpr.str eventName, YulExpr.lit 0]]))])
+  | .inlineWords =>
+      pure (lowered.prologue ++
+        [YulStmt.expr (YulExpr.call "log1" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.call "keccak256" [YulExpr.str eventName, YulExpr.lit 0]])])
+
+def lowerExternalCall (callName : String) (target value : YulExpr) (fields : List FrameField) : Except String (List YulStmt) := do
+  let lowered ← lowerFrameSpilled callName fields
+  let callArgs :=
+    match lowered.layout.mode with
+    | .pointer => [YulExpr.call "gas" [], target, value] ++ lowered.args ++ [YulExpr.lit 0, YulExpr.lit 0]
+    | .inlineWords => [YulExpr.call "gas" [], target, value, YulExpr.lit 0, YulExpr.lit 0, YulExpr.lit 0, YulExpr.lit 0]
+  pure (lowered.prologue ++ [YulStmt.let_ ("__" ++ callName ++ "_ok") (YulExpr.call "call" callArgs)])
+
+def lowerDynamicReturn (returnName : String) (fields : List FrameField) : Except String (List YulStmt) := do
+  let lowered ← lowerFrameSpilled returnName fields
+  match lowered.layout.mode with
+  | .pointer => pure (lowered.prologue ++ [YulStmt.expr (YulExpr.call "return" lowered.args)])
+  | .inlineWords => pure (lowered.prologue ++ [YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])])
+
+def usesPointerAbi (stmts : List YulStmt) : Bool :=
+  stmts.any fun stmt =>
+    match stmt with
+    | .expr (.call "return" [_ptr, _size]) => true
+    | .expr (.call "log1" [_ptr, _size, _topic]) => true
+    | .let_ _ (.call "call" [_gas, _target, _value, _ptr, _size, _out, _outSize]) => true
+    | _ => false
+
+end Compiler.Lowering.StackSafeAbi

--- a/Compiler/Lowering/StackSafeAbi.lean
+++ b/Compiler/Lowering/StackSafeAbi.lean
@@ -14,10 +14,6 @@ structure LoweredFrame where
 def eventNameTopicWord (eventName : String) : Nat :=
   UInt64.toNat (hash eventName)
 
-def inlinePayloadToScratch (words : List YulExpr) : List YulStmt :=
-  words.zipIdx.map fun (word, idx) =>
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit (idx * 32), word])
-
 def lowerFrameSpilled (base : String) (fields : List FrameField) : Except String LoweredFrame := do
   let l := layout fields
   if !layoutSourcesSupported l then
@@ -30,13 +26,8 @@ def lowerFrameSpilled (base : String) (fields : List FrameField) : Except String
 
 def lowerFrameAsMemoryPayload (base : String) (fields : List FrameField) : Except String (List YulStmt × List YulExpr × FrameLayout) := do
   let lowered ← lowerFrameSpilled base fields
-  match lowered.layout.mode with
-  | .pointer =>
-      pure (lowered.prologue, lowered.args, lowered.layout)
-  | .inlineWords =>
-      pure (lowered.prologue ++ inlinePayloadToScratch lowered.args,
-        [YulExpr.lit 0, YulExpr.lit (lowered.layout.headWords * 32)],
-        lowered.layout)
+  let (prologue, args) := materializePayloadToMemory base lowered.layout
+  pure (prologue, args, lowered.layout)
 
 def lowerEventWithTopic (base : String) (topic0 : YulExpr) (fields : List FrameField) : Except String (List YulStmt) := do
   let (prologue, payloadArgs, _) ← lowerFrameAsMemoryPayload base fields

--- a/Compiler/Lowering/StackSafeAbi.lean
+++ b/Compiler/Lowering/StackSafeAbi.lean
@@ -11,6 +11,13 @@ structure LoweredFrame where
   layout : FrameLayout
   deriving Repr
 
+def eventNameTopicWord (eventName : String) : Nat :=
+  UInt64.toNat (hash eventName)
+
+def inlinePayloadToScratch (words : List YulExpr) : List YulStmt :=
+  words.zipIdx.map fun (word, idx) =>
+    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit (idx * 32), word])
+
 def lowerFrameSpilled (base : String) (fields : List FrameField) : Except String LoweredFrame := do
   let l := layout fields
   if !layoutSourcesSupported l then
@@ -21,29 +28,32 @@ def lowerFrameSpilled (base : String) (fields : List FrameField) : Except String
     | .inlineWords => []
   pure { prologue, args := loweredArgs base l, layout := l }
 
-def lowerEvent (eventName : String) (fields : List FrameField) : Except String (List YulStmt) := do
-  let lowered ← lowerFrameSpilled eventName fields
+def lowerFrameAsMemoryPayload (base : String) (fields : List FrameField) : Except String (List YulStmt × List YulExpr × FrameLayout) := do
+  let lowered ← lowerFrameSpilled base fields
   match lowered.layout.mode with
   | .pointer =>
-      pure (lowered.prologue ++
-        [YulStmt.expr (YulExpr.call "log1" (lowered.args ++ [YulExpr.call "keccak256" [YulExpr.str eventName, YulExpr.lit 0]]))])
+      pure (lowered.prologue, lowered.args, lowered.layout)
   | .inlineWords =>
-      pure (lowered.prologue ++
-        [YulStmt.expr (YulExpr.call "log1" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.call "keccak256" [YulExpr.str eventName, YulExpr.lit 0]])])
+      pure (lowered.prologue ++ inlinePayloadToScratch lowered.args,
+        [YulExpr.lit 0, YulExpr.lit (lowered.layout.headWords * 32)],
+        lowered.layout)
+
+def lowerEventWithTopic (base : String) (topic0 : YulExpr) (fields : List FrameField) : Except String (List YulStmt) := do
+  let (prologue, payloadArgs, _) ← lowerFrameAsMemoryPayload base fields
+  pure (prologue ++
+    [YulStmt.expr (YulExpr.call "log1" (payloadArgs ++ [topic0]))])
+
+def lowerEvent (eventName : String) (fields : List FrameField) : Except String (List YulStmt) := do
+  lowerEventWithTopic eventName (YulExpr.lit (eventNameTopicWord eventName)) fields
 
 def lowerExternalCall (callName : String) (target value : YulExpr) (fields : List FrameField) : Except String (List YulStmt) := do
-  let lowered ← lowerFrameSpilled callName fields
-  let callArgs :=
-    match lowered.layout.mode with
-    | .pointer => [YulExpr.call "gas" [], target, value] ++ lowered.args ++ [YulExpr.lit 0, YulExpr.lit 0]
-    | .inlineWords => [YulExpr.call "gas" [], target, value, YulExpr.lit 0, YulExpr.lit 0, YulExpr.lit 0, YulExpr.lit 0]
-  pure (lowered.prologue ++ [YulStmt.let_ ("__" ++ callName ++ "_ok") (YulExpr.call "call" callArgs)])
+  let (prologue, payloadArgs, _) ← lowerFrameAsMemoryPayload callName fields
+  let callArgs := [YulExpr.call "gas" [], target, value] ++ payloadArgs ++ [YulExpr.lit 0, YulExpr.lit 0]
+  pure (prologue ++ [YulStmt.let_ ("__" ++ callName ++ "_ok") (YulExpr.call "call" callArgs)])
 
 def lowerDynamicReturn (returnName : String) (fields : List FrameField) : Except String (List YulStmt) := do
-  let lowered ← lowerFrameSpilled returnName fields
-  match lowered.layout.mode with
-  | .pointer => pure (lowered.prologue ++ [YulStmt.expr (YulExpr.call "return" lowered.args)])
-  | .inlineWords => pure (lowered.prologue ++ [YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])])
+  let (prologue, payloadArgs, _) ← lowerFrameAsMemoryPayload returnName fields
+  pure (prologue ++ [YulStmt.expr (YulExpr.call "return" payloadArgs)])
 
 def usesPointerAbi (stmts : List YulStmt) : Bool :=
   stmts.any fun stmt =>

--- a/Compiler/Lowering/StackSafeAbiTest.lean
+++ b/Compiler/Lowering/StackSafeAbiTest.lean
@@ -15,7 +15,7 @@ private def assert (label : String) (ok : Bool) : IO Unit := do
 private def bigDynamicPayload : List FrameField :=
   [ { name := "toId", ty := .bytes32, source := .calldata }
   , { name := "toMarket", ty := .tuple [.address, .uint256, .uint256, .address], source := .calldata }
-  , { name := "takes", ty := .array (.tuple [.address, .uint256, .bytes]), source := .calldata } ]
+  , { name := "takes", ty := .array (.tuple [.address, .uint256, .bytes]), source := .calldata, tailBytes := 128 } ]
 
 private def smallStaticPayload : List FrameField :=
   [ { name := "id", ty := .bytes32, source := .calldata }

--- a/Compiler/Lowering/StackSafeAbiTest.lean
+++ b/Compiler/Lowering/StackSafeAbiTest.lean
@@ -12,10 +12,10 @@ private def assert (label : String) (ok : Bool) : IO Unit := do
     throw (IO.userError s!"stack safe ABI test failed: {label}")
   IO.println s!"ok: {label}"
 
-private def bigDynamicPayload : List FrameField :=
+private def bigStaticPayload : List FrameField :=
   [ { name := "toId", ty := .bytes32, source := .calldata }
   , { name := "toMarket", ty := .tuple [.address, .uint256, .uint256, .address], source := .calldata }
-  , { name := "takes", ty := .array (.tuple [.address, .uint256, .bytes]), source := .calldata, tailBytes := 128 } ]
+  , { name := "units", ty := .tuple [.uint256, .uint256, .uint256], source := .calldata } ]
 
 private def smallStaticPayload : List FrameField :=
   [ { name := "id", ty := .bytes32, source := .calldata }
@@ -46,18 +46,21 @@ private def logsWithDataBytes (bytes : Nat) : List YulStmt → Bool :=
     | _ => false
 
 #eval! do
-  match lowerEvent "Take" bigDynamicPayload with
+  match lowerEvent "Take" bigStaticPayload with
   | .ok ev => assert "event lowering uses memory pointer" (usesPointerAbi ev)
   | .error err => throw (IO.userError err)
-  match lowerExternalCall "callback" (YulExpr.ident "target") (YulExpr.lit 0) bigDynamicPayload with
+  match lowerExternalCall "callback" (YulExpr.ident "target") (YulExpr.lit 0) bigStaticPayload with
   | .ok call => assert "external-call lowering uses memory pointer" (usesPointerAbi call)
   | .error err => throw (IO.userError err)
-  match lowerDynamicReturn "dynamicReturn" bigDynamicPayload with
+  match lowerDynamicReturn "dynamicReturn" bigStaticPayload with
   | .ok ret => assert "dynamic return lowering uses memory pointer" (usesPointerAbi ret)
   | .error err => throw (IO.userError err)
-  match lowerFrameSpilled "toMarket" bigDynamicPayload with
+  match lowerFrameSpilled "toMarket" bigStaticPayload with
   | .ok lowered => assert "frame-spilled lowering allocates memory early" (!lowered.prologue.isEmpty && lowered.args.length == 2)
   | .error err => throw (IO.userError err)
+  match lowerDynamicReturn "dynamicUnsupported" [{ name := "payload", ty := .bytes, source := .calldata, tailBytes := 64 }] with
+  | .ok _ => throw (IO.userError "dynamic ABI frame unexpectedly lowered")
+  | .error _ => assert "dynamic ABI frames are rejected until runtime-sized lowering exists" true
   match lowerEvent "SmallStatic" smallStaticPayload with
   | .ok ev =>
       assert "inline event lowering stores payload" (countMstores ev == 2)

--- a/Compiler/Lowering/StackSafeAbiTest.lean
+++ b/Compiler/Lowering/StackSafeAbiTest.lean
@@ -17,6 +17,34 @@ private def bigDynamicPayload : List FrameField :=
   , { name := "toMarket", ty := .tuple [.address, .uint256, .uint256, .address], source := .calldata }
   , { name := "takes", ty := .array (.tuple [.address, .uint256, .bytes]), source := .calldata } ]
 
+private def smallStaticPayload : List FrameField :=
+  [ { name := "id", ty := .bytes32, source := .calldata }
+  , { name := "amount", ty := .uint256, source := .calldata } ]
+
+private def countMstores : List YulStmt → Nat :=
+  List.length ∘ List.filter (fun stmt =>
+    match stmt with
+    | .expr (.call "mstore" _) => true
+    | _ => false)
+
+private def returnsBytes (bytes : Nat) : List YulStmt → Bool :=
+  fun stmts => stmts.any fun stmt =>
+    match stmt with
+    | .expr (.call "return" [.lit 0, .lit n]) => n == bytes
+    | _ => false
+
+private def callsWithInputBytes (bytes : Nat) : List YulStmt → Bool :=
+  fun stmts => stmts.any fun stmt =>
+    match stmt with
+    | .let_ _ (.call "call" [_gas, _target, _value, .lit 0, .lit n, _out, _outSize]) => n == bytes
+    | _ => false
+
+private def logsWithDataBytes (bytes : Nat) : List YulStmt → Bool :=
+  fun stmts => stmts.any fun stmt =>
+    match stmt with
+    | .expr (.call "log1" [.lit 0, .lit n, .lit topic]) => n == bytes && topic != 0
+    | _ => false
+
 #eval! do
   match lowerEvent "Take" bigDynamicPayload with
   | .ok ev => assert "event lowering uses memory pointer" (usesPointerAbi ev)
@@ -29,6 +57,21 @@ private def bigDynamicPayload : List FrameField :=
   | .error err => throw (IO.userError err)
   match lowerFrameSpilled "toMarket" bigDynamicPayload with
   | .ok lowered => assert "frame-spilled lowering allocates memory early" (!lowered.prologue.isEmpty && lowered.args.length == 2)
+  | .error err => throw (IO.userError err)
+  match lowerEvent "SmallStatic" smallStaticPayload with
+  | .ok ev =>
+      assert "inline event lowering stores payload" (countMstores ev == 2)
+      assert "inline event lowering logs payload bytes" (logsWithDataBytes 64 ev)
+  | .error err => throw (IO.userError err)
+  match lowerExternalCall "smallCallback" (YulExpr.ident "target") (YulExpr.lit 0) smallStaticPayload with
+  | .ok call =>
+      assert "inline external-call lowering stores payload" (countMstores call == 2)
+      assert "inline external-call lowering passes payload bytes" (callsWithInputBytes 64 call)
+  | .error err => throw (IO.userError err)
+  match lowerDynamicReturn "smallReturn" smallStaticPayload with
+  | .ok ret =>
+      assert "inline dynamic return lowering stores payload" (countMstores ret == 2)
+      assert "inline dynamic return lowering returns payload bytes" (returnsBytes 64 ret)
   | .error err => throw (IO.userError err)
 
 end Compiler.Lowering.StackSafeAbiTest

--- a/Compiler/Lowering/StackSafeAbiTest.lean
+++ b/Compiler/Lowering/StackSafeAbiTest.lean
@@ -1,0 +1,34 @@
+import Compiler.Lowering.StackSafeAbi
+
+namespace Compiler.Lowering.StackSafeAbiTest
+
+open Compiler.ABI.Frame
+open Compiler.CompilationModel
+open Compiler.Lowering.StackSafeAbi
+open Compiler.Yul
+
+private def assert (label : String) (ok : Bool) : IO Unit := do
+  if !ok then
+    throw (IO.userError s!"stack safe ABI test failed: {label}")
+  IO.println s!"ok: {label}"
+
+private def bigDynamicPayload : List FrameField :=
+  [ { name := "toId", ty := .bytes32, source := .calldata }
+  , { name := "toMarket", ty := .tuple [.address, .uint256, .uint256, .address], source := .calldata }
+  , { name := "takes", ty := .array (.tuple [.address, .uint256, .bytes]), source := .calldata } ]
+
+#eval! do
+  match lowerEvent "Take" bigDynamicPayload with
+  | .ok ev => assert "event lowering uses memory pointer" (usesPointerAbi ev)
+  | .error err => throw (IO.userError err)
+  match lowerExternalCall "callback" (YulExpr.ident "target") (YulExpr.lit 0) bigDynamicPayload with
+  | .ok call => assert "external-call lowering uses memory pointer" (usesPointerAbi call)
+  | .error err => throw (IO.userError err)
+  match lowerDynamicReturn "dynamicReturn" bigDynamicPayload with
+  | .ok ret => assert "dynamic return lowering uses memory pointer" (usesPointerAbi ret)
+  | .error err => throw (IO.userError err)
+  match lowerFrameSpilled "toMarket" bigDynamicPayload with
+  | .ok lowered => assert "frame-spilled lowering allocates memory early" (!lowered.prologue.isEmpty && lowered.args.length == 2)
+  | .error err => throw (IO.userError err)
+
+end Compiler.Lowering.StackSafeAbiTest

--- a/Compiler/Modules.lean
+++ b/Compiler/Modules.lean
@@ -5,3 +5,5 @@ import Compiler.Modules.ERC20
 import Compiler.Modules.Hashing
 import Compiler.Modules.Oracle
 import Compiler.Modules.Precompiles
+import Compiler.Modules.Create2SSTORE2
+import Compiler.Modules.CodeData

--- a/Compiler/Modules/CodeData.lean
+++ b/Compiler/Modules/CodeData.lean
@@ -10,8 +10,6 @@ open Compiler.Yul
 structure CodeDataWrite where
   salt : YulExpr
   value : YulExpr := YulExpr.lit 0
-  initcodeOffset : YulExpr
-  initcodeSize : YulExpr
   payload : FrameLayout
   deriving Repr
 
@@ -32,12 +30,17 @@ def trustSurface : List String :=
 def writeTyped (resultVar base : String) (write : CodeDataWrite) : Except String (List YulStmt) := do
   if !layoutSourcesSupported write.payload then
     throw "CodeData write payload has unsupported frame source"
-  let prelude :=
-    match write.payload.mode with
-    | .pointer => spillPayloadToMemory base write.payload
-    | .inlineWords => []
+  let (prelude, payloadArgs) := materializePayloadToMemory base write.payload
+  let initcodeOffset ←
+    match payloadArgs with
+    | [offset, _size] => pure offset
+    | _ => throw "CodeData write expected a memory payload pointer and size"
+  let initcodeSize ←
+    match payloadArgs with
+    | [_offset, size] => pure size
+    | _ => throw "CodeData write expected a memory payload pointer and size"
   let deploy ← (Compiler.Modules.Create2SSTORE2.deployModule resultVar).compile {}
-    [write.value, write.initcodeOffset, write.initcodeSize, write.salt]
+    [write.value, initcodeOffset, initcodeSize, write.salt]
   pure (prelude ++ deploy)
 
 def readTyped (read : CodeDataRead) : Except String (List YulStmt) := do

--- a/Compiler/Modules/CodeData.lean
+++ b/Compiler/Modules/CodeData.lean
@@ -1,0 +1,64 @@
+import Compiler.ABI.Frame
+import Compiler.Modules.Create2SSTORE2
+
+namespace Compiler.Modules.CodeData
+
+open Compiler.ABI.Frame
+open Compiler.ECM
+open Compiler.Yul
+
+structure CodeDataWrite where
+  salt : YulExpr
+  value : YulExpr := YulExpr.lit 0
+  initcodeOffset : YulExpr
+  initcodeSize : YulExpr
+  payload : FrameLayout
+  deriving Repr
+
+structure CodeDataRead where
+  pointer : YulExpr
+  destOffset : YulExpr
+  codeOffset : YulExpr
+  size : YulExpr
+  payload : FrameLayout
+  deriving Repr
+
+def trustSurface : List String :=
+  [ "CREATE2 address derivation is trusted at the EVM boundary"
+  , "SSTORE2 pointer code layout is trusted as code-as-data"
+  , "extcodecopy reads immutable deployed code bytes into caller-owned memory"
+  , "ABI frame layout is typed by Compiler.ABI.Frame before write/read lowering" ]
+
+def writeTyped (resultVar base : String) (write : CodeDataWrite) : Except String (List YulStmt) := do
+  if !layoutSourcesSupported write.payload then
+    throw "CodeData write payload has unsupported frame source"
+  let prelude :=
+    match write.payload.mode with
+    | .pointer => spillPayloadToMemory base write.payload
+    | .inlineWords => []
+  let deploy ← (Compiler.Modules.Create2SSTORE2.deployModule resultVar).compile {}
+    [write.value, write.initcodeOffset, write.initcodeSize, write.salt]
+  pure (prelude ++ deploy)
+
+def readTyped (read : CodeDataRead) : Except String (List YulStmt) := do
+  if !layoutSourcesSupported read.payload then
+    throw "CodeData read payload has unsupported frame source"
+  (Compiler.Modules.Create2SSTORE2.readCodeModule).compile {}
+    [read.pointer, read.destOffset, read.codeOffset, read.size]
+
+def roundtripShape (resultVar base : String) (write : CodeDataWrite) (read : CodeDataRead) :
+    Except String (List YulStmt) := do
+  let w ← writeTyped resultVar base write
+  let r ← readTyped read
+  pure (w ++ r)
+
+def hasCreate2AndExtcodecopy (stmts : List YulStmt) : Bool :=
+  let hasCreate2 := stmts.any fun
+    | .let_ _ (.call "create2" _) => true
+    | _ => false
+  let hasExtcodecopy := stmts.any fun
+    | .expr (.call "extcodecopy" _) => true
+    | _ => false
+  hasCreate2 && hasExtcodecopy
+
+end Compiler.Modules.CodeData

--- a/Compiler/Modules/CodeDataTest.lean
+++ b/Compiler/Modules/CodeDataTest.lean
@@ -14,13 +14,13 @@ private def assert (label : String) (ok : Bool) : IO Unit := do
   IO.println s!"ok: {label}"
 
 private def payload := layout
-  [ { name := "blob", ty := .bytes, source := .memory, tailBytes := 96 }
+  [ { name := "blob", ty := .tuple [.bytes32, .bytes32, .bytes32], source := .memory }
   , { name := "meta", ty := .tuple [.bytes32, .uint256], source := .calldata } ]
 
 private def deployUsesPayloadBuffer : List YulStmt → Bool :=
   fun stmts => stmts.any fun stmt =>
     match stmt with
-    | .let_ _ (.call "create2" [_value, .ident "__abi_frame_sstore2", .lit 192, _salt]) => true
+    | .let_ _ (.call "create2" [_value, .ident "__abi_frame_sstore2", .lit 160, _salt]) => true
     | _ => false
 
 private def returnCodeDataHasExtentGuard : List YulStmt → Bool

--- a/Compiler/Modules/CodeDataTest.lean
+++ b/Compiler/Modules/CodeDataTest.lean
@@ -13,14 +13,18 @@ private def assert (label : String) (ok : Bool) : IO Unit := do
   IO.println s!"ok: {label}"
 
 private def payload := layout
-  [ { name := "blob", ty := .bytes, source := .memory }
+  [ { name := "blob", ty := .bytes, source := .memory, tailBytes := 96 }
   , { name := "meta", ty := .tuple [.bytes32, .uint256], source := .calldata } ]
+
+private def deployUsesPayloadBuffer : List YulStmt → Bool :=
+  fun stmts => stmts.any fun stmt =>
+    match stmt with
+    | .let_ _ (.call "create2" [_value, .ident "__abi_frame_sstore2", .lit 192, _salt]) => true
+    | _ => false
 
 #eval! do
   let write : CodeDataWrite :=
     { salt := YulExpr.ident "salt"
-      initcodeOffset := YulExpr.ident "init"
-      initcodeSize := YulExpr.ident "size"
       payload }
   let read : CodeDataRead :=
     { pointer := YulExpr.ident "ptr"
@@ -33,6 +37,7 @@ private def payload := layout
     | .ok stmts => pure stmts
     | .error err => throw (IO.userError err)
   assert "typed roundtrip has create2 and extcodecopy" (hasCreate2AndExtcodecopy roundtrip)
+  assert "typed write deploys the materialized payload buffer" (deployUsesPayloadBuffer roundtrip)
   assert "trust surface is explicit" (trustSurface.length == 4)
 
 end Compiler.Modules.CodeDataTest

--- a/Compiler/Modules/CodeDataTest.lean
+++ b/Compiler/Modules/CodeDataTest.lean
@@ -1,4 +1,5 @@
 import Compiler.Modules.CodeData
+import Compiler.CompilationModel.Compile
 
 namespace Compiler.Modules.CodeDataTest
 
@@ -22,6 +23,21 @@ private def deployUsesPayloadBuffer : List YulStmt → Bool :=
     | .let_ _ (.call "create2" [_value, .ident "__abi_frame_sstore2", .lit 192, _salt]) => true
     | _ => false
 
+private def returnCodeDataHasExtentGuard : List YulStmt → Bool
+  | [YulStmt.block stmts] =>
+      stmts.any fun stmt =>
+        match stmt with
+        | YulStmt.if_
+            (.call "iszero" [
+              .call "gt" [
+                .ident "__return_code_extent",
+                .ident "__return_code_offset"
+              ]
+            ])
+            [YulStmt.expr (.call "revert" [.lit 0, .lit 0])] => true
+        | _ => false
+  | _ => false
+
 #eval! do
   let write : CodeDataWrite :=
     { salt := YulExpr.ident "salt"
@@ -39,5 +55,11 @@ private def deployUsesPayloadBuffer : List YulStmt → Bool :=
   assert "typed roundtrip has create2 and extcodecopy" (hasCreate2AndExtcodecopy roundtrip)
   assert "typed write deploys the materialized payload buffer" (deployUsesPayloadBuffer roundtrip)
   assert "trust surface is explicit" (trustSurface.length == 4)
+  let returnCodeData ←
+    match compileStmt [] [] [] .calldata [] false [] [] (Stmt.returnCodeData (Expr.param "ptr")) with
+    | .ok stmts => pure stmts
+    | .error err => throw (IO.userError err)
+  assert "returnCodeData guards extcodesize before subtracting code offset"
+    (returnCodeDataHasExtentGuard returnCodeData)
 
 end Compiler.Modules.CodeDataTest

--- a/Compiler/Modules/CodeDataTest.lean
+++ b/Compiler/Modules/CodeDataTest.lean
@@ -1,0 +1,38 @@
+import Compiler.Modules.CodeData
+
+namespace Compiler.Modules.CodeDataTest
+
+open Compiler.ABI.Frame
+open Compiler.CompilationModel
+open Compiler.Modules.CodeData
+open Compiler.Yul
+
+private def assert (label : String) (ok : Bool) : IO Unit := do
+  if !ok then
+    throw (IO.userError s!"CodeData test failed: {label}")
+  IO.println s!"ok: {label}"
+
+private def payload := layout
+  [ { name := "blob", ty := .bytes, source := .memory }
+  , { name := "meta", ty := .tuple [.bytes32, .uint256], source := .calldata } ]
+
+#eval! do
+  let write : CodeDataWrite :=
+    { salt := YulExpr.ident "salt"
+      initcodeOffset := YulExpr.ident "init"
+      initcodeSize := YulExpr.ident "size"
+      payload }
+  let read : CodeDataRead :=
+    { pointer := YulExpr.ident "ptr"
+      destOffset := YulExpr.ident "dest"
+      codeOffset := YulExpr.lit 1
+      size := YulExpr.ident "size"
+      payload }
+  let roundtrip ←
+    match roundtripShape "storedPtr" "sstore2" write read with
+    | .ok stmts => pure stmts
+    | .error err => throw (IO.userError err)
+  assert "typed roundtrip has create2 and extcodecopy" (hasCreate2AndExtcodecopy roundtrip)
+  assert "trust surface is explicit" (trustSurface.length == 4)
+
+end Compiler.Modules.CodeDataTest

--- a/Compiler/Modules/README.md
+++ b/Compiler/Modules/README.md
@@ -16,6 +16,7 @@ structure that the compiler can plug in without modification.
 | `Callbacks.lean` | `callback` | `Stmt.callback` |
 | `Calls.lean` | `withReturn`, `callWithValue`, `callWithValueBytes`, `bubblingValueCall`, `bubblingValueCallNoOutput` | `Stmt.externalCallWithReturn`; generic `call{value:v}` adapter calls; handwritten low-level `call{value: ...}` wrappers |
 | `Create2SSTORE2.lean` | `create2Deploy`, `sstore2ReadCode` | handwritten CREATE2 deployment and SSTORE2-style `extcodecopy` code-as-data reads |
+| `CodeData.lean` | `writeTyped`, `readTyped`, `roundtripShape` | typed CREATE2/SSTORE2 code-as-data facade using `Compiler.ABI.Frame` layouts and an explicit trust surface |
 
 ## Usage
 

--- a/Compiler/Proofs/GeneratedTransition.lean
+++ b/Compiler/Proofs/GeneratedTransition.lean
@@ -124,6 +124,7 @@ private partial def stmtSummary : Stmt → TransitionSummary
       { reads := dedup (exprReads value) }
   | .returnValues values => { reads := dedup (values.flatMap exprReads) }
   | .returnArray name | .returnBytes name | .returnStorageWords name => { reads := [name] }
+  | .returnCodeData pointer => { reads := dedup (exprReads pointer), events := ["returnCodeData"] }
   | .calldatacopy dest src size | .returndataCopy dest src size =>
       { reads := dedup (exprReads dest ++ exprReads src ++ exprReads size) }
   | .internalCall _ args | .internalCallAssign _ _ args =>

--- a/Compiler/Proofs/GeneratedTransition.lean
+++ b/Compiler/Proofs/GeneratedTransition.lean
@@ -1,0 +1,149 @@
+import Compiler.CompilationModel
+
+namespace Compiler.Proofs.GeneratedTransition
+
+open Compiler.CompilationModel
+
+structure TransitionSummary where
+  reads : List String := []
+  writes : List String := []
+  guards : List String := []
+  events : List String := []
+  deriving Repr, BEq, Inhabited
+
+private def dedup (xs : List String) : List String :=
+  xs.foldl (fun acc x => if acc.contains x then acc else acc ++ [x]) []
+
+private def merge (a b : TransitionSummary) : TransitionSummary :=
+  { reads := dedup (a.reads ++ b.reads)
+    writes := dedup (a.writes ++ b.writes)
+    guards := dedup (a.guards ++ b.guards)
+    events := dedup (a.events ++ b.events) }
+
+private partial def exprReads : Expr → List String
+  | .storage field => [field]
+  | .storageAddr field => [field]
+  | .mapping field key => field :: exprReads key
+  | .mapping2 field key1 key2 => field :: exprReads key1 ++ exprReads key2
+  | .mappingUint field key => field :: exprReads key
+  | .mappingChain field keys => field :: keys.flatMap exprReads
+  | .structMember field key _ => field :: exprReads key
+  | .structMember2 field key1 key2 _ => field :: exprReads key1 ++ exprReads key2
+  | .mload a | .tload a | .calldataload a | .extcodesize a | .returndataOptionalBoolAt a
+  | .storageArrayElement _ a | .memoryArrayElement _ a =>
+      exprReads a
+  | .keccak256 a b | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b
+  | .mod a b | .smod a b | .eq a b | .ge a b | .gt a b | .sgt a b | .lt a b
+  | .slt a b | .le a b | .logicalAnd a b | .logicalOr a b | .bitAnd a b
+  | .bitOr a b | .bitXor a b | .shl a b | .shr a b | .sar a b | .byte a b
+  | .signextend a b | .ceilDiv a b | .wMulDown a b | .wDivUp a b
+  | .min a b | .max a b =>
+      exprReads a ++ exprReads b
+  | .call gas target value inOffset inSize outOffset outSize =>
+      [gas, target, value, inOffset, inSize, outOffset, outSize].flatMap exprReads
+  | .staticcall gas target inOffset inSize outOffset outSize
+  | .delegatecall gas target inOffset inSize outOffset outSize =>
+      [gas, target, inOffset, inSize, outOffset, outSize].flatMap exprReads
+  | .bitNot a | .logicalNot a => exprReads a
+  | .externalCall _ args | .internalCall _ args => args.flatMap exprReads
+  | .intrinsic _ _ _ args => args.flatMap exprReads
+  | .forkIfAtLeast _ t e => exprReads t ++ exprReads e
+  | .arrayLength name => [name ++ ".length"]
+  | .arrayElement name idx => name :: exprReads idx
+  | .memoryArrayLength name => [name ++ ".length"]
+  | .arrayElementWord name idx _ _ => name :: exprReads idx
+  | .arrayElementDynamicWord name idx _ => name :: exprReads idx
+  | .arrayElementDynamicDataOffset name idx => name :: exprReads idx
+  | .arrayElementDynamicMemberLength name idx _ => name :: exprReads idx
+  | .arrayElementDynamicMemberDataOffset name idx _ => name :: exprReads idx
+  | .arrayElementDynamicMemberElement name idx _ memberIdx => name :: (exprReads idx ++ exprReads memberIdx)
+  | .paramDynamicHeadWord name _ => [name]
+  | .paramDynamicStaticComposite name _ => [name]
+  | .paramDynamicMemberLength name _ => [name]
+  | .paramDynamicMemberDataOffset name _ => [name]
+  | .paramDynamicMemberElement name _ _ => [name]
+  | .storageArrayLength field => [field ++ ".length"]
+  | .dynamicBytesEq lhs rhs => [lhs, rhs]
+  | .ite c t e => exprReads c ++ exprReads t ++ exprReads e
+  | .adtConstruct _ _ args => args.flatMap exprReads
+  | .adtTag _ field => [field]
+  | .adtField _ _ _ _ field => [field]
+  | .mulDivDown a b c | .mulDivUp a b c | .mulDiv512Down a b c | .mulDiv512Up a b c =>
+      exprReads a ++ exprReads b ++ exprReads c
+  | _ => []
+
+mutual
+private partial def stmtSummary : Stmt → TransitionSummary
+  | .setStorage field value | .setStorageAddr field value =>
+      { reads := dedup (exprReads value), writes := [field] }
+  | .setStorageWord field offset value =>
+      { reads := dedup (exprReads value), writes := [field ++ "+" ++ toString offset] }
+  | .storageArrayPush field value =>
+      { reads := dedup ((field ++ ".length") :: exprReads value), writes := [field] }
+  | .storageArrayPop field =>
+      { reads := [field ++ ".length"], writes := [field] }
+  | .setStorageArrayElement field idx value =>
+      { reads := dedup (exprReads idx ++ exprReads value), writes := [field ++ "[]"] }
+  | .setMapping field key value | .setMappingUint field key value =>
+      { reads := dedup (exprReads key ++ exprReads value), writes := [field] }
+  | .setMappingWord field key offset value =>
+      { reads := dedup (exprReads key ++ exprReads value), writes := [field ++ "+" ++ toString offset] }
+  | .setMappingPackedWord field key offset _ value =>
+      { reads := dedup (field :: (exprReads key ++ exprReads value)), writes := [field ++ "+" ++ toString offset] }
+  | .setMapping2 field key1 key2 value =>
+      { reads := dedup (exprReads key1 ++ exprReads key2 ++ exprReads value), writes := [field] }
+  | .setMapping2Word field key1 key2 offset value =>
+      { reads := dedup (exprReads key1 ++ exprReads key2 ++ exprReads value), writes := [field ++ "+" ++ toString offset] }
+  | .setMappingChain field keys value =>
+      { reads := dedup (keys.flatMap exprReads ++ exprReads value), writes := [field] }
+  | .setStructMember field key member value =>
+      { reads := dedup (exprReads key ++ exprReads value), writes := [field ++ "." ++ member] }
+  | .setStructMember2 field key1 key2 member value =>
+      { reads := dedup (exprReads key1 ++ exprReads key2 ++ exprReads value), writes := [field ++ "." ++ member] }
+  | .require cond label | .requireError cond label _ =>
+      { reads := dedup (exprReads cond), guards := [label] }
+  | .revertError label args =>
+      { reads := dedup (args.flatMap exprReads), guards := [label] }
+  | .emit eventName args =>
+      { reads := dedup (args.flatMap exprReads), events := [eventName] }
+  | .rawLog topics dataOffset dataSize =>
+      { reads := dedup (topics.flatMap exprReads ++ exprReads dataOffset ++ exprReads dataSize), events := ["rawLog"] }
+  | .externalCallBind results externalName args =>
+      { reads := dedup (args.flatMap exprReads), writes := results.map ("local:" ++ ·), events := ["external:" ++ externalName] }
+  | .tryExternalCallBind success results externalName args =>
+      { reads := dedup (args.flatMap exprReads), writes := ("local:" ++ success) :: results.map ("local:" ++ ·), events := ["external:" ++ externalName] }
+  | .ecm mod args =>
+      { reads := if mod.readsState then ["ecm:" ++ mod.name] else dedup (args.flatMap exprReads)
+        writes := if mod.writesState then ["ecm:" ++ mod.name] else []
+        events := ["ecm:" ++ mod.name] }
+  | .ite cond t e =>
+      merge { reads := dedup (exprReads cond), guards := ["branch"] } (merge (stmtsSummary t) (stmtsSummary e))
+  | .forEach name count body =>
+      merge { reads := dedup (exprReads count), guards := ["loop:" ++ name] } (stmtsSummary body)
+  | .letVar _ value | .assignVar _ value | .return value | .mstore _ value | .tstore _ value =>
+      { reads := dedup (exprReads value) }
+  | .returnValues values => { reads := dedup (values.flatMap exprReads) }
+  | .returnArray name | .returnBytes name | .returnStorageWords name => { reads := [name] }
+  | .calldatacopy dest src size | .returndataCopy dest src size =>
+      { reads := dedup (exprReads dest ++ exprReads src ++ exprReads size) }
+  | .internalCall _ args | .internalCallAssign _ _ args =>
+      { reads := dedup (args.flatMap exprReads) }
+  | .unsafeBlock reason body =>
+      merge { guards := ["unsafe:" ++ reason] } (stmtsSummary body)
+  | .unsafeYul _ => { events := ["unsafeYul"] }
+  | .matchAdt adtName scrutinee branches =>
+      merge { reads := dedup (exprReads scrutinee), guards := ["match:" ++ adtName] }
+        (branches.foldl (fun acc (_, _, body) => merge acc (stmtsSummary body)) {})
+  | .stop | .revertReturndata => {}
+
+private partial def stmtsSummary (stmts : List Stmt) : TransitionSummary :=
+  stmts.foldl (fun acc stmt => merge acc (stmtSummary stmt)) {}
+end
+
+def extract (stmts : List Stmt) : TransitionSummary :=
+  stmts.foldl (fun acc stmt => merge acc (stmtSummary stmt)) {}
+
+def enoughForMidnightRcfTotalUnits (summary : TransitionSummary) : Bool :=
+  !summary.reads.isEmpty || !summary.writes.isEmpty || !summary.guards.isEmpty || !summary.events.isEmpty
+
+end Compiler.Proofs.GeneratedTransition

--- a/Compiler/Proofs/GeneratedTransitionTest.lean
+++ b/Compiler/Proofs/GeneratedTransitionTest.lean
@@ -1,0 +1,24 @@
+import Compiler.Proofs.GeneratedTransition
+
+namespace Compiler.Proofs.GeneratedTransitionTest
+
+open Compiler.CompilationModel
+open Compiler.Proofs.GeneratedTransition
+
+private def assert (label : String) (ok : Bool) : IO Unit := do
+  if !ok then
+    throw (IO.userError s!"GeneratedTransition test failed: {label}")
+  IO.println s!"ok: {label}"
+
+#eval! do
+  let summary := extract
+    [ Stmt.require (Expr.gt (Expr.storage "totalUnits") (Expr.literal 0)) "nonzero"
+    , Stmt.setMapping "position" (Expr.param "borrower") (Expr.storage "totalUnits")
+    , Stmt.emit "Take" [Expr.param "borrower", Expr.storage "totalUnits"] ]
+  assert "extracts reads" (summary.reads.contains "totalUnits")
+  assert "extracts writes" (summary.writes.contains "position")
+  assert "extracts guards" (summary.guards.contains "nonzero")
+  assert "extracts events" (summary.events.contains "Take")
+  assert "non-empty summary can feed later Midnight RCF/totalUnits" (enoughForMidnightRcfTotalUnits summary)
+
+end Compiler.Proofs.GeneratedTransitionTest

--- a/Compiler/Proofs/IRGeneration/FunctionBody.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody.lean
@@ -8161,7 +8161,7 @@ private theorem compileStmt_ok_any_scope_aux
       | setMappingPackedWord | setMapping2 | setMapping2Word | setMappingUint
       | setMappingChain | setStructMember | setStructMember2 | require
       | requireError | revertError | «return» | returnValues | returnArray
-      | returnBytes | returnStorageWords | mstore | tstore | calldatacopy
+      | returnBytes | returnStorageWords | returnCodeData | mstore | tstore | calldatacopy
       | returndataCopy | revertReturndata | stop | emit | internalCall
       | internalCallAssign | externalCallBind | tryExternalCallBind | ecm | rawLog
       | unsafeYul =>
@@ -8281,7 +8281,7 @@ private theorem compileStmt_ok_any_scope_with_surface_aux
       | setMappingPackedWord | setMapping2 | setMapping2Word | setMappingUint
       | setMappingChain | setStructMember | setStructMember2 | require
       | requireError | revertError | «return» | returnValues | returnArray
-      | returnBytes | returnStorageWords | mstore | tstore | calldatacopy
+      | returnBytes | returnStorageWords | returnCodeData | mstore | tstore | calldatacopy
       | returndataCopy | revertReturndata | stop | emit | internalCall
       | internalCallAssign | externalCallBind | tryExternalCallBind
       | ecm | rawLog | unsafeYul =>

--- a/Compiler/Proofs/IRGeneration/GenericInduction.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction.lean
@@ -1829,7 +1829,7 @@ theorem legacyCompatibleExternalStmtList_of_compileStmt_ok_on_supportedContractS
   | storageArrayPush _ _ | storageArrayPop _ | setStorageArrayElement _ _ _
   | require _ | requireError _ _ | revertError _ _
   | «return» _ | returnValues _ | returnArray _ | returnBytes _
-  | returnStorageWords _ | mstore _ _ | tstore _ _ | calldatacopy _ _ _
+  | returnStorageWords _ | returnCodeData _ | mstore _ _ | tstore _ _ | calldatacopy _ _ _
   | returndataCopy _ _ _ | revertReturndata | stop
   | ite _ _ _ | forEach _ _ _ | emit _ _
   | internalCall _ _ | internalCallAssign _ _ _ | rawLog _ _ _
@@ -3779,7 +3779,7 @@ theorem stmtListScopeCore_prefix_of_compileStmtList_ok_of_stmtListTouchesUnsuppo
       | setStructMember _ _ _ _ | setStructMember2 _ _ _ _ _
       | storageArrayPush _ _ | storageArrayPop _ | setStorageArrayElement _ _ _
       | requireError _ _ _ | revertError _ _ | returnValues _ | returnArray _
-      | returnBytes _ | returnStorageWords _ | calldatacopy _ _ _
+      | returnBytes _ | returnStorageWords _ | returnCodeData _ | calldatacopy _ _ _
       | returndataCopy _ _ _ | revertReturndata
       | emit _ _ | internalCall _ _ | internalCallAssign _ _ _
       | rawLog _ _ _ | externalCallBind _ _ _ | tryExternalCallBind _ _ _ _ | ecm _ _

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -4736,6 +4736,7 @@ private theorem execStmtWithHelpers_eq_execStmt_of_helperSurfaceClosed_aux
   | .returnArray _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .returnBytes _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .returnStorageWords _ => simp [execStmtWithHelpers, execStmtWithEvents]
+  | .returnCodeData _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .calldatacopy _ _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .returndataCopy _ _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .revertReturndata => simp [execStmtWithHelpers, execStmtWithEvents]

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -641,6 +641,8 @@ def stmtTouchesUnsupportedConstructorRawCalldataSurface : Stmt → Bool
   | .require value _ | .return value
   | .storageArrayPush _ value =>
       exprTouchesUnsupportedConstructorRawCalldataSurface value
+  | .returnCodeData pointer =>
+      exprTouchesUnsupportedConstructorRawCalldataSurface pointer
   | .setMapping _ key value | .setMappingWord _ key _ value
   | .setMappingPackedWord _ key _ _ value | .setMappingUint _ key value
   | .setStructMember _ key _ value | .setStorageArrayElement _ key value
@@ -1175,7 +1177,7 @@ mutual
 theorem: richer returns, logs, typed errors, and raw external effect hooks. -/
 def stmtTouchesUnsupportedEffectSurface : Stmt → Bool
   | .requireError _ _ _ | .revertError _ _ | .returnValues _ | .returnArray _
-  | .returnBytes _ | .returnStorageWords _ | .emit _ _ | .rawLog _ _ _
+  | .returnBytes _ | .returnStorageWords _ | .returnCodeData _ | .emit _ _ | .rawLog _ _ _
   | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _ | .ecm _ _ => true
   | .letVar _ _ | .assignVar _ _ | .setStorage _ _ | .setStorageAddr _ _
   | .setStorageWord _ _ _
@@ -1235,7 +1237,7 @@ def stmtTouchesUnsupportedCoreSurface : Stmt → Bool
   | .forEach _ _ _ => true
   | .storageArrayPop _
   | .requireError _ _ _ | .revertError _ _ | .returnValues _ | .returnArray _
-  | .returnBytes _ | .returnStorageWords _ | .calldatacopy _ _ _
+  | .returnBytes _ | .returnStorageWords _ | .returnCodeData _ | .calldatacopy _ _ _
   | .returndataCopy _ _ _ | .revertReturndata
   | .emit _ _ | .internalCall _ _ | .internalCallAssign _ _ _
   | .rawLog _ _ _ | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _ | .ecm _ _ => false
@@ -1260,7 +1262,7 @@ def stmtTouchesUnsupportedStateSurface : Stmt → Bool
         exprTouchesUnsupportedStateSurface value
   | .stop
   | .requireError _ _ _ | .revertError _ _ | .returnValues _ | .returnArray _
-  | .returnBytes _ | .returnStorageWords _ | .calldatacopy _ _ _
+  | .returnBytes _ | .returnStorageWords _ | .returnCodeData _ | .calldatacopy _ _ _
   | .returndataCopy _ _ _ | .revertReturndata
   | .emit _ _ | .internalCall _ _ | .internalCallAssign _ _ _
   | .rawLog _ _ _ | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _ | .ecm _ _ => false
@@ -1307,6 +1309,7 @@ def stmtTouchesUnsupportedCallSurface : Stmt → Bool
         exprTouchesUnsupportedCallSurface value
   | .require cond _ | .return cond =>
       exprTouchesUnsupportedCallSurface cond
+  | .returnCodeData _ => true
   | .internalCall _ _ | .internalCallAssign _ _ _ => true
   | .calldatacopy _ _ _
   | .returndataCopy _ _ _ | .revertReturndata
@@ -1348,6 +1351,8 @@ def stmtTouchesUnsupportedHelperSurface : Stmt → Bool
         exprTouchesUnsupportedHelperSurface value
   | .require cond _ | .return cond =>
       exprTouchesUnsupportedHelperSurface cond
+  | .returnCodeData pointer =>
+      exprTouchesUnsupportedHelperSurface pointer
   | .internalCall _ _ | .internalCallAssign _ _ _ => true
   | .stop | .calldatacopy _ _ _
   | .returndataCopy _ _ _ | .revertReturndata | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _
@@ -1390,6 +1395,8 @@ def stmtTouchesInternalHelperSurface : Stmt → Bool
         exprTouchesInternalHelperSurface value
   | .require cond _ | .return cond =>
       exprTouchesInternalHelperSurface cond
+  | .returnCodeData pointer =>
+      exprTouchesInternalHelperSurface pointer
   | .internalCall _ _ | .internalCallAssign _ _ _ => true
   | .stop | .calldatacopy _ _ _
   | .returndataCopy _ _ _ | .revertReturndata | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _
@@ -1455,6 +1462,8 @@ def stmtTouchesExprInternalHelperSurface : Stmt → Bool
         exprTouchesInternalHelperSurface value
   | .require cond _ | .return cond =>
       exprTouchesInternalHelperSurface cond
+  | .returnCodeData pointer =>
+      exprTouchesInternalHelperSurface pointer
   | .ite cond _ _ =>
       exprTouchesInternalHelperSurface cond
   | .forEach _ count _ =>
@@ -1478,7 +1487,7 @@ def stmtTouchesStructuralInternalHelperSurface : Stmt → Bool
   | .forEach _ _ body =>
       stmtListTouchesInternalHelperSurface body
   | .letVar _ _ | .assignVar _ _ | .setStorage _ _ | .require _ _
-  | .return _ | .internalCall _ _ | .internalCallAssign _ _ _
+  | .return _ | .returnCodeData _ | .internalCall _ _ | .internalCallAssign _ _ _
   | .stop | .setStorageAddr _ _ | .setStorageWord _ _ _ | .mstore _ _ | .tstore _ _
  
   | .calldatacopy _ _ _ | .returndataCopy _ _ _
@@ -1518,6 +1527,8 @@ def stmtTouchesUnsupportedForeignSurface : Stmt → Bool
         exprTouchesUnsupportedForeignSurface value
   | .require cond _ | .return cond =>
       exprTouchesUnsupportedForeignSurface cond
+  | .returnCodeData pointer =>
+      exprTouchesUnsupportedForeignSurface pointer
   | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _ | .ecm _ _ => true
   | .stop
   | .internalCall _ _ | .internalCallAssign _ _ _
@@ -1558,6 +1569,7 @@ def stmtTouchesUnsupportedLowLevelSurface : Stmt → Bool
         exprTouchesUnsupportedLowLevelSurface value
   | .require cond _ | .return cond =>
       exprTouchesUnsupportedLowLevelSurface cond
+  | .returnCodeData _ => true
   | .calldatacopy _ _ _
   | .returndataCopy _ _ _ | .revertReturndata => true
   | .stop
@@ -1585,6 +1597,7 @@ def stmtTouchesUnsupportedContractSurface (stmt : Stmt) : Bool :=
       exprTouchesUnsupportedContractSurface value
   | .require cond _ | .return cond =>
       exprTouchesUnsupportedContractSurface cond
+  | .returnCodeData _ => true
   | .mstore offset value | .tstore offset value =>
       exprTouchesUnsupportedContractSurface offset ||
         exprTouchesUnsupportedContractSurface value
@@ -1862,6 +1875,8 @@ mutual
     | .setStorageWord _ _ value
     | .storageArrayPush _ value | .return value | .require value _ =>
         exprInternalHelperCallNames value
+    | .returnCodeData pointer =>
+        exprInternalHelperCallNames pointer
     | .setStorageArrayElement _ index value =>
         exprInternalHelperCallNames index ++ exprInternalHelperCallNames value
     | .requireError cond _ args =>
@@ -1927,6 +1942,8 @@ mutual
     | .setStorageWord _ _ value
     | .storageArrayPush _ value | .return value | .require value _ =>
         exprInternalHelperCallNames value
+    | .returnCodeData pointer =>
+        exprInternalHelperCallNames pointer
     | .setStorageArrayElement _ index value =>
         exprInternalHelperCallNames index ++ exprInternalHelperCallNames value
     | .requireError cond _ args =>
@@ -3477,6 +3494,10 @@ mutual
           stmtListTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.2]
     | unsafeBlock _ _ | unsafeYul _ | matchAdt _ _ _ =>
         simp [stmtTouchesUnsupportedHelperSurface] at hsurface
+    | returnCodeData pointer =>
+        simp [stmtTouchesUnsupportedHelperSurface] at hsurface
+        simp [stmtTouchesInternalHelperSurface,
+          exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface]
     | stop | calldatacopy _ _ _ | returndataCopy _ _ _ | revertReturndata
     | externalCallBind _ _ _ | tryExternalCallBind _ _ _ _ | ecm _ _ | storageArrayPop _ | requireError _ _ _
     | revertError _ _ | returnValues _ | returnArray _ | returnBytes _
@@ -4467,7 +4488,7 @@ theorem stmtTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
   | setMappingChain _ _ _ | setStructMember _ _ _ _ | setStructMember2 _ _ _ _ _
   | storageArrayPop _ | setStorageArrayElement _ _ _ | requireError _ _ _
   | revertError _ _ | returnValues _ | returnArray _ | returnBytes _
-  | returnStorageWords _ | calldatacopy _ _ _ | returndataCopy _ _ _
+  | returnStorageWords _ | returnCodeData _ | calldatacopy _ _ _ | returndataCopy _ _ _
   | revertReturndata | emit _ _ | internalCall _ _
   | internalCallAssign _ _ _ | rawLog _ _ _ | externalCallBind _ _ _ | ecm _ _ =>
       cases hsurface

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -261,6 +261,8 @@ def returnArray {α : Type} (values : Array α) : Contract (Array α) := pure va
 def returnValues (_values : List Uint256) : Contract Unit := pure ()
 def returnBytes {α : Type} (value : α) : Contract α := pure value
 def returnStorageWords {α : Type} (_slots : Array α) : Contract (Array Uint256) := pure #[]
+def returnCodeData {α : Type} [Inhabited α] (_pointer : Address) : Contract α :=
+  pure (Inhabited.default : α)
 
 inductive EventArg where
   | word (value : Contract Uint256)

--- a/Contracts/StringSmoke.lean
+++ b/Contracts/StringSmoke.lean
@@ -119,6 +119,30 @@ verity_contract BytesEqSmoke where
     else
       return 0
 
+verity_contract CodeDataReturnSmoke where
+  storage
+    sentinel : Uint256 := slot 0
+
+  struct Item where
+    owner : Address,
+    amount : Uint256,
+    payload : Bytes
+
+  function load (pointer : Address) : Item := do
+    returnCodeData pointer
+
+example :
+    CodeDataReturnSmoke.load_model.returns =
+      [Compiler.CompilationModel.ParamType.tuple
+        [Compiler.CompilationModel.ParamType.address,
+         Compiler.CompilationModel.ParamType.uint256,
+         Compiler.CompilationModel.ParamType.bytes]] := rfl
+
+example :
+    CodeDataReturnSmoke.load_model.body =
+      [Compiler.CompilationModel.Stmt.returnCodeData
+        (Compiler.CompilationModel.Expr.param "pointer")] := rfl
+
 def bytesEqExecutableMatches : Bool :=
   let mkBytes (xs : List UInt8) : ByteArray := ByteArray.mk xs.toArray
   let abc : ByteArray := mkBytes [0x01, 0x02, 0x03]

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -803,7 +803,7 @@ private partial def modelReturnsTerm (ty : ValueType) : CommandElabM Term :=
       `([ $[$elemTerms.toArray],* ])
   | .struct _ fields => do
       let elemTerms ← fields.mapM (fun field => modelParamTypeTerm field.snd)
-      `([ $[$elemTerms.toArray],* ])
+      `([Compiler.CompilationModel.ParamType.tuple [ $[$elemTerms.toArray],* ]])
   | .newtype name baseType => do
       let baseTerm ← modelParamTypeTerm baseType
       `([Compiler.CompilationModel.ParamType.newtypeOf $(Lean.quote name) $baseTerm])
@@ -6664,6 +6664,9 @@ private partial def validateEffectStmtExprTypes
   | `(term| returnStorageWords $name:term) => do
       let ty ← requireDirectParamRef name "returnStorageWords" params
       requireSupportedReturnStorageWordsType name "returnStorageWords" ty
+  | `(term| returnCodeData $pointer:term) => do
+      requireDeclaredValueType pointer "returnCodeData pointer" .address
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals pointer)
   | `(term| externalCallBind $_names:term $_fnName:term $args:term)
     | `(term| tryExternalCallBind $_successVar:term $_names:term $_fnName:term $args:term) =>
       match stripParens args with
@@ -7128,6 +7131,9 @@ private def translateEffectStmt
       `(Compiler.CompilationModel.Stmt.returnBytes $(strTerm (← expectStringOrIdent name)))
   | `(term| returnStorageWords $name:term) =>
       `(Compiler.CompilationModel.Stmt.returnStorageWords $(strTerm (← expectStringOrIdent name)))
+  | `(term| returnCodeData $pointer:term) =>
+      `(Compiler.CompilationModel.Stmt.returnCodeData
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals pointer))
   | `(term| emit $eventName:term $args:term) =>
       let evName := ← expectStringOrIdent eventName
       let argExprs ← expectEmitExprList fields constDecls immutableDecls params locals args

--- a/artifacts/macro_property_tests/PropertyCodeDataReturnSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyCodeDataReturnSmoke.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyCodeDataReturnSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/StringSmoke.lean
+ */
+contract PropertyCodeDataReturnSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("CodeDataReturnSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `load` result
+    function testTODO_Load_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("load(address)", alice));
+        require(ok, "load reverted unexpectedly");
+        require(ret.length >= 96, "load ABI tuple return payload unexpectedly short");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}


### PR DESCRIPTION
## Summary

- add `Compiler.ABI.Frame` typed ABI frame layouts for nested structs, dynamic bytes/arrays, and calldata/memory/code/storage sources
- add `Compiler.Lowering.StackSafeAbi` frame-spilled lowering for events, external calls, and dynamic returns so large payloads are materialized in memory and passed as pointers
- add `Compiler.Modules.CodeData` typed CREATE2/SSTORE2 code-as-data read/write facade with explicit trust surface and roundtrip shape tests
- add `Compiler.Proofs.GeneratedTransition` minimal reads/writes/guards/events extraction for later Midnight RCF/totalUnits wiring

## Verification

- `lake build Compiler.ABI.FrameTest Compiler.Lowering.StackSafeAbiTest Compiler.Modules.CodeDataTest Compiler.Proofs.GeneratedTransitionTest`
- `lake build Compiler.Modules`
- `lake build Compiler`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler ABI lowering and EVM boundary behavior (`extcodecopy`, CREATE2, dynamic returns); impact is broad across validation/proofs but guarded by tests and explicit unsupported-frame checks.
> 
> **Overview**
> Introduces **typed ABI frame layouts** (`Compiler.ABI.Frame`) that decide inline vs **memory `(ptr, size)`** passing for nested structs and large payloads, with Yul spill logic from calldata/memory/code/storage (dynamic tails still gated by `layoutSourcesSupported`).
> 
> Adds **`Compiler.Lowering.StackSafeAbi`** to lower events, external calls, and dynamic returns through frame materialization so big ABI payloads avoid deep Yul stacks, plus **`Compiler.Modules.CodeData`** wiring CREATE2/SSTORE2 read/write to those layouts with an explicit trust surface.
> 
> Adds **`Stmt.returnCodeData`**: external functions can return ABI bytes copied from runtime code at an address (`extcodesize` guard, skip byte 1, `extcodecopy` + `return`), plumbed through compile/validation/trust-surface, **`returnCodeData` in the Verity macro**, contract stubs, and proof “unsupported surface” lists; struct **return types in the macro now map to `ParamType.tuple`**.
> 
> Adds **`Compiler.Proofs.GeneratedTransition`** to extract reads/writes/guards/events from stmt lists (scaffold for later RCF wiring) and smoke/property tests for CodeData return behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6ffd3861a5bd04111e89636e61038843fd3d4e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->