### PR TITLE
Integrate typed-interface compiler support

### DIFF
--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -840,7 +840,10 @@ def validateIdentifierShapes (spec : CompilationModel) : Except String Unit := d
   for err in spec.errors do
     ensureContractIdentifier "custom error" err.name
   for ext in spec.externals do
-    ensureContractIdentifier "external declaration" ext.name
+    -- dotted abi-interface externals (e.g. `IPool.supply`) lower by selector, never as a yul
+    -- identifier; the id-check applies only to object-linked externals. (fixes #1952)
+    unless ext.name.contains '.' do
+      ensureContractIdentifier "external declaration" ext.name
 
 private theorem ensureNonReservedYulIdentifier_ok
     {kind name : String}

--- a/Compiler/ModuleInput.lean
+++ b/Compiler/ModuleInput.lean
@@ -105,7 +105,10 @@ unsafe def loadSpecsFromModules (moduleNames : List Name) : IO (Except String (L
   let extraSearchRoots ← existingSplitPackageSearchRoots
   searchPathRef.set (originalSearchPath ++ extraSearchRoots)
   try
+    -- `loadExts := true` so `evalConstCheck` can evaluate specs that apply imported functions
+    -- (the `withReturnModule` ecm from typed-interface calls), not just inductive constructors. (#1951)
     let env ← Lean.importModules (moduleNames.toArray.map fun moduleName => { module := moduleName }) {}
+                (loadExts := true)
     let opts : Options := {}
     pure <| moduleNames.mapM (fun moduleName => evalSpecConst env opts (specNameOfModule moduleName))
   catch e =>

--- a/Compiler/Modules/Calls.lean
+++ b/Compiler/Modules/Calls.lean
@@ -142,12 +142,12 @@ def withReturn (resultVar : String) (target : Expr) (selector : Nat)
     - `numArgs`: number of ABI-encoded arguments (not counting target)
 
     Arguments passed to compile: [target] ++ argExprs -/
-def noReturnModule (selector : Nat) (numArgs : Nat)
+def noReturnModule (selector : Nat) (numArgs : Nat) (isStatic : Bool := false)
     : ExternalCallModule where
   name := "externalCallNoReturn"
   numArgs := 1 + numArgs  -- target + args
   resultVars := []
-  writesState := true
+  writesState := !isStatic
   readsState := true
   axioms := ["external_call_abi_interface"]
   compile := fun _ctx args => do
@@ -172,14 +172,21 @@ def noReturnModule (selector : Nat) (numArgs : Nat)
       YulExpr.call "add" [ptrExpr, YulExpr.lit frameSize]
     ])
     -- no output slice: return data is intentionally ignored
+    let opcode := if isStatic then "staticcall" else "call"
+    let callArgs :=
+      if isStatic then
+        [ YulExpr.call "gas" []
+        , targetExpr
+        , ptrExpr, YulExpr.lit calldataSize
+        , YulExpr.lit 0, YulExpr.lit 0 ]
+      else
+        [ YulExpr.call "gas" []
+        , targetExpr
+        , YulExpr.lit 0
+        , ptrExpr, YulExpr.lit calldataSize
+        , YulExpr.lit 0, YulExpr.lit 0 ]
     let callExpr :=
-      YulExpr.call "call" [
-        YulExpr.call "gas" [],
-        targetExpr,
-        YulExpr.lit 0,
-        ptrExpr, YulExpr.lit calldataSize,
-        YulExpr.lit 0, YulExpr.lit 0
-      ]
+      YulExpr.call opcode callArgs
     let letSuccess := YulStmt.let_ "__ecnr_success" callExpr
     -- bubble failure returndata exactly, like withReturnModule; but on success
     -- do NOT check returndatasize or decode a return value
@@ -191,8 +198,8 @@ def noReturnModule (selector : Nat) (numArgs : Nat)
     pure [YulStmt.block ([loadPtr, storeSelector] ++ storeArgs ++ [advancePtr, letSuccess, revertBlock])]
 
 /-- Convenience: create a `Stmt.ecm` for a void external call (no return). -/
-def noReturn (target : Expr) (selector : Nat) (args : List Expr) : Stmt :=
-  .ecm (noReturnModule selector args.length) ([target] ++ args)
+def noReturn (target : Expr) (selector : Nat) (args : List Expr) (isStatic : Bool := false) : Stmt :=
+  .ecm (noReturnModule selector args.length isStatic) ([target] ++ args)
 
 /-- Generic Solidity-style low-level value call with revert-data bubbling.
 

--- a/Compiler/Modules/Calls.lean
+++ b/Compiler/Modules/Calls.lean
@@ -127,6 +127,73 @@ def withReturn (resultVar : String) (target : Expr) (selector : Nat)
     (args : List Expr) (isStatic : Bool := false) : Stmt :=
   .ecm (withReturnModule resultVar selector args.length isStatic) ([target] ++ args)
 
+/-- Generic external call to a void (no-return) function.
+
+    Identical ABI-encoding and revert-forward-on-failure behaviour to
+    `withReturnModule`, but binds no result and performs no `returndatasize`
+    check or return decode. This is the ECM behind statement-position typed
+    interface calls whose method declares no return type (e.g. Aave V3
+    `supply`/`borrow`, which are `void`): such callees leave returndata empty,
+    so the strict 32-byte check in `withReturnModule` would revert *after* the
+    callee already ran and committed state.
+
+    The module is parameterized by:
+    - `selector`: the 4-byte function selector
+    - `numArgs`: number of ABI-encoded arguments (not counting target)
+
+    Arguments passed to compile: [target] ++ argExprs -/
+def noReturnModule (selector : Nat) (numArgs : Nat)
+    : ExternalCallModule where
+  name := "externalCallNoReturn"
+  numArgs := 1 + numArgs  -- target + args
+  resultVars := []
+  writesState := true
+  readsState := true
+  axioms := ["external_call_abi_interface"]
+  compile := fun _ctx args => do
+    let targetExpr ← match args.head? with
+      | some t => pure t
+      | none => throw "externalCallNoReturn expects at least 1 argument (target)"
+    let argExprs := args.drop 1
+    let selectorExpr := YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex selector]
+    let ptrName := "__ecnr_ptr"
+    let ptrExpr := YulExpr.ident ptrName
+    let storeSelector := YulStmt.expr (YulExpr.call "mstore" [ptrExpr, selectorExpr])
+    let storeArgs := argExprs.zipIdx.map fun (argExpr, i) =>
+      YulStmt.expr (YulExpr.call "mstore" [
+        YulExpr.call "add" [ptrExpr, YulExpr.lit (4 + i * 32)],
+        argExpr
+      ])
+    let calldataSize := 4 + numArgs * 32
+    let frameSize := ((Nat.max calldataSize 32 + 31) / 32) * 32
+    let loadPtr := YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
+    let advancePtr := YulStmt.expr (YulExpr.call "mstore" [
+      YulExpr.lit freeMemoryPointer,
+      YulExpr.call "add" [ptrExpr, YulExpr.lit frameSize]
+    ])
+    -- no output slice: return data is intentionally ignored
+    let callExpr :=
+      YulExpr.call "call" [
+        YulExpr.call "gas" [],
+        targetExpr,
+        YulExpr.lit 0,
+        ptrExpr, YulExpr.lit calldataSize,
+        YulExpr.lit 0, YulExpr.lit 0
+      ]
+    let letSuccess := YulStmt.let_ "__ecnr_success" callExpr
+    -- bubble failure returndata exactly, like withReturnModule; but on success
+    -- do NOT check returndatasize or decode a return value
+    let revertBlock := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__ecnr_success"]) [
+      YulStmt.let_ "__ecnr_rds" (YulExpr.call "returndatasize" []),
+      YulStmt.expr (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__ecnr_rds"]),
+      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__ecnr_rds"])
+    ]
+    pure [YulStmt.block ([loadPtr, storeSelector] ++ storeArgs ++ [advancePtr, letSuccess, revertBlock])]
+
+/-- Convenience: create a `Stmt.ecm` for a void external call (no return). -/
+def noReturn (target : Expr) (selector : Nat) (args : List Expr) : Stmt :=
+  .ecm (noReturnModule selector args.length) ([target] ++ args)
+
 /-- Generic Solidity-style low-level value call with revert-data bubbling.
 
     This models the common wrapper:

--- a/Contracts/Smoke/InternalInterfaceSmoke.lean
+++ b/Contracts/Smoke/InternalInterfaceSmoke.lean
@@ -95,6 +95,97 @@ example :
           | _ => false)) = true := by
   decide
 
+-- Void (no-`returns`) interface methods lower to the no-output `externalCallNoReturn` ECM:
+-- a selector+args `call(...)` that bubbles failure returndata but performs no `returndatasize`
+-- check and binds no result. This is what real void callees (e.g. Aave V3 `supply`/`borrow`,
+-- ERC20 `approve` in OZ's no-return variant) need; the strict `externalCallWithReturn` ECM would
+-- otherwise revert after the callee already ran. The selector is computed from the params only, so
+-- a void method's canonical signature matches its non-void counterpart exactly.
+verity_contract VoidInterfaceCallSmoke where
+  storage
+
+  interfaces
+    interface IPool where
+      function supply(Address, Uint256, Address, Uint16)
+      function balanceOf(Address) view returns (Uint256)
+    end
+
+  -- statement-position call to a void method → no-output ECM
+  function doSupply (pool : IPool, asset : Address, amount : Uint256, onBehalfOf : Address) : Unit := do
+    pool.supply asset amount onBehalfOf 0
+
+  -- a non-void method on the same interface still binds and return-checks as before
+  function readBal (pool : IPool, owner : Address) : Uint256 := do
+    let bal ← pool.balanceOf owner
+    return bal
+
+-- the void method is recorded as an external with no return type
+example :
+    (VoidInterfaceCallSmoke.spec.externals).any (fun ext =>
+      ext.name == "IPool.supply" && ext.returns.isEmpty && ext.returnType.isNone) = true := by
+  decide
+
+-- `supply` lowers to the void ECM: `externalCallNoReturn`, no result vars, writes state,
+-- 5 args (pool + asset, amount, onBehalfOf, referralCode).
+example :
+    (VoidInterfaceCallSmoke.spec.functions).any (fun fn =>
+      fn.name == "doSupply" &&
+        fn.body.any (fun stmt =>
+          match stmt with
+          | Compiler.CompilationModel.Stmt.ecm mod args =>
+              mod.name == "externalCallNoReturn" &&
+                mod.numArgs == 5 &&
+                mod.resultVars == [] &&
+                mod.writesState &&
+                args.length == 5
+          | _ => false)) = true := by
+  decide
+
+-- the non-void method on the same interface is unaffected: still `externalCallWithReturn`,
+-- binds its result, performs the 32-byte returndata check.
+example :
+    (VoidInterfaceCallSmoke.spec.functions).any (fun fn =>
+      fn.name == "readBal" &&
+        fn.body.any (fun stmt =>
+          match stmt with
+          | Compiler.CompilationModel.Stmt.ecm mod args =>
+              mod.name == "externalCallWithReturn" &&
+                mod.resultVars == ["bal"] &&
+                args.length == 2
+          | _ => false)) = true := by
+  decide
+
+/--
+error: interface call returns Verity.Macro.ValueType.uint256; bind it with `let ... ← ...`
+-/
+#guard_msgs in
+verity_contract VoidCallBindNonVoidAsStmtRejected where
+  storage
+
+  interfaces
+    interface IPool where
+      function balanceOf(Address) view returns (Uint256)
+    end
+
+  function bad (pool : IPool, owner : Address) : Unit := do
+    pool.balanceOf owner
+
+/--
+error: interface call 'b' binds a void method; call it as a statement, not `let ... ←`
+-/
+#guard_msgs in
+verity_contract VoidCallLetBindVoidRejected where
+  storage
+
+  interfaces
+    interface IPool where
+      function supply(Address, Uint256, Address, Uint16)
+    end
+
+  function bad (pool : IPool, asset : Address, amount : Uint256, onBehalfOf : Address) : Unit := do
+    let b ← pool.supply asset amount onBehalfOf 0
+    pure ()
+
 /--
 error: interface name 'Clash' conflicts with an existing type name
 -/

--- a/Contracts/Smoke/InternalInterfaceSmoke.lean
+++ b/Contracts/Smoke/InternalInterfaceSmoke.lean
@@ -155,6 +155,32 @@ example :
           | _ => false)) = true := by
   decide
 
+verity_contract VoidViewInterfaceCallSmoke where
+  storage
+
+  interfaces
+    interface IHook where
+      function ping(Address) view
+    end
+
+  function pingHook (hook : IHook, account : Address) : Unit := do
+    hook.ping account
+
+example :
+    (VoidViewInterfaceCallSmoke.spec.functions).any (fun fn =>
+      fn.name == "pingHook" &&
+        fn.body.any (fun stmt =>
+          match stmt with
+          | Compiler.CompilationModel.Stmt.ecm mod args =>
+              mod.name == "externalCallNoReturn" &&
+                mod.numArgs == 2 &&
+                mod.resultVars == [] &&
+                mod.readsState &&
+                !mod.writesState &&
+                args.length == 2
+          | _ => false)) = true := by
+  decide
+
 /--
 error: interface call returns Verity.Macro.ValueType.uint256; bind it with `let ... ← ...`
 -/
@@ -185,6 +211,21 @@ verity_contract VoidCallLetBindVoidRejected where
   function bad (pool : IPool, asset : Address, amount : Uint256, onBehalfOf : Address) : Unit := do
     let b ← pool.supply asset amount onBehalfOf 0
     pure ()
+
+/--
+error: void typed interface call 'IPool.submit' currently supports only static single-word parameters; argument 1 has Verity.Macro.ValueType.bytes
+-/
+#guard_msgs in
+verity_contract VoidCallDynamicParamRejected where
+  storage
+
+  interfaces
+    interface IPool where
+      function submit(Bytes)
+    end
+
+  function bad (pool : IPool, payload : Bytes) : Unit := do
+    pool.submit payload
 
 /--
 error: interface name 'Clash' conflicts with an existing type name

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -75,6 +75,11 @@ syntax "function " ident "(" sepBy(term, ",") ")" verityMutability* ident "(" se
 syntax "function " ident " (" sepBy(term, ",") ")" verityMutability* ident "(" sepBy(term, ",") ")" : verityInterfaceFunction
 syntax "function " ident "(" sepBy(verityInterfaceParam, ",") ")" verityMutability* ident "(" sepBy(term, ",") ")" : verityInterfaceFunction
 syntax "function " ident " (" sepBy(verityInterfaceParam, ",") ")" verityMutability* ident "(" sepBy(term, ",") ")" : verityInterfaceFunction
+-- void interface methods: no returns clause (e.g. aave supply/borrow are `void`)
+syntax "function " ident "(" sepBy(term, ",") ")" verityMutability* : verityInterfaceFunction
+syntax "function " ident " (" sepBy(term, ",") ")" verityMutability* : verityInterfaceFunction
+syntax "function " ident "(" sepBy(verityInterfaceParam, ",") ")" verityMutability* : verityInterfaceFunction
+syntax "function " ident " (" sepBy(verityInterfaceParam, ",") ")" verityMutability* : verityInterfaceFunction
 syntax "interface " ident " where " verityInterfaceFunction* "end" : verityInterface
 syntax ident " := " ident ppSpace str : verityLocalObligation
 syntax "local_obligations " "[" sepBy(verityLocalObligation, ",") "]" : verityLocalObligations

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1261,8 +1261,9 @@ private def parseInterfaceFunction
   let expectReturnsMarker (marker : Ident) : CommandElabM Unit := do
     unless toString marker.getId == "returns" do
       throwErrorAt marker "expected 'returns'"
+  -- `returnTys?` is `none` for a void interface method (no returns clause).
   let parseParts (name : Ident) (params : Array ParamDecl)
-      (mods : TSyntaxArray `verityMutability) (returnTys : TSyntaxArray `term) := do
+      (mods : TSyntaxArray `verityMutability) (returnTys? : Option (TSyntaxArray `term)) := do
     let mut isView := false
     for mod in mods do
       match mod with
@@ -1271,11 +1272,16 @@ private def parseInterfaceFunction
             throwErrorAt mod "duplicate 'view' modifier"
           isView := true
       | _ => throwErrorAt mod "interface functions currently support only the optional `view` modifier"
-    let parsedReturns ← returnTys.mapM (valueTypeFromSyntax newtypes structDecls adtDecls)
-    if parsedReturns.isEmpty then
-      throwErrorAt stx "interface function returns clause must contain at least one return type"
-    if parsedReturns.size > 1 then
-      throwErrorAt stx "typed interface calls currently support exactly one return value"
+    let parsedReturns ←
+      match returnTys? with
+      | none => pure #[]
+      | some returnTys => do
+          let parsed ← returnTys.mapM (valueTypeFromSyntax newtypes structDecls adtDecls)
+          if parsed.isEmpty then
+            throwErrorAt stx "interface function returns clause must contain at least one return type"
+          if parsed.size > 1 then
+            throwErrorAt stx "typed interface calls currently support exactly one return value"
+          pure parsed
     pure {
       ident := name
       name := toString name.getId
@@ -1283,19 +1289,26 @@ private def parseInterfaceFunction
       returnTys := parsedReturns
       isView := isView
     }
+  -- positional (`(term, ...)`) params lower to synthetic arg0/arg1/... names.
+  let parsePositionalParams (paramTys : TSyntaxArray `term) : CommandElabM (Array ParamDecl) :=
+    paramTys.mapIdxM fun idx ty => do
+      pure {
+        ident := mkIdent (Name.mkSimple s!"arg{idx}")
+        name := s!"arg{idx}"
+        ty := ← valueTypeFromSyntax newtypes structDecls adtDecls ty
+      }
   match stx with
   | `(verityInterfaceFunction| function $name:ident ($[$params:verityInterfaceParam],*) $[$mods:verityMutability]* $returnsMarker:ident ($[$returnTys:term],*)) => do
       expectReturnsMarker returnsMarker
-      parseParts name (← params.mapM (parseInterfaceParam newtypes structDecls adtDecls)) mods returnTys
+      parseParts name (← params.mapM (parseInterfaceParam newtypes structDecls adtDecls)) mods (some returnTys)
   | `(verityInterfaceFunction| function $name:ident ($[$paramTys:term],*) $[$mods:verityMutability]* $returnsMarker:ident ($[$returnTys:term],*)) => do
       expectReturnsMarker returnsMarker
-      let parsedParams ← paramTys.mapIdxM fun idx ty => do
-        pure {
-          ident := mkIdent (Name.mkSimple s!"arg{idx}")
-          name := s!"arg{idx}"
-          ty := ← valueTypeFromSyntax newtypes structDecls adtDecls ty
-        }
-      parseParts name parsedParams mods returnTys
+      parseParts name (← parsePositionalParams paramTys) mods (some returnTys)
+  -- void forms: no returns clause
+  | `(verityInterfaceFunction| function $name:ident ($[$params:verityInterfaceParam],*) $[$mods:verityMutability]*) => do
+      parseParts name (← params.mapM (parseInterfaceParam newtypes structDecls adtDecls)) mods none
+  | `(verityInterfaceFunction| function $name:ident ($[$paramTys:term],*) $[$mods:verityMutability]*) => do
+      parseParts name (← parsePositionalParams paramTys) mods none
   | _ => throwErrorAt stx "invalid interface function declaration"
 
 private def parseInterface
@@ -6280,7 +6293,7 @@ private partial def resolveTypedInterfaceCall?
     (externalDecls : Array ExternalDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (stx : Term) : CommandElabM (Option (ExternalDecl × Term × Array Term × ValueType × Nat)) := do
+    (stx : Term) : CommandElabM (Option (ExternalDecl × Term × Array Term × Option ValueType × Nat)) := do
   let some (target, methodName, argTerms) := typedDotCallSyntax? stx
     | pure none
   let targetName ←
@@ -6299,11 +6312,13 @@ private partial def resolveTypedInterfaceCall?
     unless actualTy == expectedTy || (isNatLiteralTerm argTerm && numericLiteralCompatibleValueType expectedTy) do
       throwErrorAt argTerm
         s!"interface call '{interfaceName}.{methodName}' argument expects {renderValueType expectedTy}, got {renderValueType actualTy}"
+  -- the selector is computed from the params only, so a void method's canonical
+  -- signature is identical to its non-void counterpart (e.g. aave
+  -- `supply(address,uint256,address,uint16)`).
+  let selector := Compiler.keccak256_first_4_bytes (interfaceFunctionSignature methodName ext.params)
   match ext.returnTys.toList with
-  | [retTy] =>
-      let selector := Compiler.keccak256_first_4_bytes (interfaceFunctionSignature methodName ext.params)
-      pure (some (ext, target, argTerms, retTy, selector))
-  | [] => throwErrorAt stx s!"interface call '{interfaceName}.{methodName}' returns no values"
+  | [retTy] => pure (some (ext, target, argTerms, some retTy, selector))
+  | [] => pure (some (ext, target, argTerms, none, selector))  -- void interface method
   | _ => throwErrorAt stx s!"interface call '{interfaceName}.{methodName}' returns multiple values; typed dot calls currently support one return value"
 
 mutual
@@ -6457,9 +6472,12 @@ private partial def validateDoElemExprTypes
                         params errorDecls args.getElems
                   | _ => pure ()
                   match ← resolveTypedInterfaceCall? fields constDecls immutableDecls externalDecls params locals rhs with
-                  | some (_, _, _, retTy, _) =>
+                  | some (_, _, _, some retTy, _) =>
                       requireSupportedLocalBindingType name s!"local binding '{toString name.getId}'" retTy
                       pure <| locals.push (mkTypedLocal (toString name.getId) retTy)
+                  | some (_, _, _, none, _) =>
+                      -- void interface method: cannot bind its (empty) result
+                      throwErrorAt rhs s!"interface call '{toString name.getId}' binds a void method; call it as a statement, not `let ... ←`"
                   | none =>
                       let ty ← inferBindSourceType fields constDecls immutableDecls externalDecls functions params locals rhs
                       requireSupportedLocalBindingType name s!"local binding '{toString name.getId}'" ty
@@ -6674,6 +6692,15 @@ private partial def validateEffectStmtExprTypes
   | `(term| revertReturndata) =>
       pure ()
   | _ =>
+      -- a typed interface call in statement position is only valid when the
+      -- method is void; `resolveTypedInterfaceCall?` already validates arg
+      -- count and arg types.
+      match ← resolveTypedInterfaceCall? fields constDecls immutableDecls externalDecls params locals stx with
+      | some (_, _, _, none, _) => pure ()
+      | some (_, _, _, some retTy, _) =>
+          throwErrorAt stx
+            s!"interface call returns {renderValueType retTy}; bind it with `let ... ← ...`"
+      | none =>
       match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals stx with
       | some (fn, argTerms) =>
           ensureSupportsInternalHelperSpec stx fn
@@ -7171,6 +7198,23 @@ private def translateEffectStmt
           $(strTerm memberName)
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
   | _ =>
+      -- void typed interface call in statement position lowers to the
+      -- no-return ECM (selector + args call, failure-returndata bubbled, but
+      -- no returndatasize check and no return decode).
+      match ← resolveTypedInterfaceCall? fields constDecls immutableDecls externalDecls params locals stx with
+      | some (_, target, argTerms, none, selector) =>
+          let targetExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals target
+          let argExprs ← argTerms.mapM
+            (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+          `(Compiler.CompilationModel.Stmt.ecm
+              (Compiler.Modules.Calls.noReturnModule
+                $(natTerm selector)
+                $(natTerm argExprs.size))
+              [ $targetExpr, $[$argExprs],* ])
+      | some (_, _, _, some retTy, _) =>
+          throwErrorAt stx
+            s!"interface call returns {renderValueType retTy}; bind it with `let ... ← ...`"
+      | none =>
       match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals stx with
       | some (fn, argTerms) =>
           ensureSupportsInternalHelperSpec stx fn
@@ -7501,7 +7545,7 @@ private partial def translateDoElem
                           pure (#[(stmt)], locals.push (mkTypedLocal varName .uint256), mutableLocals)
                       | none =>
                           match ← resolveTypedInterfaceCall? fields constDecls immutableDecls externalDecls params locals rhs with
-                          | some (ext, target, argTerms, retTy, selector) =>
+                          | some (ext, target, argTerms, some retTy, selector) =>
                               let targetExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals target
                               let argExprs ← argTerms.mapM
                                 (translatePureExprWithTypes fields constDecls immutableDecls params locals)
@@ -7516,6 +7560,9 @@ private partial def translateDoElem
                                         [ $targetExpr, $[$argExprs],* ]))],
                                   locals.push (mkTypedLocal varName retTy),
                                   mutableLocals)
+                          | some (_, _, _, none, _) =>
+                              -- void interface method bound with `let ... ←`: not allowed
+                              throwErrorAt rhs s!"interface call '{varName}' binds a void method; call it as a statement, not `let ... ←`"
                           | none =>
                               let rhsExpr ← translateBindSource fields constDecls immutableDecls externalDecls functions params locals rhs
                               let ty ← inferBindSourceType fields constDecls immutableDecls externalDecls functions params locals rhs
@@ -7786,6 +7833,27 @@ private def typedInterfaceCallReturnType?
   | [retTy] => pure (some retTy)
   | _ => pure none
 
+/-- True when `stx` is a typed interface call whose method is void (no returns
+    clause). Used to drop statement-position void calls from the executable
+    wrapper, where they have nothing to bind. -/
+private def isVoidTypedInterfaceCall?
+    (externalDecls : Array ExternalDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (stx : Term) : CommandElabM Bool := do
+  let some (target, methodName, _argTerms) := typedDotCallSyntax? stx
+    | pure false
+  let targetName ←
+    match stripParens target with
+    | `(term| $targetIdent:ident) => pure (toString targetIdent.getId)
+    | _ => pure ""
+  let some interfaceName := lookupInterfaceName? params locals targetName
+    | pure false
+  let externalName := interfaceExternalName interfaceName methodName
+  let some ext := externalDecls.find? (fun ext => ext.name == externalName)
+    | pure false
+  pure ext.returnTys.isEmpty
+
 mutual
 private partial def rewriteForEachExecutableDoSeq
     (externalDecls : Array ExternalDecl)
@@ -7874,6 +7942,13 @@ private partial def rewriteForEachExecutableDoElem
   | `(doElem| unsafe $_reason:str do $body:doSeq) =>
       let body ← rewriteForEachExecutableDoSeq externalDecls params locals body
       pure (#[← `(doElem| do $body)], locals)
+  | `(doElem| $stmt:term) =>
+      -- a void typed interface call in statement position is compiler-only;
+      -- drop it from the executable wrapper (it returns nothing to bind).
+      if (← isVoidTypedInterfaceCall? externalDecls params locals stmt) then
+        pure (#[← `(doElem| pure ())], locals)
+      else
+        pure (#[elem], locals)
   | other =>
       pure (#[other], locals)
 end

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2697,6 +2697,14 @@ private def throwStructNonLeafProjectionError (stx : Term) : CommandElabM α :=
 private def renderValueType (ty : ValueType) : String :=
   reprStr ty
 
+private def requireNoReturnInterfaceStaticParams
+    (stx : Syntax) (externalName : String) (params : Array ValueType) : CommandElabM Unit := do
+  for h : i in [:params.size] do
+    let ty := params[i]
+    unless isSingleWordStaticValueType ty do
+      throwErrorAt stx
+        s!"void typed interface call '{externalName}' currently supports only static single-word parameters; argument {i + 1} has {renderValueType ty}"
+
 /-- verity#1849, G3: allow `Array <wordLike>` and `bytes` / `string` as
     external-call / event / custom-error argument types when the argument
     is a direct param reference. The lowering still happens through
@@ -6696,7 +6704,9 @@ private partial def validateEffectStmtExprTypes
       -- method is void; `resolveTypedInterfaceCall?` already validates arg
       -- count and arg types.
       match ← resolveTypedInterfaceCall? fields constDecls immutableDecls externalDecls params locals stx with
-      | some (_, _, _, none, _) => pure ()
+      | some (ext, _, _, none, _) => do
+          requireNoReturnInterfaceStaticParams stx ext.name ext.params
+          pure ()
       | some (_, _, _, some retTy, _) =>
           throwErrorAt stx
             s!"interface call returns {renderValueType retTy}; bind it with `let ... ← ...`"
@@ -7202,14 +7212,17 @@ private def translateEffectStmt
       -- no-return ECM (selector + args call, failure-returndata bubbled, but
       -- no returndatasize check and no return decode).
       match ← resolveTypedInterfaceCall? fields constDecls immutableDecls externalDecls params locals stx with
-      | some (_, target, argTerms, none, selector) =>
+      | some (ext, target, argTerms, none, selector) =>
+          requireNoReturnInterfaceStaticParams stx ext.name ext.params
           let targetExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals target
           let argExprs ← argTerms.mapM
             (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+          let isStaticTerm ← if ext.isView then `(true) else `(false)
           `(Compiler.CompilationModel.Stmt.ecm
               (Compiler.Modules.Calls.noReturnModule
                 $(natTerm selector)
-                $(natTerm argExprs.size))
+                $(natTerm argExprs.size)
+                $isStaticTerm)
               [ $targetExpr, $[$argExprs],* ])
       | some (_, _, _, some retTy, _) =>
           throwErrorAt stx

--- a/artifacts/macro_property_tests/PropertyVoidInterfaceCallSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyVoidInterfaceCallSmoke.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyVoidInterfaceCallSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/InternalInterfaceSmoke.lean
+ */
+contract PropertyVoidInterfaceCallSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("VoidInterfaceCallSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: doSupply has no unexpected revert
+    function testAuto_DoSupply_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("doSupply(address,address,uint256,address)", alice, alice, uint256(1), alice));
+        require(ok, "doSupply reverted unexpectedly");
+    }
+    // Property 2: TODO decode and assert `readBal` result
+    function testTODO_ReadBal_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("readBal(address,address)", alice, alice));
+        require(ok, "readBal reverted unexpectedly");
+        assertEq(ret.length, 32, "readBal ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/artifacts/macro_property_tests/PropertyVoidViewInterfaceCallSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyVoidViewInterfaceCallSmoke.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyVoidViewInterfaceCallSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/InternalInterfaceSmoke.lean
+ */
+contract PropertyVoidViewInterfaceCallSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("VoidViewInterfaceCallSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: pingHook has no unexpected revert
+    function testAuto_PingHook_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("pingHook(address,address)", alice, alice));
+        require(ok, "pingHook reverted unexpectedly");
+    }
+}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -50,6 +50,8 @@ lean_lib «PrintAxioms» where
 
 lean_exe «verity-compiler» where
   root := `Compiler.Main
+  -- interpreter eval of ecm/interface specs forces init/std decls (e.g. `UInt64.ofNatLT`). (#1951)
+  supportInterpreter := true
 
 lean_exe «verity-compiler-patched» where
   root := `Compiler.MainPatched

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -55,6 +55,8 @@ lean_exe «verity-compiler» where
 
 lean_exe «verity-compiler-patched» where
   root := `Compiler.MainPatched
+  -- interpreter eval of ecm/interface specs forces init/std decls (e.g. `UInt64.ofNatLT`). (#1951)
+  supportInterpreter := true
 
 lean_exe «difftest-interpreter» where
   root := `Contracts.Interpreter


### PR DESCRIPTION
Supersedes the non-Th0rgal compiler integration PRs while preserving their original commits:

- #1953: compiler loads env extensions + interpreter support for typed-interface/ECM contracts
- #1954: dotted ABI-interface external names are not validated as plain Yul identifiers
- #1957: void / empty-returndata typed-interface calls

Additional fix included here:

- Reject void typed-interface calls with dynamic params (`Bytes`, `String`, arrays, tuples/structs) until no-return lowering is backed by ABI-frame encoding. The current no-return ECM only encodes selector + static single-word args, so accepting dynamic params would silently generate the wrong calldata.

Validation:

```bash
lake build
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect external-call lowering and compiler spec evaluation for interface-heavy contracts; incorrect void vs return ECM choice could revert after successful calls or mis-encode calldata, though static-param rejection limits the worst cases.
> 
> **Overview**
> This PR wires **typed interface** compilation end-to-end: specs that use interface ECMs can be loaded and evaluated, and **void** interface methods (no `returns` clause) compile correctly instead of forcing the 32-byte return path.
> 
> **Compiler loading & validation:** Module import now uses `loadExts := true` so `evalConstCheck` can evaluate specs referencing ECM helpers like `withReturnModule`; `verity-compiler` executables enable `supportInterpreter` for the same reason. Identifier validation skips dotted ABI names such as `IPool.supply` because they are selector-based, not Yul identifiers.
> 
> **Void interface calls:** Syntax and translation accept interface functions without a returns clause. Statement-position void calls lower to new **`externalCallNoReturn`** ECM (ABI encode + call/staticcall, bubble failure returndata, no returndata size check or decode). Returning methods still use **`externalCallWithReturn`**. The macro rejects `let ... ←` on void methods, statement use of returning methods, and void calls with non-static single-word parameters until proper ABI-frame encoding exists.
> 
> **Tests:** Smoke contracts and generated Foundry property stubs cover void/state-changing and view void paths plus the new error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3779e1869829418b671f5dd0eda9b27750186564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->