### PR TITLE
Model stateful external interactions (#1963)

### DIFF
--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -836,12 +836,24 @@ private def ecmJson (entry : String × String) : String :=
     ("boundaryClass", jsonString (boundaryClassFromAxiom entry.2))
   ]
 
+private def externalSummaryJson (summary : ECM.StatefulExternal.Summary) : String :=
+  jsonObject [
+    ("name", jsonString summary.name),
+    ("selector",
+      match summary.selector with
+      | some selector => toString selector
+      | none => "null"),
+    ("mutability", jsonString summary.mutability.toJsonString),
+    ("assumptions", jsonArray (summary.assumptionNames.map jsonString))
+  ]
+
 private def ecmModuleJson (entry : ECM.ExternalCallModule) : String :=
   jsonObject [
     ("module", jsonString entry.name),
     ("status", proofStatusString entry.proofStatus),
     ("axioms", jsonArray (entry.axioms.map jsonString)),
-    ("boundaryClass", jsonString (boundaryClassFromModule entry))
+    ("boundaryClass", jsonString (boundaryClassFromModule entry)),
+    ("externalSummary", externalSummaryJson entry.externalSummary)
   ]
 
 private def frameSpecJson (frame : FrameSpec) : String :=
@@ -882,6 +894,8 @@ private structure AssumptionReportEntry where
   linkMode : String := ""
   moduleName : String := ""
   axioms : List String := []
+  mutability : String := ""
+  selector : Option Nat := none
 
 private def assumptionReportEntryJson (entry : AssumptionReportEntry) : String :=
   jsonObject [
@@ -895,6 +909,11 @@ private def assumptionReportEntryJson (entry : AssumptionReportEntry) : String :
     ("linkMode", jsonString entry.linkMode),
     ("module", jsonString entry.moduleName),
     ("axioms", jsonArray (entry.axioms.map jsonString)),
+    ("mutability", jsonString entry.mutability),
+    ("selector",
+      match entry.selector with
+      | some selector => toString selector
+      | none => "null"),
     ("boundaryClass", jsonString entry.boundaryClass)
   ]
 
@@ -1086,7 +1105,9 @@ private def usageSitesJson (spec : CompilationModel) : String :=
         ("axiomatizedPrimitives", jsonArray (site.primitives.map primitiveAssumptionJson)),
         ("linkedExternals", jsonArray (site.externals.map assumptionJson)),
         ("ecmAxioms", jsonArray ((ecmAxiomsFromModules site.modules).map ecmJson)),
-        ("ecmModules", jsonArray (site.modules.map ecmModuleJson))
+        ("ecmModules", jsonArray (site.modules.map ecmModuleJson)),
+        ("externalSummaries", jsonArray (site.modules.map (fun mod =>
+          externalSummaryJson mod.externalSummary)))
       ])
     ]
   jsonArray ((collectUsageSiteSummaries spec).map siteJson)
@@ -1130,6 +1151,19 @@ private def assumptionReportEntriesForSite (site : UsageSiteSummary) : List Assu
           name := assumptionName
           status := mod.proofStatus
           moduleName := mod.name }))
+  let summaryEntries :=
+    site.modules.map (fun mod =>
+      let summary := mod.externalSummary
+      { category := "externalSummary"
+        boundaryClass := boundaryClassFromModule mod
+        siteKind := site.kind
+        siteName := site.name
+        name := summary.name
+        status := mod.proofStatus
+        moduleName := mod.name
+        axioms := summary.assumptionNames
+        mutability := summary.mutability.toJsonString
+        selector := summary.selector })
   let localObligationEntries :=
     site.localObligations.map (fun obligation =>
       { category := "localObligation"
@@ -1139,7 +1173,8 @@ private def assumptionReportEntriesForSite (site : UsageSiteSummary) : List Assu
         name := obligation.name
         status := obligation.proofStatus
         detail := obligation.obligation })
-  primitiveEntries ++ externalEntries ++ moduleEntries ++ axiomEntries ++ localObligationEntries
+  primitiveEntries ++ externalEntries ++ moduleEntries ++ axiomEntries ++ summaryEntries ++
+    localObligationEntries
 
 private def assumptionReportEntries (spec : CompilationModel) : List AssumptionReportEntry :=
   (collectUsageSiteSummaries spec).flatMap assumptionReportEntriesForSite
@@ -1500,7 +1535,9 @@ where
           jsonArray ((collectAxiomatizedPrimitives spec).map primitiveAssumptionJson)),
         ("linkedExternals", jsonArray ((collectUsedExternalAssumptions spec).map assumptionJson)),
         ("ecmAxioms", jsonArray ((collectEcmAxioms spec).map ecmJson)),
-        ("ecmModules", jsonArray ((collectUsedEcmModules spec).map ecmModuleJson))
+        ("ecmModules", jsonArray ((collectUsedEcmModules spec).map ecmModuleJson)),
+        ("externalSummaries", jsonArray ((collectUsedEcmModules spec).map (fun mod =>
+          externalSummaryJson mod.externalSummary)))
       ])
     ]
 

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -1366,8 +1366,10 @@ unsafe def runTests : IO Unit := do
     throw (IO.userError "✗ trust report emits linked external axioms")
   if !contains trustReport "\"module\":\"testCall\"" || !contains trustReport "\"assumption\":\"test_call_interface\"" then
     throw (IO.userError "✗ trust report emits ECM axioms")
-  if !contains trustReport "\"ecmModules\":[{\"module\":\"testCall\",\"status\":\"assumed\",\"axioms\":[\"test_call_interface\"],\"boundaryClass\":\"abiBoundary\"}]" then
+  if !contains trustReport "\"ecmModules\":[{\"module\":\"testCall\",\"status\":\"assumed\",\"axioms\":[\"test_call_interface\"],\"boundaryClass\":\"abiBoundary\",\"externalSummary\":{\"name\":\"testCall\",\"selector\":null,\"mutability\":\"staticcall\",\"assumptions\":[\"test_call_interface\"]}}]" then
     throw (IO.userError "✗ trust report emits ECM module status")
+  if !contains trustReport "\"externalSummaries\":[{\"name\":\"testCall\",\"selector\":null,\"mutability\":\"staticcall\",\"assumptions\":[\"test_call_interface\"]}]" then
+    throw (IO.userError "✗ trust report emits assumed external summaries")
   if !contains trustReport "\"linkedExternals\":[{\"name\":\"PoseidonT3_hash\",\"status\":\"assumed\",\"linkMode\":\"objectLinked\",\"axioms\":[\"poseidon_t3_deterministic\"],\"boundaryClass\":\"compilerIntrinsic\"}]" then
     throw (IO.userError "✗ trust report classifies linked external boundaries")
   if !contains trustReport "\"ecmAxioms\":[{\"module\":\"testCall\",\"assumption\":\"test_call_interface\",\"boundaryClass\":\"abiBoundary\"}]" then
@@ -1557,25 +1559,27 @@ unsafe def runTests : IO Unit := do
     throw (IO.userError "✗ assumption report emits contract name")
   if !contains assumptionReport "\"category\":\"axiomatizedPrimitive\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"keccak256\",\"status\":\"assumed\",\"detail\":\"\",\"assumption\":\"keccak256_memory_slice_matches_evm\"" then
     throw (IO.userError "✗ assumption report emits primitive assumption entries")
-  if !contains assumptionReport "\"category\":\"axiomatizedPrimitive\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"keccak256\",\"status\":\"assumed\",\"detail\":\"\",\"assumption\":\"keccak256_memory_slice_matches_evm\",\"linkMode\":\"\",\"module\":\"\",\"axioms\":[],\"boundaryClass\":\"compilerIntrinsic\"" then
+  if !contains assumptionReport "\"category\":\"axiomatizedPrimitive\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"keccak256\",\"status\":\"assumed\",\"detail\":\"\",\"assumption\":\"keccak256_memory_slice_matches_evm\",\"linkMode\":\"\",\"module\":\"\",\"axioms\":[],\"mutability\":\"\",\"selector\":null,\"boundaryClass\":\"compilerIntrinsic\"" then
     throw (IO.userError "✗ assumption report classifies primitive boundaries")
   if !contains assumptionReport "\"category\":\"linkedExternal\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"PoseidonT3_hash\",\"status\":\"assumed\"" ||
       !contains assumptionReport "\"linkMode\":\"objectLinked\"" then
     throw (IO.userError "✗ assumption report emits linked external entries")
-  if !contains assumptionReport "\"category\":\"linkedExternal\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"PoseidonT3_hash\",\"status\":\"assumed\",\"detail\":\"\",\"assumption\":\"\",\"linkMode\":\"objectLinked\",\"module\":\"\",\"axioms\":[\"poseidon_t3_deterministic\"],\"boundaryClass\":\"compilerIntrinsic\"" then
+  if !contains assumptionReport "\"category\":\"linkedExternal\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"PoseidonT3_hash\",\"status\":\"assumed\",\"detail\":\"\",\"assumption\":\"\",\"linkMode\":\"objectLinked\",\"module\":\"\",\"axioms\":[\"poseidon_t3_deterministic\"],\"mutability\":\"\",\"selector\":null,\"boundaryClass\":\"compilerIntrinsic\"" then
     throw (IO.userError "✗ assumption report classifies linked external boundaries")
   if !contains assumptionReport "\"category\":\"ecmModule\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"testCall\",\"status\":\"assumed\"" then
     throw (IO.userError "✗ assumption report emits ECM module entries")
-  if !contains assumptionReport "\"category\":\"ecmModule\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"testCall\",\"status\":\"assumed\",\"detail\":\"\",\"assumption\":\"\",\"linkMode\":\"\",\"module\":\"\",\"axioms\":[\"test_call_interface\"],\"boundaryClass\":\"abiBoundary\"" then
+  if !contains assumptionReport "\"category\":\"ecmModule\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"testCall\",\"status\":\"assumed\",\"detail\":\"\",\"assumption\":\"\",\"linkMode\":\"\",\"module\":\"\",\"axioms\":[\"test_call_interface\"],\"mutability\":\"\",\"selector\":null,\"boundaryClass\":\"abiBoundary\"" then
     throw (IO.userError "✗ assumption report classifies ECM module boundaries")
+  if !contains assumptionReport "\"category\":\"externalSummary\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"testCall\",\"status\":\"assumed\",\"detail\":\"\",\"assumption\":\"\",\"linkMode\":\"\",\"module\":\"testCall\",\"axioms\":[\"test_call_interface\"],\"mutability\":\"staticcall\",\"selector\":null,\"boundaryClass\":\"abiBoundary\"" then
+    throw (IO.userError "✗ assumption report emits external summary entries")
   if !contains assumptionReport "\"category\":\"ecmAxiom\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"test_call_interface\",\"status\":\"assumed\"" ||
       !contains assumptionReport "\"module\":\"testCall\"" then
     throw (IO.userError "✗ assumption report emits ECM axiom entries")
-  if !contains assumptionReport "\"category\":\"ecmAxiom\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"test_call_interface\",\"status\":\"assumed\",\"detail\":\"\",\"assumption\":\"\",\"linkMode\":\"\",\"module\":\"testCall\",\"axioms\":[],\"boundaryClass\":\"abiBoundary\"" then
+  if !contains assumptionReport "\"category\":\"ecmAxiom\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"test_call_interface\",\"status\":\"assumed\",\"detail\":\"\",\"assumption\":\"\",\"linkMode\":\"\",\"module\":\"testCall\",\"axioms\":[],\"mutability\":\"\",\"selector\":null,\"boundaryClass\":\"abiBoundary\"" then
     throw (IO.userError "✗ assumption report classifies ECM axiom boundaries")
   if !contains assumptionReport "\"category\":\"localObligation\",\"siteKind\":\"function\",\"siteName\":\"unsafeEdge\",\"name\":\"manual_delegatecall_refinement\",\"status\":\"assumed\",\"detail\":\"Caller must separately prove the handwritten assembly path refines the intended state transition.\"" then
     throw (IO.userError "✗ assumption report emits localized local-obligation entries")
-  if !contains assumptionReport "\"category\":\"localObligation\",\"siteKind\":\"function\",\"siteName\":\"unsafeEdge\",\"name\":\"manual_delegatecall_refinement\",\"status\":\"assumed\",\"detail\":\"Caller must separately prove the handwritten assembly path refines the intended state transition.\",\"assumption\":\"\",\"linkMode\":\"\",\"module\":\"\",\"axioms\":[],\"boundaryClass\":\"gate\"" then
+  if !contains assumptionReport "\"category\":\"localObligation\",\"siteKind\":\"function\",\"siteName\":\"unsafeEdge\",\"name\":\"manual_delegatecall_refinement\",\"status\":\"assumed\",\"detail\":\"Caller must separately prove the handwritten assembly path refines the intended state transition.\",\"assumption\":\"\",\"linkMode\":\"\",\"module\":\"\",\"axioms\":[],\"mutability\":\"\",\"selector\":null,\"boundaryClass\":\"gate\"" then
     throw (IO.userError "✗ assumption report classifies gate boundaries")
   if !contains assumptionReport "\"undischarged\":[{\"category\":\"localObligation\",\"siteKind\":\"function\",\"siteName\":\"unsafeEdge\",\"name\":\"manual_delegatecall_refinement\",\"status\":\"assumed\"" then
     throw (IO.userError "✗ assumption report tracks undischarged entries separately")
@@ -1593,7 +1597,7 @@ unsafe def runTests : IO Unit := do
   let constructorOnlyEcmTrustReport := emitTrustReportJson [constructorOnlyEcmTrustSurfaceSpec]
   if !contains constructorOnlyEcmTrustReport "\"unchecked\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"ctorHook\"],\"localObligations\":[]}" then
     throw (IO.userError "✗ trust report includes constructor-only ECM modules in proof-status buckets")
-  if !contains constructorOnlyEcmTrustReport "\"ecmModules\":[{\"module\":\"ctorHook\",\"status\":\"unchecked\",\"axioms\":[\"ctor_hook_interface\"],\"boundaryClass\":\"abiBoundary\"}]" then
+  if !contains constructorOnlyEcmTrustReport "\"ecmModules\":[{\"module\":\"ctorHook\",\"status\":\"unchecked\",\"axioms\":[\"ctor_hook_interface\"],\"boundaryClass\":\"abiBoundary\",\"externalSummary\":{\"name\":\"ctorHook\",\"selector\":null,\"mutability\":\"staticcall\",\"assumptions\":[\"ctor_hook_interface\"]}}]" then
     throw (IO.userError "✗ trust report includes constructor-only ECM modules in external assumptions")
   if !contains constructorOnlyEcmTrustReport "\"usageSites\":[{\"kind\":\"constructor\",\"name\":\"constructor\"" then
     throw (IO.userError "✗ trust report localizes constructor-only trust usage sites")

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -74,6 +74,43 @@ example :
         defaultState := by
   rfl
 
+namespace StatefulExternalSmoke
+
+open Compiler.ECM.StatefulExternal
+
+private def world : ExternalWorld :=
+  { accountState := fun address index => address + index }
+
+private def request : Request :=
+  { caller := 1
+    target := 2
+    selector := some 305419896
+    calldata := [7]
+    value := 0
+    world := world }
+
+private def balanceSummary : Summary :=
+  { name := "balanceOf"
+    selector := some 1889561905
+    mutability := .staticcall
+    assumptionNames := ["erc20_balanceOf_interface"] }
+
+example :
+    world = request.world := by
+  have h :
+      balanceSummary.interprets request (.success world [7]) := by
+    simp [Summary.interprets, balanceSummary, request]
+  have hsame :=
+    Summary.static_success_preserves_world (summary := balanceSummary)
+      (request := request) (world := world) (data := [7]) rfl h
+  exact hsame
+
+example :
+    (Outcome.revert [1, 2, 3]).committedWorld? = none := by
+  exact Summary.revert_has_no_committed_world [1, 2, 3]
+
+end StatefulExternalSmoke
+
 verity_contract LinkedExternalDynamicArgSmoke where
   storage
   linked_externals

--- a/Verity/Core/Model/ECM.lean
+++ b/Verity/Core/Model/ECM.lean
@@ -20,6 +20,94 @@ namespace Compiler.ECM
 open Compiler.Yul
 open Compiler.Constants (errorStringSelectorWord addressMask)
 
+namespace StatefulExternal
+
+/-- Call mutability at the external-world boundary. `staticcall` summaries are
+    interpreted with an unchanged external world. -/
+inductive Mutability where
+  | call
+  | staticcall
+  deriving Repr, BEq
+
+def Mutability.toJsonString : Mutability → String
+  | .call => "call"
+  | .staticcall => "staticcall"
+
+/-- Abstract state for contracts outside the current caller. The first index is
+    the account address and the second index is that account's modeled slot. -/
+structure ExternalWorld where
+  accountState : Nat → Nat → Nat := fun _ _ => 0
+
+/-- Caller-visible request sent to an external contract summary. -/
+structure Request where
+  caller : Nat
+  target : Nat
+  selector : Option Nat
+  calldata : List Nat
+  value : Nat
+  world : ExternalWorld
+
+/-- Successful calls commit an external world and returndata. Reverting calls
+    expose revert data but do not commit a caller continuation. -/
+inductive Outcome where
+  | success (world : ExternalWorld) (returndata : List Nat)
+  | revert (revertData : List Nat)
+
+namespace Outcome
+
+def returndata : Outcome → List Nat
+  | .success _ data => data
+  | .revert data => data
+
+def committedWorld? : Outcome → Option ExternalWorld
+  | .success world _ => some world
+  | .revert _ => none
+
+@[simp] theorem committedWorld?_revert (data : List Nat) :
+    (Outcome.revert data).committedWorld? = none := rfl
+
+end Outcome
+
+/-- Interface summary for an external contract interaction. The executable
+    semantics quantifies over this relation instead of treating the callee as a
+    pure oracle. -/
+structure Summary where
+  name : String
+  selector : Option Nat := none
+  mutability : Mutability
+  assumptionNames : List String := []
+  pre : Request → Prop := fun _ => True
+  post : Request → ExternalWorld → List Nat → Prop := fun _ _ _ => True
+  revert : Request → List Nat → Prop := fun _ _ => True
+
+instance : Repr Summary where
+  reprPrec summary prec :=
+    reprPrec
+      (summary.name, summary.selector, summary.mutability, summary.assumptionNames)
+      prec
+
+def Summary.interprets (summary : Summary) (request : Request) (outcome : Outcome) : Prop :=
+  summary.pre request ∧
+    match outcome with
+    | .success world data =>
+        summary.post request world data ∧
+          (summary.mutability = .staticcall → world = request.world)
+    | .revert data =>
+        summary.revert request data
+
+theorem Summary.static_success_preserves_world
+    {summary : Summary} {request : Request} {world : ExternalWorld} {data : List Nat}
+    (hstatic : summary.mutability = .staticcall)
+    (hinterp : summary.interprets request (.success world data)) :
+    world = request.world := by
+  exact hinterp.2.2 hstatic
+
+theorem Summary.revert_has_no_committed_world
+    (data : List Nat) :
+    (Outcome.revert data).committedWorld? = none := rfl
+
+end StatefulExternal
+
 /-- Context provided to ECM compile functions beyond the argument expressions.
     This gives modules access to compiler services without coupling them to
     the full CompilationModel compilation pipeline. -/
@@ -62,17 +150,46 @@ structure ExternalCallModule where
   /-- Proof-accounting status for this module's behavior. -/
   proofStatus : Compiler.ProofStatus := .assumed
 
+  /-- Stable name for the stateful external-world summary associated with this
+      ECM. Defaults to the module name so every typed ECM has a reportable
+      summary without duplicating boilerplate in module definitions. -/
+  summaryName : String := name
+
+  /-- Optional ABI selector described by the external summary. Generic modules
+      that close over a selector can override this, while dynamic wrappers may
+      leave it unknown. -/
+  summarySelector : Option Nat := none
+
+  /-- Whether the summary is interpreted as a mutable call or staticcall. The
+      default mirrors the existing `writesState` gate. -/
+  summaryMutability : StatefulExternal.Mutability :=
+    if writesState then .call else .staticcall
+
 instance : BEq ExternalCallModule where
   beq a b := a.name == b.name && a.numArgs == b.numArgs &&
     a.resultVars == b.resultVars && a.writesState == b.writesState &&
     a.readsState == b.readsState && a.axioms == b.axioms &&
-    a.proofStatus == b.proofStatus
+    a.proofStatus == b.proofStatus && a.summaryName == b.summaryName &&
+    a.summarySelector == b.summarySelector && a.summaryMutability == b.summaryMutability
 
 instance : Repr ExternalCallModule where
   reprPrec m _ := s!"ECM[{m.name}]"
 
 instance : ToString ExternalCallModule where
   toString m := s!"ECM[{m.name}]"
+
+namespace ExternalCallModule
+
+/-- Derive the semantic external-world summary carried by an ECM. Standard ECMs
+    use permissive pre/post relations for now; downstream proofs can refine the
+    relation while trust reports still expose the assumed boundary uniformly. -/
+def externalSummary (mod : ExternalCallModule) : StatefulExternal.Summary :=
+  { name := mod.summaryName
+    selector := mod.summarySelector
+    mutability := mod.summaryMutability
+    assumptionNames := mod.axioms }
+
+end ExternalCallModule
 
 /-! ### Shared Compilation Utilities
 


### PR DESCRIPTION
## Summary
- Adds `Compiler.ECM.StatefulExternal` to `Verity/Core/Model/ECM.lean`: `ExternalWorld`, `Request`, `Outcome`, `Summary`, call/staticcall mutability, returndata/revert data, and committed-world modeling.
- Derives `ExternalCallModule.externalSummary` metadata from ECMs; trust reports emit `externalSummary` per ECM plus `externalSummaries` inventories, and assumption reports gain `externalSummary`/mutability/selector fields.
- Theorems: `Summary.static_success_preserves_world`, `Summary.revert_has_no_committed_world`, `Outcome.committedWorld?_revert`; smoke coverage for staticcall world preservation and revert no-commit behavior.

Stacked on #2010 (Call.Result, #1891). Tier 3 of the external-world track; direct prerequisite of #1964 oracle summaries (which will refine the intentionally permissive default pre/post relations).

## Test plan
- [x] `lake build Verity Contracts Compiler PrintAxioms` → "Build completed successfully."
- [x] `refresh_verification_artifacts.sh` → `[refresh] PASS`
- [x] `make check` → "All checks passed."
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trust-report JSON schema and ECM metadata used in proof accounting; permissive default pre/post relations are intentional but affect how external boundaries are modeled until follow-up work refines them.
> 
> **Overview**
> Introduces **`Compiler.ECM.StatefulExternal`** in the ECM model: an abstract **`ExternalWorld`**, caller **`Request`**, success/revert **`Outcome`**, and interface **`Summary`** with **call/staticcall** mutability and optional selector. **`ExternalCallModule`** gains summary metadata (name, selector, mutability from **`writesState`**) and **`externalSummary`** derivation; **`Summary.interprets`** ties assumptions to outcomes, with lemmas that **staticcall success preserves world** and **reverts commit no world**.
> 
> **Trust and assumption JSON** now embed **`externalSummary`** on each ECM module, add contract- and usage-site **`externalSummaries`** inventories, and extend flat assumption entries with **`externalSummary`** category plus **`mutability`** / **`selector`** on all report rows. **`CompileDriverTest`** and **`ExternalCalls`** smoke examples lock in the new report shape and the stateful semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 000899b13a6945b213e7749633cdc26494dd65a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->