### PR TITLE
docs: fix archived IR storage refactor links

### DIFF
--- a/docs/archive/IR_STORAGE_PHASE1_PLAN.md
+++ b/docs/archive/IR_STORAGE_PHASE1_PLAN.md
@@ -1,6 +1,6 @@
 # IR Storage Refactor — Phase 1 Plan
 
-Phase 1 of [`IR_STORAGE_UINT256_REFACTOR.md`](IR_STORAGE_UINT256_REFACTOR.md): flip
+Phase 1 of [`IR_STORAGE_UINT256_REFACTOR.md`](../IR_STORAGE_UINT256_REFACTOR.md): flip
 `IRStorageWord` from its Phase-0 `abbrev := Nat` surface to a `UInt256`-backed
 representation, and audit every former `Nat → Nat` callsite that flowed through
 `IRState.storage`.

--- a/docs/archive/IR_STORAGE_PHASE2_PLAN.md
+++ b/docs/archive/IR_STORAGE_PHASE2_PLAN.md
@@ -1,6 +1,6 @@
 # IR Storage Refactor — Phase 2 Plan
 
-Phase 2 of [`IR_STORAGE_UINT256_REFACTOR.md`](IR_STORAGE_UINT256_REFACTOR.md)
+Phase 2 of [`IR_STORAGE_UINT256_REFACTOR.md`](../IR_STORAGE_UINT256_REFACTOR.md)
 originally tracked discharging the retrieve-hit fuel-wrapper bridge after the
 `UInt256`-bounded IR storage carrier landed.
 

--- a/docs/archive/IR_STORAGE_PHASE3_PLAN.md
+++ b/docs/archive/IR_STORAGE_PHASE3_PLAN.md
@@ -1,6 +1,6 @@
 # IR Storage Refactor — Phase 3 Plan
 
-Phase 3 of [`IR_STORAGE_UINT256_REFACTOR.md`](IR_STORAGE_UINT256_REFACTOR.md)
+Phase 3 of [`IR_STORAGE_UINT256_REFACTOR.md`](../IR_STORAGE_UINT256_REFACTOR.md)
 originally tracked discharging the store-hit fuel-wrapper bridge and dropping the
 `hStoreHit` premise from `simpleStorage_endToEnd_native_evmYulLean`.
 


### PR DESCRIPTION
## Summary
- Fix the archived IR storage phase plans so their parent refactor link resolves from `docs/archive/`.
- Point Phase 1/2/3 plan links at `../IR_STORAGE_UINT256_REFACTOR.md` instead of a non-existent same-directory file.

## Test Plan
- Verified the three archive links resolve locally.
- `python3 -m unittest discover -s scripts -p 'test_*.py' -v`

## Related Issues
N/A
