### PR TITLE
docs: add docstring to parse_args function

### DIFF
--- a/scripts/check_macro_health.py
+++ b/scripts/check_macro_health.py
@@ -9,6 +9,15 @@ import check_macro_property_test_generation
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for macro-health checks.
+
+    Args:
+        argv: List of command-line arguments. Defaults to None, which
+            uses sys.argv[1:].
+
+    Returns:
+        argparse.Namespace object containing parsed arguments.
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--skip-property-tests", action="store_true")
     return parser.parse_args(argv)


### PR DESCRIPTION
### 问题背景
公共函数 `parse_args` 在 `scripts/check_macro_health.py` 中缺少 docstring。这降低了代码的可读性和维护性，特别是在开源项目中，清晰的文档对于新贡献者和用户至关重要。

### 修改内容
- **修改了什么**: 为 `parse_args` 函数添加了详细的 docstring，包括函数描述、参数说明和返回值信息。
- **为什么这样改**: 遵循 Python 最佳实践和仓库的文档标准，增强代码的自解释性，使其更易于理解和维护。
- **对代码质量的提升**: 提高代码可读性，方便开发者快速理解函数的目的和用法，从而减少潜在的错误和提升开发效率。

### 验证方式
- 由于修改仅限于 docstring，没有改变代码逻辑，所有现有测试应继续通过。
- 可以手动验证：检查文件格式正确，docstring 内容准确且与函数行为一致。

### 其他信息
- 没有 breaking changes。
- 不需要更新外部文档，因为这是内部代码文档的改进。
- 没有已知限制。