### PR TITLE
feat(#1998): signed cubic-kernel error bound vs Real.exp (non-negative residual)

### DIFF
--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -764,6 +764,11 @@ end Verity.AxiomAudit
   Verity.Proofs.Stdlib.Math.exact_cubic_lt_wExpCubicKernel_scaled_add_three
   Verity.Proofs.Stdlib.Math.exact_cubic_real_error
   Verity.Proofs.Stdlib.Math.wExpCubicKernel_real_error
+  -- Verity.Proofs.Stdlib.Math.sdivTrunc_of_nonneg  -- private
+  -- Verity.Proofs.Stdlib.Math.sdivTrunc_ofNat_mul_WAD  -- private
+  -- Verity.Proofs.Stdlib.Math.sdivTrunc_sq_of_nonneg  -- private
+  Verity.Proofs.Stdlib.Math.wExpSignedCubicKernel_eq_natKernel_of_nonneg
+  Verity.Proofs.Stdlib.Math.wExpSignedCubicKernel_real_error_nonneg
   Verity.Proofs.Stdlib.Math.wExpRangeReduction_exact
   -- Verity.Proofs.Stdlib.Math.WEXP_LN2_pos  -- private
   -- Verity.Proofs.Stdlib.Math.WEXP_RANGE_OFFSET_lt_LN2  -- private
@@ -5733,4 +5738,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5375 theorems/lemmas (3709 public, 1666 private, 0 sorry'd)
+-- Total: 5380 theorems/lemmas (3711 public, 1669 private, 0 sorry'd)

--- a/Verity/Proofs/Stdlib/Math.lean
+++ b/Verity/Proofs/Stdlib/Math.lean
@@ -377,6 +377,81 @@ theorem wExpCubicKernel_real_error {r : Nat} (hr : r ≤ WEXP_LN2) :
     |k - Real.exp x| ≤ |k - P| + |P - Real.exp x| := abs_sub_le k P (Real.exp x)
     _ ≤ 3 / (WAD_NAT : ℝ) + x^4 * (5 / 96) := add_le_add hkP hPexp
 
+private theorem sdivTrunc_of_nonneg {a b : Int} (ha : 0 ≤ a) (hb : 0 < b) :
+    sdivTrunc a b = Int.ofNat (a.toNat / b.natAbs) := by
+  unfold sdivTrunc
+  have hb_ne : b ≠ 0 := by omega
+  have hnot : ¬a < 0 := by omega
+  simp [hb_ne, hnot]
+
+private theorem sdivTrunc_ofNat_mul_WAD (a k : Nat) (hk : 0 < k) :
+    sdivTrunc (Int.ofNat a) (Int.ofNat (k * WAD_NAT)) =
+      Int.ofNat (a / (k * WAD_NAT)) := by
+  have hden : (0 : Int) < Int.ofNat (k * WAD_NAT) := by
+    exact Int.natCast_pos.mpr (Nat.mul_pos hk WAD_NAT_pos)
+  have h :=
+    sdivTrunc_of_nonneg (a := Int.ofNat a) (b := Int.ofNat (k * WAD_NAT))
+      (Int.natCast_nonneg a) hden
+  have hnum : (Int.ofNat a).toNat = a := Int.toNat_natCast a
+  have hdenAbs : (Int.ofNat (k * WAD_NAT)).natAbs = k * WAD_NAT :=
+    Int.natAbs_natCast (k * WAD_NAT)
+  rw [hnum, hdenAbs] at h
+  exact h
+
+private theorem sdivTrunc_sq_of_nonneg {r : Int} (hr : 0 ≤ r) :
+    sdivTrunc (r * r) (2 * Int.ofNat WAD_NAT) =
+      Int.ofNat ((r.toNat * r.toNat) / (2 * WAD_NAT)) := by
+  have hsquare : r * r = Int.ofNat (r.toNat * r.toNat) := by
+    rw [← Int.toNat_of_nonneg hr]
+    change ((r.toNat : Nat) : Int) * ((r.toNat : Nat) : Int) =
+      ((r.toNat * r.toNat : Nat) : Int)
+    exact_mod_cast rfl
+  rw [hsquare]
+  simpa [Int.natCast_mul] using
+    sdivTrunc_ofNat_mul_WAD (r.toNat * r.toNat) 2 (by norm_num)
+
+/-- On the non-negative residual branch, signed truncating division agrees with
+the natural-number cubic kernel used by the Tier-B real-error proof. -/
+theorem wExpSignedCubicKernel_eq_natKernel_of_nonneg {r : Int} (hr : 0 ≤ r) :
+    wExpSignedCubicKernel r = (wExpCubicKernel r.toNat : Int) := by
+  unfold wExpSignedCubicKernel wExpCubicKernel
+  rw [sdivTrunc_sq_of_nonneg hr]
+  have hr_cast : (Int.ofNat r.toNat : Int) = r := by
+    exact Int.toNat_of_nonneg hr
+  let secondNat := r.toNat * r.toNat / (2 * WAD_NAT)
+  have hthird :
+      sdivTrunc (Int.ofNat secondNat * r) (3 * Int.ofNat WAD_NAT) =
+        Int.ofNat ((secondNat * r.toNat) / (3 * WAD_NAT)) := by
+    have hleft : Int.ofNat secondNat * r = Int.ofNat (secondNat * r.toNat) := by
+      rw [← hr_cast]
+      change ((secondNat : Nat) : Int) * ((r.toNat : Nat) : Int) =
+        ((secondNat * r.toNat : Nat) : Int)
+      exact_mod_cast rfl
+    rw [hleft]
+    simpa [Int.natCast_mul] using
+      sdivTrunc_ofNat_mul_WAD (secondNat * r.toNat) 3 (by norm_num)
+  change
+    Int.ofNat WAD_NAT + r + Int.ofNat secondNat +
+        sdivTrunc (Int.ofNat secondNat * r) (3 * Int.ofNat WAD_NAT) =
+      ↑(WAD_NAT + r.toNat + secondNat + secondNat * r.toNat / (3 * WAD_NAT))
+  rw [hthird, ← hr_cast]
+  simp [secondNat]
+
+/-- Tier-B's natural cubic-kernel error bound applies directly to the signed
+kernel on the non-negative residual branch. -/
+theorem wExpSignedCubicKernel_real_error_nonneg {r : Int}
+    (hr0 : 0 ≤ r) (hr1 : r ≤ (WEXP_LN2 : Int)) :
+    |((wExpSignedCubicKernel r : ℝ) / WAD_NAT) - Real.exp ((r:ℝ)/WAD_NAT)|
+      ≤ 3 / (WAD_NAT : ℝ) + ((r:ℝ)/WAD_NAT)^4 * (5 / 96) := by
+  have hrNat : r.toNat ≤ WEXP_LN2 := by
+    omega
+  have hcastR : ((r.toNat : Nat) : ℝ) = (r : ℝ) := by
+    exact_mod_cast Int.toNat_of_nonneg hr0
+  have hkernel := wExpSignedCubicKernel_eq_natKernel_of_nonneg (r := r) hr0
+  have hnat := wExpCubicKernel_real_error (r := r.toNat) hrNat
+  rw [hkernel]
+  simpa [hcastR] using hnat
+
 /-- `wExpRangeR` is exactly the signed residual left by `wExpRangeQ`. -/
 theorem wExpRangeReduction_exact (xAbs : Nat) :
     Int.ofNat (wExpRangeQ xAbs * WEXP_LN2) + wExpRangeR xAbs =


### PR DESCRIPTION
## Summary

Follow-up to #2042 (which landed the TickLib cubic-kernel error bound vs `Real.exp`, Tier B). This PR continues #1998 toward retiring the hand-written Yul `TickLib.tickToPrice`/`wExp` external-call-model (ECM) by lifting the Tier-B error bound from the **`Nat` cubic kernel** (`wExpCubicKernel`) to the **signed cubic kernel** (`wExpSignedCubicKernel`) that the actual reference `tickWExpReference` uses after range reduction — on the **non-negative residual branch**.

The reference computes a signed range-reduction residual `r = wExpRangeR xAbs` and feeds it to `wExpSignedCubicKernel`, which uses EVM-style truncate-toward-zero division (`sdivTrunc`). On `0 ≤ r`, every `sdivTrunc` argument is non-negative, so it coincides with `Nat` floor division and the kernel agrees exactly with `wExpCubicKernel`. That lets Tier B transfer with no new analysis.

### New theorems (in `Verity/Proofs/Stdlib/Math.lean`)
- `wExpSignedCubicKernel_eq_natKernel_of_nonneg {r : Int} (hr : 0 ≤ r) : wExpSignedCubicKernel r = (wExpCubicKernel r.toNat : Int)` — signed↔`Nat` kernel agreement on the non-negative branch (pure `Int`/`Nat` arithmetic, via three private `sdivTrunc` helper lemmas).
- `wExpSignedCubicKernel_real_error_nonneg {r : Int} (hr0 : 0 ≤ r) (hr1 : r ≤ (WEXP_LN2 : Int)) : |((wExpSignedCubicKernel r : ℝ) / WAD_NAT) - Real.exp ((r:ℝ)/WAD_NAT)| ≤ 3 / (WAD_NAT : ℝ) + ((r:ℝ)/WAD_NAT)^4 * (5 / 96)` — the Tier-B real-exp error bound, now for the signed kernel, on `0 ≤ r ≤ WEXP_LN2`.

Three supporting private lemmas (`sdivTrunc_of_nonneg`, `sdivTrunc_ofNat_mul_WAD`, `sdivTrunc_sq_of_nonneg`) discharge that `sdivTrunc` reduces to `Nat` division on non-negative arguments.

## Soundness

0 sorry / 0 admit / 0 native_decide / no new axiom. Both new public theorems' `#print axioms` depend only on `[propext, Classical.choice, Quot.sound]` (no `Lean.ofReduceBool`). No existing theorem weakened or deleted — the diff is purely additive (+75 lines `Verity/Proofs/Stdlib/Math.lean`, +5 registry entries). PrintAxioms registry updated (5375→5380: 3709→3711 public, 1666→1669 private, 0 sorry'd).

## Still deferred (tracked under #1998)

- **Negative-residual branch** (`r < 0`, down to `-WEXP_RANGE_OFFSET`): honest BLOCKED. `sdivTrunc` truncates toward zero there, so the third kernel term rounds up rather than down, and the existing Tier-B/B1 `Nat` floor sandwich does not cover it. Closing it needs a signed analog of the floor-slack bound (`|signed-kernel/WAD − cubic| ≤ 3/WAD` for `r < 0`). `Real.exp_bound` itself still applies (it only needs `|x| ≤ 1`).
- **Full `tickWExpReference` error bound:** beyond the residual kernel, this additionally requires bounding the `2^q` scaling step, the rational-`ln 2` approximation error (`WEXP_LN2/WAD` vs `Real.log 2`) accumulated over `q` range-reduction steps, and the reciprocal branch for negative inputs.
- **Tier C — ECM equivalence** (`tickToPriceReference`/`tickWExpReference` ≡ the Yul ECM): genuinely cross-repo. `tickToPriceModule` and its correctness axiom `midnight_ticklib_tick_to_price_exact_yul` live in the downstream `morpho-verity/morpho-midnight-verity` repo (`Midnight/Contract.lean`), which imports verity, so the linking theorem must be authored there. Until that downstream PR lands, the Yul ECM remains honestly `assumed`.

## Test plan

- [x] `lake build` — exit 0 (verified locally)
- [x] `lake build PrintAxioms` (the real proof gate) — exit 0 (verified locally)
- [x] `python3 scripts/generate_print_axioms.py --check` — exit 0 (verified locally)
- [x] `make check` — exit 0 (verified locally)
- [ ] CI: build / build-audits / build-compiler-binaries / compiler-regressions green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal verification in Mathlib-style proofs only; no runtime, auth, or contract execution behavior changes.
> 
> **Overview**
> Extends the existing Tier-B **`wExpCubicKernel`** vs **`Real.exp`** bound to **`wExpSignedCubicKernel`**, which **`tickWExpReference`** uses after range reduction, for the case **`0 ≤ r ≤ WEXP_LN2`**.
> 
> On non-negative residuals, **`sdivTrunc`** is shown to match **`Nat`** division via three private helper lemmas, yielding **`wExpSignedCubicKernel_eq_natKernel_of_nonneg`**. **`wExpSignedCubicKernel_real_error_nonneg`** then reuses **`wExpCubicKernel_real_error`** with no new Taylor analysis.
> 
> **`PrintAxioms.lean`** registers the new public theorems and bumps the theorem count (5375→5380). The change is additive only; negative-residual and full reference bounds remain out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 251c2ac11ba2f58fada44f251eceae20cc263004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->