### PR TITLE
IR: add Expr.txOrigin to the proof-side scanners (closes exprBoundNames missing case)

### DIFF
--- a/Compiler/Proofs/IRGeneration/ExprCore.lean
+++ b/Compiler/Proofs/IRGeneration/ExprCore.lean
@@ -74,7 +74,7 @@ def exprBoundNames : Expr → List String
   | .dynamicBytesEq lhsName rhsName => [lhsName, rhsName]
   | .literal _ | .constructorArg _ | .storage _ | .storageAddr _ | .caller
   | .contractAddress | .chainid | .msgValue | .blockTimestamp | .blockNumber
-  | .selfBalance | .blobbasefee | .calldatasize | .returndataSize => []
+  | .selfBalance | .blobbasefee | .calldatasize | .returndataSize | .txOrigin => []
 termination_by expr => sizeOf expr
 decreasing_by
   all_goals simp_wf

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -2787,6 +2787,9 @@ mutual
     | .constructorArg idx =>
         lookupBinding? state.bindings s!"arg{idx}"
     | .caller => some state.world.sender.val
+    -- `evalExpr` has no `.txOrigin` support yet (falls through to `none`);
+    -- mirror that here so the helper-aware semantics stays in lockstep.
+    | .txOrigin => none
     | .contractAddress => some state.world.thisAddress.val
     | .chainid => some state.world.chainId.val
     | .msgValue => some state.world.msgValue.val
@@ -4130,6 +4133,11 @@ mutual
         simpa [evalExprWithHelpers, evalExpr_param]
     | localVar _ =>
         simpa [evalExprWithHelpers, evalExpr_localVar]
+    | txOrigin =>
+        have h2 : evalExpr fields state .txOrigin = none := rfl
+        rw [h2]
+        set_option maxHeartbeats 1000000 in
+        simp only [evalExprWithHelpers]
     | caller | contractAddress | chainid | msgValue | selfBalance | blockTimestamp | blockNumber | blobbasefee
     | calldatasize =>
         simp [evalExprWithHelpers, evalExpr_caller, evalExpr_contractAddress, evalExpr_chainid,

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -554,7 +554,7 @@ decoding. Raw constructor calldata observations therefore remain outside the
 current body-level support interface until the deploy-wrapper proof exists. -/
 def exprTouchesUnsupportedConstructorRawCalldataSurface : Expr → Bool
   | .literal _ | .param _ | .localVar _ | .caller | .contractAddress
-  | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
+  | .chainid | .msgValue | .selfBalance | .txOrigin | .blockTimestamp | .blockNumber
   | .blobbasefee | .constructorArg _ | .returndataSize | .extcodesize _ => false
   | .calldatasize => true
   | .storage _ | .storageAddr _ | .arrayLength _ | .memoryArrayLength _
@@ -706,7 +706,7 @@ def exprTouchesUnsupportedCoreSurface : Expr → Bool
   | .literal _ | .param _ | .caller | .contractAddress
   | .chainid | .msgValue | .blockTimestamp | .blockNumber
   | .blobbasefee | .calldatasize | .localVar _ => false
-  | .selfBalance => true
+  | .selfBalance | .txOrigin => true
   | .storage _ | .storageAddr _ => false
   | .add a b | .sub a b | .mul a b | .div a b | .mod a b
   | .eq a b | .ge a b | .gt a b | .lt a b | .le a b
@@ -760,7 +760,7 @@ def exprTouchesUnsupportedCoreSurface : Expr → Bool
 interface. These are the next storage/layout-style widening targets. -/
 def exprTouchesUnsupportedStateSurface : Expr → Bool
   | .literal _ | .param _ | .caller | .contractAddress
-  | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
+  | .chainid | .msgValue | .selfBalance | .txOrigin | .blockTimestamp | .blockNumber
   | .localVar _ => false
   | .storage _ | .storageAddr _ => true
   | .mapping _ _ | .mappingWord _ _ _ | .mappingPackedWord _ _ _ _
@@ -813,7 +813,7 @@ def exprTouchesUnsupportedCallSurface : Expr → Bool
   | .internalCall _ _ | .externalCall _ _ => true
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => true
   | .literal _ | .param _ | .caller | .contractAddress
-  | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
+  | .chainid | .msgValue | .selfBalance | .txOrigin | .blockTimestamp | .blockNumber
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
@@ -872,7 +872,7 @@ generic whole-contract theorem. -/
 def exprTouchesUnsupportedHelperSurface : Expr → Bool
   | .internalCall _ _ => true
   | .literal _ | .param _ | .caller | .contractAddress
-  | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
+  | .chainid | .msgValue | .selfBalance | .txOrigin | .blockTimestamp | .blockNumber
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
@@ -940,7 +940,7 @@ still-unsupported expression shapes that currently share the coarse
 def exprTouchesInternalHelperSurface : Expr → Bool
   | .internalCall _ _ => true
   | .literal _ | .param _ | .caller | .contractAddress
-  | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
+  | .chainid | .msgValue | .selfBalance | .txOrigin | .blockTimestamp | .blockNumber
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
@@ -1003,7 +1003,7 @@ whole-contract theorem. -/
 def exprTouchesUnsupportedForeignSurface : Expr → Bool
   | .externalCall _ _ => true
   | .literal _ | .param _ | .caller | .contractAddress
-  | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
+  | .chainid | .msgValue | .selfBalance | .txOrigin | .blockTimestamp | .blockNumber
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
@@ -1064,7 +1064,7 @@ whole-contract theorem. -/
 def exprTouchesUnsupportedLowLevelSurface : Expr → Bool
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => true
   | .literal _ | .param _ | .caller | .contractAddress
-  | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
+  | .chainid | .msgValue | .selfBalance | .txOrigin | .blockTimestamp | .blockNumber
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize | .extcodesize _
@@ -1128,7 +1128,7 @@ def exprTouchesUnsupportedContractSurface (expr : Expr) : Bool :=
   | .literal _ | .param _ | .caller | .contractAddress
   | .chainid | .msgValue | .blockTimestamp | .blockNumber
   | .blobbasefee | .calldatasize | .localVar _ => false
-  | .selfBalance => true
+  | .selfBalance | .txOrigin => true
   | .storage _ | .storageAddr _ => true
   | .add a b | .sub a b | .mul a b | .div a b | .mod a b
   | .bitAnd a b | .bitOr a b | .bitXor a b | .eq a b
@@ -1845,7 +1845,7 @@ mutual
     -- validators).
     | .literal _ | .param _ | .constructorArg _
     | .storage _ | .storageAddr _
-    | .caller | .contractAddress | .chainid | .msgValue | .selfBalance
+    | .caller | .contractAddress | .chainid | .msgValue | .selfBalance | .txOrigin
     | .blockTimestamp | .blockNumber | .blobbasefee
     | .calldatasize | .returndataSize
     | .localVar _ | .arrayLength _ | .memoryArrayLength _ | .storageArrayLength _
@@ -3327,6 +3327,7 @@ mutual
     | mappingChain _ _ => simp [exprTouchesUnsupportedHelperSurface] at hsurface
     | intrinsic _ _ _ _ => simp [exprTouchesUnsupportedHelperSurface] at hsurface
     | literal _ | param _ | caller | contractAddress | chainid | msgValue | selfBalance
+    | txOrigin
     | blockTimestamp | blockNumber | localVar _ | storage _ | storageAddr _
     | constructorArg _ | blobbasefee | calldatasize | returndataSize
     | arrayLength _ | memoryArrayLength _ | storageArrayLength _ | dynamicBytesEq _ _
@@ -3742,7 +3743,7 @@ private theorem exprTouchesUnsupportedCallSurface_eq_featureOr
         exprTouchesUnsupportedLowLevelSurface expr) := by
   cases expr with
   | literal _ | param _ | caller | contractAddress
-  | chainid | msgValue | selfBalance | blockTimestamp | blockNumber
+  | chainid | msgValue | selfBalance | txOrigin | blockTimestamp | blockNumber
   | localVar _ | storage _ | storageAddr _
   | paramDynamicHeadWord _ _ | paramDynamicStaticComposite _ _
   | paramDynamicMemberLength _ _
@@ -3977,7 +3978,7 @@ private theorem exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
   | chainid | msgValue | blockTimestamp | blockNumber | blobbasefee
   | calldatasize =>
       simp [exprTouchesUnsupportedContractSurface]
-  | selfBalance =>
+  | selfBalance | txOrigin =>
       simp [exprTouchesUnsupportedCoreSurface] at hcore
   | storage _ | storageAddr _ =>
       cases hstate
@@ -4364,7 +4365,7 @@ theorem exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
   | chainid | msgValue | blockTimestamp | blockNumber | blobbasefee
   | calldatasize =>
       simp [exprTouchesUnsupportedHelperSurface]
-  | selfBalance =>
+  | selfBalance | txOrigin =>
       simp [exprTouchesUnsupportedContractSurface] at hsurface
   | adtConstruct _ _ _ | adtTag _ _ | adtField _ _ _ _ _ =>
       simp [exprTouchesUnsupportedContractSurface] at hsurface


### PR DESCRIPTION
PR-bot merge ca3fd95 added `Expr.txOrigin` to `Compiler.CompilationModel.Types`
but did not update the proof-side files. The missing case in
`exprBoundNames` (ExprCore.lean) caused a flood of `'sorry'` cascade-failures
in every downstream proof that touches an expression scanner. This patch
adds `.txOrigin` everywhere `.selfBalance` was already enumerated — a
twinned nullary environment-reading leaf that is not in the current proof
core.

## Uniform policy applied across all touched sites

**ExprCore.lean** (line 77): add `.txOrigin` to the nullary-leaf arm of
`exprBoundNames` (binds nothing).

**SupportedSpec.lean** (14 sites): join `.selfBalance` in the seven shared
leaf groups of the surface scanners
(constructor-calldata/state/call/helper/internal-helper/foreign/low-level;
not touching those surfaces), join `.selfBalance` in the standalone
`.selfBalance => true` arms of `exprTouchesUnsupportedCoreSurface` and
`exprTouchesUnsupportedContractSurface` (unsupported by the core —
fail-closed), plus the `exprInternalHelperCallNames` leaf and the four
case-analysis proofs, where the `txOrigin` alternatives discharge exactly
like `selfBalance`'s.

**SourceSemantics.lean** (1 site): the one semantic decision — `evalExpr`
has no `.txOrigin` arm and falls through to `none`, so
`evalExprWithHelpers` gets an explicit `.txOrigin => none` to stay in
lockstep with `evalExpr` (commented as such). The equivalence proof's
`txOrigin` case needed care: `evalExpr [] st .txOrigin = none` is rfl,
but the mutual/fuel-recursive `evalExprWithHelpers` doesn't reduce
definitionally — closed with `simp only [evalExprWithHelpers]` under a
local 1 M-heartbeat bump, because deriving the equation lemmas for that
giant match hits exactly the catch-all-complement cost the file itself
warns about (the verity#1842 pitfall).

## Net effect on the trust surface: zero

`.txOrigin` is classified outside every supported fragment, so the
generic theorems' boundaries only stay closed; nothing your verifiers
use changed meaning.

## Verification

```
$ lake build Compiler.Proofs.IRGeneration.{ExprCore,SourceSemantics,SupportedSpec}
Build completed successfully.
```

No new axioms, no sorry. The downstream `lfglabs-dev/SPHINCS-` repo
already consumes this patch uncommitted to unblock the C13 FIPS-FORS
migration; please merge so the next `git pull` doesn't reintroduce the
breakage for other consumers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical proof maintenance with no semantic or verifier-facing behavior change; `.txOrigin` remains explicitly unsupported in the proof core.
> 
> **Overview**
> **Fixes incomplete `Expr.txOrigin` coverage in IR generation proofs** after the constructor landed in the compilation model. Without the missing `exprBoundNames` case, downstream proofs failed with cascading `sorry`s.
> 
> **ExprCore:** `.txOrigin` is treated like other nullary env leaves (binds no names).
> 
> **SupportedSpec:** `.txOrigin` is added everywhere `.selfBalance` already appeared—surface scanners, unsupported-core/contract arms (still **outside** the supported proof core, same fail-closed policy as `selfBalance`), helper-call name leaves, and related case splits.
> 
> **SourceSemantics:** `evalExprWithHelpers` gets an explicit `.txOrigin => none` to match `evalExpr` (no `.txOrigin` arm yet). The equivalence proof adds a `txOrigin` branch using `simp only [evalExprWithHelpers]` with a local heartbeat bump.
> 
> **Net effect:** proof boundaries stay closed; no widening of what generic theorems treat as supported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a86f0f2e1ecc69d28a7802cfecf0530205ed55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->