### PR TITLE
Finite mapping slot non-alias certificates (#2001)

### DIFF
--- a/Compiler/Proofs/MappingSlot.lean
+++ b/Compiler/Proofs/MappingSlot.lean
@@ -1,4 +1,5 @@
 import EvmYul
+import Mathlib.Data.List.Nodup
 import Compiler.Constants
 import Compiler.Proofs.KeccakBound
 import Compiler.Proofs.IRGeneration.IRStorageWord
@@ -69,6 +70,42 @@ def abstractDecodeMappingSlot (_slot : Nat) : Option (Nat × Nat) := none
 def abstractNestedMappingSlot (baseSlot key1 key2 : Nat) : Nat :=
   abstractMappingSlot (abstractMappingSlot baseSlot key1) key2
 
+/-- Concrete storage location for a mapping value word.  Offsets are normalized
+    to the EVM storage-key width, matching generated mapping-struct member
+    accesses. -/
+def mappingSlotLocation (baseSlot key wordOffset : Nat) : Nat :=
+  (solidityMappingSlot baseSlot key + wordOffset) % Compiler.Constants.evmModulus
+
+/-- Concrete storage location for a nested-mapping value word. -/
+def nestedMappingSlotLocation (baseSlot key1 key2 wordOffset : Nat) : Nat :=
+  (solidityMappingSlot (solidityMappingSlot baseSlot key1) key2 + wordOffset) %
+    Compiler.Constants.evmModulus
+
+/-- Finite list of mapping-derived locations touched by one generated proof port. -/
+def mappingSlotLocations (baseSlot : Nat) (keysAndOffsets : List (Nat × Nat)) : List Nat :=
+  keysAndOffsets.map fun keyAndOffset =>
+    mappingSlotLocation baseSlot keyAndOffset.1 keyAndOffset.2
+
+/-- Finite list of nested-mapping-derived locations touched by one generated proof port. -/
+def nestedMappingSlotLocations
+    (baseSlot : Nat) (keysAndOffsets : List (Nat × Nat × Nat)) : List Nat :=
+  keysAndOffsets.map fun keyAndOffset =>
+    nestedMappingSlotLocation baseSlot keyAndOffset.1 keyAndOffset.2.1 keyAndOffset.2.2
+
+/-- Local non-alias proposition for two concrete storage slots. -/
+abbrev StorageSlotNonAlias (a b : Nat) : Prop := a ≠ b
+
+/-- Finite distinctness certificate for the concrete storage slots a proof port
+    actually touches.  This is the restricted replacement surface for downstream
+    global mapping-slot injectivity assumptions: generators may prove or emit one
+    certificate per finite location set, and consumers derive only the pairwise
+    facts they use. -/
+abbrev StorageSlotsDistinct (slots : List Nat) : Prop := slots.Nodup
+
+/-- Layout-certificate-backed non-alias evidence for one finite location set. -/
+structure StorageSlotNonAliasCertificate (slots : List Nat) : Prop where
+  distinct : StorageSlotsDistinct slots
+
 /-- Derived mapping-table view from flat storage. -/
 def storageAsMappings (storage : IRStorageSlot → IRStorageWord) : Nat → Nat → IRStorageWord :=
   fun baseSlot key => storage (IRStorageSlot.ofNat (solidityMappingSlot baseSlot key))
@@ -120,6 +157,52 @@ def abstractStoreStorageOrMapping
       solidityMappingSlot (solidityMappingSlot baseSlot key1) key2 := by
   simp [abstractNestedMappingSlot]
 
+theorem StorageSlotNonAliasCertificate.nonAlias_get
+    {slots : List Nat} (cert : StorageSlotNonAliasCertificate slots)
+    {i j : Nat} (hi : i < slots.length) (hj : j < slots.length)
+    (hne : i ≠ j) :
+    StorageSlotNonAlias slots[i] slots[j] := by
+  intro hEq
+  exact hne ((cert.distinct.getElem_inj_iff (i := i) (j := j) (hi := hi) (hj := hj)).mp hEq)
+
+theorem StorageSlotNonAliasCertificate.of_distinct
+    {slots : List Nat} (h : StorageSlotsDistinct slots) :
+    StorageSlotNonAliasCertificate slots :=
+  ⟨h⟩
+
+theorem StorageSlotNonAliasCertificate.nonAlias_pair
+    {a b : Nat} (cert : StorageSlotNonAliasCertificate [a, b]) :
+    StorageSlotNonAlias a b := by
+  simpa using
+    (cert.nonAlias_get (i := 0) (j := 1) (hi := by simp) (hj := by simp)
+      (hne := by decide))
+
+theorem mappingSlotLocations_nonAlias_get
+    {baseSlot : Nat} {keysAndOffsets : List (Nat × Nat)}
+    (cert : StorageSlotNonAliasCertificate
+      (mappingSlotLocations baseSlot keysAndOffsets))
+    {i j : Nat}
+    (hi : i < (mappingSlotLocations baseSlot keysAndOffsets).length)
+    (hj : j < (mappingSlotLocations baseSlot keysAndOffsets).length)
+    (hne : i ≠ j) :
+    StorageSlotNonAlias
+      (mappingSlotLocations baseSlot keysAndOffsets)[i]
+      (mappingSlotLocations baseSlot keysAndOffsets)[j] :=
+  cert.nonAlias_get hi hj hne
+
+theorem nestedMappingSlotLocations_nonAlias_get
+    {baseSlot : Nat} {keysAndOffsets : List (Nat × Nat × Nat)}
+    (cert : StorageSlotNonAliasCertificate
+      (nestedMappingSlotLocations baseSlot keysAndOffsets))
+    {i j : Nat}
+    (hi : i < (nestedMappingSlotLocations baseSlot keysAndOffsets).length)
+    (hj : j < (nestedMappingSlotLocations baseSlot keysAndOffsets).length)
+    (hne : i ≠ j) :
+    StorageSlotNonAlias
+      (nestedMappingSlotLocations baseSlot keysAndOffsets)[i]
+      (nestedMappingSlotLocations baseSlot keysAndOffsets)[j] :=
+  cert.nonAlias_get hi hj hne
+
 @[simp] theorem abstractLoadMappingEntry_eq
     (storage : IRStorageSlot → IRStorageWord)
     (baseSlot key : Nat) :
@@ -157,6 +240,11 @@ theorem solidityMappingSlot_lt_evmModulus (baseSlot key : Nat) :
   unfold solidityMappingSlot
   exact fromByteArrayBigEndian_lt_of_size _ (by
     rw [KeccakEngine.keccak256_size])
+
+@[simp] theorem mappingSlotLocation_zero (baseSlot key : Nat) :
+    mappingSlotLocation baseSlot key 0 = solidityMappingSlot baseSlot key := by
+  unfold mappingSlotLocation
+  exact Nat.mod_eq_of_lt (solidityMappingSlot_lt_evmModulus baseSlot key)
 
 theorem abstractMappingSlot_lt_evmModulus (baseSlot key : Nat) :
     abstractMappingSlot baseSlot key < Compiler.Constants.evmModulus :=

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3536,11 +3536,17 @@ end Verity.AxiomAudit
   Compiler.Proofs.activeMappingSlotBackend_eq_keccak
   Compiler.Proofs.activeMappingSlotBackendIsEvmFaithful_eq_true
   Compiler.Proofs.abstractNestedMappingSlot_eq_solidityNested
+  Compiler.Proofs.StorageSlotNonAliasCertificate.nonAlias_get
+  Compiler.Proofs.StorageSlotNonAliasCertificate.of_distinct
+  Compiler.Proofs.StorageSlotNonAliasCertificate.nonAlias_pair
+  Compiler.Proofs.mappingSlotLocations_nonAlias_get
+  Compiler.Proofs.nestedMappingSlotLocations_nonAlias_get
   Compiler.Proofs.abstractLoadMappingEntry_eq
   Compiler.Proofs.abstractStoreMappingEntry_eq
   Compiler.Proofs.abstractLoadStorageOrMapping_eq
   Compiler.Proofs.abstractStoreStorageOrMapping_eq
   Compiler.Proofs.solidityMappingSlot_lt_evmModulus
+  Compiler.Proofs.mappingSlotLocation_zero
   Compiler.Proofs.abstractMappingSlot_lt_evmModulus
   Compiler.Proofs.solidityMappingSlot_add_lt_evmModulus
   Compiler.Proofs.solidityMappingSlot_add_wordOffset_lt_evmModulus
@@ -5551,4 +5557,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5196 theorems/lemmas (3590 public, 1606 private, 0 sorry'd)
+-- Total: 5202 theorems/lemmas (3596 public, 1606 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- Adds finite mapping-slot location helpers for mapping and nested-mapping slots
- Introduces `StorageSlotNonAlias`, `StorageSlotsDistinct`, and `StorageSlotNonAliasCertificate` with certificate-consuming non-alias lemmas (`nonAlias_get`, `of_distinct`, `nonAlias_pair`, `mappingSlotLocations_nonAlias_get`, `nestedMappingSlotLocations_nonAlias_get`, `mappingSlotLocation_zero`)
- Deliberately avoids any global keccak injectivity claim: consumers supply finite `Nodup`/certificate facts for the concrete slots they touch

Closes #2001

## Test plan
- [x] `lake build Verity Contracts Compiler PrintAxioms` — Build completed successfully
- [x] `scripts/refresh_verification_artifacts.sh` — [refresh] PASS
- [x] `make check` — All checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive proof-layer definitions and lemmas in MappingSlot.lean with PrintAxioms registry updates; no runtime or auth changes.
> 
> **Overview**
> Adds **concrete EVM storage location helpers** for mapping and nested-mapping value words (`mappingSlotLocation`, list builders for proof ports), plus a **finite distinctness API** (`StorageSlotsDistinct` as `List.Nodup`, `StorageSlotNonAliasCertificate`) so downstream proofs can assume pairwise non-alias only for the slots a port actually touches—**without** a global Keccak injectivity axiom.
> 
> New lemmas wire certificates to indexed pairs (`nonAlias_get`, `nonAlias_pair`) and to `mappingSlotLocations` / `nestedMappingSlotLocations`; **`mappingSlotLocation_zero`** links zero word offset back to `solidityMappingSlot`. **`PrintAxioms.lean`** registers the new theorems (5202 total public theorems).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acca599997468e36d28f116fee33c31c3402cdbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->