### PR TITLE
[Compiler Enhancement] Compile typed-interface/ECM contracts to Yul: load env exts + supportInterpreter (#1951)

### DIFF
--- a/Compiler/ModuleInput.lean
+++ b/Compiler/ModuleInput.lean
@@ -105,7 +105,10 @@ unsafe def loadSpecsFromModules (moduleNames : List Name) : IO (Except String (L
   let extraSearchRoots ← existingSplitPackageSearchRoots
   searchPathRef.set (originalSearchPath ++ extraSearchRoots)
   try
+    -- `loadExts := true` so `evalConstCheck` can evaluate specs that apply imported functions
+    -- (the `withReturnModule` ecm from typed-interface calls), not just inductive constructors. (#1951)
     let env ← Lean.importModules (moduleNames.toArray.map fun moduleName => { module := moduleName }) {}
+                (loadExts := true)
     let opts : Options := {}
     pure <| moduleNames.mapM (fun moduleName => evalSpecConst env opts (specNameOfModule moduleName))
   catch e =>

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -50,6 +50,8 @@ lean_lib «PrintAxioms» where
 
 lean_exe «verity-compiler» where
   root := `Compiler.Main
+  -- interpreter eval of ecm/interface specs forces init/std decls (e.g. `UInt64.ofNatLT`). (#1951)
+  supportInterpreter := true
 
 lean_exe «verity-compiler-patched» where
   root := `Compiler.MainPatched


### PR DESCRIPTION
## Summary
- `Compiler/ModuleInput.lean` — import modules with `loadExts := true` so env extensions (incl. the compiler-IR extension) load; an ECM spec *applies* an imported function (`withReturnModule`) that `evalConstCheck` can only materialize once extensions are loaded.
- `lakefile.lean` — `supportInterpreter := true` on the `verity-compiler` exe; evaluating an ECM spec drives Init/Std decls (e.g. `UInt64.ofNatLT`) through the interpreter.
- Net: the stock `verity-compiler` lowers typed-interface / ECM contracts to Yul (was: `Unable to evaluate '<Module>.spec' as CompilationModel`). Non-ECM contracts are unaffected.

## Test Plan
- `lake build` green off `origin/main` (verified in a clean worktree).
- Stock `verity-compiler --manifest … --output …` on a typed-interface contract calling `IPool.supply/borrow/repay/withdraw` emits the expected `call(gas(), target, …)` — no abort, no workaround.
- Not run: the full `FOUNDRY_PROFILE=difftest forge test` suite.

## Related Issues
Fixes #1951. Complements #1954 (dotted external-name validation) and #1957 (void calls) — all three are needed for a dotted-interface contract with void external calls to compile end to end.
