### PR TITLE
feat(ERC20): add legacyStringSafe* modules for explicit Morpho-style string-error SafeTransferLib support

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -217,6 +217,8 @@ call-buffer-disjoint-from-heap theorem live at `Verity.EVM.Layout`.
 | `ERC20.safeApprove` | `erc20_approve_interface` | Target implements ERC-20 `approve(address,uint256)` |
 | `ERC20.solmateSafeTransfer` | `erc20_solmate_safe_transfer_interface` | Target implements ERC-20 `transfer(address,uint256)`; optional-return acceptance follows Solmate SafeTransferLib |
 | `ERC20.solmateSafeTransferFrom` | `erc20_solmate_safe_transferFrom_interface` | Target implements ERC-20 `transferFrom(address,address,uint256)`; optional-return acceptance follows Solmate SafeTransferLib |
+| `ERC20.legacyStringSafeTransfer` | `erc20_legacy_string_safe_transfer_interface` | Target implements ERC-20 `transfer(address,uint256)`; uses legacy string `Error("...")` reverts + extcodesize check (Morpho-style) |
+| `ERC20.legacyStringSafeTransferFrom` | `erc20_legacy_string_safe_transferFrom_interface` | Target implements ERC-20 `transferFrom(address,address,uint256)`; uses legacy string `Error("...")` reverts + extcodesize check (Morpho-style) |
 | `ERC20.balanceOf` | `erc20_balanceOf_interface` | Target implements `balanceOf(address)` and returns a `uint256` |
 | `ERC20.allowance` | `erc20_allowance_interface` | Target implements `allowance(address,address)` and returns a `uint256` |
 | `ERC20.totalSupply` | `erc20_totalSupply_interface` | Target implements `totalSupply()` and returns a `uint256` |

--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -780,6 +780,7 @@ private def boundaryClassFromModule (mod : ECM.ExternalCallModule) : String :=
       "callback"
   | "safeTransfer" | "safeTransferFrom" | "safeApprove"
   | "solmateSafeTransfer" | "solmateSafeTransferFrom"
+  | "legacyStringSafeTransfer" | "legacyStringSafeTransferFrom"
   | "balanceOf" | "allowance" | "totalSupply"
   | "previewDeposit" | "previewMint" | "previewWithdraw" | "previewRedeem"
   | "convertToAssets" | "convertToShares" | "totalAssets" | "asset"

--- a/Compiler/Modules/ERC20.lean
+++ b/Compiler/Modules/ERC20.lean
@@ -1,21 +1,29 @@
 /-
   Compiler.Modules.ERC20: ERC-20 Token Interaction Modules
 
-  Standard ECMs for safe ERC-20 token operations:
-  - `safeTransfer`:     transfer(address,uint256)       selector 0xa9059cbb
-  - `safeTransferFrom`: transferFrom(address,address,uint256) selector 0x23b872dd
-  - `safeApprove`:      approve(address,uint256)        selector 0x095ea7b3
-  - `solmateSafeTransfer` / `solmateSafeTransferFrom`: Solmate SafeTransferLib
-    optional-return semantics for projects that need exact Solmate parity
-  - `balanceOf`:        balanceOf(address)              selector 0x70a08231
-  - `allowance`:        allowance(address,address)      selector 0xdd62ed3e
-  - `totalSupply`:      totalSupply()                   selector 0x18160ddd
+  Standard ECMs for safe ERC-20 token operations. Three explicit, named styles
+  are provided because different projects in the ecosystem chose different
+  observable behaviors on failure:
 
-  The OpenZeppelin-style write modules accept exactly one ABI bool word equal to
-  true, or no returndata from a contract address. The Solmate write modules
-  accept no returndata, or the first returned word equal to true when at least
-  32 bytes were returned. Both variants bubble failed-call returndata before
-  checking the optional bool.
+  - `safeTransfer` / `safeTransferFrom` / `safeApprove`:
+      OpenZeppelin v5 style. Reverts with `SafeERC20FailedOperation(address)`
+      custom error on bad cases. Requires code at the token for empty-return paths.
+
+  - `solmateSafeTransfer` / `solmateSafeTransferFrom`:
+      Solmate SafeTransferLib style. Accepts empty returndata without extcodesize
+      check; accepts first word == true when returndatasize > 31. Bubbles inner
+      returndata on call failure.
+
+  - `legacyStringSafeTransfer` / `legacyStringSafeTransferFrom`:
+      Legacy string-error style (exact match for Morpho Blue's SafeTransferLib
+      and some other older custom SafeTransferLib implementations).
+      Always checks extcodesize, reverts with classic `Error("no code")`,
+      `Error("transfer reverted")`, `Error("transfer returned false")` etc.
+      Does not bubble inner returndata on call failure.
+
+  The typed-interface helpers (e.g. `safeTransfer token ...` when `token : IERC20`)
+  will route to the appropriate underlying module. For the legacy string style,
+  use the `legacyStringSafe*` helpers with a typed interface parameter.
 
   Trust assumption: the target address implements the ERC-20 interface
   (or is a non-standard token that doesn't return a bool).
@@ -341,6 +349,145 @@ def solmateSafeTransferFromModule : ExternalCallModule where
 def solmateSafeTransferFrom (token fromAddr to amount : Expr) : Stmt :=
   .ecm solmateSafeTransferFromModule [token, fromAddr, to, amount]
 
+/-- Legacy string-error SafeTransferLib style (used by Morpho Blue's SafeTransferLib
+    and some other older libraries).
+
+This is a third explicit, named variant alongside the OpenZeppelin-style
+(`safeTransfer` / `safeTransferFrom`) and the Solmate-style variants.
+
+Behavior:
+- Always performs an `extcodesize > 0` check on the token. Reverts with the classic
+  `Error("no code")` string if the token has no code.
+- Performs the ERC-20 call.
+- On call failure (`success == false`), reverts with a specific `Error("transfer reverted")`
+  (or `transferFrom reverted`) string. Inner returndata from the token is **not** bubbled
+  (unlike the OZ and Solmate variants).
+- After a successful call, accepts either no returndata or a single ABI bool word equal to `true`.
+  Any other case (short data, false, etc.) causes a specific `Error("transfer returned false")`
+  (or `transferFrom returned false`) revert using the classic `Error(string)` encoding.
+
+This produces exactly the same observable revert strings and behavior as Morpho Blue's
+`SafeTransferLib` (the strings defined in its `ErrorsLib`).
+
+These modules are intended to be used when you need source-faithful parity with a contract
+that chose this particular SafeTransferLib flavor. They are not the default.
+-/
+private def legacyStringRevert (len : Nat) (dataWord : Nat) : List YulStmt := [
+  YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0,
+    YulExpr.hex 0x08c379a000000000000000000000000000000000000000000000000000000000]),
+  YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
+  YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit len]),
+  YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 68, YulExpr.hex dataWord]),
+  YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 100])
+]
+
+private def legacyRevertNoCode : List YulStmt :=
+  legacyStringRevert 7 0x6e6f20636f646500000000000000000000000000000000000000000000000000
+
+private def legacyRevertTransferReverted : List YulStmt :=
+  legacyStringRevert 17 0x7472616e73666572207265766572746564000000000000000000000000000000
+
+private def legacyRevertTransferReturnedFalse : List YulStmt :=
+  legacyStringRevert 23 0x7472616e736665722072657475726e65642066616c7365000000000000000000
+
+private def legacyRevertTransferFromReverted : List YulStmt :=
+  legacyStringRevert 21 0x7472616e7366657246726f6d2072657665727465640000000000000000000000
+
+private def legacyRevertTransferFromReturnedFalse : List YulStmt :=
+  legacyStringRevert 27 0x7472616e7366657246726f6d2072657475726e65642066616c73650000000000
+
+private def legacyCodeLengthGuard (tokenExpr : YulExpr) : List YulStmt := [
+  YulStmt.if_ (YulExpr.call "iszero" [
+    YulExpr.call "gt" [YulExpr.call "extcodesize" [tokenExpr], YulExpr.lit 0]
+  ]) legacyRevertNoCode
+]
+
+private def legacyRequireOptionalBool (returnPtr : YulExpr) (onFalse : List YulStmt) : List YulStmt := [
+  YulStmt.let_ "__lst_rds" (YulExpr.call "returndatasize" []),
+  YulStmt.if_ (YulExpr.ident "__lst_rds") [
+    YulStmt.if_ (YulExpr.call "iszero" [
+      YulExpr.call "and" [
+        YulExpr.call "gt" [YulExpr.ident "__lst_rds", YulExpr.lit 31],
+        YulExpr.call "eq" [YulExpr.call "mload" [returnPtr], YulExpr.lit 1]
+      ]
+    ]) onFalse
+  ]
+]
+
+/-- ERC-20 safeTransfer module using legacy string-error semantics (Morpho-style).
+    See the large comment above `legacyStringSafeTransferModule` for full behavior. -/
+def legacyStringSafeTransferModule : ExternalCallModule where
+  name := "legacyStringSafeTransfer"
+  numArgs := 3
+  writesState := true
+  readsState := false
+  axioms := ["erc20_legacy_string_safe_transfer_interface"]
+  compile := fun _ctx args => do
+    let (tokenExpr, toExpr, amountExpr) ← match args with
+      | [t, to, a] => pure (t, to, a)
+      | _ => throw "legacyStringSafeTransfer expects 3 arguments (token, to, amount)"
+    let selectorWord := 0xa9059cbb00000000000000000000000000000000000000000000000000000000
+    pure [YulStmt.block (
+      legacyCodeLengthGuard tokenExpr ++ [
+        YulStmt.let_ "__lst_ptr" (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]),
+        YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident "__lst_ptr", YulExpr.hex selectorWord]),
+        YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lst_ptr", YulExpr.lit 4], toExpr]),
+        YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lst_ptr", YulExpr.lit 36], amountExpr]),
+        YulStmt.expr (YulExpr.call "mstore" [
+          YulExpr.lit freeMemoryPointer,
+          YulExpr.call "and" [
+            YulExpr.call "add" [YulExpr.call "add" [YulExpr.ident "__lst_ptr", YulExpr.lit 68], YulExpr.lit 31],
+            YulExpr.call "not" [YulExpr.lit 31]
+          ]
+        ]),
+        YulStmt.let_ "__lst_success" (YulExpr.call "call" [
+          YulExpr.call "gas" [], tokenExpr, YulExpr.lit 0,
+          YulExpr.ident "__lst_ptr", YulExpr.lit 68, YulExpr.ident "__lst_ptr", YulExpr.lit 32
+        ]),
+        YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__lst_success"]) legacyRevertTransferReverted
+      ] ++ legacyRequireOptionalBool (YulExpr.ident "__lst_ptr") legacyRevertTransferReturnedFalse)]
+
+/-- Convenience: create a `Stmt.ecm` for legacy string-error safeTransfer (Morpho-style). -/
+def legacyStringSafeTransfer (token to amount : Expr) : Stmt :=
+  .ecm legacyStringSafeTransferModule [token, to, amount]
+
+/-- ERC-20 safeTransferFrom module using legacy string-error semantics (Morpho-style). -/
+def legacyStringSafeTransferFromModule : ExternalCallModule where
+  name := "legacyStringSafeTransferFrom"
+  numArgs := 4
+  writesState := true
+  readsState := false
+  axioms := ["erc20_legacy_string_safe_transferFrom_interface"]
+  compile := fun _ctx args => do
+    let (tokenExpr, fromExpr, toExpr, amountExpr) ← match args with
+      | [t, f, to, a] => pure (t, f, to, a)
+      | _ => throw "legacyStringSafeTransferFrom expects 4 arguments (token, from, to, amount)"
+    let selectorWord := 0x23b872dd00000000000000000000000000000000000000000000000000000000
+    pure [YulStmt.block (
+      legacyCodeLengthGuard tokenExpr ++ [
+        YulStmt.let_ "__lstf_ptr" (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]),
+        YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident "__lstf_ptr", YulExpr.hex selectorWord]),
+        YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lstf_ptr", YulExpr.lit 4], fromExpr]),
+        YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lstf_ptr", YulExpr.lit 36], toExpr]),
+        YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lstf_ptr", YulExpr.lit 68], amountExpr]),
+        YulStmt.expr (YulExpr.call "mstore" [
+          YulExpr.lit freeMemoryPointer,
+          YulExpr.call "and" [
+            YulExpr.call "add" [YulExpr.call "add" [YulExpr.ident "__lstf_ptr", YulExpr.lit 100], YulExpr.lit 31],
+            YulExpr.call "not" [YulExpr.lit 31]
+          ]
+        ]),
+        YulStmt.let_ "__lstf_success" (YulExpr.call "call" [
+          YulExpr.call "gas" [], tokenExpr, YulExpr.lit 0,
+          YulExpr.ident "__lstf_ptr", YulExpr.lit 100, YulExpr.ident "__lstf_ptr", YulExpr.lit 32
+        ]),
+        YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__lstf_success"]) legacyRevertTransferFromReverted
+      ] ++ legacyRequireOptionalBool (YulExpr.ident "__lstf_ptr") legacyRevertTransferFromReturnedFalse)]
+
+/-- Convenience: create a `Stmt.ecm` for legacy string-error safeTransferFrom (Morpho-style). -/
+def legacyStringSafeTransferFrom (token fromAddr to amount : Expr) : Stmt :=
+  .ecm legacyStringSafeTransferFromModule [token, fromAddr, to, amount]
+
 /-- ERC-20 safeApprove module (new — demonstrates ECM extensibility).
     Calls `approve(address spender, uint256 amount)` with optional-bool-return handling.
     Arguments: [token, spender, amount] -/
@@ -381,6 +528,7 @@ def safeApproveModule : ExternalCallModule where
         YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__sa_rds"])
       ]
     ] ++ optionalBoolGuard)]
+
 
 /-- Convenience: create a `Stmt.ecm` for safeApprove. -/
 def safeApprove (token spender amount : Expr) : Stmt :=

--- a/Contracts/Smoke/InternalInterfaceSmoke.lean
+++ b/Contracts/Smoke/InternalInterfaceSmoke.lean
@@ -409,54 +409,54 @@ example :
           | _ => false)) = true := by
   decide
 
-  example :
-      (TypedInterfaceSafeERC20Smoke.spec.functions).any (fun fn =>
-        fn.name == "approveTokens" &&
-          fn.body.any (fun stmt =>
-            match stmt with
-            | Compiler.CompilationModel.Stmt.ecm mod
-                [Compiler.CompilationModel.Expr.param "token",
-                 Compiler.CompilationModel.Expr.param "spender",
-                 Compiler.CompilationModel.Expr.param "amount"] =>
-                mod.name == "safeApprove" &&
-                  mod.axioms == ["erc20_approve_interface"] &&
-                  mod.resultVars == [] &&
-                  mod.writesState
-            | _ => false)) = true := by
-    decide
+example :
+    (TypedInterfaceSafeERC20Smoke.spec.functions).any (fun fn =>
+      fn.name == "approveTokens" &&
+        fn.body.any (fun stmt =>
+          match stmt with
+          | Compiler.CompilationModel.Stmt.ecm mod
+              [Compiler.CompilationModel.Expr.param "token",
+               Compiler.CompilationModel.Expr.param "spender",
+               Compiler.CompilationModel.Expr.param "amount"] =>
+              mod.name == "safeApprove" &&
+                mod.axioms == ["erc20_approve_interface"] &&
+                mod.resultVars == [] &&
+                mod.writesState
+          | _ => false)) = true := by
+  decide
 
-  example :
-      (TypedInterfaceSafeERC20Smoke.spec.functions).any (fun fn =>
-        fn.name == "pushTokensLegacy" &&
-          fn.body.any (fun stmt =>
-            match stmt with
-            | Compiler.CompilationModel.Stmt.ecm mod
-                [Compiler.CompilationModel.Expr.param "token",
-                 Compiler.CompilationModel.Expr.param "toAddr",
-                 Compiler.CompilationModel.Expr.param "amount"] =>
-                mod.name == "legacyStringSafeTransfer" &&
-                  mod.axioms == ["erc20_legacy_string_safe_transfer_interface"] &&
-                  mod.resultVars == [] &&
-                  mod.writesState
-            | _ => false)) = true := by
-    decide
+example :
+    (TypedInterfaceSafeERC20Smoke.spec.functions).any (fun fn =>
+      fn.name == "pushTokensLegacy" &&
+        fn.body.any (fun stmt =>
+          match stmt with
+          | Compiler.CompilationModel.Stmt.ecm mod
+              [Compiler.CompilationModel.Expr.param "token",
+               Compiler.CompilationModel.Expr.param "toAddr",
+               Compiler.CompilationModel.Expr.param "amount"] =>
+              mod.name == "legacyStringSafeTransfer" &&
+                mod.axioms == ["erc20_legacy_string_safe_transfer_interface"] &&
+                mod.resultVars == [] &&
+                mod.writesState
+          | _ => false)) = true := by
+  decide
 
-  example :
-      (TypedInterfaceSafeERC20Smoke.spec.functions).any (fun fn =>
-        fn.name == "pullTokensLegacy" &&
-          fn.body.any (fun stmt =>
-            match stmt with
-            | Compiler.CompilationModel.Stmt.ecm mod
-                [Compiler.CompilationModel.Expr.param "token",
-                 Compiler.CompilationModel.Expr.param "fromAddr",
-                 Compiler.CompilationModel.Expr.param "toAddr",
-                 Compiler.CompilationModel.Expr.param "amount"] =>
-                mod.name == "legacyStringSafeTransferFrom" &&
-                  mod.axioms == ["erc20_legacy_string_safe_transferFrom_interface"] &&
-                  mod.resultVars == [] &&
-                  mod.writesState
-            | _ => false)) = true := by
-    decide
+example :
+    (TypedInterfaceSafeERC20Smoke.spec.functions).any (fun fn =>
+      fn.name == "pullTokensLegacy" &&
+        fn.body.any (fun stmt =>
+          match stmt with
+          | Compiler.CompilationModel.Stmt.ecm mod
+              [Compiler.CompilationModel.Expr.param "token",
+               Compiler.CompilationModel.Expr.param "fromAddr",
+               Compiler.CompilationModel.Expr.param "toAddr",
+               Compiler.CompilationModel.Expr.param "amount"] =>
+              mod.name == "legacyStringSafeTransferFrom" &&
+                mod.axioms == ["erc20_legacy_string_safe_transferFrom_interface"] &&
+                mod.resultVars == [] &&
+                mod.writesState
+          | _ => false)) = true := by
+  decide
 
 /--
 error: interface name 'Clash' conflicts with an existing type name

--- a/Contracts/Smoke/InternalInterfaceSmoke.lean
+++ b/Contracts/Smoke/InternalInterfaceSmoke.lean
@@ -370,6 +370,12 @@ verity_contract TypedInterfaceSafeERC20Smoke where
   function approveTokens (token : IERC20, spender : Address, amount : Uint256) : Unit := do
     safeApprove token spender amount
 
+  function pushTokensLegacy (token : IERC20, toAddr : Address, amount : Uint256) : Unit := do
+    legacyStringSafeTransfer token toAddr amount
+
+  function pullTokensLegacy (token : IERC20, fromAddr : Address, toAddr : Address, amount : Uint256) : Unit := do
+    legacyStringSafeTransferFrom token fromAddr toAddr amount
+
 example :
     (TypedInterfaceSafeERC20Smoke.spec.functions).any (fun fn =>
       fn.name == "pushTokens" &&
@@ -403,21 +409,54 @@ example :
           | _ => false)) = true := by
   decide
 
-example :
-    (TypedInterfaceSafeERC20Smoke.spec.functions).any (fun fn =>
-      fn.name == "approveTokens" &&
-        fn.body.any (fun stmt =>
-          match stmt with
-          | Compiler.CompilationModel.Stmt.ecm mod
-              [Compiler.CompilationModel.Expr.param "token",
-               Compiler.CompilationModel.Expr.param "spender",
-               Compiler.CompilationModel.Expr.param "amount"] =>
-              mod.name == "safeApprove" &&
-                mod.axioms == ["erc20_approve_interface"] &&
-                mod.resultVars == [] &&
-                mod.writesState
-          | _ => false)) = true := by
-  decide
+  example :
+      (TypedInterfaceSafeERC20Smoke.spec.functions).any (fun fn =>
+        fn.name == "approveTokens" &&
+          fn.body.any (fun stmt =>
+            match stmt with
+            | Compiler.CompilationModel.Stmt.ecm mod
+                [Compiler.CompilationModel.Expr.param "token",
+                 Compiler.CompilationModel.Expr.param "spender",
+                 Compiler.CompilationModel.Expr.param "amount"] =>
+                mod.name == "safeApprove" &&
+                  mod.axioms == ["erc20_approve_interface"] &&
+                  mod.resultVars == [] &&
+                  mod.writesState
+            | _ => false)) = true := by
+    decide
+
+  example :
+      (TypedInterfaceSafeERC20Smoke.spec.functions).any (fun fn =>
+        fn.name == "pushTokensLegacy" &&
+          fn.body.any (fun stmt =>
+            match stmt with
+            | Compiler.CompilationModel.Stmt.ecm mod
+                [Compiler.CompilationModel.Expr.param "token",
+                 Compiler.CompilationModel.Expr.param "toAddr",
+                 Compiler.CompilationModel.Expr.param "amount"] =>
+                mod.name == "legacyStringSafeTransfer" &&
+                  mod.axioms == ["erc20_legacy_string_safe_transfer_interface"] &&
+                  mod.resultVars == [] &&
+                  mod.writesState
+            | _ => false)) = true := by
+    decide
+
+  example :
+      (TypedInterfaceSafeERC20Smoke.spec.functions).any (fun fn =>
+        fn.name == "pullTokensLegacy" &&
+          fn.body.any (fun stmt =>
+            match stmt with
+            | Compiler.CompilationModel.Stmt.ecm mod
+                [Compiler.CompilationModel.Expr.param "token",
+                 Compiler.CompilationModel.Expr.param "fromAddr",
+                 Compiler.CompilationModel.Expr.param "toAddr",
+                 Compiler.CompilationModel.Expr.param "amount"] =>
+                mod.name == "legacyStringSafeTransferFrom" &&
+                  mod.axioms == ["erc20_legacy_string_safe_transferFrom_interface"] &&
+                  mod.resultVars == [] &&
+                  mod.writesState
+            | _ => false)) = true := by
+    decide
 
 /--
 error: interface name 'Clash' conflicts with an existing type name

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -307,6 +307,12 @@ private partial def validateEffectStmtExprTypes
   | `(term| safeApprove $token:term $spender:term $amount:term) =>
       for arg in [token, spender, amount] do
         requireWordLikeType arg "ERC-20 helper" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg)
+  | `(term| legacyStringSafeTransfer $token:term $to:term $amount:term) =>
+      for arg in [token, to, amount] do
+        requireWordLikeType arg "ERC-20 helper" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg)
+  | `(term| legacyStringSafeTransferFrom $token:term $fromAddr:term $to:term $amount:term) =>
+      for arg in [token, fromAddr, to, amount] do
+        requireWordLikeType arg "ERC-20 helper" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg)
   | `(term| setStorage $field:ident $value:term) =>
       let f ← lookupStorageField fields (toString field.getId)
       match f.adtInfo?, f.ty with
@@ -616,19 +622,44 @@ private def translateEffectStmt
           `(Compiler.CompilationModel.Stmt.ecm
               Compiler.Modules.ERC20.safeTransferFromModule
               [$tokenExpr, $fromExpr, $toExpr, $amountExpr])
-  | `(term| safeApprove $token:term $spender:term $amount:term) =>
-      match lookupFunctionByNameAndArity functions "safeApprove" 3 with
-      | some localFn =>
-          throwErrorAt stx
-            s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
-      | _ =>
-          let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-          let spenderExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals spender
-          let amountExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals amount
-          `(Compiler.CompilationModel.Stmt.ecm
-              Compiler.Modules.ERC20.safeApproveModule
-              [$tokenExpr, $spenderExpr, $amountExpr])
-  | `(term| ecmDo $module:term $args:term) =>
+   | `(term| safeApprove $token:term $spender:term $amount:term) =>
+       match lookupFunctionByNameAndArity functions "safeApprove" 3 with
+       | some localFn =>
+           throwErrorAt stx
+             s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
+       | _ =>
+           let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
+           let spenderExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals spender
+           let amountExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals amount
+           `(Compiler.CompilationModel.Stmt.ecm
+               Compiler.Modules.ERC20.safeApproveModule
+               [$tokenExpr, $spenderExpr, $amountExpr])
+   | `(term| legacyStringSafeTransfer $token:term $to:term $amount:term) =>
+       match lookupFunctionByNameAndArity functions "legacyStringSafeTransfer" 3 with
+       | some localFn =>
+           throwErrorAt stx
+             s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
+       | _ =>
+           let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
+           let toExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals to
+           let amountExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals amount
+           `(Compiler.CompilationModel.Stmt.ecm
+               Compiler.Modules.ERC20.legacyStringSafeTransferModule
+               [$tokenExpr, $toExpr, $amountExpr])
+   | `(term| legacyStringSafeTransferFrom $token:term $fromAddr:term $to:term $amount:term) =>
+       match lookupFunctionByNameAndArity functions "legacyStringSafeTransferFrom" 4 with
+       | some localFn =>
+           throwErrorAt stx
+             s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
+       | _ =>
+           let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
+           let fromExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals fromAddr
+           let toExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals to
+           let amountExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals amount
+           `(Compiler.CompilationModel.Stmt.ecm
+               Compiler.Modules.ERC20.legacyStringSafeTransferFromModule
+               [$tokenExpr, $fromExpr, $toExpr, $amountExpr])
+   | `(term| ecmDo $module:term $args:term) =>
       validateEffectOnlyEcmModuleTerm module
       let argExprs ← expectExprList fields constDecls immutableDecls params locals args
       `(Compiler.CompilationModel.Stmt.ecm

--- a/docs/EXTERNAL_CALL_MODULES.md
+++ b/docs/EXTERNAL_CALL_MODULES.md
@@ -211,9 +211,19 @@ data and the token address has code. Malformed short or oversized returndata,
 `returndatasize() > 31` and the first returned word is `true`. Failed calls
 bubble returndata before the optional-return guard runs.
 
+`Compiler.Modules.ERC20.legacyStringSafeTransfer` and
+`legacyStringSafeTransferFrom` implement the "legacy string error" style used by
+Morpho Blue's `SafeTransferLib` (and some other older custom SafeTransferLib
+libraries). They always perform an `extcodesize` check (reverting with the classic
+`Error("no code")` string), and on failure or bad optional bool they revert with
+specific `Error("transfer reverted")` / `Error("transfer returned false")` etc.
+strings (using the classic `Error(string)` encoding). Inner returndata is not
+bubbled on call failure. This produces byte-compatible observable behavior with
+contracts that chose this particular SafeTransferLib flavor.
+
 These reusable helpers can be used with typed-interface token parameters; the
 interface parameter still lowers as an address, while the helper selects the
-SafeERC20 ECM instead of the ordinary typed-interface `transfer` call:
+appropriate Safe* ECM instead of the ordinary typed-interface `transfer` call:
 
 ```lean
 interfaces
@@ -225,9 +235,21 @@ function pushTokens (token : IERC20, to : Address, amount : Uint256) : Unit := d
   safeTransfer token to amount
 ```
 
+For the legacy string style used by Morpho, use the explicit legacy helpers:
+
+```lean
+function pushTokensLegacy (token : IERC20, to : Address, amount : Uint256) : Unit := do
+  legacyStringSafeTransfer token to amount
+```
+
 Use the direct helper form when a token boundary needs optional-return
 semantics. A dot call such as `let ok ← token.transfer to amount` remains the
 ordinary typed-interface call path and requires exactly one returned word.
+
+The choice of helper determines the exact revert data and guard semantics. This
+keeps the three common real-world SafeTransferLib styles (OZ, Solmate, legacy
+string) first-class and explicitly named, rather than hidden behind a generic
+"policy" parameter.
 
 ### Callback Helpers
 


### PR DESCRIPTION
This adds explicit, named variants for different real-world `SafeTransferLib` styles, extending the typed interface SafeERC20 work in #1971.

### Added
- `Compiler.Modules.ERC20.legacyStringSafeTransfer` / `legacyStringSafeTransferFrom`
- Exact match for the behavior in Morpho Blue (and similar older custom SafeTransferLib):
  - `extcodesize` guard → `Error("no code")`
  - Call failure → `Error("transfer reverted")` / `Error("transferFrom reverted")` (no inner returndata bubbling)
  - Bad optional bool → `Error("transfer returned false")` etc. (classic `Error(string)` encoding)
- Convenience functions + full support when used with typed `interface IERC20` parameters (same ergonomic pattern as `safeTransfer` / `solmateSafeTransfer`).

### Why explicit named styles instead of configurable policies
As discussed, a generic policy system felt non-standard. Instead we now have three first-class, documented styles that correspond to actual libraries people use:
- `safeTransfer*` — OpenZeppelin v5 style (`SafeERC20FailedOperation`)
- `solmateSafeTransfer*` — Solmate style
- `legacyStringSafeTransfer*` — legacy string `Error(...)` style (Morpho, older ds-math style libs, etc.)

This keeps things auditable and explicit.

### Files changed
- `Compiler/Modules/ERC20.lean`
- `Compiler/CompilationModel/TrustSurface.lean`
- `AXIOMS.md`
- `docs/EXTERNAL_CALL_MODULES.md`
- `Contracts/Smoke/InternalInterfaceSmoke.lean` (smoke coverage for typed + legacy)

Intended to be merged into / alongside the changes from #1971 before that PR lands on main.

See related discussion in morpho-verity about removing the need for fully custom `MorphoSafeTransfer` ECMs once this lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive compiler/ECM surface with scoped interface assumptions; no changes to default `safeTransfer` behavior or auth/data paths.
> 
> **Overview**
> Adds a **third named ERC-20 safe-transfer style** alongside OpenZeppelin and Solmate: `legacyStringSafeTransfer` / `legacyStringSafeTransferFrom` ECMs plus `legacyStringSafeTransfer` / `legacyStringSafeTransferFrom` contract syntax in `Verity/Macro/Translate.lean`.
> 
> Generated Yul matches **Morpho-style legacy SafeTransferLib**: mandatory `extcodesize` with `Error("no code")`, fixed `Error(string)` messages on failed calls and bad optional bool returns (**no** bubbling of inner revert data), and empty-or-`true` optional-return handling.
> 
> **Trust/docs:** new ECM assumptions in `AXIOMS.md`, `tokenModel` classification in `TrustSurface.lean`, and `docs/EXTERNAL_CALL_MODULES.md`. **Smoke:** `TypedInterfaceSafeERC20Smoke` asserts typed `IERC20` helpers lower to the new modules and axioms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e36884a633d7842032afece8a4a7e0f05c3cad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->