### PR TITLE
Validate dotted externals by link mode

### DIFF
--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -772,6 +772,14 @@ def ensureContractIdentifier (kind name : String) : Except String Unit := do
   | .ok _ => pure ()
   | .error err => throw s!"Compilation error: {err}"
 
+private def ensureAbiInterfaceExternalIdentifier (name : String) : Except String Unit := do
+  match name.splitOn "." with
+  | [iface, method] => do
+      ensureContractIdentifier "external interface" iface
+      ensureContractIdentifier "external interface method" method
+  | _ =>
+      throw s!"Compilation error: external ABI declaration name must be '<Interface>.<method>': {name}"
+
 /-- Source identifiers that lower directly to Yul variables must avoid the
 compiler-reserved `__` prefix used by dispatch and scratch temporaries. -/
 private def ensureNonReservedYulIdentifier (kind name : String) : Except String Unit := do
@@ -840,9 +848,11 @@ def validateIdentifierShapes (spec : CompilationModel) : Except String Unit := d
   for err in spec.errors do
     ensureContractIdentifier "custom error" err.name
   for ext in spec.externals do
-    -- dotted abi-interface externals (e.g. `IPool.supply`) lower by selector, never as a yul
-    -- identifier; the id-check applies only to object-linked externals. (fixes #1952)
-    unless ext.name.contains '.' do
+    if ext.linkMode == .external && ext.name.contains '.' then
+      -- Dotted ABI-interface externals (e.g. `IPool.supply`) lower by selector, never
+      -- as a Yul identifier. Other external forms are linked/called by their name.
+      ensureAbiInterfaceExternalIdentifier ext.name
+    else
       ensureContractIdentifier "external declaration" ext.name
 
 private theorem ensureNonReservedYulIdentifier_ok

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -6431,7 +6431,7 @@ set_option maxRecDepth 4096 in
   expectTrue "macro locals and params shadow contract constants"
     MacroConstantSmoke.shadowedConstantModelPrefersLocalAndParamBindings
 
-/- Regression for lfglabs-dev/verity#1952. Identifier-shape validation must treat the two external
+/- Regression for lfglabs-dev/verity#1961. Identifier-shape validation must treat the two external
 forms differently: an ABI-boundary external derived from a typed `interface` carries a dotted
 `Interface.method` audit label (`IPool.supply`) that is lowered by selector and never emitted as a
 Yul identifier, so it must be accepted; an object-linked external's name is the Yul function
@@ -6468,6 +6468,21 @@ private def invalidObjectLinkedSpec : CompilationModel := {
   functions := []
 }
 
+private def dottedObjectLinkedSpec : CompilationModel := {
+  name := "DottedObjectLinkedExternal"
+  fields := []
+  «constructor» := none
+  externals := [
+    { name := "Poseidon.hash"
+      params := [ParamType.uint256]
+      returnType := some ParamType.uint256
+      returns := [ParamType.uint256]
+      axiomNames := []
+      linkMode := .objectLinked }
+  ]
+  functions := []
+}
+
 #eval! do
   expectTrue "dotted ABI-interface external names skip Yul identifier validation"
     (match validateIdentifierShapes dottedAbiInterfaceSpec with
@@ -6475,6 +6490,10 @@ private def invalidObjectLinkedSpec : CompilationModel := {
       | .error _ => false)
   expectTrue "object-linked external names still require valid Yul identifiers"
     (match validateIdentifierShapes invalidObjectLinkedSpec with
+      | .ok _ => false
+      | .error _ => true)
+  expectTrue "dotted object-linked external names are rejected"
+    (match validateIdentifierShapes dottedObjectLinkedSpec with
       | .ok _ => false
       | .error _ => true)
 


### PR DESCRIPTION
## Summary
- allow dotted external names only for ABI-boundary externals (`linkMode := .external`)
- validate dotted ABI labels as `<Interface>.<method>` instead of skipping identifier validation entirely
- add a regression proving dotted object-linked externals are rejected

Fixes #1961.

## Tests
- `lake build Compiler.CompilationModel.ValidationCalls`
- `lake env lean Compiler/CompilationModelFeatureTest.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time validation only in `validateIdentifierShapes`; may reject specs that incorrectly used dotted object-linked externals, which is intended.
> 
> **Overview**
> **External identifier validation** now branches on `linkMode` instead of treating any dotted name as exempt from normal checks.
> 
> For **`linkMode := .external`** ABI-interface labels (e.g. `IPool.supply`), dotted names are allowed and must match **`<Interface>.<method>`** with exactly one dot; both segments are checked with `ensureContractIdentifier`. For all other externals (including object-linked), the full name must still pass **external declaration** validation—so dotted object-linked names like `Poseidon.hash` are **rejected**.
> 
> Regression coverage in `ExternalNameValidationSmoke` is retargeted to **#1961** and adds a spec proving dotted object-linked externals fail `validateIdentifierShapes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2380de3a496c7dfd681de23013ddd24d2682f27a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->