### PR TITLE
docs: correct reentrancy known-limitation in proof-techniques

### DIFF
--- a/docs-site/content/proof-techniques.mdx
+++ b/docs-site/content/proof-techniques.mdx
@@ -92,7 +92,7 @@ Two approaches coexist for overflow safety:
 
 ## Known limitations
 
-No multi-contract interaction, no reentrancy modeling, no gas modeling. The CompilationModel supports events and double mappings, but EDSL-level proofs for those are still limited. Conservation is proven as exact `countOcc`-based sum equations, not as a global invariant over all addresses; transfer theorems treat self-transfer as a no-op. `ContractResult.fst` returns `default` on revert (requires `[Inhabited α]`), so proofs using `.fst` show `success` first. Mathlib tactics (`set`, `ring`, `linarith`) are unavailable.
+No multi-contract interaction and no gas modeling. Reentrancy is not modeled via cross-call semantics either, but it is enforced by a mandatory fail-closed [disposition gate](/edsl/functions#reentrancy-disposition): every non-`view` function that opens a reentrancy window must declare a `nonreentrant(lock)` runtime guard or an explicit `reentrancy_trusted` assertion, and the build fails closed if neither is present. The CompilationModel supports events and double mappings, but EDSL-level proofs for those are still limited. Conservation is proven as exact `countOcc`-based sum equations, not as a global invariant over all addresses; transfer theorems treat self-transfer as a no-op. `ContractResult.fst` returns `default` on revert (requires `[Inhabited α]`), so proofs using `.fst` show `success` first. Mathlib tactics (`set`, `ring`, `linarith`) are unavailable.
 
 ## See also
 


### PR DESCRIPTION
## Summary

The `## Known limitations` section of `proof-techniques.mdx` listed "no reentrancy modeling" alongside genuine gaps, which reads as if Verity offers no reentrancy protection at all. That is misleading: while cross-call semantics are not modeled, reentrancy is enforced by the **mandatory fail-closed disposition gate** already documented in [`/edsl/functions#reentrancy-disposition`](https://github.com/lfglabs-dev/verity/blob/main/docs-site/content/edsl/functions.mdx) (every non-`view` function opening a reentrancy window must declare `nonreentrant(lock)` or an explicit `reentrancy_trusted` assertion, else the build fails closed).

This one-line reword keeps the honest limitation (no cross-call modeling) but points readers to the enforcement mechanism instead of implying the protection does not exist. No structural docs reorg.

## Changes
- `docs-site/content/proof-techniques.mdx:95` — reword the reentrancy clause and link to the disposition gate.

## Test plan
- [x] Anchor `#reentrancy-disposition` exists (`## Reentrancy disposition` heading in `edsl/functions.mdx`).
- Docs-only change; no Lean/Foundry impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording in `proof-techniques.mdx`; no Lean, build, or runtime behavior changes.
> 
> **Overview**
> Updates the **Known limitations** paragraph in `proof-techniques.mdx` so reentrancy is described accurately for reviewers and readers.
> 
> Instead of grouping “no reentrancy modeling” with gaps that sound like no protection exists, the text now states that **cross-call reentrancy semantics are not modeled**, while pointing to the **mandatory fail-closed [disposition gate](/edsl/functions#reentrancy-disposition)**: non-`view` functions that open a reentrancy window must use `nonreentrant(lock)` or `reentrancy_trusted`, or the build fails closed. The multi-contract and gas limitations are unchanged; only the reentrancy clause is expanded and linked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f0668faa7b36780fd479904907c83961dc361da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->