### PR TITLE
Add LawfulBEq Uint256 instance

### DIFF
--- a/Verity/Core/Uint256.lean
+++ b/Verity/Core/Uint256.lean
@@ -58,6 +58,15 @@ instance : Inhabited Uint256 := ⟨ofNat 0⟩
 instance : Repr Uint256 := ⟨fun u _ => repr u.val⟩
 instance : Coe Uint256 Nat := ⟨Uint256.val⟩
 instance : Coe Nat Uint256 := ⟨ofNat⟩
+instance : BEq Uint256 := ⟨fun a b => decide (a = b)⟩
+
+instance : LawfulBEq Uint256 where
+  eq_of_beq {a b} h := by
+    simp only [BEq.beq] at h
+    exact of_decide_eq_true h
+  rfl {a} := by
+    show decide (a = a) = true
+    exact decide_eq_true rfl
 
 @[simp] theorem val_ofNat (n : Nat) : (ofNat n).val = n % modulus := rfl
 @[simp] theorem coe_ofNat (n : Nat) : ((ofNat n : Uint256) : Nat) = n % modulus := rfl


### PR DESCRIPTION
## Summary
- Add a `BEq Uint256` instance (`decide (a = b)`) and a `LawfulBEq Uint256` instance with honest proofs (`eq_of_beq` via `of_decide_eq_true`, `rfl` via `decide_eq_true rfl`).

Closes #2033.

## Soundness
- Net diff vs main is additive: only `Verity/Core/Uint256.lean`, +9 lines. No `sorry`/`admit`/`native_decide`/new axiom; no theorem deleted or weakened.
- Local gates all green: `lake build`, `lake build Compiler.CompilationModelFeatureTest`, `lake build PrintAxioms`, `python3 scripts/generate_print_axioms.py --check`, `make check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, proof-only addition to core types; no changes to Uint256 operations or existing theorems.
> 
> **Overview**
> Adds **`BEq Uint256`** (`decide (a = b)`) and a **`LawfulBEq Uint256`** instance in `Verity/Core/Uint256.lean`, with proofs tying `==` to propositional equality via `of_decide_eq_true` and reflexivity via `decide_eq_true rfl`.
> 
> This is additive only alongside the existing `DecidableEq` on `Uint256`; it does not change arithmetic or EVM semantics. It supplies the typeclass pair generic list utilities (e.g. `eraseDups`) expect when comparing values at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a489aa77f0b082e5e0900b2d2d900a7035ebd22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->