### PR TITLE
chore(ci): evict stale lake-packages cache in host maintenance

### DIFF
--- a/scripts/ci_host_maintenance.sh
+++ b/scripts/ci_host_maintenance.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 CACHE_ROOT="${CACHE_ROOT:-/srv/verity-ci-cache}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LAKE_BUILD_MAX_AGE_DAYS="${LAKE_BUILD_MAX_AGE_DAYS:-21}"
+LAKE_PACKAGES_MAX_AGE_DAYS="${LAKE_PACKAGES_MAX_AGE_DAYS:-14}"
 COMPILER_CCACHE_MAX_AGE_DAYS="${COMPILER_CCACHE_MAX_AGE_DAYS:-21}"
 ARTIFACT_MAX_AGE_HOURS="${ARTIFACT_MAX_AGE_HOURS:-24}"
 JOURNAL_VACUUM_TIME="${JOURNAL_VACUUM_TIME:-14d}"
@@ -23,6 +24,7 @@ Subcommands:
 Environment:
   CACHE_ROOT                    Default: /srv/verity-ci-cache
   LAKE_BUILD_MAX_AGE_DAYS       Default: 21
+  LAKE_PACKAGES_MAX_AGE_DAYS    Default: 14
   COMPILER_CCACHE_MAX_AGE_DAYS  Default: 21
   ARTIFACT_MAX_AGE_HOURS        Default: 24
   JOURNAL_VACUUM_TIME           Default: 14d
@@ -61,6 +63,7 @@ run_maintenance() {
 
   mkdir -p "$CACHE_ROOT"
   prune_tree "$CACHE_ROOT/lake-build" "$LAKE_BUILD_MAX_AGE_DAYS" "lake-build cache"
+  prune_tree "$CACHE_ROOT/lake-packages" "$LAKE_PACKAGES_MAX_AGE_DAYS" "lake-packages cache"
   prune_tree "$CACHE_ROOT/compiler-ccache" "$COMPILER_CCACHE_MAX_AGE_DAYS" "compiler ccache"
 
   if [ -x "$SCRIPT_DIR/ci_local_persistence.sh" ]; then


### PR DESCRIPTION
## Summary
- `scripts/ci_host_maintenance.sh run` (weekly `verity-ci-host-maintenance.timer`, Sun 04:30) prunes `lake-build`, `compiler-ccache`, journald, and docker — but had **no rule for `lake-packages`**.
- `/srv/verity-ci-cache/lake-packages` grows one ~5.7G entry per PR/branch/content-hash and was never evicted. On 2026-06-18/19 both x64 CI runner root disks hit 100% (hz2 701G/125 entries, hz1 1.1T/194 entries, some back to April) and the runners silently dropped offline — the runner systemd service stays `active running` but can't write to a full disk, so it just disconnects from GitHub.
- This adds an mtime-based prune for `lake-packages` (default **14 days**, override via `LAKE_PACKAGES_MAX_AGE_DAYS`), mirroring the existing `lake-build` eviction and reusing the same `prune_tree` helper.

## Risk
- Worst case of an over-prune (e.g. an active long-lived branch whose cache hasn't been touched in 14 days) is a **cache miss** on the next build — slower, never incorrect. Same risk profile as the existing `lake-build`/`compiler-ccache` evictions.

## Test plan
- [x] `bash -n scripts/ci_host_maintenance.sh` (syntax)
- [ ] On a runner host: `LAKE_PACKAGES_MAX_AGE_DAYS=14 scripts/ci_host_maintenance.sh run` prints `lake-packages cache: removed N entries older than 14 days` and frees disk
- [ ] Re-run `install-systemd` so the weekly timer picks up the new prune (no unit change required; the `run` subcommand reads the updated script)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational disk cleanup only; over-pruning would cause slower rebuilds (cache miss), not incorrect builds—same profile as existing `lake-build` eviction.
> 
> **Overview**
> Weekly **`scripts/ci_host_maintenance.sh run`** now prunes **`$CACHE_ROOT/lake-packages`** the same way it already prunes `lake-build` and `compiler-ccache`, using the existing **`prune_tree`** helper (top-level entries older than mtime threshold).
> 
> A new env knob **`LAKE_PACKAGES_MAX_AGE_DAYS`** defaults to **14** and is documented in **`usage()`**, alongside the existing cache age variables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc5f015cc571134e6f52f87904e690861d60152e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->