### PR TITLE
feat(Core,Macro): add txOrigin as a let ← bind source

### DIFF
--- a/Compiler/CompilationModel/ExpressionCompile.lean
+++ b/Compiler/CompilationModel/ExpressionCompile.lean
@@ -183,6 +183,7 @@ def compileExpr (fields : List Field)
             | none => throw s!"Compilation error: unknown mapping field '{field}'"
   | Expr.caller => pure (YulExpr.call "caller" [])
   | Expr.contractAddress => pure (YulExpr.call "address" [])
+  | Expr.txOrigin => pure (YulExpr.call "origin" [])
   | Expr.chainid => pure (YulExpr.call "chainid" [])
   | Expr.extcodesize addr => do
       pure (YulExpr.call "extcodesize" [← compileExpr fields dynamicSource addr])

--- a/Compiler/CompilationModel/LogicalPurity.lean
+++ b/Compiler/CompilationModel/LogicalPurity.lean
@@ -65,7 +65,7 @@ partial def exprContainsCallLike (expr : Expr) : Bool :=
   | Expr.adtField _ _ _ _ _ =>
       false
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _ | Expr.storageArrayLength _
@@ -178,7 +178,7 @@ def exprContainsUnsafeLogicalCallLike (expr : Expr) : Bool :=
   | Expr.adtField _ _ _ _ _ =>
       false
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _ | Expr.storageArrayLength _

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -423,7 +423,7 @@ def validateScopedExprIdentifiers
       pure ()
   | Expr.adtField _ _ _ _ _ =>
       pure ()
-  | Expr.literal _ | Expr.storage _ | Expr.storageAddr _ | Expr.caller | Expr.contractAddress | Expr.chainid
+  | Expr.literal _ | Expr.storage _ | Expr.storageAddr _ | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid
   | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize =>
       pure ()

--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -435,6 +435,7 @@ def collectProxyUpgradeabilityMechanics (spec : CompilationModel) : List String 
 
 private partial def collectRuntimeIntrospectionExprMechanics : Expr → List String
   | .contractAddress => ["contractAddress"]
+  | .txOrigin => ["txOrigin"]
   | .chainid => ["chainid"]
   | .selfBalance => ["selfBalance"]
   | .blockNumber => ["blockNumber"]

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -580,6 +580,7 @@ inductive LowLevelMechanic where
   | tstore
   | rawLog
   | contractAddress
+  | txOrigin
   | chainid
   | selfBalance
   | blockNumber
@@ -610,6 +611,7 @@ def toReportString : LowLevelMechanic → String
   | .tstore => "tstore"
   | .rawLog => "rawLog"
   | .contractAddress => "contractAddress"
+  | .txOrigin => "txOrigin"
   | .chainid => "chainid"
   | .selfBalance => "selfBalance"
   | .blockNumber => "blockNumber"
@@ -716,6 +718,10 @@ inductive Expr
   | structMember2 (field : String) (key1 key2 : Expr) (memberName : String)
   | caller
   | contractAddress
+  /-- `tx.origin` — the EOA at the root of the call chain.  Lowers to
+      the EVM `origin()` opcode.  Distinct from `caller` whenever the
+      call passes through a contract intermediary. -/
+  | txOrigin
   | chainid
   | msgValue
   | selfBalance

--- a/Compiler/CompilationModel/UsageAnalysis.lean
+++ b/Compiler/CompilationModel/UsageAnalysis.lean
@@ -161,7 +161,7 @@ def exprUsesArrayElementKind (includePlain includeWord : Bool) : Expr → Bool
   | Expr.adtConstruct _ _ args => exprListUsesArrayElementKind includePlain includeWord args
   | Expr.adtField _ _ _ _ _ => false
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _
@@ -343,7 +343,7 @@ def exprUsesArrayElement : Expr → Bool
   | Expr.ite cond thenVal elseVal =>
       exprUsesArrayElement cond || exprUsesArrayElement thenVal || exprUsesArrayElement elseVal
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _
@@ -551,7 +551,7 @@ def exprUsesParamDynamicHeadWord : Expr → Bool
       exprUsesParamDynamicHeadWord c
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _
   | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _
@@ -695,7 +695,7 @@ def exprUsesMulDiv512 : Expr → Bool
       exprUsesMulDiv512 a || exprUsesMulDiv512 b || exprUsesMulDiv512 c
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _
   | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _
@@ -863,7 +863,7 @@ def exprUsesStorageArrayElement : Expr → Bool
   | Expr.adtConstruct _ _ args => exprListUsesStorageArrayElement args
   | Expr.adtField _ _ _ _ _ => false
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _ | Expr.storageArrayLength _
@@ -1030,7 +1030,7 @@ def exprUsesDynamicBytesEq : Expr → Bool
   | Expr.adtConstruct _ _ args => exprListUsesDynamicBytesEq args
   | Expr.adtField _ _ _ _ _ => false
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp
   | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _ | Expr.storageArrayLength _

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -253,6 +253,7 @@ def exprReadsStateOrEnv : Expr → Bool
   | Expr.structMember _ _ _ | Expr.structMember2 _ _ _ _ => true
   | Expr.caller => true
   | Expr.contractAddress => true
+  | Expr.txOrigin => true
   | Expr.chainid => true
   | Expr.extcodesize _ => true
   | Expr.msgValue => true
@@ -381,7 +382,7 @@ def exprWritesState : Expr → Bool
   -- Pure leaves: no state writes. Listed explicitly to avoid `_mutual.eq_def`
   -- heartbeat-ceiling failures when new constructors land.
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _
@@ -567,7 +568,7 @@ def exprHasUntrackableWrites : Expr → Bool
   -- Pure leaves: cannot write state. Listed explicitly to avoid
   -- `_mutual.eq_def` heartbeat-ceiling failures when new constructors land.
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _
@@ -730,7 +731,7 @@ def exprContainsExternalCall : Expr → Bool
   -- Pure leaves: no external call inside. Listed explicitly to avoid
   -- `_mutual.eq_def` heartbeat-ceiling failures when new constructors land.
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _
@@ -812,7 +813,7 @@ def exprMayContainExternalCall : Expr → Bool
   -- Pure leaves: no external call inside. Listed explicitly to avoid
   -- `_mutual.eq_def` heartbeat-ceiling failures when new constructors land.
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _
@@ -1165,7 +1166,7 @@ def exprWritesStateWithFunctionEffects
       exprWritesStateWithFunctionEffects effects index ||
         exprWritesStateWithFunctionEffects effects innerIndex
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.selfBalance
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _
   | Expr.memoryArrayLength _
@@ -1293,6 +1294,7 @@ def exprReadsStateOrEnvWithFunctionEffects
   | Expr.structMember _ _ _ | Expr.structMember2 _ _ _ _ => true
   | Expr.caller => true
   | Expr.contractAddress => true
+  | Expr.txOrigin => true
   | Expr.chainid => true
   | Expr.extcodesize _ => true
   | Expr.msgValue => true
@@ -1754,7 +1756,7 @@ def exprContainsAdtConstruct : Expr → Bool
   | Expr.externalCall _ args | Expr.internalCall _ args =>
       exprListContainsAdtConstruct args
   | Expr.dynamicBytesEq _ _ | Expr.literal _ | Expr.param _ | Expr.constructorArg _
-  | Expr.storage _ | Expr.storageAddr _ | Expr.caller | Expr.contractAddress
+  | Expr.storage _ | Expr.storageAddr _ | Expr.caller | Expr.contractAddress | Expr.txOrigin
   | Expr.chainid | Expr.msgValue | Expr.selfBalance | Expr.blockTimestamp | Expr.blockNumber
   | Expr.blobbasefee | Expr.calldatasize | Expr.returndataSize
   | Expr.localVar _

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -267,7 +267,7 @@ def validateInternalCallShapesInExpr
   -- land (e.g. verity#1832's `paramDynamicHeadWord`).
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _
   | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid
   | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize
@@ -543,7 +543,7 @@ def validateExternalCallTargetsInExpr
   -- land (e.g. verity#1832's `paramDynamicHeadWord`).
   | Expr.literal _ | Expr.param _ | Expr.constructorArg _
   | Expr.storage _ | Expr.storageAddr _
-  | Expr.caller | Expr.contractAddress | Expr.chainid
+  | Expr.caller | Expr.contractAddress | Expr.txOrigin | Expr.chainid
   | Expr.msgValue | Expr.selfBalance
   | Expr.blockTimestamp | Expr.blockNumber | Expr.blobbasefee
   | Expr.calldatasize | Expr.returndataSize

--- a/Compiler/CompilationModel/ValidationHelpers.lean
+++ b/Compiler/CompilationModel/ValidationHelpers.lean
@@ -50,6 +50,7 @@ def collectExprNames : Expr → List String
   | Expr.structMember2 field key1 key2 _ => field :: collectExprNames key1 ++ collectExprNames key2
   | Expr.caller => []
   | Expr.contractAddress => []
+  | Expr.txOrigin => []
   | Expr.chainid => []
   | Expr.extcodesize addr => collectExprNames addr
   | Expr.msgValue => []

--- a/Compiler/CompilationModel/ValidationInterop.lean
+++ b/Compiler/CompilationModel/ValidationInterop.lean
@@ -46,7 +46,7 @@ def validateInteropExpr (context : String) : Expr → Except String Unit
       validateInteropExpr context inSize
       validateInteropExpr context outOffset
       validateInteropExpr context outSize
-  | Expr.contractAddress | Expr.chainid | Expr.blobbasefee =>
+  | Expr.contractAddress | Expr.txOrigin | Expr.chainid | Expr.blobbasefee =>
       pure ()
   | Expr.extcodesize addr =>
       validateInteropExpr context addr

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -78,6 +78,12 @@ structure ContractState where
   storageArray : Nat → List Uint256  -- Dynamic-array storage grouped by base slot (#1571)
   sender : Address
   thisAddress : Address
+  -- `tx.origin` — the externally owned account that initiated the
+  -- top-level transaction.  Equal to `sender` when the contract is
+  -- called directly from an EOA; differs when a contract intermediary
+  -- forwards the call.  Defaults to `0` for backwards compatibility
+  -- with state literals that pre-date this field.
+  txOrigin : Address := 0
   msgValue : Uint256
   selfBalance : Uint256 := 0
   blockTimestamp : Uint256
@@ -102,6 +108,7 @@ def defaultState : ContractState where
   storageArray := fun _ => []
   sender := 0
   thisAddress := 0
+  txOrigin := 0
   msgValue := 0
   selfBalance := 0
   blockTimestamp := 0
@@ -538,6 +545,14 @@ def msgSender : Contract Address :=
 def contractAddress : Contract Address :=
   fun state => ContractResult.success state.thisAddress state
 
+/-- `tx.origin` — the EOA at the root of the call chain.  Distinct
+    from `msgSender`/`caller` when the call passes through a contract
+    intermediary.  ERC-4337 v0.9's `nonReentrant` modifier uses
+    `tx.origin == msg.sender` together with `extcodesize(msg.sender) ==
+    0` to reject every contract caller. -/
+def txOrigin : Contract Address :=
+  fun state => ContractResult.success state.txOrigin state
+
 def msgValue : Contract Uint256 :=
   fun state => ContractResult.success state.msgValue state
 
@@ -561,6 +576,9 @@ def chainid : Contract Uint256 :=
 
 @[simp] theorem contractAddress_run (state : ContractState) :
   contractAddress.run state = ContractResult.success state.thisAddress state := rfl
+
+@[simp] theorem txOrigin_run (state : ContractState) :
+  txOrigin.run state = ContractResult.success state.txOrigin state := rfl
 
 @[simp] theorem msgValue_run (state : ContractState) :
   msgValue.run state = ContractResult.success state.msgValue state := rfl

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -618,6 +618,7 @@ def contextAccessorBareName? (name : String) : Option String :=
   else if matchesBareName name "blockNumber" then some "blockNumber"
   else if matchesBareName name "blobbasefee" then some "blobbasefee"
   else if matchesBareName name "contractAddress" then some "contractAddress"
+  else if matchesBareName name "txOrigin" then some "txOrigin"
   else if matchesBareName name "chainid" then some "chainid"
   else none
 
@@ -1785,6 +1786,8 @@ partial def inferPureExprType
       throwPureContextAccessorError stx "chainid"
   | `(term| Verity.contractAddress) =>
       throwPureContextAccessorError stx "contractAddress"
+  | `(term| Verity.txOrigin) =>
+      throwPureContextAccessorError stx "txOrigin"
   | `(term| $id:ident) =>
       let name := toString id.getId
       match params.findSome? (fun p => if p.name == name then some p.ty else none)
@@ -2232,6 +2235,8 @@ partial def inferBindSourceType
       pure .uint256
   | `(term| contractAddress) | `(term| Verity.contractAddress) =>
       pure .address
+  | `(term| txOrigin) | `(term| Verity.txOrigin) =>
+      pure .address
   | `(term| tload $offset:term) => do
       requireWordLikeType offset "tload offset" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals offset)
       pure .uint256
@@ -2553,6 +2558,7 @@ partial def validateConstantBody
   | `(term| blobbasefee) | `(term| Verity.blobbasefee) =>
       throwNonCompileTimeConstantError stx "blobbasefee"
   | `(term| contractAddress) => throwNonCompileTimeConstantError stx "contractAddress"
+  | `(term| txOrigin) => throwNonCompileTimeConstantError stx "txOrigin"
   | `(term| chainid) => throwNonCompileTimeConstantError stx "chainid"
   | `(term| calldatasize) => throwNonCompileTimeConstantError stx "calldatasize"
   | `(term| returndataSize) => throwNonCompileTimeConstantError stx "returndataSize"
@@ -2922,6 +2928,8 @@ partial def translatePureExprWithTypes
       throwPureContextAccessorError stx "blobbasefee"
   | `(term| Verity.contractAddress) =>
       throwPureContextAccessorError stx "contractAddress"
+  | `(term| Verity.txOrigin) =>
+      throwPureContextAccessorError stx "txOrigin"
   | `(term| Verity.chainid) =>
       throwPureContextAccessorError stx "chainid"
   | `(term| $id:ident) =>
@@ -4426,6 +4434,8 @@ def translateBindSource
       `(Compiler.CompilationModel.Expr.blobbasefee)
   | `(term| contractAddress) | `(term| Verity.contractAddress) =>
       `(Compiler.CompilationModel.Expr.contractAddress)
+  | `(term| txOrigin) | `(term| Verity.txOrigin) =>
+      `(Compiler.CompilationModel.Expr.txOrigin)
   | `(term| chainid) | `(term| Verity.chainid) =>
       `(Compiler.CompilationModel.Expr.chainid)
   | `(term| tload $offset:term) =>

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 711,
+    "core_lines": 729,
     "example_contracts": 15
   },
   "proofs": {


### PR DESCRIPTION
## Summary

Adds `txOrigin : Contract Address` to the user-facing EDSL, lowered to the EVM `origin()` opcode. Mirrors the surface of the existing `msgSender` / `contractAddress` accessors.

## Why

ERC-4337 v0.9's `nonReentrant` modifier reads

```solidity
require(tx.origin == msg.sender && msg.sender.code.length == 0, Reentrancy());
```

Until this PR, faithful Verity translations could only model the second half (`extcodesize(msgSender) == 0`) — the first half had no surface in the EDSL, so the gap was documented as a residual trust assumption. The `lfglabs-dev/verity-benchmark` ERC-4337 case study tracks this in `TRUST_DIVERGENCES.md` (item 1b).

## Changes

- **`Verity/Core.lean`**: add `txOrigin : Address` to `ContractState`, default `0`; add `txOrigin : Contract Address` accessor + `@[simp]` reduction lemma, mirroring the existing `msgSender` / `contractAddress` pattern. The default `0` keeps every pre-existing `defaultState`-derived literal compiling unchanged.
- **`Verity/Macro/Translate.lean`**: recognise `txOrigin` / `Verity.txOrigin` as a context accessor name; type-infer to `.address` in `inferBindSourceType` and in the do-element codegen pass; lower to `Compiler.CompilationModel.Expr.txOrigin`.
- **`Compiler/CompilationModel/Types.lean`**: add `Expr.txOrigin` and `LowLevelMechanic.txOrigin` constructors, plus `toReportString` case.
- **`Compiler/CompilationModel/ExpressionCompile.lean`**: lower to `YulExpr.call \"origin\" []`.
- **Pattern-match completeness**: extend the alternation patterns in `UsageAnalysis`, `LogicalPurity`, `ValidationCalls`, `ScopeValidation`, `Validation`, `ValidationInterop`, `ValidationHelpers`, `TrustSurface` to include `Expr.txOrigin` alongside `Expr.contractAddress`.

## Verification

- `lake build` — full corpus green (verified locally).
- Downstream: `lfglabs-dev/verity-benchmark/Benchmark/Cases/ERC4337/EntryPointInvariant/EntryPointV09.lean` will replace its `extcodesize`-only guard with the faithful `tx.origin == msg.sender && extcodesize(msg.sender) == 0` once this lands. Removes one entry from that case's `TRUST_DIVERGENCES.md`.

## Test plan

- [x] `lake build` green on this branch
- [ ] Downstream verity-benchmark patched to use `txOrigin`; lake build + Foundry differential tests stay green (4/4)
- [ ] Reviewer to confirm pattern-match completeness in the eight `Compiler/CompilationModel/*.lean` files

## Out of scope

A separate proposed PR adds `contractAddress` as a `let ←` bind source — currently it already works upstream, but the Lean ambiguity with `Contracts.contractAddress` (in `Contracts/Common.lean`) bites users; recommendation is to namespace-qualify the macro patterns rather than introducing a new helper. Tracked in #1003.

The companion bigger features — compile-time `keccak256` over string literals, `revertError` with non-literal args, struct-array calldata decoding, bitfield-packed struct storage — are each substantial PRs and are tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical extension of an established accessor pattern; default txOrigin preserves backward compatibility and changes are limited to read-only transaction context, not auth or storage semantics.
> 
> **Overview**
> Adds **`txOrigin`** as a first-class EDSL context accessor for `tx.origin`, parallel to **`msgSender`** / **`contractAddress`**, so specs can express guards like ERC-4337 v0.9’s `tx.origin == msg.sender`.
> 
> **Runtime model:** `ContractState` gains **`txOrigin`** (default `0` for existing state literals), plus a **`txOrigin : Contract Address`** accessor and **`@[simp]`** reduction lemma in **`Verity/Core.lean`**.
> 
> **Macro / IR:** **`Verity/Macro/Translate/Expr.lean`** recognizes `txOrigin` / `Verity.txOrigin`, types it as address, blocks it in compile-time constant bodies, and lowers to **`Expr.txOrigin`**. **`Types.lean`** adds **`Expr.txOrigin`** and **`LowLevelMechanic.txOrigin`**; **`ExpressionCompile.lean`** emits Yul **`origin()`**.
> 
> **Compiler plumbing:** Pattern-match completeness updates across validation, usage analysis, logical purity, scope validation, trust surface (runtime introspection reporting), and related helpers treat **`Expr.txOrigin`** like other pure environment leaves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75096cd050315fa15db7f48e58c4f71bbf0c742b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->