### PR TITLE
make array length work for Bytes and Bytes32

### DIFF
--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -256,7 +256,15 @@ def ecrecover (hash v r sigS : Uint256) : Contract Address := fun state =>
 def calldatacopy (_destOffset _sourceOffset _size : Uint256) : Contract Unit := pure ()
 def returndataCopy (_destOffset _sourceOffset _size : Uint256) : Contract Unit := pure ()
 def revertReturndata : Contract Unit := pure ()
-def arrayLength {α : Type} (values : Array α) : Uint256 := values.size
+class ArrayLength (α : Type) where
+  size: α → Nat
+instance : ArrayLength ByteArray where
+  size := ByteArray.size
+instance {α : Type } : ArrayLength (Array α) where
+  size := Array.size
+instance : ArrayLength Verity.Bytes32 where
+  size := 32
+def arrayLength {α : Type} [ArrayLength α] (values : α) : Uint256 := ArrayLength.size values
 def arrayElement {α : Type} [Inhabited α] (values : Array α) (index : Uint256) : α :=
   values.getD (index : Nat) (Inhabited.default : α)
 def abiHeadWord {α : Type} [Inhabited α] (_value : α) (_wordOffset : Uint256) : Uint256 := 0

--- a/Contracts/Smoke/ArrayElementDynamicMemberBytesSmoke.lean
+++ b/Contracts/Smoke/ArrayElementDynamicMemberBytesSmoke.lean
@@ -1,0 +1,33 @@
+import Contracts.Common
+
+namespace Contracts.Smoke
+
+open Verity hiding pure bind
+
+verity_contract ArrayElementDynamicMemberBytesSmoke where
+  storage
+
+  struct Operation where
+    callData: Bytes
+
+  function callDataLength(ops: Operation) : Uint256 := do
+    return arrayLength ops.callData
+
+  function getElmLength(ops: Array Operation, idx : Uint256) : Uint256 := do
+    return arrayLength ( arrayElement ops idx).callData
+
+
+example :
+  ArrayElementDynamicMemberBytesSmoke.callDataLength_modelBody = [
+    Compiler.CompilationModel.Stmt.return
+      (Compiler.CompilationModel.Expr.paramDynamicMemberLength "ops" 0)
+  ] := rfl
+
+example :
+ ArrayElementDynamicMemberBytesSmoke.getElmLength_modelBody = [ Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+            "ops"
+            (Compiler.CompilationModel.Expr.param "idx")
+            0)
+      ] := rfl
+end Contracts.Smoke


### PR DESCRIPTION
The user can use `arrayLength` with `Bytes` and `Bytes32`. This change is related to #1975 

I could not understand the #1975. let me know if this is sufficient to unblock the underlying issue. let me if not, I'm happy to spend my time on this. 