### PR TITLE
Derive frame theorems from declared effects (#1895)

### DIFF
--- a/Contracts/Smoke/Effects.lean
+++ b/Contracts/Smoke/Effects.lean
@@ -39,6 +39,19 @@ verity_contract ModifiesSmoke where
     let current ← getStorage counter
     return current
 
+example (s : ContractState) :
+    ModifiesSmoke.increment_frame s (ModifiesSmoke.increment.run s).snd :=
+  ModifiesSmoke.increment_frame_holds s
+
+example (s : ContractState) (newOwner : Address) :
+    ModifiesSmoke.transferOwnership_frame s
+      ((ModifiesSmoke.transferOwnership newOwner).run s).snd :=
+  ModifiesSmoke.transferOwnership_frame_holds newOwner s
+
+example (s : ContractState) :
+    Verity.Specs.viewPreservesState s (ModifiesSmoke.getCounter.run s).snd :=
+  ModifiesSmoke.getCounter_view_frame s
+
 -- #1729, Axis 3 Step 1c: smoke test for no_external_calls annotation
 verity_contract NoExternalCallsSmoke where
   storage

--- a/Verity/Macro/Bridge.lean
+++ b/Verity/Macro/Bridge.lean
@@ -55,6 +55,54 @@ def mkViewTheoremCommand (fnDecl : FunctionDecl) : CommandElabM Cmd := do
         (Compiler.CompilationModel.FunctionSpec.isView
           ($modelName : Compiler.CompilationModel.FunctionSpec)) = true := rfl)
 
+/-- Apply a generated executable function to all of its source parameters. -/
+private def mkFunctionApplication (fnDecl : FunctionDecl) : CommandElabM Term := do
+  let mut fnApp : Term := mkIdent fnDecl.ident.getId
+  for param in fnDecl.params do
+    let paramIdent : Term := mkIdent param.ident.getId
+    fnApp ← `($fnApp $paramIdent)
+  pure fnApp
+
+/-- Quantify a theorem proposition over a function's parameters followed by
+    the pre-state. -/
+private def mkFunctionStateForall (fnDecl : FunctionDecl) (body : Term) : CommandElabM Term := do
+  let mut prop := body
+  prop ← `(∀ (s : Verity.ContractState), $prop)
+  for param in fnDecl.params.reverse do
+    let pid := param.ident
+    let pty ← contractValueTypeTerm param.ty
+    prop ← `(∀ ($pid : $pty), $prop)
+  pure prop
+
+/-- Auto-generated execution-level frame theorem for `view` functions.
+    Validation guarantees that view bodies do not write contract state; this
+    theorem exposes that guarantee as a reusable preservation fact. -/
+def mkViewFrameTheoremCommand (fnDecl : FunctionDecl) : CommandElabM Cmd := do
+  let viewFrameName ← mkSuffixedIdent fnDecl.ident "_view_frame"
+  let fnIdent := fnDecl.ident
+  let fnApp ← mkFunctionApplication fnDecl
+  let prop ← mkFunctionStateForall fnDecl
+    (← `(Verity.Specs.viewPreservesState s (($fnApp).run s).snd))
+  `(command|
+    /-- Auto-generated execution frame: this `view` function preserves state. -/
+    theorem $viewFrameName : $prop := by
+      intros
+      unfold $fnIdent
+      simp [msgSender, getStorageAddr, getStorage, setStorage, setStorageAddr,
+        getMapping, setMapping, setMapping2, getMappingUint, setMappingUint,
+        getMapping2, ContractState.readSlot, ContractState.writeSlot,
+        ContractState.readAddrSlot, ContractState.writeAddrSlot,
+        ContractState.readMap, ContractState.writeMap, ContractState.readMapUint,
+        ContractState.writeMapUint, ContractState.readMap2, ContractState.writeMap2,
+        Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
+        Contract.run, ContractResult.snd, ContractResult.fst,
+        Verity.Specs.viewPreservesState, Verity.Specs.sameAllStorage,
+        Verity.Specs.sameContext, Verity.Specs.sameEvents,
+        Verity.Specs.sameKnownAddresses, Verity.Specs.sameStorage,
+        Verity.Specs.sameStorageAddr, Verity.Specs.sameStorageMap,
+        Verity.Specs.sameStorageMapUint, Verity.Specs.sameStorageMap2,
+        Verity.Specs.sameStorageArray])
+
 /-- Auto-generated `_is_pure` theorem for pure functions.
     Emits a `@[simp]` lemma stating the model's `isPure` flag is `true`, making this
     fact available to downstream proof automation. Only called when `fnDecl.isPure`. -/
@@ -181,6 +229,7 @@ def mkFrameDefCommand
     (fnDecl : FunctionDecl) : CommandElabM (Array Cmd) := do
   let frameName ← mkSuffixedIdent fnDecl.ident "_frame"
   let frameRflName ← mkSuffixedIdent fnDecl.ident "_frame_rfl"
+  let frameHoldsName ← mkSuffixedIdent fnDecl.ident "_frame_holds"
   let modifiesNames := fnDecl.modifies.map fun ident => toString ident.getId
   let unmodifiedFields := fields.filter fun f => !modifiesNames.contains f.name
 
@@ -201,7 +250,31 @@ def mkFrameDefCommand
       simp [Verity.Specs.sameContext, Verity.Specs.sameStorageSlot,
             Verity.Specs.sameStorageAddrSlot, Verity.Specs.sameStorage])
 
-  pure #[frameCmd, frameRflCmd]
+  if fnDecl.requiresRole.isSome || fnDecl.nonReentrantLock.isSome || fnDecl.initGuard?.isSome then
+    pure #[frameCmd, frameRflCmd]
+  else
+    let fnApp ← mkFunctionApplication fnDecl
+    let fnIdent := fnDecl.ident
+    let fieldSimpLemmas ← fields.mapM fun field =>
+      `(Lean.Parser.Tactic.simpLemma| $(field.ident):ident)
+    let frameHoldsProp ← mkFunctionStateForall fnDecl
+      (← `($frameName s (($fnApp).run s).snd))
+    let frameHoldsCmd : Cmd ← `(command|
+      /-- Auto-generated execution frame: fields outside `modifies(...)` are preserved. -/
+      theorem $frameHoldsName : $frameHoldsProp := by
+        intros
+        unfold $frameName $fnIdent
+        simp [$[$fieldSimpLemmas],*, msgSender, getStorageAddr, getStorage, setStorage, setStorageAddr,
+          getMapping, setMapping, setMapping2, getMappingUint, setMappingUint,
+          getMapping2, ContractState.readSlot, ContractState.writeSlot,
+          ContractState.readAddrSlot, ContractState.writeAddrSlot,
+          ContractState.readMap, ContractState.writeMap, ContractState.readMapUint,
+          ContractState.writeMapUint, ContractState.readMap2, ContractState.writeMap2,
+          Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
+          Contract.run, ContractResult.snd, ContractResult.fst,
+          Verity.Specs.sameContext, Verity.Specs.sameStorageSlot,
+          Verity.Specs.sameStorageAddrSlot, Verity.Specs.sameStorage])
+    pure #[frameCmd, frameRflCmd, frameHoldsCmd]
 
 /-- Count how many effect annotations are active on a function declaration. -/
 def effectAnnotationCount (fnDecl : FunctionDecl) : Nat :=

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -89,6 +89,8 @@ def elabVerityContract : CommandElab := fun stx => do
     for fn in functions do
       if fn.isView then
         elabCommand (← mkViewTheoremCommand fn)
+        if fn.params.isEmpty && fn.requiresRole.isNone && fn.nonReentrantLock.isNone then
+          elabCommand (← mkViewFrameTheoremCommand fn)
 
     -- Emit per-function _is_pure theorems for pure functions.
     for fn in functions do


### PR DESCRIPTION
## Summary
- Auto-generates execution-level frame theorems from declared effects in the contract macro (`Verity/Macro/Bridge.lean`, `Elaborate.lean`): `<fn>_view_frame` for eligible no-arg `view` functions (full state preservation) and `<fn>_frame_holds` for eligible `modifies(...)` functions.
- Smoke consumers: `ModifiesSmoke.increment_frame_holds`, `transferOwnership_frame_holds`, `getCounter_view_frame` (`Contracts/Smoke/Effects.lean`).

Closes #1895. Tier 2 (axiom-discharge track); downstream consumer is Morpho Blue `Proofs/Disciplines.lean`. Stacked on #2013 (#1993 obligations) → #2009 (#1994 execution summaries).

## Test plan
- [x] `lake build Verity Contracts Compiler PrintAxioms` → "Build completed successfully."
- [x] `refresh_verification_artifacts.sh` → `[refresh] PASS`
- [x] `make check` → "All checks passed."
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Macro-generated proofs rely on large `simp` sets and are omitted for role/reentrancy/init-guarded functions, so behavior may differ across contracts and complex bodies could break elaboration.
> 
> **Overview**
> The contract macro now emits **execution-level frame theorems** alongside the existing model-level effect lemmas, so proofs can relate `(fn.run s).snd` to preservation predicates without hand-written `simp` scripts.
> 
> For **`view`** functions that have no parameters and no `requires` / `nonreentrant` guards, it generates `<fn>_view_frame`, stating `viewPreservesState` for the post-state. For **`modifies(...)`** functions without role, reentrancy, or initializer guards, it adds `<fn>_frame_holds`, proving the auto-generated `_frame` predicate between pre-state and post-state. Functions with access control, reentrancy locks, or init guards still get `_frame` / `_frame_rfl` only—the macro skips `_frame_holds` because injected prelude code makes the generic `simp` proof unreliable.
> 
> `Contracts/Smoke/Effects.lean` adds examples that consume `increment_frame_holds`, `transferOwnership_frame_holds`, and `getCounter_view_frame`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66aad984d3d60637634b88a8b3d66e7de26c7551. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->