### PR TITLE
feat(Macro): support multi-parameter verity_intrinsic declarations

### DIFF
--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -152,14 +152,32 @@ def elabVerityContract : CommandElab := fun stx => do
 @[command_elab verityIntrinsicCmd]
 def elabVerityIntrinsic : CommandElab := fun stx => do
   match stx with
-  | `(verity_intrinsic $name:ident ($paramName:ident : $paramTy:term) : $retTy:term
+  | `(verity_intrinsic $name:ident ( $[$params:verityParam],* ) : $retTy:term
         where $pureKw:ident; yul := $yul:verityIntrinsicYul; min_fork := $fork:ident;
         semantics := $semantics:term; obligation [ $[$obligations:verityIntrinsicObligation],* ]) => do
       unless toString pureKw.getId == "pure" do
         throwErrorAt pureKw "verity_intrinsic currently supports only pure intrinsics"
+      -- Destructure each `verityParam` into (name, type) — accepts any
+      -- non-zero arity.  The syntax category at the parser level
+      -- (`sepBy(verityParam, ",")`) has always accepted multiple
+      -- params; this elaborator now matches the parser shape instead
+      -- of hard-coding a single param.
+      if params.isEmpty then
+        throwErrorAt stx "verity_intrinsic requires at least one parameter"
+      let parsedParams ← params.mapM fun p => do
+        match p with
+        | `(verityParam| $pn:ident : $pt:term) => pure (pn, pt)
+        | _ => throwErrorAt p "expected `name : Type`"
+      let paramNamesStr := parsedParams.toList.map (fun (pn, _) => toString pn.getId)
+      let paramTypesStr := parsedParams.toList.map (fun (_, pt) => toString pt)
       let yulLowering ←
         match yul with
         | `(verityIntrinsicYul| verbatim $inArity:num $outArity:num (hex $opcode:str)) =>
+            -- Sanity-check: declared param count matches Yul opcode
+            -- input arity, so consumers can't ship a mismatched stub.
+            unless inArity.getNat == params.size do
+              throwErrorAt inArity
+                s!"verbatim Yul lowering declares {inArity.getNat} input(s) but intrinsic has {params.size} parameter(s)"
             pure <| Verity.Core.Intrinsics.YulLowering.verbatim
               inArity.getNat outArity.getNat opcode.getString
         | `(verityIntrinsicYul| builtin $builtin:str) =>
@@ -180,8 +198,8 @@ def elabVerityIntrinsic : CommandElab := fun stx => do
       let nameStr := toString name.getId
       let decl : Verity.Core.Intrinsics.IntrinsicDecl := {
         name := nameStr,
-        paramNames := [toString paramName.getId],
-        paramTypes := [toString paramTy],
+        paramNames := paramNamesStr,
+        paramTypes := paramTypesStr,
         returnType := toString retTy,
         isPure := true,
         yul := yulLowering,
@@ -190,7 +208,11 @@ def elabVerityIntrinsic : CommandElab := fun stx => do
         sourceHint := some "elabVerityIntrinsic"
       }
       liftIO <| Verity.Macro.registerIntrinsic decl
-      let wrapperCmd ← `(command| def $name:ident : $paramTy -> $retTy := $semantics)
+      -- Build the curried function type `T1 → T2 → ... → Tn → R`.
+      let funcTy ← parsedParams.foldrM
+        (fun (_, pt) acc => `($pt -> $acc))
+        (← `($retTy))
+      let wrapperCmd ← `(command| def $name:ident : $funcTy := $semantics)
       elabCommand wrapperCmd
       let obligationSummaryName : Ident :=
         ⟨mkIdent (name.getId.appendAfter "_intrinsic_obligations")⟩
@@ -200,6 +222,6 @@ def elabVerityIntrinsic : CommandElab := fun stx => do
       elabCommand obligationCmd
   | _ =>
       throwErrorAt stx
-        "unsupported verity_intrinsic declaration; expected one parameter, yul, min_fork, semantics, and obligation clauses"
+        "unsupported verity_intrinsic declaration; expected `verity_intrinsic name (p1 : T1, ..., pn : Tn) : R where ...`"
 
 end Verity.Macro


### PR DESCRIPTION
## Summary

The `verity_intrinsic` command elaborator hard-coded a single `name : Type` parameter, so any intrinsic with more than one input arg (e.g. the keccak256-shaped intrinsics needed by the ERC-4337 benchmark) had to be hand-rolled.

The parser (`sepBy(verityParam, ",")`) and the registered `IntrinsicDecl` shape already supported arbitrary arity — only the elaborator was out of sync.

## Changes

* Match the parser shape via `$[$params:verityParam],*`.
* Reject the zero-arg case with a clear error.
* Sanity-check that the Yul `verbatim` lowering's declared input arity matches the number of intrinsic parameters (catches stubs that would otherwise silently miscompile).
* Build the curried function type `T1 -> T2 -> ... -> Tn -> R` for the generated wrapper definition.

`lake build` green.

## Why this is safe

The change is elaborator-only: the parser, the registered `IntrinsicDecl` record, and all existing `verity_intrinsic` call sites are untouched. Single-arg intrinsics elaborate to the same wrapper shape as before (`def name : T -> R := semantics`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Macro elaborator-only change; existing single-arg sites and `IntrinsicDecl` consumers are unchanged, with added compile-time arity validation for verbatim Yul.
> 
> **Overview**
> The **`verity_intrinsic` elaborator** now matches the parser’s comma-separated parameter list instead of assuming a single `(name : Type)` argument.
> 
> It **parses any non-empty parameter list** into `IntrinsicDecl.paramNames` / `paramTypes`, **rejects zero parameters**, and for **`verbatim` Yul lowerings** requires the declared input arity to equal the number of parameters. The generated wrapper **`def`** uses a **curried** type `T1 → … → Tn → R` built from those types. Single-parameter intrinsics should elaborate the same as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e4cedf4292dc7348156308402691502f42130ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->