### PR TITLE
feat(EDSL): arrayLength for Bytes/String dynamic values (supersedes #1991)

### DIFF
--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -256,14 +256,19 @@ def ecrecover (hash v r sigS : Uint256) : Contract Address := fun state =>
 def calldatacopy (_destOffset _sourceOffset _size : Uint256) : Contract Unit := pure ()
 def returndataCopy (_destOffset _sourceOffset _size : Uint256) : Contract Unit := pure ()
 def revertReturndata : Contract Unit := pure ()
+/-- Executable length surface for `arrayLength`: dynamic ABI values that
+carry a length word (`bytes`, `string`, `T[]`). Deliberately not
+instantiated for word types: `Bytes32` is a reducible abbrev of `Uint256`,
+so an instance there would make `arrayLength` typecheck (and return 32)
+for arbitrary words. -/
 class ArrayLength (α : Type) where
-  size: α → Nat
+  size : α → Nat
 instance : ArrayLength ByteArray where
   size := ByteArray.size
-instance {α : Type } : ArrayLength (Array α) where
+instance : ArrayLength String where
+  size := String.utf8ByteSize
+instance {α : Type} : ArrayLength (Array α) where
   size := Array.size
-instance : ArrayLength Verity.Bytes32 where
-  size := 32
 def arrayLength {α : Type} [ArrayLength α] (values : α) : Uint256 := ArrayLength.size values
 def arrayElement {α : Type} [Inhabited α] (values : Array α) (index : Uint256) : α :=
   values.getD (index : Nat) (Inhabited.default : α)

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -256,7 +256,15 @@ def ecrecover (hash v r sigS : Uint256) : Contract Address := fun state =>
 def calldatacopy (_destOffset _sourceOffset _size : Uint256) : Contract Unit := pure ()
 def returndataCopy (_destOffset _sourceOffset _size : Uint256) : Contract Unit := pure ()
 def revertReturndata : Contract Unit := pure ()
-def arrayLength {α : Type} (values : Array α) : Uint256 := values.size
+class ArrayLength (α : Type) where
+  size: α → Nat
+instance : ArrayLength ByteArray where
+  size := ByteArray.size
+instance {α : Type } : ArrayLength (Array α) where
+  size := Array.size
+instance : ArrayLength Verity.Bytes32 where
+  size := 32
+def arrayLength {α : Type} [ArrayLength α] (values : α) : Uint256 := ArrayLength.size values
 def arrayElement {α : Type} [Inhabited α] (values : Array α) (index : Uint256) : α :=
   values.getD (index : Nat) (Inhabited.default : α)
 def abiHeadWord {α : Type} [Inhabited α] (_value : α) (_wordOffset : Uint256) : Uint256 := 0

--- a/Contracts/Smoke/ArrayElementDynamicMemberBytesSmoke.lean
+++ b/Contracts/Smoke/ArrayElementDynamicMemberBytesSmoke.lean
@@ -4,30 +4,47 @@ namespace Contracts.Smoke
 
 open Verity hiding pure bind
 
+-- Smoke test for `arrayLength` on `bytes`/`string` dynamic members (PR
+-- verity#1991 follow-up). The model side already lowered these through
+-- `Expr.paramDynamicMemberLength` / `Expr.arrayElementDynamicMemberLength`;
+-- the executable side needs the `ArrayLength` instances for `ByteArray`
+-- (Bytes) and `String` so the same source elaborates as a runnable
+-- `Contract` function.
 verity_contract ArrayElementDynamicMemberBytesSmoke where
   storage
 
   struct Operation where
-    callData: Bytes
+    callData : Bytes,
+    label : String
 
-  function callDataLength(ops: Operation) : Uint256 := do
+  function callDataLength (ops : Operation) : Uint256 := do
     return arrayLength ops.callData
 
-  function getElmLength(ops: Array Operation, idx : Uint256) : Uint256 := do
-    return arrayLength ( arrayElement ops idx).callData
+  function labelLength (ops : Operation) : Uint256 := do
+    return arrayLength ops.label
 
-
-example :
-  ArrayElementDynamicMemberBytesSmoke.callDataLength_modelBody = [
-    Compiler.CompilationModel.Stmt.return
-      (Compiler.CompilationModel.Expr.paramDynamicMemberLength "ops" 0)
-  ] := rfl
+  function getElmLength (ops : Array Operation, idx : Uint256) : Uint256 := do
+    return arrayLength (arrayElement ops idx).callData
 
 example :
- ArrayElementDynamicMemberBytesSmoke.getElmLength_modelBody = [ Compiler.CompilationModel.Stmt.return
+    ArrayElementDynamicMemberBytesSmoke.callDataLength_modelBody =
+      [ Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.paramDynamicMemberLength "ops" 0)
+      ] := rfl
+
+example :
+    ArrayElementDynamicMemberBytesSmoke.labelLength_modelBody =
+      [ Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.paramDynamicMemberLength "ops" 1)
+      ] := rfl
+
+example :
+    ArrayElementDynamicMemberBytesSmoke.getElmLength_modelBody =
+      [ Compiler.CompilationModel.Stmt.return
           (Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
             "ops"
             (Compiler.CompilationModel.Expr.param "idx")
             0)
       ] := rfl
+
 end Contracts.Smoke

--- a/Contracts/Smoke/ArrayElementDynamicMemberBytesSmoke.lean
+++ b/Contracts/Smoke/ArrayElementDynamicMemberBytesSmoke.lean
@@ -1,0 +1,33 @@
+import Contracts.Common
+
+namespace Contracts.Smoke
+
+open Verity hiding pure bind
+
+verity_contract ArrayElementDynamicMemberBytesSmoke where
+  storage
+
+  struct Operation where
+    callData: Bytes
+
+  function callDataLength(ops: Operation) : Uint256 := do
+    return arrayLength ops.callData
+
+  function getElmLength(ops: Array Operation, idx : Uint256) : Uint256 := do
+    return arrayLength ( arrayElement ops idx).callData
+
+
+example :
+  ArrayElementDynamicMemberBytesSmoke.callDataLength_modelBody = [
+    Compiler.CompilationModel.Stmt.return
+      (Compiler.CompilationModel.Expr.paramDynamicMemberLength "ops" 0)
+  ] := rfl
+
+example :
+ ArrayElementDynamicMemberBytesSmoke.getElmLength_modelBody = [ Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+            "ops"
+            (Compiler.CompilationModel.Expr.param "idx")
+            0)
+      ] := rfl
+end Contracts.Smoke

--- a/artifacts/macro_property_tests/PropertyArrayElementDynamicMemberBytesSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyArrayElementDynamicMemberBytesSmoke.t.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyArrayElementDynamicMemberBytesSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/ArrayElementDynamicMemberBytesSmoke.lean
+ */
+contract PropertyArrayElementDynamicMemberBytesSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("ArrayElementDynamicMemberBytesSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `callDataLength` result
+    function testTODO_CallDataLength_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("callDataLength((bytes,string))", abi.decode(abi.encode(hex"CAFE", "verity"), (bytes, string))));
+        require(ok, "callDataLength reverted unexpectedly");
+        assertEq(ret.length, 32, "callDataLength ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: TODO decode and assert `labelLength` result
+    function testTODO_LabelLength_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("labelLength((bytes,string))", abi.decode(abi.encode(hex"CAFE", "verity"), (bytes, string))));
+        require(ok, "labelLength reverted unexpectedly");
+        assertEq(ret.length, 32, "labelLength ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 3: TODO decode and assert `getElmLength` result
+    function testTODO_GetElmLength_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getElmLength((bytes,string)[],uint256)", abi.decode(abi.encode(uint256(0)), ((bytes,string)[])), uint256(1)));
+        require(ok, "getElmLength reverted unexpectedly");
+        assertEq(ret.length, 32, "getElmLength ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -348,6 +348,8 @@ returnArray amounts
 
 `String`/`Bytes` support ABI transport (`returnBytes`, custom-error/event payloads, parameter flow) and direct `==`/`!=` checks. Other word-level operators (`<`, `add`, `logicalAnd`) on `String`/`Bytes` are rejected, applies to function bodies, constructor bodies, constants, and immutable initializers.
 
+`arrayLength` also works on `Bytes`/`String` dynamic struct members (e.g. `arrayLength ops.callData`, `arrayLength (arrayElement ops i).callData`), reading the ABI length word in bytes. It lowers through `Expr.paramDynamicMemberLength` / `Expr.arrayElementDynamicMemberLength`; the executable path is backed by the `ArrayLength` typeclass (`ByteArray`, `String`, `Array α`). Fixed-width word types such as `Bytes32` intentionally have no length surface — `bytes32` carries no ABI length word.
+
 ### Modifiers, structs, ADTs, and namespaced storage
 
 `verity_contract` also supports Solidity-style **modifiers** (`modifier onlyRelayer := do ...` then `with onlyRelayer`), **struct declarations** (including packed storage structs via `@word N packed(byteOffset, byteWidth)`), **algebraic data types**, **newtype wrappers**, **storage namespaces** (`storage_namespace erc7201 "myapp.storage.X"`), and **mapping-of-struct** sugar (`MappingStruct`, `MappingStruct2`). The full grammar lives in [`Verity/Macro/Syntax.lean`](https://github.com/lfglabs-dev/verity/blob/main/Verity/Macro/Syntax.lean); concrete usage shapes are in the [production Solidity patterns guide](/guides/production-solidity-patterns).


### PR DESCRIPTION
## Summary

Supersedes #1991 (thanks @poonai — your commit is included as-is, you're a co-author of this PR). This lands `arrayLength` support for `bytes`/`string` dynamic values at the executable level, plus the CI fix and a small architecture review pass.

### What's included

**poonai's commit (cherry-picked, authorship preserved):**
- `ArrayLength` typeclass in `Contracts/Common.lean` so `arrayLength` accepts non-`Array` dynamic values.
- `ArrayElementDynamicMemberBytesSmoke` covering `arrayLength ops.callData` (struct param member) and `arrayLength (arrayElement ops idx).callData` (struct-array element member).

**Follow-up commit (review findings):**
1. **Removed the `Bytes32` instance.** `Verity.Bytes32` is a reducible abbrev of `Uint256`, so `instance : ArrayLength Bytes32 := 32` silently made `arrayLength (x : Uint256)` typecheck and return `32` for *every* word value — a spec-level footgun. It was also unreachable from contract bodies: the macro type gate (`Verity/Macro/Translate/Expr.lean`) rejects `arrayLength` on non-dynamic named values, and `bytes32` carries no ABI length word. Documented the decision in a docstring.
2. **Added the `String` instance** (`String.utf8ByteSize`). `.string` dynamic members pass the exact same macro gate (`paramDynamicMemberProjection?` accepts `.array | .bytes | .string`), so without it the string analogue of the fixed case still failed executable elaboration. `utf8ByteSize` matches the EVM ABI length-word semantics (byte length, not codepoints).
3. **Extended the smoke** with a `String`-member case (`labelLength`, asserting `paramDynamicMemberLength "ops" 1`) and normalized formatting to match `ArrayElementDynamicMemberLengthSmoke`.
4. **Committed the generated property-test artifact** `PropertyArrayElementDynamicMemberBytesSmoke.t.sol` (the missing artifact that failed `checks` on #1991) via `scripts/check_macro_property_test_generation.py`.
5. **Docs**: `docs-site/content/edsl-api-reference.mdx` dynamic-arrays section now documents `arrayLength` on `Bytes`/`String` members, the lowering path, and why fixed-width word types intentionally have no length surface.

### Verification

- `make check` passes locally (including the macro property-test artifact check — the job that failed on #1991).
- A local `lake build Contracts.Smoke.ArrayElementDynamicMemberBytesSmoke` was still running when this PR was opened; CI is the authority for the Lean compilation of the smoke `rfl` examples and the executable elaboration through the new instances.

### Relation to issues

This is an EDSL-surface primitive on the dynamic-ABI track (#1982 P0-1). It does not close #1975 (struct-array calldata decoding), which needs ABI head/tail lowering in codegen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> EDSL executable/runtime surface and tests/docs only; no auth or on-chain behavior changes, and the Bytes32 removal reduces incorrect typechecking risk.
> 
> **Overview**
> **Replaces** the old `arrayLength` on `Array α` only with an **`ArrayLength` typeclass** so executable Lean code can take byte length from **`ByteArray`**, **`String`** (`utf8ByteSize`), and **`Array α`**, matching ABI length-word semantics for dynamic types.
> 
> **Deliberately omits** a `Bytes32` instance so `arrayLength` cannot typecheck on arbitrary words (since `Bytes32` abbreviates `Uint256`).
> 
> Adds **`ArrayElementDynamicMemberBytesSmoke`** with `rfl` proofs that `arrayLength` on struct **`bytes`/`string` members** and on **`(arrayElement ops idx).callData`** lowers to **`paramDynamicMemberLength`** / **`arrayElementDynamicMemberLength`**. Commits the **generated Solidity property-test stub** for CI. **Docs** now describe member-level `arrayLength` and why fixed-width words have no length surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a78f9da9bbfec07f9293c7c69a2bd77b449d4cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->