### PR TITLE
feat(#1998): negative-residual signed-kernel eval + sign-agnostic cubic Taylor remainder

### DIFF
--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -769,6 +769,11 @@ end Verity.AxiomAudit
   -- Verity.Proofs.Stdlib.Math.sdivTrunc_sq_of_nonneg  -- private
   Verity.Proofs.Stdlib.Math.wExpSignedCubicKernel_eq_natKernel_of_nonneg
   Verity.Proofs.Stdlib.Math.wExpSignedCubicKernel_real_error_nonneg
+  -- Verity.Proofs.Stdlib.Math.sdivTrunc_neg_ofNat_mul_WAD  -- private
+  -- Verity.Proofs.Stdlib.Math.sdivTrunc_sq_of_neg_nat  -- private
+  -- Verity.Proofs.Stdlib.Math.sdivTrunc_neg_third_of_nat  -- private
+  Verity.Proofs.Stdlib.Math.wExpSignedCubicKernel_neg_eq
+  Verity.Proofs.Stdlib.Math.cubic_real_error_abs
   Verity.Proofs.Stdlib.Math.wExpRangeReduction_exact
   -- Verity.Proofs.Stdlib.Math.WEXP_LN2_pos  -- private
   -- Verity.Proofs.Stdlib.Math.WEXP_RANGE_OFFSET_lt_LN2  -- private
@@ -5738,4 +5743,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5380 theorems/lemmas (3711 public, 1669 private, 0 sorry'd)
+-- Total: 5385 theorems/lemmas (3713 public, 1672 private, 0 sorry'd)

--- a/Verity/Proofs/Stdlib/Math.lean
+++ b/Verity/Proofs/Stdlib/Math.lean
@@ -452,6 +452,80 @@ theorem wExpSignedCubicKernel_real_error_nonneg {r : Int}
   rw [hkernel]
   simpa [hcastR] using hnat
 
+private theorem sdivTrunc_neg_ofNat_mul_WAD (a k : Nat) (hk : 0 < k) :
+    sdivTrunc (-(Int.ofNat a)) (Int.ofNat (k * WAD_NAT)) =
+      -Int.ofNat (a / (k * WAD_NAT)) := by
+  unfold sdivTrunc
+  have hb_ne : (Int.ofNat (k * WAD_NAT) : Int) ≠ 0 := by
+    exact Int.natCast_ne_zero.mpr (Nat.ne_of_gt (Nat.mul_pos hk WAD_NAT_pos))
+  have hk_ne : k ≠ 0 := Nat.ne_of_gt hk
+  by_cases ha : a = 0
+  · subst a
+    simp [WAD_NAT, hk_ne]
+  · have hneg : (-(Int.ofNat a) : Int) < 0 := by
+      exact neg_neg_of_pos (Int.natCast_pos.mpr (Nat.pos_of_ne_zero ha))
+    have ha_pos : 0 < a := Nat.pos_of_ne_zero ha
+    have hdenAbs : Int.natAbs ((k : Int) * (WAD_NAT : Int)) = k * WAD_NAT := by
+      simpa [Int.natCast_mul] using Int.natAbs_natCast (k * WAD_NAT)
+    have hdenAbsInt : ((Int.natAbs ((k : Int) * (WAD_NAT : Int)) : Nat) : Int) =
+        (k : Int) * (WAD_NAT : Int) := by
+      rw [hdenAbs]
+      norm_num [Int.natCast_mul]
+    have hdenAbsInt' :
+        |(k : Int) * (1000000000000000000 : Int)| =
+          (k : Int) * (1000000000000000000 : Int) := by
+      rw [abs_of_nonneg]
+      positivity
+    simp [WAD_NAT, hk_ne, ha_pos]
+    exact congrArg (fun d : Int => (a : Int) / d) hdenAbsInt'
+
+private theorem sdivTrunc_sq_of_neg_nat (s : Nat) :
+    sdivTrunc (-(s : Int) * -(s : Int)) (2 * Int.ofNat WAD_NAT) =
+      Int.ofNat ((s * s) / (2 * WAD_NAT)) := by
+  have hsquare : (-(s : Int) * -(s : Int)) = Int.ofNat (s * s) := by
+    norm_num [Int.natCast_mul]
+  rw [hsquare]
+  simpa [Int.natCast_mul] using
+    sdivTrunc_ofNat_mul_WAD (s * s) 2 (by norm_num)
+
+private theorem sdivTrunc_neg_third_of_nat (secondNat s : Nat) :
+    sdivTrunc (Int.ofNat secondNat * -(s : Int)) (3 * Int.ofNat WAD_NAT) =
+      -Int.ofNat ((secondNat * s) / (3 * WAD_NAT)) := by
+  have hmul : Int.ofNat secondNat * -(s : Int) = -Int.ofNat (secondNat * s) := by
+    norm_num [Int.natCast_mul]
+  rw [hmul]
+  simpa [Int.natCast_mul] using
+    sdivTrunc_neg_ofNat_mul_WAD (secondNat * s) 3 (by norm_num)
+
+/-- On a negative residual, signed truncating division evaluates the TickLib
+cubic kernel as the expected alternating floor expression. -/
+theorem wExpSignedCubicKernel_neg_eq (s : Nat) :
+    wExpSignedCubicKernel (-(s:Int))
+      = (WAD_NAT:Int) - s + ((s*s)/(2*WAD_NAT) : Nat)
+          - ((((s*s)/(2*WAD_NAT)) * s)/(3*WAD_NAT) : Nat) := by
+  unfold wExpSignedCubicKernel
+  rw [sdivTrunc_sq_of_neg_nat s]
+  let secondNat := (s * s) / (2 * WAD_NAT)
+  change
+    Int.ofNat WAD_NAT + -(s : Int) + Int.ofNat secondNat +
+        sdivTrunc (Int.ofNat secondNat * -(s : Int)) (3 * Int.ofNat WAD_NAT) =
+      (WAD_NAT : Int) - s + (secondNat : Int) -
+        (((secondNat * s) / (3 * WAD_NAT) : Nat) : Int)
+  rw [sdivTrunc_neg_third_of_nat secondNat s]
+  simp [sub_eq_add_neg, add_assoc, add_comm]
+
+/-- The cubic Taylor polynomial has the same fourth-order analytic error bound
+for any real argument with absolute value at most one. -/
+theorem cubic_real_error_abs {x : ℝ} (hx : |x| ≤ 1) :
+    |Real.exp x - (1 + x + x^2 / 2 + x^3 / 6)| ≤ |x|^4 * (5 / 96) := by
+  have h := Real.exp_bound (x := x) hx (n := 4) (by norm_num)
+  have hsum : (∑ m ∈ Finset.range 4, x ^ m / (m.factorial : ℝ)) =
+      1 + x + x^2 / 2 + x^3 / 6 := by
+    norm_num [Finset.sum_range_succ, Nat.factorial]
+  rw [hsum] at h
+  norm_num [Nat.factorial] at h
+  exact h
+
 /-- `wExpRangeR` is exactly the signed residual left by `wExpRangeQ`. -/
 theorem wExpRangeReduction_exact (xAbs : Nat) :
     Int.ofNat (wExpRangeQ xAbs * WEXP_LN2) + wExpRangeR xAbs =


### PR DESCRIPTION
## Summary

Follow-up to #2043 (signed cubic-kernel error bound on the **non-negative** residual). This PR continues #1998 toward retiring the hand-written Yul `TickLib.tickToPrice`/`wExp` external-call-model (ECM) by laying the two reusable building blocks for the **negative-residual branch** of `wExpSignedCubicKernel`.

The reference `tickWExpReference` range-reduces to a signed residual `r = wExpRangeR xAbs` and feeds it to `wExpSignedCubicKernel`, which uses EVM-style truncate-toward-zero division (`sdivTrunc`). The non-negative branch (`0 ≤ r`) already has its full `Real.exp` bound (#2043, where `sdivTrunc` coincides with `Nat` floor division). On the **negative** branch (`r < 0`, down to `-WEXP_RANGE_OFFSET`) `sdivTrunc` truncates the third kernel term toward zero (i.e. rounds its magnitude *down*), so the kernel evaluates as an *alternating* floor expression and the existing `Nat` floor sandwich does not transfer directly.

This PR lands the two pieces that branch needs, both independently useful:

### New theorems (in `Verity/Proofs/Stdlib/Math.lean`)
- `wExpSignedCubicKernel_neg_eq (s : Nat) : wExpSignedCubicKernel (-(s:Int)) = (WAD_NAT:Int) - s + ((s*s)/(2*WAD_NAT) : Nat) - ((((s*s)/(2*WAD_NAT)) * s)/(3*WAD_NAT) : Nat)` — closed-form evaluation of the signed kernel at a negative argument. Pure `Int`/`Nat` arithmetic: the square `(-s)·(-s) = s·s ≥ 0` takes the non-negative `sdivTrunc` branch, while the third term `second·(-s) ≤ 0` takes the truncate-toward-zero branch, yielding the alternating `+second − third` floor expression.
- `cubic_real_error_abs {x : ℝ} (hx : |x| ≤ 1) : |Real.exp x - (1 + x + x^2 / 2 + x^3 / 6)| ≤ |x|^4 * (5 / 96)` — a **sign-agnostic** fourth-order Taylor remainder for the cubic polynomial (the existing `exact_cubic_real_error` was stated only for the `Nat`-indexed non-negative residual). Via Mathlib's `Real.exp_bound` at `n = 4` (remainder constant `5/(4!·4) = 5/96`); works for either sign of `x`, so it serves the negative branch directly.

Three supporting private lemmas (`sdivTrunc_neg_ofNat_mul_WAD`, `sdivTrunc_sq_of_neg_nat`, `sdivTrunc_neg_third_of_nat`) discharge the `sdivTrunc` `a < 0` branch on the negated arguments (including the degenerate `secondNat·s = 0` case, where `−Int.ofNat 0 = 0`).

## Soundness

0 sorry / 0 admit / 0 native_decide / no new axiom. Both new public theorems' `#print axioms` depend only on `[propext, Classical.choice, Quot.sound]` (no `Lean.ofReduceBool`, no `sorryAx`). No existing theorem weakened or deleted — the diff is purely additive (+74 lines `Verity/Proofs/Stdlib/Math.lean`, +5 registry entries). PrintAxioms registry updated 5380→5385 (3711→3713 public, 1669→1672 private, 0 sorry'd).

## Still deferred (tracked under #1998)

- **Negative-branch real-exp bound (`wExpSignedCubicKernel_real_error_neg`):** honest BLOCKED. With `wExpSignedCubicKernel_neg_eq` and `cubic_real_error_abs` in hand, the analytic half reduces cleanly; the remaining obligation is the *alternating* integer floor-slack sandwich
  ```
  |((WAD − s + secondNat − thirdNat : ℝ)/WAD) − (1 − s/WAD + (s/WAD)²/2 − (s/WAD)³/6)| ≤ 4/WAD
  ```
  where `secondNat = (s·s)/(2·WAD)`, `thirdNat = (secondNat·s)/(3·WAD)`. The third term's truncate-toward-zero rounding flips the direction of the floor slack relative to the non-negative `Nat` sandwich (#2042 B1), so it needs a signed analog of that bound rather than a re-use. Left for a focused follow-up.
- **Full `tickWExpReference` error bound:** beyond the residual kernel, additionally needs bounding the `2^q` scaling step, the rational-`ln 2` approximation error (`WEXP_LN2/WAD` vs `Real.log 2`) accumulated over `q` range-reduction steps, and the reciprocal branch for negative inputs.
- **Tier C — ECM equivalence:** genuinely cross-repo. `tickToPriceModule` and its correctness axiom `midnight_ticklib_tick_to_price_exact_yul` live in the downstream `morpho-verity/morpho-midnight-verity` repo (`Midnight/Contract.lean`), which imports verity, so the linking theorem must be authored there. Until that downstream PR lands, the Yul ECM remains honestly `assumed`.

## Test plan

- [x] `lake build` — exit 0 (verified locally)
- [x] `lake build PrintAxioms` (the real proof gate) — exit 0 (verified locally, boss-reverified)
- [x] `#print axioms` of both new theorems — only `[propext, Classical.choice, Quot.sound]` (boss-reverified)
- [x] `python3 scripts/generate_print_axioms.py --check` — exit 0 (verified locally)
- [x] `make check` — exit 0 (verified locally)
- [ ] CI: build / build-audits / build-compiler-binaries / compiler-regressions green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive formal proofs in `Verity/Proofs/Stdlib/Math.lean` with no runtime, auth, or contract behavior changes.
> 
> **Overview**
> Adds formal Lean building blocks for the **negative-residual** branch of `wExpSignedCubicKernel`, complementing the existing non-negative error bound.
> 
> **`wExpSignedCubicKernel_neg_eq`** gives a closed-form alternating floor expression for `wExpSignedCubicKernel (-s)`, backed by three private `sdivTrunc` lemmas that handle truncate-toward-zero division on negated arguments.
> 
> **`cubic_real_error_abs`** states the fourth-order Taylor remainder for the cubic polynomial using `|x| ≤ 1`, so the analytic bound applies regardless of sign (unlike `exact_cubic_real_error`, which was `Nat`-indexed and non-negative only).
> 
> `PrintAxioms` registry grows by five entries (5380→5385 theorems); changes are additive with no new axioms or weakened proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ef09505c25c53ddf58c2b382be399d094f3c785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->