### PR TITLE
feat(Codegen): factor solidityPanicPayload for Panic(uint256) emission (#1999)

### DIFF
--- a/Compiler/CompilationModel/DynamicData.lean
+++ b/Compiler/CompilationModel/DynamicData.lean
@@ -117,8 +117,12 @@ def panicError0x11HelperName : String :=
 def panicError0x12HelperName : String :=
   "panic_error_0x12"
 
-def panicErrorHelper (helperName : String) (code : Nat) : YulStmt :=
-  YulStmt.funcDef helperName [] [] [
+/-- ABI payload for Solidity's built-in `Panic(uint256)` error.
+
+    The payload is exactly 36 bytes:
+    4-byte selector `0x4e487b71` followed by one ABI word containing `code`. -/
+def solidityPanicPayload (code : Nat) : List YulStmt :=
+  [
     YulStmt.expr (YulExpr.call "mstore" [
       YulExpr.lit 0,
       YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex 0x4e487b71]
@@ -126,6 +130,9 @@ def panicErrorHelper (helperName : String) (code : Nat) : YulStmt :=
     YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit code]),
     YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 36])
   ]
+
+def panicErrorHelper (helperName : String) (code : Nat) : YulStmt :=
+  YulStmt.funcDef helperName [] [] (solidityPanicPayload code)
 
 def panicError0x11Helper : YulStmt :=
   panicErrorHelper panicError0x11HelperName 0x11

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -5731,6 +5731,8 @@ set_option maxRecDepth 4096 in
     (contains arithmeticPanicYul s!"function {panicError0x11HelperName}()" &&
       contains arithmeticPanicYul s!"function {panicError0x12HelperName}()" &&
       contains arithmeticPanicYul "shl(224, 0x4e487b71)" &&
+      contains arithmeticPanicYul "mstore(4, 17)" &&
+      contains arithmeticPanicYul "mstore(4, 18)" &&
       contains arithmeticPanicYul "revert(0, 36)")
   let envYul ← expectCompileToYul "env runtime smoke spec" envRuntimeSmokeSpec
   expectTrue "address(this) lowers to the Yul address builtin"


### PR DESCRIPTION
## Summary
- Factor the `Panic(uint256)` ABI payload into a reusable `solidityPanicPayload` builder in `Compiler/CompilationModel/DynamicData.lean`; `panicErrorHelper` now delegates to it. Behavior-preserving emission refactor (emitted Yul unchanged).
- Strengthen the arithmetic-panic smoke test to assert the exact `mstore(4, 17)` / `mstore(4, 18)` panic-code stores.
- No new axioms or theorems; refresh artifacts unchanged.

## Notes
- Stacked on #2028 (`task/1993a-checked-arith`) — the smoke test exercises the checked-arithmetic emission landed there, so this merges after the Tier-1 chain. The downstream `solidityPanicModule` ECM kill lives in morpho-verity and is out of scope here.

## Verification
- `lake build Verity Contracts Compiler PrintAxioms` → Build completed successfully
- `scripts/refresh_verification_artifacts.sh` → `[refresh] PASS`
- `make check` → All checks passed (607 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only codegen with strengthened compile-to-Yul assertions; emitted panic shape is unchanged.
> 
> **Overview**
> Extracts Solidity **`Panic(uint256)`** revert emission into a reusable **`solidityPanicPayload`** builder in `DynamicData.lean`; **`panicErrorHelper`** now wraps that list in a Yul function definition instead of inlining the same **`mstore` / `revert(0, 36)`** sequence.
> 
> The arithmetic-panic compile smoke test now also checks that panic helpers store codes **17** and **18** at word offset 4 (**`mstore(4, 17)`** / **`mstore(4, 18)`**), alongside the existing selector and **`revert(0, 36)`** assertions. Intended as a behavior-preserving refactor for reuse (e.g. downstream panic module work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17cba0557819689564876df691380cb2e641a240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->