### PR TITLE
Proof-backed CEI safety surface (#1892)

### DIFF
--- a/Compiler/Proofs/IRGeneration/CEISafety.lean
+++ b/Compiler/Proofs/IRGeneration/CEISafety.lean
@@ -1,0 +1,93 @@
+import Compiler.CompilationModel.Validation
+
+/-!
+Proof-layer CEI safety surface.
+
+`stmtListCEIViolation` is the compiler checker used before code generation.
+This module gives that checker a public proof-facing meaning: a function has
+proof-backed CEI execution safety exactly when the checker accepts its body and
+the recognized trust exits are absent at the function boundary.
+-/
+
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.CompilationModel
+
+/-- Execution-level CEI claim for a function body: along the source statement
+order recognized by the compiler, no persistent state write is reachable after
+an external interaction barrier. -/
+def CEIExecutionSafe (fn : FunctionSpec) : Prop :=
+  stmtListCEIViolation fn.body false = none
+
+/-- Explicit CEI trust-exit obligations. A proof-backed `cei_safe` function must
+not rely on the untyped post-interaction-write opt-out, the generated
+`nonreentrant` runtime guard, or local unsafe/refinement obligations. -/
+structure CEITrustExitsClosed (fn : FunctionSpec) : Prop where
+  noPostInteractionWriteOptOut : fn.allowPostInteractionWrites = false
+  noNonReentrantRuntimeGuard : fn.nonReentrantLock = none
+  noLocalUnsafeObligations : fn.localObligations = []
+
+/-- The public proof-backed `cei_safe` contract: the annotation is present, the
+compiler CEI checker accepted the body, and all trust exits are closed. -/
+structure CEIProofBackedExecution (fn : FunctionSpec) : Prop where
+  annotated : fn.ceiSafe = true
+  executionSafe : CEIExecutionSafe fn
+  trustExitsClosed : CEITrustExitsClosed fn
+
+theorem CEIProofBackedExecution.execution_safe
+    {fn : FunctionSpec}
+    (h : CEIProofBackedExecution fn) :
+    CEIExecutionSafe fn :=
+  h.executionSafe
+
+theorem CEIProofBackedExecution.no_post_interaction_write_opt_out
+    {fn : FunctionSpec}
+    (h : CEIProofBackedExecution fn) :
+    fn.allowPostInteractionWrites = false :=
+  h.trustExitsClosed.noPostInteractionWriteOptOut
+
+theorem CEIProofBackedExecution.no_nonreentrant_runtime_guard
+    {fn : FunctionSpec}
+    (h : CEIProofBackedExecution fn) :
+    fn.nonReentrantLock = none :=
+  h.trustExitsClosed.noNonReentrantRuntimeGuard
+
+theorem CEIProofBackedExecution.no_local_unsafe_obligations
+    {fn : FunctionSpec}
+    (h : CEIProofBackedExecution fn) :
+    fn.localObligations = [] :=
+  h.trustExitsClosed.noLocalUnsafeObligations
+
+/-- Bridge the concrete facts emitted by the macro/checker into the public CEI
+execution theorem. Escape hatches are hypotheses rather than hidden premises. -/
+theorem ceiProofBackedExecution_of_checker
+    {fn : FunctionSpec}
+    (hAnnotated : fn.ceiSafe = true)
+    (hChecked : stmtListCEIViolation fn.body false = none)
+    (hAllow : fn.allowPostInteractionWrites = false)
+    (hLock : fn.nonReentrantLock = none)
+    (hLocal : fn.localObligations = []) :
+    CEIProofBackedExecution fn :=
+  { annotated := hAnnotated
+    executionSafe := hChecked
+    trustExitsClosed :=
+      { noPostInteractionWriteOptOut := hAllow
+        noNonReentrantRuntimeGuard := hLock
+        noLocalUnsafeObligations := hLocal } }
+
+/-- Smoke theorem for the public bridge: an explicit `cei_safe` function whose
+body is accepted by the CEI checker discharges the execution theorem without
+any escape hatch premise. -/
+theorem ceiProofBackedExecution_checked_empty_body :
+    CEIProofBackedExecution
+      { name := "checkedEmptyBody"
+        params := []
+        returnType := none
+        body := []
+        ceiSafe := true } :=
+  by
+    refine ceiProofBackedExecution_of_checker rfl ?_ rfl rfl rfl
+    change stmtListCEIViolation [] false = none
+    simp [stmtListCEIViolation]
+
+end Compiler.Proofs.IRGeneration

--- a/Contracts/Smoke/Effects.lean
+++ b/Contracts/Smoke/Effects.lean
@@ -164,6 +164,25 @@ verity_contract CEILadderSmoke where
 -- guard prevents reentrant state corruption at runtime.
 #check_contract CEILadderSmoke
 
+-- `cei_safe` is proof-backed metadata, not a CEI escape hatch: a post-call
+-- persistent write is still rejected unless the function uses an explicit
+-- trust exit such as `allow_post_interaction_writes` or `nonreentrant`.
+verity_contract CEISafePostInteractionWriteRejected where
+  storage
+    result : Uint256 := slot 0
+  linked_externals
+    external echo(Uint256) -> (Uint256)
+
+  function cei_safe callThenStoreClaimed (x : Uint256) : Unit := do
+    let echoed := externalCall "echo" [x]
+    setStorage result echoed
+
+/--
+error: #check_contract failed for 'Contracts.Smoke.CEISafePostInteractionWriteRejected': Compilation error: function 'callThenStoreClaimed' violates CEI (Checks-Effects-Interactions) ordering: state write after external call. Reorder state writes before external calls, or annotate with allow_post_interaction_writes / nonreentrant(<lock>) to opt out (Issue #1728 (CEI enforcement — Checks-Effects-Interactions ordering))
+-/
+#guard_msgs in
+#check_contract CEISafePostInteractionWriteRejected
+
 -- Roles / requires(field) smoke test (#1728, Axis 2 Step 2c)
 verity_contract RolesSmoke where
   storage

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -39,6 +39,7 @@ import Compiler.Proofs.EndToEnd.SimpleStorage
 import Compiler.Proofs.EventSemantics
 import Compiler.Proofs.Frames
 import Compiler.Proofs.HelperStepProofs
+import Compiler.Proofs.IRGeneration.CEISafety
 import Compiler.Proofs.IRGeneration.Contract
 import Compiler.Proofs.IRGeneration.ContractFeatureTest
 import Compiler.Proofs.IRGeneration.ContractShape
@@ -1628,6 +1629,14 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.fullHelperAwareListWitness_of_allInterfaces_disjoint
   Compiler.Proofs.HelperStepProofs.helperFreeContractWitness
   Compiler.Proofs.HelperStepProofs.helperFreeContractWitness_disjoint
+
+  -- Compiler/Proofs/IRGeneration/CEISafety.lean
+  Compiler.Proofs.IRGeneration.CEIProofBackedExecution.execution_safe
+  Compiler.Proofs.IRGeneration.CEIProofBackedExecution.no_post_interaction_write_opt_out
+  Compiler.Proofs.IRGeneration.CEIProofBackedExecution.no_nonreentrant_runtime_guard
+  Compiler.Proofs.IRGeneration.CEIProofBackedExecution.no_local_unsafe_obligations
+  Compiler.Proofs.IRGeneration.ceiProofBackedExecution_of_checker
+  Compiler.Proofs.IRGeneration.ceiProofBackedExecution_checked_empty_body
 
   -- Compiler/Proofs/IRGeneration/Contract.lean
   -- Compiler.Proofs.IRGeneration.Contract.pickUniqueFunctionByName_eq_ok_none_of_absent  -- private
@@ -5551,4 +5560,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5196 theorems/lemmas (3590 public, 1606 private, 0 sorry'd)
+-- Total: 5202 theorems/lemmas (3596 public, 1606 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- New proof module `Compiler.Proofs.IRGeneration.CEISafety` with `CEExecutionSafe`, `CETrustExitsClosed`, and `CEProofBackedExecution`
- Makes `allow_post_interaction_writes`, `nonreentrant`, and local unsafe/refinement obligations explicit trust-exit facts
- Theorems: `CEProofBackedExecution.execution_safe` / `.no_post_interaction_write_opt_out` / `.no_nonreentrant_runtime_guard` / `.no_local_unsafe_obligations`, plus `ceiProofBackedExecution_of_checker` and `ceiProofBackedExecution_checked_empty_body`
- Smoke coverage in `Contracts/Smoke/Effects.lean`

Closes #1892

## Test plan
- [x] `lake build Verity Contracts Compiler PrintAxioms` — Build completed successfully
- [x] `scripts/refresh_verification_artifacts.sh` — [refresh] PASS
- [x] `make check` — All checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-layer definitions and smoke tests only; no changes to the CEI checker or code generation paths.
> 
> **Overview**
> Introduces a **proof-layer CEI contract** that ties the existing compiler checker `stmtListCEIViolation` to a public meaning for `cei_safe` functions: execution safety when the checker passes, plus explicit closure of trust exits (`allow_post_interaction_writes`, `nonreentrant`, local unsafe obligations).
> 
> The new module defines `CEIExecutionSafe`, `CEITrustExitsClosed`, and `CEIProofBackedExecution`, with accessor theorems and a `ceiProofBackedExecution_of_checker` bridge so macro/checker facts become hypotheses instead of hidden premises. A smoke proof on an empty body and **PrintAxioms** registration add six public theorems to the verified artifact set.
> 
> **Smoke coverage** adds `CEISafePostInteractionWriteRejected`, asserting that **`cei_safe` alone does not opt out of CEI**—a post-call persistent write still fails `#check_contract` unless an explicit trust exit is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6d1c408cf75404647f35852cfeeebe172d61340. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->