### PR TITLE
feat(#1998): decompose tickWExp real exp via exact range reduction

### DIFF
--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -766,6 +766,8 @@ end Verity.AxiomAudit
   Verity.Proofs.Stdlib.Math.wExpCubicKernel_real_error
   Verity.Proofs.Stdlib.Math.wExpLn2_approx_error
   Verity.Proofs.Stdlib.Math.wExpLn2_exp_approx_two
+  Verity.Proofs.Stdlib.Math.wExpRangeReduction_real
+  Verity.Proofs.Stdlib.Math.tickWExp_exp_decomp
   -- Verity.Proofs.Stdlib.Math.sdivTrunc_of_nonneg  -- private
   -- Verity.Proofs.Stdlib.Math.sdivTrunc_ofNat_mul_WAD  -- private
   -- Verity.Proofs.Stdlib.Math.sdivTrunc_sq_of_nonneg  -- private
@@ -5754,4 +5756,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5396 theorems/lemmas (3717 public, 1679 private, 0 sorry'd)
+-- Total: 5398 theorems/lemmas (3719 public, 1679 private, 0 sorry'd)

--- a/Verity/Proofs/Stdlib/Math.lean
+++ b/Verity/Proofs/Stdlib/Math.lean
@@ -418,6 +418,29 @@ theorem wExpLn2_exp_approx_two :
           (mul_le_mul_of_nonneg_left hbound (by norm_num)) (by norm_num)
     _ ≤ 2 / 10 ^ 9 := by norm_num
 
+/-- Exact range-reduction identity at WAD scale: the full WAD-scaled input
+decomposes as the reduced residual plus `q` copies of the `ln 2` constant.
+No approximation — this is the real-cast counterpart of `wExpRangeReduction_exact`. -/
+theorem wExpRangeReduction_real (xAbs : Nat) :
+    (xAbs : ℝ) / (WAD_NAT : ℝ)
+      = (wExpRangeR xAbs : ℝ) / (WAD_NAT : ℝ)
+        + (wExpRangeQ xAbs : ℝ) * ((WEXP_LN2 : ℝ) / (WAD_NAT : ℝ)) := by
+  have hcast : (xAbs : ℝ)
+      = (wExpRangeR xAbs : ℝ) + (wExpRangeQ xAbs : ℝ) * (WEXP_LN2 : ℝ) := by
+    simp only [wExpRangeR, Int.ofNat_eq_natCast]
+    push_cast
+    ring
+  rw [hcast]; ring
+
+/-- `Real.exp` of the full WAD-scaled input factors through the reduced residual
+and the `2^q` scaling base `exp (ln2 / WAD)`, by `exp` of the exact range-reduction
+decomposition. Bridges the residual-kernel error bound to full `exp`. -/
+theorem tickWExp_exp_decomp (xAbs : Nat) :
+    Real.exp ((xAbs : ℝ) / (WAD_NAT : ℝ))
+      = Real.exp ((wExpRangeR xAbs : ℝ) / (WAD_NAT : ℝ))
+        * Real.exp ((WEXP_LN2 : ℝ) / (WAD_NAT : ℝ)) ^ (wExpRangeQ xAbs) := by
+  rw [wExpRangeReduction_real, Real.exp_add, Real.exp_nat_mul]
+
 private theorem sdivTrunc_of_nonneg {a b : Int} (ha : 0 ≤ a) (hb : 0 < b) :
     sdivTrunc a b = Int.ofNat (a.toNat / b.natAbs) := by
   unfold sdivTrunc


### PR DESCRIPTION
## Summary

Two backbone lemmas in `Verity/Proofs/Stdlib/Math.lean` that bridge the
already-landed residual-kernel `Real.exp` error bound (PR #2043–#2046) to the
**full** WAD-scaled input, by factoring `exp` through the exact range reduction.

- **`wExpRangeReduction_real`** — exact real-cast range-reduction identity:
  `(xAbs:ℝ)/WAD = wExpRangeR(xAbs)/WAD + wExpRangeQ(xAbs) * (WEXP_LN2/WAD)`.
  The ℝ counterpart of `wExpRangeReduction_exact`; **no approximation** (follows
  directly from the integer definition `wExpRangeR = xAbs − q·WEXP_LN2`).
- **`tickWExp_exp_decomp`** — factors the full exp:
  `exp(xAbs/WAD) = exp(wExpRangeR/WAD) * exp(WEXP_LN2/WAD)^q`
  via `Real.exp_add` and `Real.exp_nat_mul`.

Together these are the decomposition step toward the full `tickWExpReference`
error bound: combine the residual-kernel bound on `wExpRangeR` with the
`exp(WEXP_LN2/WAD) ≈ 2` constant bound (`wExpLn2_exp_approx_two`, #2047) over `q`
scaling steps.

## Soundness

- Both new theorems depend **only** on `[propext, Classical.choice, Quot.sound]`
  (verified via `#print axioms`) — no `sorryAx`, no `ofReduceBool`, no new axiom.
- Purely additive; no existing statement weakened. 0 sorry.
- `PrintAxioms.lean` registry: 5396 → 5398 (+2 public, private unchanged),
  entries in source-declaration order.

## Test plan

- [x] `lake build` (Verity.Proofs.Stdlib.Math) — green
- [x] `lake build PrintAxioms` — green
- [x] `python3 scripts/generate_print_axioms.py --check` — up to date
- [x] `#print axioms` on both theorems — only the classical trio
- [ ] CI: build / build-audits / build-compiler-binaries / compiler-regressions / compiler-audits / Bugbot (foundry shards proof-irrelevant — Lean-only diff, zero bytecode delta)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proofs only; no runtime, compiler, or axiom changes beyond two new registered public theorems.
> 
> **Overview**
> Adds two **ℝ** lemmas in `Verity/Proofs/Stdlib/Math.lean` that lift the existing integer range-reduction story to full WAD-scaled `Real.exp`, as a step toward a complete `tickWExpReference` error bound.
> 
> **`wExpRangeReduction_real`** is the exact real identity matching `wExpRangeReduction_exact`: the input `(xAbs:ℝ)/WAD` splits into the reduced residual plus `q` times `WEXP_LN2/WAD`, with no approximation.
> 
> **`tickWExp_exp_decomp`** applies `Real.exp_add` and `Real.exp_nat_mul` so `exp(xAbs/WAD)` factors as `exp(wExpRangeR/WAD) * exp(WEXP_LN2/WAD)^q`, linking residual-kernel bounds to the full exponential.
> 
> `PrintAxioms.lean` registers both theorems (+2 public; total 5398).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc848935b8b91414b81c3b99bc8dd69a78d641b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->