### PR TITLE
Bound TickLib ln2 reduction constant and its exp against log 2 / 2 (#1998)

### DIFF
--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -764,6 +764,7 @@ end Verity.AxiomAudit
   Verity.Proofs.Stdlib.Math.exact_cubic_lt_wExpCubicKernel_scaled_add_three
   Verity.Proofs.Stdlib.Math.exact_cubic_real_error
   Verity.Proofs.Stdlib.Math.wExpCubicKernel_real_error
+  Verity.Proofs.Stdlib.Math.wExpLn2_approx_error
   -- Verity.Proofs.Stdlib.Math.sdivTrunc_of_nonneg  -- private
   -- Verity.Proofs.Stdlib.Math.sdivTrunc_ofNat_mul_WAD  -- private
   -- Verity.Proofs.Stdlib.Math.sdivTrunc_sq_of_nonneg  -- private
@@ -5752,4 +5753,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5394 theorems/lemmas (3715 public, 1679 private, 0 sorry'd)
+-- Total: 5395 theorems/lemmas (3716 public, 1679 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -765,6 +765,7 @@ end Verity.AxiomAudit
   Verity.Proofs.Stdlib.Math.exact_cubic_real_error
   Verity.Proofs.Stdlib.Math.wExpCubicKernel_real_error
   Verity.Proofs.Stdlib.Math.wExpLn2_approx_error
+  Verity.Proofs.Stdlib.Math.wExpLn2_exp_approx_two
   -- Verity.Proofs.Stdlib.Math.sdivTrunc_of_nonneg  -- private
   -- Verity.Proofs.Stdlib.Math.sdivTrunc_ofNat_mul_WAD  -- private
   -- Verity.Proofs.Stdlib.Math.sdivTrunc_sq_of_nonneg  -- private
@@ -5753,4 +5754,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5395 theorems/lemmas (3716 public, 1679 private, 0 sorry'd)
+-- Total: 5396 theorems/lemmas (3717 public, 1679 private, 0 sorry'd)

--- a/Verity/Proofs/Stdlib/Math.lean
+++ b/Verity/Proofs/Stdlib/Math.lean
@@ -8,6 +8,7 @@
 import Verity.Core
 import Verity.Stdlib.Math
 import Mathlib.Data.Complex.Exponential
+import Mathlib.Data.Complex.ExponentialBounds
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.Ring
 
@@ -376,6 +377,19 @@ theorem wExpCubicKernel_real_error {r : Nat} (hr : r ≤ WEXP_LN2) :
   calc
     |k - Real.exp x| ≤ |k - P| + |P - Real.exp x| := abs_sub_le k P (Real.exp x)
     _ ≤ 3 / (WAD_NAT : ℝ) + x^4 * (5 / 96) := add_le_add hkP hPexp
+
+/-- The TickLib range-reduction `ln 2` constant approximates `Real.log 2`
+within three tenths of a nanounit at WAD scale. -/
+theorem wExpLn2_approx_error :
+    |((WEXP_LN2 : ℝ) / WAD_NAT) - Real.log 2| ≤ 3 / 10 ^ 10 := by
+  rw [abs_le]
+  constructor
+  · have hlog_lt : Real.log 2 < (0.6931471808 : ℝ) := Real.log_two_lt_d9
+    norm_num [WEXP_LN2, WAD_NAT] at hlog_lt ⊢
+    linarith
+  · have hlog_gt : (0.6931471803 : ℝ) < Real.log 2 := Real.log_two_gt_d9
+    norm_num [WEXP_LN2, WAD_NAT] at hlog_gt ⊢
+    linarith
 
 private theorem sdivTrunc_of_nonneg {a b : Int} (ha : 0 ≤ a) (hb : 0 < b) :
     sdivTrunc a b = Int.ofNat (a.toNat / b.natAbs) := by

--- a/Verity/Proofs/Stdlib/Math.lean
+++ b/Verity/Proofs/Stdlib/Math.lean
@@ -391,6 +391,33 @@ theorem wExpLn2_approx_error :
     norm_num [WEXP_LN2, WAD_NAT] at hlog_gt ⊢
     linarith
 
+/-- `Real.exp` of the TickLib range-reduction `ln 2` constant equals `2` to
+within two parts per billion: the base of the `2^q` scaling in
+`tickWExpReference`. -/
+theorem wExpLn2_exp_approx_two :
+    |Real.exp ((WEXP_LN2 : ℝ) / WAD_NAT) - 2| ≤ 2 / 10 ^ 9 := by
+  have hbound : |((WEXP_LN2 : ℝ) / WAD_NAT) - Real.log 2| ≤ 3 / 10 ^ 10 :=
+    wExpLn2_approx_error
+  have hle1 : |((WEXP_LN2 : ℝ) / WAD_NAT) - Real.log 2| ≤ 1 :=
+    le_trans hbound (by norm_num)
+  have hstep :
+      |Real.exp ((WEXP_LN2 : ℝ) / WAD_NAT - Real.log 2) - 1|
+        ≤ 2 * |((WEXP_LN2 : ℝ) / WAD_NAT) - Real.log 2| :=
+    Real.abs_exp_sub_one_le hle1
+  have hexp :
+      Real.exp ((WEXP_LN2 : ℝ) / WAD_NAT) - 2
+        = 2 * (Real.exp ((WEXP_LN2 : ℝ) / WAD_NAT - Real.log 2) - 1) := by
+    rw [Real.exp_sub, Real.exp_log (by norm_num : (0 : ℝ) < 2)]
+    ring
+  rw [hexp, abs_mul, show |(2 : ℝ)| = 2 from by norm_num]
+  calc 2 * |Real.exp ((WEXP_LN2 : ℝ) / WAD_NAT - Real.log 2) - 1|
+        ≤ 2 * (2 * |((WEXP_LN2 : ℝ) / WAD_NAT) - Real.log 2|) :=
+        mul_le_mul_of_nonneg_left hstep (by norm_num)
+    _ ≤ 2 * (2 * (3 / 10 ^ 10)) :=
+        mul_le_mul_of_nonneg_left
+          (mul_le_mul_of_nonneg_left hbound (by norm_num)) (by norm_num)
+    _ ≤ 2 / 10 ^ 9 := by norm_num
+
 private theorem sdivTrunc_of_nonneg {a b : Int} (ha : 0 ≤ a) (hb : 0 < b) :
     sdivTrunc a b = Int.ofNat (a.toNat / b.natAbs) := by
   unfold sdivTrunc


### PR DESCRIPTION
## Summary

Two tightly-related lemmas about the TickLib range-reduction `ln 2` constant `WEXP_LN2/WAD_NAT` (the fixed-point value `0.693147180559945309` used by `tickWExpReference`), both proven against Mathlib `Real`:

- **`wExpLn2_approx_error`** — `|WEXP_LN2/WAD_NAT - Real.log 2| ≤ 3e-10`, via Mathlib `Real.log_two_{lt,gt}_d9`. Bounds the rational reduction constant against the true `ln 2`.
- **`wExpLn2_exp_approx_two`** — `|Real.exp(WEXP_LN2/WAD_NAT) - 2| ≤ 2e-9`. Corollary of the above via `Real.abs_exp_sub_one_le` / `Real.exp_sub` / `Real.exp_log`, showing the base of the `2^q` scaling step in `tickWExpReference` is `2` to two parts per billion.

Together these pin down the error of the `ln 2` range-reduction step — a prerequisite for the full `tickWExpReference` error bound vs `Real.exp` (#1998).

## Verification
- `lake build Verity.Proofs.Stdlib.Math` — green
- `lake build PrintAxioms` (full proof gate) — green
- `python3 scripts/generate_print_axioms.py --check` — up to date
- Registry 5394 → 5396 (+2 public). Both theorems depend only on `[propext, Classical.choice, Quot.sound]`; 0 sorry, no `native_decide`, no new axiom.

## Test plan
- [x] Lean proofs compile (`lake build PrintAxioms`)
- [x] Axiom registry regenerated and `--check` clean
- [ ] CI full bar green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only Mathlib additions with no runtime or contract behavior changes; risk is limited to build time and theorem registry upkeep.
> 
> **Overview**
> Adds two public lemmas in `Verity/Proofs/Stdlib/Math.lean` for the TickLib **`wExp`** soundness chain: **`wExpLn2_approx_error`** shows the fixed-point **`WEXP_LN2`** at WAD scale is within **3×10⁻¹⁰** of **`Real.log 2`** (via Mathlib **`log_two_*_d9`** and **`linarith`**), and **`wExpLn2_exp_approx_two`** shows **`Real.exp`** of that constant is within **2×10⁻⁹** of **2**, using the log bound plus **`Real.abs_exp_sub_one_le`**.
> 
> Pulls in **`Mathlib.Data.Complex.ExponentialBounds`** and registers both theorems in **`PrintAxioms.lean`** (public count **3715 → 3717**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb2e31a692d6560040dcdf0ab0ff067c3507ca2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->