### PR TITLE
fix(Macro): keccak256_lit also needs a type-inference case

### DIFF
--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -2076,6 +2076,12 @@ partial def inferPureExprType
       requireWordLikeType key1 "structMember2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key1 visitingConstants)
       requireWordLikeType key2 "structMember2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key2 visitingConstants)
       pure memberDecl.ty
+  -- `Verity.keccak256_lit "literal"` / `keccak256_lit "literal"` —
+  -- compile-time Keccak-256 of a UTF-8 string literal.  Always
+  -- `.uint256` (the hash is 256 bits, fits exactly).  Validated +
+  -- lowered to `Expr.literal n` later in the same file.
+  | `(term| Verity.keccak256_lit $_:str) | `(term| keccak256_lit $_:str) =>
+      pure .uint256
   | _ =>
       match qualifiedFunctionAppSyntax? stx with
       | some (fnName, _) =>


### PR DESCRIPTION
Follow-up to #1978. Adds the missing `inferPureExprType` case for `Verity.keccak256_lit "..."` / `keccak256_lit "..."` so it can be used inside `constants` blocks (or any pure-expression position). Without this, the contract macro rejects `(Verity.keccak256_lit "ERC4337")` with 'unsupported expression in verity_contract body (#1003)' because type inference runs before the constant-body validator. `lake build` green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single macro pattern match in type inference; behavior matches existing keccak256_lit validation and lowering with no runtime or security impact.
> 
> **Overview**
> Adds a **`inferPureExprType`** match for **`Verity.keccak256_lit "…"`** and unqualified **`keccak256_lit "…"`**, returning **`.uint256`**, so compile-time Keccak literals type-check in pure positions (e.g. **`constants`** blocks) before constant-body validation runs.
> 
> Without this arm, those forms were treated like unsupported **`Verity.*`** calls during inference and failed with the generic #1003 error even though validation and lowering for the same syntax already exist elsewhere in **`Expr.lean`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9462ebe00652ce74364205697e94b67d87f56532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->