### PR TITLE
First-class Call.Result for external calls (#1891)

### DIFF
--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -374,12 +374,45 @@ instance : ExternalResult Address where
   fromWord value := wordToAddress value
 instance : ExternalResult Bool where
   fromWord value := value != 0
+
+namespace Call
+
+/-- First-class external-call result used by executable contract wrappers.
+    The compilation-model path lowers `callResult` binds to the same low-level
+    try-call wrapper as `tryExternalCall`, while executable tests can inspect
+    success and payload as one value. -/
+structure Result (α : Type) where
+  success : Bool
+  returndata : α
+  deriving Repr, BEq
+
+namespace Result
+
+def failed (result : Result α) : Bool :=
+  !result.success
+
+def payload (result : Result α) : α :=
+  result.returndata
+
+end Result
+
+end Call
+
 private def externalCallStubWord (name : String) (args : List Uint256) : Uint256 :=
   match name, args with
   | "echo", [value] => value
   | _, _ => args.foldl add name.length
 def externalCallWords {α : Type} [ExternalResult α] (name : String) (args : List Uint256) : α :=
   ExternalResult.fromWord (externalCallStubWord name args)
+def callResultWords {α : Type} [ExternalResult α] [Inhabited α] (name : String) (args : List Uint256) :
+    Contract (Call.Result α) :=
+  let success := name != "fail"
+  let payload :=
+    if success then
+      ExternalResult.fromWord (externalCallStubWord name args)
+    else
+      Inhabited.default
+  pure { success := success, returndata := payload }
 def tryExternalCallWords {α : Type} [Inhabited α] (_name : String) (_args : List Uint256) : Contract (Bool × α) :=
   pure (false, (Inhabited.default : α))
 def externalCallBind {α : Type} [ExternalArg α] (_names : List String) (_name : String) (_args : List α) : Contract Unit :=
@@ -391,6 +424,10 @@ macro_rules
       `(externalCallWords $(Lean.quote (toString name.getId)) [ $[ExternalArg.toWord $args],* ])
   | `(term| externalCall $name:str [ $[$args:term],* ]) =>
       `(externalCallWords $name [ $[ExternalArg.toWord $args],* ])
+  | `(term| callResult $name:str [ $[$args:term],* ]) =>
+      `(callResultWords $name [ $[ExternalArg.toWord $args],* ])
+  | `(term| callResult $name:ident [ $[$args:term],* ]) =>
+      `(callResultWords $(Lean.quote (toString name.getId)) [ $[ExternalArg.toWord $args],* ])
   | `(term| tryExternalCall $name:str [ $[$args:term],* ]) =>
       `(tryExternalCallWords $name [ $[ExternalArg.toWord $args],* ])
   | `(term| tryExternalCall $name:ident [ $[$args:term],* ]) =>

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -39,6 +39,41 @@ verity_contract TryExternalCallSmoke where
     else
       setStorage callSucceeded 0
 
+-- First-class Call.Result smoke: callers inspect the named result instead of
+-- destructuring ad hoc `(success, value)` tuples (#1891).
+verity_contract CallResultSmoke where
+  storage
+    lastResult : Uint256 := slot 0
+    callSucceeded : Uint256 := slot 1
+  linked_externals
+    external echo(Uint256) -> (Uint256)
+    external echo_try(Uint256) -> (Bool, Uint256)
+
+  function allow_post_interaction_writes storeCallResult (x : Uint256) : Unit := do
+    let result ← callResult "echo" [x]
+    if result.success then
+      setStorage lastResult result.returndata
+      setStorage callSucceeded 1
+    else
+      setStorage callSucceeded 0
+
+example :
+    CallResultSmoke.storeCallResult_modelBody.head? =
+      some (Compiler.CompilationModel.Stmt.tryExternalCallBind
+          "result_success"
+          ["result_returndata"]
+          "echo"
+          [ Compiler.CompilationModel.Expr.param "x" ]) := rfl
+
+example :
+    (Contracts.callResultWords "echo" [7] :
+      Contract (Contracts.Call.Result Uint256)).run
+        defaultState =
+      ContractResult.success
+        { success := true, returndata := (7 : Uint256) }
+        defaultState := by
+  rfl
+
 verity_contract LinkedExternalDynamicArgSmoke where
   storage
   linked_externals

--- a/Contracts/Smoke/SpecGenAndChecks.lean
+++ b/Contracts/Smoke/SpecGenAndChecks.lean
@@ -94,6 +94,7 @@ end SpecGenSmoke
 #check_contract UintKeyStructMappingSmoke
 #check_contract ExternalCallSmoke
 #check_contract TryExternalCallSmoke
+#check_contract CallResultSmoke
 #check_contract LinkedExternalDynamicArgSmoke
 #check_contract LinkedExternalProjectedArrayArgSmoke
 #check_contract NestedStructArrayProjectionSmoke

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -200,9 +200,13 @@ private partial def validateDoElemExprTypes
                       -- void interface method: cannot bind its (empty) result
                       throwErrorAt rhs s!"interface call '{toString name.getId}' binds a void method; call it as a statement, not `let ... ←`"
                   | none =>
-                      let ty ← inferBindSourceType fields constDecls immutableDecls externalDecls functions params locals rhs
-                      requireSupportedLocalBindingType name s!"local binding '{toString name.getId}'" ty
-                      pure <| locals.push (mkTypedLocal (toString name.getId) ty)
+                      match ← callResultBindStmt? fields constDecls immutableDecls externalDecls params locals rhs (toString name.getId) with
+                      | some (_, resultLocal) =>
+                          pure <| locals.push resultLocal
+                      | none =>
+                          let ty ← inferBindSourceType fields constDecls immutableDecls externalDecls functions params locals rhs
+                          requireSupportedLocalBindingType name s!"local binding '{toString name.getId}'" ty
+                          pure <| locals.push (mkTypedLocal (toString name.getId) ty)
       | `(doElem| $name:ident := $rhs:term) =>
           let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals rhs
           pure locals
@@ -1222,6 +1226,10 @@ private partial def translateDoElem
           if localNames.contains varName then
             throwErrorAt name s!"duplicate local variable '{varName}'"
           match stripParens rhs with
+          | `(term| callResult $_extName:term $_args:term) =>
+              match (← callResultBindStmt? fields constDecls immutableDecls externalDecls params locals rhs varName) with
+              | some (stmt, resultLocal) => pure (#[stmt], locals.push resultLocal, mutableLocals)
+              | none => throwErrorAt rhs "invalid callResult bind"
           | `(term| ecmCall $moduleFactory:term $args:term) =>
               let argExprs ← expectEcmExprList fields constDecls immutableDecls params locals args
               let moduleTerm ← `(term| (($moduleFactory) $(strTerm varName)))

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -2139,6 +2139,20 @@ partial def inferBindSourceType
     (rhs : Term) : CommandElabM ValueType := do
   let rhs := stripParens rhs
   match rhs with
+  | `(term| callResult $name:term $_args:term) =>
+      let extName := ← expectStringOrIdent name
+      let ext ←
+        match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt rhs s!"unknown external function '{extName}'"
+      let fields :=
+        match ext.returnTys.toList with
+        | [] => [("success", .bool)]
+        | [retTy] => [("success", .bool), ("returndata", retTy)]
+        | retTys =>
+            ("success", .bool) ::
+              retTys.zipIdx.map (fun (retTy, idx) => (s!"returndata{idx}", retTy))
+      pure (.struct "Call.Result" fields)
   | `(term| getStorage $field:ident) =>
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with
@@ -4164,6 +4178,68 @@ def tryExternalCallBindStmt?
           $(strTerm extName)
           [ $[$argExprs],* ])
       pure (some (stmt, visibleLocals))
+  | _ => pure none
+
+/-- Translate `let r ← callResult "name" [args]` into the existing try-call
+    lowering while exposing `r.success` and `r.returndata` (or
+    `r.returndata0`, `r.returndata1`, ...) as one source-level result value. -/
+def callResultBindStmt?
+    (fields : Array StorageFieldDecl)
+    (constDecls : Array ConstantDecl)
+    (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (rhs : Term)
+    (resultName : String) : CommandElabM (Option (Term × TypedLocal)) := do
+  let rhs := stripParens rhs
+  match rhs with
+  | `(term| callResult $name:term $args:term) =>
+      let extName := ← expectStringOrIdent name
+      let argExprs ← match stripParens args with
+        | `(term| [ $[$xs],* ]) =>
+            translateLinkedExternalCallArgs fields constDecls immutableDecls params locals xs
+        | _ => throwErrorAt args "expected list literal [..]"
+      let ext ←
+        match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt rhs s!"unknown external function '{extName}'"
+      for retTy in ext.returnTys do
+        unless isSingleWordStaticValueType retTy do
+          throwErrorAt rhs
+            s!"callResult '{extName}' currently supports only zero or more single-word static return values; got {renderValueType retTy}"
+      let successVar := freshSyntheticLocalName s!"{resultName}_success" params locals #[]
+      let usedAfterSuccess : Array TypedLocal := locals.push (mkTypedLocal successVar .bool)
+      let mut fieldLocals : List (String × String) := [("success", successVar)]
+      let mut resultVars : Array String := #[]
+      let mut resultFields : List (String × ValueType) := [("success", .bool)]
+      match ext.returnTys.toList with
+      | [] => pure ()
+      | [retTy] =>
+          let payloadVar := freshSyntheticLocalName s!"{resultName}_returndata" params usedAfterSuccess #[]
+          resultVars := resultVars.push payloadVar
+          fieldLocals := fieldLocals ++ [("returndata", payloadVar)]
+          resultFields := resultFields ++ [("returndata", retTy)]
+      | retTys =>
+          let mut indexedLocals := usedAfterSuccess
+          for (retTy, idx) in retTys.zipIdx do
+            let fieldName := s!"returndata{idx}"
+            let payloadVar := freshSyntheticLocalName s!"{resultName}_{fieldName}" params indexedLocals #[]
+            indexedLocals := indexedLocals.push (mkTypedLocal payloadVar retTy)
+            resultVars := resultVars.push payloadVar
+            fieldLocals := fieldLocals ++ [(fieldName, payloadVar)]
+            resultFields := resultFields ++ [(fieldName, retTy)]
+      let resultVarTerms := resultVars.map strTerm
+      let stmt ← `(Compiler.CompilationModel.Stmt.tryExternalCallBind
+          $(strTerm successVar)
+          [ $[$resultVarTerms],* ]
+          $(strTerm extName)
+          [ $[$argExprs],* ])
+      let resultLocal : TypedLocal :=
+        { name := resultName
+          ty := .struct "Call.Result" resultFields
+          source := .externalStaticStruct fieldLocals }
+      pure (some (stmt, resultLocal))
   | _ => pure none
 
 def expectExprList

--- a/artifacts/macro_property_tests/PropertyCallResultSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyCallResultSmoke.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyCallResultSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/ExternalCalls.lean
+ */
+contract PropertyCallResultSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("CallResultSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+}


### PR DESCRIPTION
## Summary
- Adds `Contracts.Call.Result α` (`success`, `returndata`) and the `callResult "external" [args]` contract syntax; `let result ← callResult ...` lowers to the existing `Stmt.tryExternalCallBind`.
- Projections are first-class locals (`result.success`, `result.returndata`; multi-return uses `returndata0`, `returndata1`, …) with executable fallback semantics via `callResultWords`.
- Smoke coverage: lowering + executable-semantics `example`s, `#check_contract CallResultSmoke`, and a macro property test.

Closes #1891. Tier 3 (external-world track) — foundation for #1963 (stateful external interactions) and #1964 (oracle summaries killing the `oracle_read_uint256_interface` ECM).

Known limitation: payload projections are word-static on the compilation-model path; dynamic/composite payloads fail closed until ABI-frame result payload lowering lands.

## Test plan
- [x] `lake build Verity Contracts Compiler PrintAxioms` → "Build completed successfully."
- [x] `make check` → "All checks passed."
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches contract DSL macro translation and external-call lowering, but reuses the existing tryExternalCallBind path; dynamic/composite returndata is rejected at compile time.
> 
> **Overview**
> Introduces **`Contracts.Call.Result α`** with `success` and `returndata`, plus the **`callResult "external" [args]`** surface so contract code can bind one named value instead of ad hoc `(Bool, …)` tuples from `tryExternalCall`.
> 
> **`let result ← callResult …`** is wired through the macro translator (`callResultBindStmt?`, type inference in `inferBindSourceType`) and still lowers to **`Stmt.tryExternalCallBind`**—same path as `tryExternalCall`. Projections **`result.success`** and **`result.returndata`** (multi-return: **`returndata0`**, **`returndata1`**, …) use the existing **`externalStaticStruct`** local source. Executable tests get **`callResultWords`** via new macro rules in `Contracts/Common.lean`.
> 
> Coverage adds **`CallResultSmoke`**, `#check_contract`, rfl examples for lowering and stub semantics, and an auto-generated **`PropertyCallResultSmokeTest`** deploy stub.
> 
> **Limitation:** compilation-model **`callResult`** only accepts zero or more **single-word static** return types; other payloads error until ABI-frame payload lowering exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4207e8cae234b7a3826d16344f658e5325ac3dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->