### PR TITLE
Oracle summaries for typed external reads (#1964)

### DIFF
--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -775,7 +775,7 @@ private def boundaryClassFromModule (mod : ECM.ExternalCallModule) : String :=
   match mod.name with
   | "ecrecover" | "sha256Memory" | "sha256" | "bn256Add" | "bn256ScalarMul" | "bn256Pairing" =>
       "compilerIntrinsic"
-  | "oracleReadUint256" =>
+  | "oracleReadUint256" | "oracleSummary" =>
       "oracleSummary"
   | "callback" =>
       "callback"

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -710,6 +710,31 @@ private def oracleTrustSurfaceSpec : CompilationModel := {
   ]
 }
 
+private def typedOracleSummaryTrustSurfaceSpec : CompilationModel := {
+  name := "TypedOracleSummaryTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "price"
+      params := [
+        { name := "oracle", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Stmt.ecm
+          (Compiler.Modules.Oracle.typedReadWordSummaryModule
+            "answer"
+            "IOracle.price"
+            0xa035b1fe
+            0)
+          [Expr.param "oracle"],
+        Stmt.returnValues [Expr.localVar "answer"]
+      ]
+    }
+  ]
+}
+
 private def callWithValueTrustSurfaceSpec : CompilationModel := {
   name := "CallWithValueTrustSurface"
   fields := []
@@ -1629,6 +1654,16 @@ unsafe def runTests : IO Unit := do
   if !contains oracleTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"oracleReadUint256\"],\"localObligations\":[]}" then
     throw (IO.userError "✗ oracle trust report emits assumed ECM proof-status bucket")
   IO.println "✓ oracle trust report emits standard oracle module assumption"
+
+  let typedOracleTrustReport := emitTrustReportJson [typedOracleSummaryTrustSurfaceSpec]
+  if !contains typedOracleTrustReport "\"module\":\"oracleSummary\"" ||
+      !contains typedOracleTrustReport "\"assumption\":\"oracle_summary:IOracle.price\"" then
+    throw (IO.userError "✗ typed oracle summary trust report emits source-shaped summary assumption")
+  if !contains typedOracleTrustReport "\"externalSummary\":{\"name\":\"IOracle.price\",\"selector\":2687873534,\"mutability\":\"staticcall\",\"assumptions\":[\"oracle_summary:IOracle.price\"]}" then
+    throw (IO.userError "✗ typed oracle summary trust report emits exact summary name, selector, and staticcall mutability")
+  if contains typedOracleTrustReport "oracle_read_uint256_interface" then
+    throw (IO.userError "✗ typed oracle summary trust report should not use legacy oracle_read_uint256_interface")
+  IO.println "✓ typed oracle summary trust report emits exact summary metadata"
 
   let callWithValueTrustReport := emitTrustReportJson [callWithValueTrustSurfaceSpec]
   if !contains callWithValueTrustReport "\"contract\":\"CallWithValueTrustSurface\"" then

--- a/Compiler/Modules/Oracle.lean
+++ b/Compiler/Modules/Oracle.lean
@@ -18,25 +18,17 @@ open Compiler.Yul
 open Compiler.ECM
 open Compiler.CompilationModel (Stmt Expr freeMemoryPointer)
 
-/-- Read-only oracle module that ABI-encodes `selector(staticArgs...)`, performs
-    a `staticcall`, forwards revert returndata on failure, requires exactly one
-    32-byte return word, and binds it to `resultVar`.
+private def selectorHex (selector : Nat) : String :=
+  "0x" ++ String.mk (Nat.toDigits 16 selector)
 
-    Arguments passed to the module are `[target] ++ staticArgs`. -/
-def oracleReadUint256Module (resultVar : String) (selector : Nat) (numStaticArgs : Nat) :
-    ExternalCallModule where
-  name := "oracleReadUint256"
-  numArgs := 1 + numStaticArgs
-  resultVars := [resultVar]
-  writesState := false
-  readsState := true
-  axioms := ["oracle_read_uint256_interface"]
-  compile := fun _ctx args => do
+private def compileStaticSingleWordRead
+    (moduleName : String) (selector : Nat) (numStaticArgs : Nat)
+    (resultVar : String) (args : List YulExpr) : Except String (List YulStmt) := do
     if selector >= 2^32 then
-      throw s!"oracleReadUint256: selector 0x{String.mk (Nat.toDigits 16 selector)} exceeds 4 bytes"
+      throw s!"{moduleName}: selector {selectorHex selector} exceeds 4 bytes"
     let targetExpr ← match args.head? with
       | some target => pure target
-      | none => throw "oracleReadUint256 expects at least 1 argument (target)"
+      | none => throw s!"{moduleName} expects at least 1 argument (target)"
     let staticArgExprs := args.drop 1
     let calldataSize := 4 + numStaticArgs * 32
     let frameSize := ((Nat.max calldataSize 32 + 31) / 32) * 32
@@ -81,9 +73,56 @@ def oracleReadUint256Module (resultVar : String) (selector : Nat) (numStaticArgs
       [YulStmt.let_ "__oracle_success" callExpr, revertOnFailure, requireSingleWord, assignResult]
     )]
 
+/-- Read-only oracle module that ABI-encodes `selector(staticArgs...)`, performs
+    a `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds it to `resultVar`.
+
+    Arguments passed to the module are `[target] ++ staticArgs`. -/
+def oracleReadUint256Module (resultVar : String) (selector : Nat) (numStaticArgs : Nat) :
+    ExternalCallModule where
+  name := "oracleReadUint256"
+  numArgs := 1 + numStaticArgs
+  resultVars := [resultVar]
+  writesState := false
+  readsState := true
+  axioms := ["oracle_read_uint256_interface"]
+  summarySelector := some selector
+  summaryMutability := .staticcall
+  compile := fun _ctx args =>
+    compileStaticSingleWordRead "oracleReadUint256" selector numStaticArgs resultVar args
+
+/-- Typed-interface oracle summary for a view method with one static ABI-word
+    return. The summary name is source-shaped, e.g. `IOracle.price`, while the
+    selector records the exact ABI method selector used by the generated
+    `staticcall`. -/
+def typedReadWordSummaryModule
+    (resultVar summaryName : String) (selector : Nat) (numStaticArgs : Nat) :
+    ExternalCallModule where
+  name := "oracleSummary"
+  numArgs := 1 + numStaticArgs
+  resultVars := [resultVar]
+  writesState := false
+  readsState := true
+  axioms := [s!"oracle_summary:{summaryName}"]
+  summaryName := summaryName
+  summarySelector := some selector
+  summaryMutability := .staticcall
+  compile := fun _ctx args =>
+    compileStaticSingleWordRead "oracleSummary" selector numStaticArgs resultVar args
+
 /-- Convenience: create a `Stmt.ecm` for a read-only `uint256` oracle call. -/
 def oracleReadUint256 (resultVar : String) (target : Expr) (selector : Nat) (staticArgs : List Expr) :
     Stmt :=
   .ecm (oracleReadUint256Module resultVar selector staticArgs.length) ([target] ++ staticArgs)
+
+theorem typedReadWordSummaryModule_static
+    (resultVar summaryName : String) (selector numStaticArgs : Nat) :
+    (typedReadWordSummaryModule resultVar summaryName selector numStaticArgs).summaryMutability =
+      .staticcall := rfl
+
+theorem typedReadWordSummaryModule_assumption
+    (resultVar summaryName : String) (selector numStaticArgs : Nat) :
+    (typedReadWordSummaryModule resultVar summaryName selector numStaticArgs).axioms =
+      [s!"oracle_summary:{summaryName}"] := rfl
 
 end Compiler.Modules.Oracle

--- a/Contracts/Smoke/InternalInterfaceSmoke.lean
+++ b/Contracts/Smoke/InternalInterfaceSmoke.lean
@@ -360,6 +360,26 @@ verity_contract ReturnCallNestedStructParamSmoke where
     let result ← pool.submit item
     return result
 
+/- A view method with a static composite return is accepted by the interface
+   declaration checks, but must not lower through the single-word oracle
+   summary. -/
+
+/--
+error: typed interface view call 'IPool.fetch' can use the oracle summary only for one static ABI word; return has 2 static ABI words (Verity.Macro.ValueType.tuple [Verity.Macro.ValueType.uint256, Verity.Macro.ValueType.address]). ABI-frame typed-interface view returns are not implemented yet (#1982).
+-/
+#guard_msgs in
+verity_contract ViewStaticCompositeReturnRejected where
+  storage
+
+  interfaces
+    interface IPool where
+      function fetch() view returns (Tuple [Uint256, Address])
+    end
+
+  function bad (pool : IPool) : Tuple [Uint256, Address] := do
+    let result ← pool.fetch
+    return result
+
 /--
 error: typed interface call 'IPool.submit' currently supports only static (single-word or composite) parameters; argument 1 has Verity.Macro.ValueType.string. Dynamic and composite ABI parameters require ABI-frame typed-interface lowering, which is not implemented yet (#1982).
 -/

--- a/Contracts/Smoke/InternalInterfaceSmoke.lean
+++ b/Contracts/Smoke/InternalInterfaceSmoke.lean
@@ -60,9 +60,13 @@ example :
         fn.body.any (fun stmt =>
           match stmt with
           | Compiler.CompilationModel.Stmt.ecm mod args =>
-              mod.name == "externalCallWithReturn" &&
+              mod.name == "oracleSummary" &&
                 mod.numArgs == 2 &&
                 mod.resultVars == ["bal"] &&
+                mod.summaryName == "IERC20.balanceOf" &&
+                mod.summarySelector == some 0x70a08231 &&
+                mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.staticcall &&
+                mod.axioms == ["oracle_summary:IERC20.balanceOf"] &&
                 mod.readsState &&
                 !mod.writesState &&
                 args.length == 2
@@ -75,9 +79,13 @@ example :
         fn.body.any (fun stmt =>
           match stmt with
           | Compiler.CompilationModel.Stmt.ecm mod args =>
-              mod.name == "externalCallWithReturn" &&
+              mod.name == "oracleSummary" &&
                 mod.numArgs == 2 &&
                 mod.resultVars == ["bal"] &&
+                mod.summaryName == "IERC20.balanceOf" &&
+                mod.summarySelector == some 0x70a08231 &&
+                mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.staticcall &&
+                mod.axioms == ["oracle_summary:IERC20.balanceOf"] &&
                 mod.readsState &&
                 !mod.writesState &&
                 args.length == 2
@@ -99,6 +107,42 @@ example :
           | _ => false)) = true := by
   decide
 
+verity_contract MorphoStyleOracleSummarySmoke where
+  storage
+    lastPrice : Uint256 := slot 0
+
+  interfaces
+    interface IOracle where
+      function price() view returns (Uint256)
+    end
+
+  function allow_post_interaction_writes snapshotPrice (oracle : IOracle) : Uint256 := do
+    let price ← oracle.price
+    setStorage lastPrice price
+    return price
+
+def morphoOracleReadUsesSummary : Bool :=
+  (MorphoStyleOracleSummarySmoke.spec.functions).any (fun fn =>
+    fn.name == "snapshotPrice" &&
+      fn.body.any (fun stmt =>
+        match stmt with
+        | Compiler.CompilationModel.Stmt.ecm mod args =>
+            mod.name == "oracleSummary" &&
+              mod.numArgs == 1 &&
+              mod.resultVars == ["price"] &&
+              mod.summaryName == "IOracle.price" &&
+              mod.summarySelector == some 0xa035b1fe &&
+              mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.staticcall &&
+              mod.axioms == ["oracle_summary:IOracle.price"] &&
+              !mod.axioms.contains "oracle_read_uint256_interface" &&
+              mod.readsState &&
+              !mod.writesState &&
+              args.length == 1
+        | _ => false))
+
+example : morphoOracleReadUsesSummary = true := by
+  decide
+
 -- Void (no-`returns`) interface methods lower to the no-output `externalCallNoReturn` ECM:
 -- a selector+args `call(...)` that bubbles failure returndata but performs no `returndatasize`
 -- check and binds no result. This is what real void callees (e.g. Aave V3 `supply`/`borrow`,
@@ -118,7 +162,7 @@ verity_contract VoidInterfaceCallSmoke where
   function doSupply (pool : IPool, asset : Address, amount : Uint256, onBehalfOf : Address) : Unit := do
     pool.supply asset amount onBehalfOf 0
 
-  -- a non-void method on the same interface still binds and return-checks as before
+  -- a non-void view method on the same interface still binds its single ABI-word result.
   function readBal (pool : IPool, owner : Address) : Uint256 := do
     let bal ← pool.balanceOf owner
     return bal
@@ -145,16 +189,18 @@ example :
           | _ => false)) = true := by
   decide
 
--- the non-void method on the same interface is unaffected: still `externalCallWithReturn`,
--- binds its result, performs the 32-byte returndata check.
+-- the non-void view method on the same interface lowers through an oracle
+-- summary and binds its single ABI-word result.
 example :
     (VoidInterfaceCallSmoke.spec.functions).any (fun fn =>
       fn.name == "readBal" &&
         fn.body.any (fun stmt =>
           match stmt with
           | Compiler.CompilationModel.Stmt.ecm mod args =>
-              mod.name == "externalCallWithReturn" &&
+                mod.name == "oracleSummary" &&
                 mod.resultVars == ["bal"] &&
+                mod.summaryName == "IPool.balanceOf" &&
+                mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.staticcall &&
                 args.length == 2
           | _ => false)) = true := by
   decide

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1,6 +1,7 @@
 import Lean
 import Compiler.Modules.ERC20
 import Compiler.Modules.Calls
+import Compiler.Modules.Oracle
 import Compiler.Modules.Precompiles
 import Compiler.Selectors
 import Compiler.CompilationModel.InternalNaming
@@ -1331,15 +1332,25 @@ private partial def translateDoElem
                               let targetExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals target
                               let argExprs ← argTerms.mapM
                                 (translatePureExprWithTypes fields constDecls immutableDecls params locals)
-                              let isStaticTerm ← if ext.isView then `(true) else `(false)
+                              let stmt ←
+                                if ext.isView then
+                                  `(Compiler.CompilationModel.Stmt.ecm
+                                      (Compiler.Modules.Oracle.typedReadWordSummaryModule
+                                        $(strTerm varName)
+                                        $(strTerm ext.name)
+                                        $(natTerm selector)
+                                        $(natTerm argExprs.size))
+                                      [ $targetExpr, $[$argExprs],* ])
+                                else
+                                  `(Compiler.CompilationModel.Stmt.ecm
+                                      (Compiler.Modules.Calls.withReturnModule
+                                        $(strTerm varName)
+                                        $(natTerm selector)
+                                        $(natTerm argExprs.size)
+                                        false)
+                                      [ $targetExpr, $[$argExprs],* ])
                               pure
-                                (#[(← `(Compiler.CompilationModel.Stmt.ecm
-                                        (Compiler.Modules.Calls.withReturnModule
-                                          $(strTerm varName)
-                                          $(natTerm selector)
-                                          $(natTerm argExprs.size)
-                                          $isStaticTerm)
-                                        [ $targetExpr, $[$argExprs],* ]))],
+                                (#[stmt],
                                   locals.push (mkTypedLocal varName retTy),
                                   mutableLocals)
                           | some (_, _, _, none, _) =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1334,13 +1334,21 @@ private partial def translateDoElem
                                 (translatePureExprWithTypes fields constDecls immutableDecls params locals)
                               let stmt ←
                                 if ext.isView then
-                                  `(Compiler.CompilationModel.Stmt.ecm
-                                      (Compiler.Modules.Oracle.typedReadWordSummaryModule
-                                        $(strTerm varName)
-                                        $(strTerm ext.name)
-                                        $(natTerm selector)
-                                        $(natTerm argExprs.size))
-                                      [ $targetExpr, $[$argExprs],* ])
+                                  match staticAbiWordCount? retTy with
+                                  | some 1 =>
+                                      `(Compiler.CompilationModel.Stmt.ecm
+                                          (Compiler.Modules.Oracle.typedReadWordSummaryModule
+                                            $(strTerm varName)
+                                            $(strTerm ext.name)
+                                            $(natTerm selector)
+                                            $(natTerm argExprs.size))
+                                          [ $targetExpr, $[$argExprs],* ])
+                                  | some n =>
+                                      throwErrorAt rhs
+                                        s!"typed interface view call '{ext.name}' can use the oracle summary only for one static ABI word; return has {n} static ABI words ({renderValueType retTy}). ABI-frame typed-interface view returns are not implemented yet (#1982)."
+                                  | none =>
+                                      throwErrorAt rhs
+                                        s!"typed interface view call '{ext.name}' can use the oracle summary only for one static ABI word; return has no static ABI word layout ({renderValueType retTy}). ABI-frame typed-interface view returns are not implemented yet (#1982)."
                                 else
                                   `(Compiler.CompilationModel.Stmt.ecm
                                       (Compiler.Modules.Calls.withReturnModule

--- a/artifacts/macro_property_tests/PropertyMorphoStyleOracleSummarySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyMorphoStyleOracleSummarySmoke.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyMorphoStyleOracleSummarySmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/InternalInterfaceSmoke.lean
+ */
+contract PropertyMorphoStyleOracleSummarySmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("MorphoStyleOracleSummarySmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+}

--- a/docs/EXTERNAL_CALL_MODULES.md
+++ b/docs/EXTERNAL_CALL_MODULES.md
@@ -69,9 +69,13 @@ function readBalance (token : IERC20, owner : Address) : Uint256 := do
   return bal
 ```
 
-The interface-typed parameter is ABI-encoded as `Address`. The dot call emits
-`Compiler.Modules.Calls.withReturnModule`; `view` selects `staticcall`, while
-non-`view` selects `call`. Interface methods with no `returns` clause lower to
+The interface-typed parameter is ABI-encoded as `Address`. A bound `view` dot
+call with one static ABI-word return emits
+`Compiler.Modules.Oracle.typedReadWordSummaryModule`, which lowers to
+`staticcall` and records a source-shaped oracle summary name such as
+`IERC20.balanceOf` plus the exact ABI selector in trust reports. Non-`view`
+single-return calls continue to use `Compiler.Modules.Calls.withReturnModule`
+and select `call`. Interface methods with no `returns` clause lower to
 `Compiler.Modules.Calls.noReturnModule` in statement position. Interface calls
 currently support one return value and type-only interface parameter lists.
 
@@ -140,6 +144,8 @@ Standard modules ship in `Compiler/Modules/`:
 | `Precompiles.bn256Pairing` | Precompile 0x08 (EIP-197) | BN254 optimal-Ate pairing check over a caller-supplied input region; binds the single 32-byte boolean word | `evm_bn256_pairing_precompile` |
 | `Callbacks.callback` | Parameterized | ABI-encode selector + static args + bytes, call target | `callback_target_interface` |
 | `Calls.withReturn` | Parameterized | Generic call/staticcall with single uint256 return | `external_call_abi_interface` |
+| `Oracle.typedReadWordSummary` | Typed-interface `view` read | ABI-encode selector + static args, `staticcall` target, bind one static ABI-word return, and surface the source-shaped summary name and selector | `oracle_summary:<Interface.method>` (`oracle_summary:{summaryName}` in the module template) |
+| `Oracle.oracleReadUint256` | Legacy generic oracle read | ABI-encode selector + static args, `staticcall` target, bind one uint256 return | `oracle_read_uint256_interface` |
 | `Calls.callWithValue` | Parameterized | Generic `call{value:v}` over an already prepared calldata slice, with revert bubbling | `generic_call_with_value_interface` |
 | `Calls.callWithValueBytes` | Parameterized | Generic `call{value:v}` over a `bytes` parameter, with revert bubbling | `generic_call_with_value_interface` |
 | `Calls.bubblingValueCall` / `Calls.bubblingValueCallNoOutput` | `call{value: v}(data)` shape | Generic low-level value call over caller-provided memory slices; bubbles exact revert returndata on failure | `generic_low_level_value_call_interface` |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -135,6 +135,11 @@ Recent progress for dynamic ABI-shaped parameters:
   (bytes/string, dynamic-element arrays, etc.) are still rejected at
   declaration/call time with an explicit #1982 error until full ABI-frame
   typed-interface lowering exists.
+- Typed `view` interface reads with one static ABI-word return now lower
+  through an oracle-summary ECM (#1964): reports show the source-shaped
+  summary name (for example `IOracle.price`), exact selector, and staticcall
+  mutability, so Morpho-style oracle reads no longer need the broad
+  `oracle_read_uint256_interface` helper.
 
 Recent progress for arithmetic modeling:
 - `Stdlib.Math` now exposes `mulDiv512Down?` and `mulDiv512Up?` as proof-facing full-precision multiply-divide helpers. They compute `a * b` in unbounded natural-number precision and return `none` only when the divisor is zero or the final floor/ceil quotient does not fit in `uint256`, removing the artificial intermediate-product overflow hypothesis when modeling Solidity `Math.mulDiv` behavior. A compiled Yul primitive using the usual 512-bit division algorithm is still tracked by #1761.


### PR DESCRIPTION
## Summary
- Adds `Compiler.Modules.Oracle.typedReadWordSummaryModule`: typed `view` interface reads with one static ABI-word return now lower to `oracleSummary` instead of the `oracle_read_uint256_interface` ECM.
- Summary metadata records the source-shaped name, selector, and `staticcall` mutability; trust reports classify these as `oracleSummary` (e.g. `oracle_summary:IOracle.price`, selector `0xa035b1fe`).
- Theorems: `typedReadWordSummaryModule_static`, `typedReadWordSummaryModule_assumption`; Morpho-style oracle smoke + macro property test; docs updated.

Closes #1964 — kills the `oracle_read_uint256_interface` ECM for downstream Morpho Blue/Midnight (morpho-verity). Stacked on #2012 (#1963) → #2010 (#1891).

## Test plan
- [x] `lake build Verity Contracts Compiler PrintAxioms` → "Build completed successfully."
- [x] `refresh_verification_artifacts.sh` → `[refresh] PASS`
- [x] `make check` → 607 tests, "All checks passed."
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler lowering and trust assumptions for typed external view reads; wrong eligibility (return shape) could mis-classify boundaries or break contracts relying on the old ECM.
> 
> **Overview**
> Typed **`view`** interface calls that bind a **single static ABI-word** return now lower through **`Oracle.typedReadWordSummaryModule`** (`oracleSummary` ECM) instead of generic **`externalCallWithReturn`**. Trust reports record **source-shaped** assumptions like `oracle_summary:IOracle.price`, plus selector and **`staticcall`** mutability; **`oracleSummary`** is classified like legacy **`oracleReadUint256`**.
> 
> **`Oracle.lean`** factors shared Yul into **`compileStaticSingleWordRead`**; the legacy module keeps **`oracle_read_uint256_interface`**. **`Translate.lean`** routes eligible view binds to the new ECM and **errors** on multi-word or non-static view returns (#1982). Smoke tests, compile-driver trust JSON checks, docs, and a Morpho-style property stub cover the new path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea00af582c630b82fded72f86f19398684246810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->