### PR TITLE
Add fail-closed reentrancy rely-guarantee gate

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -142,6 +142,19 @@ sibling entrypoint.
   assertion — emits no code, no proof obligation, recorded as a trust boundary).
 - **Deliberately rejected**: `cei_safe` and `allow_post_interaction_writes`
   concern single-function CEI ordering only and do **not** satisfy the gate.
+- **Internal-helper closure** (Bugbot HIGH on #2032): the `nonreentrant(<lock>)`
+  transient guard is attached **only** at the external dispatch boundary
+  (`attachNonReentrantGuard`, #1893), so it is absent on the lock-free
+  internal-helper shadow the macro emits for direct intra-contract calls. A
+  *lock-only* `nonreentrant` function (no `reentrancy_trusted`) is therefore
+  **rejected when invoked as an internal helper** at macro lowering
+  (`ensureCallableAsInternalHelper`,
+  [Verity/Macro/Internal.lean](Verity/Macro/Internal.lean)); routing such a call
+  through the shadow would run the guarded body without the lock and silently
+  bypass its only protection. A callee that *also* carries `reentrancy_trusted`
+  is accepted (the assertion covers the lock-free internal path). This mirrors
+  the existing `internal nonreentrant(<lock>)` rejection
+  (`NonreentrantInternalHelperRejected`, #1971).
 - **CEISafety demoted**: `Compiler.Proofs.IRGeneration.CEISafety`
   (`CEIProofBackedExecution`) remains a valid proof surface, but it certifies
   *single-function* Checks-Effects-Interactions ordering — it is **not** a

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -91,6 +91,77 @@ arbitrary `pfx ++ sfx` split. End-to-end smoke proof in the same file.
 Wiring of `SupportedFragment` / `SupportedSpec` for contracts that
 actually use this family is the next milestone.
 
+## Reentrancy Rely-Guarantee Framework (2026-06)
+
+A new proof-level reentrancy framework, complementary to the runtime
+`nonreentrant` transient-storage guard (#1893). Additive and axiom-free; it
+keeps the "Project-level Lean axioms: 0" invariant above.
+
+- **New modules** (no `sorry`, no `axiom`, no `native_decide`):
+  - `Verity/Core/Invariant.lean` — state-polymorphic rely-guarantee library
+    (`Preserves` / `runSeq` / `runSeq_preserves`).
+  - `Verity/Core/Reentrancy.lean` — grounds it against the `Contract` monad:
+    `reentrantCall`, `ContractPreserves`, `ReentrancySpec` and the
+    whole-interleaving meta-theorem `ReentrancySpec.schedule_preserves`, plus a
+    forward-compatible multi-contract layer (`System` / `lift` / `Isys` /
+    `cross_contract_schedule_preserves`).
+- **New semantic surface**: `Env.reenter : ContractState → ContractState`
+  (default `id`, the no-reentry case) on `Verity/Core/Semantics.lean`.
+- **Worked example**: `Contracts/ReentrancyRelyGuarantee` machine-checks the
+  Midnight `take`/`liquidate` callback bug — the no-lock `take` admits a
+  permanent bad-debt liquidation; the locked `take` admits none for any
+  lock-respecting adversary.
+- **Trust boundary**: author obligations (entrypoint-registry completeness,
+  adversary-model fidelity, invariant adequacy). See the
+  "Reentrancy Rely-Guarantee Framework" section in `TRUST_ASSUMPTIONS.md`.
+- **CI state**: the example is registered in `test/property_manifest.json` and
+  classified proof-only in `test/property_exclusions.json` (abstract
+  state-transformer proofs, no compiled bytecode to property- or
+  differential-test); structure/Foundry-test exemptions are recorded in
+  `scripts/check_contract_structure.py`. `artifacts/verification_status.json`
+  and `docs/VERIFICATION_STATUS.md` now record 15 example contracts and +8
+  proven theorems (all proof-only, so runtime coverage moves 90% → 88% by
+  construction while proven count rises 283 → 291).
+
+### Cross-Function Reentrancy Gate (fail-closed)
+
+A compilation-level gate that complements the proof framework above:
+`validateReentrancyDisposition`
+([Compiler/CompilationModel/Validation.lean](Compiler/CompilationModel/Validation.lean)),
+a dedicated pass run after call well-formedness validation (and independent of
+the single-function CEI check in `validateFunctionSpec`),
+now **rejects** any non-`view`/`pure` function whose body makes a direct
+external call unless it carries a sound reentrancy disposition. This closes the
+cross-function reentrancy class (Midnight `take`/`liquidate`) at the toolchain
+boundary: a CEI-clean function is no longer enough, because its external
+callback still leaves a transiently-exploitable state live for a reentrant
+sibling entrypoint.
+
+- **Accept-set** (sound only): `nonreentrant(<lock>)` (runtime transient-storage
+  guard, #1893) or `reentrancy_trusted` (new metadata-only, unproven author
+  assertion — emits no code, no proof obligation, recorded as a trust boundary).
+- **Deliberately rejected**: `cei_safe` and `allow_post_interaction_writes`
+  concern single-function CEI ordering only and do **not** satisfy the gate.
+- **CEISafety demoted**: `Compiler.Proofs.IRGeneration.CEISafety`
+  (`CEIProofBackedExecution`) remains a valid proof surface, but it certifies
+  *single-function* Checks-Effects-Interactions ordering — it is **not** a
+  reentrancy defense and is no longer presented as one. Cross-function
+  reentrancy safety is owned solely by this gate's accept-set
+  (`nonreentrant`/`reentrancy_trusted`); CEI is subordinate ordering hygiene.
+- **New annotation surface**: `reentrancy_trusted` threads through the macro
+  (`Verity/Macro/Syntax.lean` → `Translate/Parsing.lean` → `Types.lean` →
+  `Translate.lean`) onto `FunctionDecl.reentrancyTrusted` /
+  `FunctionSpec.reentrancyTrusted` (defaulted `false`, backward compatible).
+- **Regression evidence**: `Contracts/Smoke/SecurityCombos.lean` pairs
+  `ReentrancyDispositionRequired` (a CEI-clean `take` rejected by the gate,
+  pinned with `#guard_msgs`) against `ReentrancyDispositionDeclared` (the
+  identical body accepted once it declares `reentrancy_trusted`) — identical
+  bodies, opposite verdicts, the Midnight shape proven unable to pass
+  `#check_contract` undeclared.
+- **Axiom-free**: the gate is a pure validation predicate; `AXIOMS.md` is
+  unchanged. Trust-boundary prose is in the "Cross-Function Reentrancy Gate"
+  section of `TRUST_ASSUMPTIONS.md`.
+
 ## Audit Artifacts
 
 | Artifact | Purpose | Check |
@@ -129,4 +200,4 @@ actually use this family is the next milestone.
    command.
 5. Run `make check`; run targeted Lean builds for changed proof modules.
 
-**Last Updated**: 2026-06 (event emission proof-model alignment, emit-argument scope collection, scratch memory wrapping; storage layout audit artifacts, #1897; nonreentrant transient-storage guard, #1893; non-alias certificate write-set overlap, #1967; nonreentrant fork requirement, #1968)
+**Last Updated**: 2026-06 (cross-function reentrancy gate: fail-closed `validateReentrancyDisposition` rejection of external-call functions lacking a sound disposition, new `reentrancy_trusted` metadata annotation, CEISafety demoted to single-function ordering hygiene, `#guard_msgs` regression pair in `SecurityCombos.lean` — axiom-free; reentrancy rely-guarantee framework: `Verity.Core.Invariant` / `Verity.Core.Reentrancy`, `Env.reenter` hook, Midnight `take`/`liquidate` worked example — additive, 0 axioms; event emission proof-model alignment, emit-argument scope collection, scratch memory wrapping; storage layout audit artifacts, #1897; nonreentrant transient-storage guard, #1893; non-alias certificate write-set overlap, #1967; nonreentrant fork requirement, #1968)

--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -404,6 +404,10 @@ private def validateCompileInputsBeforeFieldWriteConflict
     validateCustomErrorArgShapesInFunction fn spec.errors
     validateInternalCallShapesInFunction spec.functions fn
     validateExternalCallTargetsInFunction spec.externals fn
+    -- Fail-closed cross-function reentrancy gate. Runs last so structural
+    -- well-formedness errors (call shape/target above) win over the policy
+    -- check; the gate only judges otherwise well-formed external calls.
+    validateReentrancyDisposition fn
   validateConstructorSpec spec.constructor
   validateInteropConstructorSpec spec.constructor
   validateExternalCallTargetsInConstructor spec.externals spec.constructor

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -584,6 +584,27 @@ def stmtListContainsExternalCall (stmts : List Stmt) : Bool :=
 def matchBranchesContainExternalCall (branches : List (String × List String × List Stmt)) : Bool :=
   branches.any fun (_, _, body) => stmtListContainsExternalCall body
 
+/-- Node-local classifier for the cross-function reentrancy gate: which
+    statements hand control to untrusted code in a way that can corrupt this
+    contract's state via a reentrant entrypoint. It mirrors
+    `stmtContainsExternalCallNode` but refines the `ecm` arm: an External Call
+    Module summarised as a `staticcall` (precompiles, `keccak`/`sha256`, ABI
+    encoding, view-only reads) runs in the EVM static context, where any
+    state-mutating opcode reverts — such a call provably cannot open a
+    state-corrupting reentrancy window, so it does not require a disposition.
+    Every other external-call form (a mutating `call` ECM, a `externalCall`
+    binding, a non-builtin `externalCall` expression, raw-Yul `call`/`staticcall`/
+    `delegatecall`) stays window-opening: it reaches an external contract that
+    may re-enter. -/
+def stmtReentrancyWindowNode : Stmt → Bool
+  | Stmt.ecm mod _ =>
+      mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.call
+  | s => stmtContainsExternalCallNode s
+
+/-- Whether a statement (deeply) opens a cross-function reentrancy window. -/
+def stmtOpensReentrancyWindow (s : Stmt) : Bool :=
+  s.anyDeep stmtReentrancyWindowNode
+
 /-- Conservative variant of `stmtContainsExternalCallNode` for
     `no_external_calls` validation. Returns `true` for internal calls because
     callee bodies may contain external calls that are not visible at
@@ -1279,6 +1300,33 @@ def validateFunctionSpec (spec : FunctionSpec) : Except String Unit := do
         throw s!"Compilation error: function '{spec.name}' violates CEI (Checks-Effects-Interactions) ordering: {violation}. Reorder state writes before external calls, or annotate with allow_post_interaction_writes / nonreentrant(<lock>) to opt out ({issue1728Ref})"
     | none => pure ()
   validateFunctionIdentifierReferences spec
+
+/-- Cross-function reentrancy gate (fail-closed). A function that makes a direct
+    external call opens a reentrancy window: while control is handed to an
+    external callee, another entrypoint can re-enter and observe or exploit this
+    contract's mid-update state (the Midnight `take`/`liquidate` class of bug,
+    which single-function CEI does NOT prevent — even a CEI-clean function leaves
+    a transiently-exploitable state live during its callback). Such a function
+    must therefore carry a *sound* reentrancy disposition: either a runtime
+    `nonreentrant(<lock>)` guard (closes the window at the external dispatch
+    boundary, #1893) or an explicit audited `reentrancy_trusted` assertion.
+    `cei_safe` / `allow_post_interaction_writes` only concern single-function CEI
+    and are intentionally NOT accepted here. `view`/`pure` functions are exempt:
+    a read-only (staticcall) context cannot mutate state and so cannot open a
+    state-corrupting reentrancy window. For the same reason `stmtOpensReentrancyWindow`
+    (unlike `stmtContainsExternalCall`) does not count a `staticcall`-summarised
+    ECM — precompiles, `keccak`/`sha256`, ABI encoding, view-only reads — which
+    the EVM runs in a static context where any state mutation reverts.
+
+    This runs as a dedicated pass *after* call well-formedness validation
+    (`validateExternalCallTargetsInFunction`), so a malformed external call
+    surfaces its structural error first; the reentrancy policy only judges
+    otherwise well-formed external calls. -/
+def validateReentrancyDisposition (spec : FunctionSpec) : Except String Unit := do
+  if spec.body.any stmtOpensReentrancyWindow
+      && !spec.isView && !spec.isPure
+      && !(spec.nonReentrantLock.isSome || spec.reentrancyTrusted) then
+    throw s!"Compilation error: function '{spec.name}' makes an external call but declares no reentrancy disposition. An external call hands control to an untrusted callee that may re-enter another entrypoint while this contract's state is mid-update (cross-function reentrancy). Add `nonreentrant(<lock>)` to synthesise a runtime guard, or `reentrancy_trusted` to assert — and own — that every external callee is trusted not to re-enter ({issue1728Ref}). cei_safe / allow_post_interaction_writes cover only single-function CEI and do not satisfy this gate."
 
 /-- Node-local constructor return check; nested statement bodies are reached
     via the canonical `Stmt.forDeepM`. -/

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -328,7 +328,7 @@ verity_contract MacroExternal where
   linked_externals
     external echo(Uint256) -> (Uint256)
 
-  function allow_post_interaction_writes storeEcho (next : Uint256) : Unit := do
+  function allow_post_interaction_writes reentrancy_trusted storeEcho (next : Uint256) : Unit := do
     let echoed := externalCall "echo" [next]
     setStorage echoedValue echoed
 
@@ -2909,6 +2909,7 @@ private def unsafeYulRawCallAllowedSpec : CompilationModel := {
     { name := "bad"
       params := []
       returnType := none
+      reentrancyTrusted := true
       body := [unsafeYulRawCallStmt, Stmt.stop]
     }
   ]

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -419,6 +419,7 @@ def linkModeTrustSurfaceSpec : CompilationModel := {
     { name := "exercise"
       params := [{ name := "next", ty := ParamType.uint256 }]
       returnType := some FieldType.uint256
+      reentrancyTrusted := true
       body := [
         Stmt.letVar "a" (Expr.externalCall "oracleEcho" [Expr.param "next"]),
         Stmt.letVar "b" (Expr.externalCall "poseidonHash" [Expr.param "next", Expr.param "next"]),
@@ -2754,6 +2755,7 @@ private def effectOnlyExternalBindSpec : CompilationModel := {
     { name := "poke"
       params := [{ name := "next", ty := ParamType.uint256 }]
       returnType := none
+      reentrancyTrusted := true
       body := [
         Stmt.externalCallBind [] "notify" [Expr.param "next"],
         Stmt.stop
@@ -3343,6 +3345,7 @@ private def adtAliasPayloadMemoizesExprSpec : CompilationModel := {
       params := [{ name := "input", ty := ParamType.uint256 }]
       returnType := none
       allowPostInteractionWrites := true
+      reentrancyTrusted := true
       body := [
         Stmt.setStorage "choice"
           (Expr.adtConstruct "Choice" "Some" [Expr.externalCall "echo" [Expr.param "input"]]),
@@ -4351,6 +4354,7 @@ private def bubblingValueCallSmokeSpec : CompilationModel := {
         , { name := "outputSize", ty := ParamType.uint256 }
       ]
       returnType := none
+      reentrancyTrusted := true
       body := [
         Compiler.Modules.Calls.bubblingValueCall
           (Expr.param "target")
@@ -4430,6 +4434,7 @@ private def bubblingValueCallNoOutputSmokeSpec : CompilationModel := {
         , { name := "inputSize", ty := ParamType.uint256 }
       ]
       returnType := none
+      reentrancyTrusted := true
       body := [
         Compiler.Modules.Calls.bubblingValueCallNoOutput
           (Expr.param "target")
@@ -4502,6 +4507,7 @@ private def callbackSmokeSpec : CompilationModel := {
         , { name := "data", ty := ParamType.bytes }
       ]
       returnType := none
+      reentrancyTrusted := true
       body := [
         Compiler.Modules.Callbacks.callback
           (Expr.param "target")
@@ -4550,6 +4556,7 @@ private def erc20SafeTransferSmokeSpec : CompilationModel := {
       ]
       returnType := none
       returns := []
+      reentrancyTrusted := true
       body := [
         Compiler.Modules.ERC20.safeTransfer
           (Expr.param "token")
@@ -4575,6 +4582,7 @@ private def erc20SafeTransferFromSmokeSpec : CompilationModel := {
       ]
       returnType := none
       returns := []
+      reentrancyTrusted := true
       body := [
         Compiler.Modules.ERC20.safeTransferFrom
           (Expr.param "token")
@@ -4600,6 +4608,7 @@ private def erc20SolmateSafeTransferSmokeSpec : CompilationModel := {
       ]
       returnType := none
       returns := []
+      reentrancyTrusted := true
       body := [
         Compiler.Modules.ERC20.solmateSafeTransfer
           (Expr.param "token")
@@ -4625,6 +4634,7 @@ private def erc20SolmateSafeTransferFromSmokeSpec : CompilationModel := {
       ]
       returnType := none
       returns := []
+      reentrancyTrusted := true
       body := [
         Compiler.Modules.ERC20.solmateSafeTransferFrom
           (Expr.param "token")
@@ -4650,6 +4660,7 @@ private def erc20SafeApproveSmokeSpec : CompilationModel := {
       ]
       returnType := none
       returns := []
+      reentrancyTrusted := true
       body := [
         Compiler.Modules.ERC20.safeApprove
           (Expr.param "token")
@@ -4674,6 +4685,7 @@ private def callWithValueSmokeSpec : CompilationModel := {
         , { name := "dataSize", ty := ParamType.uint256 }
       ]
       returnType := none
+      reentrancyTrusted := true
       body := [
         Compiler.Modules.Calls.callWithValue
           (Expr.param "target")
@@ -4724,6 +4736,7 @@ private def callWithValueBytesSmokeSpec : CompilationModel := {
         , { name := "data", ty := ParamType.bytes }
       ]
       returnType := none
+      reentrancyTrusted := true
       body := [
         Compiler.Modules.Calls.callWithValueBytes
           (Expr.param "target")
@@ -5084,6 +5097,7 @@ private def erc4626DepositSmokeSpec : CompilationModel := {
       ]
       returnType := none
       returns := [ParamType.uint256]
+      reentrancyTrusted := true
       body := [
         Compiler.Modules.ERC4626.deposit
           "shares"

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -297,6 +297,7 @@ private def linkedLibrarySpec : CompilationModel := {
       ]
       returnType := none
       allowPostInteractionWrites := true
+      reentrancyTrusted := true
       body := [
         Stmt.letVar "h" (Expr.externalCall "PoseidonT3_hash" [Expr.param "a", Expr.param "b"]),
         Stmt.setStorage "lastHash" (Expr.localVar "h"),
@@ -320,6 +321,7 @@ private def trustSurfaceSpec : CompilationModel := {
     { name := "exercise"
       params := [{ name := "target", ty := ParamType.address }]
       returnType := none
+      reentrancyTrusted := true
       body := [
         Stmt.letVar "ok"
           (Expr.staticcall
@@ -548,6 +550,7 @@ private def uncheckedTrustSurfaceSpec : CompilationModel := {
     { name := "exercise"
       params := []
       returnType := none
+      reentrancyTrusted := true
       body := [
         Stmt.letVar "peek" (Expr.externalCall "DebugOracle_peek" []),
         Stmt.ecm
@@ -748,6 +751,7 @@ private def callWithValueTrustSurfaceSpec : CompilationModel := {
         , { name := "dataSize", ty := ParamType.uint256 }
       ]
       returnType := none
+      reentrancyTrusted := true
       body := [
         Compiler.Modules.Calls.callWithValue
           (Expr.param "target")
@@ -772,6 +776,7 @@ private def callWithValueBytesTrustSurfaceSpec : CompilationModel := {
         , { name := "data", ty := ParamType.bytes }
       ]
       returnType := none
+      reentrancyTrusted := true
       body := [
         Compiler.Modules.Calls.callWithValueBytes
           (Expr.param "target")
@@ -1131,6 +1136,7 @@ private def erc4626DepositTrustSurfaceSpec : CompilationModel := {
       ]
       returnType := none
       returns := [ParamType.uint256]
+      reentrancyTrusted := true
       body := [
         Compiler.Modules.ERC4626.deposit
           "shares"

--- a/Compiler/Proofs/IRGeneration/CEISafety.lean
+++ b/Compiler/Proofs/IRGeneration/CEISafety.lean
@@ -7,6 +7,15 @@ Proof-layer CEI safety surface.
 This module gives that checker a public proof-facing meaning: a function has
 proof-backed CEI execution safety exactly when the checker accepts its body and
 the recognized trust exits are absent at the function boundary.
+
+Scope: this certifies *single-function* Checks-Effects-Interactions ordering
+only. It is **not** a cross-function reentrancy defense — a CEI-clean function
+can still hand control to a callee that re-enters a sibling entrypoint while
+state is mid-update (the Midnight `take`/`liquidate` class). Cross-function
+reentrancy is owned by the separate fail-closed gate
+`Compiler.CompilationModel.validateReentrancyDisposition`, whose sound
+accept-set is `nonreentrant(<lock>)` or `reentrancy_trusted` — explicitly *not*
+`cei_safe`/`allow_post_interaction_writes`.
 -/
 
 namespace Compiler.Proofs.IRGeneration

--- a/Contracts.lean
+++ b/Contracts.lean
@@ -16,4 +16,5 @@ import Contracts.ERC721
 import Contracts.SimpleToken
 import Contracts.CryptoHash
 import Contracts.ReentrancyExample
+import Contracts.ReentrancyRelyGuarantee
 import Contracts.LocalObligationMacroSmoke

--- a/Contracts/Counter/Counter.lean
+++ b/Contracts/Counter/Counter.lean
@@ -60,7 +60,7 @@ verity_contract Counter where
     let digest := keccak256 memWord 64
     return (add (add digest flagAnd) (add flagOr flagNot))
 
-  function previewLowLevel (target : Uint256, count : Uint256)
+  function reentrancy_trusted previewLowLevel (target : Uint256, count : Uint256)
     local_obligations [manual_low_level_refinement := assumed "Caller must separately prove the direct low-level call and returndata choreography refines the intended external-call behavior."]
     : Uint256 := do
     let cds := calldatasize

--- a/Contracts/ProxyUpgradeabilityLayoutCompatibleSmoke.lean
+++ b/Contracts/ProxyUpgradeabilityLayoutCompatibleSmoke.lean
@@ -26,7 +26,7 @@ verity_contract ProxyUpgradeabilityLayoutCompatibleSmoke where
     let nextImplementation ← getStorageAddr pendingImplementation
     setStorageAddr implementation nextImplementation
 
-  function forward (gas : Uint256, inOffset : Uint256, inSize : Uint256, outOffset : Uint256, outSize : Uint256)
+  function reentrancy_trusted forward (gas : Uint256, inOffset : Uint256, inSize : Uint256, outOffset : Uint256, outSize : Uint256)
       local_obligations [delegatecall_refinement := assumed "Delegatecall fallback behavior must be shown to refine the selected proxy semantics."] : Uint256 := do
     let target ← getStorageAddr implementation
     let ok := delegatecall gas (addressToWord target) inOffset inSize outOffset outSize

--- a/Contracts/ProxyUpgradeabilityLayoutIncompatibleSmoke.lean
+++ b/Contracts/ProxyUpgradeabilityLayoutIncompatibleSmoke.lean
@@ -26,7 +26,7 @@ verity_contract ProxyUpgradeabilityLayoutIncompatibleSmoke where
     let nextImplementation ← getStorageAddr pendingImplementation
     setStorageAddr implementation nextImplementation
 
-  function forward (gas : Uint256, inOffset : Uint256, inSize : Uint256, outOffset : Uint256, outSize : Uint256)
+  function reentrancy_trusted forward (gas : Uint256, inOffset : Uint256, inSize : Uint256, outOffset : Uint256, outSize : Uint256)
       local_obligations [delegatecall_refinement := assumed "Delegatecall fallback behavior must be shown to refine the selected proxy semantics."] : Uint256 := do
     let target ← getStorageAddr implementation
     let ok := delegatecall gas (addressToWord target) inOffset inSize outOffset outSize

--- a/Contracts/ProxyUpgradeabilityMacroSmoke.lean
+++ b/Contracts/ProxyUpgradeabilityMacroSmoke.lean
@@ -21,7 +21,7 @@ verity_contract ProxyUpgradeabilityMacroSmoke where
       local_obligations [upgrade_authorization := assumed "Caller must separately prove that only the intended admin can authorize upgrades.", storage_layout_compatibility := unchecked "Storage-layout compatibility across versions remains a manual proof obligation."] : Unit := do
     setStorageAddr implementation newImplementation
 
-  function forward (gas : Uint256, inOffset : Uint256, inSize : Uint256, outOffset : Uint256, outSize : Uint256)
+  function reentrancy_trusted forward (gas : Uint256, inOffset : Uint256, inSize : Uint256, outOffset : Uint256, outSize : Uint256)
       local_obligations [delegatecall_refinement := assumed "Delegatecall fallback behavior must be shown to refine the selected proxy semantics."] : Uint256 := do
     let target ← getStorageAddr implementation
     let ok := delegatecall gas (addressToWord target) inOffset inSize outOffset outSize

--- a/Contracts/ReentrancyRelyGuarantee.lean
+++ b/Contracts/ReentrancyRelyGuarantee.lean
@@ -1,0 +1,1 @@
+import Contracts.ReentrancyRelyGuarantee.Contract

--- a/Contracts/ReentrancyRelyGuarantee/Contract.lean
+++ b/Contracts/ReentrancyRelyGuarantee/Contract.lean
@@ -1,0 +1,195 @@
+/-
+  Reentrancy rely-guarantee worked example: the Midnight `take` callback bug.
+
+  This grounds the abstract rely-guarantee proof-of-concept against Verity's real
+  `ContractState`/`Contract` monad and the `Verity.Core.Reentrancy` framework.
+  It machine-checks the same two claims that motivated the framework:
+
+    * the buggy (no-lock) `take` admits a PERMANENT bad-debt liquidation during
+      the transient trade window, despite the final health check;
+
+    * the lock-based `take` admits NO new liquidation for ANY reentrant adversary
+      that respects the per-position lock — the rely condition that `liquidate`
+      itself satisfies — and preserves the global invariant `I s := healthy ∨ locked`.
+
+  Storage layout for the abstract position (one word each):
+    slot 0 : health      (nonzero = healthy)
+    slot 1 : lock        (nonzero = locked)
+    slot 2 : liquidated  (nonzero = irreversibly liquidated / bad debt realized)
+-/
+
+import Verity.Core
+import Verity.Core.Semantics
+import Verity.Core.Reentrancy
+
+namespace Contracts.ReentrancyRelyGuarantee
+
+open Verity
+open Verity.Core.Invariant
+open Verity.Core.Reentrancy
+
+/-! ## Storage predicates and the lock-as-disjunct invariant -/
+
+def healthSlot : Nat := 0
+def lockSlot : Nat := 1
+def liquidatedSlot : Nat := 2
+
+def healthy (s : ContractState) : Prop := s.storage healthSlot ≠ 0
+def locked (s : ContractState) : Prop := s.storage lockSlot ≠ 0
+def liquidated (s : ContractState) : Prop := s.storage liquidatedSlot ≠ 0
+
+/-- Global contract invariant: every position is healthy *or* currently locked.
+    The `locked` disjunct is exactly what lets `take` hold the invariant while the
+    seller is transiently unhealthy during the trade window. -/
+def I (s : ContractState) : Prop := healthy s ∨ locked s
+
+/-! ## The reentrant entrypoint: `liquidate` -/
+
+/-- The irreversible liquidation, performed only on a genuinely unhealthy
+    position that is NOT locked. Touches only the `liquidated` slot. -/
+def liquidate (s : ContractState) : ContractState :=
+  if s.storage lockSlot == 0 && s.storage healthSlot == 0 then
+    s.writeSlot liquidatedSlot 1
+  else s
+
+@[simp] theorem liquidate_health (s : ContractState) :
+    (liquidate s).storage healthSlot = s.storage healthSlot := by
+  unfold liquidate; split <;> simp [healthSlot, liquidatedSlot]
+
+@[simp] theorem liquidate_lock (s : ContractState) :
+    (liquidate s).storage lockSlot = s.storage lockSlot := by
+  unfold liquidate; split <;> simp [lockSlot, liquidatedSlot]
+
+/-- Guarantee discharged by `liquidate`: it preserves `I`. It only ever changes
+    the `liquidated` slot, leaving both `I` disjuncts (health, lock) untouched. -/
+theorem liquidate_preserves_I : Preserves I liquidate := by
+  intro s h
+  simpa only [I, healthy, locked, liquidate_health, liquidate_lock] using h
+
+/-- Guarantee discharged by `liquidate`: it never touches a *locked* position. -/
+theorem liquidate_respects_lock {s : ContractState} (h : locked s) :
+    liquidate s = s := by
+  unfold liquidate
+  split
+  · next hcond =>
+      rw [Bool.and_eq_true] at hcond
+      exact absurd (eq_of_beq hcond.1) h
+  · rfl
+
+/-! ## Position setters (frame: each touches exactly one slot) -/
+
+def setHealthy (b : Bool) (s : ContractState) : ContractState :=
+  s.writeSlot healthSlot (if b then 1 else 0)
+
+def setLock (b : Bool) (s : ContractState) : ContractState :=
+  s.writeSlot lockSlot (if b then 1 else 0)
+
+@[simp] theorem setHealthy_liq (b : Bool) (s : ContractState) :
+    (setHealthy b s).storage liquidatedSlot = s.storage liquidatedSlot := by
+  simp [setHealthy, healthSlot, liquidatedSlot]
+
+@[simp] theorem setLock_liq (b : Bool) (s : ContractState) :
+    (setLock b s).storage liquidatedSlot = s.storage liquidatedSlot := by
+  simp [setLock, lockSlot, liquidatedSlot]
+
+@[simp] theorem setHealthy_lock (b : Bool) (s : ContractState) :
+    (setHealthy b s).storage lockSlot = s.storage lockSlot := by
+  simp [setHealthy, healthSlot, lockSlot]
+
+/-! ## Buggy `take`: trade ⇒ transiently unhealthy, NO lock, final health check -/
+
+def takeBuggy (adv : ContractState → ContractState) (s : ContractState) : ContractState :=
+  let s1 := setHealthy false s          -- trade ⇒ seller transiently unhealthy
+  let s2 := adv s1                       -- callback / reentrancy window (no lock held)
+  setHealthy true s2                     -- close: require(isHealthy(seller))
+
+/-- The bug: from a healthy, unlocked seller (`I` holds), a single reentrant
+    `liquidate` in the window yields a PERMANENT liquidation, even though the
+    seller is healthy again at the final check. -/
+theorem buggy_admits_permanent_bad_debt :
+    ∃ s : ContractState, I s ∧ liquidated (takeBuggy liquidate s) := by
+  refine ⟨setHealthy true (setLock false defaultState), ?_, ?_⟩
+  · left
+    show (setHealthy true (setLock false defaultState)).storage healthSlot ≠ 0
+    decide
+  · simp only [liquidated, takeBuggy, liquidate, setHealthy, setLock,
+      healthSlot, lockSlot, liquidatedSlot, ContractState.writeSlot]
+    decide
+
+/-! ## Fixed `take`: acquire lock, trade, window, health check, release -/
+
+def takeLocked (adv : ContractState → ContractState) (s : ContractState) : ContractState :=
+  let s0 := setLock true s               -- acquire the per-position lock
+  let s1 := setHealthy false s0          -- trade (transiently unhealthy, but locked)
+  let s2 := adv s1                        -- window: I holds here via the lock disjunct
+  let s3 := setHealthy true s2            -- close: require(isHealthy(seller))
+  setLock false s3                        -- release the lock
+
+/-- Rely-guarantee safety: for ANY reentrant adversary that respects the lock,
+    the locked `take` introduces no new liquidation — the `liquidated` slot is
+    left exactly as it started. -/
+theorem locked_take_no_new_liquidation
+    (adv : ContractState → ContractState)
+    (hAdv : ∀ v, locked v → (adv v).storage liquidatedSlot = v.storage liquidatedSlot)
+    (s : ContractState) :
+    (takeLocked adv s).storage liquidatedSlot = s.storage liquidatedSlot := by
+  have hlock : locked (setHealthy false (setLock true s)) := by
+    show (setHealthy false (setLock true s)).storage lockSlot ≠ 0
+    have hval : (setHealthy false (setLock true s)).storage lockSlot = 1 := by
+      simp [setHealthy, setLock, healthSlot, lockSlot]
+    rw [hval]; decide
+  simp only [takeLocked, setHealthy_liq, setLock_liq, hAdv _ hlock]
+
+/-- Rely-guarantee invariant preservation: the locked `take` preserves `I` for
+    ANY adversary, because the final health check re-establishes the `healthy`
+    disjunct unconditionally. -/
+theorem locked_take_preserves_I (adv : ContractState → ContractState) (s : ContractState) :
+    I (takeLocked adv s) := by
+  left
+  show (takeLocked adv s).storage healthSlot ≠ 0
+  have hval : (takeLocked adv s).storage healthSlot = 1 := by
+    simp [takeLocked, setLock, setHealthy, healthSlot, lockSlot]
+  rw [hval]; decide
+
+/-- Concrete corollary: the lock blocks the real `liquidate` adversary, because
+    `liquidate` discharges the rely condition (`liquidate_respects_lock`). -/
+theorem locked_blocks_concrete_liquidation (s : ContractState) :
+    (takeLocked liquidate s).storage liquidatedSlot = s.storage liquidatedSlot := by
+  apply locked_take_no_new_liquidation
+  intro v hv
+  rw [liquidate_respects_lock hv]
+
+/-! ## Wiring into the framework: a `ReentrancySpec` whose registry is `[liquidate]` -/
+
+/-- The contract's reentrancy spec: the lock-as-disjunct invariant `I`, the
+    entrypoint registry `[liquidate]`, and the single per-entrypoint obligation
+    (here `liquidate_preserves_I`). The macro-emitted registry would supply the
+    `entrypoints` list; the proof obligation is one lemma per entrypoint. -/
+def spec : ReentrancySpec where
+  Inv := I
+  entrypoints := [liquidate]
+  entrypoints_preserve := by
+    intro f hf
+    simp only [List.mem_singleton] at hf
+    subst hf
+    exact liquidate_preserves_I
+
+/-- Framework payoff: ANY finite reentry schedule drawn from this contract's
+    registered entrypoints preserves `I`. The whole adversarial interleaving
+    space is discharged by the single obligation in `spec`. -/
+theorem any_reentry_schedule_preserves_I
+    (sched : List (ContractState → ContractState))
+    (hsched : ∀ f, f ∈ sched → f ∈ spec.entrypoints) :
+    Preserves I (runSeq sched) :=
+  spec.schedule_preserves sched hsched
+
+/-- Forward-compat payoff: the SAME spec, lifted into a multi-contract `System`,
+    preserves the joint invariant against any cross-contract reentry schedule —
+    no new per-contract proof. -/
+theorem any_cross_contract_schedule_preserves_I (inScope : List Address)
+    (steps : List (Address × (ContractState → ContractState)))
+    (hsteps : ∀ p, p ∈ steps → p.2 ∈ spec.entrypoints) :
+    Preserves (Isys I inScope) (runSeq (steps.map (fun p => lift p.1 p.2))) :=
+  cross_contract_schedule_preserves spec inScope steps hsteps
+
+end Contracts.ReentrancyRelyGuarantee

--- a/Contracts/Smoke/Declarations.lean
+++ b/Contracts/Smoke/Declarations.lean
@@ -413,15 +413,15 @@ verity_contract HelperExternalArgumentSmoke where
   function put (a : Uint256) : Unit := do
     setStorage saved a
 
-  function bindExternalArg (x : Uint256) : Uint256 := do
+  function reentrancy_trusted bindExternalArg (x : Uint256) : Uint256 := do
     let y ← idWord (externalCall "echo" [x])
     return y
 
-  function tupleExternalArg (x : Uint256) : Uint256 := do
+  function reentrancy_trusted tupleExternalArg (x : Uint256) : Uint256 := do
     let (a, b) ← pair (externalCall "echo" [x])
     return (add a b)
 
-  function statementExternalArg (x : Uint256) : Unit := do
+  function reentrancy_trusted statementExternalArg (x : Uint256) : Unit := do
     put (externalCall "echo" [x])
 
 verity_contract BlockTimestampSmoke where

--- a/Contracts/Smoke/Effects.lean
+++ b/Contracts/Smoke/Effects.lean
@@ -134,13 +134,13 @@ verity_contract CEILadderSmoke where
     return echoed
 
   -- cei_safe is recorded as metadata; it does not bypass CEI by itself.
-  function cei_safe callThenStoreProved (x : Uint256) : Uint256 := do
+  function cei_safe reentrancy_trusted callThenStoreProved (x : Uint256) : Uint256 := do
     setStorage counter x
     let echoed := externalCall "echo" [x]
     return echoed
 
   -- Normal function: CEI-compliant (effects before interactions), gets _cei_compliant
-  function storeThenCall (x : Uint256) : Uint256 := do
+  function reentrancy_trusted storeThenCall (x : Uint256) : Uint256 := do
     setStorage counter x
     let echoed := externalCall "echo" [x]
     return echoed

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -14,7 +14,7 @@ verity_contract ExternalCallSmoke where
     external echo(Uint256) -> (Uint256)
     external echo_try(Uint256) -> (Bool, Uint256)
 
-  function allow_post_interaction_writes storeEcho (next : Uint256) : Unit := do
+  function allow_post_interaction_writes reentrancy_trusted storeEcho (next : Uint256) : Unit := do
     let echoed := externalCall "echo" [next]
     setStorage echoedValue echoed
 
@@ -31,7 +31,7 @@ verity_contract TryExternalCallSmoke where
     external echo(Uint256) -> (Uint256)
     external echo_try(Uint256) -> (Bool, Uint256)
 
-  function allow_post_interaction_writes tryEcho (x : Uint256) : Unit := do
+  function allow_post_interaction_writes reentrancy_trusted tryEcho (x : Uint256) : Unit := do
     let (success, result) ← tryExternalCall "echo" [x]
     if success then
       setStorage lastResult result
@@ -49,7 +49,7 @@ verity_contract CallResultSmoke where
     external echo(Uint256) -> (Uint256)
     external echo_try(Uint256) -> (Bool, Uint256)
 
-  function allow_post_interaction_writes storeCallResult (x : Uint256) : Unit := do
+  function allow_post_interaction_writes reentrancy_trusted storeCallResult (x : Uint256) : Unit := do
     let result ← callResult "echo" [x]
     if result.success then
       setStorage lastResult result.returndata
@@ -119,20 +119,20 @@ verity_contract LinkedExternalDynamicArgSmoke where
     external notifyArray(Array Uint256)
     external hashBytes(Bytes) -> (Uint256)
 
-  function hashLeaves (leaves : Array Uint256) : Uint256 := do
+  function reentrancy_trusted hashLeaves (leaves : Array Uint256) : Uint256 := do
     return externalCall "hashArray" [leaves]
 
-  function sendLeaves (leaves : Array Uint256) : Unit := do
+  function reentrancy_trusted sendLeaves (leaves : Array Uint256) : Unit := do
     externalCallBind [] "notifyArray" [leaves]
 
-  function discardHash (leaves : Array Uint256) : Unit := do
+  function reentrancy_trusted discardHash (leaves : Array Uint256) : Unit := do
     let _ := (externalCall "hashArray" [leaves] : Uint256)
 
-  function tryHash (leaves : Array Uint256) : Uint256 := do
+  function reentrancy_trusted tryHash (leaves : Array Uint256) : Uint256 := do
     let (_success, h) ← tryExternalCall "hashArray" [leaves]
     return h
 
-  function hashPayload (payload : Bytes) : Uint256 := do
+  function reentrancy_trusted hashPayload (payload : Bytes) : Uint256 := do
     return externalCall "hashBytes" [payload]
 
 example :
@@ -196,14 +196,14 @@ verity_contract LinkedExternalProjectedArrayArgSmoke where
     external hashBytes(Bytes) -> (Uint256)
     external hashBytes_try(Bytes) -> (Bool, Uint256)
 
-  function tryHashNullifiers (txs : Array Transaction, idx : Uint256) : Uint256 := do
+  function reentrancy_trusted tryHashNullifiers (txs : Array Transaction, idx : Uint256) : Uint256 := do
     let (_success, h) ← tryExternalCall "hashArray" [(arrayElement txs idx).nullifierHashes]
     return h
 
-  function hashCallData (txs : Array Transaction, idx : Uint256) : Uint256 := do
+  function reentrancy_trusted hashCallData (txs : Array Transaction, idx : Uint256) : Uint256 := do
     return externalCall "hashBytes" [(arrayElement txs idx).callData]
 
-  function tryHashCallData (txs : Array Transaction, idx : Uint256) : Uint256 := do
+  function reentrancy_trusted tryHashCallData (txs : Array Transaction, idx : Uint256) : Uint256 := do
     let (_success, h) ← tryExternalCall "hashBytes" [(arrayElement txs idx).callData]
     return h
 
@@ -475,7 +475,7 @@ verity_contract Create2SSTORE2Smoke where
   storage
     lastPointer : Address := slot 0
 
-  function allow_post_interaction_writes deploy (value : Uint256, initOffset : Uint256, initSize : Uint256, salt : Uint256) : Address := do
+  function allow_post_interaction_writes reentrancy_trusted deploy (value : Uint256, initOffset : Uint256, initSize : Uint256, salt : Uint256) : Address := do
     let pointer ← ecmCall Compiler.Modules.Create2SSTORE2.deployModule
       [value, initOffset, initSize, salt]
     setStorageAddr lastPointer (wordToAddress pointer)
@@ -489,7 +489,7 @@ set_option linter.unusedVariables false in
 verity_contract CallbackABISmoke where
   storage
 
-  function onAction (target : Address, amount : Uint256, data : Bytes) : Unit := do
+  function reentrancy_trusted onAction (target : Address, amount : Uint256, data : Bytes) : Unit := do
     ecmDo (Compiler.Modules.Callbacks.callbackModule 0x12345678 1 "data")
       [addressToWord target, amount]
 
@@ -508,7 +508,7 @@ verity_contract LowLevelTryCatchSmoke where
   storage
     lastOutcome : Uint256 := slot 0
 
-  function allow_post_interaction_writes catchFailure ()
+  function allow_post_interaction_writes reentrancy_trusted catchFailure ()
     local_obligations [manual_low_level_refinement := assumed "Low-level call success/failure boundary still requires a manual refinement argument."]
     : Uint256
     := do
@@ -517,7 +517,7 @@ verity_contract LowLevelTryCatchSmoke where
     let current ← getStorage lastOutcome
     return current
 
-  function allow_post_interaction_writes skipCatchOnSuccess ()
+  function allow_post_interaction_writes reentrancy_trusted skipCatchOnSuccess ()
     local_obligations [manual_low_level_refinement := assumed "Low-level call success/failure boundary still requires a manual refinement argument."]
     : Uint256
     := do
@@ -526,7 +526,7 @@ verity_contract LowLevelTryCatchSmoke where
     let current ← getStorage lastOutcome
     return current
 
-  function allow_post_interaction_writes catchFailureWithShadowedParam (verity_try_success : Uint256)
+  function allow_post_interaction_writes reentrancy_trusted catchFailureWithShadowedParam (verity_try_success : Uint256)
     local_obligations [manual_low_level_refinement := assumed "Low-level call success/failure boundary still requires a manual refinement argument."]
     : Uint256
     := do
@@ -598,7 +598,7 @@ verity_contract ExternalCallMultiReturn where
     external fanout(Uint256) -> (Uint256, Address)
     external fanout_try(Uint256) -> (Bool, Uint256, Address)
 
-  function allow_post_interaction_writes callFanout (x : Uint256) : Unit := do
+  function allow_post_interaction_writes reentrancy_trusted callFanout (x : Uint256) : Unit := do
     let (success, value, addr) ← tryExternalCall "fanout" [x]
     if success then
       setStorage lastValue value

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -497,10 +497,10 @@ set_option linter.unusedVariables false in
 verity_contract CallWithValueSmoke where
   storage
 
-  function execute (target : Address, value : Uint256, dataOffset : Uint256, dataSize : Uint256) : Unit := do
+  function reentrancy_trusted execute (target : Address, value : Uint256, dataOffset : Uint256, dataSize : Uint256) : Unit := do
     ecmDo Compiler.Modules.Calls.callWithValueModule [addressToWord target, value, dataOffset, dataSize]
 
-  function executeBytes (target : Address, value : Uint256, data : Bytes) : Unit := do
+  function reentrancy_trusted executeBytes (target : Address, value : Uint256, data : Bytes) : Unit := do
     ecmDo (Compiler.Modules.Calls.callWithValueBytesModule "data") [addressToWord target, value]
 
 set_option linter.unusedVariables false in

--- a/Contracts/Smoke/HelperCalls.lean
+++ b/Contracts/Smoke/HelperCalls.lean
@@ -126,7 +126,7 @@ verity_contract ForEachMutableLocalSmoke where
       total := add total value)
     return total
 
-  function allow_post_interaction_writes sumOnCatch (values : Array Uint256)
+  function allow_post_interaction_writes reentrancy_trusted sumOnCatch (values : Array Uint256)
     local_obligations [manual_low_level_refinement := assumed "Low-level call success/failure boundary still requires a manual refinement argument."]
     : Uint256 := do
     tryCatch (call 0 0 1 0 0 0 0) (do

--- a/Contracts/Smoke/SecurityCombos.lean
+++ b/Contracts/Smoke/SecurityCombos.lean
@@ -126,6 +126,55 @@ verity_contract NonreentrantInternalHelperRejected where
   function internal nonreentrant(lock) guardedHelper () : Unit := do
     pure ()
 
+-- Regression for the Bugbot HIGH on PR #2032 ("internal call routes through the
+-- lock-free shadow of a nonreentrant entry"): a *public* `nonreentrant(<lock>)`
+-- entry can be invoked from another function's body, which lowers to the
+-- internal-helper shadow. The shadow drops the lock (the transient guard only
+-- materialises at the external dispatch boundary), so the call would run the
+-- guarded body with no reentrancy protection. Fail closed at lowering unless the
+-- callee also carries `reentrancy_trusted` (a global author assertion that the
+-- body is safe under every entry path).
+/--
+error: helper call 'guardedEntry': nonreentrant(<lock>) functions cannot be invoked as internal helpers; the synthesised transient-storage guard runs only at the external dispatch boundary, so an internal call would execute the body without the reentrancy lock. Expose 'guardedEntry' only as an external entrypoint, or add `reentrancy_trusted` if its body is safe under every entry path.
+-/
+#guard_msgs in
+verity_contract NonreentrantCalledAsInternalHelperRejected where
+  storage
+    lock : Uint256 := slot 0
+    counter : Uint256 := slot 1
+  linked_externals
+    external echo(Uint256) -> (Uint256)
+
+  function nonreentrant(lock) guardedEntry (x : Uint256) : Uint256 := do
+    let echoed := externalCall "echo" [x]
+    setStorage counter echoed
+    return echoed
+
+  function caller (x : Uint256) : Uint256 := do
+    let y ← guardedEntry x
+    return y
+
+-- Companion positive case: a `nonreentrant(lock) reentrancy_trusted` entry MAY be
+-- invoked internally — the author's global `reentrancy_trusted` assertion covers
+-- the lock-free internal path, so the shadow is sound and the call is accepted.
+verity_contract NonreentrantTrustedInternalHelperAccepted where
+  storage
+    lock : Uint256 := slot 0
+    counter : Uint256 := slot 1
+  linked_externals
+    external echo(Uint256) -> (Uint256)
+
+  function nonreentrant(lock) reentrancy_trusted trustedEntry (x : Uint256) : Uint256 := do
+    let echoed := externalCall "echo" [x]
+    setStorage counter echoed
+    return echoed
+
+  function callerTrusted (x : Uint256) : Uint256 := do
+    let y ← trustedEntry x
+    return y
+
+#check_contract NonreentrantTrustedInternalHelperAccepted
+
 -- ════════════════════════════════════════════════════════════════════════════
 -- Stress-test contracts: edge-case coverage for Language Design Axes (#1731)
 -- ════════════════════════════════════════════════════════════════════════════

--- a/Contracts/Smoke/SecurityCombos.lean
+++ b/Contracts/Smoke/SecurityCombos.lean
@@ -172,6 +172,54 @@ error: #check_contract failed for 'Contracts.Smoke.CEICallBothBranchesWrite': Co
 #guard_msgs in
 #check_contract CEICallBothBranchesWrite
 
+-- ════════════════════════════════════════════════════════════════════════════
+-- Cross-function reentrancy gate (#1728): the Midnight `take`/`liquidate` shape
+-- ════════════════════════════════════════════════════════════════════════════
+-- `takeWithoutDisposition` is textbook CEI-CLEAN: every state write precedes the
+-- external call, so the single-function CEI check is satisfied — yet the
+-- contract is still REJECTED. That is the entire point of the gate. A CEI-clean
+-- `take` is exactly the Midnight bug shape: while the external call is in
+-- flight, control is handed to an untrusted callee that can re-enter a
+-- *different* entrypoint (e.g. `liquidate`) and observe this contract's
+-- half-updated state. CEI reasons within one function and cannot see that
+-- cross-function window; only an explicit disposition can close it. This is the
+-- keystone regression test — it proves the Midnight callback reentrancy bug
+-- cannot pass `#check_contract` undeclared.
+verity_contract ReentrancyDispositionRequired where
+  storage
+    balance : Uint256 := slot 0
+  linked_externals
+    external echo(Uint256) -> (Uint256)
+
+  function takeWithoutDisposition (amount : Uint256) : Uint256 := do
+    setStorage balance amount
+    let echoed := externalCall "echo" [amount]
+    return echoed
+
+/--
+error: #check_contract failed for 'Contracts.Smoke.ReentrancyDispositionRequired': Compilation error: function 'takeWithoutDisposition' makes an external call but declares no reentrancy disposition. An external call hands control to an untrusted callee that may re-enter another entrypoint while this contract's state is mid-update (cross-function reentrancy). Add `nonreentrant(<lock>)` to synthesise a runtime guard, or `reentrancy_trusted` to assert — and own — that every external callee is trusted not to re-enter (Issue #1728 (CEI enforcement — Checks-Effects-Interactions ordering)). cei_safe / allow_post_interaction_writes cover only single-function CEI and do not satisfy this gate.
+-/
+#guard_msgs in
+#check_contract ReentrancyDispositionRequired
+
+-- Positive control: the SAME CEI-clean body is ACCEPTED once it declares a
+-- disposition. `reentrancy_trusted` is the audited author assertion that every
+-- external callee ('echo' here, an in-repo trusted fixture) will not re-enter.
+-- Pairing this with the rejection above isolates the gate as the deciding pass:
+-- identical bodies, opposite verdicts, the disposition the only difference.
+verity_contract ReentrancyDispositionDeclared where
+  storage
+    balance : Uint256 := slot 0
+  linked_externals
+    external echo(Uint256) -> (Uint256)
+
+  function reentrancy_trusted takeWithDisposition (amount : Uint256) : Uint256 := do
+    setStorage balance amount
+    let echoed := externalCall "echo" [amount]
+    return echoed
+
+#check_contract ReentrancyDispositionDeclared
+
 -- Modifies + roles: combined annotation
 verity_contract ModifiesRolesSmoke where
   storage
@@ -321,7 +369,7 @@ verity_contract UnsafeCEICompliant where
   linked_externals
     external echo(Uint256) -> (Uint256)
 
-  function writeBeforeUnsafeCall (x : Uint256) : Uint256 := do
+  function reentrancy_trusted writeBeforeUnsafeCall (x : Uint256) : Uint256 := do
     setStorage counter x
     unsafe "test: call inside unsafe after write" do
       let echoed := externalCall "echo" [x]
@@ -363,7 +411,7 @@ verity_contract RolesCEISmoke where
     setStorageAddr admin initialAdmin
 
   -- CEI compliant: write, then call
-  function setAndCall (value : Uint256) requires(admin) : Uint256 := do
+  function reentrancy_trusted setAndCall (value : Uint256) requires(admin) : Uint256 := do
     setStorage counter value
     let echoed := externalCall "echo" [value]
     return echoed

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -5566,4 +5566,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5202 theorems/lemmas (3596 public, 1606 private, 0 sorry'd)
+-- Total: 5208 theorems/lemmas (3602 public, 1606 private, 0 sorry'd)

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@
 <!-- BEGIN GENERATED STATS -->
 | Metric | Value |
 |--------|-------|
-| Theorems | 283 (283 proven, 0 sorry) |
+| Theorems | 291 (291 proven, 0 sorry) |
 | Axioms | 0 |
 | Foundry tests | 522 (239 property) |
-| Verified contracts | 12 |
-| Core EDSL | 649 lines |
+| Verified contracts | 13 |
+| Core EDSL | 830 lines |
 | Lean | 4.22.0 |
 <!-- END GENERATED STATS -->
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -270,15 +270,38 @@ silently ships without a disposition; it does not, for `reentrancy_trusted`,
 prove the assertion. Functions carrying a proof-level guarantee should instead
 use the rely-guarantee framework above and/or the `nonreentrant` runtime guard.
 
+Internal-call interaction: the `nonreentrant(<lock>)` guard is synthesised
+**only** at the external dispatch boundary (`attachNonReentrantGuard`, #1893), so
+its protection does not survive on the internal-helper *shadow* the macro emits
+for direct intra-contract calls (the shadow drops the lock to avoid
+double-guarding the already-guarded public chain). Consequently a *lock-only*
+`nonreentrant(<lock>)` function (one that does **not** also carry
+`reentrancy_trusted`) **cannot be invoked as an internal helper**: such a call is
+rejected at macro lowering (`ensureCallableAsInternalHelper`,
+[Verity/Macro/Internal.lean](Verity/Macro/Internal.lean)), because routing it
+through the lock-free shadow would run the guarded body without the lock and
+silently bypass the only reentrancy protection it had. Calling a function that
+*also* carries `reentrancy_trusted` is accepted — that disposition is a global
+author assertion covering every entry path, including the lock-free internal one.
+This mirrors the parse-time rejection of an `internal nonreentrant(<lock>)`
+helper (`NonreentrantInternalHelperRejected`, #1971).
+
 - **Reference**: [Compiler/CompilationModel/Validation.lean](Compiler/CompilationModel/Validation.lean)
   (`validateReentrancyDisposition`, the cross-function reentrancy gate — a
   dedicated pass run after call well-formedness, distinct from the
-  single-function CEI check in `validateFunctionSpec`).
+  single-function CEI check in `validateFunctionSpec`);
+  [Verity/Macro/Internal.lean](Verity/Macro/Internal.lean)
+  (`ensureCallableAsInternalHelper`, the lowering-time rejection of internal
+  calls to lock-only `nonreentrant` entries).
 - **Regression evidence**: [Contracts/Smoke/SecurityCombos.lean](Contracts/Smoke/SecurityCombos.lean)
   pairs `ReentrancyDispositionRequired` (a CEI-clean `take` rejected by the gate,
   asserted via `#guard_msgs`) with `ReentrancyDispositionDeclared` (the identical
   body accepted once it carries `reentrancy_trusted`) — the Midnight
-  `take`/`liquidate` shape cannot pass `#check_contract` undeclared.
+  `take`/`liquidate` shape cannot pass `#check_contract` undeclared. The
+  internal-helper rule is pinned by `NonreentrantCalledAsInternalHelperRejected`
+  (a public `nonreentrant` entry called from another body, rejected at lowering)
+  and `NonreentrantTrustedInternalHelperAccepted` (the same call accepted once the
+  callee adds `reentrancy_trusted`).
 
 ## Security Audit Checklist
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -173,6 +173,113 @@ guard attachment as the identity on the lock-free fragment. Proof-side
 guard preservation lemmas (modelling the TLOAD/TSTORE prologue itself)
 remain deferred follow-up work.
 
+### Reentrancy Rely-Guarantee Framework (`Verity.Core.Reentrancy`)
+A proof-level companion to the runtime `nonreentrant` guard above. Where the
+guard *prevents* reentry at runtime (transient storage), this framework lets an
+author *prove* that reentry — even when permitted — cannot break a declared
+global invariant `I : ContractState → Prop`.
+
+- **What it adds (all additive, all proven in-kernel)**:
+  - `Verity.Core.Invariant` — a state-polymorphic rely-guarantee library
+    (`Preserves`, `runSeq`, `runSeq_preserves`); no imports, no axioms.
+  - `Verity.Core.Reentrancy` — grounds the library against the real
+    `ContractState`/`Contract` monad: `reentrantCall` (adversarial reentry as a
+    `Contract Unit` effect), `ContractPreserves`, and `ReentrancySpec` (a global
+    invariant + entrypoint registry + one preservation obligation per
+    entrypoint). The meta-theorem `ReentrancySpec.schedule_preserves` discharges
+    the *entire* adversarial interleaving space from those per-entrypoint
+    obligations — no interleaving enumeration.
+  - `Env.reenter` — a hook on `Env` (default `id`, the no-reentry case) so the
+    adversary transformer threads through semantics like any other effect.
+  - A forward-compatible multi-contract layer (`System` / `lift` / `Isys` /
+    `cross_contract_schedule_preserves`) that reuses the same library at
+    `σ := System` with no single-contract proof redone.
+- **Proven, not assumed**: every theorem closes in the Lean kernel
+  (`decide` / structural induction); the framework adds **zero project-level
+  axioms** and uses no `native_decide`. The Midnight `take`/`liquidate` worked
+  example (`Contracts/ReentrancyRelyGuarantee`) machine-checks both that the
+  no-lock `take` admits a permanent bad-debt liquidation and that the locked
+  `take` admits none for any lock-respecting adversary.
+- **Trust boundary (author obligations)**:
+  1. **Registry completeness** — `ReentrancySpec.entrypoints` must list *every*
+     externally reachable state transformer an adversary can invoke during a
+     reentry window. Omitting a reachable entrypoint voids the guarantee
+     (analogous to declaring the lock field for `nonreentrant`). The
+     macro-emitted entrypoint registry is the intended source of this list; until
+     that emission lands, the list is author-supplied.
+  2. **Adversary-model fidelity** — reentry is modeled as an arbitrary
+     `ContractState → ContractState` over *this* contract's persistent channels
+     (`adv` in `reentrantCall`). This captures self- and cross-contract reentry
+     that affects only this contract's storage. It does **not** model, in this
+     version: unbounded mutual A↔B recursion, or read-only / oracle-return-value
+     precision. Those are explicit `System`-layer follow-ups.
+  3. **Invariant adequacy** — the safety claim is only as strong as the chosen
+     invariant `I`. The lock-as-disjunct idiom (`I s := healthy s ∨ locked s`)
+     is the recommended pattern for trade-window safety, but `I` itself is
+     author-chosen and not verified against any external specification.
+- **Reference**: [Verity/Core/Reentrancy.lean](Verity/Core/Reentrancy.lean),
+  [Contracts/ReentrancyRelyGuarantee/Contract.lean](Contracts/ReentrancyRelyGuarantee/Contract.lean).
+
+### Cross-Function Reentrancy Gate (fail-closed)
+Every function whose body opens a reentrancy window (`externalCallBind`,
+`tryExternalCallBind`, a state-changing `call`-summarised `ecm`, a non-builtin
+`externalCall` expression, or an `unsafeYul` fragment carrying an external-call
+mechanic) and that is **not** `view`/`pure` must declare a reentrancy
+disposition or compilation fails (`validateReentrancyDisposition`, keyed on
+`stmtOpensReentrancyWindow`, in
+[Compiler/CompilationModel/Validation.lean](Compiler/CompilationModel/Validation.lean)).
+This is a dedicated pass that runs *after* call well-formedness validation, so a
+malformed external call surfaces its structural error first and the reentrancy
+policy only judges otherwise well-formed calls. It is also independent of the
+single-function CEI check (in `validateFunctionSpec`), which runs earlier in the
+per-function pipeline; a CEI-violating function is therefore rejected by the CEI
+check before this gate is consulted.
+An external call hands control to an untrusted callee that may re-enter a
+*different* entrypoint while this contract's state is mid-update — the Midnight
+`take`/`liquidate` class of bug. Single-function CEI ordering does **not**
+prevent this, so `cei_safe` and `allow_post_interaction_writes` are
+intentionally **not** accepted by this gate; only the two dispositions below
+are:
+
+- `nonreentrant(<lock>)` — synthesises the runtime transient-storage guard
+  documented above (#1893), closing the window at the external-dispatch
+  boundary. Sound by construction (reduces to TLOAD/TSTORE semantics).
+- `reentrancy_trusted` — a **metadata-only, unproven author assertion** that
+  every external callee reachable from this function is trusted not to re-enter.
+  It emits no code and carries no proof obligation: it is a recorded trust
+  boundary, the audited opt-out for functions whose external targets are
+  known-safe (e.g. a hard-coded protocol-owned contract) or which run in a
+  context where no exploitable reentry exists. The author owns this assertion;
+  the compiler does not verify it. `view`/`pure` functions need no disposition
+  because a read-only (`staticcall`) context cannot mutate state and so cannot
+  open a state-corrupting reentry window.
+
+For the same EVM-static-context reason, a `staticcall`-summarised External Call
+Module (`ecm` whose `summaryMutability = .staticcall`: precompiles such as
+`sha256`/`bn256`, `keccak`, ABI-encoding helpers, and view-only cross-contract
+reads) is **not** treated as window-opening and needs no disposition — any
+state-mutating opcode in the callee reverts under STATICCALL. Only a
+state-changing `call`-summarised ECM (e.g. an ERC-20 transfer) is gated. This
+keeps the gate precise rather than flooding hash/precompile-using contracts with
+vacuous `reentrancy_trusted` tags.
+
+Trust boundary: a `reentrancy_trusted` annotation is exactly as strong as the
+author's audit of the called targets — it is the reentrancy analogue of trusting
+a linked Yul library. The gate guarantees only that *no* external-call function
+silently ships without a disposition; it does not, for `reentrancy_trusted`,
+prove the assertion. Functions carrying a proof-level guarantee should instead
+use the rely-guarantee framework above and/or the `nonreentrant` runtime guard.
+
+- **Reference**: [Compiler/CompilationModel/Validation.lean](Compiler/CompilationModel/Validation.lean)
+  (`validateReentrancyDisposition`, the cross-function reentrancy gate — a
+  dedicated pass run after call well-formedness, distinct from the
+  single-function CEI check in `validateFunctionSpec`).
+- **Regression evidence**: [Contracts/Smoke/SecurityCombos.lean](Contracts/Smoke/SecurityCombos.lean)
+  pairs `ReentrancyDispositionRequired` (a CEI-clean `take` rejected by the gate,
+  asserted via `#guard_msgs`) with `ReentrancyDispositionDeclared` (the identical
+  body accepted once it carries `reentrancy_trusted`) — the Midnight
+  `take`/`liquidate` shape cannot pass `#check_contract` undeclared.
+
 ## Security Audit Checklist
 
 1. Confirm deployment uses the supported EDSL CLI path.

--- a/Verity/Core/Invariant.lean
+++ b/Verity/Core/Invariant.lean
@@ -1,0 +1,66 @@
+/-
+  Rely-guarantee core for Verity reentrancy reasoning.
+
+  This module is deliberately *state-polymorphic*: nothing here mentions
+  `ContractState`. The v1 single-contract development instantiates every
+  definition at `σ := ContractState` (see `Verity/Core/Reentrancy.lean`); a
+  future multi-contract development instantiates the SAME definitions at
+  `σ := System`. Because the library never commits to a state type, the v1
+  proofs transfer to the multi-contract setting by instantiation rather than
+  re-proof — that is the forward-compatibility guarantee.
+
+  The single load-bearing result is `runSeq_preserves`: if every entrypoint
+  preserves the invariant, then *any* finite schedule of them does. This is
+  what collapses the adversarial interleaving space into one proof obligation
+  per entrypoint, with no enumeration of interleavings.
+-/
+
+namespace Verity.Core.Invariant
+
+/-- A state transformer `c` *preserves* the invariant `Inv`. -/
+def Preserves {σ : Type} (Inv : σ → Prop) (c : σ → σ) : Prop :=
+  ∀ s, Inv s → Inv (c s)
+
+namespace Preserves
+
+/-- The identity transformer preserves every invariant (the "no reentry" case). -/
+theorem id {σ : Type} (Inv : σ → Prop) : Preserves Inv (fun s => s) :=
+  fun _ h => h
+
+/-- Preservation is closed under composition: this is what lets a *sequence* of
+    adversarial reentries be discharged from the per-step obligations. -/
+theorem comp {σ : Type} {Inv : σ → Prop} {f g : σ → σ}
+    (hf : Preserves Inv f) (hg : Preserves Inv g) :
+    Preserves Inv (fun s => f (g s)) :=
+  fun s h => hf (g s) (hg s h)
+
+end Preserves
+
+/-- A reentrant adversary as a finite *schedule* of picked entrypoints, applied
+    left to right. A bounded call depth is exactly a finite list; unbounded
+    mutual recursion is out of scope (it is not expressible as a `List`). -/
+def runSeq {σ : Type} (picks : List (σ → σ)) (s : σ) : σ :=
+  picks.foldl (fun acc f => f acc) s
+
+@[simp] theorem runSeq_nil {σ : Type} (s : σ) : runSeq [] s = s := rfl
+
+@[simp] theorem runSeq_cons {σ : Type} (f : σ → σ) (fs : List (σ → σ)) (s : σ) :
+    runSeq (f :: fs) s = runSeq fs (f s) := rfl
+
+/-- Rely-guarantee meta-theorem. If every entrypoint preserves `Inv`, then any
+    finite schedule of them preserves `Inv`. The entire interleaving space
+    collapses to one obligation per entrypoint — no interleaving enumeration. -/
+theorem runSeq_preserves {σ : Type} {Inv : σ → Prop} :
+    ∀ (picks : List (σ → σ)),
+      (∀ f, f ∈ picks → Preserves Inv f) → Preserves Inv (runSeq picks) := by
+  intro picks
+  induction picks with
+  | nil => intro _ s hs; exact hs
+  | cons f fs ih =>
+      intro h s hs
+      have hf : Preserves Inv f := h f (List.mem_cons.mpr (Or.inl rfl))
+      have hfs : ∀ g, g ∈ fs → Preserves Inv g :=
+        fun g hg => h g (List.mem_cons.mpr (Or.inr hg))
+      exact ih hfs (f s) (hf s hs)
+
+end Verity.Core.Invariant

--- a/Verity/Core/Model/Types.lean
+++ b/Verity/Core/Model/Types.lean
@@ -1437,6 +1437,17 @@ structure FunctionSpec where
       safety via a machine-checked proof obligation.  CEI enforcement is bypassed
       and a proof obligation is generated.  (#1728, Axis 2 Step 2b) -/
   ceiSafe : Bool := false
+  /-- Whether this function is annotated `reentrancy_trusted` — an *unproven*
+      author assertion that the function's external interaction surface cannot be
+      exploited by a reentrant adversary (e.g. every external callee is a trusted
+      contract that does not re-enter this one). This is the audited opt-out for
+      the cross-function reentrancy gate: unlike `cei_safe`/`allow_post_interaction_writes`
+      (which only concern single-function CEI), a mutating external call still opens
+      a reentrancy window that another entrypoint could exploit, so the gate requires
+      either a runtime `nonreentrant(<lock>)` guard or this explicit trust assertion.
+      It generates no code and no proof obligation; it is a trust boundary recorded
+      for audit. -/
+  reentrancyTrusted : Bool := false
   /-- Storage field name used as access-control role when annotated `requires(field)`.
       A `require(caller == roleHolder)` check is auto-injected at the start of the
       function body.  (#1728, Axis 2 Step 2c) -/

--- a/Verity/Core/Reentrancy.lean
+++ b/Verity/Core/Reentrancy.lean
@@ -1,0 +1,160 @@
+/-
+  Reentrancy rely-guarantee framework for Verity (single-contract v1, with a
+  forward-compatible multi-contract layer).
+
+  This module grounds the state-polymorphic library in `Verity/Core/Invariant.lean`
+  against the real `ContractState`/`Contract` monad:
+
+    * `reentrantCall` — the adversarial-reentry effect in the Contract monad.
+    * `ReentrancySpec` — bundle a global invariant with the contract's entrypoint
+      registry; discharge one obligation per entrypoint and obtain safety against
+      the entire adversarial interleaving space (`schedule_preserves`).
+    * `System`/`lift`/`Isys` — the additive multi-contract (vN) layer. The v1
+      `ReentrancySpec` is the single-slot instance; no v1 proof is redone.
+
+  The design intent is the Midnight `take` callback-reentrancy bug: with a
+  lock-as-disjunct invariant `I s := healthy s ∨ locked s`, a transiently
+  unhealthy but *locked* position still satisfies `I`, so no reentrant
+  `liquidate` can fire during the trade window. See
+  `Contracts/ReentrancyRelyGuarantee/Contract.lean` for the worked example.
+-/
+
+import Verity.Core
+import Verity.Core.Semantics
+import Verity.Core.Invariant
+
+namespace Verity.Core.Reentrancy
+
+open Verity
+open Verity.Core.Invariant
+
+/-! ## Adversarial reentry in the Contract monad (S1) -/
+
+/-- One external call that may reenter, modeled as an arbitrary state
+    transformer over this contract's persistent channels. Exposed as a
+    `Contract Unit` so it threads through `bind`/do-notation like any effect.
+    The rely condition (below) constrains `adv` to preserve the contract
+    invariant; with `adv := id` this degenerates to the no-reentry case. -/
+def reentrantCall (adv : ContractState → ContractState) : Contract Unit :=
+  fun s => ContractResult.success () (adv s)
+
+@[simp] theorem reentrantCall_run (adv : ContractState → ContractState) (s : ContractState) :
+    (reentrantCall adv).run s = ContractResult.success () (adv s) := rfl
+
+@[simp] theorem reentrantCall_runState (adv : ContractState → ContractState) (s : ContractState) :
+    (reentrantCall adv).runState s = adv s := rfl
+
+/-- A `Contract` preserves a state invariant when every *successful* run from an
+    `Inv`-state lands in an `Inv`-state. Reverts are excluded on purpose: EVM
+    atomicity rolls a reverted call back to its pre-state (see `Contract.run`),
+    so a revert preserves every invariant for free. -/
+def ContractPreserves {α : Type} (Inv : ContractState → Prop) (c : Contract α) : Prop :=
+  ∀ s, Inv s → ∀ a s', c.run s = ContractResult.success a s' → Inv s'
+
+/-- Bridge from the pure rely-guarantee library to the monad: if the adversary
+    transformer preserves `Inv`, then the `reentrantCall` effect does. -/
+theorem reentrantCall_preserves {Inv : ContractState → Prop}
+    {adv : ContractState → ContractState} (hadv : Preserves Inv adv) :
+    ContractPreserves Inv (reentrantCall adv) := by
+  intro s hs a s' hrun
+  rw [reentrantCall_run] at hrun
+  injection hrun with _hval hstate
+  rw [← hstate]
+  exact hadv s hs
+
+/-! ## ReentrancySpec: register entrypoints once, get whole-interleaving safety (S3) -/
+
+/-- A reentrancy specification for one contract: a global invariant `Inv` plus
+    the finite registry of public entrypoints (each modeled as a state
+    transformer) and the proof obligation that each preserves `Inv`. The
+    macro-emitted entrypoint registry supplies `entrypoints`; the author
+    supplies `Inv` and `entrypoints_preserve` — one obligation per entrypoint. -/
+structure ReentrancySpec where
+  Inv : ContractState → Prop
+  entrypoints : List (ContractState → ContractState)
+  entrypoints_preserve : ∀ f, f ∈ entrypoints → Preserves Inv f
+
+namespace ReentrancySpec
+
+/-- The payoff. ANY finite reentry schedule drawn from the registered
+    entrypoints preserves the invariant. One proof per entrypoint discharges the
+    entire adversarial interleaving space — no interleaving enumeration. -/
+theorem schedule_preserves (spec : ReentrancySpec)
+    (sched : List (ContractState → ContractState))
+    (hsched : ∀ f, f ∈ sched → f ∈ spec.entrypoints) :
+    Preserves spec.Inv (runSeq sched) := by
+  apply runSeq_preserves
+  intro f hf
+  exact spec.entrypoints_preserve f (hsched f hf)
+
+/-- Corollary at the monad level: replaying any registered schedule as a single
+    `reentrantCall` preserves the invariant. -/
+theorem reentrantCall_schedule_preserves (spec : ReentrancySpec)
+    (sched : List (ContractState → ContractState))
+    (hsched : ∀ f, f ∈ sched → f ∈ spec.entrypoints) :
+    ContractPreserves spec.Inv (reentrantCall (runSeq sched)) :=
+  reentrantCall_preserves (spec.schedule_preserves sched hsched)
+
+end ReentrancySpec
+
+/-! ## Forward-compatibility: multi-contract `System` (vN)
+
+  Everything below is additive and reuses the SAME `Preserves`/`runSeq` library.
+  It shows the v1 single-contract `ReentrancySpec` is the degenerate (single-slot)
+  instance of a multi-contract development. No v1 proof is re-done; the only new
+  primitive is the storage lens `lift`. Deliberately out of scope here (vN proof
+  obligations, not v1 blockers): unbounded mutual A↔B recursion and oracle-return
+  precision for read-only reentrancy. -/
+
+/-- A multi-contract world: a map from address to per-contract state. The v1
+    `ContractState` is exactly one addressable slot. -/
+structure System where
+  slot : Address → ContractState
+
+/-- Run a single contract's entrypoint on its own slot, framing every other slot
+    unchanged — the one genuinely new vN primitive (a state lens). -/
+def lift (a : Address) (c : ContractState → ContractState) (sys : System) : System :=
+  { slot := fun x => if x = a then c (sys.slot a) else sys.slot x }
+
+/-- Joint invariant across the in-scope contracts, built from the SAME
+    per-contract invariant. Out-of-scope addresses are trusted and unconstrained. -/
+def Isys (Inv : ContractState → Prop) (inScope : List Address) (sys : System) : Prop :=
+  ∀ a, a ∈ inScope → Inv (sys.slot a)
+
+/-- Lens lemma: a per-contract entrypoint preserving `Inv` on its slot preserves
+    the JOINT invariant. This is the only bridging proof the multi-contract layer
+    adds. -/
+theorem lift_preserves {Inv : ContractState → Prop} {a : Address} {inScope : List Address}
+    {c : ContractState → ContractState} (hc : Preserves Inv c) :
+    Preserves (Isys Inv inScope) (lift a c) := by
+  intro sys hsys b hb
+  show Inv (if b = a then c (sys.slot a) else sys.slot b)
+  by_cases hba : b = a
+  · rw [if_pos hba]
+    exact hc (sys.slot a) (hsys a (hba ▸ hb))
+  · rw [if_neg hba]
+    exact hsys b hb
+
+/-- A v1 `ReentrancySpec` lifts to the multi-contract setting at any slot with no
+    new per-contract proof: every registered entrypoint, lifted, preserves the
+    joint invariant. -/
+theorem spec_lifts (spec : ReentrancySpec) (a : Address) (inScope : List Address)
+    (f : ContractState → ContractState) (hf : f ∈ spec.entrypoints) :
+    Preserves (Isys spec.Inv inScope) (lift a f) :=
+  lift_preserves (spec.entrypoints_preserve f hf)
+
+/-- Headline forward-compat theorem: ANY finite cross-contract reentry schedule —
+    each step reentering some contract's registered entrypoint — preserves the
+    JOINT invariant. Proven only from the per-contract obligations via the SAME
+    polymorphic library, now instantiated at `σ := System`. -/
+theorem cross_contract_schedule_preserves (spec : ReentrancySpec) (inScope : List Address)
+    (steps : List (Address × (ContractState → ContractState)))
+    (hsteps : ∀ p, p ∈ steps → p.2 ∈ spec.entrypoints) :
+    Preserves (Isys spec.Inv inScope) (runSeq (steps.map (fun p => lift p.1 p.2))) := by
+  apply runSeq_preserves
+  intro f hf
+  rw [List.mem_map] at hf
+  obtain ⟨p, hp, rfl⟩ := hf
+  exact lift_preserves (spec.entrypoints_preserve p.2 (hsteps p hp))
+
+end Verity.Core.Reentrancy

--- a/Verity/Core/Semantics.lean
+++ b/Verity/Core/Semantics.lean
@@ -17,6 +17,11 @@ structure Env where
   blockNumber : Uint256 := 0
   chainId : Uint256 := 0
   callOracle : String → List Uint256 → Uint256 := Env.defaultCallOracle
+  -- Adversarial-reentry hook: the state transformation a callee may impose on
+  -- this contract's persistent channels during an external call. Defaults to
+  -- `id` (the no-reentry case). Reentrancy proofs constrain it via the rely
+  -- condition; see `Verity/Core/Reentrancy.lean`.
+  reenter : ContractState → ContractState := id
 
 instance : Repr Env where
   reprPrec env _ :=

--- a/Verity/Macro/Internal.lean
+++ b/Verity/Macro/Internal.lean
@@ -277,4 +277,22 @@ def ensureSupportsInternalHelperSpec
     throwErrorAt stx
       s!"helper call '{fn.name}' uses a parameter or return type that direct macro helper lowering does not support yet; only static non-fallback/non-receive helpers can be lowered to internal specs"
 
+def ensureCallableAsInternalHelper
+    (stx : Syntax)
+    (fn : FunctionDecl) : CommandElabM Unit := do
+  -- Fail closed on internal calls to a function whose only reentrancy
+  -- protection is its `nonreentrant(<lock>)` guard. The transient-storage
+  -- guard is synthesised solely at the external dispatch boundary
+  -- (`attachNonReentrantGuard`, #1893); the internal-helper shadow drops the
+  -- lock, so routing a call through the shadow would execute the body without
+  -- the lock and bypass reentrancy protection. `reentrancy_trusted` is the only
+  -- sound exemption: it is an author assertion that the body is safe under every
+  -- entry path, so it covers the lock-free internal path too. (Bugbot HIGH on
+  -- PR #2032.) This is the call-site gate; the declaration-site rejection of
+  -- `internal nonreentrant(<lock>)` lives in `validateFunctionDeclsPublic` (#1971).
+  if fn.nonReentrantLock.isSome && !fn.reentrancyTrusted then
+    throwErrorAt stx
+      s!"helper call '{fn.name}': nonreentrant(<lock>) functions cannot be invoked as internal helpers; the synthesised transient-storage guard runs only at the external dispatch boundary, so an internal call would execute the body without the reentrancy lock. Expose '{fn.name}' only as an external entrypoint, or add `reentrancy_trusted` if its body is safe under every entry path."
+  ensureSupportsInternalHelperSpec stx fn
+
 end Verity.Macro

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -92,6 +92,7 @@ syntax "no_external_calls" : verityMutability
 syntax "allow_post_interaction_writes" : verityMutability
 syntax "nonreentrant(" ident ")" : verityMutability
 syntax "cei_safe" : verityMutability
+syntax "reentrancy_trusted" : verityMutability
 syntax "modifies(" sepBy1(ident, ",") ")" : verityModifies
 syntax "requires(" ident ")" : verityRequiresRole
 syntax ident " : " term:max : verityNewtype

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2187,6 +2187,19 @@ private def mkSpecCommand
         else
           `(false)
       let ceiSafeTerm ← if fn.ceiSafe then `(true) else `(false)
+      -- The internal helper shadow drops `nonReentrantLock` (the transient guard
+      -- only runs at the external dispatch boundary), so the cross-function
+      -- reentrancy gate would reject any external call it makes. The public entry
+      -- is already protected — by its `nonreentrant` guard or its own
+      -- `reentrancy_trusted` assertion — so propagate a `reentrancyTrusted` flag
+      -- onto the shadow to record that its external calls run under that
+      -- protection. When the public function carried neither, the public spec
+      -- itself fails the gate first, so this never masks an unguarded entry.
+      let shadowReentrancyTrustedTerm ←
+        if fn.nonReentrantLock.isSome || fn.reentrancyTrusted then
+          `(true)
+        else
+          `(false)
       let requiresRoleTerm ← match fn.requiresRole with
         | some roleIdent => `(some $(strTerm (toString roleIdent.getId)))
         | none => `(none)
@@ -2213,6 +2226,7 @@ private def mkSpecCommand
         allowPostInteractionWrites := $shadowAllowPostInteractionWritesTerm
         nonReentrantLock := none
         ceiSafe := $ceiSafeTerm
+        reentrancyTrusted := $shadowReentrancyTrustedTerm
         requiresRole := $requiresRoleTerm
         modifies := [ $[$internalModifiesTerms],* ]
         localObligations := [ $[$localObligationTerms],* ]
@@ -2971,6 +2985,7 @@ def mkFunctionCommandsPublic
     | some lockIdent => `(some $(strTerm (toString lockIdent.getId)))
     | none => `(none)
   let ceiSafeTerm ← if fn.ceiSafe then `(true) else `(false)
+  let reentrancyTrustedTerm ← if fn.reentrancyTrusted then `(true) else `(false)
   let requiresRoleTerm ← match fn.requiresRole with
     | some roleIdent => `(some $(strTerm (toString roleIdent.getId)))
     | none => `(none)
@@ -2998,6 +3013,7 @@ def mkFunctionCommandsPublic
     allowPostInteractionWrites := $allowPostInteractionWritesTerm
     nonReentrantLock := $nonReentrantLockTerm
     ceiSafe := $ceiSafeTerm
+    reentrancyTrusted := $reentrancyTrustedTerm
     requiresRole := $requiresRoleTerm
     modifies := [ $[$modifiesTerms],* ]
     localObligations := [ $[$localObligationTerms],* ]

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -439,7 +439,7 @@ private partial def validateEffectStmtExprTypes
       | none =>
       match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals stx with
       | some (fn, argTerms) =>
-          ensureSupportsInternalHelperSpec stx fn
+          ensureCallableAsInternalHelper stx fn
           if fn.returnTy != .unit then
             throwErrorAt stx
               s!"helper call '{fn.name}' returns {renderValueType fn.returnTy}; use `let ... ← {fn.name} ...` or tuple destructuring"
@@ -983,7 +983,7 @@ private def translateEffectStmt
       | none =>
       match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals stx with
       | some (fn, argTerms) =>
-          ensureSupportsInternalHelperSpec stx fn
+          ensureCallableAsInternalHelper stx fn
           if fn.returnTy != .unit then
             throwErrorAt stx
               s!"helper call '{fn.name}' returns {renderValueType fn.returnTy}; use `let ... ← {fn.name} ...` or tuple destructuring"
@@ -2197,6 +2197,13 @@ private def mkSpecCommand
       -- onto the shadow to record that its external calls run under that
       -- protection. When the public function carried neither, the public spec
       -- itself fails the gate first, so this never masks an unguarded entry.
+      -- For a *lock-only* function (`nonReentrantLock` set, no
+      -- `reentrancy_trusted`) the lock protection is local to the guarded entry
+      -- and does NOT survive on the lock-free shadow, so the shadow is rendered
+      -- unreachable: `ensureCallableAsInternalHelper` rejects any internal call
+      -- to such a function at lowering. The `reentrancyTrusted` flag below is
+      -- therefore only ever consumed for functions the author globally asserted
+      -- `reentrancy_trusted`, where the lock-free internal path is sound.
       let shadowReentrancyTrustedTerm ←
         if fn.nonReentrantLock.isSome || fn.reentrancyTrusted then
           `(true)

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -2377,7 +2377,7 @@ partial def inferBindSourceType
   | _ =>
       match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals rhs with
       | some (fn, _argTerms) =>
-          ensureSupportsInternalHelperSpec rhs fn
+          ensureCallableAsInternalHelper rhs fn
           match fn.returnTy with
           | .tuple _ =>
               throwErrorAt rhs
@@ -2493,7 +2493,7 @@ partial def inferTupleSourceTypes?
         | other =>
             match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals other with
             | some (fn, _argTerms) =>
-                ensureSupportsInternalHelperSpec rhs fn
+                ensureCallableAsInternalHelper rhs fn
                 match fn.returnTy with
                 | .tuple elemTys => pure (some elemTys.toArray)
                 | _ => pure none
@@ -4148,7 +4148,7 @@ def tupleInternalCallAssignStmt?
   let resultNameTerms := targetNames.toArray.map strTerm
   match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals rhs with
   | some (fn, argTerms) =>
-      ensureSupportsInternalHelperSpec rhs fn
+      ensureCallableAsInternalHelper rhs fn
       let argExprs ← translateInternalHelperCallArgs
         fields constDecls immutableDecls params locals fn argTerms
       pure (some (← `(Compiler.CompilationModel.Stmt.internalCallAssign
@@ -4645,7 +4645,7 @@ def translateBindSource
   | _ =>
       match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals rhs with
       | some (fn, argTerms) =>
-          ensureSupportsInternalHelperSpec rhs fn
+          ensureCallableAsInternalHelper rhs fn
           let argExprs ← translateInternalHelperCallArgs
             fields constDecls immutableDecls params locals fn argTerms
           `(Compiler.CompilationModel.Expr.internalCall

--- a/Verity/Macro/Translate/Parsing.lean
+++ b/Verity/Macro/Translate/Parsing.lean
@@ -345,6 +345,7 @@ structure ParsedMutability where
   allowPostInteractionWrites : Bool := false
   nonReentrantLock : Option Ident := none
   ceiSafe : Bool := false
+  reentrancyTrusted : Bool := false
 
 def parseMutabilityModifiers
     (mods : Array (TSyntax `verityMutability))
@@ -380,6 +381,10 @@ def parseMutabilityModifiers
         if result.ceiSafe then
           throwErrorAt mod "duplicate 'cei_safe' modifier"
         result := { result with ceiSafe := true }
+    | `(verityMutability| reentrancy_trusted) =>
+        if result.reentrancyTrusted then
+          throwErrorAt mod "duplicate 'reentrancy_trusted' modifier"
+        result := { result with reentrancyTrusted := true }
     | _ => throwErrorAt stx "invalid function mutability modifier"
   pure result
 
@@ -506,6 +511,7 @@ def parseFunction (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl
         allowPostInteractionWrites := mut_.allowPostInteractionWrites
         nonReentrantLock := mut_.nonReentrantLock
         ceiSafe := mut_.ceiSafe
+        reentrancyTrusted := mut_.reentrancyTrusted
         requiresRole := parsedRequiresRole
         initGuard? := parsedGuard?
         modifies := parsedModifies

--- a/Verity/Macro/Types.lean
+++ b/Verity/Macro/Types.lean
@@ -214,6 +214,14 @@ structure FunctionDecl where
       and a proof obligation is generated.
       (#1728, Axis 2 Step 2b — Lean proof rung) -/
   ceiSafe : Bool := false
+  /-- When true, the function is annotated `reentrancy_trusted` — an *unproven*
+      author assertion that the function's external interaction surface is safe
+      against cross-function reentrancy (every external callee is trusted not to
+      re-enter). This is the audited opt-out for the fail-closed reentrancy gate:
+      a mutating external call opens a reentrancy window that another entrypoint
+      could exploit, so the gate requires either `nonreentrant(<lock>)` or this
+      assertion. Generates no code and no proof obligation; recorded for audit. -/
+  reentrancyTrusted : Bool := false
   /-- When `some fieldIdent`, the function is annotated `requires(field)`.
       The named Address-typed storage field is an access-control role.
       A `require(caller == roleHolder)` check is auto-injected at the start

--- a/artifacts/macro_property_tests/PropertyArrayHelperCallSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyArrayHelperCallSmoke.t.sol
@@ -26,6 +26,12 @@ contract PropertyArrayHelperCallSmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
+    // Property 2: useFirst has no unexpected revert
+    function testAuto_UseFirst_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("useFirst(uint256[])", _singletonUintArray(1)));
+        require(ok, "useFirst reverted unexpectedly");
+    }
 
     function _singletonUintArray(uint256 x) internal pure returns (uint256[] memory arr) {
         arr = new uint256[](1);

--- a/artifacts/macro_property_tests/PropertyCEILadderSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyCEILadderSmoke.t.sol
@@ -17,16 +17,7 @@ contract PropertyCEILadderSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
-    // Property 1: TODO decode and assert `storeThenCall` result
-    function testTODO_StoreThenCall_DecodeAndAssert() public {
-        vm.prank(alice);
-        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("storeThenCall(uint256)", uint256(1)));
-        require(ok, "storeThenCall reverted unexpectedly");
-        assertEq(ret.length, 32, "storeThenCall ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
-    }
-    // Property 2: increment has no unexpected revert
+    // Property 1: increment has no unexpected revert
     function testAuto_Increment_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("increment()"));

--- a/artifacts/macro_property_tests/PropertyCEILadderSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyCEILadderSmoke.t.sol
@@ -17,7 +17,34 @@ contract PropertyCEILadderSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
-    // Property 1: increment has no unexpected revert
+    // Property 1: TODO decode and assert `callThenStoreGuarded` result
+    function testTODO_CallThenStoreGuarded_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("callThenStoreGuarded(uint256)", uint256(1)));
+        require(ok, "callThenStoreGuarded reverted unexpectedly");
+        assertEq(ret.length, 32, "callThenStoreGuarded ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: TODO decode and assert `callThenStoreProved` result
+    function testTODO_CallThenStoreProved_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("callThenStoreProved(uint256)", uint256(1)));
+        require(ok, "callThenStoreProved reverted unexpectedly");
+        assertEq(ret.length, 32, "callThenStoreProved ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 3: TODO decode and assert `storeThenCall` result
+    function testTODO_StoreThenCall_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("storeThenCall(uint256)", uint256(1)));
+        require(ok, "storeThenCall reverted unexpectedly");
+        assertEq(ret.length, 32, "storeThenCall ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 4: increment has no unexpected revert
     function testAuto_Increment_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("increment()"));

--- a/artifacts/macro_property_tests/PropertyCEISmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyCEISmoke.t.sol
@@ -43,4 +43,10 @@ contract PropertyCEISmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
+    // Property 4: callThenUpdate has no unexpected revert
+    function testAuto_CallThenUpdate_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("callThenUpdate(uint256)", uint256(1)));
+        require(ok, "callThenUpdate reverted unexpectedly");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyCallResultSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyCallResultSmoke.t.sol
@@ -17,4 +17,10 @@ contract PropertyCallResultSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: storeCallResult has no unexpected revert
+    function testAuto_StoreCallResult_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("storeCallResult(uint256)", uint256(1)));
+        require(ok, "storeCallResult reverted unexpectedly");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyCreate2SSTORE2Smoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyCreate2SSTORE2Smoke.t.sol
@@ -17,7 +17,16 @@ contract PropertyCreate2SSTORE2SmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
-    // Property 1: readCode has no unexpected revert
+    // Property 1: TODO decode and assert `deploy` result
+    function testTODO_Deploy_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("deploy(uint256,uint256,uint256,uint256)", uint256(1), uint256(1), uint256(1), uint256(1)));
+        require(ok, "deploy reverted unexpectedly");
+        assertEq(ret.length, 32, "deploy ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: readCode has no unexpected revert
     function testAuto_ReadCode_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("readCode(address,uint256,uint256,uint256)", alice, uint256(1), uint256(1), uint256(1)));

--- a/artifacts/macro_property_tests/PropertyDirectHelperCallSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyDirectHelperCallSmoke.t.sol
@@ -46,7 +46,18 @@ contract PropertyDirectHelperCallSmokeTest is YulTestBase {
         assertEq(actual0, expected, "pairWithTotal tuple element 0 should preserve the inferred result");
         assertEq(actual1, (expected + uint256(1)), "pairWithTotal tuple element 1 should preserve the inferred result");
     }
-    // Property 4: snapshot decodes and matches the inferred tuple result
+    // Property 4: runHelpers decodes and matches the inferred straight-line result
+    function testAuto_RunHelpers_ReturnsInferredStraightLineResult() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("runHelpers(uint256,uint256,uint256)", uint256(1), uint256(1), uint256(1)));
+        require(ok, "runHelpers reverted unexpectedly");
+        assertEq(ret.length, 32, "runHelpers ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, ((expected + uint256(1)) + uint256(1)), "runHelpers should preserve the inferred result");
+    }
+    // Property 5: snapshot decodes and matches the inferred tuple result
     function testAuto_Snapshot_ReturnsInferredTupleResult() public {
         uint256 expected = uint256(1);
         vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));

--- a/artifacts/macro_property_tests/PropertyERC20HelperSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyERC20HelperSmoke.t.sol
@@ -35,4 +35,40 @@ contract PropertyERC20HelperSmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("approveTokens(address,address,uint256)", alice, alice, uint256(1)));
         require(ok, "approveTokens reverted unexpectedly");
     }
+    // Property 4: snapshotBalance decodes the mocked ERC20 balance read
+    function testAuto_SnapshotBalance_ReturnsMockedBalanceRead() public {
+        uint256 expected = uint256(1);
+        vm.mockCall(alice, abi.encodeWithSignature("balanceOf(address)", alice), abi.encode(expected));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("snapshotBalance(address,address)", alice, alice));
+        require(ok, "snapshotBalance reverted unexpectedly");
+        assertEq(ret.length, 32, "snapshotBalance ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "snapshotBalance should return the mocked external read");
+        assertEq(vm.load(target, bytes32(uint256(0))), bytes32(uint256(expected)), "snapshotBalance should persist the mocked external read");
+    }
+    // Property 5: snapshotAllowance decodes the mocked ERC20 allowance read
+    function testAuto_SnapshotAllowance_ReturnsMockedAllowanceRead() public {
+        uint256 expected = uint256(1);
+        vm.mockCall(alice, abi.encodeWithSignature("allowance(address,address)", alice, alice), abi.encode(expected));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("snapshotAllowance(address,address,address)", alice, alice, alice));
+        require(ok, "snapshotAllowance reverted unexpectedly");
+        assertEq(ret.length, 32, "snapshotAllowance ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "snapshotAllowance should return the mocked external read");
+        assertEq(vm.load(target, bytes32(uint256(1))), bytes32(uint256(expected)), "snapshotAllowance should persist the mocked external read");
+    }
+    // Property 6: snapshotSupply decodes the mocked ERC20 supply read
+    function testAuto_SnapshotSupply_ReturnsMockedSupplyRead() public {
+        uint256 expected = uint256(1);
+        vm.mockCall(alice, abi.encodeWithSignature("totalSupply()"), abi.encode(expected));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("snapshotSupply(address)", alice));
+        require(ok, "snapshotSupply reverted unexpectedly");
+        assertEq(ret.length, 32, "snapshotSupply ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "snapshotSupply should return the mocked external read");
+        assertEq(vm.load(target, bytes32(uint256(2))), bytes32(uint256(expected)), "snapshotSupply should persist the mocked external read");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyEffectCompositionSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyEffectCompositionSmoke.t.sol
@@ -17,7 +17,24 @@ contract PropertyEffectCompositionSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
-    // Property 1: deposit has no unexpected revert
+    // Property 1: getCounter reads storage slot 0 and decodes the result
+    function testAuto_GetCounter_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCounter()"));
+        require(ok, "getCounter reverted unexpectedly");
+        assertEq(ret.length, 32, "getCounter ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getCounter should return storage slot 0");
+    }
+    // Property 2: setOwner has no unexpected revert
+    function testAuto_SetOwner_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("setOwner(address)", alice));
+        require(ok, "setOwner reverted unexpectedly");
+    }
+    // Property 3: deposit has no unexpected revert
     function testAuto_Deposit_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("deposit(uint256)", uint256(1)));

--- a/artifacts/macro_property_tests/PropertyExternalCallMultiReturn.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallMultiReturn.t.sol
@@ -17,7 +17,13 @@ contract PropertyExternalCallMultiReturnTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
-    // Property 1: noop has no unexpected revert
+    // Property 1: callFanout has no unexpected revert
+    function testAuto_CallFanout_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("callFanout(uint256)", uint256(1)));
+        require(ok, "callFanout reverted unexpectedly");
+    }
+    // Property 2: noop has no unexpected revert
     function testAuto_Noop_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("noop()"));

--- a/artifacts/macro_property_tests/PropertyExternalCallSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallSmoke.t.sol
@@ -17,7 +17,13 @@ contract PropertyExternalCallSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
-    // Property 1: getEchoedValue reads storage slot 0 and decodes the result
+    // Property 1: storeEcho has no unexpected revert
+    function testAuto_StoreEcho_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("storeEcho(uint256)", uint256(1)));
+        require(ok, "storeEcho reverted unexpectedly");
+    }
+    // Property 2: getEchoedValue reads storage slot 0 and decodes the result
     function testAuto_GetEchoedValue_ReadsConfiguredStorage() public {
         uint256 expected = uint256(1);
         vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));

--- a/artifacts/macro_property_tests/PropertyFullComboSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyFullComboSmoke.t.sol
@@ -17,4 +17,15 @@ contract PropertyFullComboSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: getBalance reads storage slot 1 and decodes the result
+    function testAuto_GetBalance_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(1)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getBalance()"));
+        require(ok, "getBalance reverted unexpectedly");
+        assertEq(ret.length, 32, "getBalance ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getBalance should return storage slot 1");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyGenericECMReadSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyGenericECMReadSmoke.t.sol
@@ -17,4 +17,16 @@ contract PropertyGenericECMReadSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: snapshotQuote decodes the mocked ECM oracle read
+    function testAuto_SnapshotQuote_ReturnsMockedEcmRead() public {
+        uint256 expected = uint256(1);
+        vm.mockCall(alice, abi.encodeWithSelector(bytes4(0x12345678), alice), abi.encode(expected));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("snapshotQuote(address,address)", alice, alice));
+        require(ok, "snapshotQuote reverted unexpectedly");
+        assertEq(ret.length, 32, "snapshotQuote ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "snapshotQuote should return the mocked external read");
+        assertEq(vm.load(target, bytes32(uint256(0))), bytes32(uint256(expected)), "snapshotQuote should persist the mocked external read");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyHelperExternalArgumentSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyHelperExternalArgumentSmoke.t.sol
@@ -42,28 +42,4 @@ contract PropertyHelperExternalArgumentSmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("put(uint256)", uint256(1)));
         require(ok, "put reverted unexpectedly");
     }
-    // Property 4: TODO decode and assert `bindExternalArg` result
-    function testTODO_BindExternalArg_DecodeAndAssert() public {
-        vm.prank(alice);
-        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindExternalArg(uint256)", uint256(1)));
-        require(ok, "bindExternalArg reverted unexpectedly");
-        assertEq(ret.length, 32, "bindExternalArg ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
-    }
-    // Property 5: TODO decode and assert `tupleExternalArg` result
-    function testTODO_TupleExternalArg_DecodeAndAssert() public {
-        vm.prank(alice);
-        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleExternalArg(uint256)", uint256(1)));
-        require(ok, "tupleExternalArg reverted unexpectedly");
-        assertEq(ret.length, 32, "tupleExternalArg ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
-    }
-    // Property 6: statementExternalArg has no unexpected revert
-    function testAuto_StatementExternalArg_NoUnexpectedRevert() public {
-        vm.prank(alice);
-        (bool ok,) = target.call(abi.encodeWithSignature("statementExternalArg(uint256)", uint256(1)));
-        require(ok, "statementExternalArg reverted unexpectedly");
-    }
 }

--- a/artifacts/macro_property_tests/PropertyHelperExternalArgumentSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyHelperExternalArgumentSmoke.t.sol
@@ -42,4 +42,28 @@ contract PropertyHelperExternalArgumentSmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("put(uint256)", uint256(1)));
         require(ok, "put reverted unexpectedly");
     }
+    // Property 4: TODO decode and assert `bindExternalArg` result
+    function testTODO_BindExternalArg_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindExternalArg(uint256)", uint256(1)));
+        require(ok, "bindExternalArg reverted unexpectedly");
+        assertEq(ret.length, 32, "bindExternalArg ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 5: TODO decode and assert `tupleExternalArg` result
+    function testTODO_TupleExternalArg_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleExternalArg(uint256)", uint256(1)));
+        require(ok, "tupleExternalArg reverted unexpectedly");
+        assertEq(ret.length, 32, "tupleExternalArg ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 6: statementExternalArg has no unexpected revert
+    function testAuto_StatementExternalArg_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("statementExternalArg(uint256)", uint256(1)));
+        require(ok, "statementExternalArg reverted unexpectedly");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyLinkedExternalDynamicArgSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyLinkedExternalDynamicArgSmoke.t.sol
@@ -17,48 +17,4 @@ contract PropertyLinkedExternalDynamicArgSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
-    // Property 1: TODO decode and assert `hashLeaves` result
-    function testTODO_HashLeaves_DecodeAndAssert() public {
-        vm.prank(alice);
-        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("hashLeaves(uint256[])", _singletonUintArray(1)));
-        require(ok, "hashLeaves reverted unexpectedly");
-        assertEq(ret.length, 32, "hashLeaves ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
-    }
-    // Property 2: sendLeaves has no unexpected revert
-    function testAuto_SendLeaves_NoUnexpectedRevert() public {
-        vm.prank(alice);
-        (bool ok,) = target.call(abi.encodeWithSignature("sendLeaves(uint256[])", _singletonUintArray(1)));
-        require(ok, "sendLeaves reverted unexpectedly");
-    }
-    // Property 3: discardHash has no unexpected revert
-    function testAuto_DiscardHash_NoUnexpectedRevert() public {
-        vm.prank(alice);
-        (bool ok,) = target.call(abi.encodeWithSignature("discardHash(uint256[])", _singletonUintArray(1)));
-        require(ok, "discardHash reverted unexpectedly");
-    }
-    // Property 4: TODO decode and assert `tryHash` result
-    function testTODO_TryHash_DecodeAndAssert() public {
-        vm.prank(alice);
-        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryHash(uint256[])", _singletonUintArray(1)));
-        require(ok, "tryHash reverted unexpectedly");
-        assertEq(ret.length, 32, "tryHash ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
-    }
-    // Property 5: TODO decode and assert `hashPayload` result
-    function testTODO_HashPayload_DecodeAndAssert() public {
-        vm.prank(alice);
-        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("hashPayload(bytes)", hex"CAFE"));
-        require(ok, "hashPayload reverted unexpectedly");
-        assertEq(ret.length, 32, "hashPayload ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
-    }
-
-    function _singletonUintArray(uint256 x) internal pure returns (uint256[] memory arr) {
-        arr = new uint256[](1);
-        arr[0] = x;
-    }
 }

--- a/artifacts/macro_property_tests/PropertyLinkedExternalDynamicArgSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyLinkedExternalDynamicArgSmoke.t.sol
@@ -17,4 +17,48 @@ contract PropertyLinkedExternalDynamicArgSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: TODO decode and assert `hashLeaves` result
+    function testTODO_HashLeaves_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("hashLeaves(uint256[])", _singletonUintArray(1)));
+        require(ok, "hashLeaves reverted unexpectedly");
+        assertEq(ret.length, 32, "hashLeaves ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: sendLeaves has no unexpected revert
+    function testAuto_SendLeaves_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("sendLeaves(uint256[])", _singletonUintArray(1)));
+        require(ok, "sendLeaves reverted unexpectedly");
+    }
+    // Property 3: discardHash has no unexpected revert
+    function testAuto_DiscardHash_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("discardHash(uint256[])", _singletonUintArray(1)));
+        require(ok, "discardHash reverted unexpectedly");
+    }
+    // Property 4: TODO decode and assert `tryHash` result
+    function testTODO_TryHash_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryHash(uint256[])", _singletonUintArray(1)));
+        require(ok, "tryHash reverted unexpectedly");
+        assertEq(ret.length, 32, "tryHash ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 5: TODO decode and assert `hashPayload` result
+    function testTODO_HashPayload_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("hashPayload(bytes)", hex"CAFE"));
+        require(ok, "hashPayload reverted unexpectedly");
+        assertEq(ret.length, 32, "hashPayload ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+
+    function _singletonUintArray(uint256 x) internal pure returns (uint256[] memory arr) {
+        arr = new uint256[](1);
+        arr[0] = x;
+    }
 }

--- a/artifacts/macro_property_tests/PropertyModifiesNamespaceSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyModifiesNamespaceSmoke.t.sol
@@ -17,4 +17,15 @@ contract PropertyModifiesNamespaceSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: getCounter reads storage slot 0 and decodes the result
+    function testAuto_GetCounter_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCounter()"));
+        require(ok, "getCounter reverted unexpectedly");
+        assertEq(ret.length, 32, "getCounter ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getCounter should return storage slot 0");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyModifiesRolesSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyModifiesRolesSmoke.t.sol
@@ -17,4 +17,15 @@ contract PropertyModifiesRolesSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: getCounter reads storage slot 1 and decodes the result
+    function testAuto_GetCounter_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(1)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCounter()"));
+        require(ok, "getCounter reverted unexpectedly");
+        assertEq(ret.length, 32, "getCounter ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getCounter should return storage slot 1");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyModifiesSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyModifiesSmoke.t.sol
@@ -17,4 +17,15 @@ contract PropertyModifiesSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: getCounter reads storage slot 0 and decodes the result
+    function testAuto_GetCounter_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCounter()"));
+        require(ok, "getCounter reverted unexpectedly");
+        assertEq(ret.length, 32, "getCounter ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getCounter should return storage slot 0");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyMorphoStyleOracleSummarySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyMorphoStyleOracleSummarySmoke.t.sol
@@ -17,4 +17,13 @@ contract PropertyMorphoStyleOracleSummarySmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: TODO decode and assert `snapshotPrice` result
+    function testTODO_SnapshotPrice_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("snapshotPrice(address)", alice));
+        require(ok, "snapshotPrice reverted unexpectedly");
+        assertEq(ret.length, 32, "snapshotPrice ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
 }

--- a/artifacts/macro_property_tests/PropertyMutabilitySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyMutabilitySmoke.t.sol
@@ -17,4 +17,33 @@ contract PropertyMutabilitySmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: deposit returns the active call value
+    function testAuto_Deposit_ReturnsMsgValue() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("deposit()"));
+        require(ok, "deposit reverted unexpectedly");
+        assertEq(ret.length, 32, "deposit ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, 0, "deposit should preserve the expected value");
+    }
+    // Property 2: currentOwner reads storage slot 0 and decodes the result
+    function testAuto_CurrentOwner_ReadsConfiguredStorage() public {
+        address expected = alice;
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(uint160(expected))));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("currentOwner()"));
+        require(ok, "currentOwner reverted unexpectedly");
+        assertEq(ret.length, 32, "currentOwner ABI return length mismatch (expected 32 bytes)");
+        address actual = abi.decode(ret, (address));
+        assertEq(actual, expected, "currentOwner should return storage slot 0");
+    }
+    // Property 3: double returns the declared constant result
+    function testAuto_Double_ReturnsDeclaredConstant() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("double(uint256)", uint256(1)));
+        require(ok, "double reverted unexpectedly");
+        assertEq(ret.length, 32, "double ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, 2, "double should return the declared constant");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyNewtypeModifiesSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyNewtypeModifiesSmoke.t.sol
@@ -17,4 +17,15 @@ contract PropertyNewtypeModifiesSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: getNextId reads storage slot 0 and decodes the result
+    function testAuto_GetNextId_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getNextId()"));
+        require(ok, "getNextId reverted unexpectedly");
+        assertEq(ret.length, 32, "getNextId ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getNextId should return storage slot 0");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyNewtypeNamespaceSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyNewtypeNamespaceSmoke.t.sol
@@ -23,4 +23,15 @@ contract PropertyNewtypeNamespaceSmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("setId(uint256)", uint256(1)));
         require(ok, "setId reverted unexpectedly");
     }
+    // Property 2: getId reads storage slot 0 and decodes the result
+    function testAuto_GetId_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getId()"));
+        require(ok, "getId reverted unexpectedly");
+        assertEq(ret.length, 32, "getId ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getId should return storage slot 0");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyNoExternalCallsSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyNoExternalCallsSmoke.t.sol
@@ -17,7 +17,24 @@ contract PropertyNoExternalCallsSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
-    // Property 1: setOwner has no unexpected revert
+    // Property 1: increment has no unexpected revert
+    function testAuto_Increment_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("increment()"));
+        require(ok, "increment reverted unexpectedly");
+    }
+    // Property 2: getCounter reads storage slot 0 and decodes the result
+    function testAuto_GetCounter_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCounter()"));
+        require(ok, "getCounter reverted unexpectedly");
+        assertEq(ret.length, 32, "getCounter ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getCounter should return storage slot 0");
+    }
+    // Property 3: setOwner has no unexpected revert
     function testAuto_SetOwner_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("setOwner(address)", alice));

--- a/artifacts/macro_property_tests/PropertyNonreentrantModifiesSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyNonreentrantModifiesSmoke.t.sol
@@ -17,4 +17,15 @@ contract PropertyNonreentrantModifiesSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: getBalance reads storage slot 2 and decodes the result
+    function testAuto_GetBalance_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(2)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getBalance()"));
+        require(ok, "getBalance reverted unexpectedly");
+        assertEq(ret.length, 32, "getBalance ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getBalance should return storage slot 2");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyNonreentrantTrustedInternalHelperAccepted.t.sol
+++ b/artifacts/macro_property_tests/PropertyNonreentrantTrustedInternalHelperAccepted.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyNonreentrantTrustedInternalHelperAcceptedTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/SecurityCombos.lean
+ */
+contract PropertyNonreentrantTrustedInternalHelperAcceptedTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("NonreentrantTrustedInternalHelperAccepted");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `trustedEntry` result
+    function testTODO_TrustedEntry_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("trustedEntry(uint256)", uint256(1)));
+        require(ok, "trustedEntry reverted unexpectedly");
+        assertEq(ret.length, 32, "trustedEntry ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: TODO decode and assert `callerTrusted` result
+    function testTODO_CallerTrusted_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("callerTrusted(uint256)", uint256(1)));
+        require(ok, "callerTrusted reverted unexpectedly");
+        assertEq(ret.length, 32, "callerTrusted ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/artifacts/macro_property_tests/PropertyReentrancyDispositionDeclared.t.sol
+++ b/artifacts/macro_property_tests/PropertyReentrancyDispositionDeclared.t.sol
@@ -17,4 +17,13 @@ contract PropertyReentrancyDispositionDeclaredTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: TODO decode and assert `takeWithDisposition` result
+    function testTODO_TakeWithDisposition_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("takeWithDisposition(uint256)", uint256(1)));
+        require(ok, "takeWithDisposition reverted unexpectedly");
+        assertEq(ret.length, 32, "takeWithDisposition ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
 }

--- a/artifacts/macro_property_tests/PropertyReentrancyDispositionDeclared.t.sol
+++ b/artifacts/macro_property_tests/PropertyReentrancyDispositionDeclared.t.sol
@@ -4,16 +4,16 @@ pragma solidity ^0.8.33;
 import "./yul/YulTestBase.sol";
 
 /**
- * @title PropertyUnsafeCEICompliantTest
+ * @title PropertyReentrancyDispositionDeclaredTest
  * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
  * @dev Source: Contracts/Smoke/SecurityCombos.lean
  */
-contract PropertyUnsafeCEICompliantTest is YulTestBase {
+contract PropertyReentrancyDispositionDeclaredTest is YulTestBase {
     address target;
     address alice = address(0x1111);
 
     function setUp() public {
-        target = deployYul("UnsafeCEICompliant");
+        target = deployYul("ReentrancyDispositionDeclared");
         require(target != address(0), "Deploy failed");
     }
 

--- a/artifacts/macro_property_tests/PropertyRolesCEISmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyRolesCEISmoke.t.sol
@@ -17,4 +17,15 @@ contract PropertyRolesCEISmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: getCounter reads storage slot 1 and decodes the result
+    function testAuto_GetCounter_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(1)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCounter()"));
+        require(ok, "getCounter reverted unexpectedly");
+        assertEq(ret.length, 32, "getCounter ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getCounter should return storage slot 1");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyTryExternalCallSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyTryExternalCallSmoke.t.sol
@@ -17,4 +17,10 @@ contract PropertyTryExternalCallSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: tryEcho has no unexpected revert
+    function testAuto_TryEcho_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("tryEcho(uint256)", uint256(1)));
+        require(ok, "tryEcho reverted unexpectedly");
+    }
 }

--- a/artifacts/macro_property_tests/PropertyUnsafeCEICompliant.t.sol
+++ b/artifacts/macro_property_tests/PropertyUnsafeCEICompliant.t.sol
@@ -17,4 +17,13 @@ contract PropertyUnsafeCEICompliantTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
+    // Property 1: TODO decode and assert `writeBeforeUnsafeCall` result
+    function testTODO_WriteBeforeUnsafeCall_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("writeBeforeUnsafeCall(uint256)", uint256(1)));
+        require(ok, "writeBeforeUnsafeCall reverted unexpectedly");
+        assertEq(ret.length, 32, "writeBeforeUnsafeCall ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
 }

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,7 +1,7 @@
 {
   "codebase": {
     "core_lines": 830,
-    "example_contracts": 14
+    "example_contracts": 15
   },
   "proofs": {
     "axioms": 0,
@@ -15,11 +15,11 @@
     "suites": 50
   },
   "theorems": {
-    "categories": 12,
-    "coverage_percent": 90,
+    "categories": 13,
+    "coverage_percent": 88,
     "covered": 255,
-    "excluded": 28,
-    "non_stdlib_total": 283,
+    "excluded": 36,
+    "non_stdlib_total": 291,
     "per_contract": {
       "Counter": 28,
       "ERC20": 22,
@@ -29,14 +29,15 @@
       "Owned": 23,
       "OwnedCounter": 48,
       "ReentrancyExample": 5,
+      "ReentrancyRelyGuarantee": 8,
       "SafeCounter": 25,
       "SimpleStorage": 20,
       "SimpleToken": 61,
       "Vault": 3
     },
-    "proven": 283,
+    "proven": 291,
     "stdlib": 0,
-    "total": 283
+    "total": 291
   },
   "toolchain": {
     "lean": "leanprover/lean4:v4.22.0",

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -31,9 +31,9 @@ Every transition inside the proof envelope is either fully verified or recorded 
 
 <!-- BEGIN GENERATED QUICK FACTS -->
 - **Language**: Lean 4.22.0
-- **Core Size**: 649 lines
-- **Verified Contracts**: 12 (Counter, ERC20, ERC721, Ledger, LocalObligationMacroSmoke, Owned, OwnedCounter, ReentrancyExample, SafeCounter, SimpleStorage, SimpleToken, Vault)
-- **Theorems**: 283 across 12 categories, 283 fully proven
+- **Core Size**: 830 lines
+- **Verified Contracts**: 13 (Counter, ERC20, ERC721, Ledger, LocalObligationMacroSmoke, Owned, OwnedCounter, ReentrancyExample, ReentrancyRelyGuarantee, SafeCounter, SimpleStorage, SimpleToken, Vault)
+- **Theorems**: 291 across 13 categories, 291 fully proven
 - **Axioms**: 0 documented Lean axioms (see AXIOMS.md)
 - **Tests**: 522 Foundry tests, 239 property tests
 - **Build**: `lake build` verifies all proofs

--- a/docs/LANGUAGE_DESIGN_AXES.md
+++ b/docs/LANGUAGE_DESIGN_AXES.md
@@ -53,6 +53,15 @@ SAFE BY DEFAULT (compiler enforces)
 **Files touched**: `Macro/Syntax.lean` (roles section), `Macro/Translate.lean`, new `Macro/CEICheck.lean`
 **Estimated total**: 4 weeks
 
+> **Scope note (2026-06)**: the 2b ladder above governs *single-function*
+> Checks-Effects-Interactions ordering only. It does **not** prevent
+> cross-function reentrancy (the Midnight `take`/`liquidate` class), so
+> `cei_safe`/`allow_post_interaction_writes` are intentionally **not** accepted
+> by the cross-function reentrancy gate (`validateReentrancyDisposition`); that
+> gate's sound accept-set is `nonreentrant(<lock>)` or `reentrancy_trusted`.
+> See the "Cross-Function Reentrancy Gate" sections of `AUDIT.md` /
+> `TRUST_ASSUMPTIONS.md`.
+
 ### Phase 3: Semantic Newtypes (Axis 1 partial, #1727)
 
 **Why third**: Standalone grammar change, doesn't depend on Phase 1–2.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -38,10 +38,11 @@ EVM Bytecode
 | ERC721 | 11 | Baseline | `Contracts/ERC721/Proofs/` |
 | Vault | 3 | Baseline | `Contracts/Vault/Proofs/` |
 | ReentrancyExample | 5 | Complete | `Contracts/ReentrancyExample/Contract.lean` |
+| ReentrancyRelyGuarantee | 8 | Semantic | `Contracts/ReentrancyRelyGuarantee/Contract.lean` |
 | CryptoHash | 0 | No specs | `Contracts/CryptoHash/Contract.lean` |
-| **Total** | **283** | **✅ 100%** | — |
+| **Total** | **291** | **✅ 100%** | — |
 
-> **Note**: Stdlib (0 internal proof-automation properties) is excluded from the contract-spec theorem table above but included in overall coverage statistics (283 total properties).
+> **Note**: Stdlib (0 internal proof-automation properties) is excluded from the contract-spec theorem table above but included in overall coverage statistics (291 total properties).
 
 Layer 1 uses macro-generated EDSL-to-`CompilationModel` bridge theorems backed by a generic typed-IR compilation-correctness theorem ([`TypedIRCompilerCorrectness.lean`](../Compiler/TypedIRCompilerCorrectness.lean)). Tuple/bytes/fixed-array/dynamic-array/string parameters now stay inside that proof path when they are carried as ABI head words/offsets. Advanced constructs beyond that typed-IR head-word surface (linked libraries, ECMs, fully custom ABI behavior) are still expressed directly in `CompilationModel` and trusted at that boundary. Higher-order internal helpers (function-pointer parameters, [#1747](https://github.com/lfglabs-dev/verity/issues/1747)) are eliminated by a compile-time monomorphization pre-pass that runs before any lowering, so the `CompilationModel` only ever contains first-order helpers: these calls are covered by the existing first-order proof path and introduce no new boundary trust.
 
@@ -189,6 +190,7 @@ Also note that the macro-generated `*_semantic_preservation` theorems are not co
 | ERC721 | 100% (11/11) | 0 |
 | SafeCounter | 100% (25/25) | 0 |
 | ReentrancyExample | 100% (5/5) | 0 |
+| ReentrancyRelyGuarantee | 0% (0/8) | 8 proof-only |
 | Ledger | 100% (33/33) | 0 |
 | LocalObligationMacroSmoke | 100% (4/4) | 0 |
 | SimpleStorage | 95% (19/20) | 1 proof-only |
@@ -198,13 +200,13 @@ Also note that the macro-generated `*_semantic_preservation` theorems are not co
 | Counter | 82% (23/28) | 5 proof-only |
 | Stdlib | 0% (0/0) | 0 proof-only |
 
-**Status**: 90% coverage (255/283), 28 remaining exclusions all proof-only
+**Status**: 88% coverage (255/291), 36 remaining exclusions all proof-only
 
-- **Total Properties**: 283
+- **Total Properties**: 291
 - **Covered**: 255
-- **Excluded**: 28 (all proof-only)
+- **Excluded**: 36 (all proof-only)
 
-**Proof-Only Properties (28 exclusions)**: Internal proof machinery that cannot be tested in Foundry.
+**Proof-Only Properties (36 exclusions)**: Internal proof machinery that cannot be tested in Foundry.
 
 0 `sorry` remaining across `Compiler/**/*.lean` and `Verity/**/*.lean` proof modules.
 2302 theorems/lemmas (1513 public, 789 private) verified by `lake build PrintAxioms`.

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -37,7 +37,8 @@ lean_lib «Contracts» where
     .andSubmodules `Contracts.ERC721,
     .andSubmodules `Contracts.SimpleToken,
     .andSubmodules `Contracts.CryptoHash,
-    .andSubmodules `Contracts.ReentrancyExample
+    .andSubmodules `Contracts.ReentrancyExample,
+    .andSubmodules `Contracts.ReentrancyRelyGuarantee
   ]
 
 lean_lib «Compiler» where

--- a/scripts/check_contract_structure.py
+++ b/scripts/check_contract_structure.py
@@ -16,21 +16,24 @@ from property_utils import ROOT, die
 
 # Contracts that use non-standard structure (inline proofs, proof-only, etc.)
 EXCLUDED_CONTRACTS = {
-    "ReentrancyExample",  # Inline proofs in Examples/, no separate Proofs/ dir
-    "CryptoHash",         # Axiom-based, no separate proof structure
+    "ReentrancyExample",        # Inline proofs in Examples/, no separate Proofs/ dir
+    "CryptoHash",               # Axiom-based, no separate proof structure
+    "ReentrancyRelyGuarantee",  # Proof-only rely-guarantee framework example, inline proofs
 }
 
 # Contracts excluded from property test check
 EXCLUDED_FROM_PROPERTY_TESTS = {
-    "CryptoHash",         # External-library contract, no property tests
-    "Vault",              # Minimal scaffolding landed before proof/property suite completion
+    "CryptoHash",               # External-library contract, no property tests
+    "Vault",                    # Minimal scaffolding landed before proof/property suite completion
+    "ReentrancyRelyGuarantee",  # Abstract state-transformer proofs, no compiled contract to property-test
 }
 
 # Contracts excluded from differential test check
 EXCLUDED_FROM_DIFFERENTIAL_TESTS = {
-    "CryptoHash",         # External-library oracle behavior is not differential-tested
-    "ReentrancyExample",  # Reentrancy model requires dedicated external-call harnessing
-    "Vault",              # Minimal scaffolding landed before differential harness completion
+    "CryptoHash",               # External-library oracle behavior is not differential-tested
+    "ReentrancyExample",        # Reentrancy model requires dedicated external-call harnessing
+    "Vault",                    # Minimal scaffolding landed before differential harness completion
+    "ReentrancyRelyGuarantee",  # No compiled bytecode (abstract proofs), nothing to differential-test
 }
 
 # Expected files for each contract (relative to ROOT)

--- a/scripts/check_selectors.py
+++ b/scripts/check_selectors.py
@@ -55,8 +55,18 @@ COMPILER_FILTERED_ALIAS_RE = re.compile(
     re.DOTALL,
 )
 DIRECT_MACRO_SPEC_RE = re.compile(r"Contracts\.(\w+)\.spec")
+# Optional leading mutability modifiers (`function <modifier>* <name> (...)`,
+# Verity/Macro/Syntax.lean) must be consumed before the name; otherwise an
+# annotated function (e.g. `function reentrancy_trusted f (...)`) is silently
+# skipped from selector verification. `internal` is deliberately omitted:
+# internal helpers carry no external selector, so they stay unmatched.
+_MACRO_FUNCTION_MODIFIER = (
+    r"(?:payable|view|pure|no_external_calls"
+    r"|allow_post_interaction_writes|cei_safe|reentrancy_trusted"
+    r"|nonreentrant\([^)]*\))"
+)
 MACRO_FUNCTION_RE = re.compile(
-    r"^\s*function\s+(\w+)\s*\((.*?)\)\s*:\s*([A-Za-z0-9_→ ]+)\s*:=\s*do",
+    rf"^\s*function\s+(?:{_MACRO_FUNCTION_MODIFIER}\s+)*(\w+)\s*\((.*?)\)\s*:\s*([A-Za-z0-9_→ ]+)\s*:=\s*do",
     re.MULTILINE,
 )
 MACRO_TYPE_MAP = {

--- a/scripts/generate_macro_property_tests.py
+++ b/scripts/generate_macro_property_tests.py
@@ -21,8 +21,20 @@ from property_utils import ROOT
 
 CONTRACT_RE = re.compile(r"^\s*verity_contract\s+([A-Za-z_][A-Za-z0-9_]*)\s+where\s*$")
 CHECK_CONTRACT_RE = re.compile(r"^\s*#check_contract\s+([A-Za-z_][A-Za-z0-9_]*)\s*$")
+# Optional leading mutability modifiers (`function <modifier>* <name> (...)`,
+# Verity/Macro/Syntax.lean). They sit between `function` and the name, so the
+# parser must consume them before capturing the identifier — otherwise an
+# annotated function (e.g. `function reentrancy_trusted f (...)`) is silently
+# dropped from generation. `internal` is deliberately omitted: internal helpers
+# are not externally dispatchable, so leaving them unmatched keeps them excluded
+# (a generated selector-call stub would always revert).
+_FUNCTION_MODIFIER = (
+    r"(?:payable|view|pure|no_external_calls"
+    r"|allow_post_interaction_writes|cei_safe|reentrancy_trusted"
+    r"|nonreentrant\([^)]*\))"
+)
 FUNCTION_RE = re.compile(
-    r"^\s*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*:\s*(.+?)\s*:=\s*",
+    rf"^\s*function\s+(?:{_FUNCTION_MODIFIER}\s+)*([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*:\s*(.+?)\s*:=\s*",
 )
 CONSTRUCTOR_RE = re.compile(r"^\s*constructor\s*\(([^)]*)\)\s*:=\s*")
 # `_IDENT` captures a user-facing identifier with optional `«…»` raw-identifier

--- a/test/property_exclusions.json
+++ b/test/property_exclusions.json
@@ -40,5 +40,15 @@
     "setStorageAddr_updates_owner",
     "setStorage_updates_supply",
     "transfer_sum_preserved_unique"
+  ],
+  "ReentrancyRelyGuarantee": [
+    "any_cross_contract_schedule_preserves_I",
+    "any_reentry_schedule_preserves_I",
+    "buggy_admits_permanent_bad_debt",
+    "liquidate_preserves_I",
+    "liquidate_respects_lock",
+    "locked_blocks_concrete_liquidation",
+    "locked_take_no_new_liquidation",
+    "locked_take_preserves_I"
   ]
 }

--- a/test/property_manifest.json
+++ b/test/property_manifest.json
@@ -189,6 +189,16 @@
     "withdraw_maintains_supply",
     "withdraw_maintains_supply_UNPROVABLE"
   ],
+  "ReentrancyRelyGuarantee": [
+    "any_cross_contract_schedule_preserves_I",
+    "any_reentry_schedule_preserves_I",
+    "buggy_admits_permanent_bad_debt",
+    "liquidate_preserves_I",
+    "liquidate_respects_lock",
+    "locked_blocks_concrete_liquidation",
+    "locked_take_no_new_liquidation",
+    "locked_take_preserves_I"
+  ],
   "SafeCounter": [
     "decrement_getCount_correct",
     "decrement_meets_spec",


### PR DESCRIPTION
## Summary

Single-function CEI checks (`cei_safe`, `allow_post_interaction_writes`) do **not** prevent cross-function reentrancy. A CEI-clean function that makes an external call leaves transiently-exploitable state live during its callback, which a reentrant sibling function can exploit — this is the Midnight `take()`/`liquidate()` callback bug, and it previously passed verification.

This PR adds a dedicated **fail-closed** pass, `validateReentrancyDisposition` (Compiler/CompilationModel/Validation.lean), that runs *after* call well-formedness and *separate* from the single-function CEI check:

- **Trigger:** any function whose body opens a reentrancy window (an external call **or** a raw low-level `call` opcode) and that is not `view`/`pure`.
- **Sound accept-set:** `nonreentrant(<lock>)` (runtime guard) **or** `reentrancy_trusted` (audited, author-asserted). CEI tags no longer satisfy the gate — `CEISafety` is demoted.
- **`reentrancy_trusted` is metadata-only** (no codegen, no proof obligation), so retrofitted contracts' runtime Yul is byte-identical. Existing smoke contracts that open windows are retrofitted with the appropriate tag.

`AUDIT.md` and `TRUST_ASSUMPTIONS.md` are updated to record the new trust boundary, per the synchronization non-negotiable.

## Validation

- `lake build` — green (full, incl. proofs)
- `make check` — green ("All checks passed")
- forge build (difftest profile) — green, 81 files
- Targeted suite — 38/38 (incl. full reentrancy property suite)
- Differential (Counter / SimpleStorage / Owned, reduced counts) — 23/23
- Full non-differential — 436/436 (one initial failure, `LowLevelTryCatchSmoke`, was a genuine catch by the new gate of a contract that only compiles via the CLI `--module` FFI path and slipped the build-time retrofit; fixed by tagging its 3 functions → 3/3)
- Post-fix FFI-compiled smoke contracts (all 9) — 33/33

## Test plan

- [ ] CI `lake build` passes
- [ ] CI `make check` passes
- [ ] Foundry differential + property suites pass
- [ ] Confirm a CEI-clean-but-window-opening function without a disposition is rejected (negative test: `PropertyReentrancyDispositionDeclared`)
- [ ] Confirm retrofitted contracts' Yul is byte-identical (no codegen drift)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes compiler acceptance for every mutating function with external or low-level call windows and introduces an unverified `reentrancy_trusted` trust boundary; mistakes would silently weaken reentrancy policy across the contract corpus.
> 
> **Overview**
> This PR closes the **cross-function reentrancy** gap where a CEI-clean function with an external call could still leave mid-update state exploitable by a sibling entrypoint (Midnight `take`/`liquidate` shape). Compilation now runs **`validateReentrancyDisposition`** after call well-formedness checks: any non-`view`/`pure` function whose body **`stmtOpensReentrancyWindow`** must declare **`nonreentrant(<lock>)`** or the new metadata-only **`reentrancy_trusted`** author assertion. **`cei_safe`** / **`allow_post_interaction_writes`** no longer satisfy this gate; **`CEISafety`** is documented as single-function ordering only. Window detection treats **`staticcall`-summarised ECMs** as non-opening; mutating calls, raw Yul calls, and other external forms still trigger the gate.
> 
> **`reentrancy_trusted`** threads through the macro into **`FunctionSpec.reentrancyTrusted`** (no codegen). Existing smoke and test specs that open windows are retrofitted with the tag so builds stay green while runtime Yul stays unchanged for those contracts.
> 
> Macro lowering adds **`ensureCallableAsInternalHelper`**: a **lock-only** `nonreentrant` entry cannot be called as an internal helper (the shadow path drops the transient guard); **`reentrancy_trusted`** on the callee is the accepted exemption. **`SecurityCombos.lean`** pins rejection/acceptance pairs with **`#guard_msgs`**.
> 
> Additively, **`Verity.Core.Invariant`** / **`Verity.Core.Reentrancy`**, **`Env.reenter`**, and **`Contracts/ReentrancyRelyGuarantee`** machine-check the buggy vs locked `take` story (+8 proven theorems, proof-only in CI). Audit/trust docs, verification counters, property manifests, and selector/property-test generators are updated for the new modifier and contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3945e7780e417da8e6e973757eabe2001f6776b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->