### PR TITLE
feat(#1998): unify signed cubic-kernel Real.exp error bound across full residual interval

### DIFF
--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -782,6 +782,7 @@ end Verity.AxiomAudit
   -- Verity.Proofs.Stdlib.Math.neg_kernel_floor_slack  -- private
   -- Verity.Proofs.Stdlib.Math.wExpSignedCubicKernel_real_error_neg_nat  -- private
   Verity.Proofs.Stdlib.Math.wExpSignedCubicKernel_real_error_neg
+  Verity.Proofs.Stdlib.Math.wExpSignedCubicKernel_real_error
   Verity.Proofs.Stdlib.Math.wExpRangeReduction_exact
   -- Verity.Proofs.Stdlib.Math.WEXP_LN2_pos  -- private
   -- Verity.Proofs.Stdlib.Math.WEXP_RANGE_OFFSET_lt_LN2  -- private
@@ -5751,4 +5752,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5393 theorems/lemmas (3714 public, 1679 private, 0 sorry'd)
+-- Total: 5394 theorems/lemmas (3715 public, 1679 private, 0 sorry'd)

--- a/Verity/Proofs/Stdlib/Math.lean
+++ b/Verity/Proofs/Stdlib/Math.lean
@@ -694,6 +694,24 @@ theorem wExpSignedCubicKernel_real_error_neg {r : Int}
   rw [hr_eq]
   exact wExpSignedCubicKernel_real_error_neg_nat (s := s) hs_le
 
+/-- Combined `Real.exp` error bound for the signed cubic kernel across the full
+range-reduction residual interval `-WEXP_RANGE_OFFSET ≤ r ≤ WEXP_LN2`. -/
+theorem wExpSignedCubicKernel_real_error {r : Int}
+    (hr0 : -(WEXP_RANGE_OFFSET : Int) ≤ r) (hr1 : r ≤ (WEXP_LN2 : Int)) :
+    |((wExpSignedCubicKernel r : ℝ) / WAD_NAT) - Real.exp ((r:ℝ)/WAD_NAT)|
+      ≤ 4 / (WAD_NAT : ℝ) + ((r:ℝ)/WAD_NAT)^4 * (5 / 96) := by
+  rcases le_or_gt 0 r with h | h
+  · have hnonneg := wExpSignedCubicKernel_real_error_nonneg (r := r) h hr1
+    calc
+      |((wExpSignedCubicKernel r : ℝ) / WAD_NAT) - Real.exp ((r:ℝ)/WAD_NAT)|
+          ≤ 3 / (WAD_NAT : ℝ) + ((r:ℝ)/WAD_NAT)^4 * (5 / 96) := hnonneg
+      _ ≤ 4 / (WAD_NAT : ℝ) + ((r:ℝ)/WAD_NAT)^4 * (5 / 96) := by
+        have hWpos : (0 : ℝ) < (WAD_NAT : ℝ) := by norm_num [WAD_NAT]
+        have hconst : (3 : ℝ) / WAD_NAT ≤ 4 / WAD_NAT := by
+          exact div_le_div_of_nonneg_right (by norm_num) (le_of_lt hWpos)
+        exact add_le_add_right hconst (((r:ℝ)/WAD_NAT)^4 * (5 / 96))
+  · exact wExpSignedCubicKernel_real_error_neg hr0 (le_of_lt h)
+
 /-- `wExpRangeR` is exactly the signed residual left by `wExpRangeQ`. -/
 theorem wExpRangeReduction_exact (xAbs : Nat) :
     Int.ofNat (wExpRangeQ xAbs * WEXP_LN2) + wExpRangeR xAbs =


### PR DESCRIPTION
## Summary

Follow-up to #2045 (negative-residual branch) and #2043 (non-negative branch). This PR continues #1998 toward retiring the hand-written Yul `TickLib.tickToPrice`/`wExp` external-call-model (ECM) by **unifying the two per-branch `Real.exp` error bounds** of the signed cubic kernel into a single theorem covering the full range-reduction residual interval.

With #2043 and #2045, `wExpSignedCubicKernel` already had a proven `Real.exp` error bound on each branch *separately*:
- non-negative residual (`wExpSignedCubicKernel_real_error_nonneg`, `0 ≤ r ≤ WEXP_LN2`, constant `3/WAD`), and
- negative residual (`wExpSignedCubicKernel_real_error_neg`, `-WEXP_RANGE_OFFSET ≤ r ≤ 0`, constant `4/WAD`).

This PR composes them into the single statement the full `tickWExpReference` proof will cite, with the common (looser) constant `4/WAD`.

### New theorem (in `Verity/Proofs/Stdlib/Math.lean`)
- `wExpSignedCubicKernel_real_error {r : Int} (hr0 : -(WEXP_RANGE_OFFSET : Int) ≤ r) (hr1 : r ≤ (WEXP_LN2 : Int)) : |((wExpSignedCubicKernel r : ℝ) / WAD_NAT) - Real.exp ((r:ℝ)/WAD_NAT)| ≤ 4 / (WAD_NAT : ℝ) + ((r:ℝ)/WAD_NAT)^4 * (5 / 96)` — the combined Tier-B real-exp error bound for the signed kernel across the **entire** residual interval `-WEXP_RANGE_OFFSET ≤ r ≤ WEXP_LN2`.

The proof is a sign case split (`le_or_lt 0 r`): on `0 ≤ r` it invokes the non-negative branch lemma and relaxes its `3/WAD` constant to `4/WAD` (since `3/WAD ≤ 4/WAD` and the analytic `|x|⁴·(5/96)` term is identical); on `r < 0` it invokes the negative branch lemma directly (already `4/WAD`). Purely compositional — no new analysis, no re-derivation of the branch bounds.

## Soundness

0 sorry / 0 admit / 0 native_decide / no new axiom. The new public theorem's `#print axioms` depends only on `[propext, Classical.choice, Quot.sound]` (no `Lean.ofReduceBool`, no `sorryAx`). No existing theorem weakened or deleted — the diff is purely additive (one new theorem in `Verity/Proofs/Stdlib/Math.lean` + 1 generated registry entry). PrintAxioms registry updated 5393→5394 (3714→3715 public, 1679 private unchanged, 0 sorry'd).

## Still deferred (tracked under #1998)

- **Full `tickWExpReference` error bound:** beyond the residual kernel (now bounded as a single statement across the full interval), this additionally requires bounding the `2^q` scaling step, the rational-`ln 2` approximation error (`WEXP_LN2/WAD` vs `Real.log 2`) accumulated over `q` range-reduction steps, and the reciprocal branch for negative inputs.
- **Tier C — ECM equivalence:** genuinely cross-repo. `tickToPriceModule` and its correctness axiom `midnight_ticklib_tick_to_price_exact_yul` live in the downstream `morpho-verity/morpho-midnight-verity` repo (`Midnight/Contract.lean`), which imports verity, so the linking theorem must be authored there. Until that downstream PR lands, the Yul ECM remains honestly `assumed`.

## Test plan

- [x] `lake build` — exit 0 (verified locally)
- [x] `lake build PrintAxioms` (the real proof gate) — exit 0 (verified locally, boss-reverified)
- [x] `#print axioms wExpSignedCubicKernel_real_error` — only `[propext, Classical.choice, Quot.sound]` (boss-reverified)
- [x] `python3 scripts/generate_print_axioms.py --check` — exit 0 (verified locally)
- [x] `make check` — exit 0 (verified locally)
- [ ] CI: build / build-audits / build-compiler-binaries / compiler-regressions green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proof only: one compositional theorem and a generated registry line, with no changes to existing lemmas or runtime code.
> 
> **Overview**
> Adds a **single public theorem** `wExpSignedCubicKernel_real_error` that bounds `|wExpSignedCubicKernel / WAD - Real.exp(r/WAD)|` on the full residual interval `-WEXP_RANGE_OFFSET ≤ r ≤ WEXP_LN2`, using the looser constant **4/WAD** plus the shared `|r/WAD|⁴·(5/96)` term.
> 
> The proof only **case-splits on sign**: for `r ≥ 0` it applies the existing non-negative lemma and relaxes **3/WAD → 4/WAD**; for `r < 0` it applies the existing negative lemma unchanged. No new analysis or axiom changes—**PrintAxioms** gains one public entry (5393→5394 theorems).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 151de9a13bffc766a5d4f8f698f33b566bb0a7ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->