### PR TITLE
[Compiler Enhancement] Don't validate dotted ABI-interface external names as Yul identifiers (#1952)

### DIFF
--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -840,7 +840,10 @@ def validateIdentifierShapes (spec : CompilationModel) : Except String Unit := d
   for err in spec.errors do
     ensureContractIdentifier "custom error" err.name
   for ext in spec.externals do
-    ensureContractIdentifier "external declaration" ext.name
+    -- dotted abi-interface externals (e.g. `IPool.supply`) lower by selector, never as a yul
+    -- identifier; the id-check applies only to object-linked externals. (fixes #1952)
+    unless ext.name.contains '.' do
+      ensureContractIdentifier "external declaration" ext.name
 
 private theorem ensureNonReservedYulIdentifier_ok
     {kind name : String}


### PR DESCRIPTION
## Summary
- `Compiler/CompilationModel/ValidationCalls.lean` — skip the Yul-identifier check (`ensureContractIdentifier`) for dotted ABI-interface external names (`<Interface>.<method>`, e.g. `IPool.supply`); keep it for object-linked externals (e.g. `PoseidonT3_hash`).
- Rationale: the dotted name is only an audit label — the `externalCallWithReturn` ECM lowers the call by selector (`shl(224, 0x…)` + `call(...)`), never as a Yul identifier.

## Test Plan
- `lake build` green off `origin/main`.
- A typed-interface contract no longer fails with `external declaration name must be a valid identifier: IPool.supply`; compiles to Yul (together with #1951).
- Not run: the full `FOUNDRY_PROFILE=difftest forge test` suite.

## Related Issues
Fixes #1952. Complements #1951 (which lets the ECM spec evaluate at all); both are needed to compile a dotted-interface contract.
