### PR TITLE
[Compiler Enhancement] void / empty-returndata typed-interface calls (no-return ECM)

### DIFF
--- a/Compiler/Modules/Calls.lean
+++ b/Compiler/Modules/Calls.lean
@@ -127,6 +127,73 @@ def withReturn (resultVar : String) (target : Expr) (selector : Nat)
     (args : List Expr) (isStatic : Bool := false) : Stmt :=
   .ecm (withReturnModule resultVar selector args.length isStatic) ([target] ++ args)
 
+/-- Generic external call to a void (no-return) function.
+
+    Identical ABI-encoding and revert-forward-on-failure behaviour to
+    `withReturnModule`, but binds no result and performs no `returndatasize`
+    check or return decode. This is the ECM behind statement-position typed
+    interface calls whose method declares no return type (e.g. Aave V3
+    `supply`/`borrow`, which are `void`): such callees leave returndata empty,
+    so the strict 32-byte check in `withReturnModule` would revert *after* the
+    callee already ran and committed state.
+
+    The module is parameterized by:
+    - `selector`: the 4-byte function selector
+    - `numArgs`: number of ABI-encoded arguments (not counting target)
+
+    Arguments passed to compile: [target] ++ argExprs -/
+def noReturnModule (selector : Nat) (numArgs : Nat)
+    : ExternalCallModule where
+  name := "externalCallNoReturn"
+  numArgs := 1 + numArgs  -- target + args
+  resultVars := []
+  writesState := true
+  readsState := true
+  axioms := ["external_call_abi_interface"]
+  compile := fun _ctx args => do
+    let targetExpr ← match args.head? with
+      | some t => pure t
+      | none => throw "externalCallNoReturn expects at least 1 argument (target)"
+    let argExprs := args.drop 1
+    let selectorExpr := YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex selector]
+    let ptrName := "__ecnr_ptr"
+    let ptrExpr := YulExpr.ident ptrName
+    let storeSelector := YulStmt.expr (YulExpr.call "mstore" [ptrExpr, selectorExpr])
+    let storeArgs := argExprs.zipIdx.map fun (argExpr, i) =>
+      YulStmt.expr (YulExpr.call "mstore" [
+        YulExpr.call "add" [ptrExpr, YulExpr.lit (4 + i * 32)],
+        argExpr
+      ])
+    let calldataSize := 4 + numArgs * 32
+    let frameSize := ((Nat.max calldataSize 32 + 31) / 32) * 32
+    let loadPtr := YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
+    let advancePtr := YulStmt.expr (YulExpr.call "mstore" [
+      YulExpr.lit freeMemoryPointer,
+      YulExpr.call "add" [ptrExpr, YulExpr.lit frameSize]
+    ])
+    -- no output slice: return data is intentionally ignored
+    let callExpr :=
+      YulExpr.call "call" [
+        YulExpr.call "gas" [],
+        targetExpr,
+        YulExpr.lit 0,
+        ptrExpr, YulExpr.lit calldataSize,
+        YulExpr.lit 0, YulExpr.lit 0
+      ]
+    let letSuccess := YulStmt.let_ "__ecnr_success" callExpr
+    -- bubble failure returndata exactly, like withReturnModule; but on success
+    -- do NOT check returndatasize or decode a return value
+    let revertBlock := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__ecnr_success"]) [
+      YulStmt.let_ "__ecnr_rds" (YulExpr.call "returndatasize" []),
+      YulStmt.expr (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__ecnr_rds"]),
+      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__ecnr_rds"])
+    ]
+    pure [YulStmt.block ([loadPtr, storeSelector] ++ storeArgs ++ [advancePtr, letSuccess, revertBlock])]
+
+/-- Convenience: create a `Stmt.ecm` for a void external call (no return). -/
+def noReturn (target : Expr) (selector : Nat) (args : List Expr) : Stmt :=
+  .ecm (noReturnModule selector args.length) ([target] ++ args)
+
 /-- Generic Solidity-style low-level value call with revert-data bubbling.
 
     This models the common wrapper:

--- a/Contracts/Smoke/InternalInterfaceSmoke.lean
+++ b/Contracts/Smoke/InternalInterfaceSmoke.lean
@@ -95,6 +95,97 @@ example :
           | _ => false)) = true := by
   decide
 
+-- Void (no-`returns`) interface methods lower to the no-output `externalCallNoReturn` ECM:
+-- a selector+args `call(...)` that bubbles failure returndata but performs no `returndatasize`
+-- check and binds no result. This is what real void callees (e.g. Aave V3 `supply`/`borrow`,
+-- ERC20 `approve` in OZ's no-return variant) need; the strict `externalCallWithReturn` ECM would
+-- otherwise revert after the callee already ran. The selector is computed from the params only, so
+-- a void method's canonical signature matches its non-void counterpart exactly.
+verity_contract VoidInterfaceCallSmoke where
+  storage
+
+  interfaces
+    interface IPool where
+      function supply(Address, Uint256, Address, Uint16)
+      function balanceOf(Address) view returns (Uint256)
+    end
+
+  -- statement-position call to a void method → no-output ECM
+  function doSupply (pool : IPool, asset : Address, amount : Uint256, onBehalfOf : Address) : Unit := do
+    pool.supply asset amount onBehalfOf 0
+
+  -- a non-void method on the same interface still binds and return-checks as before
+  function readBal (pool : IPool, owner : Address) : Uint256 := do
+    let bal ← pool.balanceOf owner
+    return bal
+
+-- the void method is recorded as an external with no return type
+example :
+    (VoidInterfaceCallSmoke.spec.externals).any (fun ext =>
+      ext.name == "IPool.supply" && ext.returns.isEmpty && ext.returnType.isNone) = true := by
+  decide
+
+-- `supply` lowers to the void ECM: `externalCallNoReturn`, no result vars, writes state,
+-- 5 args (pool + asset, amount, onBehalfOf, referralCode).
+example :
+    (VoidInterfaceCallSmoke.spec.functions).any (fun fn =>
+      fn.name == "doSupply" &&
+        fn.body.any (fun stmt =>
+          match stmt with
+          | Compiler.CompilationModel.Stmt.ecm mod args =>
+              mod.name == "externalCallNoReturn" &&
+                mod.numArgs == 5 &&
+                mod.resultVars == [] &&
+                mod.writesState &&
+                args.length == 5
+          | _ => false)) = true := by
+  decide
+
+-- the non-void method on the same interface is unaffected: still `externalCallWithReturn`,
+-- binds its result, performs the 32-byte returndata check.
+example :
+    (VoidInterfaceCallSmoke.spec.functions).any (fun fn =>
+      fn.name == "readBal" &&
+        fn.body.any (fun stmt =>
+          match stmt with
+          | Compiler.CompilationModel.Stmt.ecm mod args =>
+              mod.name == "externalCallWithReturn" &&
+                mod.resultVars == ["bal"] &&
+                args.length == 2
+          | _ => false)) = true := by
+  decide
+
+/--
+error: interface call returns Verity.Macro.ValueType.uint256; bind it with `let ... ← ...`
+-/
+#guard_msgs in
+verity_contract VoidCallBindNonVoidAsStmtRejected where
+  storage
+
+  interfaces
+    interface IPool where
+      function balanceOf(Address) view returns (Uint256)
+    end
+
+  function bad (pool : IPool, owner : Address) : Unit := do
+    pool.balanceOf owner
+
+/--
+error: interface call 'b' binds a void method; call it as a statement, not `let ... ←`
+-/
+#guard_msgs in
+verity_contract VoidCallLetBindVoidRejected where
+  storage
+
+  interfaces
+    interface IPool where
+      function supply(Address, Uint256, Address, Uint16)
+    end
+
+  function bad (pool : IPool, asset : Address, amount : Uint256, onBehalfOf : Address) : Unit := do
+    let b ← pool.supply asset amount onBehalfOf 0
+    pure ()
+
 /--
 error: interface name 'Clash' conflicts with an existing type name
 -/

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -75,6 +75,11 @@ syntax "function " ident "(" sepBy(term, ",") ")" verityMutability* ident "(" se
 syntax "function " ident " (" sepBy(term, ",") ")" verityMutability* ident "(" sepBy(term, ",") ")" : verityInterfaceFunction
 syntax "function " ident "(" sepBy(verityInterfaceParam, ",") ")" verityMutability* ident "(" sepBy(term, ",") ")" : verityInterfaceFunction
 syntax "function " ident " (" sepBy(verityInterfaceParam, ",") ")" verityMutability* ident "(" sepBy(term, ",") ")" : verityInterfaceFunction
+-- void interface methods: no returns clause (e.g. aave supply/borrow are `void`)
+syntax "function " ident "(" sepBy(term, ",") ")" verityMutability* : verityInterfaceFunction
+syntax "function " ident " (" sepBy(term, ",") ")" verityMutability* : verityInterfaceFunction
+syntax "function " ident "(" sepBy(verityInterfaceParam, ",") ")" verityMutability* : verityInterfaceFunction
+syntax "function " ident " (" sepBy(verityInterfaceParam, ",") ")" verityMutability* : verityInterfaceFunction
 syntax "interface " ident " where " verityInterfaceFunction* "end" : verityInterface
 syntax ident " := " ident ppSpace str : verityLocalObligation
 syntax "local_obligations " "[" sepBy(verityLocalObligation, ",") "]" : verityLocalObligations

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1261,8 +1261,9 @@ private def parseInterfaceFunction
   let expectReturnsMarker (marker : Ident) : CommandElabM Unit := do
     unless toString marker.getId == "returns" do
       throwErrorAt marker "expected 'returns'"
+  -- `returnTys?` is `none` for a void interface method (no returns clause).
   let parseParts (name : Ident) (params : Array ParamDecl)
-      (mods : TSyntaxArray `verityMutability) (returnTys : TSyntaxArray `term) := do
+      (mods : TSyntaxArray `verityMutability) (returnTys? : Option (TSyntaxArray `term)) := do
     let mut isView := false
     for mod in mods do
       match mod with
@@ -1271,11 +1272,16 @@ private def parseInterfaceFunction
             throwErrorAt mod "duplicate 'view' modifier"
           isView := true
       | _ => throwErrorAt mod "interface functions currently support only the optional `view` modifier"
-    let parsedReturns ← returnTys.mapM (valueTypeFromSyntax newtypes structDecls adtDecls)
-    if parsedReturns.isEmpty then
-      throwErrorAt stx "interface function returns clause must contain at least one return type"
-    if parsedReturns.size > 1 then
-      throwErrorAt stx "typed interface calls currently support exactly one return value"
+    let parsedReturns ←
+      match returnTys? with
+      | none => pure #[]
+      | some returnTys => do
+          let parsed ← returnTys.mapM (valueTypeFromSyntax newtypes structDecls adtDecls)
+          if parsed.isEmpty then
+            throwErrorAt stx "interface function returns clause must contain at least one return type"
+          if parsed.size > 1 then
+            throwErrorAt stx "typed interface calls currently support exactly one return value"
+          pure parsed
     pure {
       ident := name
       name := toString name.getId
@@ -1283,19 +1289,26 @@ private def parseInterfaceFunction
       returnTys := parsedReturns
       isView := isView
     }
+  -- positional (`(term, ...)`) params lower to synthetic arg0/arg1/... names.
+  let parsePositionalParams (paramTys : TSyntaxArray `term) : CommandElabM (Array ParamDecl) :=
+    paramTys.mapIdxM fun idx ty => do
+      pure {
+        ident := mkIdent (Name.mkSimple s!"arg{idx}")
+        name := s!"arg{idx}"
+        ty := ← valueTypeFromSyntax newtypes structDecls adtDecls ty
+      }
   match stx with
   | `(verityInterfaceFunction| function $name:ident ($[$params:verityInterfaceParam],*) $[$mods:verityMutability]* $returnsMarker:ident ($[$returnTys:term],*)) => do
       expectReturnsMarker returnsMarker
-      parseParts name (← params.mapM (parseInterfaceParam newtypes structDecls adtDecls)) mods returnTys
+      parseParts name (← params.mapM (parseInterfaceParam newtypes structDecls adtDecls)) mods (some returnTys)
   | `(verityInterfaceFunction| function $name:ident ($[$paramTys:term],*) $[$mods:verityMutability]* $returnsMarker:ident ($[$returnTys:term],*)) => do
       expectReturnsMarker returnsMarker
-      let parsedParams ← paramTys.mapIdxM fun idx ty => do
-        pure {
-          ident := mkIdent (Name.mkSimple s!"arg{idx}")
-          name := s!"arg{idx}"
-          ty := ← valueTypeFromSyntax newtypes structDecls adtDecls ty
-        }
-      parseParts name parsedParams mods returnTys
+      parseParts name (← parsePositionalParams paramTys) mods (some returnTys)
+  -- void forms: no returns clause
+  | `(verityInterfaceFunction| function $name:ident ($[$params:verityInterfaceParam],*) $[$mods:verityMutability]*) => do
+      parseParts name (← params.mapM (parseInterfaceParam newtypes structDecls adtDecls)) mods none
+  | `(verityInterfaceFunction| function $name:ident ($[$paramTys:term],*) $[$mods:verityMutability]*) => do
+      parseParts name (← parsePositionalParams paramTys) mods none
   | _ => throwErrorAt stx "invalid interface function declaration"
 
 private def parseInterface
@@ -6280,7 +6293,7 @@ private partial def resolveTypedInterfaceCall?
     (externalDecls : Array ExternalDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (stx : Term) : CommandElabM (Option (ExternalDecl × Term × Array Term × ValueType × Nat)) := do
+    (stx : Term) : CommandElabM (Option (ExternalDecl × Term × Array Term × Option ValueType × Nat)) := do
   let some (target, methodName, argTerms) := typedDotCallSyntax? stx
     | pure none
   let targetName ←
@@ -6299,11 +6312,13 @@ private partial def resolveTypedInterfaceCall?
     unless actualTy == expectedTy || (isNatLiteralTerm argTerm && numericLiteralCompatibleValueType expectedTy) do
       throwErrorAt argTerm
         s!"interface call '{interfaceName}.{methodName}' argument expects {renderValueType expectedTy}, got {renderValueType actualTy}"
+  -- the selector is computed from the params only, so a void method's canonical
+  -- signature is identical to its non-void counterpart (e.g. aave
+  -- `supply(address,uint256,address,uint16)`).
+  let selector := Compiler.keccak256_first_4_bytes (interfaceFunctionSignature methodName ext.params)
   match ext.returnTys.toList with
-  | [retTy] =>
-      let selector := Compiler.keccak256_first_4_bytes (interfaceFunctionSignature methodName ext.params)
-      pure (some (ext, target, argTerms, retTy, selector))
-  | [] => throwErrorAt stx s!"interface call '{interfaceName}.{methodName}' returns no values"
+  | [retTy] => pure (some (ext, target, argTerms, some retTy, selector))
+  | [] => pure (some (ext, target, argTerms, none, selector))  -- void interface method
   | _ => throwErrorAt stx s!"interface call '{interfaceName}.{methodName}' returns multiple values; typed dot calls currently support one return value"
 
 mutual
@@ -6457,9 +6472,12 @@ private partial def validateDoElemExprTypes
                         params errorDecls args.getElems
                   | _ => pure ()
                   match ← resolveTypedInterfaceCall? fields constDecls immutableDecls externalDecls params locals rhs with
-                  | some (_, _, _, retTy, _) =>
+                  | some (_, _, _, some retTy, _) =>
                       requireSupportedLocalBindingType name s!"local binding '{toString name.getId}'" retTy
                       pure <| locals.push (mkTypedLocal (toString name.getId) retTy)
+                  | some (_, _, _, none, _) =>
+                      -- void interface method: cannot bind its (empty) result
+                      throwErrorAt rhs s!"interface call '{toString name.getId}' binds a void method; call it as a statement, not `let ... ←`"
                   | none =>
                       let ty ← inferBindSourceType fields constDecls immutableDecls externalDecls functions params locals rhs
                       requireSupportedLocalBindingType name s!"local binding '{toString name.getId}'" ty
@@ -6674,6 +6692,15 @@ private partial def validateEffectStmtExprTypes
   | `(term| revertReturndata) =>
       pure ()
   | _ =>
+      -- a typed interface call in statement position is only valid when the
+      -- method is void; `resolveTypedInterfaceCall?` already validates arg
+      -- count and arg types.
+      match ← resolveTypedInterfaceCall? fields constDecls immutableDecls externalDecls params locals stx with
+      | some (_, _, _, none, _) => pure ()
+      | some (_, _, _, some retTy, _) =>
+          throwErrorAt stx
+            s!"interface call returns {renderValueType retTy}; bind it with `let ... ← ...`"
+      | none =>
       match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals stx with
       | some (fn, argTerms) =>
           ensureSupportsInternalHelperSpec stx fn
@@ -7171,6 +7198,23 @@ private def translateEffectStmt
           $(strTerm memberName)
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
   | _ =>
+      -- void typed interface call in statement position lowers to the
+      -- no-return ECM (selector + args call, failure-returndata bubbled, but
+      -- no returndatasize check and no return decode).
+      match ← resolveTypedInterfaceCall? fields constDecls immutableDecls externalDecls params locals stx with
+      | some (_, target, argTerms, none, selector) =>
+          let targetExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals target
+          let argExprs ← argTerms.mapM
+            (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+          `(Compiler.CompilationModel.Stmt.ecm
+              (Compiler.Modules.Calls.noReturnModule
+                $(natTerm selector)
+                $(natTerm argExprs.size))
+              [ $targetExpr, $[$argExprs],* ])
+      | some (_, _, _, some retTy, _) =>
+          throwErrorAt stx
+            s!"interface call returns {renderValueType retTy}; bind it with `let ... ← ...`"
+      | none =>
       match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals stx with
       | some (fn, argTerms) =>
           ensureSupportsInternalHelperSpec stx fn
@@ -7501,7 +7545,7 @@ private partial def translateDoElem
                           pure (#[(stmt)], locals.push (mkTypedLocal varName .uint256), mutableLocals)
                       | none =>
                           match ← resolveTypedInterfaceCall? fields constDecls immutableDecls externalDecls params locals rhs with
-                          | some (ext, target, argTerms, retTy, selector) =>
+                          | some (ext, target, argTerms, some retTy, selector) =>
                               let targetExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals target
                               let argExprs ← argTerms.mapM
                                 (translatePureExprWithTypes fields constDecls immutableDecls params locals)
@@ -7516,6 +7560,9 @@ private partial def translateDoElem
                                         [ $targetExpr, $[$argExprs],* ]))],
                                   locals.push (mkTypedLocal varName retTy),
                                   mutableLocals)
+                          | some (_, _, _, none, _) =>
+                              -- void interface method bound with `let ... ←`: not allowed
+                              throwErrorAt rhs s!"interface call '{varName}' binds a void method; call it as a statement, not `let ... ←`"
                           | none =>
                               let rhsExpr ← translateBindSource fields constDecls immutableDecls externalDecls functions params locals rhs
                               let ty ← inferBindSourceType fields constDecls immutableDecls externalDecls functions params locals rhs
@@ -7786,6 +7833,27 @@ private def typedInterfaceCallReturnType?
   | [retTy] => pure (some retTy)
   | _ => pure none
 
+/-- True when `stx` is a typed interface call whose method is void (no returns
+    clause). Used to drop statement-position void calls from the executable
+    wrapper, where they have nothing to bind. -/
+private def isVoidTypedInterfaceCall?
+    (externalDecls : Array ExternalDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (stx : Term) : CommandElabM Bool := do
+  let some (target, methodName, _argTerms) := typedDotCallSyntax? stx
+    | pure false
+  let targetName ←
+    match stripParens target with
+    | `(term| $targetIdent:ident) => pure (toString targetIdent.getId)
+    | _ => pure ""
+  let some interfaceName := lookupInterfaceName? params locals targetName
+    | pure false
+  let externalName := interfaceExternalName interfaceName methodName
+  let some ext := externalDecls.find? (fun ext => ext.name == externalName)
+    | pure false
+  pure ext.returnTys.isEmpty
+
 mutual
 private partial def rewriteForEachExecutableDoSeq
     (externalDecls : Array ExternalDecl)
@@ -7874,6 +7942,13 @@ private partial def rewriteForEachExecutableDoElem
   | `(doElem| unsafe $_reason:str do $body:doSeq) =>
       let body ← rewriteForEachExecutableDoSeq externalDecls params locals body
       pure (#[← `(doElem| do $body)], locals)
+  | `(doElem| $stmt:term) =>
+      -- a void typed interface call in statement position is compiler-only;
+      -- drop it from the executable wrapper (it returns nothing to bind).
+      if (← isVoidTypedInterfaceCall? externalDecls params locals stmt) then
+        pure (#[← `(doElem| pure ())], locals)
+      else
+        pure (#[elem], locals)
   | other =>
       pure (#[other], locals)
 end


### PR DESCRIPTION
## Summary
- New `externalCallNoReturn` ECM (`Compiler/Modules/Calls.lean`): selector+args `call(...)` with failure-returndata bubbling, but `resultVars := []` and **no `returndatasize` check / no return decode**.
- Interface grammar (`Verity/Macro/Syntax.lean`): `function` with no `returns` clause (positional + named params).
- Elaboration (`Verity/Macro/Translate.lean`): a void method's selector is derived from params only (canonical signature unchanged); a statement-position void call lowers to the no-return ECM; `let x ← <void call>` is rejected; void calls are dropped from the executable wrapper.
- `returns (T)` interface methods (and their `externalCallWithReturn` lowering) are unchanged.

## Test Plan
- `lake build` green; self-contained `decide` smoke test in `Contracts/Smoke/InternalInterfaceSmoke.lean` (void method → `externalCallNoReturn`; non-void unchanged; two rejection cases) — no compiler-binary or infra dependency.
- Emitted Yul: void `supply`/`borrow` are bare `call(...)` (mainnet selectors `0x617ba037` / `0xa415bcad`) with no `returndatasize` check; `repay`/`withdraw` keep their decode.
- Downstream Foundry differential (separate consumer repo): deposit against VOID `supply`/`borrow` mocks completes; the pre-change strict bytecode reverts on the same void callees.
- Not run here: the full `FOUNDRY_PROFILE=difftest forge test` suite.

## Related Issues
Closes #1956. Complements #1953 / #1954 — together they let a dotted-interface contract with void external calls compile to Yul and run against real Aave.
