### PR TITLE
feat(Macro): keccak256_lit in constants + pure if/then/else expressions

### DIFF
--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -2631,6 +2631,21 @@ partial def validateConstantBody
       validateConstantBody constDecls cond visiting *>
       validateConstantBody constDecls thenVal visiting *>
       validateConstantBody constDecls elseVal visiting
+  -- Native Lean `if cond then thenVal else elseVal` term.  Validated
+  -- the same way as `ite`; lowered identically in the corresponding
+  -- branch of `translatePureExprWithTypes`.
+  | `(term| if $cond:term then $thenVal:term else $elseVal:term) =>
+      validateConstantBody constDecls cond visiting *>
+      validateConstantBody constDecls thenVal visiting *>
+      validateConstantBody constDecls elseVal visiting
+  -- `Verity.keccak256_lit "literal"` / `keccak256_lit "literal"` —
+  -- compile-time Keccak-256 of a UTF-8 string literal.  Backed by the
+  -- in-tree Keccak engine (see `Verity/Macro/KeccakLit.lean`); no
+  -- runtime cost, deterministic at elaboration time.  Required for
+  -- EIP-712 type/name/version hashes to bind the *exact* strings
+  -- Solidity does, rather than opaque placeholder constants.
+  | `(term| Verity.keccak256_lit $_:str) => pure ()
+  | `(term| keccak256_lit $_:str) => pure ()
   | _ => throwErrorAt stx "unsupported expression in contract constant"
 
 partial def translateConstantExpr
@@ -2879,6 +2894,13 @@ partial def translatePureExprWithTypes
   match stx with
   | `(term| true) => `(Compiler.CompilationModel.Expr.literal 1)
   | `(term| false) => `(Compiler.CompilationModel.Expr.literal 0)
+  -- `Verity.keccak256_lit "literal"` / `keccak256_lit "literal"`:
+  -- elaborate the in-tree `keccak256_nat` at macro-expansion time and
+  -- emit the result as a `literal` constant.  Used for EIP-712 type
+  -- hashes, ERC-7201 storage namespaces, event topic constants, etc.
+  | `(term| Verity.keccak256_lit $s:str) | `(term| keccak256_lit $s:str) =>
+      let n := KeccakEngine.keccak256_str_nat s.getString
+      `(Compiler.CompilationModel.Expr.literal $(natTerm n))
   | `(term| constructorArg $idx:num) =>
       `(Compiler.CompilationModel.Expr.constructorArg $idx)
   | `(term| abiHeadWord $target:term $wordOffset:num) => do
@@ -3221,6 +3243,16 @@ partial def translatePureExprWithTypes
   | `(term| min $a $b) => `(Compiler.CompilationModel.Expr.min $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| max $a $b) => `(Compiler.CompilationModel.Expr.max $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| ite $cond $thenVal $elseVal) =>
+      `(Compiler.CompilationModel.Expr.ite
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals thenVal visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals elseVal visitingConstants))
+  -- Native Lean `if ... then ... else ...` term, equivalent to
+  -- `ite cond thenVal elseVal` for the macro lowering.  Lets contract
+  -- authors write idiomatic expressions like
+  -- `let x := if a > b then a else b` directly in `let :=` bindings,
+  -- without falling back to per-shape helper functions.
+  | `(term| if $cond:term then $thenVal:term else $elseVal:term) =>
       `(Compiler.CompilationModel.Expr.ite
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond visitingConstants)
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals thenVal visitingConstants)


### PR DESCRIPTION
## Summary

Two small additive macro features unblocking faithful contract translations.

### (c) `keccak256_lit` inside `constants` blocks

`Verity.keccak256_lit` already exists ([KeccakLit.lean](../blob/main/Verity/Macro/KeccakLit.lean)) but is rejected when used as a constant body — the validator only recognizes a hand-curated set of pure expressions. Adds the form to both `validateConstantBody` and `translatePureExprWithTypes` (lowering elaborates the string at macro-expansion time via `KeccakEngine.keccak256_str_nat`, emitting `Expr.literal n` — zero runtime cost).

**Unblocks** faithful EIP-712 type/name/version hashes. Today the ERC-4337 v0.9 case in `lfglabs-dev/verity-benchmark` ships opaque placeholders (\`EIP712_NAME_HASH := 0x7b8f...\` — not actually \`keccak256(\"ERC4337\")\`) and tracks the divergence in TRUST_DIVERGENCES.md. With this PR, the contract can write:

\`\`\`lean
constants
  EIP712_NAME_HASH    : Uint256 := (Verity.keccak256_lit \"ERC4337\")
  EIP712_VERSION_HASH : Uint256 := (Verity.keccak256_lit \"0.9.0\")
\`\`\`

### (g) Native Lean `if cond then thenVal else elseVal` as a pure expression

The macro already accepts `ite cond thenVal elseVal` but not the native Lean surface syntax. This has forced contract authors to spin off trivial helpers — the ERC-4337 case has ten such (\`_payerOf\`, \`_missingFunds\`, \`_postOpMode\`, \`_isEoaCaller\` predicate, ...) whose entire body is one conditional expression.

Adds the native syntax to `validateConstantBody` and `translatePureExprWithTypes`, lowered identically to the `ite` branch. Purely additive — existing `ite` callers are unaffected.

## Test plan

- [x] `lake build` green on this branch (full corpus, 122/122 modules)
- [ ] Downstream: \`lfglabs-dev/verity-benchmark\` ERC-4337 case will swap its \`EIP712_*_HASH\` placeholder constants for real \`keccak256_lit\` calls, and inline the ten \`_payerOf\` / \`_missingFunds\` / \`_postOpMode\` helpers back into their call sites. Closes TRUST_DIVERGENCES.md item 14c and removes ~30 lines of macro-workaround boilerplate.

## Closes / contributes to

- Solves item (c) from the ERC-4337 v0.9 case study's Verity-feature wishlist (compile-time keccak256 over string literals).
- Solves item (g) (\`if/then/else\` as a pure expression in \`let :=\`).
- Companion to merged #1972 (\`txOrigin\`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to macro validation/lowering in `Expr.lean`, mirror existing `ite` and in-tree Keccak paths, and only widen accepted syntax without altering runtime semantics.
> 
> **Overview**
> Extends the contract macro’s pure-expression pipeline in `Expr.lean` with two **additive** surface forms.
> 
> **`keccak256_lit` / `Verity.keccak256_lit`** is now allowed in `constants` bodies and in general pure translation: validation accepts string-literal forms, and lowering runs `KeccakEngine.keccak256_str_nat` at macro expansion and emits `Expr.literal` (same compile-time path as existing Keccak helpers, no runtime hash).
> 
> **Native `if cond then thenVal else elseVal`** is wired through `validateConstantBody` and `translatePureExprWithTypes` with the same rules and **`Expr.ite`** lowering as the existing `ite` macro; `ite` callers are unchanged.
> 
> Together this lets contract authors use real EIP-712-style string hashes in constants and idiomatic conditionals in `let :=` without one-off helper shims.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 595b64fc2b858f0a10a4f094f6dacd8c0275882e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->