### PR TITLE
Explicit role declarations (#1894)

### DIFF
--- a/Contracts/Smoke/Effects.lean
+++ b/Contracts/Smoke/Effects.lean
@@ -169,12 +169,14 @@ verity_contract RolesSmoke where
   storage
     admin : Address := slot 0
     counter : Uint256 := slot 1
+  roles
+    adminRole := admin
 
   constructor (initialAdmin : Address) := do
     setStorageAddr admin initialAdmin
 
   -- requires(admin) auto-injects: require(caller == admin) "Access denied: caller is not admin"
-  function setCounter (value : Uint256) requires(admin) : Unit := do
+  function setCounter (value : Uint256) requires(adminRole) : Unit := do
     setStorage counter value
 
   -- Normal function without access control
@@ -192,6 +194,8 @@ verity_contract RolesMappingSmoke where
   storage
     relayers : Address → Uint256 := slot 0
     counter  : Uint256 := slot 1
+  roles
+    relayer := relayers
 
   constructor (initialRelayer : Address) := do
     setMapping relayers initialRelayer 1
@@ -200,7 +204,7 @@ verity_contract RolesMappingSmoke where
   --   let sender ← msgSender
   --   let value  ← getMapping relayers sender
   --   require (value != 0) "Access denied: caller is not relayers"
-  function setCounter (value : Uint256) requires(relayers) : Unit := do
+  function setCounter (value : Uint256) requires(relayer) : Unit := do
     setStorage counter value
 
   -- Normal function without access control
@@ -239,6 +243,70 @@ verity_contract NewtypeSmoke where
 
 #check_contract RolesSmoke
 #check_contract RolesMappingSmoke
+
+-- Explicit role declarations for owner/admin/minter/relayer-style policies
+-- (#1894). Scalar address roles and mapping-backed roles are reported through
+-- the same `spec.roles` surface and generate readable access-control facts.
+verity_contract RolesDeclaredSmoke where
+  storage
+    owner : Address := slot 0
+    admin : Address := slot 1
+    minters : Address → Uint256 := slot 2
+    relayers : Address → Uint256 := slot 3
+    counter : Uint256 := slot 4
+  roles
+    ownerRole := owner
+    adminRole := admin
+    minterRole := minters
+    relayerRole := relayers
+
+  constructor (initialOwner : Address) := do
+    setStorageAddr owner initialOwner
+    setStorageAddr admin initialOwner
+    setMapping minters initialOwner 1
+    setMapping relayers initialOwner 1
+
+  function setByOwner (value : Uint256) requires(ownerRole) : Unit := do
+    setStorage counter value
+
+  function setByAdmin (value : Uint256) requires(adminRole) : Unit := do
+    setStorage counter value
+
+  function mintLike (value : Uint256) requires(minterRole) : Unit := do
+    setStorage counter value
+
+  function relayLike (value : Uint256) requires(relayerRole) : Unit := do
+    setStorage counter value
+
+#check_contract RolesDeclaredSmoke
+
+example : RolesDeclaredSmoke.spec.«roles».length = 4 := rfl
+example :
+    RolesDeclaredSmoke.setByOwner_model.requiresRole = some "ownerRole" ∧
+      RolesDeclaredSmoke.spec.«roles».contains
+        { name := "ownerRole", field := "owner",
+          kind := Compiler.CompilationModel.RoleKind.scalarAddress } = true :=
+  RolesDeclaredSmoke.setByOwner_access_control
+example :
+    RolesDeclaredSmoke.mintLike_model.requiresRole = some "minterRole" ∧
+      RolesDeclaredSmoke.spec.«roles».contains
+        { name := "minterRole", field := "minters",
+          kind := Compiler.CompilationModel.RoleKind.mappingAddressToUint256 } = true :=
+  RolesDeclaredSmoke.mintLike_access_control
+
+/--
+error: role 'badRole' uses unsupported backing field 'flag'; roles require an Address scalar field or Address→Uint256 mapping
+-/
+#guard_msgs in
+verity_contract UnsupportedRoleShapeRejected where
+  storage
+    flag : Uint256 := slot 0
+  roles
+    badRole := flag
+
+  function guarded () requires(badRole) : Unit := do
+    pure ()
+
 #check_contract NewtypeSmoke
 
 -- Smoke test for newtype-TYPED storage fields (not just newtype params).

--- a/Verity/Core/Model/Types.lean
+++ b/Verity/Core/Model/Types.lean
@@ -144,6 +144,23 @@ structure Field where
   aliasSlots : List Nat := []
   deriving Repr
 
+/-- Contract-level access-control role declaration shape.
+    `scalarAddress` models owner/admin-style roles stored as a single address.
+    `mappingAddressToUint256` models minter/relayer-style role membership maps
+    whose nonzero value grants the role. -/
+inductive RoleKind where
+  | scalarAddress
+  | mappingAddressToUint256
+  deriving Repr, BEq
+
+/-- Explicit role declaration used by generated access-control theorems and
+    reports. The `field` is the storage field backing this semantic role. -/
+structure RoleDecl where
+  name : String
+  field : String
+  kind : RoleKind
+  deriving Repr, BEq
+
 structure ReservedSlotRange where
   /-- Inclusive start slot of a reserved storage interval. -/
   start : Nat
@@ -1409,6 +1426,11 @@ structure ConstructorSpec where
 structure CompilationModel where
   name : String
   fields : List Field
+  /-- Explicit owner/admin/minter/relayer-style access-control declarations.
+      Functions annotated with `requires(role)` resolve through this list when
+      present; legacy `requires(storageField)` remains accepted for existing
+      contracts. -/
+  roles : List RoleDecl := []
   /-- Storage slots reserved for compatibility policy; compiler rejects field
       canonical/alias write slots that overlap these intervals. -/
   reservedSlotRanges : List ReservedSlotRange := []

--- a/Verity/Macro/Bridge.lean
+++ b/Verity/Macro/Bridge.lean
@@ -127,6 +127,44 @@ def mkRequiresRoleTheoremCommand (fnDecl : FunctionDecl) (roleFieldName : String
         (Compiler.CompilationModel.FunctionSpec.requiresRole
           ($modelName : Compiler.CompilationModel.FunctionSpec)) = some $(strTermPublic roleFieldName) := rfl)
 
+private def mkModelRoleKindTerm (kind : RoleKind) : CommandElabM Term := do
+  match kind with
+  | .scalarAddress => `(Compiler.CompilationModel.RoleKind.scalarAddress)
+  | .mappingAddressToUint256 => `(Compiler.CompilationModel.RoleKind.mappingAddressToUint256)
+
+private def mkModelRoleDeclTerm (role : RoleDecl) : CommandElabM Term := do
+  let kindTerm ← mkModelRoleKindTerm role.kind
+  `(({ name := $(strTermPublic role.name), field := $(strTermPublic role.fieldName), kind := $kindTerm } :
+      Compiler.CompilationModel.RoleDecl))
+
+/-- Auto-generated role declaration theorem for explicit `roles` entries.
+    The fact is intentionally over the public `CompilationModel.roles` surface,
+    so scalar owner/admin roles and mapping-backed minter/relayer roles are
+    reported on the same path. -/
+def mkRoleDeclTheoremCommand (role : RoleDecl) : CommandElabM Cmd := do
+  let roleDeclName := mkIdent (Name.mkSimple s!"{role.name}_role_decl")
+  let roleTerm ← mkModelRoleDeclTerm role
+  `(command|
+    @[simp] theorem $roleDeclName :
+        (Compiler.CompilationModel.CompilationModel.«roles»
+          (spec : Compiler.CompilationModel.CompilationModel)).contains $roleTerm = true := rfl)
+
+/-- Auto-generated readable access-control theorem for a function guarded by an
+    explicit role declaration. It connects the function's `requiresRole`
+    metadata to the contract-level role declaration. -/
+def mkAccessControlTheoremCommand (fnDecl : FunctionDecl) (role : RoleDecl) : CommandElabM Cmd := do
+  let accessName ← mkSuffixedIdent fnDecl.ident "_access_control"
+  let modelName ← mkSuffixedIdent fnDecl.ident "_model"
+  let roleDeclName := mkIdent (Name.mkSimple s!"{role.name}_role_decl")
+  let roleTerm ← mkModelRoleDeclTerm role
+  `(command|
+    theorem $accessName :
+        (Compiler.CompilationModel.FunctionSpec.requiresRole
+          ($modelName : Compiler.CompilationModel.FunctionSpec)) = some $(strTermPublic role.name) ∧
+        (Compiler.CompilationModel.CompilationModel.«roles»
+          (spec : Compiler.CompilationModel.CompilationModel)).contains $roleTerm = true := by
+      exact And.intro rfl $roleDeclName)
+
 /-- Auto-generated `_modifies` theorem for functions with a `modifies(...)` annotation
     (#1729, Axis 3 Step 1b).  Records the declared modifies set as a `@[simp]` fact. -/
 def mkModifiesTheoremCommand (fnDecl : FunctionDecl) : CommandElabM Cmd := do

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -21,6 +21,7 @@ def elabVerityContract : CommandElab := fun stx => do
   let structDecls := parsed.structDecls
   let adtDecls := parsed.adtDecls
   let fields := parsed.fields
+  let roleDecls := parsed.roleDecls
   let storageStructAccessors := parsed.storageStructAccessors
   let errorDecls := parsed.errorDecls
   let eventDecls := parsed.eventDecls
@@ -66,12 +67,12 @@ def elabVerityContract : CommandElab := fun stx => do
     elabCommand (← mkStorageNamespaceCommand (toString contractName.getId) storageNamespace)
 
     for fn in functions do
-      let fnCmds ← mkFunctionCommandsPublic fields constDecls immutableDecls externalDecls functions fn
+      let fnCmds ← mkFunctionCommandsPublic fields roleDecls constDecls immutableDecls externalDecls functions fn
       for cmd in fnCmds do
         elabCommand cmd
       elabCommand (← mkBridgeCommand fn.ident)
 
-    elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace)
+    elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace)
 
     let findIdxSimpCmds ← mkFindIdxFieldSimpCommandsPublic contractName fields
     for cmd in findIdxSimpCmds do
@@ -138,10 +139,16 @@ def elabVerityContract : CommandElab := fun stx => do
 
     -- Emit per-function _requires_role theorem for functions with requires(field).
     -- (#1728, Axis 2 Step 2c — access control)
+    for role in roleDecls do
+      elabCommand (← mkRoleDeclTheoremCommand role)
+
     for fn in functions do
       match fn.requiresRole with
       | some roleIdent =>
           elabCommand (← mkRequiresRoleTheoremCommand fn (toString roleIdent.getId))
+          match roleDecls.find? (fun role => role.name == toString roleIdent.getId) with
+          | some role => elabCommand (← mkAccessControlTheoremCommand fn role)
+          | none => pure ()
       | none => pure ()
 
     elabCommand (← `(end $contractName))

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -34,6 +34,7 @@ declare_syntax_cat verityNamespaceSpec
 declare_syntax_cat veritySpecialEntrypoint
 declare_syntax_cat verityModifier
 declare_syntax_cat verityModifierUse
+declare_syntax_cat verityRoleDecl
 declare_syntax_cat verityFunction
 declare_syntax_cat verityIntrinsicClause
 declare_syntax_cat verityIntrinsicYul
@@ -151,6 +152,7 @@ syntax "receive" (ppSpace verityLocalObligations)? " := " term : veritySpecialEn
 syntax "fallback" (ppSpace verityLocalObligations)? " := " term : veritySpecialEntrypoint
 syntax "modifier " ident " := " term : verityModifier
 syntax "with " sepBy1(ident, ",") : verityModifierUse
+syntax ident " := " ident : verityRoleDecl
 syntax "function " verityMutability* (pureMutabilityMarker)? verityMutability* ident " (" sepBy(verityParam, ",") ")" (ppSpace verityInitGuard)? (ppSpace verityModifierUse)? (ppSpace verityRequiresRole)? (ppSpace verityModifies)? (ppSpace verityLocalObligations)? " : " term " := " term : verityFunction
 
 -- verity_intrinsic syntax (minimal one-argument shape for consumer-owned intrinsics)
@@ -177,6 +179,7 @@ syntax (name := verityContractCmd)
   ("inductive " verityAdtDecl+)?
   (verityNamespaceSpec)?
   "storage " verityStorageItem*
+  ("roles " verityRoleDecl+)?
   (verityStructDecl)*
   ("errors " verityError+)?
   ("event_defs " verityEvent+)?

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1499,6 +1499,7 @@ end
 
 private def translateBodyToStmtTerms
     (fields : Array StorageFieldDecl)
+    (roleDecls : Array RoleDecl)
     (constDecls : Array ConstantDecl)
     (immutableDecls : Array ImmutableDecl)
     (externalDecls : Array ExternalDecl)
@@ -1507,7 +1508,7 @@ private def translateBodyToStmtTerms
   match fn.body with
   | `(term| do $[$elems:doElem]*) =>
       let guardPrelude ← initGuardPreludeStmtTerms fields fn
-      let rolePrelude ← roleGuardPreludeStmtTerms fields fn
+      let rolePrelude ← roleGuardPreludeStmtTerms fields roleDecls fn
       let modifierPrelude ← fn.modifiers.mapM fun modIdent =>
         `(Compiler.CompilationModel.Stmt.internalCall $(strTerm (modifierInternalName (toString modIdent.getId))) [])
       let stmts := guardPrelude ++ rolePrelude ++ modifierPrelude ++ (← translateDoElems fields constDecls immutableDecls externalDecls functions fn.params #[] #[] elems).1
@@ -2084,6 +2085,7 @@ private def mkQualifiedInternalFunctionTerm
 private def mkSpecCommand
     (contractName : String)
     (fields : Array StorageFieldDecl)
+    (roleDecls : Array RoleDecl)
     (errorDecls : Array ErrorDecl)
     (eventDecls : Array EventDecl)
     (constDecls : Array ConstantDecl)
@@ -2097,6 +2099,12 @@ private def mkSpecCommand
   let immutableFields := immutableDecls.zipIdx.map (fun (imm, idx) => immutableStorageFieldDecl fields imm idx)
   let allFields := fields ++ immutableFields
   let fieldTerms ← allFields.mapM mkModelFieldTerm
+  let roleTerms ← roleDecls.mapM fun role => do
+    let kindTerm ← match role.kind with
+      | .scalarAddress => `(Compiler.CompilationModel.RoleKind.scalarAddress)
+      | .mappingAddressToUint256 => `(Compiler.CompilationModel.RoleKind.mappingAddressToUint256)
+    `(({ name := $(strTerm role.name), field := $(strTerm role.fieldName), kind := $kindTerm } :
+        Compiler.CompilationModel.RoleDecl))
   let errorTerms ← errorDecls.mapM mkModelErrorTerm
   let eventTerms ← eventDecls.mapM mkModelEventTerm
   let externalTerms ← externalDecls.mapM mkModelExternalTerm
@@ -2229,6 +2237,7 @@ private def mkSpecCommand
   `(command| def spec : Compiler.CompilationModel.CompilationModel := {
     name := $(strTerm contractName)
     fields := [ $[$fieldTerms],* ]
+    «roles» := [ $[$roleTerms],* ]
     «errors» := [ $[$errorTerms],* ]
     «events» := [ $[$eventTerms],* ]
     «constructor» := $constructorTerm
@@ -2394,6 +2403,7 @@ structure ParsedContractSyntax where
   structDecls : Array StructDecl
   adtDecls : Array AdtDecl
   fields : Array StorageFieldDecl
+  roleDecls : Array RoleDecl
   storageStructAccessors : Array StorageStructAccessorDecl
   errorDecls : Array ErrorDecl
   eventDecls : Array EventDecl
@@ -2405,11 +2415,40 @@ structure ParsedContractSyntax where
   functions : Array FunctionDecl
   storageNamespace : Option Nat
 
+private def roleKindOfStorageField? (field : StorageFieldDecl) : Option RoleKind :=
+  match field.ty with
+  | .scalar .address | .scalar (.newtype _ .address) => some .scalarAddress
+  | .mappingAddressToUint256 => some .mappingAddressToUint256
+  | _ => none
+
+private def parseRoleDecl
+    (fields : Array StorageFieldDecl) (roleStx : TSyntax `verityRoleDecl)
+    : CommandElabM RoleDecl := do
+  match roleStx with
+  | `(verityRoleDecl| $roleName:ident := $fieldName:ident) =>
+      let backingName := toString fieldName.getId
+      match fields.find? (fun field => field.name == backingName) with
+      | none =>
+          throwErrorAt fieldName s!"role '{toString roleName.getId}' references unknown storage field '{backingName}'; known fields: {(fields.map (·.name)).toList}"
+      | some field =>
+          match roleKindOfStorageField? field with
+          | some kind =>
+              pure {
+                ident := roleName
+                name := toString roleName.getId
+                fieldIdent := fieldName
+                fieldName := backingName
+                kind := kind
+              }
+          | none =>
+              throwErrorAt fieldName s!"role '{toString roleName.getId}' uses unsupported backing field '{backingName}'; roles require an Address scalar field or Address→Uint256 mapping"
+  | _ => throwErrorAt roleStx "invalid role declaration"
+
 def parseContractSyntax
     (stx : Syntax)
     : CommandElabM ParsedContractSyntax := do
   match stx with
-  | `(command| verity_contract $contractName:ident where $[types $[$newtypeDecls:verityNewtype]*]? $[inductive $[$adtDecls:verityAdtDecl]*]? $[$nsSpec:verityNamespaceSpec]? storage $[$storageItems:verityStorageItem]* $[$structDecls:verityStructDecl]* $[errors $[$errorDecls:verityError]*]? $[event_defs $[$eventDecls:verityEvent]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[interfaces $[$interfaceDecls:verityInterface]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$entrypoints:veritySpecialEntrypoint]* $[$modifierDecls:verityModifier]* $[$functions:verityFunction]*) =>
+  | `(command| verity_contract $contractName:ident where $[types $[$newtypeDecls:verityNewtype]*]? $[inductive $[$adtDecls:verityAdtDecl]*]? $[$nsSpec:verityNamespaceSpec]? storage $[$storageItems:verityStorageItem]* $[roles $[$roleDecls:verityRoleDecl]*]? $[$structDecls:verityStructDecl]* $[errors $[$errorDecls:verityError]*]? $[event_defs $[$eventDecls:verityEvent]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[interfaces $[$interfaceDecls:verityInterface]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$entrypoints:veritySpecialEntrypoint]* $[$modifierDecls:verityModifier]* $[$functions:verityFunction]*) =>
       -- Parse newtypes first — they are needed by all downstream type resolution
       let parsedNewtypes ←
         match newtypeDecls with
@@ -2549,12 +2588,22 @@ def parseContractSyntax
                     firstNamespaceLocked := true
                 | none =>
                     throwErrorAt item "unsupported storage item"
+      let parsedRoles ←
+        match roleDecls with
+        | some decls => decls.mapM (parseRoleDecl parsedFields)
+        | none => pure #[]
+      let mut seenRoleNames : Array String := #[]
+      for role in parsedRoles do
+        if seenRoleNames.contains role.name then
+          throwErrorAt role.ident s!"duplicate role declaration '{role.name}'"
+        seenRoleNames := seenRoleNames.push role.name
       pure {
         contractName := contractName
         newtypeDecls := parsedNewtypes
         structDecls := parsedStructs
         adtDecls := parsedAdts
         fields := parsedFields
+        roleDecls := parsedRoles
         storageStructAccessors := parsedStorageStructAccessors
         errorDecls := parsedErrors
         eventDecls := parsedEvents
@@ -2711,6 +2760,7 @@ def validateGeneratedDefNamesPublic
        , s!"{generatedFnName}_nonreentrant"
        , s!"{generatedFnName}_cei_safe"
        , s!"{generatedFnName}_requires_role"
+       , s!"{generatedFnName}_access_control"
        ]
     for helperName in helperNames do
       if storageNames.contains helperName then
@@ -2867,13 +2917,14 @@ def validateFunctionDeclsPublic
 
 def mkFunctionCommandsPublic
     (fields : Array StorageFieldDecl)
+    (roleDecls : Array RoleDecl)
     (constDecls : Array ConstantDecl)
     (immutableDecls : Array ImmutableDecl)
     (externalDecls : Array ExternalDecl)
     (functions : Array FunctionDecl)
     (fn : FunctionDecl) : CommandElabM (Array Cmd) := do
   let fnType ← mkContractFnType fn.params fn.returnTy
-  let fnRoleGuardedBody ← mkRoleGuardedBody fields fn
+  let fnRoleGuardedBody ← mkRoleGuardedBody fields roleDecls fn
   let fnDecl := { fn with body := fnRoleGuardedBody }
   let fnGuardedBody ← mkInitGuardedBody fields fnDecl
   let fnBody ← mkImmutableBoundBody fields immutableDecls fn fnGuardedBody
@@ -2881,7 +2932,7 @@ def mkFunctionCommandsPublic
   let fnValue ← mkContractFnValue fn.params fnExecutableBody
   let modelBodyName ← mkSuffixedIdent fn.ident "_modelBody"
   let modelName ← mkSuffixedIdent fn.ident "_model"
-  let stmtTerms ← translateBodyToStmtTerms fields constDecls immutableDecls externalDecls functions fn
+  let stmtTerms ← translateBodyToStmtTerms fields roleDecls constDecls immutableDecls externalDecls functions fn
   let modelParams ← mkModelParamsTerm fn.params
   let localObligationTerms ← fn.localObligations.mapM mkModelLocalObligationTerm
   let payableTerm ← if fn.isPayable then `(true) else `(false)
@@ -2931,6 +2982,7 @@ def mkFunctionCommandsPublic
 def mkSpecCommandPublic
     (contractName : String)
     (fields : Array StorageFieldDecl)
+    (roleDecls : Array RoleDecl)
     (errorDecls : Array ErrorDecl)
     (eventDecls : Array EventDecl)
     (constDecls : Array ConstantDecl)
@@ -2941,7 +2993,7 @@ def mkSpecCommandPublic
     (functions : Array FunctionDecl)
     (adtDecls : Array AdtDecl)
     (storageNamespace : Option Nat) : CommandElabM Cmd :=
-  mkSpecCommand contractName fields errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace
+  mkSpecCommand contractName fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace
 
 def mkFindIdxFieldSimpCommandsPublic
     (contractIdent : Ident)

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -368,7 +368,7 @@ def mkInitGuardedBody
     `mappingAddress` is the role-as-mapping shape (e.g. `onlyRelayer`,
     `onlyMinter`) — a `mapping(address => uint256)` slot used as a 0/1 flag;
     the macro injects `require (storage[slot][caller] != 0)`. (verity#1837) -/
-inductive RoleKind where
+inductive ResolvedRoleKind where
   | scalarAddress
   | mappingAddress
 
@@ -376,19 +376,27 @@ inductive RoleKind where
     Accepts either an Address-typed scalar field (`onlyOwner`-style) or an
     `Address → Uint256` mapping field (`onlyRelayer`-style, verity#1837). -/
 def resolveRoleField
-    (fields : Array StorageFieldDecl) (roleIdent : Ident) (fnIdent : Ident)
-    : CommandElabM (StorageFieldDecl × RoleKind) := do
+    (fields : Array StorageFieldDecl) (roleDecls : Array RoleDecl) (roleIdent : Ident) (fnIdent : Ident)
+    : CommandElabM (StorageFieldDecl × ResolvedRoleKind × String) := do
   let roleName := toString roleIdent.getId
-  match fields.find? (fun f => f.name == roleName) with
+  let resolveField (fieldName : String) (diagName : String) := do
+    match fields.find? (fun f => f.name == fieldName) with
+    | none =>
+        throwErrorAt roleIdent s!"function '{toString fnIdent.getId}': requires({diagName}) references role backing field '{fieldName}', but no such storage field exists; known fields: {(fields.map (·.name)).toList}"
+    | some field =>
+        match field.ty with
+        | .scalar .address | .scalar (.newtype _ .address) =>
+            pure (field, .scalarAddress, diagName)
+        | .mappingAddressToUint256 =>
+            pure (field, .mappingAddress, diagName)
+        | _ => throwErrorAt roleIdent s!"function '{toString fnIdent.getId}': requires({diagName}) must reference an explicit role or an Address-typed scalar / Address→Uint256 role field, but backing field '{fieldName}' has an unsupported role shape"
+  match roleDecls.find? (fun r => r.name == roleName) with
+  | some role => resolveField role.fieldName role.name
   | none =>
-      throwErrorAt roleIdent s!"function '{toString fnIdent.getId}': requires references unknown storage field '{roleName}'; known fields: {(fields.map (·.name)).toList}"
-  | some field =>
-      match field.ty with
-      | .scalar .address | .scalar (.newtype _ .address) =>
-          pure (field, .scalarAddress)
-      | .mappingAddressToUint256 =>
-          pure (field, .mappingAddress)
-      | _ => throwErrorAt roleIdent s!"function '{toString fnIdent.getId}': requires({roleName}) must reference an Address-typed scalar storage field or an Address→Uint256 mapping (role-as-mapping), but '{roleName}' has a different type"
+      match fields.find? (fun f => f.name == roleName) with
+      | some _ => resolveField roleName roleName
+      | none =>
+          throwErrorAt roleIdent s!"function '{toString fnIdent.getId}': requires references unknown role '{roleName}'; known roles: {(roleDecls.map (·.name)).toList}; legacy storage fields: {(fields.map (·.name)).toList}"
 
 /-- Generate IR-level prelude statements for a `requires(role)` annotation.
     Scalar Address: injects `Stmt.require (Expr.eq Expr.caller (Expr.storageAddr roleField)) message`.
@@ -397,12 +405,13 @@ def resolveRoleField
     (#1728, Axis 2 Step 2c; mapping-keyed extension verity#1837) -/
 def roleGuardPreludeStmtTerms
     (fields : Array StorageFieldDecl)
+    (roleDecls : Array RoleDecl)
     (fn : FunctionDecl) : CommandElabM (Array Term) := do
   match fn.requiresRole with
   | none => pure #[]
   | some roleIdent =>
-      let (field, kind) ← resolveRoleField fields roleIdent fn.ident
-      let message := strTerm s!"Access denied: caller is not {field.name}"
+      let (field, kind, roleName) ← resolveRoleField fields roleDecls roleIdent fn.ident
+      let message := strTerm s!"Access denied: caller is not {roleName}"
       match kind with
       | .scalarAddress =>
           pure #[
@@ -428,13 +437,14 @@ def roleGuardPreludeStmtTerms
     (#1728, Axis 2 Step 2c; mapping-keyed extension verity#1837) -/
 def mkRoleGuardedBody
     (fields : Array StorageFieldDecl)
+    (roleDecls : Array RoleDecl)
     (fn : FunctionDecl) : CommandElabM Term := do
   match fn.requiresRole with
   | none => pure fn.body
   | some roleIdent =>
-      let (field, kind) ← resolveRoleField fields roleIdent fn.ident
+      let (field, kind, roleName) ← resolveRoleField fields roleDecls roleIdent fn.ident
       let senderVar := mkIdent (Name.mkSimple s!"__verity_role_sender_{field.name}")
-      let message := strTerm s!"Access denied: caller is not {field.name}"
+      let message := strTerm s!"Access denied: caller is not {roleName}"
       match fn.body with
       | `(term| do $[$elems:doElem]*) =>
           match kind with

--- a/Verity/Macro/Types.lean
+++ b/Verity/Macro/Types.lean
@@ -75,6 +75,19 @@ structure StorageStructAccessorDecl where
   name : String
   tree : StorageAccessorTree
 
+inductive RoleKind where
+  | scalarAddress
+  | mappingAddressToUint256
+  deriving Repr, BEq
+
+structure RoleDecl where
+  ident : Ident
+  name : String
+  fieldIdent : Ident
+  fieldName : String
+  kind : RoleKind
+  deriving Repr
+
 /-- The arrow signature of a function-pointer parameter (#1747).
     Recorded only so that good diagnostics are available; the monomorphization
     pre-pass removes every function-pointer parameter before any model/IR

--- a/artifacts/macro_property_tests/PropertyRolesDeclaredSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyRolesDeclaredSmoke.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyRolesDeclaredSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/Effects.lean
+ */
+contract PropertyRolesDeclaredSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYulWithArgs("RolesDeclaredSmoke", abi.encode(alice));
+        require(target != address(0), "Deploy failed");
+    }
+
+}


### PR DESCRIPTION
## Summary
- Adds a `roles` section to `verity_contract` (e.g. `roles ownerRole := owner`) surfaced as public `CompilationModel.roles : List RoleDecl`
- Role kinds: `scalarAddress` and `mappingAddressToUint256`; `requires(roleName)` resolves explicit role declarations first while preserving legacy `requires(storageField)`
- Generated theorem surface: per-role `<role>_role_decl`, per-function `<function>_access_control` for explicit roles (existing `<function>_requires_role` retained)
- Smoke coverage + `PropertyRolesDeclaredSmoke.t.sol`

Closes #1894

## Test plan
- [x] `lake build Verity Contracts Compiler PrintAxioms` — Build completed successfully
- [x] `scripts/refresh_verification_artifacts.sh` — [refresh] PASS
- [x] `make check` — All checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes access-control elaboration and generated proof metadata; behavior is mostly additive with legacy `requires(storageField)` preserved, but misconfigured roles or renamed resolution could affect guard messages and theorem names.
> 
> **Overview**
> Adds an optional **`roles`** block to `verity_contract` (e.g. `adminRole := admin`) so owner/admin/minter/relayer-style policies are named separately from raw storage fields. Declarations populate public **`CompilationModel.roles`** as **`RoleDecl`** entries with **`scalarAddress`** or **`mappingAddressToUint256`** kinds; invalid backing fields fail at elaboration.
> 
> **`requires(roleName)`** now resolves **explicit roles first**, then falls back to legacy **`requires(storageField)`**. Guard injection and IR preludes use the **role name** in denial messages while still reading the mapped storage field. **`FunctionSpec.requiresRole`** stores the **role identifier** when an explicit role is used.
> 
> The macro emits **`\<role\>_role_decl`** simp facts and, for guarded functions tied to explicit roles, **`\<fn\>_access_control`** theorems linking **`requiresRole`** to **`spec.roles`** (alongside existing **`_requires_role`**).
> 
> Smoke coverage updates existing role tests to use **`roles`**, adds **`RolesDeclaredSmoke`**, compile-time examples, a **`#guard_msgs`** rejection for unsupported role shapes, and a generated **`PropertyRolesDeclaredSmoke.t.sol`** stub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11997ed32cf399befe7fdba69fcde0662a4e823d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->