### PR TITLE
Decode projected struct-array bytes calldata (#1975)

### DIFF
--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -115,14 +115,24 @@ verity_contract LinkedExternalProjectedArrayArgSmoke where
   struct Transaction where
     merkleRoot : Uint256,
     nullifierHashes : Array Uint256,
-    newCommitments : Array Uint256
+    newCommitments : Array Uint256,
+    callData : Bytes
 
   linked_externals
     external hashArray(Array Uint256) -> (Uint256)
     external hashArray_try(Array Uint256) -> (Bool, Uint256)
+    external hashBytes(Bytes) -> (Uint256)
+    external hashBytes_try(Bytes) -> (Bool, Uint256)
 
   function tryHashNullifiers (txs : Array Transaction, idx : Uint256) : Uint256 := do
     let (_success, h) ← tryExternalCall "hashArray" [(arrayElement txs idx).nullifierHashes]
+    return h
+
+  function hashCallData (txs : Array Transaction, idx : Uint256) : Uint256 := do
+    return externalCall "hashBytes" [(arrayElement txs idx).callData]
+
+  function tryHashCallData (txs : Array Transaction, idx : Uint256) : Uint256 := do
+    let (_success, h) ← tryExternalCall "hashBytes" [(arrayElement txs idx).callData]
     return h
 
 example :
@@ -139,6 +149,41 @@ example :
               "txs"
               (Compiler.CompilationModel.Expr.param "idx")
               1
+          ]
+      , Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.localVar "h")
+      ] := rfl
+
+example :
+    LinkedExternalProjectedArrayArgSmoke.hashCallData_modelBody =
+      [ Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.externalCall
+            "hashBytes"
+            [ Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
+                "txs"
+                (Compiler.CompilationModel.Expr.param "idx")
+                3
+            , Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+                "txs"
+                (Compiler.CompilationModel.Expr.param "idx")
+                3
+            ])
+      ] := rfl
+
+example :
+    LinkedExternalProjectedArrayArgSmoke.tryHashCallData_modelBody =
+      [ Compiler.CompilationModel.Stmt.tryExternalCallBind
+          "_success"
+          ["h"]
+          "hashBytes"
+          [ Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
+              "txs"
+              (Compiler.CompilationModel.Expr.param "idx")
+              3
+          , Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+              "txs"
+              (Compiler.CompilationModel.Expr.param "idx")
+              3
           ]
       , Compiler.CompilationModel.Stmt.return
           (Compiler.CompilationModel.Expr.localVar "h")

--- a/Contracts/Smoke/HelperCalls.lean
+++ b/Contracts/Smoke/HelperCalls.lean
@@ -191,6 +191,40 @@ verity_contract DirectHelperCallBytesTupleSmoke where
     let (left, right) ← fanoutPayload payload
     return (left, right)
 
+verity_contract DirectHelperCallProjectedBytesArgSmoke where
+  storage
+
+  struct Operation where
+    sender : Address,
+    callData : Bytes,
+    nonce : Uint256
+
+  function consumePayload (_payload : Bytes) : Uint256 := do
+    return 1
+
+  function run (ops : Array Operation, idx : Uint256) : Uint256 := do
+    let count ← consumePayload (arrayElement ops idx).callData
+    return count
+
+example :
+    DirectHelperCallProjectedBytesArgSmoke.run_modelBody =
+      [ Compiler.CompilationModel.Stmt.letVar
+          "count"
+          (Compiler.CompilationModel.Expr.internalCall
+            "internal_consumePayload"
+            [ Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
+                "ops"
+                (Compiler.CompilationModel.Expr.param "idx")
+                1
+            , Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+                "ops"
+                (Compiler.CompilationModel.Expr.param "idx")
+                1
+            ])
+      , Compiler.CompilationModel.Stmt.return
+          (Compiler.CompilationModel.Expr.localVar "count")
+      ] := rfl
+
 verity_contract DirectHelperCallStaticCompositeSmoke where
   storage
     sentinel : Uint256 := slot 0

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -2034,26 +2034,14 @@ partial def inferPureExprType
             -- verity#1849, G3: accept `Array <wordLike>` / `bytes` / `string`
             -- direct param refs alongside word-like args.
             if let some (_, _, fieldTy, _elemTy, _) := arrayElementDynamicMemberProjection? params x then
-              match fieldTy with
-              | .array elemTy =>
-                  unless externalCallDynamicArgSupported (.array elemTy) do
-                    throwErrorAt x s!"externalCall '{extName}' dynamic-member argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
-              | _ =>
-                  throwErrorAt x s!"externalCall '{extName}' dynamic-member argument requires an Array-typed member, got {renderValueType fieldTy}"
+              unless externalCallDynamicArgSupported fieldTy do
+                throwErrorAt x s!"externalCall '{extName}' dynamic-member argument currently supports only Array<wordLike>/bytes/string members, got {renderValueType fieldTy}"
             else if let some (_, _, fieldTy, _elemTy, _) := localArrayElementDynamicMemberProjection? locals x then
-              match fieldTy with
-              | .array elemTy =>
-                  unless externalCallDynamicArgSupported (.array elemTy) do
-                    throwErrorAt x s!"externalCall '{extName}' dynamic-member alias argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
-              | _ =>
-                  throwErrorAt x s!"externalCall '{extName}' dynamic-member alias argument requires an Array-typed member, got {renderValueType fieldTy}"
+              unless externalCallDynamicArgSupported fieldTy do
+                throwErrorAt x s!"externalCall '{extName}' dynamic-member alias argument currently supports only Array<wordLike>/bytes/string members, got {renderValueType fieldTy}"
             else if let some (_, fieldTy, _) := paramDynamicMemberProjection? params x then
-              match fieldTy with
-              | .array elemTy =>
-                  unless externalCallDynamicArgSupported (.array elemTy) do
-                    throwErrorAt x s!"externalCall '{extName}' dynamic-member argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
-              | _ =>
-                  throwErrorAt x s!"externalCall '{extName}' dynamic-member argument requires an Array-typed member, got {renderValueType fieldTy}"
+              unless externalCallDynamicArgSupported fieldTy do
+                throwErrorAt x s!"externalCall '{extName}' dynamic-member argument currently supports only Array<wordLike>/bytes/string members, got {renderValueType fieldTy}"
             else
               requireWordOrDirectArrayType x s!"externalCall '{extName}' argument" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x visitingConstants)
       | _ => throwErrorAt args "expected list literal [..]"
@@ -3309,7 +3297,47 @@ partial def translatePureExprWithTypes
                   else
                     out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
               | none =>
-                  out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+                  if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
+                      arrayElementDynamicMemberProjection? params arg then
+                    if externalCallDynamicArgSupported fieldTy then
+                      let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+                      out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
+                        $(strTerm paramName)
+                        $indexExpr
+                        $(natTerm wordOffset)))
+                      out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+                        $(strTerm paramName)
+                        $indexExpr
+                        $(natTerm wordOffset)))
+                    else
+                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+                  else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
+                      localArrayElementDynamicMemberProjection? locals arg then
+                    if externalCallDynamicArgSupported fieldTy then
+                      let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+                      out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
+                        $(strTerm paramName)
+                        $indexExpr
+                        $(natTerm wordOffset)))
+                      out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+                        $(strTerm paramName)
+                        $indexExpr
+                        $(natTerm wordOffset)))
+                    else
+                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+                  else if let some (paramName, fieldTy, wordOffset) :=
+                      paramDynamicMemberProjection? params arg then
+                    if externalCallDynamicArgSupported fieldTy then
+                      out := out.push (← `(Compiler.CompilationModel.Expr.paramDynamicMemberDataOffset
+                        $(strTerm paramName)
+                        $(natTerm wordOffset)))
+                      out := out.push (← `(Compiler.CompilationModel.Expr.paramDynamicMemberLength
+                        $(strTerm paramName)
+                        $(natTerm wordOffset)))
+                    else
+                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+                  else
+                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
             pure out
         | _ => throwErrorAt args "expected list literal [..]"
       `(Compiler.CompilationModel.Expr.externalCall $(strTerm extName) [ $[$argsExprs],* ])
@@ -3458,26 +3486,14 @@ def validateEcmExprListLiteral
   | `(term| [ $[$xs],* ]) =>
       for x in xs do
         if let some (_, _, fieldTy, _elemTy, _) := arrayElementDynamicMemberProjection? params x then
-          match fieldTy with
-          | .array elemTy =>
-              unless externalCallDynamicArgSupported (.array elemTy) do
-                throwErrorAt x s!"{context} dynamic-member argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
-          | _ =>
-              throwErrorAt x s!"{context} dynamic-member argument requires an Array-typed member, got {renderValueType fieldTy}"
+          unless externalCallDynamicArgSupported fieldTy do
+            throwErrorAt x s!"{context} dynamic-member argument currently supports only Array<wordLike>/bytes/string members, got {renderValueType fieldTy}"
         else if let some (_, _, fieldTy, _elemTy, _) := localArrayElementDynamicMemberProjection? locals x then
-          match fieldTy with
-          | .array elemTy =>
-              unless externalCallDynamicArgSupported (.array elemTy) do
-                throwErrorAt x s!"{context} dynamic-member alias argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
-          | _ =>
-              throwErrorAt x s!"{context} dynamic-member alias argument requires an Array-typed member, got {renderValueType fieldTy}"
+          unless externalCallDynamicArgSupported fieldTy do
+            throwErrorAt x s!"{context} dynamic-member alias argument currently supports only Array<wordLike>/bytes/string members, got {renderValueType fieldTy}"
         else if let some (_, fieldTy, _) := paramDynamicMemberProjection? params x then
-          match fieldTy with
-          | .array elemTy =>
-              unless externalCallDynamicArgSupported (.array elemTy) do
-                throwErrorAt x s!"{context} dynamic-member argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
-          | _ =>
-              throwErrorAt x s!"{context} dynamic-member argument requires an Array-typed member, got {renderValueType fieldTy}"
+          unless externalCallDynamicArgSupported fieldTy do
+            throwErrorAt x s!"{context} dynamic-member argument currently supports only Array<wordLike>/bytes/string members, got {renderValueType fieldTy}"
         else
           requireWordOrDirectArrayType x context
             (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x)
@@ -3960,6 +3976,48 @@ def translateInternalHelperCallArgs
                 out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicDataOffset
                   $(strTerm paramName)
                   $indexExpr))
+              else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
+                  arrayElementDynamicMemberProjection? params arg then
+                match fnParam.ty, fieldTy with
+                | .bytes, .bytes | .string, .string =>
+                    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                    out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
+                      $(strTerm paramName)
+                      $indexExpr
+                      $(natTerm wordOffset)))
+                    out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+                      $(strTerm paramName)
+                      $indexExpr
+                      $(natTerm wordOffset)))
+                | _, _ =>
+                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+              else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
+                  localArrayElementDynamicMemberProjection? locals arg then
+                match fnParam.ty, fieldTy with
+                | .bytes, .bytes | .string, .string =>
+                    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                    out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
+                      $(strTerm paramName)
+                      $indexExpr
+                      $(natTerm wordOffset)))
+                    out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+                      $(strTerm paramName)
+                      $indexExpr
+                      $(natTerm wordOffset)))
+                | _, _ =>
+                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+              else if let some (paramName, fieldTy, wordOffset) :=
+                  paramDynamicMemberProjection? params arg then
+                match fnParam.ty, fieldTy with
+                | .bytes, .bytes | .string, .string =>
+                    out := out.push (← `(Compiler.CompilationModel.Expr.paramDynamicMemberDataOffset
+                      $(strTerm paramName)
+                      $(natTerm wordOffset)))
+                    out := out.push (← `(Compiler.CompilationModel.Expr.paramDynamicMemberLength
+                      $(strTerm paramName)
+                      $(natTerm wordOffset)))
+                | _, _ =>
+                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
               else
                 out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
         else
@@ -4001,55 +4059,43 @@ def translateLinkedExternalCallArgs
         | none =>
             if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 arrayElementDynamicMemberProjection? params arg then
-              match fieldTy with
-              | .array elemTy =>
-                  if externalCallDynamicArgSupported (.array elemTy) then
-                    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
-                    out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
-                      $(strTerm paramName)
-                      $indexExpr
-                      $(natTerm wordOffset)))
-                    out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
-                      $(strTerm paramName)
-                      $indexExpr
-                      $(natTerm wordOffset)))
-                  else
-                    throwErrorAt arg s!"linked external dynamic-member argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
-              | _ =>
-                  throwErrorAt arg s!"linked external dynamic-member argument requires an Array-typed member, got {renderValueType fieldTy}"
+              if externalCallDynamicArgSupported fieldTy then
+                let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
+                  $(strTerm paramName)
+                  $indexExpr
+                  $(natTerm wordOffset)))
+                out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+                  $(strTerm paramName)
+                  $indexExpr
+                  $(natTerm wordOffset)))
+              else
+                throwErrorAt arg s!"linked external dynamic-member argument currently supports only Array<wordLike>/bytes/string members, got {renderValueType fieldTy}"
             else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 localArrayElementDynamicMemberProjection? locals arg then
-              match fieldTy with
-              | .array elemTy =>
-                  if externalCallDynamicArgSupported (.array elemTy) then
-                    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
-                    out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
-                      $(strTerm paramName)
-                      $indexExpr
-                      $(natTerm wordOffset)))
-                    out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
-                      $(strTerm paramName)
-                      $indexExpr
-                      $(natTerm wordOffset)))
-                  else
-                    throwErrorAt arg s!"linked external dynamic-member alias argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
-              | _ =>
-                  throwErrorAt arg s!"linked external dynamic-member alias argument requires an Array-typed member, got {renderValueType fieldTy}"
+              if externalCallDynamicArgSupported fieldTy then
+                let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
+                  $(strTerm paramName)
+                  $indexExpr
+                  $(natTerm wordOffset)))
+                out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
+                  $(strTerm paramName)
+                  $indexExpr
+                  $(natTerm wordOffset)))
+              else
+                throwErrorAt arg s!"linked external dynamic-member alias argument currently supports only Array<wordLike>/bytes/string members, got {renderValueType fieldTy}"
             else if let some (paramName, fieldTy, wordOffset) :=
                 paramDynamicMemberProjection? params arg then
-              match fieldTy with
-              | .array elemTy =>
-                  if externalCallDynamicArgSupported (.array elemTy) then
-                    out := out.push (← `(Compiler.CompilationModel.Expr.paramDynamicMemberDataOffset
-                      $(strTerm paramName)
-                      $(natTerm wordOffset)))
-                    out := out.push (← `(Compiler.CompilationModel.Expr.paramDynamicMemberLength
-                      $(strTerm paramName)
-                      $(natTerm wordOffset)))
-                  else
-                    throwErrorAt arg s!"linked external dynamic-member argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
-              | _ =>
-                  throwErrorAt arg s!"linked external dynamic-member argument requires an Array-typed member, got {renderValueType fieldTy}"
+              if externalCallDynamicArgSupported fieldTy then
+                out := out.push (← `(Compiler.CompilationModel.Expr.paramDynamicMemberDataOffset
+                  $(strTerm paramName)
+                  $(natTerm wordOffset)))
+                out := out.push (← `(Compiler.CompilationModel.Expr.paramDynamicMemberLength
+                  $(strTerm paramName)
+                  $(natTerm wordOffset)))
+              else
+                throwErrorAt arg s!"linked external dynamic-member argument currently supports only Array<wordLike>/bytes/string members, got {renderValueType fieldTy}"
             else
               out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
   pure out
@@ -4206,8 +4252,7 @@ def expectEcmExprList
         | none =>
             if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 arrayElementDynamicMemberProjection? params x then
-              match fieldTy with
-              | .array _ =>
+              if externalCallDynamicArgSupported fieldTy then
                   let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
                   out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                     $(strTerm paramName)
@@ -4217,11 +4262,11 @@ def expectEcmExprList
                     $(strTerm paramName)
                     $indexExpr
                     $(natTerm wordOffset)))
-              | _ => out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+              else
+                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
             else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 localArrayElementDynamicMemberProjection? locals x then
-              match fieldTy with
-              | .array _ =>
+              if externalCallDynamicArgSupported fieldTy then
                   let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
                   out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                     $(strTerm paramName)
@@ -4231,18 +4276,19 @@ def expectEcmExprList
                     $(strTerm paramName)
                     $indexExpr
                     $(natTerm wordOffset)))
-              | _ => out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+              else
+                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
             else if let some (paramName, fieldTy, wordOffset) :=
                 paramDynamicMemberProjection? params x then
-              match fieldTy with
-              | .array _ =>
+              if externalCallDynamicArgSupported fieldTy then
                   out := out.push (← `(Compiler.CompilationModel.Expr.paramDynamicMemberDataOffset
                     $(strTerm paramName)
                     $(natTerm wordOffset)))
                   out := out.push (← `(Compiler.CompilationModel.Expr.paramDynamicMemberLength
                     $(strTerm paramName)
                     $(natTerm wordOffset)))
-              | _ => out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+              else
+                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
             else
               match ← translateAbiEncodeProjection? fields constDecls immutableDecls params locals x with
               | some exprs => out := out ++ exprs

--- a/artifacts/macro_property_tests/PropertyDirectHelperCallProjectedBytesArgSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyDirectHelperCallProjectedBytesArgSmoke.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyDirectHelperCallProjectedBytesArgSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/HelperCalls.lean
+ */
+contract PropertyDirectHelperCallProjectedBytesArgSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("DirectHelperCallProjectedBytesArgSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: consumePayload returns the declared constant result
+    function testAuto_ConsumePayload_ReturnsDeclaredConstant() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("consumePayload(bytes)", hex"CAFE"));
+        require(ok, "consumePayload reverted unexpectedly");
+        assertEq(ret.length, 32, "consumePayload ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, 1, "consumePayload should return the declared constant");
+    }
+    // Property 2: TODO decode and assert `run` result
+    function testTODO_Run_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("run((address,bytes,uint256)[],uint256)", abi.decode(abi.encode(uint256(0)), ((address,bytes,uint256)[])), uint256(1)));
+        require(ok, "run reverted unexpectedly");
+        assertEq(ret.length, 32, "run ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}


### PR DESCRIPTION
## Summary
- Routes projected dynamic members of struct-array elements through the existing ABI decode pair (`arrayElementDynamicMemberDataOffset` + `arrayElementDynamicMemberLength`), now covering `Bytes`/`String` in addition to `Array<wordLike>`.
- Applies across `externalCall`, linked externals / `tryExternalCall`, ECM-style arg lists, and internal helper calls.
- Adds rfl model-body smoke assertions for projected `Bytes` forwarding (`Contracts/Smoke/ExternalCalls.lean`, `Contracts/Smoke/HelperCalls.lean`) plus a macro property test.

Closes #1975. Tier 1 of the dynamic ABI codec track — unblocks killing `midnight_*_callback_dynamic_abi` ECM sites in the Morpho Midnight port.

## Test plan
- [x] `lake build Verity Contracts Compiler PrintAxioms` → "Build completed successfully."
- [x] `scripts/refresh_verification_artifacts.sh` → `[refresh] PASS`
- [x] `make check` → "All checks passed."
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core macro translation for call arguments and ABI calldata decoding; incorrect offset/length lowering could break compiled contracts at runtime, though scope is narrow and guarded by rfl smoke tests.
> 
> **Overview**
> Extends the Verity macro so **projected dynamic members** from struct-array elements (e.g. `(arrayElement txs idx).callData`) compile to **`arrayElementDynamicMemberDataOffset` + `arrayElementDynamicMemberLength`**, not only for `Array<wordLike>` but also for **`Bytes` and `String`**, via `externalCallDynamicArgSupported`.
> 
> **`Verity/Macro/Translate/Expr.lean`** wires this through **`externalCall` / `tryExternalCall`**, linked-externals arg lowering, ECM-style lists, and **internal helper** calls; validation errors now mention bytes/string instead of requiring an Array-typed member. Non-supported projected types fall back to full expression translation where appropriate.
> 
> **Smoke coverage:** `LinkedExternalProjectedArrayArgSmoke` adds `callData : Bytes`, `hashBytes` externals, and rfl checks for `hashCallData` / `tryHashCallData`; **`DirectHelperCallProjectedBytesArgSmoke`** asserts internal helper forwarding uses member offset/length at word offset 1. A generated **`PropertyDirectHelperCallProjectedBytesArgSmoke.t.sol`** stub is added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99b546d7b82e322743a96c37b61c700f36c128e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->