### PR TITLE
feat(#1998): prove signed cubic-kernel Real.exp error bound on the negative residual branch

### DIFF
--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -774,6 +774,14 @@ end Verity.AxiomAudit
   -- Verity.Proofs.Stdlib.Math.sdivTrunc_neg_third_of_nat  -- private
   Verity.Proofs.Stdlib.Math.wExpSignedCubicKernel_neg_eq
   Verity.Proofs.Stdlib.Math.cubic_real_error_abs
+  -- Verity.Proofs.Stdlib.Math.nat_div_floor_real_bounds  -- private
+  -- Verity.Proofs.Stdlib.Math.neg_second_floor_slack_bounds  -- private
+  -- Verity.Proofs.Stdlib.Math.neg_third_floor_slack_bounds  -- private
+  -- Verity.Proofs.Stdlib.Math.neg_third_exact_bridge_bounds  -- private
+  -- Verity.Proofs.Stdlib.Math.neg_kernel_inner_floor_slack  -- private
+  -- Verity.Proofs.Stdlib.Math.neg_kernel_floor_slack  -- private
+  -- Verity.Proofs.Stdlib.Math.wExpSignedCubicKernel_real_error_neg_nat  -- private
+  Verity.Proofs.Stdlib.Math.wExpSignedCubicKernel_real_error_neg
   Verity.Proofs.Stdlib.Math.wExpRangeReduction_exact
   -- Verity.Proofs.Stdlib.Math.WEXP_LN2_pos  -- private
   -- Verity.Proofs.Stdlib.Math.WEXP_RANGE_OFFSET_lt_LN2  -- private
@@ -5743,4 +5751,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5385 theorems/lemmas (3713 public, 1672 private, 0 sorry'd)
+-- Total: 5393 theorems/lemmas (3714 public, 1679 private, 0 sorry'd)

--- a/Verity/Proofs/Stdlib/Math.lean
+++ b/Verity/Proofs/Stdlib/Math.lean
@@ -526,6 +526,174 @@ theorem cubic_real_error_abs {x : ℝ} (hx : |x| ≤ 1) :
   norm_num [Nat.factorial] at h
   exact h
 
+private theorem nat_div_floor_real_bounds (n d : Nat) (hd : 0 < d) :
+    0 ≤ (n:ℝ)/(d:ℝ) - ((n/d:Nat):ℝ) ∧
+      (n:ℝ)/(d:ℝ) - ((n/d:Nat):ℝ) < 1 := by
+  have hdR : (0 : ℝ) < d := by exact_mod_cast hd
+  have hloNat : (n / d) * d ≤ n := Nat.div_mul_le_self n d
+  have hhiNat : n < (n / d + 1) * d := by
+    simpa [Nat.mul_comm] using Nat.lt_mul_div_succ n hd
+  have hlo : ((n / d : Nat) : ℝ) * (d : ℝ) ≤ (n : ℝ) := by exact_mod_cast hloNat
+  have hhi : (n : ℝ) < ((n / d + 1 : Nat) : ℝ) * (d : ℝ) := by exact_mod_cast hhiNat
+  have hlo' : ((n / d : Nat) : ℝ) ≤ (n : ℝ) / (d : ℝ) := by
+    rw [le_div_iff₀ hdR]
+    exact hlo
+  have hhi' : (n : ℝ) / (d : ℝ) < ((n / d : Nat) : ℝ) + 1 := by
+    have htmp : (n : ℝ) / (d : ℝ) < ((n / d + 1 : Nat) : ℝ) := by
+      rw [div_lt_iff₀ hdR]
+      exact hhi
+    simpa using htmp
+  constructor <;> linarith
+
+private theorem neg_second_floor_slack_bounds (s : Nat) :
+    let secondNat := (s * s) / (2 * WAD_NAT)
+    0 ≤ (s : ℝ)^2 / (2 * (WAD_NAT : ℝ)) - (secondNat : ℝ) ∧
+      (s : ℝ)^2 / (2 * (WAD_NAT : ℝ)) - (secondNat : ℝ) < 1 := by
+  intro secondNat
+  have h2W : 0 < 2 * WAD_NAT := by decide
+  have h := nat_div_floor_real_bounds (s * s) (2 * WAD_NAT) h2W
+  constructor
+  · have h0 := h.1
+    norm_num [WAD_NAT, secondNat, pow_two, mul_assoc, mul_comm, mul_left_comm] at h0 ⊢
+    exact h0
+  · have h1 := h.2
+    norm_num [WAD_NAT, secondNat, pow_two, mul_assoc, mul_comm, mul_left_comm] at h1 ⊢
+    exact h1
+
+private theorem neg_third_floor_slack_bounds (s : Nat) :
+    let secondNat := (s * s) / (2 * WAD_NAT)
+    let thirdNat := (secondNat * s) / (3 * WAD_NAT)
+    0 ≤ (secondNat : ℝ) * (s : ℝ) / (3 * (WAD_NAT : ℝ)) - (thirdNat : ℝ) ∧
+      (secondNat : ℝ) * (s : ℝ) / (3 * (WAD_NAT : ℝ)) - (thirdNat : ℝ) < 1 := by
+  intro secondNat thirdNat
+  have h3W : 0 < 3 * WAD_NAT := by decide
+  have h := nat_div_floor_real_bounds (secondNat * s) (3 * WAD_NAT) h3W
+  constructor
+  · have h0 := h.1
+    norm_num [WAD_NAT, thirdNat, mul_assoc, mul_comm, mul_left_comm] at h0 ⊢
+    exact h0
+  · have h1 := h.2
+    norm_num [WAD_NAT, thirdNat, mul_assoc, mul_comm, mul_left_comm] at h1 ⊢
+    exact h1
+
+private theorem neg_third_exact_bridge_bounds {s : Nat} (hs : s ≤ WEXP_RANGE_OFFSET) :
+    let secondNat := (s * s) / (2 * WAD_NAT)
+    0 ≤ (s : ℝ)^3 / (6 * (WAD_NAT : ℝ)^2) -
+        (secondNat : ℝ) * (s : ℝ) / (3 * (WAD_NAT : ℝ)) ∧
+      (s : ℝ)^3 / (6 * (WAD_NAT : ℝ)^2) -
+        (secondNat : ℝ) * (s : ℝ) / (3 * (WAD_NAT : ℝ)) < 1 := by
+  intro secondNat
+  have hWpos : (0 : ℝ) < (WAD_NAT : ℝ) := by norm_num [WAD_NAT]
+  have hWne : (WAD_NAT : ℝ) ≠ 0 := ne_of_gt hWpos
+  have hsR : (s : ℝ) ≤ WEXP_RANGE_OFFSET := by exact_mod_cast hs
+  have hoff : (WEXP_RANGE_OFFSET : ℝ) < WAD_NAT := by norm_num [WEXP_RANGE_OFFSET, WAD_NAT]
+  have hs_lt_W : (s : ℝ) < WAD_NAT := lt_of_le_of_lt hsR hoff
+  have hs_over_lt_one : (s : ℝ) / (3 * (WAD_NAT : ℝ)) < 1 := by
+    have h3Wreal : (0 : ℝ) < 3 * (WAD_NAT : ℝ) := by positivity
+    rw [div_lt_iff₀ h3Wreal]
+    nlinarith [hs_lt_W, hWpos]
+  have hA := neg_second_floor_slack_bounds s
+  have hCeq : (s : ℝ)^3 / (6 * (WAD_NAT : ℝ)^2) -
+        (secondNat : ℝ) * (s : ℝ) / (3 * (WAD_NAT : ℝ)) =
+      ((s : ℝ)^2 / (2 * (WAD_NAT : ℝ)) - (secondNat : ℝ)) *
+        ((s : ℝ) / (3 * (WAD_NAT : ℝ))) := by
+    field_simp [hWne]
+    ring
+  constructor
+  · rw [hCeq]
+    have hs_nonneg : (0 : ℝ) ≤ s := by positivity
+    exact mul_nonneg hA.1 (div_nonneg hs_nonneg (by positivity))
+  · rw [hCeq]
+    have hs_nonneg : (0 : ℝ) ≤ s := by positivity
+    nlinarith [hA.1, hA.2, hs_over_lt_one, hs_nonneg, hWpos]
+
+private theorem neg_kernel_inner_floor_slack {s : Nat} (hs : s ≤ WEXP_RANGE_OFFSET) :
+    let secondNat := (s * s) / (2 * WAD_NAT)
+    let thirdNat := (secondNat * s) / (3 * WAD_NAT)
+    |((secondNat : ℝ) - (s : ℝ)^2 / (2 * (WAD_NAT : ℝ)) -
+        ((thirdNat : ℝ) - (s : ℝ)^3 / (6 * (WAD_NAT : ℝ)^2)))| ≤ 4 := by
+  intro secondNat thirdNat
+  have hA := neg_second_floor_slack_bounds s
+  have hB := neg_third_floor_slack_bounds s
+  have hC := neg_third_exact_bridge_bounds hs
+  rw [abs_le]
+  constructor <;> nlinarith [hA.1, hA.2, hB.1, hB.2, hC.1, hC.2]
+
+private theorem neg_kernel_floor_slack {s : Nat} (hs : s ≤ WEXP_RANGE_OFFSET) :
+    let secondNat := (s * s) / (2 * WAD_NAT)
+    let thirdNat := (secondNat * s) / (3 * WAD_NAT)
+    let x : ℝ := -(s : ℝ) / WAD_NAT
+    let P : ℝ := 1 + x + x^2 / 2 + x^3 / 6
+    let k : ℝ := (((WAD_NAT : Int) - s + (secondNat : Int) - (thirdNat : Int) : Int) : ℝ) / WAD_NAT
+    |k - P| ≤ 4 / (WAD_NAT : ℝ) := by
+  intro secondNat thirdNat x P k
+  have hWpos : (0 : ℝ) < (WAD_NAT : ℝ) := by norm_num [WAD_NAT]
+  have hWne : (WAD_NAT : ℝ) ≠ 0 := ne_of_gt hWpos
+  have hinner := neg_kernel_inner_floor_slack (s := s) hs
+  have hdiff : k - P = (((secondNat : ℝ) - (s : ℝ)^2 / (2 * (WAD_NAT : ℝ)) -
+        ((thirdNat : ℝ) - (s : ℝ)^3 / (6 * (WAD_NAT : ℝ)^2))) / (WAD_NAT : ℝ)) := by
+    dsimp [k, P, x]
+    norm_num [Int.cast_sub, Int.cast_add, Int.cast_natCast]
+    field_simp [hWne]
+    ring
+  rw [hdiff, abs_div, abs_of_pos hWpos]
+  exact div_le_div_of_nonneg_right hinner (le_of_lt hWpos)
+
+private theorem wExpSignedCubicKernel_real_error_neg_nat {s : Nat}
+    (hs : s ≤ WEXP_RANGE_OFFSET) :
+    |((wExpSignedCubicKernel (-(s : Int)) : ℝ) / WAD_NAT) -
+        Real.exp (((-(s : Int) : Int) : ℝ) / WAD_NAT)|
+      ≤ 4 / (WAD_NAT : ℝ) + (((-(s : Int) : Int) : ℝ) / WAD_NAT)^4 * (5 / 96) := by
+  let secondNat := (s * s) / (2 * WAD_NAT)
+  let thirdNat := (secondNat * s) / (3 * WAD_NAT)
+  let x : ℝ := -(s : ℝ) / WAD_NAT
+  let P : ℝ := 1 + x + x^2 / 2 + x^3 / 6
+  let k : ℝ := (((WAD_NAT : Int) - s + (secondNat : Int) - (thirdNat : Int) : Int) : ℝ) / WAD_NAT
+  have hkernel : wExpSignedCubicKernel (-(s : Int)) =
+      (WAD_NAT : Int) - s + (secondNat : Int) - (thirdNat : Int) := by
+    simpa [secondNat, thirdNat] using wExpSignedCubicKernel_neg_eq s
+  have hfloor : |k - P| ≤ 4 / (WAD_NAT : ℝ) := by
+    simpa [secondNat, thirdNat, x, P, k] using neg_kernel_floor_slack (s := s) hs
+  have hWpos : (0 : ℝ) < (WAD_NAT : ℝ) := by norm_num [WAD_NAT]
+  have hsR : (s : ℝ) ≤ WEXP_RANGE_OFFSET := by exact_mod_cast hs
+  have hoff : (WEXP_RANGE_OFFSET : ℝ) < WAD_NAT := by norm_num [WEXP_RANGE_OFFSET, WAD_NAT]
+  have hx_abs_le : |x| ≤ 1 := by
+    have hs_nonneg : (0 : ℝ) ≤ s := by positivity
+    have hs_le_W : (s : ℝ) ≤ WAD_NAT := le_trans hsR (le_of_lt hoff)
+    dsimp [x]
+    rw [abs_div, abs_neg, abs_of_nonneg hs_nonneg, abs_of_pos hWpos]
+    rw [div_le_one hWpos]
+    exact hs_le_W
+  have hx_nonpos : x ≤ 0 := by
+    dsimp [x]
+    exact div_nonpos_of_nonpos_of_nonneg (neg_nonpos.mpr (by positivity)) (le_of_lt hWpos)
+  have hx_abs_pow : |x|^4 = x^4 := by
+    rw [abs_of_nonpos hx_nonpos]
+    ring
+  have han : |P - Real.exp x| ≤ x^4 * (5 / 96) := by
+    have h := cubic_real_error_abs (x := x) hx_abs_le
+    rw [hx_abs_pow] at h
+    rw [abs_sub_comm]
+    simpa [P] using h
+  have htri : |k - Real.exp x| ≤ 4 / (WAD_NAT : ℝ) + x^4 * (5 / 96) := by
+    calc
+      |k - Real.exp x| ≤ |k - P| + |P - Real.exp x| := abs_sub_le k P (Real.exp x)
+      _ ≤ 4 / (WAD_NAT : ℝ) + x^4 * (5 / 96) := add_le_add hfloor han
+  rw [hkernel]
+  simpa [k, x, secondNat, thirdNat] using htri
+
+theorem wExpSignedCubicKernel_real_error_neg {r : Int}
+    (hr0 : -(WEXP_RANGE_OFFSET : Int) ≤ r) (hr1 : r ≤ 0) :
+    |((wExpSignedCubicKernel r : ℝ) / WAD_NAT) - Real.exp ((r:ℝ)/WAD_NAT)|
+      ≤ 4 / (WAD_NAT : ℝ) + ((r:ℝ)/WAD_NAT)^4 * (5 / 96) := by
+  let s := (-r).toNat
+  have hs_cast : (s : Int) = -r := by
+    exact Int.toNat_of_nonneg (neg_nonneg.mpr hr1)
+  have hr_eq : r = -(s : Int) := by omega
+  have hs_le : s ≤ WEXP_RANGE_OFFSET := by omega
+  rw [hr_eq]
+  exact wExpSignedCubicKernel_real_error_neg_nat (s := s) hs_le
+
 /-- `wExpRangeR` is exactly the signed residual left by `wExpRangeQ`. -/
 theorem wExpRangeReduction_exact (xAbs : Nat) :
     Int.ofNat (wExpRangeQ xAbs * WEXP_LN2) + wExpRangeR xAbs =


### PR DESCRIPTION
## Summary

Follow-up to #2044 (which landed the negative-branch building blocks `wExpSignedCubicKernel_neg_eq` + `cubic_real_error_abs`). This PR continues #1998 toward retiring the hand-written Yul `TickLib.tickToPrice`/`wExp` external-call-model (ECM) by **closing the negative-residual branch** of the signed cubic kernel's `Real.exp` error bound.

With this PR, `wExpSignedCubicKernel` now has a proven `Real.exp` error bound on **both** residual branches: the non-negative branch (`wExpSignedCubicKernel_real_error_nonneg`, #2043) and now the negative branch — together covering the full range-reduction residual interval `-WEXP_RANGE_OFFSET ≤ r ≤ WEXP_LN2`.

### New theorem (in `Verity/Proofs/Stdlib/Math.lean`)
- `wExpSignedCubicKernel_real_error_neg {r : Int} (hr0 : -(WEXP_RANGE_OFFSET : Int) ≤ r) (hr1 : r ≤ 0) : |((wExpSignedCubicKernel r : ℝ) / WAD_NAT) - Real.exp ((r:ℝ)/WAD_NAT)| ≤ 4 / (WAD_NAT : ℝ) + ((r:ℝ)/WAD_NAT)^4 * (5 / 96)` — the Tier-B real-exp error bound for the signed kernel on the **negative** residual interval.

On `r < 0`, EVM-style `sdivTrunc` truncates the third kernel term toward zero (rounding its magnitude *down*), so the kernel evaluates as the *alternating* floor expression `WAD − s + secondNat − thirdNat` (via `wExpSignedCubicKernel_neg_eq`, where `secondNat = ⌊s²/(2·WAD)⌋`, `thirdNat = ⌊secondNat·s/(3·WAD)⌋`, `s = -r`). The proof composes, by the triangle inequality through the exact cubic `P = 1 + x + x²/2 + x³/6` (`x = r/WAD ≤ 0`):
- the **integer floor-slack** half `|kernel/WAD − P| ≤ 4/WAD`, built from a reusable two-sided Euclidean floor bound (`0 ≤ n/d − ⌊n/d⌋ < 1`, `nat_div_floor_real_bounds`) applied to both floors, plus the key bridge `s³/(6·WAD²) − secondNat·s/(3·WAD) = (s²/(2·WAD) − secondNat)·(s/(3·WAD))` (a product of two terms each in `[0,1)`, hence `< 1`); and
- the **analytic** half `|P − Real.exp x| ≤ |x|⁴·(5/96)` from the sign-agnostic `cubic_real_error_abs` (#2044), valid since `|x| = s/WAD ≤ WEXP_RANGE_OFFSET/WAD < 1`.

Seven supporting private lemmas (`nat_div_floor_real_bounds`, `neg_second_floor_slack_bounds`, `neg_third_floor_slack_bounds`, `neg_third_exact_bridge_bounds`, `neg_kernel_inner_floor_slack`, `neg_kernel_floor_slack`, `wExpSignedCubicKernel_real_error_neg_nat`) factor the floor-slack analysis.

## Soundness

0 sorry / 0 admit / 0 native_decide / no new axiom. The new public theorem's `#print axioms` depends only on `[propext, Classical.choice, Quot.sound]` (no `Lean.ofReduceBool`, no `sorryAx`). No existing theorem weakened or deleted — the diff is purely additive (+174 lines `Verity/Proofs/Stdlib/Math.lean`, +8 registry entries). PrintAxioms registry updated 5385→5393 (3713→3714 public, 1672→1679 private, 0 sorry'd).

## Still deferred (tracked under #1998)

- **Full `tickWExpReference` error bound:** beyond the residual kernel (now bounded on both branches), this additionally requires bounding the `2^q` scaling step, the rational-`ln 2` approximation error (`WEXP_LN2/WAD` vs `Real.log 2`) accumulated over `q` range-reduction steps, and the reciprocal branch for negative inputs.
- **Tier C — ECM equivalence:** genuinely cross-repo. `tickToPriceModule` and its correctness axiom `midnight_ticklib_tick_to_price_exact_yul` live in the downstream `morpho-verity/morpho-midnight-verity` repo (`Midnight/Contract.lean`), which imports verity, so the linking theorem must be authored there. Until that downstream PR lands, the Yul ECM remains honestly `assumed`.

## Test plan

- [x] `lake build` — exit 0 (verified locally)
- [x] `lake build PrintAxioms` (the real proof gate) — exit 0 (verified locally, boss-reverified)
- [x] `#print axioms wExpSignedCubicKernel_real_error_neg` — only `[propext, Classical.choice, Quot.sound]` (boss-reverified)
- [x] `python3 scripts/generate_print_axioms.py --check` — exit 0 (verified locally)
- [x] `make check` — exit 0 (verified locally)
- [ ] CI: build / build-audits / build-compiler-binaries / compiler-regressions green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proofs in `Verity/Proofs/Stdlib/Math.lean` with no runtime, auth, or API changes; only extends the verified math library and axiom registry.
> 
> **Overview**
> Adds the **negative residual branch** of the signed cubic kernel’s `Real.exp` error bound, complementing the existing non-negative `wExpSignedCubicKernel_real_error_nonneg` result so both sides of range-reduction residuals are covered.
> 
> The public theorem `wExpSignedCubicKernel_real_error_neg` bounds `|kernel/WAD − Real.exp(r/WAD)|` for `-(WEXP_RANGE_OFFSET) ≤ r ≤ 0` by **`4/WAD + (r/WAD)⁴·(5/96)`** (the floor-slack term is **4/WAD** vs **3/WAD** on the positive branch). The proof rewrites negative inputs via `wExpSignedCubicKernel_neg_eq`, splits error through the cubic Taylor polynomial `P`, and bounds **integer floor slack** (`≤ 4/WAD`) with seven new private lemmas (`nat_div_floor_real_bounds`, `neg_*_floor_slack_*`, etc.) plus the existing **`cubic_real_error_abs`** analytic term.
> 
> `PrintAxioms.lean` registers the new public theorem and the private helpers (5385→5393 entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0284e47d5cc9b5126ee064e98cd067a4e6a13d64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->