### PR TITLE
Source-shaped dynamic event proof surface (#2000)

### DIFF
--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -55,6 +55,21 @@ def eventParamScalarProofSupported (ty : ParamType) : Bool :=
 def eventDefScalarProofSupported (eventDef : EventDef) : Bool :=
   eventDefScalarCompileSupported eventDef
 
+/-- Proof-side catalog for source-shaped event declarations whose payloads are
+handled by the compiler's ABI event encoder. This deliberately lives beside,
+not inside, `eventEmissionProofSupported`: the existing semantic bridge still
+requires scalar params because it proves exact word-by-word log execution.
+All currently represented ABI `ParamType` constructors are source-shaped for
+event declarations; per-statement validation still checks the stricter
+argument-source requirements for dynamic payload copying/hashing. -/
+def eventParamSourceShapeProofSupported (_ty : ParamType) : Bool := true
+
+theorem eventParamSourceShapeProofSupported_of_scalar :
+    ∀ {ty : ParamType},
+      eventParamScalarProofSupported ty = true →
+        eventParamSourceShapeProofSupported ty = true
+  | _ty, _hsupport => rfl
+
 /-- Agreement oracle: the hand-restated `SupportedExternalParamType` Prop holds
 iff the compile-driven `externalParamScalarProofSupported` Bool is `true`.
 This is the meaning-preservation lemma for the conversion pattern: any future
@@ -200,6 +215,71 @@ def eventScratchSizeLimit : Nat := 2 ^ 32
 def eventDefScratchBounded (eventDef : EventDef) : Bool :=
   decide ((bytesFromString (eventSignature eventDef)).length ≤ eventScratchSizeLimit) &&
     decide (eventDef.params.length ≤ eventScratchSizeLimit)
+
+def eventDefSourceShapeProofSupported (eventDef : EventDef) : Bool :=
+  eventDef.params.all (fun param => eventParamSourceShapeProofSupported param.ty) &&
+    decide ((eventDef.params.filter (fun param => param.kind == EventParamKind.indexed)).length ≤ 3) &&
+    eventDefScratchBounded eventDef
+
+theorem eventDefSourceShapeProofSupported_of_scalar
+    {eventDef : EventDef}
+    (hscalar : eventDefScalarProofSupported eventDef = true)
+    (hscratch : eventDefScratchBounded eventDef = true) :
+    eventDefSourceShapeProofSupported eventDef = true := by
+  have hparams :
+      eventDef.params.all (fun param => eventParamSourceShapeProofSupported param.ty) = true := by
+    apply List.all_eq_true.mpr
+    intro param hmem
+    exact eventParamSourceShapeProofSupported_of_scalar
+      (eventParamScalarProofSupported_eq_true_of_eventDefScalarProofSupported hscalar hmem)
+  have hindexed := eventDefScalarProofSupported_indexed_length_le_three hscalar
+  simp [eventDefSourceShapeProofSupported, hparams, hscratch, hindexed]
+
+private def dynamicTupleEventSmoke : EventDef :=
+  { name := "CompositeEvent"
+    params := [
+      { name := "id", ty := .bytes32, kind := .indexed },
+      { name := "payload", ty := .tuple [.uint256, .bytes], kind := .unindexed },
+      { name := "values", ty := .array .uint256, kind := .unindexed },
+      { name := "note", ty := .bytes, kind := .unindexed }
+    ] }
+
+private def staticStructEventSmoke : EventDef :=
+  { name := "CreateMarket"
+    params := [
+      { name := "id", ty := .bytes32, kind := .indexed },
+      { name := "market"
+        ty := .tuple [.address, .address, .address, .address, .uint256]
+        kind := .unindexed }
+    ] }
+
+private def indexedDynamicStructArrayEventSmoke : EventDef :=
+  { name := "IndexedDynamicStructArray"
+    params := [
+      { name := "payload"
+        ty := .array (.tuple [.uint256, .bytes])
+        kind := .indexed }
+    ] }
+
+private def fixedArrayAndAdtEventSmoke : EventDef :=
+  { name := "FixedArrayAndAdt"
+    params := [
+      { name := "fixed", ty := .fixedArray .address 2, kind := .indexed },
+      { name := "choice", ty := .adt "Choice" 2, kind := .unindexed }
+    ] }
+
+example : eventDefSourceShapeProofSupported dynamicTupleEventSmoke = true := by
+  rfl
+
+example : eventDefSourceShapeProofSupported staticStructEventSmoke = true := by
+  rfl
+
+example :
+    eventDefSourceShapeProofSupported indexedDynamicStructArrayEventSmoke = true := by
+  rfl
+
+example : eventDefSourceShapeProofSupported fixedArrayAndAdtEventSmoke = true := by
+  rfl
 
 /-- Event arguments admitted by the semantic bridge: atomic word-pure
 expressions (literals, scope variables, transaction context). The compiled

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3272,6 +3272,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.supportedSourceContractSemanticsExceptMappingWrites_eq_sourceContractSemantics
 
   -- Compiler/Proofs/IRGeneration/SupportedSpec.lean
+  Compiler.Proofs.IRGeneration.eventParamSourceShapeProofSupported_of_scalar
   Compiler.Proofs.IRGeneration.SupportedExternalParamType_iff_externalParamScalarProofSupported
   Compiler.Proofs.IRGeneration.SupportedExternalReturnProfile_iff_externalReturnProfileProofSupported
   Compiler.Proofs.IRGeneration.eventDefScalarProofSupported_params_all
@@ -3285,6 +3286,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.eventParamScalarProofSupported_ne_array
   Compiler.Proofs.IRGeneration.eventParamScalarProofSupported_ne_fixedArray
   Compiler.Proofs.IRGeneration.eventParamScalarProofSupported_ne_tuple
+  Compiler.Proofs.IRGeneration.eventDefSourceShapeProofSupported_of_scalar
   Compiler.Proofs.IRGeneration.exists_eventDef_of_eventEmissionProofSupported
   Compiler.Proofs.IRGeneration.eventDefScratchBounded_of_eventEmissionProofSupported
   Compiler.Proofs.IRGeneration.args_all_atomic_of_eventEmissionProofSupported
@@ -5546,4 +5548,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5191 theorems/lemmas (3588 public, 1603 private, 0 sorry'd)
+-- Total: 5193 theorems/lemmas (3590 public, 1603 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- Adds source-shaped event proof-surface predicates for dynamic/struct ABI event payload declarations
- `eventParamSourceShapeProofSupported_of_scalar` / `eventDefSourceShapeProofSupported_of_scalar` keep the existing scalar-event semantic bridge intact and additive
- Smoke examples: dynamic tuples, static structs/tuples, indexed dynamic struct arrays, fixed arrays + ADT-shaped payloads

Part of #2000. Stacked on #2017 (task/1974-reverterror-args).

Note: the word-by-word semantic bridge remains the scalar bridge; this adds the dynamic/struct proof surface without claiming the scalar bridge proves non-scalar log execution.

## Test plan
- [x] `lake build Verity Contracts Compiler PrintAxioms` — Build completed successfully
- [x] `scripts/refresh_verification_artifacts.sh` — [refresh] PASS
- [x] `make check` — All checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-catalog additions only; existing scalar event emission semantics and bridges are explicitly unchanged.
> 
> **Overview**
> Adds **additive** proof-side predicates in `SupportedSpec.lean` for ABI event declarations with dynamic/struct payloads, separate from the existing scalar `eventEmissionProofSupported` bridge (word-by-word log semantics stay scalar-only).
> 
> **`eventParamSourceShapeProofSupported`** is currently a permissive catalog (`true` for all represented `ParamType` constructors). **`eventDefSourceShapeProofSupported`** checks all params pass that catalog, at most three indexed params, and **`eventDefScratchBounded`**. **`eventParamSourceShapeProofSupported_of_scalar`** and **`eventDefSourceShapeProofSupported_of_scalar`** show scalar-supported events still satisfy the new surface.
> 
> Four **`rfl`** smoke **`EventDef`** examples (dynamic tuples, static struct tuples, indexed dynamic struct arrays, fixed arrays + ADT) document that non-scalar payload shapes are admitted by the new predicate. **`PrintAxioms.lean`** registers the two new theorems and bumps the public theorem count by 2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22d551ab36edfad87e8dee86090ad9efdb01e393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->