### PR TITLE
feat(Intrinsics): add Yul template intrinsic lowering

### DIFF
--- a/Compiler/ABI/Frame.lean
+++ b/Compiler/ABI/Frame.lean
@@ -89,7 +89,7 @@ def fieldWordName (base : String) (field : FrameField) (idx : Nat) : String :=
 
 def allocateFrame (base : String) (l : FrameLayout) : List YulStmt :=
   [ YulStmt.let_ (ptrName base) (YulExpr.call "mload" [YulExpr.lit 64])
-  , YulStmt.expr (YulExpr.call "mstore"
+  , YulStmt.exprStmt (YulExpr.call "mstore"
       [ YulExpr.lit 64
       , YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit (frameAllocBytes l)] ])]
 
@@ -134,7 +134,7 @@ private def materializeSourceWord (field : FrameField) (idx : Nat) : YulExpr :=
   | .storage => YulExpr.call "sload" [sourceStorageSlot field idx]
 
 private def spillCodeWord (field : FrameField) (dest offset : YulExpr) : YulStmt :=
-  YulStmt.expr (YulExpr.call "extcodecopy"
+  YulStmt.exprStmt (YulExpr.call "extcodecopy"
     [ YulExpr.ident (sourceBaseName field), dest, offset, YulExpr.lit 32 ])
 
 private def spillStaticField (base : String) (headOffsetWords : Nat) (field : FrameField) : List YulStmt :=
@@ -143,26 +143,26 @@ private def spillStaticField (base : String) (headOffsetWords : Nat) (field : Fr
     match field.source with
     | .code => spillCodeWord field dest (sourceCodeOffset field idx)
     | _ =>
-        YulStmt.expr (YulExpr.call "mstore"
+        YulStmt.exprStmt (YulExpr.call "mstore"
           [dest, materializeSourceWord field idx])
 
 private def spillDynamicField (base : String) (headOffsetWords tailOffsetWords : Nat) (field : FrameField) : List YulStmt :=
   let tailOffsetBytes := tailOffsetWords * 32
   let headDest := YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit (headOffsetWords * 32)]
-  let head := [YulStmt.expr (YulExpr.call "mstore" [headDest, YulExpr.lit tailOffsetBytes])]
+  let head := [YulStmt.exprStmt (YulExpr.call "mstore" [headDest, YulExpr.lit tailOffsetBytes])]
   let tailWords := dynamicTailWords field
   head ++ (List.range tailWords).map fun idx =>
     let dest := YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit ((tailOffsetWords + idx) * 32)]
     match field.source with
     | .code => spillCodeWord field dest (dynamicTailByteOffset field idx)
     | .storage =>
-        YulStmt.expr (YulExpr.call "mstore"
+        YulStmt.exprStmt (YulExpr.call "mstore"
           [dest, YulExpr.call "sload" [dynamicTailByteOffset field idx]])
     | .calldata =>
-        YulStmt.expr (YulExpr.call "mstore"
+        YulStmt.exprStmt (YulExpr.call "mstore"
           [dest, YulExpr.call "calldataload" [dynamicTailByteOffset field idx]])
     | .memory =>
-        YulStmt.expr (YulExpr.call "mstore"
+        YulStmt.exprStmt (YulExpr.call "mstore"
           [dest, YulExpr.call "mload" [dynamicTailByteOffset field idx]])
 
 partial def spillFieldsAbi (base : String) (headOffsetWords tailOffsetWords : Nat) : List FrameField → List YulStmt
@@ -187,7 +187,7 @@ def pointerArgs (base : String) (l : FrameLayout) : List YulExpr :=
 
 def inlinePayloadToScratch (words : List YulExpr) : List YulStmt :=
   words.zipIdx.map fun (word, idx) =>
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit (idx * 32), word])
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit (idx * 32), word])
 
 private partial def inlineArgsFrom : List FrameField → List YulExpr
   | [] => []

--- a/Compiler/ABI/FrameTest.lean
+++ b/Compiler/ABI/FrameTest.lean
@@ -42,7 +42,7 @@ private def calldataLoadName? : YulExpr → Option String
 
 private def hasExtcodecopy : List YulStmt → Bool :=
   fun stmts => stmts.any fun
-    | .expr (.call "extcodecopy" _) => true
+    | .exprStmt (.call "extcodecopy" _) => true
     | _ => false
 
 #eval! do

--- a/Compiler/Codegen.lean
+++ b/Compiler/Codegen.lean
@@ -66,7 +66,7 @@ example :
     let runtimeMarker := "__runtime_marker"
     let contract : IRContract :=
       { name := "ScopeRegression"
-        deploy := [.expr (.call "add" [.ident deployMarker, .lit 0])]
+        deploy := [.exprStmt (.call "add" [.ident deployMarker, .lit 0])]
         constructorPayable := true
         functions :=
           [{ name := "f"
@@ -74,7 +74,7 @@ example :
              params := []
              ret := .unit
              payable := false
-             body := [.expr (.call "add" [.ident runtimeMarker, .lit 0])] }]
+             body := [.exprStmt (.call "add" [.ident runtimeMarker, .lit 0])] }]
         usesMapping := false }
     let options : YulEmitOptions := { patchConfig := { enabled := true, maxIterations := 2 } }
     let report := emitYulWithOptionsReport contract options

--- a/Compiler/CodegenCommon.lean
+++ b/Compiler/CodegenCommon.lean
@@ -46,20 +46,20 @@ structure PatchBackend where
   apply : YulObject → YulEmitOptions → EmitObjectWithOptionsReport
 
 private def yulDatacopy : YulStmt :=
-  YulStmt.expr (YulExpr.call "datacopy" [
+  YulStmt.exprStmt (YulExpr.call "datacopy" [
     YulExpr.lit 0,
     YulExpr.call "dataoffset" [YulExpr.str "runtime"],
     YulExpr.call "datasize" [YulExpr.str "runtime"]
   ])
 
 private def yulReturnRuntime : YulStmt :=
-  YulStmt.expr (YulExpr.call "return" [
+  YulStmt.exprStmt (YulExpr.call "return" [
     YulExpr.lit 0,
     YulExpr.call "datasize" [YulExpr.str "runtime"]
   ])
 
 def initFreeMemoryPointer : YulStmt :=
-  YulStmt.expr (YulExpr.call "mstore" [
+  YulStmt.exprStmt (YulExpr.call "mstore" [
     YulExpr.lit Compiler.Constants.freeMemoryPointer,
     YulExpr.lit 128
   ])
@@ -68,22 +68,22 @@ def mappingSlotFuncAt (scratchBase : Nat) : YulStmt :=
   let keyPtr := scratchBase
   let slotPtr := scratchBase + 32
   YulStmt.funcDef "mappingSlot" ["baseSlot", "key"] ["slot"] [
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit keyPtr, YulExpr.ident "key"]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit slotPtr, YulExpr.ident "baseSlot"]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit keyPtr, YulExpr.ident "key"]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit slotPtr, YulExpr.ident "baseSlot"]),
     YulStmt.assign "slot" (YulExpr.call "keccak256" [YulExpr.lit keyPtr, YulExpr.lit 64])
   ]
 
 /-- Revert if ETH is sent to a non-payable function. -/
 def callvalueGuard : YulStmt :=
   YulStmt.if_ (YulExpr.call "callvalue" [])
-    [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
+    [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
 
 /-- Revert if calldata is shorter than expected (4-byte selector + 32 bytes per param). -/
 def calldatasizeGuard (numParams : Nat) : YulStmt :=
   YulStmt.if_ (YulExpr.call "lt" [
     YulExpr.call "calldatasize" [],
     YulExpr.lit (4 + numParams * 32)])
-    [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
+    [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
 
 def dispatchBody (payable : Bool) (label : String) (body : List YulStmt) : List YulStmt :=
   let valueGuard := if payable then [] else [callvalueGuard]
@@ -94,7 +94,7 @@ def defaultDispatchCase
     (receive : Option IREntrypoint) : List YulStmt :=
   match receive, fallback with
   | none, none =>
-      [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
+      [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
   | none, some fb =>
       dispatchBody fb.payable "fallback()" fb.body
   | some rc, none =>
@@ -103,7 +103,7 @@ def defaultDispatchCase
         YulStmt.if_ (YulExpr.ident "__is_empty_calldata")
           (dispatchBody rc.payable "receive()" rc.body),
         YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__is_empty_calldata"])
-          [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
+          [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
       ]]
   | some rc, some fb =>
       [YulStmt.block [
@@ -396,7 +396,7 @@ mutual
     | .let_ _ _ => false
     | .letMany _ _ => false
     | .assign _ _ => false
-    | .expr _ => false
+    | .exprStmt _ => false
     | .leave => false
     | .if_ _ body => stmtListContainsSwitchCaseCall target body
     | .for_ init _ post body =>
@@ -407,7 +407,7 @@ mutual
         let caseHit :=
           cases.any (fun (_, body) =>
             match body with
-            | [.expr (.call fn [])] => decide (fn = target)
+            | [.exprStmt (.call fn [])] => decide (fn = target)
             | _ => false)
         let defaultHit :=
           match default with

--- a/Compiler/CompilationModel/AbiEncoding.lean
+++ b/Compiler/CompilationModel/AbiEncoding.lean
@@ -42,14 +42,14 @@ partial def compileUnindexedAbiEncode
   | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
       let loaded := dynamicWordLoad dynamicSource srcBase
       pure ([
-        YulStmt.expr (YulExpr.call "mstore" [dstBase, normalizeEventWord ty loaded])
+        YulStmt.exprStmt (YulExpr.call "mstore" [dstBase, normalizeEventWord ty loaded])
       ], YulExpr.lit 32)
   | ParamType.bytes | ParamType.string =>
       let lenName := s!"{stem}_len"
       let paddedName := s!"{stem}_padded"
       pure ([
         YulStmt.let_ lenName (dynamicWordLoad dynamicSource srcBase),
-        YulStmt.expr (YulExpr.call "mstore" [dstBase, YulExpr.ident lenName])
+        YulStmt.exprStmt (YulExpr.call "mstore" [dstBase, YulExpr.ident lenName])
       ] ++ dynamicCopyData dynamicSource
         (YulExpr.call "add" [dstBase, YulExpr.lit 32])
         (YulExpr.call "add" [srcBase, YulExpr.lit 32])
@@ -58,7 +58,7 @@ partial def compileUnindexedAbiEncode
           YulExpr.call "add" [YulExpr.ident lenName, YulExpr.lit 31],
           YulExpr.call "not" [YulExpr.lit 31]
         ]),
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.call "add" [
             YulExpr.call "add" [dstBase, YulExpr.lit 32],
             YulExpr.ident lenName
@@ -90,7 +90,7 @@ partial def compileUnindexedAbiEncode
                 [YulStmt.let_ elemSrcName (YulExpr.call "add" [srcBase, YulExpr.lit headOffset])]
             let encStmts ←
               if eventIsDynamicType elemTy then do
-                let storeOffset := YulStmt.expr (YulExpr.call "mstore" [
+                let storeOffset := YulStmt.exprStmt (YulExpr.call "mstore" [
                   YulExpr.call "add" [dstBase, YulExpr.lit headOffset],
                   YulExpr.ident tailLenName
                 ])
@@ -125,7 +125,7 @@ partial def compileUnindexedAbiEncode
             let elemSrcName := s!"{stem}_fa{i}_src"
             let elemDstName := s!"{stem}_fa{i}_dst"
             let relName := s!"{stem}_fa{i}_rel"
-            let storeOffset := YulStmt.expr (YulExpr.call "mstore" [
+            let storeOffset := YulStmt.exprStmt (YulExpr.call "mstore" [
               YulExpr.call "add" [dstBase, YulExpr.lit (i * 32)],
               YulExpr.ident tailLenName
             ])
@@ -172,7 +172,7 @@ partial def compileUnindexedAbiEncode
   | ParamType.array elemTy =>
       let lenName := s!"{stem}_arr_len"
       let lenStmt := YulStmt.let_ lenName (dynamicWordLoad dynamicSource srcBase)
-      let storeLenStmt := YulStmt.expr (YulExpr.call "mstore" [dstBase, YulExpr.ident lenName])
+      let storeLenStmt := YulStmt.exprStmt (YulExpr.call "mstore" [dstBase, YulExpr.ident lenName])
       if eventIsDynamicType elemTy then
         let headLenName := s!"{stem}_arr_head_len"
         let tailLenName := s!"{stem}_arr_tail_len"
@@ -194,7 +194,7 @@ partial def compileUnindexedAbiEncode
             YulExpr.call "add" [srcBase, YulExpr.lit 32],
             YulExpr.ident elemRelName
           ]),
-          YulStmt.expr (YulExpr.call "mstore" [
+          YulStmt.exprStmt (YulExpr.call "mstore" [
             YulExpr.call "add" [
               YulExpr.call "add" [dstBase, YulExpr.lit 32],
               YulExpr.call "mul" [YulExpr.ident loopIdxName, YulExpr.lit 32]
@@ -256,14 +256,14 @@ partial def compileUnindexedAbiEncode
       -- ADTs are ABI-encoded as (uint8 tag, uint256 field0, ..., uint256 fieldN)
       -- Tag word: load and mask to uint8
       let tagLoaded := dynamicWordLoad dynamicSource srcBase
-      let tagStore := YulStmt.expr (YulExpr.call "mstore" [
+      let tagStore := YulStmt.exprStmt (YulExpr.call "mstore" [
         dstBase, YulExpr.call "and" [tagLoaded, YulExpr.lit 0xFF]
       ])
       -- Field words: load consecutive words from source
       let fieldStores := (List.range maxFields).map fun i =>
         let srcOff := YulExpr.call "add" [srcBase, YulExpr.lit ((i + 1) * 32)]
         let dstOff := YulExpr.call "add" [dstBase, YulExpr.lit ((i + 1) * 32)]
-        YulStmt.expr (YulExpr.call "mstore" [dstOff, dynamicWordLoad dynamicSource srcOff])
+        YulStmt.exprStmt (YulExpr.call "mstore" [dstOff, dynamicWordLoad dynamicSource srcOff])
       let totalBytes := 32 * (1 + maxFields)
       pure (tagStore :: fieldStores, YulExpr.lit totalBytes)
 
@@ -279,7 +279,7 @@ def revertWithCustomError (dynamicSource : DynamicDataSource)
   let sigBytes := bytesFromString (errorSignature errorDef)
   let storePtr := YulStmt.let_ "__err_ptr" (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
   let sigStores := (chunkBytes32 sigBytes).zipIdx.map fun (chunk, idx) =>
-    YulStmt.expr (YulExpr.call "mstore" [
+    YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.call "add" [YulExpr.ident "__err_ptr", YulExpr.lit (idx * 32)],
       YulExpr.hex (wordFromBytes chunk)
     ])
@@ -287,7 +287,7 @@ def revertWithCustomError (dynamicSource : DynamicDataSource)
     (YulExpr.call "keccak256" [YulExpr.ident "__err_ptr", YulExpr.lit sigBytes.length])
   let selectorStmt := YulStmt.let_ "__err_selector"
     (YulExpr.call "shl" [YulExpr.lit selectorShift, YulExpr.call "shr" [YulExpr.lit selectorShift, YulExpr.ident "__err_hash"]])
-  let selectorStore := YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.ident "__err_selector"])
+  let selectorStore := YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.ident "__err_selector"])
   let headSize := abiHeadSize errorDef.params
   let tailInit := YulStmt.let_ "__err_tail" (YulExpr.lit headSize)
   let argsWithSources := (errorDef.params.zip sourceArgs).zip args |>.map (fun ((ty, srcExpr), argExpr) => (ty, srcExpr, argExpr))
@@ -302,16 +302,16 @@ def revertWithCustomError (dynamicSource : DynamicDataSource)
     match ty with
     | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
         let encoded ← encodeStaticCustomErrorArg errorDef.name ty argExpr
-        pure [YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit headOffset, encoded])]
+        pure [YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit headOffset, encoded])]
     | ParamType.adt _ maxFields =>
         match srcExpr with
         | Expr.param name =>
-            let tagStore := YulStmt.expr (YulExpr.call "mstore" [
+            let tagStore := YulStmt.exprStmt (YulExpr.call "mstore" [
               YulExpr.lit headOffset,
               YulExpr.call "and" [argExpr, YulExpr.lit 0xFF]
             ])
             let fieldStores := (List.range maxFields).map fun fieldIdx =>
-              YulStmt.expr (YulExpr.call "mstore" [
+              YulStmt.exprStmt (YulExpr.call "mstore" [
                 YulExpr.lit (headOffset + (fieldIdx + 1) * 32),
                 YulExpr.ident s!"{name}_f{fieldIdx}"
               ])
@@ -321,7 +321,7 @@ def revertWithCustomError (dynamicSource : DynamicDataSource)
     | ParamType.newtypeOf _ baseType =>
         -- Newtypes erased to base type (#1727 Step 3b)
         let encoded ← encodeStaticCustomErrorArg errorDef.name baseType argExpr
-        pure [YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit headOffset, encoded])]
+        pure [YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit headOffset, encoded])]
     | ParamType.tuple _ | ParamType.fixedArray _ _ =>
         match srcExpr with
         | Expr.param name =>
@@ -331,7 +331,7 @@ def revertWithCustomError (dynamicSource : DynamicDataSource)
               let (encStmts, encLen) ←
                 compileUnindexedAbiEncode dynamicSource ty srcBase (YulExpr.ident dstName) s!"__err_arg{idx}"
               pure ([
-                YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit headOffset, YulExpr.ident "__err_tail"]),
+                YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit headOffset, YulExpr.ident "__err_tail"]),
                 YulStmt.let_ dstName (YulExpr.call "add" [YulExpr.lit 4, YulExpr.ident "__err_tail"])
               ] ++ encStmts ++ [
                 YulStmt.assign "__err_tail" (YulExpr.call "add" [YulExpr.ident "__err_tail", encLen])
@@ -339,7 +339,7 @@ def revertWithCustomError (dynamicSource : DynamicDataSource)
             else
               let leaves := staticCompositeLeaves name ty
               let stores := leaves.zipIdx.map fun ((leafTy, leafExpr), wordIdx) =>
-                YulStmt.expr (YulExpr.call "mstore" [
+                YulStmt.exprStmt (YulExpr.call "mstore" [
                   YulExpr.lit (headOffset + wordIdx * 32),
                   normalizeEventWord leafTy leafExpr
                 ])
@@ -354,14 +354,14 @@ def revertWithCustomError (dynamicSource : DynamicDataSource)
             let (encStmts, encLen) ←
               compileUnindexedAbiEncode dynamicSource ty srcBase (YulExpr.ident dstName) s!"__err_arg{idx}"
             pure ([
-              YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit headOffset, YulExpr.ident "__err_tail"]),
+              YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit headOffset, YulExpr.ident "__err_tail"]),
               YulStmt.let_ dstName (YulExpr.call "add" [YulExpr.lit 4, YulExpr.ident "__err_tail"])
             ] ++ encStmts ++ [
               YulStmt.assign "__err_tail" (YulExpr.call "add" [YulExpr.ident "__err_tail", encLen])
             ])
         | _ =>
             throw s!"Compilation error: custom error '{errorDef.name}' parameter of type {repr ty} currently requires direct parameter reference ({issue586Ref})."
-  let revertStmt := YulStmt.expr (YulExpr.call "revert" [
+  let revertStmt := YulStmt.exprStmt (YulExpr.call "revert" [
     YulExpr.lit 0,
     YulExpr.call "add" [YulExpr.lit 4, YulExpr.ident "__err_tail"]
   ])

--- a/Compiler/CompilationModel/AbiHelpers.lean
+++ b/Compiler/CompilationModel/AbiHelpers.lean
@@ -30,17 +30,17 @@ def revertWithMessage (message : String) : List YulStmt :=
   let len := bytes.length
   let paddedLen := ((len + 31) / 32) * 32
   let header := [
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit len])
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit len])
   ]
   let dataStmts :=
     (chunkBytes32 bytes).zipIdx.map fun (chunk, idx) =>
       let offset := 68 + idx * 32
       let word := wordFromBytes chunk
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit offset, YulExpr.hex word])
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit offset, YulExpr.hex word])
   let totalSize := 68 + paddedLen
-  header ++ dataStmts ++ [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit totalSize])]
+  header ++ dataStmts ++ [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit totalSize])]
 
 mutual
   def paramTypeToSolidityString : ParamType → String

--- a/Compiler/CompilationModel/AdtStorageLayout.lean
+++ b/Compiler/CompilationModel/AdtStorageLayout.lean
@@ -53,7 +53,7 @@ def compileAdtTagRead (baseSlot : YulExpr) : YulExpr :=
 
 /-- Write the tag byte to an ADT's storage base slot. -/
 def compileAdtTagWrite (baseSlot : YulExpr) (tagValue : Nat) : YulStmt :=
-  YulStmt.expr (YulExpr.call "sstore" [baseSlot, YulExpr.lit tagValue])
+  YulStmt.exprStmt (YulExpr.call "sstore" [baseSlot, YulExpr.lit tagValue])
 
 /-- Read a field from an ADT variant in storage.
     `baseSlot` is the ADT's first slot, `fieldIndex` is 0-based within the variant.
@@ -67,7 +67,7 @@ def compileAdtFieldRead (baseSlot : YulExpr) (fieldIndex : Nat) : YulExpr :=
     `baseSlot` is the ADT's first slot, `fieldIndex` is 0-based. -/
 def compileAdtFieldWrite (baseSlot : YulExpr) (fieldIndex : Nat)
     (valueExpr : YulExpr) : YulStmt :=
-  YulStmt.expr (YulExpr.call "sstore" [
+  YulStmt.exprStmt (YulExpr.call "sstore" [
     YulExpr.call "add" [baseSlot, YulExpr.lit (fieldIndex + 1)],
     valueExpr
   ])

--- a/Compiler/CompilationModel/Compile.lean
+++ b/Compiler/CompilationModel/Compile.lean
@@ -165,7 +165,7 @@ def compileStmtWithFork (fields : List Field) (events : List EventDef := [])
   | Stmt.setImmutable name value => do
       match dynamicSource with
       | .memory =>
-          pure [YulStmt.expr (YulExpr.call "setimmutable" [
+          pure [YulStmt.exprStmt (YulExpr.call "setimmutable" [
             YulExpr.call "dataoffset" [YulExpr.str "runtime"],
             YulExpr.str name,
             ← compileExprWithInternals fields dynamicSource internalFunctions value
@@ -193,13 +193,13 @@ def compileStmtWithFork (fields : List Field) (events : List EventDef := [])
             else YulExpr.call "add" [YulExpr.lit baseSlot, YulExpr.lit wordOffset]
           match f.aliasSlots with
           | [] =>
-              pure [YulStmt.expr (YulExpr.call storeBuiltin [slotExpr slot, valueExpr])]
+              pure [YulStmt.exprStmt (YulExpr.call storeBuiltin [slotExpr slot, valueExpr])]
           | _ =>
               pure [
                 YulStmt.block (
                   [YulStmt.let_ "__compat_value" valueExpr] ++
                   (slot :: f.aliasSlots).map (fun writeSlot =>
-                    YulStmt.expr (YulExpr.call storeBuiltin [
+                    YulStmt.exprStmt (YulExpr.call storeBuiltin [
                       slotExpr writeSlot,
                       YulExpr.ident "__compat_value"
                     ]))
@@ -283,10 +283,10 @@ def compileStmtWithFork (fields : List Field) (events : List EventDef := [])
         | [] => throw s!"Compilation error: internal return target is missing"
       else
         pure [
-          YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueExpr]),
-          YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
+          YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueExpr]),
+          YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
         ]
-  | Stmt.stop => return [YulStmt.expr (YulExpr.call "stop" [])]
+  | Stmt.stop => return [YulStmt.exprStmt (YulExpr.call "stop" [])]
 
   | Stmt.ite cond thenBranch elseBranch => do
       -- If/else: compile to Yul if + negated if (#179)
@@ -382,14 +382,14 @@ def compileStmtWithFork (fields : List Field) (events : List EventDef := [])
   | Stmt.internalCall functionName args => do
       -- Internal function call as statement (#181)
       let argExprs ← compileInternalCallArgs fields dynamicSource internalFunctions functionName args
-      pure [YulStmt.expr (YulExpr.call (internalFunctionYulName functionName) argExprs)]
+      pure [YulStmt.exprStmt (YulExpr.call (internalFunctionYulName functionName) argExprs)]
   | Stmt.internalCallAssign names functionName args => do
       let argExprs ← compileInternalCallArgs fields dynamicSource internalFunctions functionName args
       pure [YulStmt.letMany names (YulExpr.call (internalFunctionYulName functionName) argExprs)]
   | Stmt.externalCallBind resultVars externalName args => do
       let argExprs ← compileExprListWithInternals fields dynamicSource internalFunctions args
       if resultVars.isEmpty then
-        pure [YulStmt.expr (YulExpr.call externalName argExprs)]
+        pure [YulStmt.exprStmt (YulExpr.call externalName argExprs)]
       else
         pure [YulStmt.letMany resultVars (YulExpr.call externalName argExprs)]
   -- Try-call variant: calls {externalName}_try which returns (success, result...)
@@ -418,12 +418,12 @@ def compileStmtWithFork (fields : List Field) (events : List EventDef := [])
             YulStmt.assign name valueExpr
           pure (assigns ++ [YulStmt.leave])
       else if values.isEmpty then
-        pure [YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 0])]
+        pure [YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 0])]
       else
         let compiled ← compileExprListWithInternals fields dynamicSource internalFunctions values
         let stores := (compiled.zipIdx.map fun (valueExpr, idx) =>
-          YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit (idx * 32), valueExpr]))
-        pure (stores ++ [YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit (values.length * 32)])])
+          YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit (idx * 32), valueExpr]))
+        pure (stores ++ [YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit (values.length * 32)])])
   | Stmt.returnArray name => do
       let lenIdent := YulExpr.ident s!"{name}_length"
       let dataOffset := YulExpr.ident s!"{name}_data_offset"
@@ -440,10 +440,10 @@ def compileStmtWithFork (fields : List Field) (events : List EventDef := [])
             throw s!"Compilation error: internal array return target is missing offset/length registers"
       else
         pure ([
-          YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit 32]),
-          YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 32, lenIdent]),
+          YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit 32]),
+          YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 32, lenIdent]),
         ] ++ dynamicCopyData dynamicSource (YulExpr.lit 64) dataOffset byteLen ++ [
-          YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.call "add" [YulExpr.lit 64, byteLen]])
+          YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.call "add" [YulExpr.lit 64, byteLen]])
         ])
   | Stmt.returnBytes name => do
       let lenIdent := YulExpr.ident s!"{name}_length"
@@ -455,18 +455,18 @@ def compileStmtWithFork (fields : List Field) (events : List EventDef := [])
           YulExpr.call "not" [YulExpr.lit 31]
         ]
       pure ([
-        YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit 32]),
-        YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 32, lenIdent]),
+        YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit 32]),
+        YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 32, lenIdent]),
       ] ++ dynamicCopyData dynamicSource (YulExpr.lit 64) dataOffset lenIdent ++ [
-        YulStmt.expr (YulExpr.call "mstore" [tailOffset, YulExpr.lit 0]),
-        YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.call "add" [YulExpr.lit 64, paddedLen]])
+        YulStmt.exprStmt (YulExpr.call "mstore" [tailOffset, YulExpr.lit 0]),
+        YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.call "add" [YulExpr.lit 64, paddedLen]])
       ])
   | Stmt.returnStorageWords name => do
       let lenIdent := YulExpr.ident s!"{name}_length"
       let dataOffset := YulExpr.ident s!"{name}_data_offset"
       pure [
-        YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit 32]),
-        YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 32, lenIdent]),
+        YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit 32]),
+        YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 32, lenIdent]),
         YulStmt.for_
           [YulStmt.let_ "__i" (YulExpr.lit 0)]
           (YulExpr.call "lt" [YulExpr.ident "__i", lenIdent])
@@ -476,12 +476,12 @@ def compileStmtWithFork (fields : List Field) (events : List EventDef := [])
               dataOffset,
               YulExpr.call "mul" [YulExpr.ident "__i", YulExpr.lit 32]
             ])),
-            YulStmt.expr (YulExpr.call "mstore" [
+            YulStmt.exprStmt (YulExpr.call "mstore" [
               YulExpr.call "add" [YulExpr.lit 64, YulExpr.call "mul" [YulExpr.ident "__i", YulExpr.lit 32]],
               YulExpr.call "sload" [YulExpr.ident "__slot"]
             ])
           ],
-        YulStmt.expr (YulExpr.call "return" [
+        YulStmt.exprStmt (YulExpr.call "return" [
           YulExpr.lit 0,
           YulExpr.call "add" [YulExpr.lit 64, YulExpr.call "mul" [lenIdent, YulExpr.lit 32]]
         ])
@@ -504,7 +504,7 @@ def compileStmtWithFork (fields : List Field) (events : List EventDef := [])
                 YulExpr.ident "__return_code_offset"
               ]
             ])
-            [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])],
+            [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])],
           YulStmt.let_ "__return_code_size"
             (YulExpr.call "sub" [
               YulExpr.ident "__return_code_extent",
@@ -512,36 +512,36 @@ def compileStmtWithFork (fields : List Field) (events : List EventDef := [])
             ]),
           YulStmt.let_ "__return_code_ptr"
             (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]),
-          YulStmt.expr (YulExpr.call "extcodecopy" [
+          YulStmt.exprStmt (YulExpr.call "extcodecopy" [
             YulExpr.ident "__return_code_pointer",
             YulExpr.ident "__return_code_ptr",
             YulExpr.ident "__return_code_offset",
             YulExpr.ident "__return_code_size"
           ]),
-          YulStmt.expr (YulExpr.call "return" [
+          YulStmt.exprStmt (YulExpr.call "return" [
             YulExpr.ident "__return_code_ptr",
             YulExpr.ident "__return_code_size"
           ])
         ]
       ]
   | Stmt.mstore offset value => do
-      pure [YulStmt.expr (YulExpr.call "mstore" [
+      pure [YulStmt.exprStmt (YulExpr.call "mstore" [
         ← compileExprWithInternals fields dynamicSource internalFunctions offset,
         ← compileExprWithInternals fields dynamicSource internalFunctions value
       ])]
   | Stmt.tstore offset value => do
-      pure [YulStmt.expr (YulExpr.call "tstore" [
+      pure [YulStmt.exprStmt (YulExpr.call "tstore" [
         ← compileExprWithInternals fields dynamicSource internalFunctions offset,
         ← compileExprWithInternals fields dynamicSource internalFunctions value
       ])]
   | Stmt.calldatacopy destOffset sourceOffset size => do
-      pure [YulStmt.expr (YulExpr.call "calldatacopy" [
+      pure [YulStmt.exprStmt (YulExpr.call "calldatacopy" [
         ← compileExprWithInternals fields dynamicSource internalFunctions destOffset,
         ← compileExprWithInternals fields dynamicSource internalFunctions sourceOffset,
         ← compileExprWithInternals fields dynamicSource internalFunctions size
       ])]
   | Stmt.returndataCopy destOffset sourceOffset size => do
-      pure [YulStmt.expr (YulExpr.call "returndatacopy" [
+      pure [YulStmt.exprStmt (YulExpr.call "returndatacopy" [
         ← compileExprWithInternals fields dynamicSource internalFunctions destOffset,
         ← compileExprWithInternals fields dynamicSource internalFunctions sourceOffset,
         ← compileExprWithInternals fields dynamicSource internalFunctions size
@@ -549,12 +549,12 @@ def compileStmtWithFork (fields : List Field) (events : List EventDef := [])
   | Stmt.revertReturndata =>
       pure [YulStmt.block [
         YulStmt.let_ "__returndata_size" (YulExpr.call "returndatasize" []),
-        YulStmt.expr (YulExpr.call "returndatacopy" [
+        YulStmt.exprStmt (YulExpr.call "returndatacopy" [
           YulExpr.lit 0,
           YulExpr.lit 0,
           YulExpr.ident "__returndata_size"
         ]),
-        YulStmt.expr (YulExpr.call "revert" [
+        YulStmt.exprStmt (YulExpr.call "revert" [
           YulExpr.lit 0,
           YulExpr.ident "__returndata_size"
         ])
@@ -566,7 +566,7 @@ def compileStmtWithFork (fields : List Field) (events : List EventDef := [])
       let offsetExpr ← compileExprWithInternals fields dynamicSource internalFunctions dataOffset
       let sizeExpr ← compileExprWithInternals fields dynamicSource internalFunctions dataSize
       let logFn := s!"log{topics.length}"
-      pure [YulStmt.expr (YulExpr.call logFn ([offsetExpr, sizeExpr] ++ topicExprs))]
+      pure [YulStmt.exprStmt (YulExpr.call logFn ([offsetExpr, sizeExpr] ++ topicExprs))]
   -- ADT pattern match: compile to YulStmt.switch on tag value (#1727 Steps 5c/5d)
   | Stmt.matchAdt adtName scrutinee branches => do
       let def_ ← lookupAdtTypeDef adtTypes adtName
@@ -587,7 +587,7 @@ def compileStmtWithFork (fields : List Field) (events : List EventDef := [])
       let cases ← compileMatchAdtBranches fields events errors dynamicSource internalRetNames isInternal
         inScopeNames adtTypes targetFork internalFunctions def_ baseSlot branches
       -- Default case: revert (should be unreachable for exhaustive matches)
-      let defaultCase := [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
+      let defaultCase := [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
       pure [YulStmt.switch scrutineeExpr cases (some defaultCase)]
 
 def compileMatchAdtBranches (fields : List Field) (events : List EventDef)

--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -561,27 +561,45 @@ def compileGuardedFunctionSpec (fields : List Field) (events : List EventDef)
   let irFn ← compileFunctionSpec fields events errors adtTypes sel fnSpec (targetFork := targetFork) internalFunctions
   attachNonReentrantGuard fields fnSpec irFn
 
-private partial def collectTemplateIntrinsicsFromExpr (expr : Expr) :
+def collectTemplateIntrinsicsFromExpr (expr : Expr) :
     List (String × Verity.Core.Intrinsics.YulLowering) :=
   let here :=
     match expr with
     | .intrinsic name lowering@(.template ..) _ _ => [(name, lowering)]
     | _ => []
-  here ++ expr.children.flatMap collectTemplateIntrinsicsFromExpr
+  here ++ expr.children.attach.flatMap (fun ⟨child, hchild⟩ =>
+    have := Expr.children_sizeOf_lt expr child hchild
+    collectTemplateIntrinsicsFromExpr child)
+termination_by sizeOf expr
 
-private partial def collectTemplateIntrinsicsFromStmt (stmt : Stmt) :
+def collectTemplateIntrinsicsFromStmt (stmt : Stmt) :
     List (String × Verity.Core.Intrinsics.YulLowering) :=
   let fromExprs :=
     stmt.directMetadata.subexpressions.flatMap collectTemplateIntrinsicsFromExpr
   let fromChildren :=
-    stmt.childLists.flatMap (fun body => body.flatMap collectTemplateIntrinsicsFromStmt)
+    stmt.childLists.attach.flatMap (fun ⟨body, hbody⟩ =>
+      body.attach.flatMap (fun ⟨child, hchild⟩ =>
+        have := Stmt.childLists_sizeOf_lt stmt body hbody child hchild
+        collectTemplateIntrinsicsFromStmt child))
   fromExprs ++ fromChildren
+termination_by sizeOf stmt
+decreasing_by exact Nat.lt_trans this.1 this.2
 
-private def collectTemplateIntrinsicsFromStmts (stmts : List Stmt) :
+def collectTemplateIntrinsicsFromStmts (stmts : List Stmt) :
     List (String × Verity.Core.Intrinsics.YulLowering) :=
   stmts.flatMap collectTemplateIntrinsicsFromStmt
 
-private def addTemplateIntrinsic
+def templateIntrinsicItems (spec : CompilationModel) :
+    List (String × Verity.Core.Intrinsics.YulLowering) :=
+  let functionItems :=
+    spec.functions.flatMap (fun fn => collectTemplateIntrinsicsFromStmts fn.body)
+  let constructorItems :=
+    match spec.constructor with
+    | none => []
+    | some ctor => collectTemplateIntrinsicsFromStmts ctor.body
+  functionItems ++ constructorItems
+
+def addTemplateIntrinsic
     (acc : List (String × Verity.Core.Intrinsics.YulLowering))
     (item : String × Verity.Core.Intrinsics.YulLowering) :
     Except String (List (String × Verity.Core.Intrinsics.YulLowering)) :=
@@ -593,20 +611,14 @@ private def addTemplateIntrinsic
       else
         throw s!"Compilation error: intrinsic template '{item.1}' is used with conflicting Yul template bodies"
 
-private def dedupTemplateIntrinsics
+def dedupTemplateIntrinsics
     (items : List (String × Verity.Core.Intrinsics.YulLowering)) :
     Except String (List (String × Verity.Core.Intrinsics.YulLowering)) :=
   items.foldlM addTemplateIntrinsic []
 
-private def compileTemplateIntrinsicHelpers (spec : CompilationModel) :
+def compileTemplateIntrinsicHelpers (spec : CompilationModel) :
     Except String (List YulStmt) := do
-  let functionItems :=
-    spec.functions.flatMap (fun fn => collectTemplateIntrinsicsFromStmts fn.body)
-  let constructorItems :=
-    match spec.constructor with
-    | none => []
-    | some ctor => collectTemplateIntrinsicsFromStmts ctor.body
-  let items ← dedupTemplateIntrinsics (functionItems ++ constructorItems)
+  let items ← dedupTemplateIntrinsics (templateIntrinsicItems spec)
   items.mapM fun (name, lowering) =>
     match Verity.Core.Intrinsics.YulLowering.templateFuncDef? name lowering with
     | some funcDef => pure funcDef
@@ -690,7 +702,11 @@ def compileValidatedCore (spec : CompilationModel) (selectors : List Nat)
       [dynamicBytesEqCalldataHelper, dynamicBytesEqMemoryHelper]
     else
       []
-  let templateIntrinsicHelpers ← compileTemplateIntrinsicHelpers spec
+  let templateIntrinsicHelpers ←
+    if (templateIntrinsicItems spec).isEmpty then
+      pure []
+    else
+      compileTemplateIntrinsicHelpers spec
   let checkedArithmeticHelpers :=
     if checkedArithmeticHelpersRequired then
       [ panicError0x11Helper

--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -222,9 +222,9 @@ def nonReentrantGuardPrologue (fields : List Field) (lockField : String) :
       let revertOnReentry :=
         YulStmt.if_
           (YulExpr.call "eq" [YulExpr.call "tload" [lockSlot], YulExpr.lit 1])
-          [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
+          [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
       let acquire :=
-        YulStmt.expr (YulExpr.call "tstore" [lockSlot, YulExpr.lit 1])
+        YulStmt.exprStmt (YulExpr.call "tstore" [lockSlot, YulExpr.lit 1])
       pure [revertOnReentry, acquire]
 
 /-- Wrap an already-compiled `IRFunction` with the `nonreentrant(lockField)`
@@ -256,7 +256,7 @@ def attachNonReentrantGuard (fields : List Field) (spec : FunctionSpec)
       let releaseSlot := match findFieldWithResolvedSlot fields lockField with
         | some (_, s) => s
         | none => 0   -- unreachable after prologue validation
-      let release := YulStmt.expr (YulExpr.call "tstore" [YulExpr.lit releaseSlot, YulExpr.lit 0])
+      let release := YulStmt.exprStmt (YulExpr.call "tstore" [YulExpr.lit releaseSlot, YulExpr.lit 0])
       pure { irFn with body := prefixLoads ++ guardStmts ++ suffix ++ [release] }
 
 private def compileSpecialEntrypoint (fields : List Field) (events : List EventDef)
@@ -275,7 +275,7 @@ private def compileSpecialEntrypoint (fields : List Field) (events : List EventD
         let releaseSlot := match findFieldWithResolvedSlot fields lockField with
           | some (_, s) => s
           | none => 0
-        let release := YulStmt.expr (YulExpr.call "tstore" [YulExpr.lit releaseSlot, YulExpr.lit 0])
+        let release := YulStmt.exprStmt (YulExpr.call "tstore" [YulExpr.lit releaseSlot, YulExpr.lit 0])
         pure (guardStmts ++ bodyChunks ++ [release])
   pure {
     payable := spec.isPayable
@@ -561,6 +561,57 @@ def compileGuardedFunctionSpec (fields : List Field) (events : List EventDef)
   let irFn ← compileFunctionSpec fields events errors adtTypes sel fnSpec (targetFork := targetFork) internalFunctions
   attachNonReentrantGuard fields fnSpec irFn
 
+private partial def collectTemplateIntrinsicsFromExpr (expr : Expr) :
+    List (String × Verity.Core.Intrinsics.YulLowering) :=
+  let here :=
+    match expr with
+    | .intrinsic name lowering@(.template ..) _ _ => [(name, lowering)]
+    | _ => []
+  here ++ expr.children.flatMap collectTemplateIntrinsicsFromExpr
+
+private partial def collectTemplateIntrinsicsFromStmt (stmt : Stmt) :
+    List (String × Verity.Core.Intrinsics.YulLowering) :=
+  let fromExprs :=
+    stmt.directMetadata.subexpressions.flatMap collectTemplateIntrinsicsFromExpr
+  let fromChildren :=
+    stmt.childLists.flatMap (fun body => body.flatMap collectTemplateIntrinsicsFromStmt)
+  fromExprs ++ fromChildren
+
+private def collectTemplateIntrinsicsFromStmts (stmts : List Stmt) :
+    List (String × Verity.Core.Intrinsics.YulLowering) :=
+  stmts.flatMap collectTemplateIntrinsicsFromStmt
+
+private def addTemplateIntrinsic
+    (acc : List (String × Verity.Core.Intrinsics.YulLowering))
+    (item : String × Verity.Core.Intrinsics.YulLowering) :
+    Except String (List (String × Verity.Core.Intrinsics.YulLowering)) :=
+  match acc.find? (fun prev => prev.1 == item.1) with
+  | none => pure (acc ++ [item])
+  | some prev =>
+      if prev.2 == item.2 then
+        pure acc
+      else
+        throw s!"Compilation error: intrinsic template '{item.1}' is used with conflicting Yul template bodies"
+
+private def dedupTemplateIntrinsics
+    (items : List (String × Verity.Core.Intrinsics.YulLowering)) :
+    Except String (List (String × Verity.Core.Intrinsics.YulLowering)) :=
+  items.foldlM addTemplateIntrinsic []
+
+private def compileTemplateIntrinsicHelpers (spec : CompilationModel) :
+    Except String (List YulStmt) := do
+  let functionItems :=
+    spec.functions.flatMap (fun fn => collectTemplateIntrinsicsFromStmts fn.body)
+  let constructorItems :=
+    match spec.constructor with
+    | none => []
+    | some ctor => collectTemplateIntrinsicsFromStmts ctor.body
+  let items ← dedupTemplateIntrinsics (functionItems ++ constructorItems)
+  items.mapM fun (name, lowering) =>
+    match Verity.Core.Intrinsics.YulLowering.templateFuncDef? name lowering with
+    | some funcDef => pure funcDef
+    | none => throw s!"Compilation error: intrinsic {name} is not a template lowering"
+
 def compileValidatedCore (spec : CompilationModel) (selectors : List Nat)
     (targetFork : HardFork := .cancun) : Except String IRContract := do
   let fields := applySlotAliasRanges spec.fields spec.slotAliasRanges
@@ -639,6 +690,7 @@ def compileValidatedCore (spec : CompilationModel) (selectors : List Nat)
       [dynamicBytesEqCalldataHelper, dynamicBytesEqMemoryHelper]
     else
       []
+  let templateIntrinsicHelpers ← compileTemplateIntrinsicHelpers spec
   let checkedArithmeticHelpers :=
     if checkedArithmeticHelpersRequired then
       [ panicError0x11Helper
@@ -662,7 +714,9 @@ def compileValidatedCore (spec : CompilationModel) (selectors : List Nat)
     fallbackEntrypoint := fallbackEntrypoint
     receiveEntrypoint := receiveEntrypoint
     usesMapping := mappingHelpersRequired
-    internalFunctions := arrayElementHelpers ++ storageArrayElementHelpers ++ dynamicBytesEqHelpers ++ checkedArithmeticHelpers ++ internalFuncDefs
+    internalFunctions :=
+      arrayElementHelpers ++ storageArrayElementHelpers ++ dynamicBytesEqHelpers ++
+        checkedArithmeticHelpers ++ templateIntrinsicHelpers ++ internalFuncDefs
   }
 
 /-- Compile a `CompilationModel` to an `IRContract`.

--- a/Compiler/CompilationModel/DynamicData.lean
+++ b/Compiler/CompilationModel/DynamicData.lean
@@ -123,12 +123,12 @@ def panicError0x12HelperName : String :=
     4-byte selector `0x4e487b71` followed by one ABI word containing `code`. -/
 def solidityPanicPayload (code : Nat) : List YulStmt :=
   [
-    YulStmt.expr (YulExpr.call "mstore" [
+    YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit 0,
       YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex 0x4e487b71]
     ]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit code]),
-    YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 36])
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit code]),
+    YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 36])
   ]
 
 def panicErrorHelper (helperName : String) (code : Nat) : YulStmt :=
@@ -144,14 +144,14 @@ def checkedAddUint256Helper : YulStmt :=
   YulStmt.funcDef checkedAddUint256HelperName ["x", "y"] ["sum"] [
     YulStmt.assign "sum" (YulExpr.call "add" [YulExpr.ident "x", YulExpr.ident "y"]),
     YulStmt.if_ (YulExpr.call "gt" [YulExpr.ident "x", YulExpr.ident "sum"]) [
-      YulStmt.expr (YulExpr.call panicError0x11HelperName [])
+      YulStmt.exprStmt (YulExpr.call panicError0x11HelperName [])
     ]
   ]
 
 def checkedSubUint256Helper : YulStmt :=
   YulStmt.funcDef checkedSubUint256HelperName ["x", "y"] ["diff"] [
     YulStmt.if_ (YulExpr.call "gt" [YulExpr.ident "y", YulExpr.ident "x"]) [
-      YulStmt.expr (YulExpr.call panicError0x11HelperName [])
+      YulStmt.exprStmt (YulExpr.call panicError0x11HelperName [])
     ],
     YulStmt.assign "diff" (YulExpr.call "sub" [YulExpr.ident "x", YulExpr.ident "y"])
   ]
@@ -168,14 +168,14 @@ def checkedMulUint256Helper : YulStmt :=
         ]
       ]
     ]) [
-      YulStmt.expr (YulExpr.call panicError0x11HelperName [])
+      YulStmt.exprStmt (YulExpr.call panicError0x11HelperName [])
     ]
   ]
 
 def checkedDivUint256Helper : YulStmt :=
   YulStmt.funcDef checkedDivUint256HelperName ["x", "y"] ["quotient"] [
     YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "y"]) [
-      YulStmt.expr (YulExpr.call panicError0x12HelperName [])
+      YulStmt.exprStmt (YulExpr.call panicError0x12HelperName [])
     ],
     YulStmt.assign "quotient" (YulExpr.call "div" [YulExpr.ident "x", YulExpr.ident "y"])
   ]
@@ -185,7 +185,7 @@ private def checkedArrayElementHelper (helperName loadOp : String) : YulStmt :=
     YulStmt.if_ (YulExpr.call "iszero" [
       YulExpr.call "lt" [YulExpr.ident "index", YulExpr.ident "length"]
     ]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ],
     YulStmt.assign "word" (YulExpr.call loadOp [
       YulExpr.call "add" [
@@ -212,7 +212,7 @@ private def checkedArrayElementWordHelper (helperName loadOp : String) : YulStmt
     YulStmt.if_ (YulExpr.call "iszero" [
       YulExpr.call "lt" [YulExpr.ident "index", YulExpr.ident "length"]
     ]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ],
     YulStmt.assign "word" (YulExpr.call loadOp [
       YulExpr.call "add" [
@@ -245,7 +245,7 @@ private def checkedArrayElementDynamicWordHelper (helperName loadOp : String) (s
           YulExpr.ident "__element_word_pos",
           YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
         ]) [
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
         ]]
     | none => []
   YulStmt.funcDef helperName ["data_offset", "length", "index", "word_offset"] ["word"] (
@@ -253,11 +253,11 @@ private def checkedArrayElementDynamicWordHelper (helperName loadOp : String) (s
       YulStmt.if_ (YulExpr.call "iszero" [
         YulExpr.call "lt" [YulExpr.ident "index", YulExpr.ident "length"]
       ]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
       YulStmt.let_ "__element_rel_offset" (YulExpr.call loadOp [elementOffsetSlot]),
       YulStmt.if_ (YulExpr.call "lt" [YulExpr.ident "__element_rel_offset", offsetTableBytes]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
       YulStmt.let_ "__element_word_pos" wordPos
     ] ++ sizeCheck ++ [
@@ -292,7 +292,7 @@ private def checkedArrayElementDynamicDataOffsetHelper
           YulExpr.ident "__element_head_pos",
           YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
         ]) [
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
         ]]
     | none => []
   YulStmt.funcDef helperName ["data_offset", "length", "index"] ["word"] (
@@ -300,11 +300,11 @@ private def checkedArrayElementDynamicDataOffsetHelper
       YulStmt.if_ (YulExpr.call "iszero" [
         YulExpr.call "lt" [YulExpr.ident "index", YulExpr.ident "length"]
       ]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
       YulStmt.let_ "__element_rel_offset" (YulExpr.call loadOp [elementOffsetSlot]),
       YulStmt.if_ (YulExpr.call "lt" [YulExpr.ident "__element_rel_offset", offsetTableBytes]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
       YulStmt.let_ "__element_head_pos" elementHeadPos
     ] ++ sizeCheck ++ [
@@ -342,7 +342,7 @@ private def checkedParamDynamicHeadWordHelper (helperName loadOp : String) (size
           YulExpr.ident "__head_word_pos",
           YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
         ]) [
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
         ]]
     | none => []
   YulStmt.funcDef helperName ["data_offset", "word_offset"] ["word"] (
@@ -376,7 +376,7 @@ private def checkedParamDynamicMemberLengthHelper
           YulExpr.ident "__member_data_pos",
           YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
         ]) [
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
         ]]
     | none => []
   YulStmt.funcDef helperName ["data_offset", "word_offset"] ["word"] (
@@ -416,7 +416,7 @@ private def checkedParamDynamicMemberDataOffsetHelper
           YulExpr.ident "__member_data_pos",
           YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
         ]) [
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
         ]]
     | none => []
   YulStmt.funcDef helperName ["data_offset", "word_offset"] ["word"] (
@@ -463,7 +463,7 @@ private def checkedParamDynamicMemberElementHelper
           YulExpr.ident "__word_pos",
           YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
         ]) [
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
         ]]
     | none => []
   YulStmt.funcDef helperName ["data_offset", "word_offset", "inner_index"] ["word"] (
@@ -474,7 +474,7 @@ private def checkedParamDynamicMemberElementHelper
       YulStmt.if_ (YulExpr.call "iszero" [
         YulExpr.call "lt" [YulExpr.ident "inner_index", YulExpr.ident "__member_length"]
       ]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
       YulStmt.let_ "__word_pos" wordPos
     ] ++ sizeCheck ++ [
@@ -537,7 +537,7 @@ private def checkedArrayElementDynamicMemberLengthHelper
           YulExpr.ident "__member_data_pos",
           YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
         ]) [
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
         ]]
     | none => []
   YulStmt.funcDef helperName ["data_offset", "length", "index", "word_offset"] ["word"] (
@@ -545,11 +545,11 @@ private def checkedArrayElementDynamicMemberLengthHelper
       YulStmt.if_ (YulExpr.call "iszero" [
         YulExpr.call "lt" [YulExpr.ident "index", YulExpr.ident "length"]
       ]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
       YulStmt.let_ "__element_rel_offset" (YulExpr.call loadOp [elementOffsetSlot]),
       YulStmt.if_ (YulExpr.call "lt" [YulExpr.ident "__element_rel_offset", offsetTableBytes]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
       YulStmt.let_ "__element_head_pos" elementHeadPos,
       YulStmt.let_ "__member_rel_offset" (YulExpr.call loadOp [memberHeadSlot]),
@@ -601,7 +601,7 @@ private def checkedArrayElementDynamicMemberDataOffsetHelper
           YulExpr.ident "__member_data_pos",
           YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
         ]) [
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
         ]]
     | none => []
   YulStmt.funcDef helperName ["data_offset", "length", "index", "word_offset"] ["word"] (
@@ -609,11 +609,11 @@ private def checkedArrayElementDynamicMemberDataOffsetHelper
       YulStmt.if_ (YulExpr.call "iszero" [
         YulExpr.call "lt" [YulExpr.ident "index", YulExpr.ident "length"]
       ]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
       YulStmt.let_ "__element_rel_offset" (YulExpr.call loadOp [elementOffsetSlot]),
       YulStmt.if_ (YulExpr.call "lt" [YulExpr.ident "__element_rel_offset", offsetTableBytes]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
       YulStmt.let_ "__element_head_pos" elementHeadPos,
       YulStmt.let_ "__member_rel_offset" (YulExpr.call loadOp [memberHeadSlot]),
@@ -683,7 +683,7 @@ private def checkedArrayElementDynamicMemberElementHelper
           YulExpr.ident "__word_pos",
           YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
         ]) [
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
         ]]
     | none => []
   YulStmt.funcDef helperName ["data_offset", "length", "index", "word_offset", "inner_index"] ["word"] (
@@ -691,11 +691,11 @@ private def checkedArrayElementDynamicMemberElementHelper
       YulStmt.if_ (YulExpr.call "iszero" [
         YulExpr.call "lt" [YulExpr.ident "index", YulExpr.ident "length"]
       ]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
       YulStmt.let_ "__element_rel_offset" (YulExpr.call loadOp [elementOffsetSlot]),
       YulStmt.if_ (YulExpr.call "lt" [YulExpr.ident "__element_rel_offset", offsetTableBytes]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
       YulStmt.let_ "__element_head_pos" elementHeadPos,
       YulStmt.let_ "__member_rel_offset" (YulExpr.call loadOp [memberHeadSlot]),
@@ -704,7 +704,7 @@ private def checkedArrayElementDynamicMemberElementHelper
       YulStmt.if_ (YulExpr.call "iszero" [
         YulExpr.call "lt" [YulExpr.ident "inner_index", YulExpr.ident "__member_length"]
       ]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
       YulStmt.let_ "__word_pos" wordPos
     ] ++ sizeCheck ++ [
@@ -752,7 +752,7 @@ def fullMulDivHelper : YulStmt :=
     -- Short-circuit when the product fits in 256 bits.
     YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "prod1"]) [
       YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "denominator"]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
       YulStmt.assign "result" (YulExpr.call "div" [
         YulExpr.ident "prod0", YulExpr.ident "denominator"
@@ -763,7 +763,7 @@ def fullMulDivHelper : YulStmt :=
     YulStmt.if_ (YulExpr.call "iszero" [
       YulExpr.call "gt" [YulExpr.ident "denominator", YulExpr.ident "prod1"]
     ]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ],
     -- 512-by-256 division (Knuth Algorithm D / OpenZeppelin Math.mulDiv).
     -- Step 1: subtract the remainder from [prod1 prod0].
@@ -887,9 +887,9 @@ def checkedStorageArrayElementHelper : YulStmt :=
     YulStmt.if_ (YulExpr.call "iszero" [
       YulExpr.call "lt" [YulExpr.ident "index", YulExpr.ident "__array_len"]
     ]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ],
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.ident "slot"]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.ident "slot"]),
     YulStmt.let_ "__array_base" (YulExpr.call "keccak256" [YulExpr.lit 0, YulExpr.lit 32]),
     YulStmt.assign "word" (YulExpr.call "sload" [
       YulExpr.call "add" [YulExpr.ident "__array_base", YulExpr.ident "index"]
@@ -938,13 +938,13 @@ def dynamicCopyData (source : DynamicDataSource)
     (destOffset sourceOffset len : YulExpr) : List YulStmt :=
   match source with
   | .calldata =>
-      [YulStmt.expr (YulExpr.call "calldatacopy" [destOffset, sourceOffset, len])]
+      [YulStmt.exprStmt (YulExpr.call "calldatacopy" [destOffset, sourceOffset, len])]
   | .memory =>
       [YulStmt.for_
         [YulStmt.let_ "__copy_i" (YulExpr.lit 0)]
         (YulExpr.call "lt" [YulExpr.ident "__copy_i", len])
         [YulStmt.assign "__copy_i" (YulExpr.call "add" [YulExpr.ident "__copy_i", YulExpr.lit 32])]
-        [YulStmt.expr (YulExpr.call "mstore" [
+        [YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.call "add" [destOffset, YulExpr.ident "__copy_i"],
           YulExpr.call "mload" [YulExpr.call "add" [sourceOffset, YulExpr.ident "__copy_i"]]
         ])]]

--- a/Compiler/CompilationModel/EventAbiHelpers.lean
+++ b/Compiler/CompilationModel/EventAbiHelpers.lean
@@ -70,7 +70,7 @@ partial def compileIndexedInPlaceEncoding
   | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.uint16 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
       let loaded := dynamicWordLoad dynamicSource srcBase
       pure ([
-        YulStmt.expr (YulExpr.call "mstore" [dstBase, normalizeEventWord ty loaded])
+        YulStmt.exprStmt (YulExpr.call "mstore" [dstBase, normalizeEventWord ty loaded])
       ], YulExpr.lit 32)
   | ParamType.bytes | ParamType.string =>
       let lenName := s!"{stem}_len"
@@ -85,7 +85,7 @@ partial def compileIndexedInPlaceEncoding
           YulExpr.call "add" [YulExpr.ident lenName, YulExpr.lit 31],
           YulExpr.call "not" [YulExpr.lit 31]
         ]),
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.call "add" [dstBase, YulExpr.ident lenName],
           YulExpr.lit 0
         ])
@@ -203,13 +203,13 @@ partial def compileIndexedInPlaceEncoding
   | ParamType.adt _ maxFields =>
       -- ADTs: ABI-encode as (uint8 tag, uint256 field0, ..., uint256 fieldN)
       let tagLoaded := dynamicWordLoad dynamicSource srcBase
-      let tagStore := YulStmt.expr (YulExpr.call "mstore" [
+      let tagStore := YulStmt.exprStmt (YulExpr.call "mstore" [
         dstBase, YulExpr.call "and" [tagLoaded, YulExpr.lit 0xFF]
       ])
       let fieldStores := (List.range maxFields).map fun i =>
         let srcOff := YulExpr.call "add" [srcBase, YulExpr.lit ((i + 1) * 32)]
         let dstOff := YulExpr.call "add" [dstBase, YulExpr.lit ((i + 1) * 32)]
-        YulStmt.expr (YulExpr.call "mstore" [dstOff, dynamicWordLoad dynamicSource srcOff])
+        YulStmt.exprStmt (YulExpr.call "mstore" [dstOff, dynamicWordLoad dynamicSource srcOff])
       let totalBytes := 32 * (1 + maxFields)
       pure (tagStore :: fieldStores, YulExpr.lit totalBytes)
   | ParamType.newtypeOf _ baseType =>

--- a/Compiler/CompilationModel/EventEmission.lean
+++ b/Compiler/CompilationModel/EventEmission.lean
@@ -97,7 +97,7 @@ def scalarEventUnindexedStoresFrom
   match unindexed with
   | [] => []
   | (p, _, argExpr) :: rest =>
-      YulStmt.expr (YulExpr.call "mstore" [
+      YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.call "add" [YulExpr.ident "__evt_ptr", YulExpr.lit headOffset],
         normalizeEventWord p.ty argExpr
       ]) :: scalarEventUnindexedStoresFrom rest (headOffset + eventHeadWordSize p.ty)
@@ -115,12 +115,12 @@ def scalarEventIndexedTopicParts
 
 def adtEventWordStores (basePtr : YulExpr) (sourceName : String)
     (maxFields : Nat) (tagExpr : YulExpr) : List YulStmt :=
-  let tagStore := YulStmt.expr (YulExpr.call "mstore" [
+  let tagStore := YulStmt.exprStmt (YulExpr.call "mstore" [
     basePtr,
     normalizeEventWord ParamType.uint8 tagExpr
   ])
   let fieldStores := (List.range maxFields).map fun fieldIdx =>
-    YulStmt.expr (YulExpr.call "mstore" [
+    YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.call "add" [basePtr, YulExpr.lit ((fieldIdx + 1) * 32)],
       YulExpr.ident s!"{sourceName}_f{fieldIdx}"
     ])
@@ -143,7 +143,7 @@ def compileStaticCompositeEventWordStores
   | Expr.param name =>
       let leaves := staticCompositeLeaves name ty
       pure <| leaves.zipIdx.map fun ((leafTy, leafExpr), wordIdx) =>
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.call "add" [basePtr, YulExpr.lit (wordIdx * 32)],
           normalizeEventWord leafTy leafExpr
         ])
@@ -153,7 +153,7 @@ def compileStaticCompositeEventWordStores
           argExpr,
           YulExpr.lit leafOffset
         ])
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.call "add" [basePtr, YulExpr.lit leafOffset],
           normalizeEventWord leafTy loadExpr
         ])
@@ -171,7 +171,7 @@ def compileScalarEmitFromCompiledArgs
   let freeMemPtr := YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]
   let storePtr := YulStmt.let_ "__evt_ptr" freeMemPtr
   let sigStores := (chunkBytes32 sigBytes).zipIdx.map fun (chunk, idx) =>
-    YulStmt.expr (YulExpr.call "mstore" [
+    YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.call "add" [YulExpr.ident "__evt_ptr", YulExpr.lit (idx * 32)],
       YulExpr.hex (wordFromBytes chunk)
     ])
@@ -182,7 +182,7 @@ def compileScalarEmitFromCompiledArgs
   let dataSizeExpr := YulExpr.lit (eventUnindexedHeadSize unindexed)
   let logFn := eventLogFunction indexed.length
   let logArgs := eventLogArgs dataSizeExpr indexedTopicParts
-  let logStmt := YulStmt.expr (YulExpr.call logFn logArgs)
+  let logStmt := YulStmt.exprStmt (YulExpr.call logFn logArgs)
   [YulStmt.block ([storePtr] ++ sigStores ++ [topic0Store] ++
     unindexedStores ++ [logStmt])]
 
@@ -211,7 +211,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
   let freeMemPtr := YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]
   let storePtr := YulStmt.let_ "__evt_ptr" freeMemPtr
   let sigStores := (chunkBytes32 sigBytes).zipIdx.map fun (chunk, idx) =>
-    YulStmt.expr (YulExpr.call "mstore" [
+    YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.call "add" [YulExpr.ident "__evt_ptr", YulExpr.lit (idx * 32)],
       YulExpr.hex (wordFromBytes chunk)
     ])
@@ -240,10 +240,10 @@ def compileEmit (fields : List Field) (events : List EventDef)
                   let dstName := s!"__evt_arg{argIdx}_dst"
                   let paddedName := s!"__evt_arg{argIdx}_padded"
                   pure ([
-                    YulStmt.expr (YulExpr.call "mstore" [curHeadPtr, YulExpr.ident "__evt_data_tail"]),
+                    YulStmt.exprStmt (YulExpr.call "mstore" [curHeadPtr, YulExpr.ident "__evt_data_tail"]),
                     YulStmt.let_ lenName (YulExpr.ident s!"{name}_length"),
                     YulStmt.let_ dstName (YulExpr.call "add" [YulExpr.ident "__evt_ptr", YulExpr.ident "__evt_data_tail"]),
-                    YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident dstName, YulExpr.ident lenName]),
+                    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.ident dstName, YulExpr.ident lenName]),
                   ] ++ dynamicCopyData dynamicSource
                     (YulExpr.call "add" [YulExpr.ident dstName, YulExpr.lit 32])
                     (YulExpr.ident s!"{name}_data_offset")
@@ -252,7 +252,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
                       YulExpr.call "add" [YulExpr.ident lenName, YulExpr.lit 31],
                       YulExpr.call "not" [YulExpr.lit 31]
                     ]),
-                    YulStmt.expr (YulExpr.call "mstore" [
+                    YulStmt.exprStmt (YulExpr.call "mstore" [
                       YulExpr.call "add" [
                         YulExpr.call "add" [YulExpr.ident dstName, YulExpr.lit 32],
                         YulExpr.ident lenName
@@ -282,10 +282,10 @@ def compileEmit (fields : List Field) (events : List EventDef)
                       let elemDstName := s!"__evt_arg{argIdx}_elem_dst"
                       let elemPaddedName := s!"__evt_arg{argIdx}_elem_padded"
                       pure ([
-                        YulStmt.expr (YulExpr.call "mstore" [curHeadPtr, YulExpr.ident "__evt_data_tail"]),
+                        YulStmt.exprStmt (YulExpr.call "mstore" [curHeadPtr, YulExpr.ident "__evt_data_tail"]),
                         YulStmt.let_ lenName (YulExpr.ident s!"{name}_length"),
                         YulStmt.let_ dstName (YulExpr.call "add" [YulExpr.ident "__evt_ptr", YulExpr.ident "__evt_data_tail"]),
-                        YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident dstName, YulExpr.ident lenName]),
+                        YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.ident dstName, YulExpr.ident lenName]),
                         YulStmt.let_ headLenName (YulExpr.call "mul" [YulExpr.ident lenName, YulExpr.lit 32]),
                         YulStmt.let_ tailLenName (YulExpr.ident headLenName),
                         YulStmt.for_
@@ -303,7 +303,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
                             ]),
                             YulStmt.let_ elemLenName (dynamicWordLoad dynamicSource (YulExpr.ident elemLenPosName)),
                             YulStmt.let_ elemDataName (YulExpr.call "add" [YulExpr.ident elemLenPosName, YulExpr.lit 32]),
-                            YulStmt.expr (YulExpr.call "mstore" [
+                            YulStmt.exprStmt (YulExpr.call "mstore" [
                               YulExpr.call "add" [
                                 YulExpr.call "add" [YulExpr.ident dstName, YulExpr.lit 32],
                                 YulExpr.call "mul" [YulExpr.ident loopIndexName, YulExpr.lit 32]
@@ -314,7 +314,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
                               YulExpr.call "add" [YulExpr.ident dstName, YulExpr.lit 32],
                               YulExpr.ident tailLenName
                             ]),
-                            YulStmt.expr (YulExpr.call "mstore" [
+                            YulStmt.exprStmt (YulExpr.call "mstore" [
                               YulExpr.ident elemDstName,
                               YulExpr.ident elemLenName
                             ])
@@ -326,7 +326,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
                               YulExpr.call "add" [YulExpr.ident elemLenName, YulExpr.lit 31],
                               YulExpr.call "not" [YulExpr.lit 31]
                             ]),
-                            YulStmt.expr (YulExpr.call "mstore" [
+                            YulStmt.exprStmt (YulExpr.call "mstore" [
                               YulExpr.call "add" [
                                 YulExpr.call "add" [YulExpr.ident elemDstName, YulExpr.lit 32],
                                 YulExpr.ident elemLenName
@@ -362,15 +362,15 @@ def compileEmit (fields : List Field) (events : List EventDef)
                           YulExpr.ident elemBaseName,
                           YulExpr.lit leafOffset
                         ])
-                        YulStmt.expr (YulExpr.call "mstore" [
+                        YulStmt.exprStmt (YulExpr.call "mstore" [
                           YulExpr.call "add" [YulExpr.ident elemOutBaseName, YulExpr.lit leafOffset],
                           normalizeEventWord leafTy loadExpr
                         ])
                     pure ([
-                      YulStmt.expr (YulExpr.call "mstore" [curHeadPtr, YulExpr.ident "__evt_data_tail"]),
+                      YulStmt.exprStmt (YulExpr.call "mstore" [curHeadPtr, YulExpr.ident "__evt_data_tail"]),
                       YulStmt.let_ lenName source.lengthExpr,
                       YulStmt.let_ dstName (YulExpr.call "add" [YulExpr.ident "__evt_ptr", YulExpr.ident "__evt_data_tail"]),
-                      YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident dstName, YulExpr.ident lenName]),
+                      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.ident dstName, YulExpr.ident lenName]),
                       YulStmt.let_ byteLenName (YulExpr.call "mul" [YulExpr.ident lenName, YulExpr.lit elemWordSize]),
                       YulStmt.for_
                         [YulStmt.let_ loopIndexName (YulExpr.lit 0)]
@@ -390,7 +390,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
                         YulExpr.call "add" [YulExpr.ident byteLenName, YulExpr.lit 31],
                         YulExpr.call "not" [YulExpr.lit 31]
                       ]),
-                      YulStmt.expr (YulExpr.call "mstore" [
+                      YulStmt.exprStmt (YulExpr.call "mstore" [
                         YulExpr.call "add" [
                           YulExpr.call "add" [YulExpr.ident dstName, YulExpr.lit 32],
                           YulExpr.ident byteLenName
@@ -412,7 +412,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
                     let (encStmts, encLen) ←
                       compileUnindexedAbiEncode dynamicSource p.ty srcBase (YulExpr.ident dstName) s!"__evt_arg{argIdx}"
                     pure ([
-                      YulStmt.expr (YulExpr.call "mstore" [curHeadPtr, YulExpr.ident "__evt_data_tail"]),
+                      YulStmt.exprStmt (YulExpr.call "mstore" [curHeadPtr, YulExpr.ident "__evt_data_tail"]),
                       YulStmt.let_ dstName (YulExpr.call "add" [YulExpr.ident "__evt_ptr", YulExpr.ident "__evt_data_tail"])
                     ] ++ encStmts ++ [
                       YulStmt.assign "__evt_data_tail" (YulExpr.call "add" [YulExpr.ident "__evt_data_tail", encLen])
@@ -430,7 +430,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
                     let (encStmts, encLen) ←
                       compileUnindexedAbiEncode dynamicSource p.ty srcBase (YulExpr.ident dstName) s!"__evt_arg{argIdx}"
                     pure ([
-                      YulStmt.expr (YulExpr.call "mstore" [curHeadPtr, YulExpr.ident "__evt_data_tail"]),
+                      YulStmt.exprStmt (YulExpr.call "mstore" [curHeadPtr, YulExpr.ident "__evt_data_tail"]),
                       YulStmt.let_ dstName (YulExpr.call "add" [YulExpr.ident "__evt_ptr", YulExpr.ident "__evt_data_tail"])
                     ] ++ encStmts ++ [
                       YulStmt.assign "__evt_data_tail" (YulExpr.call "add" [YulExpr.ident "__evt_data_tail", encLen])
@@ -442,7 +442,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
           | ParamType.adt _ maxFields =>
               compileAdtEventWordStores eventName p.name srcExpr argExpr curHeadPtr maxFields
           | _ =>
-              pure [YulStmt.expr (YulExpr.call "mstore" [curHeadPtr, normalizeEventWord p.ty argExpr])]
+              pure [YulStmt.exprStmt (YulExpr.call "mstore" [curHeadPtr, normalizeEventWord p.ty argExpr])]
         let tail ← compileUnindexedStores rest (argIdx + 1) (headOffset + eventHeadWordSize p.ty)
         pure (current ++ tail)
   let unindexedStores ← compileUnindexedStores unindexed 0 0
@@ -510,7 +510,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
                         YulExpr.call "add" [YulExpr.ident elemLenName, YulExpr.lit 31],
                         YulExpr.call "not" [YulExpr.lit 31]
                       ]),
-                      YulStmt.expr (YulExpr.call "mstore" [
+                      YulStmt.exprStmt (YulExpr.call "mstore" [
                         YulExpr.call "add" [YulExpr.ident elemDstName, YulExpr.ident elemLenName],
                         YulExpr.lit 0
                       ]),
@@ -543,7 +543,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
                         YulExpr.ident elemBaseName,
                         YulExpr.lit leafOffset
                       ])
-                      YulStmt.expr (YulExpr.call "mstore" [
+                      YulStmt.exprStmt (YulExpr.call "mstore" [
                         YulExpr.call "add" [
                           YulExpr.ident elemOutBaseName,
                           YulExpr.lit leafOffset
@@ -627,7 +627,7 @@ def compileEmit (fields : List Field) (events : List EventDef)
   let indexedTopicStmts := indexedTopicParts.flatMap (·.1)
   let logFn := eventLogFunction indexed.length
   let logArgs := eventLogArgs dataSizeExpr indexedTopicParts
-  let logStmt := YulStmt.expr (YulExpr.call logFn logArgs)
+  let logStmt := YulStmt.exprStmt (YulExpr.call logFn logArgs)
   pure [YulStmt.block ([storePtr] ++ sigStores ++ [topic0Store] ++ indexedTopicStmts ++ unindexedTailInit ++ unindexedStores ++ [logStmt])]
 
 end Compiler.CompilationModel

--- a/Compiler/CompilationModel/ExpressionCompile.lean
+++ b/Compiler/CompilationModel/ExpressionCompile.lean
@@ -591,6 +591,10 @@ def compileExprWithInternals (fields : List Field)
           if args.length != inArity then
             throw s!"Compilation error: intrinsic {name} builtin {builtinName} expects {inArity} arg(s), got {args.length}"
           pure (YulExpr.call builtinName argExprs)
+      | .template params _output _body =>
+          if args.length != params.length then
+            throw s!"Compilation error: intrinsic {name} template expects {params.length} arg(s), got {args.length}"
+          pure (YulExpr.call (Verity.Core.Intrinsics.YulLowering.templateHelperName name) argExprs)
   | Expr.forkIfAtLeast required _thenExpr _elseExpr =>
       throw s!"Compilation error: unresolved fork_if_at_least {required}; compile through compileSpecsWithOptions so the branch can be selected from --target-fork before Yul emission"
   | Expr.eq a b      => return yulBinOp "eq"  (← compileExprWithInternals fields dynamicSource internalFunctions a) (← compileExprWithInternals fields dynamicSource internalFunctions b)

--- a/Compiler/CompilationModel/MappingWrites.lean
+++ b/Compiler/CompilationModel/MappingWrites.lean
@@ -31,7 +31,7 @@ def compileMappingSlotWrite (fields : List Field) (field : String)
                 match findFieldWithResolvedSlot fields field with
                 | some (_, _) =>
                     pure [
-                      YulStmt.expr (YulExpr.call storeBuiltin [
+                      YulStmt.exprStmt (YulExpr.call storeBuiltin [
                         writeSlot,
                         valueExpr
                       ])
@@ -39,7 +39,7 @@ def compileMappingSlotWrite (fields : List Field) (field : String)
                 | none => throw s!"Compilation error: unknown mapping field '{field}' in {label}"
               else
                 pure [
-                  YulStmt.expr (YulExpr.call "sstore" [
+                  YulStmt.exprStmt (YulExpr.call "sstore" [
                     writeSlot,
                     valueExpr
                   ])
@@ -52,7 +52,7 @@ def compileMappingSlotWrite (fields : List Field) (field : String)
                 YulStmt.block (
                   [YulStmt.let_ "__compat_key" keyExpr, YulStmt.let_ "__compat_value" valueExpr] ++
                   slots.map (fun slot =>
-                    YulStmt.expr (YulExpr.call storeBuiltin [
+                    YulStmt.exprStmt (YulExpr.call storeBuiltin [
                       compatSlotExpr slot,
                       YulExpr.ident "__compat_value"
                     ]))
@@ -101,7 +101,7 @@ def compileMappingPackedSlotWrite (fields : List Field) (field : String)
                   YulExpr.ident "__compat_slot_word",
                   YulExpr.call "not" [YulExpr.lit shiftedMaskNat]
                 ]),
-                YulStmt.expr (YulExpr.call storeBuiltin [
+                YulStmt.exprStmt (YulExpr.call storeBuiltin [
                   writeSlot,
                   YulExpr.call "or" [
                     YulExpr.ident "__compat_slot_cleared",
@@ -128,7 +128,7 @@ def compileMappingPackedSlotWrite (fields : List Field) (field : String)
                       YulExpr.ident "__compat_slot_word",
                       YulExpr.call "not" [YulExpr.lit shiftedMaskNat]
                     ]),
-                    YulStmt.expr (YulExpr.call storeBuiltin [
+                    YulStmt.exprStmt (YulExpr.call storeBuiltin [
                       slotExpr slot,
                       YulExpr.call "or" [
                         YulExpr.ident "__compat_slot_cleared",

--- a/Compiler/CompilationModel/ParamLoading.lean
+++ b/Compiler/CompilationModel/ParamLoading.lean
@@ -46,13 +46,13 @@ private def genDynamicParamLoads
   let absoluteOffsetLoad := YulStmt.let_ absoluteOffsetName absoluteOffsetExpr
   let absoluteOffset := YulExpr.ident absoluteOffsetName
   let offsetBoundsCheck := YulStmt.if_ (YulExpr.call "lt" [relativeOffset, YulExpr.lit headSize]) [
-    YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+    YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
   ]
   let absoluteBoundsCheck := YulStmt.if_ (YulExpr.call "gt" [
     absoluteOffset,
     YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
   ]) [
-    YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+    YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
   ]
   let preamble := [offsetLoad, offsetBoundsCheck, absoluteOffsetLoad, absoluteBoundsCheck]
   if isLengthPrefixedDynamicShape ty then
@@ -73,7 +73,7 @@ private def genDynamicParamLoads
               YulExpr.ident s!"{name}_length",
               YulExpr.ident tailRemainingName
             ]) [
-              YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+              YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
             ]]
       | ParamType.array elemTy =>
           let elemWords := dynamicArrayElementStrideWords elemTy
@@ -81,7 +81,7 @@ private def genDynamicParamLoads
               YulExpr.ident s!"{name}_length",
               YulExpr.call "div" [YulExpr.ident tailRemainingName, YulExpr.lit (32 * elemWords)]
             ]) [
-              YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+              YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
             ]]
       | _ => []
     let dataOffsetLoad := YulStmt.let_ s!"{name}_data_offset"
@@ -209,7 +209,7 @@ def genParamLoadsFrom
   let headSize := (params.map (fun p => paramHeadSize p.ty)).foldl (· + ·) 0
   let minInputSizeCheck :=
     YulStmt.if_ (YulExpr.call "lt" [sizeExpr, YulExpr.lit (baseOffset + headSize)]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ]
   minInputSizeCheck :: genParamLoadBodyFrom loadWord sizeExpr headSize baseOffset params headStart
 
@@ -244,7 +244,7 @@ def genConstructorArgLoads (params : List Param) : List YulStmt :=
       YulStmt.let_ "argsOffset" argsOffset,
       YulStmt.let_ "argsSize"
         (YulExpr.call "sub" [YulExpr.call "codesize" [], YulExpr.ident "argsOffset"]),
-      YulStmt.expr (YulExpr.call "codecopy" [YulExpr.lit 0, YulExpr.ident "argsOffset", YulExpr.ident "argsSize"])
+      YulStmt.exprStmt (YulExpr.call "codecopy" [YulExpr.lit 0, YulExpr.ident "argsOffset", YulExpr.ident "argsSize"])
     ]
     let paramLoads := genParamLoadsFrom (fun pos => YulExpr.call "mload" [pos]) (YulExpr.ident "argsSize") 0 0 params
     initcodeArgCopy ++ paramLoads ++ constructorArgAliases params

--- a/Compiler/CompilationModel/StorageWrites.lean
+++ b/Compiler/CompilationModel/StorageWrites.lean
@@ -36,7 +36,7 @@ def compilePackedStorageWrite (writeSlot valueExpr : YulExpr) (packed : PackedBi
         YulExpr.ident "__compat_slot_word",
         YulExpr.call "not" [YulExpr.lit shiftedMaskNat]
       ]),
-      YulStmt.expr (YulExpr.call storeBuiltin [
+      YulStmt.exprStmt (YulExpr.call storeBuiltin [
         writeSlot,
         YulExpr.call "or" [
           YulExpr.ident "__compat_slot_cleared",
@@ -62,7 +62,7 @@ def compileCompatPackedStorageWrites (writeSlots : List YulExpr) (valueExpr : Yu
             YulExpr.ident "__compat_slot_word",
             YulExpr.call "not" [YulExpr.lit shiftedMaskNat]
           ]),
-          YulStmt.expr (YulExpr.call storeBuiltin [
+          YulStmt.exprStmt (YulExpr.call storeBuiltin [
             writeSlot,
             YulExpr.call "or" [
               YulExpr.ident "__compat_slot_cleared",
@@ -106,7 +106,7 @@ def compileSetStorage (fields : List Field) (dynamicSource : DynamicDataSource)
             | [singleSlot] =>
                 match f.packedBits with
                 | none =>
-                    pure [YulStmt.expr (YulExpr.call storeBuiltin [YulExpr.lit singleSlot, storedValueExpr])]
+                    pure [YulStmt.exprStmt (YulExpr.call storeBuiltin [YulExpr.lit singleSlot, storedValueExpr])]
                 | some packed =>
                     pure (compilePackedStorageWrite (YulExpr.lit singleSlot) storedValueExpr packed loadBuiltin storeBuiltin)
             | _ =>
@@ -117,7 +117,7 @@ def compileSetStorage (fields : List Field) (dynamicSource : DynamicDataSource)
                       YulStmt.block (
                         [YulStmt.let_ "__compat_value" storedValueExpr] ++
                         writeSlots.map (fun writeSlot =>
-                          YulStmt.expr (YulExpr.call storeBuiltin [writeSlot, YulExpr.ident "__compat_value"]))
+                          YulStmt.exprStmt (YulExpr.call storeBuiltin [writeSlot, YulExpr.ident "__compat_value"]))
                       )
                     ]
                 | some packed =>
@@ -132,13 +132,13 @@ def compileStorageArrayPush (fields : List Field) (dynamicSource : DynamicDataSo
   pure [
     YulStmt.block [
       YulStmt.let_ "__array_len" (YulExpr.call "sload" [YulExpr.lit slot]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit slot]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit slot]),
       YulStmt.let_ "__array_base" (YulExpr.call "keccak256" [YulExpr.lit 0, YulExpr.lit 32]),
-      YulStmt.expr (YulExpr.call "sstore" [
+      YulStmt.exprStmt (YulExpr.call "sstore" [
         YulExpr.call "add" [YulExpr.ident "__array_base", YulExpr.ident "__array_len"],
         valueExpr
       ]),
-      YulStmt.expr (YulExpr.call "sstore" [
+      YulStmt.exprStmt (YulExpr.call "sstore" [
         YulExpr.lit slot,
         YulExpr.call "add" [YulExpr.ident "__array_len", YulExpr.lit 1]
       ])
@@ -151,16 +151,16 @@ def compileStorageArrayPop (fields : List Field) (field : String) : Except Strin
     YulStmt.block [
       YulStmt.let_ "__array_len" (YulExpr.call "sload" [YulExpr.lit slot]),
       YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__array_len"]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
       YulStmt.let_ "__array_new_len" (YulExpr.call "sub" [YulExpr.ident "__array_len", YulExpr.lit 1]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit slot]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit slot]),
       YulStmt.let_ "__array_base" (YulExpr.call "keccak256" [YulExpr.lit 0, YulExpr.lit 32]),
-      YulStmt.expr (YulExpr.call "sstore" [
+      YulStmt.exprStmt (YulExpr.call "sstore" [
         YulExpr.call "add" [YulExpr.ident "__array_base", YulExpr.ident "__array_new_len"],
         YulExpr.lit 0
       ]),
-      YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit slot, YulExpr.ident "__array_new_len"])
+      YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit slot, YulExpr.ident "__array_new_len"])
     ]
   ]
 
@@ -177,11 +177,11 @@ def compileSetStorageArrayElement (fields : List Field) (dynamicSource : Dynamic
       YulStmt.if_ (YulExpr.call "iszero" [
         YulExpr.call "lt" [YulExpr.ident "__array_index", YulExpr.ident "__array_len"]
       ]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ],
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit slot]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit slot]),
       YulStmt.let_ "__array_base" (YulExpr.call "keccak256" [YulExpr.lit 0, YulExpr.lit 32]),
-      YulStmt.expr (YulExpr.call "sstore" [
+      YulStmt.exprStmt (YulExpr.call "sstore" [
         YulExpr.call "add" [YulExpr.ident "__array_base", YulExpr.ident "__array_index"],
         valueExpr
       ])
@@ -209,7 +209,7 @@ def compileSetMapping2 (fields : List Field) (dynamicSource : DynamicDataSource)
         | [slot] =>
             let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1Expr]
             pure [
-              YulStmt.expr (YulExpr.call storeBuiltin [
+              YulStmt.exprStmt (YulExpr.call storeBuiltin [
                 YulExpr.call "mappingSlot" [innerSlot, key2Expr],
                 valueExpr
               ])
@@ -221,7 +221,7 @@ def compileSetMapping2 (fields : List Field) (dynamicSource : DynamicDataSource)
                   YulStmt.let_ "__compat_value" valueExpr] ++
                 slots.map (fun slot =>
                   let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key1"]
-                  YulStmt.expr (YulExpr.call storeBuiltin [
+                  YulStmt.exprStmt (YulExpr.call storeBuiltin [
                     YulExpr.call "mappingSlot" [innerSlot, YulExpr.ident "__compat_key2"],
                     YulExpr.ident "__compat_value"
                   ]))
@@ -252,7 +252,7 @@ def compileSetMapping2Word (fields : List Field) (dynamicSource : DynamicDataSou
             let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1Expr]
             let outerSlot := YulExpr.call "mappingSlot" [innerSlot, key2Expr]
             let finalSlot := if wordOffset == 0 then outerSlot else YulExpr.call "add" [outerSlot, YulExpr.lit wordOffset]
-            pure [YulStmt.expr (YulExpr.call storeBuiltin [finalSlot, valueExpr])]
+            pure [YulStmt.exprStmt (YulExpr.call storeBuiltin [finalSlot, valueExpr])]
         | _ =>
             pure [
               YulStmt.block (
@@ -262,7 +262,7 @@ def compileSetMapping2Word (fields : List Field) (dynamicSource : DynamicDataSou
                   let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key1"]
                   let outerSlot := YulExpr.call "mappingSlot" [innerSlot, YulExpr.ident "__compat_key2"]
                   let finalSlot := if wordOffset == 0 then outerSlot else YulExpr.call "add" [outerSlot, YulExpr.lit wordOffset]
-                  YulStmt.expr (YulExpr.call storeBuiltin [finalSlot, YulExpr.ident "__compat_value"])))
+                  YulStmt.exprStmt (YulExpr.call storeBuiltin [finalSlot, YulExpr.ident "__compat_value"])))
             ]
     | none => throw s!"Compilation error: unknown mapping field '{field}' in setMapping2Word"
 
@@ -281,7 +281,7 @@ def compileSetMappingChain (fields : List Field) (dynamicSource : DynamicDataSou
         let keyExprs ← compileExprListWithInternals fields dynamicSource internalFunctions keys
         let valueExpr ← compileExprWithInternals fields dynamicSource internalFunctions value
         let writeAt (slot : Nat) (keysRef : List YulExpr) (valueRef : YulExpr) : YulStmt :=
-          YulStmt.expr (YulExpr.call storeBuiltin [
+          YulStmt.exprStmt (YulExpr.call storeBuiltin [
             keysRef.foldl (fun slotExpr keyExpr => YulExpr.call "mappingSlot" [slotExpr, keyExpr]) (YulExpr.lit slot),
             valueRef
           ])
@@ -366,7 +366,7 @@ def compileSetStructMember2 (fields : List Field) (dynamicSource : DynamicDataSo
                     let finalSlot := if member.wordOffset == 0 then outerSlot else YulExpr.call "add" [outerSlot, YulExpr.lit member.wordOffset]
                     match member.packed with
                     | none =>
-                        pure [YulStmt.expr (YulExpr.call storeBuiltin [finalSlot, valueExpr])]
+                        pure [YulStmt.exprStmt (YulExpr.call storeBuiltin [finalSlot, valueExpr])]
                     | some packed =>
                         pure (compilePackedStorageWrite finalSlot valueExpr packed loadBuiltin storeBuiltin)
                 | _ =>
@@ -381,7 +381,7 @@ def compileSetStructMember2 (fields : List Field) (dynamicSource : DynamicDataSo
                             [YulStmt.let_ "__compat_key1" key1Expr, YulStmt.let_ "__compat_key2" key2Expr,
                               YulStmt.let_ "__compat_value" valueExpr] ++
                             finalSlots.map (fun finalSlot =>
-                              YulStmt.expr (YulExpr.call storeBuiltin [finalSlot, YulExpr.ident "__compat_value"]))
+                              YulStmt.exprStmt (YulExpr.call storeBuiltin [finalSlot, YulExpr.ident "__compat_value"]))
                           )
                         ]
                     | some packed =>

--- a/Compiler/CompilationModel/YulImporter.lean
+++ b/Compiler/CompilationModel/YulImporter.lean
@@ -87,7 +87,7 @@ private partial def mechanicsOfExpr : YulExpr → List LowLevelMechanic
 mutual
 private partial def mechanicsOfStmt : YulStmt → List LowLevelMechanic
   | .comment _ | .leave => []
-  | .let_ _ value | .letMany _ value | .assign _ value | .expr value =>
+  | .let_ _ value | .letMany _ value | .assign _ value | .exprStmt value =>
       mechanicsOfExpr value
   | .if_ cond body =>
       mechanicsOfExpr cond ++ mechanicsOfStmts body
@@ -119,7 +119,7 @@ private partial def controlFlowOfStmt : YulStmt → ControlFlowSummary
       .fallsThrough
   | .leave =>
       .returns
-  | .expr expr =>
+  | .exprStmt expr =>
       controlFlowOfExpr expr
   | .if_ cond body =>
       (controlFlowOfExpr cond).union { (controlFlowOfStmts body) with mayFallThrough := true }

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -97,9 +97,9 @@ private def importedAssemblyStmt : Stmt :=
     stmts := [
       YulStmt.let_ "ptr" (YulExpr.call "mload" [YulExpr.lit 64]),
       YulStmt.assign "ptr" (YulExpr.call "add" [YulExpr.ident "ptr", YulExpr.lit 32]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident "ptr", YulExpr.lit 1]),
-      YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.lit 1]),
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.ident "ptr", YulExpr.lit 32])
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.ident "ptr", YulExpr.lit 1]),
+      YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.lit 1]),
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.ident "ptr", YulExpr.lit 32])
     ]
   }
 
@@ -1662,7 +1662,7 @@ def compileSetStorageAddrMasksAddressWrites : Bool :=
   let fields : List Compiler.CompilationModel.Field :=
     [{ name := "owner", ty := Compiler.CompilationModel.FieldType.address }]
   match Compiler.CompilationModel.compileSetStorage fields .calldata "owner" (Expr.literal 42) true with
-  | .ok [Compiler.Yul.YulStmt.expr
+  | .ok [Compiler.Yul.YulStmt.exprStmt
       (Compiler.Yul.YulExpr.call "sstore"
         [Compiler.Yul.YulExpr.lit 0,
          Compiler.Yul.YulExpr.call "and"
@@ -1682,11 +1682,11 @@ def compileSetStorageWordMirrorsAliasSlots : Bool :=
   | .ok [
       Compiler.Yul.YulStmt.block [
         Compiler.Yul.YulStmt.let_ "__compat_value" (Compiler.Yul.YulExpr.lit 42),
-        Compiler.Yul.YulStmt.expr
+        Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call "sstore"
             [Compiler.Yul.YulExpr.call "add" [Compiler.Yul.YulExpr.lit 10, Compiler.Yul.YulExpr.lit 1],
              Compiler.Yul.YulExpr.ident "__compat_value"]),
-        Compiler.Yul.YulStmt.expr
+        Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call "sstore"
             [Compiler.Yul.YulExpr.call "add" [Compiler.Yul.YulExpr.lit 100, Compiler.Yul.YulExpr.lit 1],
              Compiler.Yul.YulExpr.ident "__compat_value"])
@@ -3017,7 +3017,7 @@ private def unsafeYulRawCallExpr : Compiler.Yul.YulExpr :=
 private def unsafeYulRawCallStmt : Stmt :=
   Stmt.unsafeYul {
     label := "raw_yul_call"
-    stmts := [Compiler.Yul.YulStmt.expr unsafeYulRawCallExpr]
+    stmts := [Compiler.Yul.YulStmt.exprStmt unsafeYulRawCallExpr]
     obligations := [unsafeYulScopeObligation "raw_yul_call_obligation"]
   }
 
@@ -3096,7 +3096,7 @@ private def unsafeYulUnderDeclaredStorageSpec : CompilationModel := {
         Stmt.unsafeYul {
           label := "under_declared_storage"
           stmts := [
-            Compiler.Yul.YulStmt.expr
+            Compiler.Yul.YulStmt.exprStmt
               (Compiler.Yul.YulExpr.call "sstore" [Compiler.Yul.YulExpr.lit 0, Compiler.Yul.YulExpr.lit 1])
           ]
           obligations := [unsafeYulScopeObligation "under_declared_storage_obligation"]

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -664,7 +664,7 @@ private def rawYulTrustSurfaceSpec : CompilationModel := {
         Stmt.unsafeYul {
           label := "manual_memory_refinement"
           stmts := [
-            Compiler.Yul.YulStmt.expr
+            Compiler.Yul.YulStmt.exprStmt
               (Compiler.Yul.YulExpr.call "mstore" [Compiler.Yul.YulExpr.lit 0, Compiler.Yul.YulExpr.lit 1])
           ]
           obligations := [

--- a/Compiler/Gas/StaticAnalysis.lean
+++ b/Compiler/Gas/StaticAnalysis.lean
@@ -149,7 +149,7 @@ def stmtUpperBoundFuel (cfg : GasConfig) (env : FunctionEnv) : Nat â†’ YulStmt â
   | fuel + 1, .let_ _ value => exprUpperBoundFuel cfg env fuel value
   | fuel + 1, .letMany _ value => exprUpperBoundFuel cfg env fuel value
   | fuel + 1, .assign _ value => exprUpperBoundFuel cfg env fuel value
-  | fuel + 1, .expr e => exprUpperBoundFuel cfg env fuel e
+  | fuel + 1, .exprStmt e => exprUpperBoundFuel cfg env fuel e
   | _ + 1, .leave => 0
   | fuel + 1, .if_ cond body => exprUpperBoundFuel cfg env fuel cond + stmtsUpperBoundFuel cfg env fuel body
   | fuel + 1, .for_ init cond post body =>
@@ -197,8 +197,8 @@ def gasUpperBound (stmts : List YulStmt) : Nat :=
 
 def simpleStoreProgram : List YulStmt :=
   [
-    .expr (.call "sstore" [.lit 0, .lit 777]),
-    .expr (.call "stop" [])
+    .exprStmt (.call "sstore" [.lit 0, .lit 777]),
+    .exprStmt (.call "stop" [])
   ]
 
 def boundedLoopProgram : List YulStmt :=
@@ -208,24 +208,24 @@ def boundedLoopProgram : List YulStmt :=
       (.call "lt" [.ident "i", .lit 3])
       [.assign "i" (.call "add" [.ident "i", .lit 1])]
       [
-        .expr (.call "sload" [.lit 0]),
-        .expr (.call "mstore" [.lit 0, .lit 1])
+        .exprStmt (.call "sload" [.lit 0]),
+        .exprStmt (.call "mstore" [.lit 0, .lit 1])
       ]
   ]
 
 def externalCallProgram : List YulStmt :=
   [
-    .expr (.call "call" [.lit 50000, .lit 1, .lit 1, .lit 0, .lit 0, .lit 0, .lit 0]),
-    .expr (.call "stop" [])
+    .exprStmt (.call "call" [.lit 50000, .lit 1, .lit 1, .lit 0, .lit 0, .lit 0, .lit 0]),
+    .exprStmt (.call "stop" [])
   ]
 
 def functionDeclAndCallProgram : List YulStmt :=
   [
     .funcDef "store" ["x"] [] [
-      .expr (.call "sstore" [.lit 0, .ident "x"])
+      .exprStmt (.call "sstore" [.lit 0, .ident "x"])
     ],
-    .expr (.call "store" [.lit 777]),
-    .expr (.call "stop" [])
+    .exprStmt (.call "store" [.lit 777]),
+    .exprStmt (.call "stop" [])
   ]
 
 example : gasUpperBound simpleStoreProgram = 22100 := rfl

--- a/Compiler/Linker.lean
+++ b/Compiler/Linker.lean
@@ -329,7 +329,7 @@ private def callsWithArityFromStmt : YulStmt → List (String × Nat)
   | YulStmt.let_ _ value => callsWithArityFromExpr value
   | YulStmt.letMany _ value => callsWithArityFromExpr value
   | YulStmt.assign _ value => callsWithArityFromExpr value
-  | YulStmt.expr e => callsWithArityFromExpr e
+  | YulStmt.exprStmt e => callsWithArityFromExpr e
   | YulStmt.leave => []
   | YulStmt.if_ cond body => callsWithArityFromExpr cond ++ callsWithArityFromStmts body
   | YulStmt.for_ init cond post body =>
@@ -412,7 +412,7 @@ example :
     let obj : YulObject :=
       { name := "Main"
         deployCode := []
-        runtimeCode := [.expr (.call "A" [])] }
+        runtimeCode := [.exprStmt (.call "A" [])] }
     let libs : List LibraryFunction :=
       [ { name := "A", arity := 0, body := ["function A() {", "B()", "}"] }
       , { name := "B", arity := 0, body := ["function B() {", "let x := 1", "}"] }

--- a/Compiler/Lowering/StackSafeAbi.lean
+++ b/Compiler/Lowering/StackSafeAbi.lean
@@ -35,7 +35,7 @@ def lowerFrameAsMemoryPayload (base : String) (fields : List FrameField) : Excep
 def lowerEventWithTopic (base : String) (topic0 : YulExpr) (fields : List FrameField) : Except String (List YulStmt) := do
   let (prologue, payloadArgs, _) ← lowerFrameAsMemoryPayload base fields
   pure (prologue ++
-    [YulStmt.expr (YulExpr.call "log1" (payloadArgs ++ [topic0]))])
+    [YulStmt.exprStmt (YulExpr.call "log1" (payloadArgs ++ [topic0]))])
 
 def lowerEvent (eventName : String) (fields : List FrameField) : Except String (List YulStmt) := do
   lowerEventWithTopic eventName (YulExpr.lit (eventNameTopicWord eventName)) fields
@@ -47,13 +47,13 @@ def lowerExternalCall (callName : String) (target value : YulExpr) (fields : Lis
 
 def lowerDynamicReturn (returnName : String) (fields : List FrameField) : Except String (List YulStmt) := do
   let (prologue, payloadArgs, _) ← lowerFrameAsMemoryPayload returnName fields
-  pure (prologue ++ [YulStmt.expr (YulExpr.call "return" payloadArgs)])
+  pure (prologue ++ [YulStmt.exprStmt (YulExpr.call "return" payloadArgs)])
 
 def usesPointerAbi (stmts : List YulStmt) : Bool :=
   stmts.any fun stmt =>
     match stmt with
-    | .expr (.call "return" [_ptr, _size]) => true
-    | .expr (.call "log1" [_ptr, _size, _topic]) => true
+    | .exprStmt (.call "return" [_ptr, _size]) => true
+    | .exprStmt (.call "log1" [_ptr, _size, _topic]) => true
     | .let_ _ (.call "call" [_gas, _target, _value, _ptr, _size, _out, _outSize]) => true
     | _ => false
 

--- a/Compiler/Lowering/StackSafeAbiTest.lean
+++ b/Compiler/Lowering/StackSafeAbiTest.lean
@@ -24,13 +24,13 @@ private def smallStaticPayload : List FrameField :=
 private def countMstores : List YulStmt → Nat :=
   List.length ∘ List.filter (fun stmt =>
     match stmt with
-    | .expr (.call "mstore" _) => true
+    | .exprStmt (.call "mstore" _) => true
     | _ => false)
 
 private def returnsBytes (bytes : Nat) : List YulStmt → Bool :=
   fun stmts => stmts.any fun stmt =>
     match stmt with
-    | .expr (.call "return" [.lit 0, .lit n]) => n == bytes
+    | .exprStmt (.call "return" [.lit 0, .lit n]) => n == bytes
     | _ => false
 
 private def callsWithInputBytes (bytes : Nat) : List YulStmt → Bool :=
@@ -42,7 +42,7 @@ private def callsWithInputBytes (bytes : Nat) : List YulStmt → Bool :=
 private def logsWithDataBytes (bytes : Nat) : List YulStmt → Bool :=
   fun stmts => stmts.any fun stmt =>
     match stmt with
-    | .expr (.call "log1" [.lit 0, .lit n, .lit topic]) => n == bytes && topic != 0
+    | .exprStmt (.call "log1" [.lit 0, .lit n, .lit topic]) => n == bytes && topic != 0
     | _ => false
 
 #eval! do

--- a/Compiler/Modules/Callbacks.lean
+++ b/Compiler/Modules/Callbacks.lean
@@ -55,21 +55,21 @@ def callbackModule (selector : Nat) (numStaticArgs : Nat) (bytesParam : String)
     let ptrName := "__cb_ptr"
     let ptrExpr := YulExpr.ident ptrName
     let loadPtr := YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
-    let storeSelector := YulStmt.expr (YulExpr.call "mstore" [ptrExpr, selectorExpr])
+    let storeSelector := YulStmt.exprStmt (YulExpr.call "mstore" [ptrExpr, selectorExpr])
     let storeArgs := staticArgExprs.zipIdx.map fun (argExpr, i) =>
-      YulStmt.expr (YulExpr.call "mstore" [
+      YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.call "add" [ptrExpr, YulExpr.lit (4 + i * 32)],
         argExpr
       ])
     let bytesOffsetSlot := 4 + numStaticArgs * 32
     let bytesOffset := (numStaticArgs + 1) * 32
-    let storeOffset := YulStmt.expr (YulExpr.call "mstore" [
+    let storeOffset := YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.call "add" [ptrExpr, YulExpr.lit bytesOffsetSlot],
       YulExpr.lit bytesOffset
     ])
     let bytesLenExpr := YulExpr.ident s!"{bytesParam}_length"
     let bytesLenSlot := 4 + (numStaticArgs + 1) * 32
-    let storeBytesLen := YulStmt.expr (YulExpr.call "mstore" [
+    let storeBytesLen := YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.call "add" [ptrExpr, YulExpr.lit bytesLenSlot],
       bytesLenExpr
     ])
@@ -88,7 +88,7 @@ def callbackModule (selector : Nat) (numStaticArgs : Nat) (bytesParam : String)
       YulExpr.call "add" [totalSize, YulExpr.lit 31],
       YulExpr.call "not" [YulExpr.lit 31]
     ]
-    let advancePtr := YulStmt.expr (YulExpr.call "mstore" [
+    let advancePtr := YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit freeMemoryPointer,
       YulExpr.call "add" [ptrExpr, paddedTotalSize]
     ])
@@ -101,8 +101,8 @@ def callbackModule (selector : Nat) (numStaticArgs : Nat) (bytesParam : String)
     ]
     let revertBlock := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__cb_success"]) [
       YulStmt.let_ "__cb_rds" (YulExpr.call "returndatasize" []),
-      YulStmt.expr (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__cb_rds"]),
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__cb_rds"])
+      YulStmt.exprStmt (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__cb_rds"]),
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__cb_rds"])
     ]
     pure [YulStmt.block (
       [loadPtr, storeSelector] ++ storeArgs ++ [storeOffset, storeBytesLen] ++ copyBytes ++

--- a/Compiler/Modules/Calls.lean
+++ b/Compiler/Modules/Calls.lean
@@ -49,10 +49,10 @@ private def bubblingValueCallYul
     YulStmt.let_ "__bvc_success" callExpr,
     YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__bvc_success"]) [
       YulStmt.let_ "__bvc_rds" (YulExpr.call "returndatasize" []),
-      YulStmt.expr (YulExpr.call "returndatacopy" [
+      YulStmt.exprStmt (YulExpr.call "returndatacopy" [
         YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__bvc_rds"
       ]),
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__bvc_rds"])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__bvc_rds"])
     ]
   ]]
 
@@ -82,7 +82,7 @@ def selfDelegateMulticallBytesBody
       [
         YulStmt.let_ "__mc_rel_offset" (YulExpr.call "calldataload" [elementOffsetSlot]),
         YulStmt.if_ (YulExpr.call "lt" [YulExpr.ident "__mc_rel_offset", offsetTableBytes]) [
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
         ],
         YulStmt.if_ (YulExpr.call "gt" [
           YulExpr.ident "__mc_rel_offset",
@@ -91,14 +91,14 @@ def selfDelegateMulticallBytesBody
             arrayDataOffset
           ]
         ]) [
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
         ],
         YulStmt.let_ "__mc_head_offset" (YulExpr.call "add" [arrayDataOffset, YulExpr.ident "__mc_rel_offset"]),
         YulStmt.if_ (YulExpr.call "gt" [
           YulExpr.ident "__mc_head_offset",
           YulExpr.call "sub" [YulExpr.call "calldatasize" [], YulExpr.lit 32]
         ]) [
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
         ],
         YulStmt.let_ "__mc_data_size" (YulExpr.call "calldataload" [YulExpr.ident "__mc_head_offset"]),
         YulStmt.let_ "__mc_data_offset" (YulExpr.call "add" [YulExpr.ident "__mc_head_offset", YulExpr.lit 32]),
@@ -106,14 +106,14 @@ def selfDelegateMulticallBytesBody
           YulExpr.ident "__mc_data_size",
           YulExpr.call "sub" [YulExpr.call "calldatasize" [], YulExpr.ident "__mc_data_offset"]
         ]) [
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
         ],
-        YulStmt.expr (YulExpr.call "calldatacopy" [
+        YulStmt.exprStmt (YulExpr.call "calldatacopy" [
           ptrExpr,
           YulExpr.ident "__mc_data_offset",
           YulExpr.ident "__mc_data_size"
         ]),
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.lit freeMemoryPointer,
           YulExpr.call "add" [ptrExpr, paddedSizeExpr]
         ]),
@@ -127,10 +127,10 @@ def selfDelegateMulticallBytesBody
         ]),
         YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident successName]) [
           YulStmt.let_ rdsName (YulExpr.call "returndatasize" []),
-          YulStmt.expr (YulExpr.call "returndatacopy" [
+          YulStmt.exprStmt (YulExpr.call "returndatacopy" [
             YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident rdsName
           ]),
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident rdsName])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident rdsName])
         ]
       ]
   ]
@@ -167,16 +167,16 @@ def withReturnModule (resultVar : String) (selector : Nat) (numArgs : Nat) (isSt
     let selectorExpr := YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex selector]
     let ptrName := "__ecwr_ptr"
     let ptrExpr := YulExpr.ident ptrName
-    let storeSelector := YulStmt.expr (YulExpr.call "mstore" [ptrExpr, selectorExpr])
+    let storeSelector := YulStmt.exprStmt (YulExpr.call "mstore" [ptrExpr, selectorExpr])
     let storeArgs := argExprs.zipIdx.map fun (argExpr, i) =>
-      YulStmt.expr (YulExpr.call "mstore" [
+      YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.call "add" [ptrExpr, YulExpr.lit (4 + i * 32)],
         argExpr
       ])
     let calldataSize := 4 + numArgs * 32
     let frameSize := ((Nat.max calldataSize 32 + 31) / 32) * 32
     let loadPtr := YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
-    let advancePtr := YulStmt.expr (YulExpr.call "mstore" [
+    let advancePtr := YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit freeMemoryPointer,
       YulExpr.call "add" [ptrExpr, YulExpr.lit frameSize]
     ])
@@ -199,11 +199,11 @@ def withReturnModule (resultVar : String) (selector : Nat) (numArgs : Nat) (isSt
     let letSuccess := YulStmt.let_ "__ecwr_success" callExpr
     let revertBlock := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__ecwr_success"]) [
       YulStmt.let_ "__ecwr_rds" (YulExpr.call "returndatasize" []),
-      YulStmt.expr (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__ecwr_rds"]),
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__ecwr_rds"])
+      YulStmt.exprStmt (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__ecwr_rds"]),
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__ecwr_rds"])
     ]
     let sizeCheck := YulStmt.if_ (YulExpr.call "lt" [YulExpr.call "returndatasize" [], YulExpr.lit 32]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ]
     let bindResult := YulStmt.let_ resultVar (YulExpr.lit 0)
     let assignResult := YulStmt.assign resultVar (YulExpr.call "mload" [ptrExpr])
@@ -247,16 +247,16 @@ def noReturnModule (selector : Nat) (numArgs : Nat) (isStatic : Bool := false)
     let selectorExpr := YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex selector]
     let ptrName := "__ecnr_ptr"
     let ptrExpr := YulExpr.ident ptrName
-    let storeSelector := YulStmt.expr (YulExpr.call "mstore" [ptrExpr, selectorExpr])
+    let storeSelector := YulStmt.exprStmt (YulExpr.call "mstore" [ptrExpr, selectorExpr])
     let storeArgs := argExprs.zipIdx.map fun (argExpr, i) =>
-      YulStmt.expr (YulExpr.call "mstore" [
+      YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.call "add" [ptrExpr, YulExpr.lit (4 + i * 32)],
         argExpr
       ])
     let calldataSize := 4 + numArgs * 32
     let frameSize := ((Nat.max calldataSize 32 + 31) / 32) * 32
     let loadPtr := YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
-    let advancePtr := YulStmt.expr (YulExpr.call "mstore" [
+    let advancePtr := YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit freeMemoryPointer,
       YulExpr.call "add" [ptrExpr, YulExpr.lit frameSize]
     ])
@@ -281,8 +281,8 @@ def noReturnModule (selector : Nat) (numArgs : Nat) (isStatic : Bool := false)
     -- do NOT check returndatasize or decode a return value
     let revertBlock := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__ecnr_success"]) [
       YulStmt.let_ "__ecnr_rds" (YulExpr.call "returndatasize" []),
-      YulStmt.expr (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__ecnr_rds"]),
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__ecnr_rds"])
+      YulStmt.exprStmt (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__ecnr_rds"]),
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__ecnr_rds"])
     ]
     pure [YulStmt.block ([loadPtr, storeSelector] ++ storeArgs ++ [advancePtr, letSuccess, revertBlock])]
 
@@ -388,10 +388,10 @@ def callWithValueModule : ExternalCallModule where
         let letSuccess := YulStmt.let_ "__cwv_success" callExpr
         let revertBlock := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__cwv_success"]) [
           YulStmt.let_ "__cwv_rds" (YulExpr.call "returndatasize" []),
-          YulStmt.expr (YulExpr.call "returndatacopy" [
+          YulStmt.exprStmt (YulExpr.call "returndatacopy" [
             YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__cwv_rds"
           ]),
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__cwv_rds"])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__cwv_rds"])
         ]
         pure [YulStmt.block [letSuccess, revertBlock]]
     | _ =>
@@ -435,7 +435,7 @@ def callWithValueBytesModule (bytesParam : String) : ExternalCallModule where
           YulExpr.call "add" [dataSizeExpr, YulExpr.lit 31],
           YulExpr.call "not" [YulExpr.lit 31]
         ])
-        let advancePtr := YulStmt.expr (YulExpr.call "mstore" [
+        let advancePtr := YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.lit freeMemoryPointer,
           YulExpr.call "add" [ptrExpr, YulExpr.ident paddedName]
         ])
@@ -449,10 +449,10 @@ def callWithValueBytesModule (bytesParam : String) : ExternalCallModule where
         let letSuccess := YulStmt.let_ "__cwv_success" callExpr
         let revertBlock := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__cwv_success"]) [
           YulStmt.let_ "__cwv_rds" (YulExpr.call "returndatasize" []),
-          YulStmt.expr (YulExpr.call "returndatacopy" [
+          YulStmt.exprStmt (YulExpr.call "returndatacopy" [
             YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__cwv_rds"
           ]),
-          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__cwv_rds"])
+          YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__cwv_rds"])
         ]
         pure [YulStmt.block ([loadPtr] ++ copyData ++ [computePadded, advancePtr, letSuccess, revertBlock])]
     | _ =>

--- a/Compiler/Modules/CodeData.lean
+++ b/Compiler/Modules/CodeData.lean
@@ -60,7 +60,7 @@ def hasCreate2AndExtcodecopy (stmts : List YulStmt) : Bool :=
     | .let_ _ (.call "create2" _) => true
     | _ => false
   let hasExtcodecopy := stmts.any fun
-    | .expr (.call "extcodecopy" _) => true
+    | .exprStmt (.call "extcodecopy" _) => true
     | _ => false
   hasCreate2 && hasExtcodecopy
 

--- a/Compiler/Modules/CodeDataTest.lean
+++ b/Compiler/Modules/CodeDataTest.lean
@@ -34,7 +34,7 @@ private def returnCodeDataHasExtentGuard : List YulStmt → Bool
                 .ident "__return_code_offset"
               ]
             ])
-            [YulStmt.expr (.call "revert" [.lit 0, .lit 0])] => true
+            [YulStmt.exprStmt (.call "revert" [.lit 0, .lit 0])] => true
         | _ => false
   | _ => false
 

--- a/Compiler/Modules/Create2SSTORE2.lean
+++ b/Compiler/Modules/Create2SSTORE2.lean
@@ -41,7 +41,7 @@ def readCodeModule : ExternalCallModule where
   compile := fun _ctx args => do
     match args with
     | [pointer, destOffset, codeOffset, size] =>
-        pure [YulStmt.expr (YulExpr.call "extcodecopy" [pointer, destOffset, codeOffset, size])]
+        pure [YulStmt.exprStmt (YulExpr.call "extcodecopy" [pointer, destOffset, codeOffset, size])]
     | _ =>
         throw s!"sstore2ReadCode expects 4 arguments, got {args.length}"
 

--- a/Compiler/Modules/ERC20.lean
+++ b/Compiler/Modules/ERC20.lean
@@ -45,12 +45,12 @@ private def safeERC20FailedOperationSelectorWord : Nat :=
 
 /-- Revert with OpenZeppelin v5's `SafeERC20FailedOperation(address)` custom error. -/
 private def revertSafeERC20FailedOperation (tokenExpr : YulExpr) : List YulStmt := [
-  YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex safeERC20FailedOperationSelectorWord]),
-  YulStmt.expr (YulExpr.call "mstore" [
+  YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex safeERC20FailedOperationSelectorWord]),
+  YulStmt.exprStmt (YulExpr.call "mstore" [
     YulExpr.lit 4,
     YulExpr.call "and" [tokenExpr, YulExpr.lit Compiler.Constants.addressMask]
   ]),
-  YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 36])
+  YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 36])
 ]
 
 /-- Post-call guard for OpenZeppelin-style optional-bool ERC-20 operations.
@@ -95,7 +95,7 @@ private def requireSolmateOptionalBoolSuccess
       ]
     ]
   ]) [
-    YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+    YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
   ]
 ]
 
@@ -124,16 +124,16 @@ private def readUint256Module
       let ptrName := s!"__{moduleName}_ptr"
       let ptrExpr := YulExpr.ident ptrName
       let loadPtr := YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
-      let storeSelector := YulStmt.expr (YulExpr.call "mstore" [
+      let storeSelector := YulStmt.exprStmt (YulExpr.call "mstore" [
         ptrExpr,
         YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex selector]
       ])
       let storeArgs := argExprs.zipIdx.map fun (argExpr, idx) =>
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.call "add" [ptrExpr, YulExpr.lit (4 + idx * 32)],
           argExpr
         ])
-      let advancePtr := YulStmt.expr (YulExpr.call "mstore" [
+      let advancePtr := YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.lit freeMemoryPointer,
         YulExpr.call "add" [ptrExpr, YulExpr.lit frameSize]
       ])
@@ -145,15 +145,15 @@ private def readUint256Module
       ]
       let revertOnFailure := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident s!"__{moduleName}_success"]) [
         YulStmt.let_ s!"__{moduleName}_rds" (YulExpr.call "returndatasize" []),
-        YulStmt.expr (YulExpr.call "returndatacopy" [
+        YulStmt.exprStmt (YulExpr.call "returndatacopy" [
           YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident s!"__{moduleName}_rds"
         ]),
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident s!"__{moduleName}_rds"])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident s!"__{moduleName}_rds"])
       ]
       let requireSingleWord := YulStmt.if_ (YulExpr.call "iszero" [
         YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 32]
       ]) [
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
       ]
       let bindResult := YulStmt.let_ resultVar (YulExpr.lit 0)
       let assignResult := YulStmt.assign resultVar (YulExpr.call "mload" [ptrExpr])
@@ -181,10 +181,10 @@ def safeTransferModule : ExternalCallModule where
     let optionalBoolGuard := requireOptionalBoolSuccess tokenExpr (YulExpr.ident "__st_ptr")
     pure [YulStmt.block ([
       YulStmt.let_ "__st_ptr" (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident "__st_ptr", YulExpr.hex selectorWord]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__st_ptr", YulExpr.lit 4], toExpr]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__st_ptr", YulExpr.lit 36], amountExpr]),
-      YulStmt.expr (YulExpr.call "mstore" [
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.ident "__st_ptr", YulExpr.hex selectorWord]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__st_ptr", YulExpr.lit 4], toExpr]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__st_ptr", YulExpr.lit 36], amountExpr]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.lit freeMemoryPointer,
         YulExpr.call "and" [
           YulExpr.call "add" [
@@ -200,8 +200,8 @@ def safeTransferModule : ExternalCallModule where
       ]),
       YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__st_success"]) [
         YulStmt.let_ "__st_rds" (YulExpr.call "returndatasize" []),
-        YulStmt.expr (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__st_rds"]),
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__st_rds"])
+        YulStmt.exprStmt (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__st_rds"]),
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__st_rds"])
       ]
     ] ++ optionalBoolGuard)]
 
@@ -226,11 +226,11 @@ def safeTransferFromModule : ExternalCallModule where
     let optionalBoolGuard := requireOptionalBoolSuccess tokenExpr (YulExpr.ident "__stf_ptr")
     pure [YulStmt.block ([
       YulStmt.let_ "__stf_ptr" (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident "__stf_ptr", YulExpr.hex selectorWord]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__stf_ptr", YulExpr.lit 4], fromExpr]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__stf_ptr", YulExpr.lit 36], toExpr]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__stf_ptr", YulExpr.lit 68], amountExpr]),
-      YulStmt.expr (YulExpr.call "mstore" [
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.ident "__stf_ptr", YulExpr.hex selectorWord]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__stf_ptr", YulExpr.lit 4], fromExpr]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__stf_ptr", YulExpr.lit 36], toExpr]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__stf_ptr", YulExpr.lit 68], amountExpr]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.lit freeMemoryPointer,
         YulExpr.call "and" [
           YulExpr.call "add" [
@@ -246,8 +246,8 @@ def safeTransferFromModule : ExternalCallModule where
       ]),
       YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__stf_success"]) [
         YulStmt.let_ "__stf_rds" (YulExpr.call "returndatasize" []),
-        YulStmt.expr (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__stf_rds"]),
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__stf_rds"])
+        YulStmt.exprStmt (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__stf_rds"]),
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__stf_rds"])
       ]
     ] ++ optionalBoolGuard)]
 
@@ -276,10 +276,10 @@ def solmateSafeTransferModule : ExternalCallModule where
     let optionalBoolGuard := requireSolmateOptionalBoolSuccess (YulExpr.ident "__sst_ptr")
     pure [YulStmt.block ([
       YulStmt.let_ "__sst_ptr" (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident "__sst_ptr", YulExpr.hex selectorWord]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__sst_ptr", YulExpr.lit 4], toExpr]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__sst_ptr", YulExpr.lit 36], amountExpr]),
-      YulStmt.expr (YulExpr.call "mstore" [
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.ident "__sst_ptr", YulExpr.hex selectorWord]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__sst_ptr", YulExpr.lit 4], toExpr]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__sst_ptr", YulExpr.lit 36], amountExpr]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.lit freeMemoryPointer,
         YulExpr.call "and" [
           YulExpr.call "add" [
@@ -295,8 +295,8 @@ def solmateSafeTransferModule : ExternalCallModule where
       ]),
       YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__sst_success"]) [
         YulStmt.let_ "__sst_rds" (YulExpr.call "returndatasize" []),
-        YulStmt.expr (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__sst_rds"]),
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__sst_rds"])
+        YulStmt.exprStmt (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__sst_rds"]),
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__sst_rds"])
       ]
     ] ++ optionalBoolGuard)]
 
@@ -320,11 +320,11 @@ def solmateSafeTransferFromModule : ExternalCallModule where
     let optionalBoolGuard := requireSolmateOptionalBoolSuccess (YulExpr.ident "__sstf_ptr")
     pure [YulStmt.block ([
       YulStmt.let_ "__sstf_ptr" (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident "__sstf_ptr", YulExpr.hex selectorWord]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__sstf_ptr", YulExpr.lit 4], fromExpr]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__sstf_ptr", YulExpr.lit 36], toExpr]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__sstf_ptr", YulExpr.lit 68], amountExpr]),
-      YulStmt.expr (YulExpr.call "mstore" [
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.ident "__sstf_ptr", YulExpr.hex selectorWord]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__sstf_ptr", YulExpr.lit 4], fromExpr]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__sstf_ptr", YulExpr.lit 36], toExpr]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__sstf_ptr", YulExpr.lit 68], amountExpr]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.lit freeMemoryPointer,
         YulExpr.call "and" [
           YulExpr.call "add" [
@@ -340,8 +340,8 @@ def solmateSafeTransferFromModule : ExternalCallModule where
       ]),
       YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__sstf_success"]) [
         YulStmt.let_ "__sstf_rds" (YulExpr.call "returndatasize" []),
-        YulStmt.expr (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__sstf_rds"]),
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__sstf_rds"])
+        YulStmt.exprStmt (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__sstf_rds"]),
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__sstf_rds"])
       ]
     ] ++ optionalBoolGuard)]
 
@@ -373,12 +373,12 @@ These modules are intended to be used when you need source-faithful parity with 
 that chose this particular SafeTransferLib flavor. They are not the default.
 -/
 private def legacyStringRevert (len : Nat) (dataWord : Nat) : List YulStmt := [
-  YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0,
+  YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0,
     YulExpr.hex 0x08c379a000000000000000000000000000000000000000000000000000000000]),
-  YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
-  YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit len]),
-  YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 68, YulExpr.hex dataWord]),
-  YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 100])
+  YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
+  YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit len]),
+  YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 68, YulExpr.hex dataWord]),
+  YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 100])
 ]
 
 private def legacyRevertNoCode : List YulStmt :=
@@ -430,10 +430,10 @@ def legacyStringSafeTransferModule : ExternalCallModule where
     pure [YulStmt.block (
       legacyCodeLengthGuard tokenExpr ++ [
         YulStmt.let_ "__lst_ptr" (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]),
-        YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident "__lst_ptr", YulExpr.hex selectorWord]),
-        YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lst_ptr", YulExpr.lit 4], toExpr]),
-        YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lst_ptr", YulExpr.lit 36], amountExpr]),
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.ident "__lst_ptr", YulExpr.hex selectorWord]),
+        YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lst_ptr", YulExpr.lit 4], toExpr]),
+        YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lst_ptr", YulExpr.lit 36], amountExpr]),
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.lit freeMemoryPointer,
           YulExpr.call "and" [
             YulExpr.call "add" [YulExpr.call "add" [YulExpr.ident "__lst_ptr", YulExpr.lit 68], YulExpr.lit 31],
@@ -466,11 +466,11 @@ def legacyStringSafeTransferFromModule : ExternalCallModule where
     pure [YulStmt.block (
       legacyCodeLengthGuard tokenExpr ++ [
         YulStmt.let_ "__lstf_ptr" (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]),
-        YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident "__lstf_ptr", YulExpr.hex selectorWord]),
-        YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lstf_ptr", YulExpr.lit 4], fromExpr]),
-        YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lstf_ptr", YulExpr.lit 36], toExpr]),
-        YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lstf_ptr", YulExpr.lit 68], amountExpr]),
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.ident "__lstf_ptr", YulExpr.hex selectorWord]),
+        YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lstf_ptr", YulExpr.lit 4], fromExpr]),
+        YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lstf_ptr", YulExpr.lit 36], toExpr]),
+        YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__lstf_ptr", YulExpr.lit 68], amountExpr]),
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.lit freeMemoryPointer,
           YulExpr.call "and" [
             YulExpr.call "add" [YulExpr.call "add" [YulExpr.ident "__lstf_ptr", YulExpr.lit 100], YulExpr.lit 31],
@@ -505,10 +505,10 @@ def safeApproveModule : ExternalCallModule where
     let optionalBoolGuard := requireOptionalBoolSuccess tokenExpr (YulExpr.ident "__sa_ptr")
     pure [YulStmt.block ([
       YulStmt.let_ "__sa_ptr" (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.ident "__sa_ptr", YulExpr.hex selectorWord]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__sa_ptr", YulExpr.lit 4], spenderExpr]),
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__sa_ptr", YulExpr.lit 36], amountExpr]),
-      YulStmt.expr (YulExpr.call "mstore" [
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.ident "__sa_ptr", YulExpr.hex selectorWord]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__sa_ptr", YulExpr.lit 4], spenderExpr]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [YulExpr.ident "__sa_ptr", YulExpr.lit 36], amountExpr]),
+      YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.lit freeMemoryPointer,
         YulExpr.call "and" [
           YulExpr.call "add" [
@@ -524,8 +524,8 @@ def safeApproveModule : ExternalCallModule where
       ]),
       YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__sa_success"]) [
         YulStmt.let_ "__sa_rds" (YulExpr.call "returndatasize" []),
-        YulStmt.expr (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__sa_rds"]),
-        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__sa_rds"])
+        YulStmt.exprStmt (YulExpr.call "returndatacopy" [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__sa_rds"]),
+        YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__sa_rds"])
       ]
     ] ++ optionalBoolGuard)]
 

--- a/Compiler/Modules/ERC4626.lean
+++ b/Compiler/Modules/ERC4626.lean
@@ -69,16 +69,16 @@ private def readUint256Module
     let ptrName := s!"__erc4626_{moduleName}_ptr"
     let ptrExpr := YulExpr.ident ptrName
     let loadPtr := YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
-    let storeSelector := YulStmt.expr (YulExpr.call "mstore" [
+    let storeSelector := YulStmt.exprStmt (YulExpr.call "mstore" [
       ptrExpr,
       YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex selector]
     ])
     let storeArgs := argExprs.zipIdx.map fun (argExpr, idx) =>
-      YulStmt.expr (YulExpr.call "mstore" [
+      YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.call "add" [ptrExpr, YulExpr.lit (4 + idx * 32)],
         argExpr
       ])
-    let advancePtr := YulStmt.expr (YulExpr.call "mstore" [
+    let advancePtr := YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit freeMemoryPointer,
       YulExpr.call "add" [ptrExpr, YulExpr.lit frameSize]
     ])
@@ -90,15 +90,15 @@ private def readUint256Module
     ]
     let revertOnFailure := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__erc4626_success"]) [
       YulStmt.let_ "__erc4626_rds" (YulExpr.call "returndatasize" []),
-      YulStmt.expr (YulExpr.call "returndatacopy" [
+      YulStmt.exprStmt (YulExpr.call "returndatacopy" [
         YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__erc4626_rds"
       ]),
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__erc4626_rds"])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__erc4626_rds"])
     ]
     let requireSingleWord := YulStmt.if_ (YulExpr.call "iszero" [
       YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 32]
     ]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ]
     let bindResult := YulStmt.let_ resultVar (YulExpr.lit 0)
     let assignResult := YulStmt.assign resultVar (YulExpr.call "mload" [ptrExpr])
@@ -133,16 +133,16 @@ private def writeUint256Module
     let ptrName := s!"__erc4626_{moduleName}_ptr"
     let ptrExpr := YulExpr.ident ptrName
     let loadPtr := YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
-    let storeSelector := YulStmt.expr (YulExpr.call "mstore" [
+    let storeSelector := YulStmt.exprStmt (YulExpr.call "mstore" [
       ptrExpr,
       YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex selector]
     ])
     let storeArgs := argExprs.zipIdx.map fun (argExpr, idx) =>
-      YulStmt.expr (YulExpr.call "mstore" [
+      YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.call "add" [ptrExpr, YulExpr.lit (4 + idx * 32)],
         argExpr
       ])
-    let advancePtr := YulStmt.expr (YulExpr.call "mstore" [
+    let advancePtr := YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit freeMemoryPointer,
       YulExpr.call "add" [ptrExpr, YulExpr.lit frameSize]
     ])
@@ -155,15 +155,15 @@ private def writeUint256Module
     ]
     let revertOnFailure := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__erc4626_success"]) [
       YulStmt.let_ "__erc4626_rds" (YulExpr.call "returndatasize" []),
-      YulStmt.expr (YulExpr.call "returndatacopy" [
+      YulStmt.exprStmt (YulExpr.call "returndatacopy" [
         YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__erc4626_rds"
       ]),
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__erc4626_rds"])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__erc4626_rds"])
     ]
     let requireSingleWord := YulStmt.if_ (YulExpr.call "iszero" [
       YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 32]
     ]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ]
     let bindResult := YulStmt.let_ resultVar (YulExpr.lit 0)
     let assignResult := YulStmt.assign resultVar (YulExpr.call "mload" [ptrExpr])
@@ -332,11 +332,11 @@ def assetModule (resultVar : String) : ExternalCallModule where
     let ptrName := "__erc4626_asset_ptr"
     let ptrExpr := YulExpr.ident ptrName
     let loadPtr := YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
-    let storeSelector := YulStmt.expr (YulExpr.call "mstore" [
+    let storeSelector := YulStmt.exprStmt (YulExpr.call "mstore" [
       ptrExpr,
       YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex 0x38d52e0f]
     ])
-    let advancePtr := YulStmt.expr (YulExpr.call "mstore" [
+    let advancePtr := YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit freeMemoryPointer,
       YulExpr.call "add" [ptrExpr, YulExpr.lit 32]
     ])
@@ -348,15 +348,15 @@ def assetModule (resultVar : String) : ExternalCallModule where
     ]
     let revertOnFailure := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__erc4626_success"]) [
       YulStmt.let_ "__erc4626_rds" (YulExpr.call "returndatasize" []),
-      YulStmt.expr (YulExpr.call "returndatacopy" [
+      YulStmt.exprStmt (YulExpr.call "returndatacopy" [
         YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__erc4626_rds"
       ]),
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__erc4626_rds"])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__erc4626_rds"])
     ]
     let requireSingleWord := YulStmt.if_ (YulExpr.call "iszero" [
       YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 32]
     ]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ]
     let bindResult := YulStmt.let_ resultVar (YulExpr.lit 0)
     let assignResult := YulStmt.assign resultVar

--- a/Compiler/Modules/Hashing.lean
+++ b/Compiler/Modules/Hashing.lean
@@ -29,7 +29,7 @@ private def packedWordBindings (words : List YulExpr) : List YulStmt :=
 
 private def packedWordTempStoresAt (base : YulExpr) (wordCount : Nat) : List YulStmt :=
   (List.range wordCount).map fun idx =>
-    YulStmt.expr (YulExpr.call "mstore" [
+    YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.call "add" [base, YulExpr.lit (idx * 32)],
       YulExpr.ident (packedWordTempName idx)
     ])
@@ -50,7 +50,7 @@ private def packedSegmentTempStoreAt (base : YulExpr) (offset width idx : Nat) :
         YulExpr.lit ((32 - width) * 8),
         YulExpr.call "and" [value, YulExpr.hex (packedSegmentMask width)]
       ]
-  YulStmt.expr (YulExpr.call "mstore" [
+  YulStmt.exprStmt (YulExpr.call "mstore" [
     YulExpr.call "add" [base, YulExpr.lit offset],
     stored
   ])
@@ -94,7 +94,7 @@ def abiEncodePackedWordsModule (resultVar : String) (wordCount : Nat) : External
         [YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])] ++
         packedWordTempStoresAt ptr wordCount ++
         [
-      YulStmt.expr (YulExpr.call "mstore" [
+      YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.lit freeMemoryPointer,
         YulExpr.call "add" [ptr, YulExpr.lit (alignUp32 size)]
       ]),
@@ -139,7 +139,7 @@ def abiEncodeStaticWordsModule (resultVar : String) (wordCount : Nat) : External
         [YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])] ++
         packedWordTempStoresAt ptr wordCount ++
         [
-          YulStmt.expr (YulExpr.call "mstore" [
+          YulStmt.exprStmt (YulExpr.call "mstore" [
             YulExpr.lit freeMemoryPointer,
             YulExpr.call "add" [ptr, YulExpr.lit (alignUp32 size)]
           ]),
@@ -181,7 +181,7 @@ def permitStructHashExpectedYul (typeHash : Nat) : List YulStmt :=
       packedWordBindings args ++
       [YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])] ++
       packedWordTempStoresAt ptr 6 ++
-      [ YulStmt.expr (YulExpr.call "mstore"
+      [ YulStmt.exprStmt (YulExpr.call "mstore"
           [ YulExpr.lit freeMemoryPointer
           , yulAdd ptr 192
           ])
@@ -246,8 +246,8 @@ def abiEncodeStaticArrayModule
       YulStmt.block ([
         YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]),
         YulStmt.let_ lengthName arrayLengthExpr,
-        YulStmt.expr (YulExpr.call "mstore" [ptr, YulExpr.lit 32]),
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [ptr, YulExpr.lit 32]),
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.call "add" [ptr, YulExpr.lit 32],
           length
         ]),
@@ -264,7 +264,7 @@ def abiEncodeStaticArrayModule
           YulExpr.call "add" [totalBytes, YulExpr.lit 31],
           YulExpr.call "not" [YulExpr.lit 31]
         ]),
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.lit freeMemoryPointer,
           YulExpr.call "add" [ptr, YulExpr.ident paddedTotalName]
         ]),
@@ -304,7 +304,7 @@ def abiEncodePackedStaticSegmentsModule (resultVar : String) (widths : List Nat)
         [YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])] ++
         packedSegmentTempStoresAt ptr widths ++
         [
-          YulStmt.expr (YulExpr.call "mstore" [
+          YulStmt.exprStmt (YulExpr.call "mstore" [
             YulExpr.lit freeMemoryPointer,
             YulExpr.call "add" [ptr, YulExpr.lit (alignUp32 size)]
           ]),
@@ -341,19 +341,19 @@ def eip712DigestModule (resultVar : String) : ExternalCallModule where
       YulStmt.let_ resultVar (YulExpr.lit 0),
       YulStmt.block [
         YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer]),
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           ptr,
           YulExpr.call "shl" [YulExpr.lit 240, YulExpr.hex 0x1901]
         ]),
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.call "add" [ptr, YulExpr.lit 2],
           domainSeparatorExpr
         ]),
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.call "add" [ptr, YulExpr.lit 34],
           structHashExpr
         ]),
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.lit freeMemoryPointer,
           YulExpr.call "add" [ptr, YulExpr.lit 96]
         ]),
@@ -375,15 +375,15 @@ def eip712DigestExpectedYul : List YulStmt :=
   , YulStmt.block
       [ YulStmt.let_ ptrName
           (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
-      , YulStmt.expr (YulExpr.call "mstore"
+      , YulStmt.exprStmt (YulExpr.call "mstore"
           [ ptr
           , YulExpr.call "shl" [YulExpr.lit 240, YulExpr.hex 0x1901]
           ])
-      , YulStmt.expr (YulExpr.call "mstore"
+      , YulStmt.exprStmt (YulExpr.call "mstore"
           [yulAdd ptr 2, YulExpr.ident "domainSeparator"])
-      , YulStmt.expr (YulExpr.call "mstore"
+      , YulStmt.exprStmt (YulExpr.call "mstore"
           [yulAdd ptr 34, YulExpr.ident "structHash"])
-      , YulStmt.expr (YulExpr.call "mstore"
+      , YulStmt.exprStmt (YulExpr.call "mstore"
           [ YulExpr.lit freeMemoryPointer
           , yulAdd ptr 96
           ])
@@ -425,7 +425,7 @@ def sha256PackedWordsModule (resultVar : String) (wordCount : Nat) : ExternalCal
       outputOffset, YulExpr.lit 32
     ]
     let revertBlock := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__sha256_packed_success"]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ]
     pure [
       YulStmt.let_ resultVar (YulExpr.lit 0),
@@ -436,7 +436,7 @@ def sha256PackedWordsModule (resultVar : String) (wordCount : Nat) : ExternalCal
         YulStmt.let_ "__sha256_packed_success" callExpr,
         revertBlock,
         YulStmt.assign resultVar (YulExpr.call "mload" [outputOffset]),
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.lit freeMemoryPointer,
           YulExpr.call "add" [outputOffset, YulExpr.lit 32]
         ])
@@ -479,7 +479,7 @@ def sha256PackedStaticSegmentsModule (resultVar : String) (widths : List Nat) : 
       outputOffset, YulExpr.lit 32
     ]
     let revertBlock := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__sha256_packed_segments_success"]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ]
     pure [
       YulStmt.let_ resultVar (YulExpr.lit 0),
@@ -490,7 +490,7 @@ def sha256PackedStaticSegmentsModule (resultVar : String) (widths : List Nat) : 
         YulStmt.let_ "__sha256_packed_segments_success" callExpr,
         revertBlock,
         YulStmt.assign resultVar (YulExpr.call "mload" [outputOffset]),
-        YulStmt.expr (YulExpr.call "mstore" [
+        YulStmt.exprStmt (YulExpr.call "mstore" [
           YulExpr.lit freeMemoryPointer,
           YulExpr.call "add" [outputOffset, YulExpr.lit 32]
         ])

--- a/Compiler/Modules/Oracle.lean
+++ b/Compiler/Modules/Oracle.lean
@@ -35,16 +35,16 @@ private def compileStaticSingleWordRead
     let ptrName := "__oracle_ptr"
     let ptrExpr := YulExpr.ident ptrName
     let loadPtr := YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
-    let storeSelector := YulStmt.expr (YulExpr.call "mstore" [
+    let storeSelector := YulStmt.exprStmt (YulExpr.call "mstore" [
       ptrExpr,
       YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex selector]
     ])
     let storeArgs := staticArgExprs.zipIdx.map fun (argExpr, idx) =>
-      YulStmt.expr (YulExpr.call "mstore" [
+      YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.call "add" [ptrExpr, YulExpr.lit (4 + idx * 32)],
         argExpr
       ])
-    let advancePtr := YulStmt.expr (YulExpr.call "mstore" [
+    let advancePtr := YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit freeMemoryPointer,
       YulExpr.call "add" [ptrExpr, YulExpr.lit frameSize]
     ])
@@ -56,15 +56,15 @@ private def compileStaticSingleWordRead
     ]
     let revertOnFailure := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__oracle_success"]) [
       YulStmt.let_ "__oracle_rds" (YulExpr.call "returndatasize" []),
-      YulStmt.expr (YulExpr.call "returndatacopy" [
+      YulStmt.exprStmt (YulExpr.call "returndatacopy" [
         YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__oracle_rds"
       ]),
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__oracle_rds"])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__oracle_rds"])
     ]
     let requireSingleWord := YulStmt.if_ (YulExpr.call "iszero" [
       YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 32]
     ]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ]
     let bindResult := YulStmt.let_ resultVar (YulExpr.lit 0)
     let assignResult := YulStmt.assign resultVar (YulExpr.call "mload" [ptrExpr])

--- a/Compiler/Modules/Precompiles.lean
+++ b/Compiler/Modules/Precompiles.lean
@@ -42,11 +42,11 @@ def ecrecoverModule (resultVar : String) : ExternalCallModule where
     let ptrName := "__ecr_ptr"
     let ptrExpr := YulExpr.ident ptrName
     let loadPtr := YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
-    let storeHash := YulStmt.expr (YulExpr.call "mstore" [ptrExpr, hashExpr])
-    let storeV := YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 32], vExpr])
-    let storeR := YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 64], rExpr])
-    let storeS := YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 96], sExpr])
-    let advancePtr := YulStmt.expr (YulExpr.call "mstore" [
+    let storeHash := YulStmt.exprStmt (YulExpr.call "mstore" [ptrExpr, hashExpr])
+    let storeV := YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 32], vExpr])
+    let storeR := YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 64], rExpr])
+    let storeS := YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 96], sExpr])
+    let advancePtr := YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit freeMemoryPointer,
       YulExpr.call "add" [ptrExpr, YulExpr.lit 128]
     ])
@@ -57,10 +57,10 @@ def ecrecoverModule (resultVar : String) : ExternalCallModule where
       ptrExpr, YulExpr.lit 32
     ]
     let revertBlock := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__ecr_success"]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ]
     let guardStale := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.call "returndatasize" []]) [
-      YulStmt.expr (YulExpr.call "mstore" [ptrExpr, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "mstore" [ptrExpr, YulExpr.lit 0])
     ]
     let bindResult := YulStmt.let_ resultVar (YulExpr.lit 0)
     let assignResult := YulStmt.assign resultVar
@@ -100,7 +100,7 @@ def sha256MemoryModule (resultVar : String) : ExternalCallModule where
       outputOffsetTemp, YulExpr.lit 32
     ]
     let revertBlock := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__sha256_success"]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ]
     let bindResult := YulStmt.let_ resultVar (YulExpr.lit 0)
     let assignResult := YulStmt.assign resultVar (YulExpr.call "mload" [outputOffsetTemp])
@@ -153,11 +153,11 @@ def bn256AddModule (resultXVar resultYVar : String) : ExternalCallModule where
     let ptrName := "__bn256_add_ptr"
     let ptrExpr := YulExpr.ident ptrName
     let loadPtr := YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
-    let storeX1 := YulStmt.expr (YulExpr.call "mstore" [ptrExpr, x1])
-    let storeY1 := YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 32], y1])
-    let storeX2 := YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 64], x2])
-    let storeY2 := YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 96], y2])
-    let advancePtr := YulStmt.expr (YulExpr.call "mstore" [
+    let storeX1 := YulStmt.exprStmt (YulExpr.call "mstore" [ptrExpr, x1])
+    let storeY1 := YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 32], y1])
+    let storeX2 := YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 64], x2])
+    let storeY2 := YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 96], y2])
+    let advancePtr := YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit freeMemoryPointer,
       YulExpr.call "add" [ptrExpr, YulExpr.lit 128]
     ])
@@ -168,7 +168,7 @@ def bn256AddModule (resultXVar resultYVar : String) : ExternalCallModule where
       ptrExpr, YulExpr.lit 64
     ]
     let revertBlock := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__bn256_add_success"]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ]
     let bindX := YulStmt.let_ resultXVar (YulExpr.lit 0)
     let bindY := YulStmt.let_ resultYVar (YulExpr.lit 0)
@@ -207,10 +207,10 @@ def bn256ScalarMulModule (resultXVar resultYVar : String) : ExternalCallModule w
     let ptrName := "__bn256_mul_ptr"
     let ptrExpr := YulExpr.ident ptrName
     let loadPtr := YulStmt.let_ ptrName (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])
-    let storeX := YulStmt.expr (YulExpr.call "mstore" [ptrExpr, x])
-    let storeY := YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 32], y])
-    let storeS := YulStmt.expr (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 64], scalar])
-    let advancePtr := YulStmt.expr (YulExpr.call "mstore" [
+    let storeX := YulStmt.exprStmt (YulExpr.call "mstore" [ptrExpr, x])
+    let storeY := YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 32], y])
+    let storeS := YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.call "add" [ptrExpr, YulExpr.lit 64], scalar])
+    let advancePtr := YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit freeMemoryPointer,
       YulExpr.call "add" [ptrExpr, YulExpr.lit 96]
     ])
@@ -221,7 +221,7 @@ def bn256ScalarMulModule (resultXVar resultYVar : String) : ExternalCallModule w
       ptrExpr, YulExpr.lit 64
     ]
     let revertBlock := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__bn256_mul_success"]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ]
     let bindX := YulStmt.let_ resultXVar (YulExpr.lit 0)
     let bindY := YulStmt.let_ resultYVar (YulExpr.lit 0)
@@ -269,7 +269,7 @@ def bn256PairingModule (resultVar : String) : ExternalCallModule where
       outputOffsetTemp, YulExpr.lit 32
     ]
     let revertBlock := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__bn256_pairing_success"]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ]
     let bindResult := YulStmt.let_ resultVar (YulExpr.lit 0)
     let assignResult := YulStmt.assign resultVar (YulExpr.call "mload" [outputOffsetTemp])

--- a/Compiler/Proofs/EndToEnd/Base.lean
+++ b/Compiler/Proofs/EndToEnd/Base.lean
@@ -715,7 +715,7 @@ private theorem sizeOf_buildSwitch_noFallback_noReceive_ge_source_cases_length
   set cases :=
     Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases fns
   set defaultStmts : List Compiler.Yul.YulStmt :=
-    [Compiler.Yul.YulStmt.expr
+    [Compiler.Yul.YulStmt.exprStmt
       (Compiler.Yul.YulExpr.call "revert"
         [Compiler.Yul.YulExpr.lit 0, Compiler.Yul.YulExpr.lit 0])]
   set sw := Compiler.Yul.YulStmt.switch
@@ -780,7 +780,7 @@ private theorem sizeOf_buildSwitch_noFallback_noReceive_ge_source_cases_length_p
   set cases :=
     Compiler.Proofs.YulGeneration.Backends.Native.buildSwitchSourceCases fns
   set defaultStmts : List Compiler.Yul.YulStmt :=
-    [Compiler.Yul.YulStmt.expr
+    [Compiler.Yul.YulStmt.exprStmt
       (Compiler.Yul.YulExpr.call "revert"
         [Compiler.Yul.YulExpr.lit 0, Compiler.Yul.YulExpr.lit 0])]
   set sw := Compiler.Yul.YulStmt.switch
@@ -8036,7 +8036,7 @@ private theorem lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_no
   cases hTail :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
         (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
-          [Yul.YulStmt.expr
+          [Yul.YulStmt.exprStmt
             (Yul.YulExpr.call "mstore"
               [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
                 Yul.YulExpr.lit 128]),
@@ -8054,7 +8054,7 @@ private theorem lowerStmtsNative_initFreeMemoryPointer_buildSwitch_noFallback_no
           rcases
             lowerStmtsNativeWithSwitchIds_buildSwitch_noFallback_noReceive_ok_block
               (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
-                [Yul.YulStmt.expr
+                [Yul.YulStmt.exprStmt
                   (Yul.YulExpr.call "mstore"
                     [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
                       Yul.YulExpr.lit 128]),
@@ -21364,7 +21364,7 @@ private theorem nativeResultsMatchOn_execIRFunction_stop_body_markedPrefix
     (fn : IRFunction)
     (switchId : Nat)
     (store : EvmYul.Yul.VarStore)
-    (hBody : fn.body = [Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])]) :
+    (hBody : fn.body = [Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])]) :
     nativeResultsMatchOn observableSlots
       (execIRFunction fn tx.args (applyIRTransactionContext tx state))
       (.ok
@@ -21411,12 +21411,12 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_stop_body
       ∀ fn,
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
-        fn.body = [Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])]) :
+        fn.body = [Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])]) :
     NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel irContract tx state
       observableSlots := by
   intro nativeContract fn reservedNames n0 cases' bodyNative bodyEnd
     userBodyStart _hLowerRuntime hFind hUserBodyLower _hguards _hArgs
-  have hBody : fn.body = [Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])] :=
+  have hBody : fn.body = [Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])] :=
     hStop fn hFind
   rw [hBody] at hUserBodyLower
   simp [Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds_cons,
@@ -21565,7 +21565,7 @@ theorem NativeGeneratedSelectedUserBodyResultBridgeAtFuel.of_stop_body
       ∀ fn,
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
-        fn.body = [Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])]) :
+        fn.body = [Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])]) :
     NativeGeneratedSelectedUserBodyResultBridgeAtFuel irContract tx state
       observableSlots :=
   NativeGeneratedSelectedUserBodyResultBridgeAtFuel.of_halt irContract tx state
@@ -27753,7 +27753,7 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_s
       ∀ fn,
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
-        fn.body = [Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])]) :
+        fn.body = [Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])]) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
         (Compiler.emitYul irContract).runtimeCode = .ok nativeContract ∧

--- a/Compiler/Proofs/EndToEnd/SimpleStorage.lean
+++ b/Compiler/Proofs/EndToEnd/SimpleStorage.lean
@@ -254,7 +254,7 @@ private theorem simpleStorageNativeRuntimeDispatcherStmts_exists_init_block :
           have hInner' :
               Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
                 (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
-                  [Yul.YulStmt.expr
+                  [Yul.YulStmt.exprStmt
                     (Yul.YulExpr.call "mstore"
                       [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
                        Yul.YulExpr.lit 128]),
@@ -303,7 +303,7 @@ private theorem simpleStorageNativeRuntimeDispatcherStmts_exists_init_block :
             have hInnerMap :
                 Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
                   (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
-                    [Yul.YulStmt.expr
+                    [Yul.YulStmt.exprStmt
                       (Yul.YulExpr.call "mstore"
                         [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
                          Yul.YulExpr.lit 128]),
@@ -366,7 +366,7 @@ private theorem simpleStorageNativeRuntimeDispatcherStmts_exists_init_block :
           have hInner' :
               Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
                 (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
-                  [Yul.YulStmt.expr
+                  [Yul.YulStmt.exprStmt
                     (Yul.YulExpr.call "mstore"
                       [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
                        Yul.YulExpr.lit 128]),
@@ -425,7 +425,7 @@ private theorem simpleStorageNativeRuntimeDispatcherStmts_exists_init_block :
             have hInnerMap :
                 Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
                   (Compiler.Proofs.YulGeneration.Backends.yulStmtsIdentifierNames
-                    [Yul.YulStmt.expr
+                    [Yul.YulStmt.exprStmt
                       (Yul.YulExpr.call "mstore"
                         [Yul.YulExpr.lit Compiler.Constants.freeMemoryPointer,
                          Yul.YulExpr.lit 128]),
@@ -989,7 +989,7 @@ private theorem lowerStmtsNativeWithSwitchIds_revert_zero_zero
     (reservedNames : List String) (n : Nat) :
     Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
         reservedNames n
-        [Yul.YulStmt.expr (Yul.YulExpr.call "revert"
+        [Yul.YulStmt.exprStmt (Yul.YulExpr.call "revert"
           [Yul.YulExpr.lit 0, Yul.YulExpr.lit 0])] =
       .ok ([Backends.Native.nativeRevertZeroZeroStmt], n) := by
   exact Backends.Native.lowerStmtsNativeWithSwitchIds_revert_zero_zero
@@ -1011,7 +1011,7 @@ private theorem lowerStmtsNativeWithSwitchIds_singleton_switch_revert_default_eq
     (inner : List EvmYul.Yul.Ast.Stmt) (next : Nat)
     (h : Backends.lowerStmtsNativeWithSwitchIds reservedNames n0
             [Yul.YulStmt.switch expr cases
-              (some [Yul.YulStmt.expr (Yul.YulExpr.call "revert"
+              (some [Yul.YulStmt.exprStmt (Yul.YulExpr.call "revert"
                 [Yul.YulExpr.lit 0, Yul.YulExpr.lit 0])])] = .ok (inner, next)) :
     ∃ (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)),
       inner = [Backends.lowerNativeSwitchBlock expr
@@ -1033,7 +1033,7 @@ private theorem lowerStmtsNativeWithSwitchIds_singleton_switch_revert_default_eq
     (inner : List EvmYul.Yul.Ast.Stmt) (next : Nat)
     (h : Backends.lowerStmtsNativeWithSwitchIds reservedNames n0
             [Yul.YulStmt.switch expr cases
-              (some [Yul.YulStmt.expr (Yul.YulExpr.call "revert"
+              (some [Yul.YulStmt.exprStmt (Yul.YulExpr.call "revert"
                 [Yul.YulExpr.lit 0, Yul.YulExpr.lit 0])])] = .ok (inner, next)) :
     ∃ (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) (midN : Nat),
       inner = [Backends.lowerNativeSwitchBlock expr
@@ -1278,7 +1278,7 @@ private theorem simpleStorageNativeDispatcher_if1Body_eq :
       Compiler.CodegenCommon.defaultDispatchCase
           (none : Option Compiler.IREntrypoint)
           (none : Option Compiler.IREntrypoint) =
-        [Yul.YulStmt.expr
+        [Yul.YulStmt.exprStmt
           (Yul.YulExpr.call "revert" [Yul.YulExpr.lit 0, Yul.YulExpr.lit 0])] :=
     rfl
   rw [hDef, lowerStmtsNativeWithSwitchIds_revert_zero_zero,
@@ -3417,9 +3417,9 @@ private theorem interpretIR_simpleStorage_retrieveHit
   -- Closed-form evaluation of the retrieve body for any fuel ≥ 2.
   have hbody : ∀ (n : Nat) (s : IRState), 2 ≤ n →
       execIRStmts (n + 1) s
-        [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+        [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-         Yul.YulStmt.expr (Yul.YulExpr.call "return"
+         Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] =
           .return ((s.storage (IRStorageSlot.ofNat 0)).toNat)
             { s with memory := fun o =>
@@ -3434,9 +3434,9 @@ private theorem interpretIR_simpleStorage_retrieveHit
   -- The retrieve body has at least 2 statements, so `sizeOf body ≥ 2` by
   -- direct computation on the auto-derived size measure.
   have hsize : 2 ≤ sizeOf
-      ([Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+      ([Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-        Yul.YulStmt.expr (Yul.YulExpr.call "return"
+        Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] : List Yul.YulStmt) := by
     decide
   unfold interpretIR
@@ -3478,9 +3478,9 @@ private theorem interpretIR_simpleStorage_storeHit_arg
       ret := IRType.unit
       body := [
         Yul.YulStmt.let_ "value" (Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]),
-        Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+        Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
           [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-        Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])] }
+        Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])] }
   have hExec :=
     Compiler.Proofs.IRGeneration.execIRFunction_store0_calldataload4_stop_of_args_cons
       storeFn tx initialState arg rest (by rfl) hArgs
@@ -4158,8 +4158,8 @@ private theorem nativeResultsMatchOn_execIRFunction_store0_calldataload4_stop_ma
     (arg : Nat) (rest : List Nat)
     (hBody : fn.body = [
       Yul.YulStmt.let_ "value" (Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]),
-      Yul.YulStmt.expr (Yul.YulExpr.call "sstore" [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-      Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])])
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore" [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])])
     (hArgs : tx.args = arg :: rest) :
     let yulTx := YulTransaction.ofIR tx
     let slots :=
@@ -4246,8 +4246,8 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_store0_ca
           some fn →
         fn.body = [
           Yul.YulStmt.let_ "value" (Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "sstore" [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])])
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore" [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])])
     (hArgsCons : ∃ arg rest, tx.args = arg :: rest) :
     NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel irContract tx state
       observableSlots := by
@@ -4260,10 +4260,10 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_store0_ca
           reservedNames userBodyStart
           ([Yul.YulStmt.let_ "value"
               (Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]),
-            Yul.YulStmt.expr
+            Yul.YulStmt.exprStmt
               (Yul.YulExpr.call "sstore"
                 [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-            Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])] : List Yul.YulStmt) =
+            Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])] : List Yul.YulStmt) =
         .ok (simpleStorageLoweredStoreCaseBodyTail3, userBodyStart) := by
     simp [simpleStorageLoweredStoreCaseBodyTail3,
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds_cons,
@@ -4323,8 +4323,8 @@ private theorem NativeGeneratedSelectedUserBodyResultBridgeAtFuel.of_store0_call
           some fn →
         fn.body = [
           Yul.YulStmt.let_ "value" (Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "sstore" [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])])
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore" [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])])
     (hArgsCons : ∃ arg rest, tx.args = arg :: rest) :
     NativeGeneratedSelectedUserBodyResultBridgeAtFuel irContract tx state
       observableSlots :=
@@ -4362,8 +4362,8 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_s
           some fn →
         fn.body = [
           Yul.YulStmt.let_ "value" (Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "sstore" [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])])
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore" [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])])
     (hArgsCons : ∃ arg rest, tx.args = arg :: rest) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -4663,9 +4663,9 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_sload0_return32_mark
     (switchId : Nat)
     (store : EvmYul.Yul.VarStore)
     (hBody : fn.body = [
-      Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
         [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-      Yul.YulStmt.expr (Yul.YulExpr.call "return"
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     let yulTx := YulTransaction.ofIR tx
     let slots :=
@@ -4772,9 +4772,9 @@ private theorem execIRFunction_zeroParam_mstore0_lit_return32
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hBody : fn.body =
       Compiler.CompilationModel.genParamLoads [] ++
-      [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+      [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-       Yul.YulStmt.expr (Yul.YulExpr.call "return"
+       Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     execIRFunction fn tx.args (applyIRTransactionContext tx initialState) =
       { success := true
@@ -4783,9 +4783,9 @@ private theorem execIRFunction_zeroParam_mstore0_lit_return32
         finalMappings := Compiler.Proofs.storageAsMappings initialState.storage
         events := initialState.events } := by
   let rest : List Yul.YulStmt :=
-    [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+    [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
       [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-     Yul.YulStmt.expr (Yul.YulExpr.call "return"
+     Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
       [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]
   let params : List CompilationModel.Param := []
   let body := Compiler.CompilationModel.genParamLoads params ++ rest
@@ -4889,9 +4889,9 @@ private theorem execIRFunction_zeroParam_mstore0_sload0_return32
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hBody : fn.body =
       Compiler.CompilationModel.genParamLoads [] ++
-      [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+      [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
         [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-       Yul.YulStmt.expr (Yul.YulExpr.call "return"
+       Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     execIRFunction fn tx.args (applyIRTransactionContext tx initialState) =
       { success := true
@@ -4900,9 +4900,9 @@ private theorem execIRFunction_zeroParam_mstore0_sload0_return32
         finalMappings := Compiler.Proofs.storageAsMappings initialState.storage
         events := initialState.events } := by
   let rest : List Yul.YulStmt :=
-    [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+    [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
       [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-     Yul.YulStmt.expr (Yul.YulExpr.call "return"
+     Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
       [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]
   let params : List CompilationModel.Param := []
   let body := Compiler.CompilationModel.genParamLoads params ++ rest
@@ -5018,9 +5018,9 @@ private theorem execIRFunction_oneParam_store0_value_stop
     (hBody : fn.body =
       Compiler.CompilationModel.genParamLoads
         [{ name := "value", ty := CompilationModel.ParamType.uint256 }] ++
-      [Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+      [Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
         [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-       Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])]) :
+       Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])]) :
     execIRFunction fn tx.args (applyIRTransactionContext tx initialState) =
       { success := true
         returnValue := none
@@ -5037,9 +5037,9 @@ private theorem execIRFunction_oneParam_store0_value_stop
   let irParams : List IRParam :=
     [{ name := "value", ty := IRType.uint256 }]
   let restBody : List Yul.YulStmt :=
-    [Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+    [Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
       [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-     Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])]
+     Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])]
   let body := Compiler.CompilationModel.genParamLoads params ++ restBody
   let txState := applyIRTransactionContext tx initialState
   let stateWithParams :=
@@ -5179,9 +5179,9 @@ private theorem nativeResultsMatchOn_execIRFunction_oneParam_store0_value_stop_m
     (hBody : fn.body =
       Compiler.CompilationModel.genParamLoads
         [{ name := "value", ty := CompilationModel.ParamType.uint256 }] ++
-      [Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+      [Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
         [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-       Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])]) :
+       Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])]) :
     let yulTx := YulTransaction.ofIR tx
     let slots :=
       Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
@@ -5274,9 +5274,9 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_oneParam_
         fn.body =
           Compiler.CompilationModel.genParamLoads
             [{ name := "value", ty := CompilationModel.ParamType.uint256 }] ++
-          [Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-           Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])])
+           Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])])
     (hArgsCons : ∃ arg rest, tx.args = arg :: rest) :
     NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel irContract tx state
       observableSlots := by
@@ -5290,9 +5290,9 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_oneParam_
           reservedNames userBodyStart
           (Compiler.CompilationModel.genParamLoads
             [{ name := "value", ty := CompilationModel.ParamType.uint256 }] ++
-          [Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-           Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])] : List Yul.YulStmt) =
+           Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])] : List Yul.YulStmt) =
         .ok (simpleStorageLoweredStoreCaseBodyTail2, userBodyStart) := by
     simp [simpleStorageLoweredStoreCaseBodyTail2,
       Compiler.CompilationModel.genParamLoads,
@@ -5386,9 +5386,9 @@ private theorem NativeGeneratedSelectedUserBodyResultBridgeAtFuel.of_oneParam_st
         fn.body =
           Compiler.CompilationModel.genParamLoads
             [{ name := "value", ty := CompilationModel.ParamType.uint256 }] ++
-          [Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-           Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])])
+           Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])])
     (hArgsCons : ∃ arg rest, tx.args = arg :: rest) :
     NativeGeneratedSelectedUserBodyResultBridgeAtFuel irContract tx state
       observableSlots :=
@@ -5427,9 +5427,9 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_o
         fn.body =
           Compiler.CompilationModel.genParamLoads
             [{ name := "value", ty := CompilationModel.ParamType.uint256 }] ++
-          [Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-           Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])])
+           Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])])
     (hArgsCons : ∃ arg rest, tx.args = arg :: rest) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -5471,9 +5471,9 @@ private theorem selectedCompiledFunction_oneParam_store0_value_stop_shape_of_for
           [] false (entry.1.params.map (·.name)) [] entry.1.body =
             Except.ok bodyStmts →
         bodyStmts =
-          [Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])])
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])])
     (irFn : IRFunction)
     (hFind :
       irFns.find? (fun fn => fn.selector == tx.functionSelector) =
@@ -5482,9 +5482,9 @@ private theorem selectedCompiledFunction_oneParam_store0_value_stop_shape_of_for
     irFn.body =
       Compiler.CompilationModel.genParamLoads
         [{ name := "value", ty := CompilationModel.ParamType.uint256 }] ++
-      [Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+      [Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
         [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-      Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])] := by
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])] := by
   induction hcompiled with
   | nil =>
       simp at hFind
@@ -5508,9 +5508,9 @@ private theorem selectedCompiledFunction_oneParam_store0_value_stop_shape_of_for
           hSourceParams entry hEntryMem hEntrySelector
         have hBodyStmts :
             bodyStmts =
-              [Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+              [Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
                 [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-              Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])] :=
+              Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])] :=
           hSourceBody entry bodyStmts hEntryMem hEntrySelector hbody
         constructor
         · rw [hirFn]
@@ -5550,9 +5550,9 @@ private theorem selectedGeneratedFunction_oneParam_store0_value_stop_shape_of_co
           .calldata [] false (entry.1.params.map (·.name)) []
           entry.1.body = Except.ok bodyStmts →
         bodyStmts =
-          [Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])])
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])])
     (irFn : IRFunction)
     (hFind :
       irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
@@ -5561,9 +5561,9 @@ private theorem selectedGeneratedFunction_oneParam_store0_value_stop_shape_of_co
     irFn.body =
       Compiler.CompilationModel.genParamLoads
         [{ name := "value", ty := CompilationModel.ParamType.uint256 }] ++
-      [Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+      [Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
         [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-      Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])] := by
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])] := by
   have hcompiled :=
     Compiler.Proofs.IRGeneration.Contract.compile_ok_yields_compiled_functions
       spec selectors hSupported irContract hcompile
@@ -5603,9 +5603,9 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_s
           .calldata [] false (entry.1.params.map (·.name)) []
           entry.1.body = Except.ok bodyStmts →
         bodyStmts =
-          [Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])])
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])])
     (hArgsCons : ∃ arg rest, tx.args = arg :: rest) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -5656,9 +5656,9 @@ private theorem compile_preserves_native_evmYulLean_of_compile_ok_supported_gene
           .calldata [] false (entry.1.params.map (·.name)) []
           entry.1.body = Except.ok bodyStmts →
         bodyStmts =
-          [Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])])
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])])
     (hArgsCons : ∃ arg rest, tx.args = arg :: rest) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -5699,9 +5699,9 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_lit_return32_markedP
     (value : Nat)
     (hValueRange : value < EvmYul.UInt256.size)
     (hBody : fn.body = [
-      Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-      Yul.YulStmt.expr (Yul.YulExpr.call "return"
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     let yulTx := YulTransaction.ofIR tx
     let slots :=
@@ -5825,9 +5825,9 @@ private theorem nativeResultsMatchOn_execIRFunction_zeroParam_mstore0_lit_return
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hBody : fn.body =
       Compiler.CompilationModel.genParamLoads [] ++
-      [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+      [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-      Yul.YulStmt.expr (Yul.YulExpr.call "return"
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     let yulTx := YulTransaction.ofIR tx
     let slots :=
@@ -5949,9 +5949,9 @@ private theorem nativeResultsMatchOn_execIRFunction_zeroParam_mstore0_sload0_ret
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hBody : fn.body =
       Compiler.CompilationModel.genParamLoads [] ++
-      [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+      [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
         [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-      Yul.YulStmt.expr (Yul.YulExpr.call "return"
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     let yulTx := YulTransaction.ofIR tx
     let slots :=
@@ -6072,10 +6072,10 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_calldataload_aligned
     (idx arg : Nat) (rest : List Nat)
     (hdrop : tx.args.drop idx = arg :: rest)
     (hBody : fn.body = [
-      Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
         [Yul.YulExpr.lit 0,
          Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit (4 + 32 * idx)]]),
-      Yul.YulStmt.expr (Yul.YulExpr.call "return"
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     let yulTx := YulTransaction.ofIR tx
     let slots :=
@@ -6199,10 +6199,10 @@ private theorem nativeResultsMatchOn_execIRFunction_mstore0_calldataload4_return
     (arg : Nat) (rest : List Nat)
     (hArgs : tx.args = arg :: rest)
     (hBody : fn.body = [
-      Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
         [Yul.YulExpr.lit 0,
          Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]]),
-      Yul.YulStmt.expr (Yul.YulExpr.call "return"
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     let yulTx := YulTransaction.ofIR tx
     let slots :=
@@ -6321,9 +6321,9 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_s
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
         fn.body = [
-          Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel irContract tx state
       observableSlots := by
@@ -6333,9 +6333,9 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_s
   have hLowerConcrete :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           reservedNames userBodyStart
-          ([Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          ([Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
               [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-            Yul.YulStmt.expr (Yul.YulExpr.call "return"
+            Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
               [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] : List Yul.YulStmt) =
         .ok (simpleStorageLoweredRetrieveCaseBodyTail3, userBodyStart) := by
     simp [simpleStorageLoweredRetrieveCaseBodyTail3,
@@ -6427,9 +6427,9 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_zeroParam
           some fn →
         fn.body =
           Compiler.CompilationModel.genParamLoads [] ++
-          [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel irContract tx state
       observableSlots := by
@@ -6441,9 +6441,9 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_zeroParam
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           reservedNames userBodyStart
           (Compiler.CompilationModel.genParamLoads [] ++
-            [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+            [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
               [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-            Yul.YulStmt.expr (Yul.YulExpr.call "return"
+            Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
               [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] : List Yul.YulStmt) =
         .ok (loweredZeroParamSload0ReturnCaseBody, userBodyStart) := by
     simp [loweredZeroParamSload0ReturnCaseBody,
@@ -6537,9 +6537,9 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_l
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
         fn.body = [
-          Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel irContract tx state
       observableSlots := by
@@ -6549,9 +6549,9 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_l
   have hLowerConcrete :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           reservedNames userBodyStart
-          ([Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          ([Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
               [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-            Yul.YulStmt.expr (Yul.YulExpr.call "return"
+            Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
               [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] : List Yul.YulStmt) =
         .ok (loweredLiteralReturnCaseBodyTail value, userBodyStart) := by
     simp [loweredLiteralReturnCaseBodyTail,
@@ -6637,9 +6637,9 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_zeroParam
           some fn →
         fn.body =
           Compiler.CompilationModel.genParamLoads [] ++
-          [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel irContract tx state
       observableSlots := by
@@ -6651,9 +6651,9 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_zeroParam
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           reservedNames userBodyStart
           (Compiler.CompilationModel.genParamLoads [] ++
-            [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+            [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
               [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-            Yul.YulStmt.expr (Yul.YulExpr.call "return"
+            Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
               [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] : List Yul.YulStmt) =
         .ok (loweredZeroParamLiteralReturnCaseBody value, userBodyStart) := by
     simp [loweredZeroParamLiteralReturnCaseBody, loweredLiteralReturnCaseBodyTail,
@@ -6744,10 +6744,10 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_c
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
         fn.body = [
-          Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0,
              Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel irContract tx state
       observableSlots := by
@@ -6758,10 +6758,10 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_c
   have hLowerConcrete :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           reservedNames userBodyStart
-          ([Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          ([Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
               [Yul.YulExpr.lit 0,
                Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]]),
-            Yul.YulStmt.expr (Yul.YulExpr.call "return"
+            Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
               [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] : List Yul.YulStmt) =
         .ok (loweredCalldataload4ReturnCaseBodyTail, userBodyStart) := by
     simp [loweredCalldataload4ReturnCaseBodyTail,
@@ -6847,10 +6847,10 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_c
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
         fn.body = [
-          Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0,
              Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit (4 + 32 * idx)]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel irContract tx state
       observableSlots := by
@@ -6860,10 +6860,10 @@ private theorem NativeGeneratedSelectedUserBodyHaltExecBridgeAtFuel.of_mstore0_c
   have hLowerConcrete :
       Compiler.Proofs.YulGeneration.Backends.lowerStmtsNativeWithSwitchIds
           reservedNames userBodyStart
-          ([Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          ([Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
               [Yul.YulExpr.lit 0,
                Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit (4 + 32 * idx)]]),
-            Yul.YulStmt.expr (Yul.YulExpr.call "return"
+            Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
               [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] : List Yul.YulStmt) =
         .ok (loweredCalldataloadReturnCaseBodyTail idx, userBodyStart) := by
     simp [loweredCalldataloadReturnCaseBodyTail,
@@ -6946,9 +6946,9 @@ private theorem NativeGeneratedSelectedUserBodyResultBridgeAtFuel.of_mstore0_slo
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
         fn.body = [
-          Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     NativeGeneratedSelectedUserBodyResultBridgeAtFuel irContract tx state
       observableSlots :=
@@ -6974,9 +6974,9 @@ private theorem NativeGeneratedSelectedUserBodyResultBridgeAtFuel.of_zeroParam_m
           some fn →
         fn.body =
           Compiler.CompilationModel.genParamLoads [] ++
-          [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     NativeGeneratedSelectedUserBodyResultBridgeAtFuel irContract tx state
       observableSlots :=
@@ -6997,9 +6997,9 @@ private theorem NativeGeneratedSelectedUserBodyResultBridgeAtFuel.of_mstore0_lit
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
         fn.body = [
-          Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     NativeGeneratedSelectedUserBodyResultBridgeAtFuel irContract tx state
       observableSlots :=
@@ -7027,9 +7027,9 @@ private theorem NativeGeneratedSelectedUserBodyResultBridgeAtFuel.of_zeroParam_m
           some fn →
         fn.body =
           Compiler.CompilationModel.genParamLoads [] ++
-          [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     NativeGeneratedSelectedUserBodyResultBridgeAtFuel irContract tx state
       observableSlots :=
@@ -7050,10 +7050,10 @@ private theorem NativeGeneratedSelectedUserBodyResultBridgeAtFuel.of_mstore0_cal
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
         fn.body = [
-          Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0,
              Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     NativeGeneratedSelectedUserBodyResultBridgeAtFuel irContract tx state
       observableSlots :=
@@ -7076,10 +7076,10 @@ private theorem NativeGeneratedSelectedUserBodyResultBridgeAtFuel.of_mstore0_cal
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
         fn.body = [
-          Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0,
              Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit (4 + 32 * idx)]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     NativeGeneratedSelectedUserBodyResultBridgeAtFuel irContract tx state
       observableSlots :=
@@ -7116,9 +7116,9 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_m
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
         fn.body = [
-          Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -7167,9 +7167,9 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_z
           some fn →
         fn.body =
           Compiler.CompilationModel.genParamLoads [] ++
-          [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -7213,9 +7213,9 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_m
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
         fn.body = [
-          Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -7257,9 +7257,9 @@ private theorem selectedCompiledFunction_zeroParam_lit_return32_shape_of_forall�
           [] false (entry.1.params.map (·.name)) [] entry.1.body =
             Except.ok bodyStmts →
         bodyStmts =
-          [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])])
     (irFn : IRFunction)
     (hFind :
@@ -7268,9 +7268,9 @@ private theorem selectedCompiledFunction_zeroParam_lit_return32_shape_of_forall�
     irFn.params = [] ∧
     irFn.body =
       Compiler.CompilationModel.genParamLoads [] ++
-      [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+      [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-      Yul.YulStmt.expr (Yul.YulExpr.call "return"
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] := by
   induction hcompiled with
   | nil =>
@@ -7293,9 +7293,9 @@ private theorem selectedCompiledFunction_zeroParam_lit_return32_shape_of_forall�
           hSourceParams entry hEntryMem hEntrySelector
         have hBodyStmts :
             bodyStmts =
-              [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+              [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
                 [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-              Yul.YulStmt.expr (Yul.YulExpr.call "return"
+              Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
                 [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] :=
           hSourceBody entry bodyStmts hEntryMem hEntrySelector hbody
         constructor
@@ -7335,9 +7335,9 @@ private theorem selectedGeneratedFunction_zeroParam_lit_return32_shape_of_compil
           .calldata [] false (entry.1.params.map (·.name)) []
           entry.1.body = Except.ok bodyStmts →
         bodyStmts =
-          [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])])
     (irFn : IRFunction)
     (hFind :
@@ -7346,9 +7346,9 @@ private theorem selectedGeneratedFunction_zeroParam_lit_return32_shape_of_compil
     irFn.params = [] ∧
     irFn.body =
       Compiler.CompilationModel.genParamLoads [] ++
-      [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+      [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-      Yul.YulStmt.expr (Yul.YulExpr.call "return"
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] := by
   have hcompiled :=
     Compiler.Proofs.IRGeneration.Contract.compile_ok_yields_compiled_functions
@@ -7382,9 +7382,9 @@ private theorem selectedCompiledFunction_zeroParam_sload0_return32_shape_of_fora
           [] false (entry.1.params.map (·.name)) [] entry.1.body =
             Except.ok bodyStmts →
         bodyStmts =
-          [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])])
     (irFn : IRFunction)
     (hFind :
@@ -7393,9 +7393,9 @@ private theorem selectedCompiledFunction_zeroParam_sload0_return32_shape_of_fora
     irFn.params = [] ∧
     irFn.body =
       Compiler.CompilationModel.genParamLoads [] ++
-      [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+      [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
         [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-      Yul.YulStmt.expr (Yul.YulExpr.call "return"
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] := by
   induction hcompiled with
   | nil =>
@@ -7418,9 +7418,9 @@ private theorem selectedCompiledFunction_zeroParam_sload0_return32_shape_of_fora
           hSourceParams entry hEntryMem hEntrySelector
         have hBodyStmts :
             bodyStmts =
-              [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+              [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
                 [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-              Yul.YulStmt.expr (Yul.YulExpr.call "return"
+              Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
                 [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] :=
           hSourceBody entry bodyStmts hEntryMem hEntrySelector hbody
         constructor
@@ -7459,9 +7459,9 @@ private theorem selectedGeneratedFunction_zeroParam_sload0_return32_shape_of_com
           .calldata [] false (entry.1.params.map (·.name)) []
           entry.1.body = Except.ok bodyStmts →
         bodyStmts =
-          [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])])
     (irFn : IRFunction)
     (hFind :
@@ -7470,9 +7470,9 @@ private theorem selectedGeneratedFunction_zeroParam_sload0_return32_shape_of_com
     irFn.params = [] ∧
     irFn.body =
       Compiler.CompilationModel.genParamLoads [] ++
-      [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+      [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
         [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-      Yul.YulStmt.expr (Yul.YulExpr.call "return"
+      Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
         [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] := by
   have hcompiled :=
     Compiler.Proofs.IRGeneration.Contract.compile_ok_yields_compiled_functions
@@ -7516,9 +7516,9 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_z
           some fn →
         fn.body =
           Compiler.CompilationModel.genParamLoads [] ++
-          [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -7572,9 +7572,9 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_s
           .calldata [] false (entry.1.params.map (·.name)) []
           entry.1.body = Except.ok bodyStmts →
         bodyStmts =
-          [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -7626,9 +7626,9 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_s
           .calldata [] false (entry.1.params.map (·.name)) []
           entry.1.body = Except.ok bodyStmts →
         bodyStmts =
-          [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -7679,9 +7679,9 @@ private theorem compile_preserves_native_evmYulLean_of_compile_ok_supported_gene
           .calldata [] false (entry.1.params.map (·.name)) []
           entry.1.body = Except.ok bodyStmts →
         bodyStmts =
-          [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit value]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -7735,9 +7735,9 @@ private theorem compile_preserves_native_evmYulLean_of_compile_ok_supported_gene
           .calldata [] false (entry.1.params.map (·.name)) []
           entry.1.body = Except.ok bodyStmts →
         bodyStmts =
-          [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          [Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -7790,10 +7790,10 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_m
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
         fn.body = [
-          Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0,
              Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -7839,10 +7839,10 @@ private theorem nativeGeneratedCallDispatcherMatchesIR_of_compile_ok_supported_m
         irContract.functions.find? (fun fn => fn.selector == tx.functionSelector) =
           some fn →
         fn.body = [
-          Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore"
             [Yul.YulExpr.lit 0,
              Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit (4 + 32 * idx)]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return"
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])]) :
     ∃ nativeContract : EvmYul.Yul.Ast.YulContract,
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
@@ -7925,8 +7925,8 @@ private theorem simpleStorageNativeRetrieveHitMatchBridge_proved
         params := []
         ret := IRType.uint256
         body := [
-          Yul.YulStmt.expr (Yul.YulExpr.call "mstore" [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "return" [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "mstore" [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "return" [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])
         ] }
     have hmem : retrieveFn ∈ simpleStorageIRContract.functions := by
       simp [retrieveFn, simpleStorageIRContract]
@@ -8057,8 +8057,8 @@ private theorem simpleStorageNativeStoreHitMatchBridge_proved
         ret := IRType.unit
         body := [
           Yul.YulStmt.let_ "value" (Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "sstore" [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
-          Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "sstore" [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
+          Yul.YulStmt.exprStmt (Yul.YulExpr.call "stop" [])
         ] }
     have hmem : storeFn ∈ simpleStorageIRContract.functions := by
       simp [storeFn, simpleStorageIRContract]

--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -163,7 +163,7 @@ private theorem compileValidatedCore_ok_yields_compiled_functions
   unfold compileValidatedCore at hcore
   rw [hSupported.normalizedFields,
     hSupported.noAdtTypes, hSupported.noEvents, hSupported.noErrors,
-    hnoInternalFns, hfallback, hreceive] at hcore
+    hnoInternalFns, hfallback, hreceive, hSupported.surface.noTemplateIntrinsics] at hcore
   simp only [bind, Except.bind, pure, Except.pure] at hcore
   rw [ContractShape.guardedFunctionsMapM_eq model.fields [] [] [] [] _
     (ContractShape.supportedSpec_entries_lock_free hSupported)] at hcore
@@ -220,7 +220,7 @@ private theorem compileValidatedCore_ok_yields_compiled_functions_except_mapping
   unfold compileValidatedCore at hcore
   rw [hSupported.normalizedFields,
     hSupported.noAdtTypes, hSupported.noEvents, hSupported.noErrors,
-    hnoInternalFns, hfallback, hreceive] at hcore
+    hnoInternalFns, hfallback, hreceive, hSupported.surface.noTemplateIntrinsics] at hcore
   simp only [bind, Except.bind, pure, Except.pure] at hcore
   rw [ContractShape.guardedFunctionsMapM_eq model.fields [] [] [] [] _
     (ContractShape.supportedSpecExceptMappingWrites_entries_lock_free hSupported)] at hcore
@@ -285,7 +285,7 @@ private theorem compileValidatedCore_ok_yields_internalFunctions_nil
     contractUsesPlainArrayElement, contractUsesArrayElementWord, harray,
     hstorageArray, hdynamicBytesEq, hmulDiv512, hparamDyn,
     hSupported.noCheckedArithmetic,
-    hnoInternalFns, hSupported.noAdtTypes] at hcore
+    hnoInternalFns, hSupported.noAdtTypes, hSupported.surface.noTemplateIntrinsics] at hcore
   simp only [bind, Except.bind, pure, Except.pure, List.mapM_nil] at hcore
   rw [ContractShape.guardedFunctionsMapM_eq model.fields model.events model.errors [] [] _
     (ContractShape.supportedSpec_entries_lock_free hSupported)] at hcore
@@ -321,7 +321,7 @@ private theorem compileValidatedCore_ok_yields_noFallbackEntrypoint
       model.functions.filter (·.isInternal) = [] :=
     filterInternalFunctions_eq_nil_of_supported model selectors hSupported
   unfold compileValidatedCore at hcore
-  rw [hnoInternalFns, hfallback, hreceive] at hcore
+  rw [hnoInternalFns, hfallback, hreceive, hSupported.surface.noTemplateIntrinsics] at hcore
   simp only [bind, Except.bind, Option.mapM_none, pure, Except.pure] at hcore
   rw [ContractShape.guardedFunctionsMapM_eq (applySlotAliasRanges model.fields model.slotAliasRanges)
     model.events model.errors model.adtTypes [] _
@@ -359,7 +359,7 @@ private theorem compileValidatedCore_ok_yields_noReceiveEntrypoint
       model.functions.filter (·.isInternal) = [] :=
     filterInternalFunctions_eq_nil_of_supported model selectors hSupported
   unfold compileValidatedCore at hcore
-  rw [hnoInternalFns, hfallback, hreceive] at hcore
+  rw [hnoInternalFns, hfallback, hreceive, hSupported.surface.noTemplateIntrinsics] at hcore
   simp only [bind, Except.bind, Option.mapM_none, pure, Except.pure] at hcore
   rw [ContractShape.guardedFunctionsMapM_eq (applySlotAliasRanges model.fields model.slotAliasRanges)
     model.events model.errors model.adtTypes [] _
@@ -667,7 +667,7 @@ theorem compile_ok_yields_internalFunctions_nil_except_mapping_writes
       contractUsesPlainArrayElement, contractUsesArrayElementWord, harray,
       hstorageArray, hdynamicBytesEq, hmulDiv512, hparamDyn,
       hcheckedArithmetic,
-      hnoInternalFns, hSupported.noAdtTypes] at hcompile
+      hnoInternalFns, hSupported.noAdtTypes, hSupported.surface.noTemplateIntrinsics] at hcompile
     simp only [bind, Except.bind, pure, Except.pure, List.mapM_nil] at hcompile
     rw [ContractShape.guardedFunctionsMapM_eq model.fields model.events model.errors [] [] _
       (ContractShape.supportedSpecExceptMappingWrites_entries_lock_free hSupported)] at hcompile
@@ -717,7 +717,7 @@ theorem compile_ok_yields_noFallbackEntrypoint_except_mapping_writes
     unfold compileValidatedCore at hcompile
     rw [hSupported.normalizedFields, hfallback, hreceive,
       contractUsesPlainArrayElement, contractUsesArrayElementWord, harray,
-      hstorageArray, hdynamicBytesEq, hnoInternalFns, hSupported.noAdtTypes] at hcompile
+      hstorageArray, hdynamicBytesEq, hnoInternalFns, hSupported.noAdtTypes, hSupported.surface.noTemplateIntrinsics] at hcompile
     simp only [bind, Except.bind, pure, Except.pure, List.mapM_nil] at hcompile
     rw [ContractShape.guardedFunctionsMapM_eq model.fields model.events model.errors [] [] _
       (ContractShape.supportedSpecExceptMappingWrites_entries_lock_free hSupported)] at hcompile
@@ -767,7 +767,7 @@ theorem compile_ok_yields_noReceiveEntrypoint_except_mapping_writes
     unfold compileValidatedCore at hcompile
     rw [hSupported.normalizedFields, hfallback, hreceive,
       contractUsesPlainArrayElement, contractUsesArrayElementWord, harray,
-      hstorageArray, hdynamicBytesEq, hnoInternalFns, hSupported.noAdtTypes] at hcompile
+      hstorageArray, hdynamicBytesEq, hnoInternalFns, hSupported.noAdtTypes, hSupported.surface.noTemplateIntrinsics] at hcompile
     simp only [bind, Except.bind, pure, Except.pure, List.mapM_nil] at hcompile
     rw [ContractShape.guardedFunctionsMapM_eq model.fields model.events model.errors [] [] _
       (ContractShape.supportedSpecExceptMappingWrites_entries_lock_free hSupported)] at hcompile

--- a/Compiler/Proofs/IRGeneration/ContractFeatureTest.lean
+++ b/Compiler/Proofs/IRGeneration/ContractFeatureTest.lean
@@ -120,6 +120,19 @@ private def literalMappingWrite_supported_spec :
           simp [contractUsesCheckedArithmetic, literalMappingWriteSpec,
             literalMappingWriteFunction, stmtListMayUseCheckedArithmetic,
             stmtMayUseCheckedArithmetic]
+        noTemplateIntrinsics := by
+          rw [templateIntrinsicItems, literalMappingWriteSpec, literalMappingWriteFunction]
+          unfold collectTemplateIntrinsicsFromStmts
+          simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+          rw [collectTemplateIntrinsicsFromStmt.eq_def]
+          simp only [Stmt.directMetadata, Stmt.childLists, List.attach_nil,
+            List.flatMap_nil, List.append_nil]
+          simp only [List.flatMap_cons, List.flatMap_nil]
+          rw [collectTemplateIntrinsicsFromExpr.eq_def]
+          rw [collectTemplateIntrinsicsFromExpr.eq_def]
+          simp [Expr.children]
+          rw [collectTemplateIntrinsicsFromStmt.eq_def]
+          simp [Stmt.directMetadata, Stmt.childLists]
         noFallback := literalMappingWrite_noFallback
         noReceive := literalMappingWrite_noReceive }
     constructor := by
@@ -1342,6 +1355,17 @@ private def scalarEventSmoke_supported_spec :
           simp [contractUsesCheckedArithmetic, scalarEventSmokeSpec,
             scalarEventSmokeFunction, stmtListMayUseCheckedArithmetic,
             stmtMayUseCheckedArithmetic]
+        noTemplateIntrinsics := by
+          rw [templateIntrinsicItems, scalarEventSmokeSpec, scalarEventSmokeFunction]
+          unfold collectTemplateIntrinsicsFromStmts
+          simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+          rw [collectTemplateIntrinsicsFromStmt.eq_def]
+          simp only [Stmt.directMetadata, Stmt.childLists, List.attach_nil,
+            List.flatMap_nil, List.append_nil]
+          simp only [List.flatMap_cons, List.flatMap_nil]
+          rw [collectTemplateIntrinsicsFromExpr.eq_def]
+          rw [collectTemplateIntrinsicsFromExpr.eq_def]
+          simp [Expr.children]
         noFallback := scalarEventSmoke_noFallback
         noReceive := scalarEventSmoke_noReceive }
     constructor := by

--- a/Compiler/Proofs/IRGeneration/ContractShape.lean
+++ b/Compiler/Proofs/IRGeneration/ContractShape.lean
@@ -188,6 +188,7 @@ private theorem compileValidatedCore_ok_yields_compiled_functions
         (fun x => compileFunctionSpec model.fields [] [] [] x.2 x.1) with _ | irFns
   · simp [hmap] at hcore
   · simp [hmap] at hcore
+    simp [hSupported.surface.noTemplateIntrinsics] at hcore
     rcases hctor :
         compileConstructor model.fields [] [] [] model.constructor with _ | deployStmts
     · simp [hctor] at hcore
@@ -254,8 +255,8 @@ private theorem compileValidatedCore_ok_yields_internalFunctions_nil
   · simp [hmap] at hcore
   · rcases hctor :
         compileConstructor model.fields model.events model.errors [] model.constructor with _ | deployStmts
-    · simp [hmap, hctor, pure, Except.pure] at hcore
-    · simp [hmap, hctor, pure, Except.pure] at hcore
+    · simp [hmap, hctor, hSupported.surface.noTemplateIntrinsics, pure, Except.pure] at hcore
+    · simp [hmap, hctor, hSupported.surface.noTemplateIntrinsics, pure, Except.pure] at hcore
       cases hcore
       rfl
 
@@ -291,6 +292,7 @@ private theorem compileValidatedCore_ok_yields_deploy_compileConstructor
         (fun x => compileFunctionSpec model.fields [] [] [] x.2 x.1) with _ | irFns
   · simp [hmap] at hcore
   · simp [hmap] at hcore
+    simp [hSupported.surface.noTemplateIntrinsics] at hcore
     rcases hctor :
         compileConstructor model.fields [] [] [] model.constructor with _ | deployStmts
     · simp [hctor] at hcore
@@ -332,8 +334,8 @@ private theorem compileValidatedCore_ok_yields_noFallbackEntrypoint
   · rcases hctor :
         compileConstructor (applySlotAliasRanges model.fields model.slotAliasRanges)
           model.events model.errors model.adtTypes model.constructor with _ | deployStmts
-    · simp [hmap, hctor, Pure.pure, Except.pure] at hcore
-    · simp [hmap, hctor, Pure.pure, Except.pure] at hcore
+    · simp [hmap, hctor, hSupported.surface.noTemplateIntrinsics, Pure.pure, Except.pure] at hcore
+    · simp [hmap, hctor, hSupported.surface.noTemplateIntrinsics, Pure.pure, Except.pure] at hcore
       cases hcore
       rfl
 
@@ -370,8 +372,8 @@ private theorem compileValidatedCore_ok_yields_noReceiveEntrypoint
   · rcases hctor :
         compileConstructor (applySlotAliasRanges model.fields model.slotAliasRanges)
           model.events model.errors model.adtTypes model.constructor with _ | deployStmts
-    · simp [hmap, hctor, Pure.pure, Except.pure] at hcore
-    · simp [hmap, hctor, Pure.pure, Except.pure] at hcore
+    · simp [hmap, hctor, hSupported.surface.noTemplateIntrinsics, Pure.pure, Except.pure] at hcore
+    · simp [hmap, hctor, hSupported.surface.noTemplateIntrinsics, Pure.pure, Except.pure] at hcore
       cases hcore
       rfl
 
@@ -428,6 +430,7 @@ private theorem compileValidatedCore_ok_yields_compiled_functions_with_scalar_ev
       (fun x => compileFunctionSpec model.fields model.events [] [] x.2 x.1) with _ | irFns
   · simp [hmap] at hcore
   · simp [hmap] at hcore
+    simp [hSupported.surface.noTemplateIntrinsics] at hcore
     rcases hctor :
         compileConstructor model.fields model.events [] [] model.constructor with _ | deployStmts
     · simp [hctor] at hcore

--- a/Compiler/Proofs/IRGeneration/Expr.lean
+++ b/Compiler/Proofs/IRGeneration/Expr.lean
@@ -23,8 +23,8 @@ def simpleStorageIRContract : IRContract :=
         ret := IRType.unit
         body := [
           YulStmt.let_ "value" (YulExpr.call "calldataload" [YulExpr.lit 4]),
-          YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "value"]),
-          YulStmt.expr (YulExpr.call "stop" [])
+          YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "value"]),
+          YulStmt.exprStmt (YulExpr.call "stop" [])
         ]
       },
       { name := "retrieve"
@@ -32,8 +32,8 @@ def simpleStorageIRContract : IRContract :=
         params := []
         ret := IRType.uint256
         body := [
-          YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 0]]),
-          YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
+          YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 0]]),
+          YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
         ]
       }
     ]
@@ -49,11 +49,11 @@ def counterIRContract : IRContract :=
         params := []
         ret := IRType.unit
         body := [
-          YulStmt.expr (YulExpr.call "sstore" [
+          YulStmt.exprStmt (YulExpr.call "sstore" [
             YulExpr.lit 0,
             YulExpr.call "add" [YulExpr.call "sload" [YulExpr.lit 0], YulExpr.lit (1 % (2 ^ 256))]
           ]),
-          YulStmt.expr (YulExpr.call "stop" [])
+          YulStmt.exprStmt (YulExpr.call "stop" [])
         ]
       },
       { name := "decrement"
@@ -61,11 +61,11 @@ def counterIRContract : IRContract :=
         params := []
         ret := IRType.unit
         body := [
-          YulStmt.expr (YulExpr.call "sstore" [
+          YulStmt.exprStmt (YulExpr.call "sstore" [
             YulExpr.lit 0,
             YulExpr.call "sub" [YulExpr.call "sload" [YulExpr.lit 0], YulExpr.lit (1 % (2 ^ 256))]
           ]),
-          YulStmt.expr (YulExpr.call "stop" [])
+          YulStmt.exprStmt (YulExpr.call "stop" [])
         ]
       },
       { name := "getCount"
@@ -73,8 +73,8 @@ def counterIRContract : IRContract :=
         params := []
         ret := IRType.uint256
         body := [
-          YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 0]]),
-          YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
+          YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 0]]),
+          YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
         ]
       }
     ]
@@ -93,9 +93,9 @@ def vaultMinimalIRContract : IRContract :=
         params := []
         ret := IRType.uint256
         body := [
-          YulStmt.expr (YulExpr.call "mstore"
+          YulStmt.exprStmt (YulExpr.call "mstore"
             [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 0]]),
-          YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
+          YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
         ]
       }
     ]
@@ -115,9 +115,9 @@ def erc20MinimalIRContract : IRContract :=
         params := []
         ret := IRType.uint256
         body := [
-          YulStmt.expr (YulExpr.call "mstore"
+          YulStmt.exprStmt (YulExpr.call "mstore"
             [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 1]]),
-          YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
+          YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
         ]
       }
     ]
@@ -125,38 +125,38 @@ def erc20MinimalIRContract : IRContract :=
 
 def safeCounterOverflowRevert : List YulStmt :=
   [
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit 21]),
-    YulStmt.expr (YulExpr.call "mstore" [
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit 21]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit 68,
       YulExpr.hex 0x4f766572666c6f7720696e20696e6372656d656e740000000000000000000000
     ]),
-    YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 100])
+    YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 100])
   ]
 
 def safeCounterUnderflowRevert : List YulStmt :=
   [
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit 22]),
-    YulStmt.expr (YulExpr.call "mstore" [
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit 22]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit 68,
       YulExpr.hex 0x556e646572666c6f7720696e2064656372656d656e7400000000000000000000
     ]),
-    YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 100])
+    YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 100])
   ]
 
 def insufficientBalanceRevert : List YulStmt :=
   [
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit 20]),
-    YulStmt.expr (YulExpr.call "mstore" [
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit 20]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit 68,
       YulExpr.hex 0x496e73756666696369656e742062616c616e6365000000000000000000000000
     ]),
-    YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 100])
+    YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 100])
   ]
 
 /-- Concrete IR contract for SafeCounter. -/
@@ -174,8 +174,8 @@ def safeCounterIRContract : IRContract :=
           YulStmt.if_
             (YulExpr.call "iszero" [YulExpr.call "gt" [YulExpr.ident "newCount", YulExpr.ident "count"]])
             safeCounterOverflowRevert,
-          YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "newCount"]),
-          YulStmt.expr (YulExpr.call "stop" [])
+          YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "newCount"]),
+          YulStmt.exprStmt (YulExpr.call "stop" [])
         ]
       },
       { name := "decrement"
@@ -186,11 +186,11 @@ def safeCounterIRContract : IRContract :=
           YulStmt.let_ "count" (YulExpr.call "sload" [YulExpr.lit 0]),
           YulStmt.if_ (YulExpr.call "lt" [YulExpr.ident "count", YulExpr.lit (1 % (2 ^ 256))])
             safeCounterUnderflowRevert,
-          YulStmt.expr (YulExpr.call "sstore" [
+          YulStmt.exprStmt (YulExpr.call "sstore" [
             YulExpr.lit 0,
             YulExpr.call "sub" [YulExpr.ident "count", YulExpr.lit (1 % (2 ^ 256))]
           ]),
-          YulStmt.expr (YulExpr.call "stop" [])
+          YulStmt.exprStmt (YulExpr.call "stop" [])
         ]
       },
       { name := "getCount"
@@ -198,8 +198,8 @@ def safeCounterIRContract : IRContract :=
         params := []
         ret := IRType.uint256
         body := [
-          YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 0]]),
-          YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
+          YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 0]]),
+          YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
         ]
       }
     ]
@@ -207,14 +207,14 @@ def safeCounterIRContract : IRContract :=
 
 def ownedNotOwnerRevert : List YulStmt :=
   [
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit 9]),
-    YulStmt.expr (YulExpr.call "mstore" [
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit 9]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.lit 68,
       YulExpr.hex 0x4e6f74206f776e65720000000000000000000000000000000000000000000000
     ]),
-    YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 100])
+    YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 100])
   ]
 
 /-- Concrete IR contract for Owned. -/
@@ -222,9 +222,9 @@ def ownedIRContract : IRContract :=
   { name := "Owned"
     deploy := [
       YulStmt.let_ "argsOffset" (YulExpr.call "sub" [YulExpr.call "codesize" [], YulExpr.lit 32]),
-      YulStmt.expr (YulExpr.call "codecopy" [YulExpr.lit 0, YulExpr.ident "argsOffset", YulExpr.lit 32]),
+      YulStmt.exprStmt (YulExpr.call "codecopy" [YulExpr.lit 0, YulExpr.ident "argsOffset", YulExpr.lit 32]),
       YulStmt.let_ "arg0" (YulExpr.call "and" [YulExpr.call "mload" [YulExpr.lit 0], YulExpr.hex addressMask]),
-      YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "arg0"])
+      YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "arg0"])
     ]
     functions := [
       { name := "transferOwnership"
@@ -239,8 +239,8 @@ def ownedIRContract : IRContract :=
           YulStmt.if_
             (YulExpr.call "iszero" [YulExpr.call "eq" [YulExpr.call "caller" [], YulExpr.call "sload" [YulExpr.lit 0]]])
             ownedNotOwnerRevert,
-          YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "newOwner"]),
-          YulStmt.expr (YulExpr.call "stop" [])
+          YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "newOwner"]),
+          YulStmt.exprStmt (YulExpr.call "stop" [])
         ]
       },
       { name := "getOwner"
@@ -248,8 +248,8 @@ def ownedIRContract : IRContract :=
         params := []
         ret := IRType.address
         body := [
-          YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 0]]),
-          YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
+          YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 0]]),
+          YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
         ]
       }
     ]
@@ -260,9 +260,9 @@ def ownedCounterIRContract : IRContract :=
   { name := "OwnedCounter"
     deploy := [
       YulStmt.let_ "argsOffset" (YulExpr.call "sub" [YulExpr.call "codesize" [], YulExpr.lit 32]),
-      YulStmt.expr (YulExpr.call "codecopy" [YulExpr.lit 0, YulExpr.ident "argsOffset", YulExpr.lit 32]),
+      YulStmt.exprStmt (YulExpr.call "codecopy" [YulExpr.lit 0, YulExpr.ident "argsOffset", YulExpr.lit 32]),
       YulStmt.let_ "arg0" (YulExpr.call "and" [YulExpr.call "mload" [YulExpr.lit 0], YulExpr.hex addressMask]),
-      YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "arg0"])
+      YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "arg0"])
     ]
     functions := [
       { name := "increment"
@@ -273,11 +273,11 @@ def ownedCounterIRContract : IRContract :=
           YulStmt.if_
             (YulExpr.call "iszero" [YulExpr.call "eq" [YulExpr.call "caller" [], YulExpr.call "sload" [YulExpr.lit 0]]])
             ownedNotOwnerRevert,
-          YulStmt.expr (YulExpr.call "sstore" [
+          YulStmt.exprStmt (YulExpr.call "sstore" [
             YulExpr.lit 1,
             YulExpr.call "add" [YulExpr.call "sload" [YulExpr.lit 1], YulExpr.lit 1]
           ]),
-          YulStmt.expr (YulExpr.call "stop" [])
+          YulStmt.exprStmt (YulExpr.call "stop" [])
         ]
       },
       { name := "decrement"
@@ -288,11 +288,11 @@ def ownedCounterIRContract : IRContract :=
           YulStmt.if_
             (YulExpr.call "iszero" [YulExpr.call "eq" [YulExpr.call "caller" [], YulExpr.call "sload" [YulExpr.lit 0]]])
             ownedNotOwnerRevert,
-          YulStmt.expr (YulExpr.call "sstore" [
+          YulStmt.exprStmt (YulExpr.call "sstore" [
             YulExpr.lit 1,
             YulExpr.call "sub" [YulExpr.call "sload" [YulExpr.lit 1], YulExpr.lit 1]
           ]),
-          YulStmt.expr (YulExpr.call "stop" [])
+          YulStmt.exprStmt (YulExpr.call "stop" [])
         ]
       },
       { name := "getCount"
@@ -300,8 +300,8 @@ def ownedCounterIRContract : IRContract :=
         params := []
         ret := IRType.uint256
         body := [
-          YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 1]]),
-          YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
+          YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 1]]),
+          YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
         ]
       },
       { name := "getOwner"
@@ -309,8 +309,8 @@ def ownedCounterIRContract : IRContract :=
         params := []
         ret := IRType.address
         body := [
-          YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 0]]),
-          YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
+          YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 0]]),
+          YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
         ]
       },
       { name := "transferOwnership"
@@ -325,8 +325,8 @@ def ownedCounterIRContract : IRContract :=
           YulStmt.if_
             (YulExpr.call "iszero" [YulExpr.call "eq" [YulExpr.call "caller" [], YulExpr.call "sload" [YulExpr.lit 0]]])
             ownedNotOwnerRevert,
-          YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "newOwner"]),
-          YulStmt.expr (YulExpr.call "stop" [])
+          YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "newOwner"]),
+          YulStmt.exprStmt (YulExpr.call "stop" [])
         ]
       }
     ]

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -2304,7 +2304,7 @@ private theorem legacyCompatibleExternalStmtList_append
   | comment msg rest _ ih => exact .comment msg (rest ++ back) (ih hback)
   | let_ name value rest _ ih => exact .let_ name value (rest ++ back) (ih hback)
   | assign name value rest _ ih => exact .assign name value (rest ++ back) (ih hback)
-  | expr value rest _ ih => exact .expr value (rest ++ back) (ih hback)
+  | expr value rest _ ih => exact .exprStmt value (rest ++ back) (ih hback)
   | if_ cond body rest hbody _ _ ihRest =>
       exact .if_ cond body (rest ++ back) hbody (ihRest hback)
   | block body rest hbody _ _ ihRest =>
@@ -2324,7 +2324,7 @@ private theorem yulStmtListCallsDisjoint_append
   | comment msg rest _ ih => exact .comment msg (rest ++ back) (ih hback)
   | let_ name value rest hval _ ih => exact .let_ name value (rest ++ back) hval (ih hback)
   | assign name value rest hval _ ih => exact .assign name value (rest ++ back) hval (ih hback)
-  | expr value rest hval _ ih => exact .expr value (rest ++ back) hval (ih hback)
+  | expr value rest hval _ ih => exact .exprStmt value (rest ++ back) hval (ih hback)
   | if_ cond body rest hcond hbody _ _ ihRest =>
       exact .if_ cond body (rest ++ back) hcond hbody (ihRest hback)
   | block body rest hbody _ _ ihRest =>
@@ -2378,7 +2378,7 @@ private theorem genParamLoads_scalar_legacy
     (fun pos => YulExpr.call "calldataload" [pos]) (YulExpr.call "calldatasize" [])
     ((params.map (fun p => paramHeadSize p.ty)).foldl (· + ·) 0) 4 params 4 hsupported
   simp [genParamLoads, genParamLoadsFrom]
-  exact .if_ _ _ _ (.expr _ _ .nil) hbody
+  exact .if_ _ _ _ (.exprStmt _ _ .nil) hbody
 
 private theorem compiledStmt_scalar_events_callsDisjoint
     (runtimeContract : IRContract) (hinternal : runtimeContract.internalFunctions = [])

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -2304,7 +2304,7 @@ private theorem legacyCompatibleExternalStmtList_append
   | comment msg rest _ ih => exact .comment msg (rest ++ back) (ih hback)
   | let_ name value rest _ ih => exact .let_ name value (rest ++ back) (ih hback)
   | assign name value rest _ ih => exact .assign name value (rest ++ back) (ih hback)
-  | expr value rest _ ih => exact .exprStmt value (rest ++ back) (ih hback)
+  | exprStmt value rest _ ih => exact .exprStmt value (rest ++ back) (ih hback)
   | if_ cond body rest hbody _ _ ihRest =>
       exact .if_ cond body (rest ++ back) hbody (ihRest hback)
   | block body rest hbody _ _ ihRest =>
@@ -2324,7 +2324,7 @@ private theorem yulStmtListCallsDisjoint_append
   | comment msg rest _ ih => exact .comment msg (rest ++ back) (ih hback)
   | let_ name value rest hval _ ih => exact .let_ name value (rest ++ back) hval (ih hback)
   | assign name value rest hval _ ih => exact .assign name value (rest ++ back) hval (ih hback)
-  | expr value rest hval _ ih => exact .exprStmt value (rest ++ back) hval (ih hback)
+  | exprStmt value rest hval _ ih => exact .exprStmt value (rest ++ back) hval (ih hback)
   | if_ cond body rest hcond hbody _ _ ihRest =>
       exact .if_ cond body (rest ++ back) hcond hbody (ihRest hback)
   | block body rest hbody _ _ ihRest =>

--- a/Compiler/Proofs/IRGeneration/FunctionBody/Stmt.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody/Stmt.lean
@@ -123,25 +123,25 @@ theorem compileStmt_core_ok
         by simp [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork, compileRequireFailCondWithInternals_nil_ok hfailCond]⟩
   | return_ hvalue =>
       rcases compileExpr_core_ok (fields := fields) hvalue with ⟨valueIR, hvalueIR⟩
-      exact ⟨[ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-            , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ],
+      exact ⟨[ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+            , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ],
         by simp [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork, compileExprWithInternals_nil_ok hvalueIR]⟩
   | stop =>
-      exact ⟨[YulStmt.expr (YulExpr.call "stop" [])], by
+      exact ⟨[YulStmt.exprStmt (YulExpr.call "stop" [])], by
         rw [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork]
         rfl⟩
   | mstore hoffset hvalue =>
       rename_i offset value
       rcases compileExpr_core_ok (fields := fields) hoffset with ⟨offsetIR, hoffsetIR⟩
       rcases compileExpr_core_ok (fields := fields) hvalue with ⟨valueIR, hvalueIR⟩
-      exact ⟨[YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])],
+      exact ⟨[YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])],
         by simp [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork, compileExprWithInternals_nil_ok hoffsetIR,
           compileExprWithInternals_nil_ok hvalueIR, Bind.bind, Except.bind, pure, Except.pure]⟩
   | tstore hoffset hvalue =>
       rename_i offset value
       rcases compileExpr_core_ok (fields := fields) hoffset with ⟨offsetIR, hoffsetIR⟩
       rcases compileExpr_core_ok (fields := fields) hvalue with ⟨valueIR, hvalueIR⟩
-      exact ⟨[YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])],
+      exact ⟨[YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])],
         by simp [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork, compileExprWithInternals_nil_ok hoffsetIR,
           compileExprWithInternals_nil_ok hvalueIR, Bind.bind, Except.bind, pure, Except.pure]⟩
 
@@ -626,8 +626,8 @@ theorem exec_compileStmt_return_core
       stmtResultMatchesIRExec fields sourceResult irExec ∧
       stmtResultMatchesIRExecExact sourceResult irExec := by
   rcases compileExpr_core_ok hcore with ⟨valueIR, hvalueIR⟩
-  refine ⟨[ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-          , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ], ?_, ?_⟩
+  refine ⟨[ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+          , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ], ?_, ?_⟩
   · have hvalueIRInternal := hvalueIR
     rw [← CompilationModel.compileExprWithInternals_nil_eq] at hvalueIRInternal
     rw [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork, hvalueIRInternal]
@@ -665,8 +665,8 @@ theorem exec_compileStmt_return_core_extraFuel
       stmtResultMatchesIRExec fields sourceResult irExec ∧
       stmtResultMatchesIRExecExact sourceResult irExec := by
   rcases compileExpr_core_ok hcore with ⟨valueIR, hvalueIR⟩
-  refine ⟨[ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-          , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ], ?_, ?_⟩
+  refine ⟨[ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+          , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ], ?_, ?_⟩
   · have hvalueIRInternal := hvalueIR
     rw [← CompilationModel.compileExprWithInternals_nil_eq] at hvalueIRInternal
     rw [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork, hvalueIRInternal]
@@ -686,8 +686,8 @@ theorem exec_compileStmt_return_core_extraFuel
       simp only [SourceSemantics.execStmt, List.length]
       -- Compute the IR execution result
       have hexec : execIRStmts (2 + extraFuel + 1) state
-          [ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-          , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] =
+          [ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+          , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] =
           .return v { state with memory := fun o => if o = 0 then v else state.memory o } := by
         have : 2 + extraFuel + 1 = Nat.succ (Nat.succ (Nat.succ extraFuel)) := by omega
         rw [this]
@@ -715,19 +715,19 @@ theorem exec_compileStmt_stop_core
       let irExec := execIRStmts (bodyIR.length + 1) state bodyIR
       stmtResultMatchesIRExec fields sourceResult irExec ∧
       stmtResultMatchesIRExecExact sourceResult irExec := by
-  refine ⟨[YulStmt.expr (YulExpr.call "stop" [])], ?_, ?_⟩
+  refine ⟨[YulStmt.exprStmt (YulExpr.call "stop" [])], ?_, ?_⟩
   · rw [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork]
     rfl
   · constructor
     · have hirExec :
-          execIRStmts ([YulStmt.expr (YulExpr.call "stop" [])].length + 1) state
-            [YulStmt.expr (YulExpr.call "stop" [])] = .stop state := by
+          execIRStmts ([YulStmt.exprStmt (YulExpr.call "stop" [])].length + 1) state
+            [YulStmt.exprStmt (YulExpr.call "stop" [])] = .stop state := by
         simp [execIRStmts]
       rw [SourceSemantics.execStmt, hirExec]
       exact hruntime
     · have hirExec :
-          execIRStmts ([YulStmt.expr (YulExpr.call "stop" [])].length + 1) state
-            [YulStmt.expr (YulExpr.call "stop" [])] = .stop state := by
+          execIRStmts ([YulStmt.exprStmt (YulExpr.call "stop" [])].length + 1) state
+            [YulStmt.exprStmt (YulExpr.call "stop" [])] = .stop state := by
         simp [execIRStmts]
       rw [SourceSemantics.execStmt, hirExec]
       exact ⟨hexact, hbounded⟩
@@ -746,14 +746,14 @@ theorem exec_compileStmt_stop_core_extraFuel
       let irExec := execIRStmts (bodyIR.length + extraFuel + 1) state bodyIR
       stmtResultMatchesIRExec fields sourceResult irExec ∧
       stmtResultMatchesIRExecExact sourceResult irExec := by
-  refine ⟨[YulStmt.expr (YulExpr.call "stop" [])], ?_, ?_⟩
+  refine ⟨[YulStmt.exprStmt (YulExpr.call "stop" [])], ?_, ?_⟩
   · rw [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork]
     rfl
   · have hirExec :
         execIRStmts
-          ([YulStmt.expr (YulExpr.call "stop" [])].length + extraFuel + 1)
+          ([YulStmt.exprStmt (YulExpr.call "stop" [])].length + extraFuel + 1)
           state
-          [YulStmt.expr (YulExpr.call "stop" [])] = .stop state := by
+          [YulStmt.exprStmt (YulExpr.call "stop" [])] = .stop state := by
       simp [execIRStmts]
     constructor
     · rw [SourceSemantics.execStmt, hirExec]
@@ -967,21 +967,21 @@ theorem compileStmt_core_ok_any_scope
         rfl⟩
   | return_ hvalue =>
       rcases compileExpr_core_ok hvalue with ⟨valueIR, hvalueIR⟩
-      exact ⟨[ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-            , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ], by
+      exact ⟨[ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+            , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ], by
         have hvalueIRInternal := hvalueIR
         rw [← CompilationModel.compileExprWithInternals_nil_eq] at hvalueIRInternal
         rw [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork, hvalueIRInternal]
         rfl⟩
   | stop =>
-      exact ⟨[YulStmt.expr (YulExpr.call "stop" [])], by
+      exact ⟨[YulStmt.exprStmt (YulExpr.call "stop" [])], by
         rw [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork]
         rfl⟩
   | mstore hoffset hvalue =>
       rename_i offset value
       rcases compileExpr_core_ok hoffset with ⟨offsetIR, hoffsetIR⟩
       rcases compileExpr_core_ok hvalue with ⟨valueIR, hvalueIR⟩
-      exact ⟨[YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])], by
+      exact ⟨[YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])], by
         have hoffsetIRInternal := hoffsetIR
         have hvalueIRInternal := hvalueIR
         rw [← CompilationModel.compileExprWithInternals_nil_eq] at hoffsetIRInternal hvalueIRInternal
@@ -991,7 +991,7 @@ theorem compileStmt_core_ok_any_scope
       rename_i offset value
       rcases compileExpr_core_ok hoffset with ⟨offsetIR, hoffsetIR⟩
       rcases compileExpr_core_ok hvalue with ⟨valueIR, hvalueIR⟩
-      exact ⟨[YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])], by
+      exact ⟨[YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])], by
         have hoffsetIRInternal := hoffsetIR
         have hvalueIRInternal := hvalueIR
         rw [← CompilationModel.compileExprWithInternals_nil_eq] at hoffsetIRInternal hvalueIRInternal
@@ -2720,7 +2720,7 @@ private theorem execIRStmt_mstore_of_eval_anyFuel
     (value : Nat)
     (heval : evalIRExpr state valueExpr = some value) :
     execIRStmt (Nat.succ fuel) state
-      (YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit offset, valueExpr])) =
+      (YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit offset, valueExpr])) =
       .continue { state with memory := fun o => if o = offset then value else state.memory o } := by
   simp [execIRStmt, evalIRExpr, heval]
 
@@ -2733,7 +2733,7 @@ private theorem execIRStmt_mstore_of_eval_nonzeroFuel
     (hfuel : fuel ≠ 0)
     (heval : evalIRExpr state valueExpr = some value) :
     execIRStmt fuel state
-      (YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit offset, valueExpr])) =
+      (YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit offset, valueExpr])) =
       .continue { state with memory := fun o => if o = offset then value else state.memory o } := by
   cases fuel with
   | zero =>
@@ -2746,7 +2746,7 @@ private theorem execIRStmt_return32_of_memory_anyFuel
     (state : IRState)
     (offset : Nat) :
     execIRStmt (Nat.succ fuel) state
-      (YulStmt.expr (YulExpr.call "return" [YulExpr.lit offset, YulExpr.lit 32])) =
+      (YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit offset, YulExpr.lit 32])) =
       .return (state.memory offset) state := by
   simp [execIRStmt, evalIRExpr]
 
@@ -2756,7 +2756,7 @@ private theorem execIRStmt_return32_of_memory_nonzeroFuel
     (offset : Nat)
     (hfuel : fuel ≠ 0) :
     execIRStmt fuel state
-      (YulStmt.expr (YulExpr.call "return" [YulExpr.lit offset, YulExpr.lit 32])) =
+      (YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit offset, YulExpr.lit 32])) =
       .return (state.memory offset) state := by
   cases fuel with
   | zero =>
@@ -2768,7 +2768,7 @@ private theorem execIRStmt_stop_nonzeroFuel
     (fuel : Nat)
     (state : IRState)
     (hfuel : fuel ≠ 0) :
-    execIRStmt fuel state (YulStmt.expr (YulExpr.call "stop" [])) = .stop state := by
+    execIRStmt fuel state (YulStmt.exprStmt (YulExpr.call "stop" [])) = .stop state := by
   cases fuel with
   | zero =>
       exact False.elim (hfuel rfl)
@@ -2787,9 +2787,9 @@ private theorem evalIRExpr_iszero_of_eval
 
 private inductive RevertPrefixStmt : YulStmt → Prop where
   | mstore_lit {offset value : Nat} :
-      RevertPrefixStmt (YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit offset, YulExpr.lit value]))
+      RevertPrefixStmt (YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit offset, YulExpr.lit value]))
   | mstore_hex {offset value : Nat} :
-      RevertPrefixStmt (YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit offset, YulExpr.hex value]))
+      RevertPrefixStmt (YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit offset, YulExpr.hex value]))
 
 private theorem execIRStmt_revertPrefix_continue
     (fuel : Nat) (state : IRState) {stmt : YulStmt}
@@ -2818,7 +2818,7 @@ private theorem execIRStmts_revertPrefix_then_revert
     (hprefix : ∀ stmt ∈ prefixStmts, RevertPrefixStmt stmt) :
     ∃ next,
       execIRStmts fuel state
-        (prefixStmts ++ [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit offset, YulExpr.lit size])]) =
+        (prefixStmts ++ [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit offset, YulExpr.lit size])]) =
           .revert next := by
   induction fuel generalizing state prefixStmts with
   | zero =>
@@ -2850,15 +2850,15 @@ theorem execIRStmts_revertWithMessage_revert
   let len := bytes.length
   let paddedLen := ((len + 31) / 32) * 32
   let header := [
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit len])
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit len])
   ]
   let dataStmts :=
     (CompilationModel.chunkBytes32 bytes).zipIdx.map fun (chunk, idx) =>
       let offset := 68 + idx * 32
       let word := CompilationModel.wordFromBytes chunk
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit offset, YulExpr.hex word])
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit offset, YulExpr.hex word])
   have hprefix : ∀ stmt ∈ header ++ dataStmts, RevertPrefixStmt stmt := by
     intro stmt hmem
     rcases List.mem_append.mp hmem with hhead | hdata
@@ -3114,8 +3114,8 @@ theorem exec_compileStmtList_core
             hbounded
             (runtimeStateMatchesIR_setBothMemory hruntime 0 retVal hlt) with
           ⟨tailIR, htailCompile, htailSem, htailExact⟩
-        refine ⟨[ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-                , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++ tailIR,
+        refine ⟨[ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+                , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++ tailIR,
           ?_, ?_⟩
         · apply compileStmtListWithFork_cons_eq_ok
           · unfold CompilationModel.compileStmt CompilationModel.compileStmtWithFork
@@ -3130,25 +3130,25 @@ theorem exec_compileStmtList_core
             bindingsExactlyMatchIRVars_setMemory hexact 0 retVal
           have hmstore :
               execIRStmt (tailIR.length + 2) state
-                (YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])) =
+                (YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])) =
                 .continue state' := by
             simp [execIRStmt, evalIRExpr, hIR, state']
           have hreturn :
               execIRStmt (tailIR.length + 1) state'
-                (YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])) =
+                (YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])) =
                 .return retVal state' := by
             simp [execIRStmt, evalIRExpr, state']
           have hirExec :
               execIRStmts (tailIR.length + 3)
                 state
-                (YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR]) ::
-                  YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ::
+                (YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR]) ::
+                  YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ::
                   tailIR) =
                 .return retVal state' := by
             simpa using
               (execIRStmts_two_of_continue_then_return state state' state'
-                (YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR]))
-                (YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]))
+                (YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR]))
+                (YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]))
                 tailIR retVal hmstore hreturn)
           rw [SourceSemantics.execStmtList, SourceSemantics.execStmt, hEvalSrc]
           dsimp [state', runtime']
@@ -3167,22 +3167,22 @@ theorem exec_compileStmtList_core
           (inScopeNames := collectStmtNames (.stop) ++ inScopeNames)
           hscope hexact hbounded hruntime with
         ⟨tailIR, htailCompile, htailSem, htailExact⟩
-      refine ⟨[YulStmt.expr (YulExpr.call "stop" [])] ++ tailIR, ?_, ?_⟩
+      refine ⟨[YulStmt.exprStmt (YulExpr.call "stop" [])] ++ tailIR, ?_, ?_⟩
       · apply compileStmtListWithFork_cons_eq_ok
         · rw [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork]
           rfl
         · exact htailCompile
       · have hstmt :
-            execIRStmt (tailIR.length + 1) state (YulStmt.expr (YulExpr.call "stop" [])) =
+            execIRStmt (tailIR.length + 1) state (YulStmt.exprStmt (YulExpr.call "stop" [])) =
               .stop state := by
           simp [execIRStmt]
         have hirExec :
             execIRStmts (tailIR.length + 2) state
-              (YulStmt.expr (YulExpr.call "stop" []) :: tailIR) =
+              (YulStmt.exprStmt (YulExpr.call "stop" []) :: tailIR) =
               .stop state := by
           simpa using
             (execIRStmts_cons_of_execIRStmt_stop state state
-              (YulStmt.expr (YulExpr.call "stop" [])) tailIR hstmt)
+              (YulStmt.exprStmt (YulExpr.call "stop" [])) tailIR hstmt)
         rw [SourceSemantics.execStmtList, SourceSemantics.execStmt]
         simp [hirExec]
         exact ⟨hruntime, ⟨hexact, hbounded⟩⟩
@@ -3228,7 +3228,7 @@ theorem exec_compileStmtList_core
               (inScopeNames := collectStmtNames (.mstore offset value) ++ inScopeNames)
               hscope hexact' hbounded' hruntime' with
             ⟨tailIR, htailCompile, htailSem, htailExact⟩
-          refine ⟨[YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])] ++ tailIR, ?_, ?_⟩
+          refine ⟨[YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])] ++ tailIR, ?_, ?_⟩
           · apply compileStmtListWithFork_cons_eq_ok
             · unfold CompilationModel.compileStmt CompilationModel.compileStmtWithFork
               have hoffsetIRInternal := hoffsetIR
@@ -3239,15 +3239,15 @@ theorem exec_compileStmtList_core
             · exact htailCompile
           · have hstmt :
                 execIRStmt (tailIR.length + 1) state
-                  (YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])) = .continue state' := by
+                  (YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])) = .continue state' := by
               simp [execIRStmt, evalIRExprs, hIROffset, hIRValue, state']
             have hirExec :
                 execIRStmts (tailIR.length + 2) state
-                  (YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR]) :: tailIR) =
+                  (YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR]) :: tailIR) =
                     execIRStmts (tailIR.length + 1) state' tailIR := by
               simpa using
                 (execIRStmts_cons_of_execIRStmt_continue state state'
-                  (YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])) tailIR hstmt)
+                  (YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])) tailIR hstmt)
             rw [SourceSemantics.execStmtList, SourceSemantics.execStmt, hOffsetSrc, hValueSrc]
             simp [hirExec]
             exact ⟨htailSem, htailExact⟩
@@ -3296,7 +3296,7 @@ theorem exec_compileStmtList_core
               (inScopeNames := collectStmtNames (.tstore offset value) ++ inScopeNames)
               hscope hexact' hbounded' hruntime' with
             ⟨tailIR, htailCompile, htailSem, htailExact⟩
-          refine ⟨[YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])] ++ tailIR, ?_, ?_⟩
+          refine ⟨[YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])] ++ tailIR, ?_, ?_⟩
           · apply compileStmtListWithFork_cons_eq_ok
             · unfold CompilationModel.compileStmt CompilationModel.compileStmtWithFork
               have hoffsetIRInternal := hoffsetIR
@@ -3307,15 +3307,15 @@ theorem exec_compileStmtList_core
             · exact htailCompile
           · have hstmt :
                 execIRStmt (tailIR.length + 1) state
-                  (YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])) = .continue state' := by
+                  (YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])) = .continue state' := by
               simp [execIRStmt, evalIRExprs, hIROffset, hIRValue, state', offsetKey]
             have hirExec :
                 execIRStmts (tailIR.length + 2) state
-                  (YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR]) :: tailIR) =
+                  (YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR]) :: tailIR) =
                     execIRStmts (tailIR.length + 1) state' tailIR := by
               simpa using
                 (execIRStmts_cons_of_execIRStmt_continue state state'
-                  (YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])) tailIR hstmt)
+                  (YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])) tailIR hstmt)
             rw [SourceSemantics.execStmtList, SourceSemantics.execStmt, hOffsetSrc, hValueSrc]
             simp [hirExec]
             exact ⟨htailSem, htailExact⟩
@@ -3592,8 +3592,8 @@ theorem exec_compileStmtList_core_extraFuel
             hbounded
             (runtimeStateMatchesIR_setBothMemory hruntime 0 retVal hlt) with
           ⟨tailIR, htailCompile, htailSem, htailExact⟩
-        refine ⟨[ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-                , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++ tailIR,
+        refine ⟨[ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+                , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++ tailIR,
           ?_, ?_⟩
         · apply compileStmtListWithFork_cons_eq_ok
           · unfold CompilationModel.compileStmt CompilationModel.compileStmtWithFork
@@ -3608,31 +3608,31 @@ theorem exec_compileStmtList_core_extraFuel
             bindingsExactlyMatchIRVars_setMemory hexact 0 retVal
           have hmstore :
               execIRStmt (tailIR.length + extraFuel + 2) state
-                (YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])) =
+                (YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])) =
                 .continue state' := by
             simp [execIRStmt, evalIRExpr, hIR, state']
           have hreturn :
               execIRStmt (tailIR.length + extraFuel + 1) state'
-                (YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])) =
+                (YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])) =
                 .return retVal state' := by
             simp [execIRStmt, evalIRExpr, state']
           have hirExec :
               execIRStmts (tailIR.length + extraFuel + 3)
                 state
-                (YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR]) ::
-                  YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ::
+                (YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR]) ::
+                  YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ::
                   tailIR) =
                 .return retVal state' := by
             simpa using
               (execIRStmts_two_of_continue_then_return_extraFuel extraFuel state state' state'
-                (YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR]))
-                (YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]))
+                (YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR]))
+                (YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]))
                 tailIR retVal hmstore hreturn)
           have hirExec' :
               execIRStmts (tailIR.length + 1 + 1 + extraFuel + 1)
                 state
-                (YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR]) ::
-                  YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ::
+                (YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR]) ::
+                  YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ::
                   tailIR) =
                 .return retVal state' := by
             simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using hirExec
@@ -3653,26 +3653,26 @@ theorem exec_compileStmtList_core_extraFuel
           (inScopeNames := collectStmtNames (.stop) ++ inScopeNames)
           hscope hexact hbounded hruntime with
         ⟨tailIR, htailCompile, htailSem, htailExact⟩
-      refine ⟨[YulStmt.expr (YulExpr.call "stop" [])] ++ tailIR, ?_, ?_⟩
+      refine ⟨[YulStmt.exprStmt (YulExpr.call "stop" [])] ++ tailIR, ?_, ?_⟩
       · apply compileStmtListWithFork_cons_eq_ok
         · rw [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork]
           rfl
         · exact htailCompile
       · have hstmt :
             execIRStmt (tailIR.length + extraFuel + 1) state
-              (YulStmt.expr (YulExpr.call "stop" [])) =
+              (YulStmt.exprStmt (YulExpr.call "stop" [])) =
               .stop state := by
           simp [execIRStmt]
         have hirExec :
             execIRStmts (tailIR.length + extraFuel + 2) state
-              (YulStmt.expr (YulExpr.call "stop" []) :: tailIR) =
+              (YulStmt.exprStmt (YulExpr.call "stop" []) :: tailIR) =
               .stop state := by
           simpa using
             (execIRStmts_cons_of_execIRStmt_stop_extraFuel extraFuel state state
-              (YulStmt.expr (YulExpr.call "stop" [])) tailIR hstmt)
+              (YulStmt.exprStmt (YulExpr.call "stop" [])) tailIR hstmt)
         have hirExec' :
             execIRStmts (tailIR.length + 1 + extraFuel + 1) state
-              (YulStmt.expr (YulExpr.call "stop" []) :: tailIR) =
+              (YulStmt.exprStmt (YulExpr.call "stop" []) :: tailIR) =
               .stop state := by
           simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using hirExec
         rw [SourceSemantics.execStmtList, SourceSemantics.execStmt]
@@ -3720,7 +3720,7 @@ theorem exec_compileStmtList_core_extraFuel
               (inScopeNames := collectStmtNames (.mstore offset value) ++ inScopeNames)
               hscope hexact' hbounded' hruntime' with
             ⟨tailIR, htailCompile, htailSem, htailExact⟩
-          refine ⟨[YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])] ++ tailIR, ?_, ?_⟩
+          refine ⟨[YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])] ++ tailIR, ?_, ?_⟩
           · apply compileStmtListWithFork_cons_eq_ok
             · unfold CompilationModel.compileStmt CompilationModel.compileStmtWithFork
               have hoffsetIRInternal := hoffsetIR
@@ -3731,18 +3731,18 @@ theorem exec_compileStmtList_core_extraFuel
             · exact htailCompile
           · have hstmt :
                 execIRStmt (tailIR.length + extraFuel + 1) state
-                  (YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])) = .continue state' := by
+                  (YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])) = .continue state' := by
               simp [execIRStmt, evalIRExprs, hIROffset, hIRValue, state']
             have hirExec :
                 execIRStmts (tailIR.length + extraFuel + 2) state
-                  (YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR]) :: tailIR) =
+                  (YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR]) :: tailIR) =
                     execIRStmts (tailIR.length + extraFuel + 1) state' tailIR := by
               simpa using
                 (execIRStmts_cons_of_execIRStmt_continue_extraFuel extraFuel state state'
-                  (YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])) tailIR hstmt)
+                  (YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])) tailIR hstmt)
             have hirExec' :
                 execIRStmts (tailIR.length + 1 + extraFuel + 1) state
-                  (YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR]) :: tailIR) =
+                  (YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR]) :: tailIR) =
                     execIRStmts (tailIR.length + extraFuel + 1) state' tailIR := by
               simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using hirExec
             rw [SourceSemantics.execStmtList, SourceSemantics.execStmt, hOffsetSrc, hValueSrc]
@@ -3793,7 +3793,7 @@ theorem exec_compileStmtList_core_extraFuel
               (inScopeNames := collectStmtNames (.tstore offset value) ++ inScopeNames)
               hscope hexact' hbounded' hruntime' with
             ⟨tailIR, htailCompile, htailSem, htailExact⟩
-          refine ⟨[YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])] ++ tailIR, ?_, ?_⟩
+          refine ⟨[YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])] ++ tailIR, ?_, ?_⟩
           · apply compileStmtListWithFork_cons_eq_ok
             · unfold CompilationModel.compileStmt CompilationModel.compileStmtWithFork
               have hoffsetIRInternal := hoffsetIR
@@ -3804,18 +3804,18 @@ theorem exec_compileStmtList_core_extraFuel
             · exact htailCompile
           · have hstmt :
                 execIRStmt (tailIR.length + extraFuel + 1) state
-                  (YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])) = .continue state' := by
+                  (YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])) = .continue state' := by
               simp [execIRStmt, evalIRExprs, hIROffset, hIRValue, state', offsetKey]
             have hirExec :
                 execIRStmts (tailIR.length + extraFuel + 2) state
-                  (YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR]) :: tailIR) =
+                  (YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR]) :: tailIR) =
                     execIRStmts (tailIR.length + extraFuel + 1) state' tailIR := by
               simpa using
                 (execIRStmts_cons_of_execIRStmt_continue_extraFuel extraFuel state state'
-                  (YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])) tailIR hstmt)
+                  (YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])) tailIR hstmt)
             have hirExec' :
                 execIRStmts (tailIR.length + 1 + extraFuel + 1) state
-                  (YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR]) :: tailIR) =
+                  (YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR]) :: tailIR) =
                     execIRStmts (tailIR.length + extraFuel + 1) state' tailIR := by
               simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using hirExec
             rw [SourceSemantics.execStmtList, SourceSemantics.execStmt, hOffsetSrc, hValueSrc]
@@ -6142,12 +6142,12 @@ theorem execIRStmts_compiled_return_core_append_wholeFuel_of_scope
       CompilationModel.compileExpr fields .calldata value = Except.ok valueIR ∧
       execIRStmts
         (sizeOf
-            ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-             , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+            ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+             , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
               tailIR) + extraFuel + 1)
         state
-        ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-         , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+        ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+         , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
           tailIR) =
         .return retVal state' := by
   rcases compileExpr_core_ok (fields := fields) hcore with ⟨valueIR, hvalueIR⟩
@@ -6165,61 +6165,61 @@ theorem execIRStmts_compiled_return_core_append_wholeFuel_of_scope
     set state' := { state with memory := fun o => if o = 0 then retVal else state.memory o }
     have hmstoreFuelNeZero :
         sizeOf
-            ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-             , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+            ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+             , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
               tailIR) + extraFuel ≠ 0 := by
       have hprefixLen :
           2 ≤
-            ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-             , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+            ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+             , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
               tailIR).length := by
         simp
       have hlen :
-          ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-           , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+          ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+           , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
             tailIR).length ≤
             sizeOf
-              ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-               , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+              ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+               , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
                 tailIR) := by
         exact yulStmtList_length_le_sizeOf _
       omega
     have hreturnFuelNeZero :
         sizeOf
-            ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-             , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+            ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+             , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
               tailIR) + extraFuel - 1 ≠ 0 := by
       have hprefixLen :
           2 ≤
-            ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-             , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+            ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+             , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
               tailIR).length := by
         simp
       have hlen :
-          ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-           , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+          ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+           , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
             tailIR).length ≤
             sizeOf
-              ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-               , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+              ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+               , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
                 tailIR) := by
         exact yulStmtList_length_le_sizeOf _
       omega
     have hmstore :
         execIRStmt
             (sizeOf
-                ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-                 , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+                ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+                 , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
                   tailIR) + extraFuel)
             state
-            (YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])) =
+            (YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])) =
           .continue state' := by
       simpa [state'] using
         execIRStmt_mstore_of_eval_nonzeroFuel
           (fuel :=
             sizeOf
-              ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-               , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+              ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+               , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
                 tailIR) + extraFuel)
           (state := state)
           (offset := 0)
@@ -6230,18 +6230,18 @@ theorem execIRStmts_compiled_return_core_append_wholeFuel_of_scope
     have hreturn :
         execIRStmt
             (sizeOf
-                ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-                 , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+                ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+                 , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
                   tailIR) + extraFuel - 1)
             state'
-            (YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])) =
+            (YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])) =
           .return retVal state' := by
       simpa [state', retVal] using
         execIRStmt_return32_of_memory_nonzeroFuel
           (fuel :=
             sizeOf
-              ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-               , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+              ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+               , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
                 tailIR) + extraFuel - 1)
           (state := state')
           (offset := 0)
@@ -6252,8 +6252,8 @@ theorem execIRStmts_compiled_return_core_append_wholeFuel_of_scope
       (state := state)
       (mid := state')
       (next := state')
-      (stmt1 := YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR]))
-      (stmt2 := YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]))
+      (stmt1 := YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR]))
+      (stmt2 := YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]))
       (rest := tailIR)
       (value := retVal)
       hmstore
@@ -6264,35 +6264,35 @@ theorem execIRStmts_compiled_stop_core_append_wholeFuel
     {tailIR : List YulStmt}
     {extraFuel : Nat} :
     execIRStmts
-      (sizeOf ([YulStmt.expr (YulExpr.call "stop" [])] ++ tailIR) + extraFuel + 1)
+      (sizeOf ([YulStmt.exprStmt (YulExpr.call "stop" [])] ++ tailIR) + extraFuel + 1)
       state
-      ([YulStmt.expr (YulExpr.call "stop" [])] ++ tailIR) =
+      ([YulStmt.exprStmt (YulExpr.call "stop" [])] ++ tailIR) =
       .stop state := by
   have hstopFuelNeZero :
-      sizeOf ([YulStmt.expr (YulExpr.call "stop" [])] ++ tailIR) + extraFuel ≠ 0 := by
+      sizeOf ([YulStmt.exprStmt (YulExpr.call "stop" [])] ++ tailIR) + extraFuel ≠ 0 := by
     have hprefixLen :
-        1 ≤ ([YulStmt.expr (YulExpr.call "stop" [])] ++ tailIR).length := by
+        1 ≤ ([YulStmt.exprStmt (YulExpr.call "stop" [])] ++ tailIR).length := by
       simp
     have hlen :
-        ([YulStmt.expr (YulExpr.call "stop" [])] ++ tailIR).length ≤
-          sizeOf ([YulStmt.expr (YulExpr.call "stop" [])] ++ tailIR) := by
+        ([YulStmt.exprStmt (YulExpr.call "stop" [])] ++ tailIR).length ≤
+          sizeOf ([YulStmt.exprStmt (YulExpr.call "stop" [])] ++ tailIR) := by
       exact yulStmtList_length_le_sizeOf _
     omega
   have hstop :
       execIRStmt
-          (sizeOf ([YulStmt.expr (YulExpr.call "stop" [])] ++ tailIR) + extraFuel)
+          (sizeOf ([YulStmt.exprStmt (YulExpr.call "stop" [])] ++ tailIR) + extraFuel)
           state
-          (YulStmt.expr (YulExpr.call "stop" [])) =
+          (YulStmt.exprStmt (YulExpr.call "stop" [])) =
         .stop state := by
     exact execIRStmt_stop_nonzeroFuel
-      (fuel := sizeOf ([YulStmt.expr (YulExpr.call "stop" [])] ++ tailIR) + extraFuel)
+      (fuel := sizeOf ([YulStmt.exprStmt (YulExpr.call "stop" [])] ++ tailIR) + extraFuel)
       (state := state)
       hstopFuelNeZero
   exact execIRStmts_singleton_append_of_execIRStmt_stop_wholeFuel
     (extraFuel := extraFuel)
     (state := state)
     (next := state)
-    (stmt := YulStmt.expr (YulExpr.call "stop" []))
+    (stmt := YulStmt.exprStmt (YulExpr.call "stop" []))
     (rest := tailIR)
     hstop
 
@@ -7104,12 +7104,12 @@ theorem stmtResultMatchesIRExec_compiled_return_core_append_wholeFuel_of_scope
       (SourceSemantics.execStmtList fields runtime (.return value :: rest))
       (execIRStmts
         (sizeOf
-            ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-             , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+            ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+             , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
               tailIR) + extraFuel + 1)
         state
-        ([ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-         , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
+        ([ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+         , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++
           tailIR)) := by
   -- Use the execution theorem to rewrite the IR side
   rcases execIRStmts_compiled_return_core_append_wholeFuel_of_scope
@@ -7153,9 +7153,9 @@ theorem stmtResultMatchesIRExec_compiled_stop_core_append_wholeFuel
       fields
       (SourceSemantics.execStmtList fields runtime (.stop :: rest))
       (execIRStmts
-        (sizeOf ([YulStmt.expr (YulExpr.call "stop" [])] ++ tailIR) + extraFuel + 1)
+        (sizeOf ([YulStmt.exprStmt (YulExpr.call "stop" [])] ++ tailIR) + extraFuel + 1)
         state
-        ([YulStmt.expr (YulExpr.call "stop" [])] ++ tailIR)) := by
+        ([YulStmt.exprStmt (YulExpr.call "stop" [])] ++ tailIR)) := by
   rw [SourceSemantics.execStmtList, SourceSemantics.execStmt]
   rw [execIRStmts_compiled_stop_core_append_wholeFuel
     (state := state)
@@ -7509,8 +7509,8 @@ theorem exec_compileStmtList_terminal_core_sizeOf_extraFuel
       rcases compileExpr_core_ok hvalue with ⟨valueIR, hvalueIR⟩
       rcases compileStmtList_core_ok (fields := fields) (inScopeNames := collectStmtNames (.return value) ++ inScopeNames) hrest with
         ⟨tailIR, htailCompile⟩
-      refine ⟨[ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-              , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++ tailIR,
+      refine ⟨[ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+              , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] ++ tailIR,
         ?_, ?_⟩
       · apply compileStmtList_cons_eq_ok
         · unfold CompilationModel.compileStmt CompilationModel.compileStmtWithFork
@@ -7525,7 +7525,7 @@ theorem exec_compileStmtList_terminal_core_sizeOf_extraFuel
       rename_i scope rest
       rcases compileStmtList_core_ok (fields := fields) (inScopeNames := collectStmtNames (.stop) ++ inScopeNames) hrest with
         ⟨tailIR, htailCompile⟩
-      refine ⟨[YulStmt.expr (YulExpr.call "stop" [])] ++ tailIR, ?_, ?_⟩
+      refine ⟨[YulStmt.exprStmt (YulExpr.call "stop" [])] ++ tailIR, ?_, ?_⟩
       · apply compileStmtList_cons_eq_ok
         · rw [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork]
           rfl
@@ -7573,12 +7573,12 @@ theorem exec_compileStmtList_terminal_core_sizeOf_extraFuel
           have hincluded' : scopeNamesIncluded scope
               (collectStmtNames (.mstore offset value) ++ inScopeNames) :=
             scopeNamesIncluded_collectStmtNames_tail hincluded
-          rcases ih (extraFuel + sizeOf (YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])))
+          rcases ih (extraFuel + sizeOf (YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])))
               (runtime := runtime') (state := state')
               (inScopeNames := collectStmtNames (.mstore offset value) ++ inScopeNames)
               hincluded' hscope' hexact' hbounded' hruntime' with
             ⟨tailIR, htailCompile, htailSem⟩
-          refine ⟨[YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])] ++ tailIR, ?_, ?_⟩
+          refine ⟨[YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])] ++ tailIR, ?_, ?_⟩
           · apply compileStmtList_cons_eq_ok
             · unfold CompilationModel.compileStmt CompilationModel.compileStmtWithFork
               have hoffsetIRInternal := hoffsetIR
@@ -7588,17 +7588,17 @@ theorem exec_compileStmtList_terminal_core_sizeOf_extraFuel
               rfl
             · exact htailCompile
           · have hstmt :
-                execIRStmt (sizeOf ([YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])] ++ tailIR) + extraFuel) state
-                  (YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])) = .continue state' := by
-              have hfuelNe : sizeOf ([YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])] ++ tailIR) + extraFuel ≠ 0 :=
+                execIRStmt (sizeOf ([YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])] ++ tailIR) + extraFuel) state
+                  (YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])) = .continue state' := by
+              have hfuelNe : sizeOf ([YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])] ++ tailIR) + extraFuel ≠ 0 :=
                 sizeOf_singleton_append_extraFuel_ne_zero _ _ _
-              cases hfuel : sizeOf ([YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])] ++ tailIR) + extraFuel with
+              cases hfuel : sizeOf ([YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])] ++ tailIR) + extraFuel with
               | zero => exact absurd hfuel hfuelNe
               | succ n =>
                   simp [execIRStmt, evalIRExprs, hIROffset, hIRValue, state']
             have hirExec :=
               execIRStmts_singleton_append_of_execIRStmt_continue_wholeFuel
-                extraFuel state state' (YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])) tailIR hstmt
+                extraFuel state state' (YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])) tailIR hstmt
             simp only [SourceSemantics.execStmtList, SourceSemantics.execStmt, hOffsetSrc, hValueSrc, hirExec]
             dsimp [runtime', state']
             convert htailSem using 2
@@ -7649,12 +7649,12 @@ theorem exec_compileStmtList_terminal_core_sizeOf_extraFuel
           have hincluded' : scopeNamesIncluded scope
               (collectStmtNames (.tstore offset value) ++ inScopeNames) :=
             scopeNamesIncluded_collectStmtNames_tail hincluded
-          rcases ih (extraFuel + sizeOf (YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])))
+          rcases ih (extraFuel + sizeOf (YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])))
               (runtime := runtime') (state := state')
               (inScopeNames := collectStmtNames (.tstore offset value) ++ inScopeNames)
               hincluded' hscope' hexact' hbounded' hruntime' with
             ⟨tailIR, htailCompile, htailSem⟩
-          refine ⟨[YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])] ++ tailIR, ?_, ?_⟩
+          refine ⟨[YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])] ++ tailIR, ?_, ?_⟩
           · apply compileStmtList_cons_eq_ok
             · unfold CompilationModel.compileStmt CompilationModel.compileStmtWithFork
               have hoffsetIRInternal := hoffsetIR
@@ -7664,16 +7664,16 @@ theorem exec_compileStmtList_terminal_core_sizeOf_extraFuel
               rfl
             · exact htailCompile
           · have hstmt :
-                execIRStmt (sizeOf ([YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])] ++ tailIR) + extraFuel) state
-                  (YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])) = .continue state' := by
-              have hfuelNe : sizeOf ([YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])] ++ tailIR) + extraFuel ≠ 0 :=
+                execIRStmt (sizeOf ([YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])] ++ tailIR) + extraFuel) state
+                  (YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])) = .continue state' := by
+              have hfuelNe : sizeOf ([YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])] ++ tailIR) + extraFuel ≠ 0 :=
                 sizeOf_singleton_append_extraFuel_ne_zero _ _ _
-              cases hfuel : sizeOf ([YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])] ++ tailIR) + extraFuel with
+              cases hfuel : sizeOf ([YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])] ++ tailIR) + extraFuel with
               | zero => exact absurd hfuel hfuelNe
               | succ n => simp [execIRStmt, evalIRExprs, hIROffset, hIRValue, state', offsetKey]
             have hirExec :=
               execIRStmts_singleton_append_of_execIRStmt_continue_wholeFuel
-                extraFuel state state' (YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])) tailIR hstmt
+                extraFuel state state' (YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])) tailIR hstmt
             simp only [SourceSemantics.execStmtList, SourceSemantics.execStmt, hOffsetSrc, hValueSrc, hirExec]
             dsimp [runtime', state']
             convert htailSem using 2

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -112,7 +112,7 @@ theorem compiledStmtStepWithHelpersAndHelperIR_internalCall
         (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
             (Stmt.internalCall calleeName args))
           (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
-            [YulStmt.expr (YulExpr.call
+            [YulStmt.exprStmt (YulExpr.call
               (CompilationModel.internalFunctionYulName calleeName) argExprs)])) :
     CompiledStmtStepWithHelpersAndHelperIR
       runtimeContract spec fields scope
@@ -132,7 +132,7 @@ theorem compiledStmtStepWithHelpersAndHelperIR_internalCall
     exact hargOk.symm
   subst hArgEq
   set singletonIR :=
-    [YulStmt.expr
+    [YulStmt.exprStmt
       (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs')]
   have hshape' : compiledIR = singletonIR := by
     simpa [singletonIR] using hshape
@@ -253,7 +253,7 @@ structure DirectInternalHelperCallHeadStepBridge
         (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
             (Stmt.internalCall calleeName args))
           (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
-            [YulStmt.expr (YulExpr.call
+            [YulStmt.exprStmt (YulExpr.call
               (CompilationModel.internalFunctionYulName calleeName) argExprs)])
 
 structure DirectInternalHelperAssignHeadStepBridge
@@ -321,7 +321,7 @@ structure DirectInternalHelperHeadStepBridgeCatalog
         (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
             (Stmt.internalCall calleeName args))
           (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
-            [YulStmt.expr (YulExpr.call
+            [YulStmt.exprStmt (YulExpr.call
               (CompilationModel.internalFunctionYulName calleeName) argExprs)])
   assignCompile :
     ∀ {scope : List String} {names : List String} {calleeName : String} {args : List Expr},
@@ -1141,7 +1141,7 @@ theorem execIRStmtsWithInternals_of_internalCall_compiledHelperWitness
       evalIRExprsWithInternals runtimeContract (irFuel + 1) state argExprs =
         .values argVals state') :
     ∃ helper,
-      compiledIR = [YulStmt.expr
+      compiledIR = [YulStmt.exprStmt
         (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs)] ∧
       findInternalFunction? runtimeContract
         (CompilationModel.internalFunctionYulName calleeName) = some helper ∧

--- a/Compiler/Proofs/IRGeneration/GenericInduction/EventBridge.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/EventBridge.lean
@@ -455,7 +455,7 @@ private theorem eventExecIRStmt_mstore_step
     (hval : evalIRExpr state valExpr = some val)
     (extraFuel : Nat) :
     execIRStmt (extraFuel + 1) state
-        (YulStmt.expr (YulExpr.call "mstore" [offsetExpr, valExpr])) =
+        (YulStmt.exprStmt (YulExpr.call "mstore" [offsetExpr, valExpr])) =
       .continue { state with
         memory := fun o => if o = offset then val else state.memory o } := by
   simp [execIRStmt, hoff, hval]
@@ -464,7 +464,7 @@ private theorem eventExecIRStmt_log1_step
     {state : IRState} {args : List YulExpr} {offset size topic0 : Nat}
     (heval : evalIRExprs state args = some [offset, size, topic0])
     (extraFuel : Nat) :
-    execIRStmt (extraFuel + 1) state (YulStmt.expr (YulExpr.call "log1" args)) =
+    execIRStmt (extraFuel + 1) state (YulStmt.exprStmt (YulExpr.call "log1" args)) =
       .continue (state.appendYulLog offset size [topic0]) := by
   simp [execIRStmt, isYulLogName, heval]
 
@@ -472,7 +472,7 @@ private theorem eventExecIRStmt_log2_step
     {state : IRState} {args : List YulExpr} {offset size topic0 topic1 : Nat}
     (heval : evalIRExprs state args = some [offset, size, topic0, topic1])
     (extraFuel : Nat) :
-    execIRStmt (extraFuel + 1) state (YulStmt.expr (YulExpr.call "log2" args)) =
+    execIRStmt (extraFuel + 1) state (YulStmt.exprStmt (YulExpr.call "log2" args)) =
       .continue (state.appendYulLog offset size [topic0, topic1]) := by
   simp [execIRStmt, isYulLogName, heval]
 
@@ -480,7 +480,7 @@ private theorem eventExecIRStmt_log3_step
     {state : IRState} {args : List YulExpr} {offset size topic0 topic1 topic2 : Nat}
     (heval : evalIRExprs state args = some [offset, size, topic0, topic1, topic2])
     (extraFuel : Nat) :
-    execIRStmt (extraFuel + 1) state (YulStmt.expr (YulExpr.call "log3" args)) =
+    execIRStmt (extraFuel + 1) state (YulStmt.exprStmt (YulExpr.call "log3" args)) =
       .continue (state.appendYulLog offset size [topic0, topic1, topic2]) := by
   simp [execIRStmt, isYulLogName, heval]
 
@@ -490,7 +490,7 @@ private theorem eventExecIRStmt_log4_step
     (heval : evalIRExprs state args =
       some [offset, size, topic0, topic1, topic2, topic3])
     (extraFuel : Nat) :
-    execIRStmt (extraFuel + 1) state (YulStmt.expr (YulExpr.call "log4" args)) =
+    execIRStmt (extraFuel + 1) state (YulStmt.exprStmt (YulExpr.call "log4" args)) =
       .continue (state.appendYulLog offset size
         [topic0, topic1, topic2, topic3]) := by
   simp [execIRStmt, isYulLogName, heval]
@@ -527,7 +527,7 @@ private theorem eventLegacy_append
       | assign name value _ hrest =>
           exact .assign name value (rest ++ back) (ih hrest hback)
       | expr value _ hrest =>
-          exact .expr value (rest ++ back) (ih hrest hback)
+          exact .exprStmt value (rest ++ back) (ih hrest hback)
       | if_ cond body _ hbody hrest =>
           exact .if_ cond body (rest ++ back) hbody (ih hrest hback)
       | block body _ hbody hrest =>
@@ -544,8 +544,8 @@ private theorem eventLegacy_singleton_let (name : String) (value : YulExpr) :
   .let_ name value [] .nil
 
 private theorem eventLegacy_singleton_expr (value : YulExpr) :
-    LegacyCompatibleExternalStmtList [YulStmt.expr value] :=
-  .expr value [] .nil
+    LegacyCompatibleExternalStmtList [YulStmt.exprStmt value] :=
+  .exprStmt value [] .nil
 
 private theorem eventIRState_set_memory_eq_self
     (state : IRState) {mem : Nat → Nat}
@@ -561,7 +561,7 @@ private def eventSignatureStoreStmtsFromWords :
     List Nat → Nat → List YulStmt
   | [], _ => []
   | word :: rest, startIdx =>
-    YulStmt.expr (YulExpr.call "mstore" [
+    YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.call "add" [
         YulExpr.ident "__evt_ptr",
         YulExpr.lit (startIdx * 32)
@@ -572,7 +572,7 @@ private def eventSignatureStoreStmtsFromWords :
 private def eventSignatureStoreStmtsFromChunks
     (chunks : List (List UInt8)) (startIdx : Nat) : List YulStmt :=
   (chunks.zipIdx startIdx).map fun (chunk, idx) =>
-    YulStmt.expr (YulExpr.call "mstore" [
+    YulStmt.exprStmt (YulExpr.call "mstore" [
       YulExpr.call "add" [
         YulExpr.ident "__evt_ptr",
         YulExpr.lit (idx * 32)
@@ -601,7 +601,7 @@ private theorem eventEvalIRExpr_evtPtr_add
 private theorem eventSignatureStoreStmtsFromWords_cons
     (word : Nat) (words : List Nat) (startIdx : Nat) :
     eventSignatureStoreStmtsFromWords (word :: words) startIdx =
-      YulStmt.expr (YulExpr.call "mstore" [
+      YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.call "add" [
           YulExpr.ident "__evt_ptr",
           YulExpr.lit (startIdx * 32)
@@ -631,7 +631,7 @@ private theorem eventSignatureStoreStmtsFromWords_legacy
       exact .nil
   | cons word rest ih =>
       rw [eventSignatureStoreStmtsFromWords_cons]
-      exact .expr _ _ (ih (startIdx + 1))
+      exact .exprStmt _ _ (ih (startIdx + 1))
 
 private theorem eventSignatureStoreStmtsFromChunks_legacy
     (chunks : List (List UInt8)) (startIdx : Nat) :
@@ -949,7 +949,7 @@ private theorem eventUnindexedStore_one_continue
     (hvalueLt : value < Compiler.Constants.evmModulus)
     (hmem : ∀ offset, state.memory offset = (srcMemory offset).val) :
     StmtsContinueFromTo state
-      [YulStmt.expr (YulExpr.call "mstore" [
+      [YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.call "add" [YulExpr.ident "__evt_ptr", YulExpr.lit (wordIdx * 32)],
         normalizeEventWord ty argExpr
       ])]
@@ -1045,7 +1045,7 @@ private theorem eventScalarUnindexedStoresFrom_legacy
   | cons entry rest ih =>
       rcases entry with ⟨param, srcExpr, argExpr⟩
       simp [scalarEventUnindexedStoresFrom]
-      exact .expr _ _ (ih (headOffset + eventHeadWordSize param.ty))
+      exact .exprStmt _ _ (ih (headOffset + eventHeadWordSize param.ty))
 
 theorem eventCompiledScalarEmit_legacy
     (eventDef : EventDef) (args : List Expr) (argExprs : List YulExpr) :
@@ -1058,7 +1058,7 @@ theorem eventCompiledScalarEmit_legacy
   let topic0Store := YulStmt.let_ "__evt_topic0"
     (YulExpr.call "keccak256" [YulExpr.ident "__evt_ptr", YulExpr.lit sigBytes.length])
   let unindexedStores := scalarEventUnindexedStores unindexed
-  let logStmt := YulStmt.expr (YulExpr.call (eventLogFunction (eventIndexedArgs zipped).length)
+  let logStmt := YulStmt.exprStmt (YulExpr.call (eventLogFunction (eventIndexedArgs zipped).length)
     (eventLogArgs (YulExpr.lit (eventUnindexedHeadSize unindexed))
       (scalarEventIndexedTopicParts (eventIndexedArgs zipped))))
   have hbody : LegacyCompatibleExternalStmtList
@@ -1122,7 +1122,7 @@ private theorem eventUnindexedStores_cons_continue
   · have hstmt :
         scalarEventUnindexedStoresFrom ((param, srcExpr, argExpr) :: rest)
             (wordIdx * 32) =
-          YulStmt.expr (YulExpr.call "mstore" [
+          YulStmt.exprStmt (YulExpr.call "mstore" [
             YulExpr.call "add" [
               YulExpr.ident "__evt_ptr", YulExpr.lit (wordIdx * 32)],
             normalizeEventWord param.ty argExpr]) ::
@@ -2073,7 +2073,7 @@ private theorem eventLogStmt_continue_zero
     (hptr : state.getVar "__evt_ptr" = some ptr)
     (htopic0 : state.getVar "__evt_topic0" = some topic0) :
     StmtsContinueFromTo state
-      [YulStmt.expr (YulExpr.call (eventLogFunction ([] : List (EventParam × Expr × YulExpr)).length)
+      [YulStmt.exprStmt (YulExpr.call (eventLogFunction ([] : List (EventParam × Expr × YulExpr)).length)
         (eventLogArgs (YulExpr.lit dataSize)
           (scalarEventIndexedTopicParts ([] : List (EventParam × Expr × YulExpr)))))]
       (state.appendYulLog ptr dataSize [topic0]) := by
@@ -2091,7 +2091,7 @@ private theorem eventLogStmt_continue_one
     (htopic0 : state.getVar "__evt_topic0" = some topic0)
     (hrel : List.Forall₂ (EventIndexedEntryOk scope state) [p1] [v1]) :
     StmtsContinueFromTo state
-      [YulStmt.expr (YulExpr.call (eventLogFunction [p1].length)
+      [YulStmt.exprStmt (YulExpr.call (eventLogFunction [p1].length)
         (eventLogArgs (YulExpr.lit dataSize)
           (scalarEventIndexedTopicParts [p1])))]
       (state.appendYulLog ptr dataSize
@@ -2115,7 +2115,7 @@ private theorem eventLogStmt_continue_two
     (htopic0 : state.getVar "__evt_topic0" = some topic0)
     (hrel : List.Forall₂ (EventIndexedEntryOk scope state) [p1, p2] [v1, v2]) :
     StmtsContinueFromTo state
-      [YulStmt.expr (YulExpr.call (eventLogFunction [p1, p2].length)
+      [YulStmt.exprStmt (YulExpr.call (eventLogFunction [p1, p2].length)
         (eventLogArgs (YulExpr.lit dataSize)
           (scalarEventIndexedTopicParts [p1, p2])))]
       (state.appendYulLog ptr dataSize
@@ -2146,7 +2146,7 @@ private theorem eventLogStmt_continue_three
     (hrel : List.Forall₂ (EventIndexedEntryOk scope state)
       [p1, p2, p3] [v1, v2, v3]) :
     StmtsContinueFromTo state
-      [YulStmt.expr (YulExpr.call (eventLogFunction [p1, p2, p3].length)
+      [YulStmt.exprStmt (YulExpr.call (eventLogFunction [p1, p2, p3].length)
         (eventLogArgs (YulExpr.lit dataSize)
           (scalarEventIndexedTopicParts [p1, p2, p3])))]
       (state.appendYulLog ptr dataSize
@@ -2588,7 +2588,7 @@ private theorem eventLogStmt_continue_le_three
     (hrel : List.Forall₂ (EventIndexedEntryOk scope state) entries values)
     (hlen : entries.length ≤ 3) :
     StmtsContinueFromTo state
-      [YulStmt.expr (YulExpr.call (eventLogFunction entries.length)
+      [YulStmt.exprStmt (YulExpr.call (eventLogFunction entries.length)
         (eventLogArgs (YulExpr.lit dataSize)
           (scalarEventIndexedTopicParts entries)))]
       (state.appendYulLog ptr dataSize
@@ -2764,7 +2764,7 @@ macro "event_emit_semantic_bridge_tac" : tactic => `(tactic| unhygienic (
         [YulExpr.ident "__evt_ptr",
           YulExpr.lit (bytesFromString (eventSignature eventDef)).length])] ++
       scalarEventUnindexedStores unindexed ++
-      [YulStmt.expr (YulExpr.call (eventLogFunction indexed.length)
+      [YulStmt.exprStmt (YulExpr.call (eventLogFunction indexed.length)
         (eventLogArgs (YulExpr.lit (eventUnindexedHeadSize unindexed))
           (scalarEventIndexedTopicParts indexed)))]
   have hbodyContinue : StmtsContinueFromTo state body

--- a/Compiler/Proofs/IRGeneration/GenericInduction/EventBridge.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/EventBridge.lean
@@ -526,7 +526,7 @@ private theorem eventLegacy_append
           exact .let_ name value (rest ++ back) (ih hrest hback)
       | assign name value _ hrest =>
           exact .assign name value (rest ++ back) (ih hrest hback)
-      | expr value _ hrest =>
+      | exprStmt value _ hrest =>
           exact .exprStmt value (rest ++ back) (ih hrest hback)
       | if_ cond body _ hbody hrest =>
           exact .if_ cond body (rest ++ back) hbody (ih hrest hback)

--- a/Compiler/Proofs/IRGeneration/GenericInduction/ExprStmt.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/ExprStmt.lean
@@ -308,8 +308,8 @@ theorem compiledStmtStep_return
     (hinScope : FunctionBody.exprBoundNamesInScope value scope)
     (hvalueIR : CompilationModel.compileExpr fields .calldata value = Except.ok valueIR) :
     CompiledStmtStep fields scope (.return value)
-      [ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-      , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] where
+      [ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+      , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ] where
   compileOk := by
     have hvalueIRInternal := hvalueIR
     rw [← CompilationModel.compileExprWithInternals_nil_eq] at hvalueIRInternal
@@ -317,8 +317,8 @@ theorem compiledStmtStep_return
       pure, Except.pure, bind, Except.bind]
   preserves runtime state extraFuel hexact hscope hbounded hruntime hslack := by
     set compiledIR :=
-      [ YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
-      , YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ]
+      [ YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])
+      , YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32]) ]
     set wholeExtraFuel := extraFuel - (sizeOf compiledIR - compiledIR.length) with hWF
     have hwhole := FunctionBody.execIRStmts_compiled_return_core_append_wholeFuel_of_scope
         (fields := fields) (runtime := runtime) (state := state) (scope := scope)
@@ -348,12 +348,12 @@ theorem compiledStmtStep_return
         rw [hWF]
         have : compiledIR.length ≤ sizeOf compiledIR := by
           show 2 ≤ sizeOf compiledIR
-          have : 0 ≤ sizeOf (YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])) :=
+          have : 0 ≤ sizeOf (YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])) :=
             Nat.zero_le _
-          have : 0 ≤ sizeOf (YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])) :=
+          have : 0 ≤ sizeOf (YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])) :=
             Nat.zero_le _
-          show 2 ≤ 1 + sizeOf (YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])) +
-                       (1 + sizeOf (YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])) + 1)
+          show 2 ≤ 1 + sizeOf (YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, valueIR])) +
+                       (1 + sizeOf (YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])) + 1)
           omega
         omega
       -- Provide explicit witnesses
@@ -381,12 +381,12 @@ theorem compiledStmtStep_return
 theorem compiledStmtStep_stop
     {fields : List Field}
     {scope : List String} :
-    CompiledStmtStep fields scope .stop [YulStmt.expr (YulExpr.call "stop" [])] where
+    CompiledStmtStep fields scope .stop [YulStmt.exprStmt (YulExpr.call "stop" [])] where
   compileOk := by
     simp [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork, pure, Except.pure]
   preserves runtime state extraFuel hexact hscope hbounded hruntime hslack := by
     -- Use the helper with wholeFuel aligned to the fuel budget
-    set compiledIR := [YulStmt.expr (YulExpr.call "stop" [])]
+    set compiledIR := [YulStmt.exprStmt (YulExpr.call "stop" [])]
     set wholeExtraFuel := extraFuel - (sizeOf compiledIR - compiledIR.length) with hWF
     have hwhole := FunctionBody.execIRStmts_compiled_stop_core_append_wholeFuel
       (state := state) (tailIR := []) (extraFuel := wholeExtraFuel)
@@ -397,7 +397,7 @@ theorem compiledStmtStep_stop
       rw [hWF]
       have : compiledIR.length ≤ sizeOf compiledIR := by
         show 1 ≤ sizeOf compiledIR
-        change 1 ≤ sizeOf ([YulStmt.expr (YulExpr.call "stop" [])] : List YulStmt)
+        change 1 ≤ sizeOf ([YulStmt.exprStmt (YulExpr.call "stop" [])] : List YulStmt)
         decide
       omega
     refine ⟨.stop runtime, .stop state, ?_, ?_, ?_⟩

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
@@ -1935,7 +1935,7 @@ private theorem execIRStmts_sstore_lit_ident_slots_continue
     (hvalue : IRState.getVar state name = value) :
     execIRStmts (slots.length + fuel + 1) state
       (slots.map (fun slot =>
-        YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit slot, YulExpr.ident name]))) =
+        YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit slot, YulExpr.ident name]))) =
       .continue
         { state with
             storage := abstractStoreStorageOrMappingMany state.storage slots value } := by
@@ -1948,7 +1948,7 @@ private theorem execIRStmts_sstore_lit_ident_slots_continue
             storage := Compiler.Proofs.abstractStoreStorageOrMapping state.storage slot value }
       have hstmt :
           execIRStmt (rest.length + fuel + 1) state
-            (YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit slot, YulExpr.ident name])) =
+            (YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit slot, YulExpr.ident name])) =
               .continue nextState := by
         apply execIRStmt_sstore_lit_expr_succ_of_eval
         simp only [evalIRExpr]; exact hvalue
@@ -1973,7 +1973,7 @@ private theorem execIRStmts_let_then_sstore_lit_ident_slots_continue
     execIRStmts (slots.length + fuel + 2) state
       (YulStmt.let_ tempName valueIR ::
         slots.map (fun slot =>
-          YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit slot, YulExpr.ident tempName]))) =
+          YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit slot, YulExpr.ident tempName]))) =
       .continue
         { state.setVar tempName value with
             storage :=
@@ -2461,12 +2461,12 @@ theorem compiledStmtStep_setStorage_singleSlot
     (hNotAdt : ∀ name maxFields, f.ty ≠ FieldType.adt name maxFields)
     (hvalueIR : CompilationModel.compileExpr fields .calldata value = Except.ok valueIR) :
     CompiledStmtStep fields scope (.setStorage fieldName value)
-      [YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit slot, valueIR])] where
+      [YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit slot, valueIR])] where
   compileOk := by
     simp [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork, CompilationModel.compileSetStorage,
       hNotMapping, hfind, halias, hunpacked, hnotTransient, hvalueIR]
   preserves runtime state extraFuel hexact hscope hbounded hruntime hslack := by
-    let compiledIR := [YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit slot, valueIR])]
+    let compiledIR := [YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit slot, valueIR])]
     have hresolvedSlot :
         findResolvedFieldAtSlotCopy fields slot = some f :=
       findResolvedFieldAtSlotCopy_of_findFieldWithResolvedSlot_singleton
@@ -2503,7 +2503,7 @@ theorem compiledStmtStep_setStorage_singleSlot
           SourceSemantics.writeMappingTargets, hwriteSlots, hValueSrc, hfieldTransient, runtime']
       have hExecStmt :
           execIRStmt (extraFuel + 1) state
-            (YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit slot, valueIR])) =
+            (YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit slot, valueIR])) =
               .continue state' :=
         execIRStmt_sstore_lit_expr_succ_of_eval
           extraFuel state slot valueIR valueNat hIRValue
@@ -2547,11 +2547,11 @@ private theorem compiledStmtStep_setStorageAddr_singleSlot_preserves
       FunctionBody.bindingsBounded runtime.bindings →
       FunctionBody.runtimeStateMatchesIR fields runtime state →
       sizeOf
-          [YulStmt.expr
+          [YulStmt.exprStmt
             (YulExpr.call "sstore"
               [YulExpr.lit slot,
                 YulExpr.call "and" [valueIR, YulExpr.hex Compiler.Constants.addressMask]])] -
-        [YulStmt.expr
+        [YulStmt.exprStmt
           (YulExpr.call "sstore"
             [YulExpr.lit slot,
               YulExpr.call "and" [valueIR, YulExpr.hex Compiler.Constants.addressMask]])].length ≤
@@ -2559,13 +2559,13 @@ private theorem compiledStmtStep_setStorageAddr_singleSlot_preserves
       ∃ sourceResult irExec,
         SourceSemantics.execStmt fields runtime (.setStorageAddr fieldName value) = sourceResult ∧
         execIRStmts
-            ([YulStmt.expr
+            ([YulStmt.exprStmt
               (YulExpr.call "sstore"
                 [YulExpr.lit slot,
                   YulExpr.call "and" [valueIR, YulExpr.hex Compiler.Constants.addressMask]])].length +
               extraFuel + 1)
             state
-            [YulStmt.expr
+            [YulStmt.exprStmt
               (YulExpr.call "sstore"
                 [YulExpr.lit slot,
                   YulExpr.call "and" [valueIR, YulExpr.hex Compiler.Constants.addressMask]])] =
@@ -2576,7 +2576,7 @@ private theorem compiledStmtStep_setStorageAddr_singleSlot_preserves
           irExec := by
   intro runtime state extraFuel hexact hscope hbounded hruntime hslack
   let compiledIR :=
-    [YulStmt.expr
+    [YulStmt.exprStmt
       (YulExpr.call "sstore"
         [YulExpr.lit slot,
           YulExpr.call "and" [valueIR, YulExpr.hex Compiler.Constants.addressMask]])]
@@ -2634,7 +2634,7 @@ private theorem compiledStmtStep_setStorageAddr_singleSlot_preserves
         hwriteSlots, hValueSrc, hfieldTransient, runtime']
     have hExecStmt :
         execIRStmt (extraFuel + 1) state
-          (YulStmt.expr
+          (YulStmt.exprStmt
             (YulExpr.call "sstore"
               [YulExpr.lit slot,
                 YulExpr.call "and" [valueIR, YulExpr.hex Compiler.Constants.addressMask]])) =
@@ -2681,7 +2681,7 @@ theorem compiledStmtStep_setStorageAddr_singleSlot
     (hnoConflict : firstFieldWriteSlotConflict fields = none)
     (hvalueIR : CompilationModel.compileExpr fields .calldata value = Except.ok valueIR) :
     CompiledStmtStep fields scope (.setStorageAddr fieldName value)
-      [YulStmt.expr
+      [YulStmt.exprStmt
         (YulExpr.call "sstore"
           [YulExpr.lit slot,
             YulExpr.call "and" [valueIR, YulExpr.hex Compiler.Constants.addressMask]])] where
@@ -2711,21 +2711,21 @@ private theorem compiledStmtStep_mstore_single_preserves
       FunctionBody.scopeNamesPresent scope runtime.bindings →
       FunctionBody.bindingsBounded runtime.bindings →
       FunctionBody.runtimeStateMatchesIR fields runtime state →
-      sizeOf [YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])] -
-        [YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])].length ≤ extraFuel →
+      sizeOf [YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])] -
+        [YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])].length ≤ extraFuel →
       ∃ sourceResult irExec,
         SourceSemantics.execStmt fields runtime (.mstore offset value) = sourceResult ∧
         execIRStmts
-            ([YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])].length +
+            ([YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])].length +
               extraFuel + 1)
             state
-            [YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])] = irExec ∧
+            [YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])] = irExec ∧
         stmtStepMatchesIRExec fields
           (stmtNextScope scope (.mstore offset value))
           sourceResult
           irExec := by
   intro runtime state extraFuel hexact hscope hbounded hruntime hslack
-  let compiledIR := [YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])]
+  let compiledIR := [YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])]
   have hOffsetEval :=
     FunctionBody.eval_compileExpr_core_of_scope
       hcoreOffset hexact hinScopeOffset hbounded
@@ -2766,7 +2766,7 @@ private theorem compiledStmtStep_mstore_single_preserves
           memory := fun o => if o = offsetNat then valueNat else state.memory o }
       have hExecStmt :
           execIRStmt (extraFuel + 1) state
-            (YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])) =
+            (YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])) =
               .continue state' := by
         simp [execIRStmt, evalIRExprs, hIROffset, hIRValue, state']
       have hfuelEq : 1 + extraFuel = extraFuel + 1 := by omega
@@ -2818,7 +2818,7 @@ theorem compiledStmtStep_mstore_single
     (hoffsetIR : CompilationModel.compileExpr fields .calldata offset = Except.ok offsetIR)
     (hvalueIR : CompilationModel.compileExpr fields .calldata value = Except.ok valueIR) :
     CompiledStmtStep fields scope (.mstore offset value)
-      [YulStmt.expr (YulExpr.call "mstore" [offsetIR, valueIR])] where
+      [YulStmt.exprStmt (YulExpr.call "mstore" [offsetIR, valueIR])] where
   compileOk := by
     have hoffsetIRInternal := compileExprWithInternals_nil_ok hoffsetIR
     have hvalueIRInternal := compileExprWithInternals_nil_ok hvalueIR
@@ -2845,21 +2845,21 @@ private theorem compiledStmtStep_tstore_single_preserves
       FunctionBody.scopeNamesPresent scope runtime.bindings →
       FunctionBody.bindingsBounded runtime.bindings →
       FunctionBody.runtimeStateMatchesIR fields runtime state →
-      sizeOf [YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])] -
-        [YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])].length ≤ extraFuel →
+      sizeOf [YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])] -
+        [YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])].length ≤ extraFuel →
       ∃ sourceResult irExec,
         SourceSemantics.execStmt fields runtime (.tstore offset value) = sourceResult ∧
         execIRStmts
-            ([YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])].length +
+            ([YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])].length +
               extraFuel + 1)
             state
-            [YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])] = irExec ∧
+            [YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])] = irExec ∧
         stmtStepMatchesIRExec fields
           (stmtNextScope scope (.tstore offset value))
           sourceResult
           irExec := by
   intro runtime state extraFuel hexact hscope hbounded hruntime hslack
-  let compiledIR := [YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])]
+  let compiledIR := [YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])]
   have hOffsetEval :=
     FunctionBody.eval_compileExpr_core_of_scope
       hcoreOffset hexact hinScopeOffset hbounded
@@ -2909,7 +2909,7 @@ private theorem compiledStmtStep_tstore_single_preserves
           transientStorage := fun o => if o = offsetKey then valueNat else state.transientStorage o }
       have hExecStmt :
           execIRStmt (extraFuel + 1) state
-            (YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])) =
+            (YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])) =
               .continue state' := by
         simp [execIRStmt, evalIRExprs, hIROffset, hIRValue, state', offsetKey]
       have hfuelEq : 1 + extraFuel = extraFuel + 1 := by omega
@@ -2955,7 +2955,7 @@ theorem compiledStmtStep_tstore_single
     (hoffsetIR : CompilationModel.compileExpr fields .calldata offset = Except.ok offsetIR)
     (hvalueIR : CompilationModel.compileExpr fields .calldata value = Except.ok valueIR) :
     CompiledStmtStep fields scope (.tstore offset value)
-      [YulStmt.expr (YulExpr.call "tstore" [offsetIR, valueIR])] where
+      [YulStmt.exprStmt (YulExpr.call "tstore" [offsetIR, valueIR])] where
   compileOk := by
     have hoffsetIRInternal := compileExprWithInternals_nil_ok hoffsetIR
     have hvalueIRInternal := compileExprWithInternals_nil_ok hvalueIR
@@ -2992,21 +2992,21 @@ private theorem compiledStmtStep_setMappingUint_singleSlot_of_slotSafety_preserv
       FunctionBody.scopeNamesPresent scope runtime.bindings →
       FunctionBody.bindingsBounded runtime.bindings →
       FunctionBody.runtimeStateMatchesIR fields runtime state →
-      sizeOf [YulStmt.expr
+      sizeOf [YulStmt.exprStmt
         (YulExpr.call (fieldStoreBuiltin fields fieldName)
           [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])] -
-        [YulStmt.expr
+        [YulStmt.exprStmt
           (YulExpr.call (fieldStoreBuiltin fields fieldName)
             [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])].length ≤ extraFuel →
       ∃ sourceResult irExec,
         SourceSemantics.execStmt fields runtime (.setMappingUint fieldName key value) = sourceResult ∧
         execIRStmts
-            ([YulStmt.expr
+            ([YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])].length +
               extraFuel + 1)
             state
-            [YulStmt.expr
+            [YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])] = irExec ∧
         stmtStepMatchesIRExec fields
@@ -3014,7 +3014,7 @@ private theorem compiledStmtStep_setMappingUint_singleSlot_of_slotSafety_preserv
           sourceResult
           irExec := by
   intro runtime state extraFuel hexact hscope hbounded hruntime hslack
-  let compiledIR := [YulStmt.expr
+  let compiledIR := [YulStmt.exprStmt
     (YulExpr.call (fieldStoreBuiltin fields fieldName)
       [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])]
   have hkeySourceEval :=
@@ -3076,7 +3076,7 @@ private theorem compiledStmtStep_setMappingUint_singleSlot_of_slotSafety_preserv
             SourceSemantics.writeUintKeyedMappingFieldSlots, htrans, target]
         have hExecStmt :
             execIRStmt (extraFuel + 1) state
-              (YulStmt.expr
+              (YulStmt.exprStmt
                 (YulExpr.call (fieldStoreBuiltin fields fieldName)
                   [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])) =
                 .continue state' := by
@@ -3129,7 +3129,7 @@ private theorem compiledStmtStep_setMappingUint_singleSlot_of_slotSafety_preserv
             SourceSemantics.writeUintKeyedMappingFieldSlots, htransFalse]
         have hExecStmt :
             execIRStmt (extraFuel + 1) state
-              (YulStmt.expr
+              (YulStmt.exprStmt
                 (YulExpr.call (fieldStoreBuiltin fields fieldName)
                   [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])) =
                 .continue state' := by
@@ -3178,7 +3178,7 @@ theorem compiledStmtStep_setMappingUint_singleSlot_of_slotSafety
     (hkeyIR : CompilationModel.compileExpr fields .calldata key = Except.ok keyIR)
     (hvalueIR : CompilationModel.compileExpr fields .calldata value = Except.ok valueIR) :
     CompiledStmtStep fields scope (.setMappingUint fieldName key value)
-      [YulStmt.expr
+      [YulStmt.exprStmt
         (YulExpr.call (fieldStoreBuiltin fields fieldName)
           [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])] where
   compileOk := by
@@ -3435,7 +3435,7 @@ private theorem execIRStmt_sstore_of_eval
     (hslot : evalIRExpr state slotExpr = some slotVal)
     (hvalue : evalIRExpr state valueExpr = some valueVal) :
     execIRStmt (Nat.succ fuel) state
-      (Compiler.Yul.YulStmt.expr (Compiler.Yul.YulExpr.call "sstore"
+      (Compiler.Yul.YulStmt.exprStmt (Compiler.Yul.YulExpr.call "sstore"
         [slotExpr, valueExpr])) =
       .continue { state with
         storage := Compiler.Proofs.abstractStoreStorageOrMapping state.storage
@@ -3481,7 +3481,7 @@ private theorem execIRStmt_tstore_of_eval
     (hslot : evalIRExpr state slotExpr = some slotVal)
     (hvalue : evalIRExpr state valueExpr = some valueVal) :
     execIRStmt (Nat.succ fuel) state
-      (Compiler.Yul.YulStmt.expr (Compiler.Yul.YulExpr.call "tstore"
+      (Compiler.Yul.YulStmt.exprStmt (Compiler.Yul.YulExpr.call "tstore"
         [slotExpr, valueExpr])) =
       .continue { state with
         transientStorage := fun slot =>
@@ -3638,7 +3638,7 @@ private theorem execIRStmt_sstore_foldl_mappingSlot
     (hkeys : List.Forall₂ (fun exprIR value => evalIRExpr state exprIR = some value) keyIRs keyVals)
     (hvalue : evalIRExpr state valueExpr = some valueVal) :
     execIRStmt (Nat.succ fuel) state
-      (Compiler.Yul.YulStmt.expr (Compiler.Yul.YulExpr.call "sstore"
+      (Compiler.Yul.YulStmt.exprStmt (Compiler.Yul.YulExpr.call "sstore"
         [keyIRs.foldl
           (fun slotExpr keyExpr => Compiler.Yul.YulExpr.call "mappingSlot" [slotExpr, keyExpr])
           (Compiler.Yul.YulExpr.lit baseSlot), valueExpr])) =
@@ -3650,7 +3650,7 @@ private theorem execIRStmt_sstore_foldl_mappingSlot
       List.Forall₂ (fun exprIR value => evalIRExpr state exprIR = some value) kIRs kVals →
       evalIRExpr state startExpr = some startSlot →
       execIRStmt (Nat.succ fuel) state
-        (Compiler.Yul.YulStmt.expr (Compiler.Yul.YulExpr.call "sstore"
+        (Compiler.Yul.YulStmt.exprStmt (Compiler.Yul.YulExpr.call "sstore"
           [kIRs.foldl
             (fun slotExpr keyExpr => Compiler.Yul.YulExpr.call "mappingSlot" [slotExpr, keyExpr])
             startExpr, valueExpr])) =
@@ -3705,12 +3705,12 @@ private theorem compiledStmtStep_setMappingChain_singleSlot_of_slotSafety_preser
       FunctionBody.scopeNamesPresent scope runtime.bindings →
       FunctionBody.bindingsBounded runtime.bindings →
       FunctionBody.runtimeStateMatchesIR fields runtime state →
-      sizeOf [YulStmt.expr
+      sizeOf [YulStmt.exprStmt
         (YulExpr.call (fieldStoreBuiltin fields fieldName)
           [keyIRs.foldl
             (fun slotExpr keyExpr => YulExpr.call "mappingSlot" [slotExpr, keyExpr])
             (YulExpr.lit slot), valueIR])] -
-        [YulStmt.expr
+        [YulStmt.exprStmt
           (YulExpr.call (fieldStoreBuiltin fields fieldName)
             [keyIRs.foldl
               (fun slotExpr keyExpr => YulExpr.call "mappingSlot" [slotExpr, keyExpr])
@@ -3718,13 +3718,13 @@ private theorem compiledStmtStep_setMappingChain_singleSlot_of_slotSafety_preser
       ∃ sourceResult irExec,
         SourceSemantics.execStmt fields runtime (.setMappingChain fieldName keys value) = sourceResult ∧
         execIRStmts
-            ([YulStmt.expr
+            ([YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [keyIRs.foldl
                   (fun slotExpr keyExpr => YulExpr.call "mappingSlot" [slotExpr, keyExpr])
                   (YulExpr.lit slot), valueIR])].length + extraFuel + 1)
             state
-            [YulStmt.expr
+            [YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [keyIRs.foldl
                   (fun slotExpr keyExpr => YulExpr.call "mappingSlot" [slotExpr, keyExpr])
@@ -3738,7 +3738,7 @@ private theorem compiledStmtStep_setMappingChain_singleSlot_of_slotSafety_preser
     keyIRs.foldl
       (fun slotExpr keyExpr => YulExpr.call "mappingSlot" [slotExpr, keyExpr])
       (YulExpr.lit slot)
-  let compiledIR := [YulStmt.expr
+  let compiledIR := [YulStmt.exprStmt
     (YulExpr.call (fieldStoreBuiltin fields fieldName) [writeSlotExpr, valueIR])]
   -- Evaluate value expression
   have hvalueSourceEval :=
@@ -3816,7 +3816,7 @@ private theorem compiledStmtStep_setMappingChain_singleSlot_of_slotSafety_preser
           SourceSemantics.mappingSlotChain]
       have hExecStmt :
           execIRStmt (extraFuel + 1) state
-            (YulStmt.expr
+            (YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName) [writeSlotExpr, valueIR])) =
               .continue state' := by
         have h := execIRStmt_tstore_of_eval
@@ -3864,7 +3864,7 @@ private theorem compiledStmtStep_setMappingChain_singleSlot_of_slotSafety_preser
           SourceSemantics.writeAddressKeyedMappingChainFieldSlots, htransFalse]
       have hExecStmt :
           execIRStmt (extraFuel + 1) state
-            (YulStmt.expr
+            (YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName) [writeSlotExpr, valueIR])) =
               .continue state' := by
         simpa [fieldStoreBuiltin, htransFalse, state'] using
@@ -3919,7 +3919,7 @@ theorem compiledStmtStep_setMappingChain_singleSlot_of_slotSafety
     (hkeyIRs : CompilationModel.compileExprList fields .calldata keys = Except.ok keyIRs)
     (hvalueIR : CompilationModel.compileExpr fields .calldata value = Except.ok valueIR) :
     CompiledStmtStep fields scope (.setMappingChain fieldName keys value)
-      [YulStmt.expr
+      [YulStmt.exprStmt
         (YulExpr.call (fieldStoreBuiltin fields fieldName)
           [keyIRs.foldl
             (fun slotExpr keyExpr => YulExpr.call "mappingSlot" [slotExpr, keyExpr])
@@ -3964,21 +3964,21 @@ private theorem compiledStmtStep_setMapping_singleSlot_of_slotSafety_preserves
       FunctionBody.scopeNamesPresent scope runtime.bindings →
       FunctionBody.bindingsBounded runtime.bindings →
       FunctionBody.runtimeStateMatchesIR fields runtime state →
-      sizeOf [YulStmt.expr
+      sizeOf [YulStmt.exprStmt
         (YulExpr.call (fieldStoreBuiltin fields fieldName)
           [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])] -
-        [YulStmt.expr
+        [YulStmt.exprStmt
           (YulExpr.call (fieldStoreBuiltin fields fieldName)
             [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])].length ≤ extraFuel →
       ∃ sourceResult irExec,
         SourceSemantics.execStmt fields runtime (.setMapping fieldName key value) = sourceResult ∧
         execIRStmts
-            ([YulStmt.expr
+            ([YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])].length +
               extraFuel + 1)
             state
-            [YulStmt.expr
+            [YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])] = irExec ∧
         stmtStepMatchesIRExec fields
@@ -3986,7 +3986,7 @@ private theorem compiledStmtStep_setMapping_singleSlot_of_slotSafety_preserves
           sourceResult
           irExec := by
   intro runtime state extraFuel hexact hscope hbounded hruntime hslack
-  let compiledIR := [YulStmt.expr
+  let compiledIR := [YulStmt.exprStmt
     (YulExpr.call (fieldStoreBuiltin fields fieldName)
       [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])]
   have hkeySourceEval :=
@@ -4048,7 +4048,7 @@ private theorem compiledStmtStep_setMapping_singleSlot_of_slotSafety_preserves
             SourceSemantics.writeAddressKeyedMappingFieldSlots, htrans, target]
         have hExecStmt :
             execIRStmt (extraFuel + 1) state
-              (YulStmt.expr
+              (YulStmt.exprStmt
                 (YulExpr.call (fieldStoreBuiltin fields fieldName)
                   [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])) =
                 .continue state' := by
@@ -4101,7 +4101,7 @@ private theorem compiledStmtStep_setMapping_singleSlot_of_slotSafety_preserves
             SourceSemantics.writeAddressKeyedMappingFieldSlots, htransFalse]
         have hExecStmt :
             execIRStmt (extraFuel + 1) state
-              (YulStmt.expr
+              (YulStmt.exprStmt
                 (YulExpr.call (fieldStoreBuiltin fields fieldName)
                   [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])) =
                 .continue state' := by
@@ -4150,7 +4150,7 @@ theorem compiledStmtStep_setMapping_singleSlot_of_slotSafety
     (hkeyIR : CompilationModel.compileExpr fields .calldata key = Except.ok keyIR)
     (hvalueIR : CompilationModel.compileExpr fields .calldata value = Except.ok valueIR) :
     CompiledStmtStep fields scope (.setMapping fieldName key value)
-      [YulStmt.expr
+      [YulStmt.exprStmt
         (YulExpr.call (fieldStoreBuiltin fields fieldName)
           [YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR], valueIR])] where
   compileOk := by
@@ -4194,12 +4194,12 @@ private theorem compiledStmtStep_setMappingWord_singleSlot_of_slotSafety_preserv
       FunctionBody.scopeNamesPresent scope runtime.bindings →
       FunctionBody.bindingsBounded runtime.bindings →
       FunctionBody.runtimeStateMatchesIR fields runtime state →
-        sizeOf [YulStmt.expr
+        sizeOf [YulStmt.exprStmt
           (YulExpr.call (fieldStoreBuiltin fields fieldName)
             [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
              if wordOffset == 0 then mappingBase
              else YulExpr.call "add" [mappingBase, YulExpr.lit wordOffset], valueIR])] -
-          [YulStmt.expr
+          [YulStmt.exprStmt
             (YulExpr.call (fieldStoreBuiltin fields fieldName)
               [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
                if wordOffset == 0 then mappingBase
@@ -4207,14 +4207,14 @@ private theorem compiledStmtStep_setMappingWord_singleSlot_of_slotSafety_preserv
       ∃ sourceResult irExec,
         SourceSemantics.execStmt fields runtime (.setMappingWord fieldName key wordOffset value) = sourceResult ∧
         execIRStmts
-              ([YulStmt.expr
+              ([YulStmt.exprStmt
                 (YulExpr.call (fieldStoreBuiltin fields fieldName)
                   [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
                    if wordOffset == 0 then mappingBase
                    else YulExpr.call "add" [mappingBase, YulExpr.lit wordOffset], valueIR])].length +
               extraFuel + 1)
             state
-              [YulStmt.expr
+              [YulStmt.exprStmt
                 (YulExpr.call (fieldStoreBuiltin fields fieldName)
                   [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
                    if wordOffset == 0 then mappingBase
@@ -4306,7 +4306,7 @@ private theorem compiledStmtStep_setMappingWord_singleSlot_of_slotSafety_preserv
             SourceSemantics.writeMappingTargets, htrans, target, targetSlot, hTargetMod]
         have hExecStmt :
             execIRStmt (extraFuel + 1) state
-              (YulStmt.expr
+              (YulStmt.exprStmt
                 (YulExpr.call (fieldStoreBuiltin fields fieldName)
                   [writeSlotExpr, valueIR])) = .continue state' := by
             simpa [fieldStoreBuiltin, htrans, state', target, hTargetMod] using
@@ -4315,7 +4315,7 @@ private theorem compiledStmtStep_setMappingWord_singleSlot_of_slotSafety_preserv
               (slotVal := targetSlot) (valueVal := valueNat) (fuel := extraFuel)
               hWriteSlotEval hIRValue)
         have hIRExec : execIRStmts (1 + extraFuel + 1) state
-            [YulStmt.expr
+            [YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName) [writeSlotExpr, valueIR])] =
             .continue state' := by
           simp [execIRStmts, hfuelEq, hExecStmt]
@@ -4358,7 +4358,7 @@ private theorem compiledStmtStep_setMappingWord_singleSlot_of_slotSafety_preserv
             htransFalse, hTargetMod, htargetSlotNorm]
         have hExecStmt :
             execIRStmt (extraFuel + 1) state
-              (YulStmt.expr
+              (YulStmt.exprStmt
                 (YulExpr.call (fieldStoreBuiltin fields fieldName)
                   [writeSlotExpr, valueIR])) = .continue state' := by
           simpa [fieldStoreBuiltin, htransFalse, state'] using
@@ -4367,7 +4367,7 @@ private theorem compiledStmtStep_setMappingWord_singleSlot_of_slotSafety_preserv
               (slotVal := targetSlot) (valueVal := valueNat) (fuel := extraFuel)
               hWriteSlotEval hIRValue)
         have hIRExec : execIRStmts (1 + extraFuel + 1) state
-            [YulStmt.expr
+            [YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName) [writeSlotExpr, valueIR])] =
             .continue state' := by
           simp [execIRStmts, hfuelEq, hExecStmt]
@@ -4412,7 +4412,7 @@ theorem compiledStmtStep_setMappingWord_singleSlot_of_slotSafety
     (hkeyIR : CompilationModel.compileExpr fields .calldata key = Except.ok keyIR)
     (hvalueIR : CompilationModel.compileExpr fields .calldata value = Except.ok valueIR) :
     CompiledStmtStep fields scope (.setMappingWord fieldName key wordOffset value)
-      [YulStmt.expr
+      [YulStmt.exprStmt
         (YulExpr.call (fieldStoreBuiltin fields fieldName)
           [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
            if wordOffset == 0 then mappingBase
@@ -4551,7 +4551,7 @@ private theorem compiledStmtStep_setMappingPackedWord_singleSlot_of_slotSafety_p
             (YulExpr.call "and"
               [YulExpr.ident "__compat_slot_word",
                 YulExpr.call "not" [YulExpr.lit (packedShiftedMaskNat packed)]])
-        , YulStmt.expr
+        , YulStmt.exprStmt
             (YulExpr.call (fieldStoreBuiltin fields fieldName)
               [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
                if wordOffset == 0 then mappingBase
@@ -4574,7 +4574,7 @@ private theorem compiledStmtStep_setMappingPackedWord_singleSlot_of_slotSafety_p
               (YulExpr.call "and"
                 [YulExpr.ident "__compat_slot_word",
                   YulExpr.call "not" [YulExpr.lit (packedShiftedMaskNat packed)]])
-          , YulStmt.expr
+          , YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
                  if wordOffset == 0 then mappingBase
@@ -4602,7 +4602,7 @@ private theorem compiledStmtStep_setMappingPackedWord_singleSlot_of_slotSafety_p
                   (YulExpr.call "and"
                     [YulExpr.ident "__compat_slot_word",
                       YulExpr.call "not" [YulExpr.lit (packedShiftedMaskNat packed)]])
-              , YulStmt.expr
+              , YulStmt.exprStmt
                   (YulExpr.call (fieldStoreBuiltin fields fieldName)
                     [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
                      if wordOffset == 0 then mappingBase
@@ -4627,7 +4627,7 @@ private theorem compiledStmtStep_setMappingPackedWord_singleSlot_of_slotSafety_p
                   (YulExpr.call "and"
                     [YulExpr.ident "__compat_slot_word",
                       YulExpr.call "not" [YulExpr.lit (packedShiftedMaskNat packed)]])
-              , YulStmt.expr
+              , YulStmt.exprStmt
                   (YulExpr.call (fieldStoreBuiltin fields fieldName)
                     [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
                      if wordOffset == 0 then mappingBase
@@ -4653,7 +4653,7 @@ private theorem compiledStmtStep_setMappingPackedWord_singleSlot_of_slotSafety_p
         (YulExpr.call "and"
           [YulExpr.ident "__compat_slot_word",
             YulExpr.call "not" [YulExpr.lit (packedShiftedMaskNat packed)]])
-    , YulStmt.expr
+    , YulStmt.exprStmt
         (YulExpr.call (fieldStoreBuiltin fields fieldName)
           [writeSlotExpr,
             YulExpr.call "or"
@@ -5111,7 +5111,7 @@ private theorem compiledStmtStep_setMappingPackedWord_singleSlot_of_slotSafety_p
           simpa [hzero, targetSlot, mappingWordTargetSlot_eq_uint256_add] using hAddEval'
       have hSstore :
           ∀ fuel, execIRStmt (fuel + 1) state4
-            (YulStmt.expr
+            (YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName)
               [writeSlotExpr,
                 YulExpr.call "or"
@@ -5411,7 +5411,7 @@ theorem compiledStmtStep_setMappingPackedWord_singleSlot_of_slotSafety
             (YulExpr.call "and"
               [YulExpr.ident "__compat_slot_word",
                 YulExpr.call "not" [YulExpr.lit (packedShiftedMaskNat packed)]])
-        , YulStmt.expr
+        , YulStmt.exprStmt
             (YulExpr.call (fieldStoreBuiltin fields fieldName)
               [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
                if wordOffset == 0 then mappingBase
@@ -5468,12 +5468,12 @@ private theorem compiledStmtStep_setStructMember_singleSlot_of_slotSafety_preser
       FunctionBody.scopeNamesPresent scope runtime.bindings →
       FunctionBody.bindingsBounded runtime.bindings →
       FunctionBody.runtimeStateMatchesIR fields runtime state →
-      sizeOf [YulStmt.expr
+      sizeOf [YulStmt.exprStmt
         (YulExpr.call (fieldStoreBuiltin fields fieldName)
           [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
            if wordOffset == 0 then mappingBase
            else YulExpr.call "add" [mappingBase, YulExpr.lit wordOffset], valueIR])] -
-        [YulStmt.expr
+        [YulStmt.exprStmt
           (YulExpr.call (fieldStoreBuiltin fields fieldName)
             [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
              if wordOffset == 0 then mappingBase
@@ -5482,14 +5482,14 @@ private theorem compiledStmtStep_setStructMember_singleSlot_of_slotSafety_preser
         SourceSemantics.execStmt fields runtime (.setStructMember fieldName key memberName value) =
           sourceResult ∧
         execIRStmts
-            ([YulStmt.expr
+            ([YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
                  if wordOffset == 0 then mappingBase
                  else YulExpr.call "add" [mappingBase, YulExpr.lit wordOffset], valueIR])].length +
               extraFuel + 1)
             state
-            [YulStmt.expr
+            [YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
                  if wordOffset == 0 then mappingBase
@@ -5542,7 +5542,7 @@ theorem compiledStmtStep_setStructMember_singleSlot_of_slotSafety
     (hkeyIR : CompilationModel.compileExpr fields .calldata key = Except.ok keyIR)
     (hvalueIR : CompilationModel.compileExpr fields .calldata value = Except.ok valueIR) :
     CompiledStmtStep fields scope (.setStructMember fieldName key memberName value)
-      [YulStmt.expr
+      [YulStmt.exprStmt
         (YulExpr.call (fieldStoreBuiltin fields fieldName)
           [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]
            if wordOffset == 0 then mappingBase
@@ -5595,24 +5595,24 @@ private theorem compiledStmtStep_setMapping2_singleSlot_of_slotSafety_preserves
       FunctionBody.scopeNamesPresent scope runtime.bindings →
       FunctionBody.bindingsBounded runtime.bindings →
       FunctionBody.runtimeStateMatchesIR fields runtime state →
-        sizeOf [YulStmt.expr
+        sizeOf [YulStmt.exprStmt
           (YulExpr.call (fieldStoreBuiltin fields fieldName)
             [YulExpr.call "mappingSlot"
               [YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR], key2IR], valueIR])] -
-          [YulStmt.expr
+          [YulStmt.exprStmt
             (YulExpr.call (fieldStoreBuiltin fields fieldName)
               [YulExpr.call "mappingSlot"
                 [YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR], key2IR], valueIR])].length ≤ extraFuel →
       ∃ sourceResult irExec,
         SourceSemantics.execStmt fields runtime (.setMapping2 fieldName key1 key2 value) = sourceResult ∧
         execIRStmts
-              ([YulStmt.expr
+              ([YulStmt.exprStmt
                 (YulExpr.call (fieldStoreBuiltin fields fieldName)
                   [YulExpr.call "mappingSlot"
                     [YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR], key2IR], valueIR])].length +
               extraFuel + 1)
             state
-              [YulStmt.expr
+              [YulStmt.exprStmt
                 (YulExpr.call (fieldStoreBuiltin fields fieldName)
                   [YulExpr.call "mappingSlot"
                     [YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR], key2IR], valueIR])] = irExec ∧
@@ -5621,7 +5621,7 @@ private theorem compiledStmtStep_setMapping2_singleSlot_of_slotSafety_preserves
           sourceResult
           irExec := by
   intro runtime state extraFuel hexact hscope hbounded hruntime hslack
-  let compiledIR := [YulStmt.expr
+  let compiledIR := [YulStmt.exprStmt
     (YulExpr.call (fieldStoreBuiltin fields fieldName)
       [YulExpr.call "mappingSlot"
         [YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR], key2IR], valueIR])]
@@ -5702,7 +5702,7 @@ private theorem compiledStmtStep_setMapping2_singleSlot_of_slotSafety_preserves
               SourceSemantics.writeAddressKeyedMapping2FieldSlots, htrans, target]
           have hExecStmt :
               execIRStmt (extraFuel + 1) state
-                (YulStmt.expr
+                (YulStmt.exprStmt
                   (YulExpr.call (fieldStoreBuiltin fields fieldName)
                     [YulExpr.call "mappingSlot"
                       [YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR], key2IR], valueIR])) =
@@ -5762,7 +5762,7 @@ private theorem compiledStmtStep_setMapping2_singleSlot_of_slotSafety_preserves
               SourceSemantics.writeAddressKeyedMapping2FieldSlots, htransFalse]
           have hExecStmt :
               execIRStmt (extraFuel + 1) state
-                (YulStmt.expr
+                (YulStmt.exprStmt
                   (YulExpr.call (fieldStoreBuiltin fields fieldName)
                     [YulExpr.call "mappingSlot"
                       [YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR], key2IR], valueIR])) =
@@ -5821,7 +5821,7 @@ theorem compiledStmtStep_setMapping2_singleSlot_of_slotSafety
     (hkey2IR : CompilationModel.compileExpr fields .calldata key2 = Except.ok key2IR)
     (hvalueIR : CompilationModel.compileExpr fields .calldata value = Except.ok valueIR) :
     CompiledStmtStep fields scope (.setMapping2 fieldName key1 key2 value)
-        [YulStmt.expr
+        [YulStmt.exprStmt
           (YulExpr.call (fieldStoreBuiltin fields fieldName)
             [YulExpr.call "mappingSlot"
               [YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR], key2IR], valueIR])] where
@@ -5872,13 +5872,13 @@ private theorem compiledStmtStep_setMapping2Word_singleSlot_of_slotSafety_preser
       FunctionBody.scopeNamesPresent scope runtime.bindings →
       FunctionBody.bindingsBounded runtime.bindings →
       FunctionBody.runtimeStateMatchesIR fields runtime state →
-      sizeOf [YulStmt.expr
+      sizeOf [YulStmt.exprStmt
         (YulExpr.call (fieldStoreBuiltin fields fieldName)
           [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR]
            let mappingSlot2 := YulExpr.call "mappingSlot" [mappingBase, key2IR]
            if wordOffset == 0 then mappingSlot2
            else YulExpr.call "add" [mappingSlot2, YulExpr.lit wordOffset], valueIR])] -
-        [YulStmt.expr
+        [YulStmt.exprStmt
           (YulExpr.call (fieldStoreBuiltin fields fieldName)
             [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR]
              let mappingSlot2 := YulExpr.call "mappingSlot" [mappingBase, key2IR]
@@ -5889,7 +5889,7 @@ private theorem compiledStmtStep_setMapping2Word_singleSlot_of_slotSafety_preser
         SourceSemantics.execStmt fields runtime (.setMapping2Word fieldName key1 key2 wordOffset value) =
           sourceResult ∧
         execIRStmts
-            ([YulStmt.expr
+            ([YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR]
                  let mappingSlot2 := YulExpr.call "mappingSlot" [mappingBase, key2IR]
@@ -5897,7 +5897,7 @@ private theorem compiledStmtStep_setMapping2Word_singleSlot_of_slotSafety_preser
                  else YulExpr.call "add" [mappingSlot2, YulExpr.lit wordOffset], valueIR])].length +
               extraFuel + 1)
             state
-            [YulStmt.expr
+            [YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR]
                  let mappingSlot2 := YulExpr.call "mappingSlot" [mappingBase, key2IR]
@@ -5908,7 +5908,7 @@ private theorem compiledStmtStep_setMapping2Word_singleSlot_of_slotSafety_preser
           sourceResult
           irExec := by
   intro runtime state extraFuel hexact hscope hbounded hruntime hslack
-  let compiledIR := [YulStmt.expr
+  let compiledIR := [YulStmt.exprStmt
     (YulExpr.call (fieldStoreBuiltin fields fieldName)
       [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR]
        let mappingSlot2 := YulExpr.call "mappingSlot" [mappingBase, key2IR]
@@ -6021,7 +6021,7 @@ private theorem compiledStmtStep_setMapping2Word_singleSlot_of_slotSafety_preser
               SourceSemantics.writeMappingTargets, htrans, target, targetSlot, hTargetMod]
           have hExecStmt :
               execIRStmt (extraFuel + 1) state
-                (YulStmt.expr
+                (YulStmt.exprStmt
                   (YulExpr.call (fieldStoreBuiltin fields fieldName)
                     [writeSlotExpr, valueIR])) = .continue state' := by
             simpa [fieldStoreBuiltin, htrans, state', target, hTargetMod] using
@@ -6032,7 +6032,7 @@ private theorem compiledStmtStep_setMapping2Word_singleSlot_of_slotSafety_preser
           have hIRExec : execIRStmts (compiledIR.length + extraFuel + 1) state compiledIR =
               .continue state' := by
             change execIRStmts (1 + extraFuel + 1) state
-              [YulStmt.expr (YulExpr.call (fieldStoreBuiltin fields fieldName)
+              [YulStmt.exprStmt (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [writeSlotExpr, valueIR])] = .continue state'
             simp [execIRStmts, hfuelEq, hExecStmt]
           have hexact' : FunctionBody.bindingsExactlyMatchIRVarsOnScope
@@ -6087,7 +6087,7 @@ private theorem compiledStmtStep_setMapping2Word_singleSlot_of_slotSafety_preser
             rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq, hTargetAdd]
           have hExecStmt :
               execIRStmt (extraFuel + 1) state
-                (YulStmt.expr
+                (YulStmt.exprStmt
                   (YulExpr.call (fieldStoreBuiltin fields fieldName)
                     [writeSlotExpr, valueIR])) = .continue state' := by
             simpa [fieldStoreBuiltin, htransFalse, state'] using
@@ -6098,7 +6098,7 @@ private theorem compiledStmtStep_setMapping2Word_singleSlot_of_slotSafety_preser
           have hIRExec : execIRStmts (compiledIR.length + extraFuel + 1) state compiledIR =
               .continue state' := by
             change execIRStmts (1 + extraFuel + 1) state
-              [YulStmt.expr (YulExpr.call (fieldStoreBuiltin fields fieldName)
+              [YulStmt.exprStmt (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [writeSlotExpr, valueIR])] = .continue state'
             simp [execIRStmts, hfuelEq, hExecStmt]
           have hexact' : FunctionBody.bindingsExactlyMatchIRVarsOnScope
@@ -6145,7 +6145,7 @@ theorem compiledStmtStep_setMapping2Word_singleSlot_of_slotSafety
     (hkey2IR : CompilationModel.compileExpr fields .calldata key2 = Except.ok key2IR)
     (hvalueIR : CompilationModel.compileExpr fields .calldata value = Except.ok valueIR) :
     CompiledStmtStep fields scope (.setMapping2Word fieldName key1 key2 wordOffset value)
-      [YulStmt.expr
+      [YulStmt.exprStmt
         (YulExpr.call (fieldStoreBuiltin fields fieldName)
           [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR]
            let mappingSlot2 := YulExpr.call "mappingSlot" [mappingBase, key2IR]
@@ -6198,13 +6198,13 @@ private theorem compiledStmtStep_setStructMember2_singleSlot_of_slotSafety_prese
       FunctionBody.scopeNamesPresent scope runtime.bindings →
       FunctionBody.bindingsBounded runtime.bindings →
       FunctionBody.runtimeStateMatchesIR fields runtime state →
-      sizeOf [YulStmt.expr
+      sizeOf [YulStmt.exprStmt
         (YulExpr.call (fieldStoreBuiltin fields fieldName)
           [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR]
            let mappingSlot2 := YulExpr.call "mappingSlot" [mappingBase, key2IR]
            if wordOffset == 0 then mappingSlot2
            else YulExpr.call "add" [mappingSlot2, YulExpr.lit wordOffset], valueIR])] -
-        [YulStmt.expr
+        [YulStmt.exprStmt
           (YulExpr.call (fieldStoreBuiltin fields fieldName)
             [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR]
              let mappingSlot2 := YulExpr.call "mappingSlot" [mappingBase, key2IR]
@@ -6215,7 +6215,7 @@ private theorem compiledStmtStep_setStructMember2_singleSlot_of_slotSafety_prese
         SourceSemantics.execStmt fields runtime
           (.setStructMember2 fieldName key1 key2 memberName value) = sourceResult ∧
         execIRStmts
-            ([YulStmt.expr
+            ([YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR]
                  let mappingSlot2 := YulExpr.call "mappingSlot" [mappingBase, key2IR]
@@ -6223,7 +6223,7 @@ private theorem compiledStmtStep_setStructMember2_singleSlot_of_slotSafety_prese
                  else YulExpr.call "add" [mappingSlot2, YulExpr.lit wordOffset], valueIR])].length +
               extraFuel + 1)
             state
-            [YulStmt.expr
+            [YulStmt.exprStmt
               (YulExpr.call (fieldStoreBuiltin fields fieldName)
                 [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR]
                  let mappingSlot2 := YulExpr.call "mappingSlot" [mappingBase, key2IR]
@@ -6275,7 +6275,7 @@ theorem compiledStmtStep_setStructMember2_singleSlot_of_slotSafety
     (hkey2IR : CompilationModel.compileExpr fields .calldata key2 = Except.ok key2IR)
     (hvalueIR : CompilationModel.compileExpr fields .calldata value = Except.ok valueIR) :
     CompiledStmtStep fields scope (.setStructMember2 fieldName key1 key2 memberName value)
-      [YulStmt.expr
+      [YulStmt.exprStmt
         (YulExpr.call (fieldStoreBuiltin fields fieldName)
           [let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1IR]
            let mappingSlot2 := YulExpr.call "mappingSlot" [mappingBase, key2IR]
@@ -6322,7 +6322,7 @@ theorem compiledStmtStep_setStorage_aliasSlots
       [YulStmt.block
         ([YulStmt.let_ "__compat_value" valueIR] ++
           (slot :: f.aliasSlots).map (fun writeSlot =>
-            YulStmt.expr
+            YulStmt.exprStmt
               (YulExpr.call "sstore" [YulExpr.lit writeSlot, YulExpr.ident "__compat_value"])))] where
   compileOk := by
     cases hty : f.ty with
@@ -6337,7 +6337,7 @@ theorem compiledStmtStep_setStorage_aliasSlots
     let blockBody :=
       [YulStmt.let_ "__compat_value" valueIR] ++
         slots.map (fun writeSlot =>
-          YulStmt.expr
+          YulStmt.exprStmt
             (YulExpr.call "sstore" [YulExpr.lit writeSlot, YulExpr.ident "__compat_value"]))
     let compiledIR := [YulStmt.block blockBody]
     have heval :=
@@ -6505,7 +6505,7 @@ theorem compiledStmtStep_setStorage_of_validateIdentifierShapes
     (hvalueIR : CompilationModel.compileExpr spec.fields .calldata value = Except.ok valueIR) :
     ∃ compiledIR, CompiledStmtStep spec.fields scope (.setStorage fieldName value) compiledIR := by
   by_cases halias : f.aliasSlots = []
-  · refine ⟨[YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit slot, valueIR])], ?_⟩
+  · refine ⟨[YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit slot, valueIR])], ?_⟩
     apply compiledStmtStep_setStorage_singleSlot
       (hcore := hcore)
       (hinScope := hinScope)
@@ -6525,7 +6525,7 @@ theorem compiledStmtStep_setStorage_of_validateIdentifierShapes
       ⟨[YulStmt.block
           ([YulStmt.let_ "__compat_value" valueIR] ++
             (slot :: f.aliasSlots).map (fun writeSlot =>
-              YulStmt.expr
+              YulStmt.exprStmt
                 (YulExpr.call "sstore" [YulExpr.lit writeSlot, YulExpr.ident "__compat_value"])))],
         ?_⟩
     apply compiledStmtStep_setStorage_aliasSlots

--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -387,9 +387,9 @@ inductive LegacyCompatibleExternalStmtList : List YulStmt → Prop
   | assign (name : String) (value : YulExpr) (rest : List YulStmt) :
       LegacyCompatibleExternalStmtList rest →
       LegacyCompatibleExternalStmtList (.assign name value :: rest)
-  | expr (value : YulExpr) (rest : List YulStmt) :
+  | exprStmt (value : YulExpr) (rest : List YulStmt) :
       LegacyCompatibleExternalStmtList rest →
-      LegacyCompatibleExternalStmtList (.expr value :: rest)
+      LegacyCompatibleExternalStmtList (.exprStmt value :: rest)
   | if_ (cond : YulExpr) (body rest : List YulStmt) :
       LegacyCompatibleExternalStmtList body →
       LegacyCompatibleExternalStmtList rest →
@@ -569,7 +569,7 @@ def execIRStmtWithInternals
           | .return value' state' => .return value' state'
           | .revert state' => .revert state'
       | .leave => .leave state
-      | .expr e =>
+      | .exprStmt e =>
           match e with
           | .call "sstore" [slotExpr, valExpr] =>
               match slotExpr with
@@ -755,7 +755,7 @@ theorem execIRStmtWithInternals_log0_of_eval_args
       evalIRExprsWithInternals contract fuel state args =
         .values [offset, size] state') :
     execIRStmtWithInternals contract (Nat.succ fuel) state
-        (YulStmt.expr (YulExpr.call "log0" args)) =
+        (YulStmt.exprStmt (YulExpr.call "log0" args)) =
       .continue (state'.appendYulLog offset size []) := by
   simp [execIRStmtWithInternals, isYulLogName, heval]
 
@@ -769,7 +769,7 @@ theorem execIRStmtWithInternals_log1_of_eval_args
       evalIRExprsWithInternals contract fuel state args =
         .values [offset, size, topic0] state') :
     execIRStmtWithInternals contract (Nat.succ fuel) state
-        (YulStmt.expr (YulExpr.call "log1" args)) =
+        (YulStmt.exprStmt (YulExpr.call "log1" args)) =
       .continue (state'.appendYulLog offset size [topic0]) := by
   simp [execIRStmtWithInternals, isYulLogName, heval]
 
@@ -783,7 +783,7 @@ theorem execIRStmtWithInternals_log2_of_eval_args
       evalIRExprsWithInternals contract fuel state args =
         .values [offset, size, topic0, topic1] state') :
     execIRStmtWithInternals contract (Nat.succ fuel) state
-        (YulStmt.expr (YulExpr.call "log2" args)) =
+        (YulStmt.exprStmt (YulExpr.call "log2" args)) =
       .continue (state'.appendYulLog offset size [topic0, topic1]) := by
   simp [execIRStmtWithInternals, isYulLogName, heval]
 
@@ -797,7 +797,7 @@ theorem execIRStmtWithInternals_log3_of_eval_args
       evalIRExprsWithInternals contract fuel state args =
         .values [offset, size, topic0, topic1, topic2] state') :
     execIRStmtWithInternals contract (Nat.succ fuel) state
-        (YulStmt.expr (YulExpr.call "log3" args)) =
+        (YulStmt.exprStmt (YulExpr.call "log3" args)) =
       .continue (state'.appendYulLog offset size [topic0, topic1, topic2]) := by
   simp [execIRStmtWithInternals, isYulLogName, heval]
 
@@ -811,7 +811,7 @@ theorem execIRStmtWithInternals_log4_of_eval_args
       evalIRExprsWithInternals contract fuel state args =
         .values [offset, size, topic0, topic1, topic2, topic3] state') :
     execIRStmtWithInternals contract (Nat.succ fuel) state
-        (YulStmt.expr (YulExpr.call "log4" args)) =
+        (YulStmt.exprStmt (YulExpr.call "log4" args)) =
       .continue (state'.appendYulLog offset size
         [topic0, topic1, topic2, topic3]) := by
   simp [execIRStmtWithInternals, isYulLogName, heval]
@@ -878,7 +878,7 @@ def execIRStmt : Nat → IRState → YulStmt → IRExecResult
           | some v => .continue (state.setVar name v)
           | none => .revert state
       | .leave => .continue state
-      | .expr e =>
+      | .exprStmt e =>
           match e with
           | .call "sstore" [slotExpr, valExpr] =>
               match slotExpr with
@@ -1321,24 +1321,24 @@ theorem execIRStmts_forEach_init_literal
   simp [execIRStmts, execIRStmt, evalIRExpr]
 
 @[simp] theorem execIRStmt_stop_succ (fuel : Nat) (state : IRState) :
-    execIRStmt (Nat.succ fuel) state (YulStmt.expr (YulExpr.call "stop" [])) =
+    execIRStmt (Nat.succ fuel) state (YulStmt.exprStmt (YulExpr.call "stop" [])) =
       .stop state := by
   simp only [execIRStmt]
 
 @[simp] theorem execIRStmt_stop_one_add (fuel : Nat) (state : IRState) :
-    execIRStmt (1 + fuel) state (YulStmt.expr (YulExpr.call "stop" [])) =
+    execIRStmt (1 + fuel) state (YulStmt.exprStmt (YulExpr.call "stop" [])) =
       .stop state := by
   simp only [execIRStmt_stop_succ, Nat.add_comm]
 
 @[simp] theorem execIRStmt_stop_one_add_add (a b : Nat) (state : IRState) :
-    execIRStmt (1 + a + b) state (YulStmt.expr (YulExpr.call "stop" [])) =
+    execIRStmt (1 + a + b) state (YulStmt.exprStmt (YulExpr.call "stop" [])) =
       .stop state := by
   simp only [execIRStmt_stop_one_add, Nat.add_assoc]
 
 @[simp] theorem execIRStmt_sstore_lit_lit_succ
     (fuel : Nat) (state : IRState) (slot val : Nat) :
     execIRStmt (Nat.succ fuel) state
-      (YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit slot, YulExpr.lit val])) =
+      (YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit slot, YulExpr.lit val])) =
       .continue { state with
         storage := Compiler.Proofs.abstractStoreStorageOrMapping state.storage slot val } := by
   simp only [execIRStmt, evalIRExpr]
@@ -1347,7 +1347,7 @@ theorem execIRStmt_sstore_lit_expr_succ_of_eval
     (fuel : Nat) (state : IRState) (slot : Nat) (valExpr : YulExpr) (val : Nat)
     (hval : evalIRExpr state valExpr = some val) :
     execIRStmt (Nat.succ fuel) state
-      (YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit slot, valExpr])) =
+      (YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit slot, valExpr])) =
       .continue { state with
         storage := Compiler.Proofs.abstractStoreStorageOrMapping state.storage slot val } := by
   simp only [execIRStmt, evalIRExpr, hval]
@@ -1356,13 +1356,13 @@ theorem execIRStmts_sstore_lit_expr_then_stop_succ_succ_succ_of_eval
     (fuel : Nat) (state : IRState) (slot : Nat) (valExpr : YulExpr) (val : Nat)
     (hval : evalIRExpr state valExpr = some val) :
     execIRStmts (Nat.succ (Nat.succ (Nat.succ fuel))) state
-      [YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit slot, valExpr]), YulStmt.expr (YulExpr.call "stop" [])] =
+      [YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit slot, valExpr]), YulStmt.exprStmt (YulExpr.call "stop" [])] =
       .stop { state with
         storage := Compiler.Proofs.abstractStoreStorageOrMapping state.storage slot val } := by
   simp only [execIRStmts, execIRStmt, evalIRExpr, hval]
 
 @[simp] theorem execIRStmts_single_stop_succ_succ (fuel : Nat) (state : IRState) :
-    execIRStmts (Nat.succ (Nat.succ fuel)) state [YulStmt.expr (YulExpr.call "stop" [])] =
+    execIRStmts (Nat.succ (Nat.succ fuel)) state [YulStmt.exprStmt (YulExpr.call "stop" [])] =
       .stop state := by
   simp only [execIRStmts, execIRStmt]
 
@@ -1380,9 +1380,9 @@ as the sole fuel metric. -/
 theorem execIRStmts_single_block_stop_length_insufficient
     (state : IRState) :
     execIRStmts
-      ([YulStmt.block [YulStmt.expr (YulExpr.call "stop" [])]].length + 1)
+      ([YulStmt.block [YulStmt.exprStmt (YulExpr.call "stop" [])]].length + 1)
       state
-      [YulStmt.block [YulStmt.expr (YulExpr.call "stop" [])]] =
+      [YulStmt.block [YulStmt.exprStmt (YulExpr.call "stop" [])]] =
         .revert state := by
   simp [execIRStmts, execIRStmt]
 
@@ -1418,10 +1418,10 @@ must not appear in a prefix that ends with `.leave` (would terminate
 before the leave runs). -/
 def NotTerminator (stmt : YulStmt) : Prop :=
   (∀ offset size,
-    stmt ≠ YulStmt.expr (YulExpr.call "return" [offset, size])) ∧
+    stmt ≠ YulStmt.exprStmt (YulExpr.call "return" [offset, size])) ∧
   (∀ offset size,
-    stmt ≠ YulStmt.expr (YulExpr.call "revert" [offset, size])) ∧
-  stmt ≠ YulStmt.expr (YulExpr.call "stop" [])
+    stmt ≠ YulStmt.exprStmt (YulExpr.call "revert" [offset, size])) ∧
+  stmt ≠ YulStmt.exprStmt (YulExpr.call "stop" [])
 
 @[simp] theorem LetManyFree_comment (text : String) : LetManyFree (.comment text) := by
   intro _ _ h; cases h
@@ -1435,7 +1435,7 @@ def NotTerminator (stmt : YulStmt) : Prop :=
   intro _ _ h; cases h
 
 @[simp] theorem LetManyFree_expr (e : YulExpr) :
-    LetManyFree (.expr e) := by
+    LetManyFree (.exprStmt e) := by
   intro _ _ h; cases h
 
 @[simp] theorem LetManyFree_leave : LetManyFree .leave := by
@@ -1511,20 +1511,20 @@ theorem IRStmtPreservesObsAt_of_assign
   refine ⟨state.setVar name v, fun _ => ?_⟩
   simp only [execIRStmt, hv]
 
-/-- Cross-cast for `.expr (.call "sstore" [slot, val])` with literal slot:
+/-- Cross-cast for `.exprStmt (.call "sstore" [slot, val])` with literal slot:
 at any state where `val` evaluates, the stmt continues, updating storage. -/
 theorem IRStmtPreservesObsAt_of_sstore_lit_expr
     (state : IRState) (slot : Nat) (valExpr : YulExpr)
     (hEval : ∃ v, evalIRExpr state valExpr = some v) :
     IRStmtPreservesObsAt state
-      (.expr (.call "sstore" [.lit slot, valExpr])) := by
+      (.exprStmt (.call "sstore" [.lit slot, valExpr])) := by
   obtain ⟨v, hv⟩ := hEval
   refine ⟨{ state with storage :=
       Compiler.Proofs.abstractStoreStorageOrMapping state.storage slot v },
     fun _ => ?_⟩
   simp only [execIRStmt, evalIRExpr, hv]
 
-/-- Cross-cast for `.expr (.call "tstore" [offset, val])`: at any state where
+/-- Cross-cast for `.exprStmt (.call "tstore" [offset, val])`: at any state where
 both `offset` and `val` evaluate, the stmt continues, updating transient
 storage. -/
 theorem IRStmtPreservesObsAt_of_tstore
@@ -1532,28 +1532,28 @@ theorem IRStmtPreservesObsAt_of_tstore
     (hOffsetEval : ∃ o, evalIRExpr state offsetExpr = some o)
     (hValEval : ∃ v, evalIRExpr state valExpr = some v) :
     IRStmtPreservesObsAt state
-      (.expr (.call "tstore" [offsetExpr, valExpr])) := by
+      (.exprStmt (.call "tstore" [offsetExpr, valExpr])) := by
   obtain ⟨o, ho⟩ := hOffsetEval
   obtain ⟨v, hv⟩ := hValEval
   refine ⟨{ state with transientStorage := fun x =>
       if x = o % Compiler.Constants.evmModulus then v else state.transientStorage x }, fun _ => ?_⟩
   simp only [execIRStmt, ho, hv]
 
-/-- Cross-cast for `.expr (.call "mstore" [offset, val])`: at any state where
+/-- Cross-cast for `.exprStmt (.call "mstore" [offset, val])`: at any state where
 both `offset` and `val` evaluate, the stmt continues, updating memory. -/
 theorem IRStmtPreservesObsAt_of_mstore
     (state : IRState) (offsetExpr valExpr : YulExpr)
     (hOffsetEval : ∃ o, evalIRExpr state offsetExpr = some o)
     (hValEval : ∃ v, evalIRExpr state valExpr = some v) :
     IRStmtPreservesObsAt state
-      (.expr (.call "mstore" [offsetExpr, valExpr])) := by
+      (.exprStmt (.call "mstore" [offsetExpr, valExpr])) := by
   obtain ⟨o, ho⟩ := hOffsetEval
   obtain ⟨v, hv⟩ := hValEval
   refine ⟨{ state with memory := fun x => if x = o then v else state.memory x },
     fun _ => ?_⟩
   simp only [execIRStmt, ho, hv]
 
-/-- Cross-cast for `.expr (.call "mstore8" [offset, val])`: the IR evaluator
+/-- Cross-cast for `.exprStmt (.call "mstore8" [offset, val])`: the IR evaluator
 treats `mstore8` opaquely (the fallthrough `.continue state` branch), so the
 stmt continues with state unchanged provided the call's args evaluate.
 Note: the IR model does NOT capture mstore8's byte-write effect on memory;
@@ -1564,57 +1564,57 @@ theorem IRStmtPreservesObsAt_of_mstore8
     (hEval : ∃ v, evalIRExpr state
       (.call "mstore8" [offsetExpr, valExpr]) = some v) :
     IRStmtPreservesObsAt state
-      (.expr (.call "mstore8" [offsetExpr, valExpr])) := by
+      (.exprStmt (.call "mstore8" [offsetExpr, valExpr])) := by
   obtain ⟨v, hv⟩ := hEval
   refine ⟨state, fun _ => ?_⟩
   simp [execIRStmt, isYulLogName, hv]
 
-/-- Cross-cast for `.expr (.call "calldatacopy" [dst, src, sz])`: opaque
+/-- Cross-cast for `.exprStmt (.call "calldatacopy" [dst, src, sz])`: opaque
 fallthrough, continues with state unchanged given the call evaluates. -/
 theorem IRStmtPreservesObsAt_of_calldatacopy
     (state : IRState) (dstExpr srcExpr sizeExpr : YulExpr)
     (hEval : ∃ v, evalIRExpr state
       (.call "calldatacopy" [dstExpr, srcExpr, sizeExpr]) = some v) :
     IRStmtPreservesObsAt state
-      (.expr (.call "calldatacopy" [dstExpr, srcExpr, sizeExpr])) := by
+      (.exprStmt (.call "calldatacopy" [dstExpr, srcExpr, sizeExpr])) := by
   obtain ⟨v, hv⟩ := hEval
   refine ⟨state, fun _ => ?_⟩
   simp [execIRStmt, isYulLogName, hv]
 
-/-- Cross-cast for `.expr (.call "returndatacopy" [dst, src, sz])`: opaque
+/-- Cross-cast for `.exprStmt (.call "returndatacopy" [dst, src, sz])`: opaque
 fallthrough. -/
 theorem IRStmtPreservesObsAt_of_returndatacopy
     (state : IRState) (dstExpr srcExpr sizeExpr : YulExpr)
     (hEval : ∃ v, evalIRExpr state
       (.call "returndatacopy" [dstExpr, srcExpr, sizeExpr]) = some v) :
     IRStmtPreservesObsAt state
-      (.expr (.call "returndatacopy" [dstExpr, srcExpr, sizeExpr])) := by
+      (.exprStmt (.call "returndatacopy" [dstExpr, srcExpr, sizeExpr])) := by
   obtain ⟨v, hv⟩ := hEval
   refine ⟨state, fun _ => ?_⟩
   simp [execIRStmt, isYulLogName, hv]
 
-/-- Cross-cast for `.expr (.call "log0" [offset, size])`. Updates events by
+/-- Cross-cast for `.exprStmt (.call "log0" [offset, size])`. Updates events by
 appending a Yul log entry. -/
 theorem IRStmtPreservesObsAt_of_log0
     (state : IRState) (offsetExpr sizeExpr : YulExpr)
     (hOffsetEval : ∃ o, evalIRExpr state offsetExpr = some o)
     (hSizeEval : ∃ s, evalIRExpr state sizeExpr = some s) :
     IRStmtPreservesObsAt state
-      (.expr (.call "log0" [offsetExpr, sizeExpr])) := by
+      (.exprStmt (.call "log0" [offsetExpr, sizeExpr])) := by
   obtain ⟨o, ho⟩ := hOffsetEval
   obtain ⟨s, hs⟩ := hSizeEval
   refine ⟨state.appendYulLog o s [], fun _ => ?_⟩
   simp [execIRStmt, isYulLogName, evalIRExprs, ho, hs,
     Option.bind, applyYulLogCall?]
 
-/-- Cross-cast for `.expr (.call "log1" [offset, size, topic0])`. -/
+/-- Cross-cast for `.exprStmt (.call "log1" [offset, size, topic0])`. -/
 theorem IRStmtPreservesObsAt_of_log1
     (state : IRState) (offsetExpr sizeExpr topic0Expr : YulExpr)
     (hOffsetEval : ∃ o, evalIRExpr state offsetExpr = some o)
     (hSizeEval : ∃ s, evalIRExpr state sizeExpr = some s)
     (hTopic0Eval : ∃ t, evalIRExpr state topic0Expr = some t) :
     IRStmtPreservesObsAt state
-      (.expr (.call "log1" [offsetExpr, sizeExpr, topic0Expr])) := by
+      (.exprStmt (.call "log1" [offsetExpr, sizeExpr, topic0Expr])) := by
   obtain ⟨o, ho⟩ := hOffsetEval
   obtain ⟨s, hs⟩ := hSizeEval
   obtain ⟨t, ht⟩ := hTopic0Eval
@@ -1622,7 +1622,7 @@ theorem IRStmtPreservesObsAt_of_log1
   simp [execIRStmt, isYulLogName, evalIRExprs, ho, hs, ht,
     Option.bind, applyYulLogCall?]
 
-/-- Cross-cast for `.expr (.call "log2" [...])`. -/
+/-- Cross-cast for `.exprStmt (.call "log2" [...])`. -/
 theorem IRStmtPreservesObsAt_of_log2
     (state : IRState) (offsetExpr sizeExpr t0Expr t1Expr : YulExpr)
     (hOffsetEval : ∃ o, evalIRExpr state offsetExpr = some o)
@@ -1630,7 +1630,7 @@ theorem IRStmtPreservesObsAt_of_log2
     (hT0Eval : ∃ t, evalIRExpr state t0Expr = some t)
     (hT1Eval : ∃ t, evalIRExpr state t1Expr = some t) :
     IRStmtPreservesObsAt state
-      (.expr (.call "log2" [offsetExpr, sizeExpr, t0Expr, t1Expr])) := by
+      (.exprStmt (.call "log2" [offsetExpr, sizeExpr, t0Expr, t1Expr])) := by
   obtain ⟨o, ho⟩ := hOffsetEval
   obtain ⟨s, hs⟩ := hSizeEval
   obtain ⟨t0, ht0⟩ := hT0Eval
@@ -1639,7 +1639,7 @@ theorem IRStmtPreservesObsAt_of_log2
   simp [execIRStmt, isYulLogName, evalIRExprs, ho, hs, ht0, ht1,
     Option.bind, applyYulLogCall?]
 
-/-- Cross-cast for `.expr (.call "log3" [...])`. -/
+/-- Cross-cast for `.exprStmt (.call "log3" [...])`. -/
 theorem IRStmtPreservesObsAt_of_log3
     (state : IRState) (offsetExpr sizeExpr t0Expr t1Expr t2Expr : YulExpr)
     (hOffsetEval : ∃ o, evalIRExpr state offsetExpr = some o)
@@ -1648,7 +1648,7 @@ theorem IRStmtPreservesObsAt_of_log3
     (hT1Eval : ∃ t, evalIRExpr state t1Expr = some t)
     (hT2Eval : ∃ t, evalIRExpr state t2Expr = some t) :
     IRStmtPreservesObsAt state
-      (.expr (.call "log3" [offsetExpr, sizeExpr, t0Expr, t1Expr, t2Expr])) := by
+      (.exprStmt (.call "log3" [offsetExpr, sizeExpr, t0Expr, t1Expr, t2Expr])) := by
   obtain ⟨o, ho⟩ := hOffsetEval
   obtain ⟨s, hs⟩ := hSizeEval
   obtain ⟨t0, ht0⟩ := hT0Eval
@@ -1658,7 +1658,7 @@ theorem IRStmtPreservesObsAt_of_log3
   simp [execIRStmt, isYulLogName, evalIRExprs, ho, hs, ht0, ht1, ht2,
     Option.bind, applyYulLogCall?]
 
-/-- Cross-cast for `.expr (.call "log4" [...])`. -/
+/-- Cross-cast for `.exprStmt (.call "log4" [...])`. -/
 theorem IRStmtPreservesObsAt_of_log4
     (state : IRState) (offsetExpr sizeExpr t0Expr t1Expr t2Expr t3Expr : YulExpr)
     (hOffsetEval : ∃ o, evalIRExpr state offsetExpr = some o)
@@ -1668,7 +1668,7 @@ theorem IRStmtPreservesObsAt_of_log4
     (hT2Eval : ∃ t, evalIRExpr state t2Expr = some t)
     (hT3Eval : ∃ t, evalIRExpr state t3Expr = some t) :
     IRStmtPreservesObsAt state
-      (.expr (.call "log4"
+      (.exprStmt (.call "log4"
         [offsetExpr, sizeExpr, t0Expr, t1Expr, t2Expr, t3Expr])) := by
   obtain ⟨o, ho⟩ := hOffsetEval
   obtain ⟨s, hs⟩ := hSizeEval
@@ -1680,7 +1680,7 @@ theorem IRStmtPreservesObsAt_of_log4
   simp [execIRStmt, isYulLogName, evalIRExprs, ho, hs, ht0, ht1, ht2, ht3,
     Option.bind, applyYulLogCall?]
 
-/-- Cross-cast for `.expr (.call "sstore" [.call "mappingSlot" [base, key], val])`:
+/-- Cross-cast for `.exprStmt (.call "sstore" [.call "mappingSlot" [base, key], val])`:
 sstore-of-mappingSlot stores `val` at the abstract mapping entry computed
 from `(base, key)`. Requires all three sub-expressions to evaluate. -/
 theorem IRStmtPreservesObsAt_of_sstore_mappingSlot
@@ -1689,7 +1689,7 @@ theorem IRStmtPreservesObsAt_of_sstore_mappingSlot
     (hKeyEval : ∃ k, evalIRExpr state keyExpr = some k)
     (hValEval : ∃ v, evalIRExpr state valExpr = some v) :
     IRStmtPreservesObsAt state
-      (.expr (.call "sstore"
+      (.exprStmt (.call "sstore"
         [.call "mappingSlot" [baseExpr, keyExpr], valExpr])) := by
   obtain ⟨b, hb⟩ := hBaseEval
   obtain ⟨k, hk⟩ := hKeyEval
@@ -1699,14 +1699,14 @@ theorem IRStmtPreservesObsAt_of_sstore_mappingSlot
     fun _ => ?_⟩
   simp only [execIRStmt, hb, hk, hv]
 
-/-- Cross-cast for `.expr (.call "sstore" [.ident name, val])` — slot is read
+/-- Cross-cast for `.exprStmt (.call "sstore" [.ident name, val])` — slot is read
 from a local variable binding. Requires the ident and val to evaluate. -/
 theorem IRStmtPreservesObsAt_of_sstore_ident
     (state : IRState) (slotName : String) (valExpr : YulExpr)
     (hSlotEval : ∃ s, state.getVar slotName = some s)
     (hValEval : ∃ v, evalIRExpr state valExpr = some v) :
     IRStmtPreservesObsAt state
-      (.expr (.call "sstore" [.ident slotName, valExpr])) := by
+      (.exprStmt (.call "sstore" [.ident slotName, valExpr])) := by
   obtain ⟨s, hs⟩ := hSlotEval
   obtain ⟨v, hv⟩ := hValEval
   refine ⟨{ state with storage :=
@@ -1714,7 +1714,7 @@ theorem IRStmtPreservesObsAt_of_sstore_ident
     fun _ => ?_⟩
   simp only [execIRStmt, evalIRExpr, hs, hv]
 
-/-- Cross-cast for `.expr (.call "sstore" [.call "add" [l, r], val])`: slot
+/-- Cross-cast for `.exprStmt (.call "sstore" [.call "add" [l, r], val])`: slot
 is the result of an `add` call. Falls through `execIRStmt`'s general
 non-mappingSlot sstore arm. -/
 theorem IRStmtPreservesObsAt_of_sstore_add
@@ -1723,7 +1723,7 @@ theorem IRStmtPreservesObsAt_of_sstore_add
       evalIRExpr state (.call "add" [leftExpr, rightExpr]) = some s)
     (hValEval : ∃ v, evalIRExpr state valExpr = some v) :
     IRStmtPreservesObsAt state
-      (.expr (.call "sstore" [.call "add" [leftExpr, rightExpr], valExpr])) := by
+      (.exprStmt (.call "sstore" [.call "add" [leftExpr, rightExpr], valExpr])) := by
   obtain ⟨s, hs⟩ := hSlotEval
   obtain ⟨v, hv⟩ := hValEval
   refine ⟨{ state with storage :=
@@ -1734,7 +1734,7 @@ theorem IRStmtPreservesObsAt_of_sstore_add
   -- branch of the inner match via `simp only`. Use `simp` to fully reduce.
   simp [execIRStmt, hs, hv]
 
-/-- General cross-cast for `.expr (.call func args)` where `func` is NOT one
+/-- General cross-cast for `.exprStmt (.call func args)` where `func` is NOT one
 of the special builtins (sstore/mstore/tstore/stop/return/revert/log*). The
 call falls through `execIRStmt`'s opaque-eval branch: requires the call to
 evaluate; yields `.continue state` with state unchanged. -/
@@ -1748,7 +1748,7 @@ theorem IRStmtPreservesObsAt_of_expr_call_opaque
     (hNotReturn : func ≠ "return")
     (hNotLog : Compiler.Proofs.YulGeneration.isYulLogName func = false)
     (hEval : ∃ v, evalIRExpr state (.call func args) = some v) :
-    IRStmtPreservesObsAt state (.expr (.call func args)) := by
+    IRStmtPreservesObsAt state (.exprStmt (.call func args)) := by
   obtain ⟨v, hv⟩ := hEval
   refine ⟨state, fun _ => ?_⟩
   cases args with
@@ -2518,10 +2518,10 @@ inductive YulStmtListCallsDisjointFromInternalTable
       yulExprCallsDisjointFromInternalTable contract value →
       YulStmtListCallsDisjointFromInternalTable contract rest →
       YulStmtListCallsDisjointFromInternalTable contract (.assign name value :: rest)
-  | expr (value : YulExpr) (rest : List YulStmt) :
+  | exprStmt (value : YulExpr) (rest : List YulStmt) :
       yulExprCallsDisjointFromInternalTable contract value →
       YulStmtListCallsDisjointFromInternalTable contract rest →
-      YulStmtListCallsDisjointFromInternalTable contract (.expr value :: rest)
+      YulStmtListCallsDisjointFromInternalTable contract (.exprStmt value :: rest)
   | if_ (cond : YulExpr) (body rest : List YulStmt) :
       yulExprCallsDisjointFromInternalTable contract cond →
       YulStmtListCallsDisjointFromInternalTable contract body →
@@ -2736,8 +2736,8 @@ theorem execIRStmtWithInternals_eq_execIRStmt_expr_of_callsDisjoint
     (contract : IRContract) :
     ∀ fuel state expr,
       yulExprCallsDisjointFromInternalTable contract expr →
-      execIRStmtWithInternals contract fuel state (.expr expr) =
-        match execIRStmt fuel state (.expr expr) with
+      execIRStmtWithInternals contract fuel state (.exprStmt expr) =
+        match execIRStmt fuel state (.exprStmt expr) with
         | .continue next => .continue next
         | .return value next => .return value next
         | .stop next => .stop next
@@ -3073,7 +3073,7 @@ theorem execIRStmtsWithInternals_eq_execIRStmts_of_callsDisjoint
             rw [execIRStmtsWithInternals, execIRStmts, hhead]
             cases hstep : execIRStmt fuel state (.assign name value) <;>
               simp only [ih]
-    | expr value rest hval_d hrest ih =>
+    | exprStmt value rest hval_d hrest ih =>
         cases fuel with
         | zero =>
             simp only [execIRStmtsWithInternals, execIRStmts]
@@ -3081,7 +3081,7 @@ theorem execIRStmtsWithInternals_eq_execIRStmts_of_callsDisjoint
             have hhead := execIRStmtWithInternals_eq_execIRStmt_expr_of_callsDisjoint
               contract fuel state value hval_d
             rw [execIRStmtsWithInternals, execIRStmts, hhead]
-            cases hstep : execIRStmt fuel state (.expr value) <;>
+            cases hstep : execIRStmt fuel state (.exprStmt value) <;>
               simp only [ih]
     | if_ cond body rest hcond_d hbody hrest ihBody ihRest =>
         cases fuel with
@@ -3297,8 +3297,8 @@ theorem YulStmtListCallsDisjointFromInternalTable_of_internalFunctions_nil
   | assign name value rest _ ih =>
       exact .assign name value rest
         (yulExprCallsDisjointFromInternalTable_of_internalFunctions_nil contract hinternal value) ih
-  | expr value rest _ ih =>
-      exact .expr value rest
+  | exprStmt value rest _ ih =>
+      exact .exprStmt value rest
         (yulExprCallsDisjointFromInternalTable_of_internalFunctions_nil contract hinternal value) ih
   | if_ cond body rest hbody _ ihBody ihRest =>
       exact .if_ cond body rest
@@ -3326,7 +3326,7 @@ theorem execIRStmtWithInternals_sstore_mappingSlot_succ_of_no_internal
     (hkey : evalIRExpr state keyExpr = some key)
     (hval : evalIRExpr state valExpr = some val) :
     execIRStmtWithInternals contract (Nat.succ fuel) state
-      (YulStmt.expr
+      (YulStmt.exprStmt
         (YulExpr.call "sstore"
           [YulExpr.call "mappingSlot" [baseExpr, keyExpr], valExpr])) =
       .continue { state with
@@ -3356,9 +3356,9 @@ theorem execIRStmtWithInternals_eq_execIRStmt_mstore_of_no_internal
     (fuel : Nat) (state : IRState)
     (offsetExpr valExpr : YulExpr) :
     execIRStmtWithInternals contract fuel state
-      (YulStmt.expr (YulExpr.call "mstore" [offsetExpr, valExpr])) =
+      (YulStmt.exprStmt (YulExpr.call "mstore" [offsetExpr, valExpr])) =
         match execIRStmt fuel state
-          (YulStmt.expr (YulExpr.call "mstore" [offsetExpr, valExpr])) with
+          (YulStmt.exprStmt (YulExpr.call "mstore" [offsetExpr, valExpr])) with
         | .continue next => .continue next
         | .return value next => .return value next
         | .stop next => .stop next
@@ -3379,9 +3379,9 @@ theorem execIRStmtWithInternals_eq_execIRStmt_tstore_of_no_internal
     (fuel : Nat) (state : IRState)
     (offsetExpr valExpr : YulExpr) :
     execIRStmtWithInternals contract fuel state
-      (YulStmt.expr (YulExpr.call "tstore" [offsetExpr, valExpr])) =
+      (YulStmt.exprStmt (YulExpr.call "tstore" [offsetExpr, valExpr])) =
         match execIRStmt fuel state
-          (YulStmt.expr (YulExpr.call "tstore" [offsetExpr, valExpr])) with
+          (YulStmt.exprStmt (YulExpr.call "tstore" [offsetExpr, valExpr])) with
         | .continue next => .continue next
         | .return value next => .return value next
         | .stop next => .stop next
@@ -3404,9 +3404,9 @@ theorem execIRStmtWithInternals_eq_execIRStmt_revert_of_no_internal
     (fuel : Nat) (state : IRState)
     (offsetExpr sizeExpr : YulExpr) :
     execIRStmtWithInternals contract fuel state
-      (YulStmt.expr (YulExpr.call "revert" [offsetExpr, sizeExpr])) =
+      (YulStmt.exprStmt (YulExpr.call "revert" [offsetExpr, sizeExpr])) =
         match execIRStmt fuel state
-          (YulStmt.expr (YulExpr.call "revert" [offsetExpr, sizeExpr])) with
+          (YulStmt.exprStmt (YulExpr.call "revert" [offsetExpr, sizeExpr])) with
         | .continue next => .continue next
         | .return value next => .return value next
         | .stop next => .stop next
@@ -3429,9 +3429,9 @@ theorem execIRStmtWithInternals_eq_execIRStmt_return_of_no_internal
     (fuel : Nat) (state : IRState)
     (offsetExpr sizeExpr : YulExpr) :
     execIRStmtWithInternals contract fuel state
-      (YulStmt.expr (YulExpr.call "return" [offsetExpr, sizeExpr])) =
+      (YulStmt.exprStmt (YulExpr.call "return" [offsetExpr, sizeExpr])) =
         match execIRStmt fuel state
-          (YulStmt.expr (YulExpr.call "return" [offsetExpr, sizeExpr])) with
+          (YulStmt.exprStmt (YulExpr.call "return" [offsetExpr, sizeExpr])) with
         | .continue next => .continue next
         | .return value next => .return value next
         | .stop next => .stop next
@@ -3465,9 +3465,9 @@ theorem execIRStmtWithInternals_eq_execIRStmt_stop_of_no_internal
     (_hinternal : contract.internalFunctions = [])
     (fuel : Nat) (state : IRState) :
     execIRStmtWithInternals contract fuel state
-      (YulStmt.expr (YulExpr.call "stop" [])) =
+      (YulStmt.exprStmt (YulExpr.call "stop" [])) =
         match execIRStmt fuel state
-          (YulStmt.expr (YulExpr.call "stop" [])) with
+          (YulStmt.exprStmt (YulExpr.call "stop" [])) with
         | .continue next => .continue next
         | .return value next => .return value next
         | .stop next => .stop next
@@ -3501,9 +3501,9 @@ theorem execIRStmtWithInternals_eq_execIRStmt_sstore_of_no_internal
     (fuel : Nat) (state : IRState)
     (slotExpr valExpr : YulExpr) :
     execIRStmtWithInternals contract fuel state
-      (YulStmt.expr (YulExpr.call "sstore" [slotExpr, valExpr])) =
+      (YulStmt.exprStmt (YulExpr.call "sstore" [slotExpr, valExpr])) =
         match execIRStmt fuel state
-          (YulStmt.expr (YulExpr.call "sstore" [slotExpr, valExpr])) with
+          (YulStmt.exprStmt (YulExpr.call "sstore" [slotExpr, valExpr])) with
         | .continue next => .continue next
         | .return value next => .return value next
         | .stop next => .stop next
@@ -3584,8 +3584,8 @@ theorem execIRStmtWithInternals_eq_execIRStmt_expr_of_no_internal
     (contract : IRContract) :
     contract.internalFunctions = [] →
       ∀ fuel state expr,
-        execIRStmtWithInternals contract fuel state (.expr expr) =
-          match execIRStmt fuel state (.expr expr) with
+        execIRStmtWithInternals contract fuel state (.exprStmt expr) =
+          match execIRStmt fuel state (.exprStmt expr) with
           | .continue next => .continue next
           | .return value next => .return value next
           | .stop next => .stop next
@@ -3705,8 +3705,8 @@ theorem execIRStmtsWithInternals_eq_execIRStmts_of_exprCompatibility
     (hexpr :
       contract.internalFunctions = [] →
         ∀ fuel state expr,
-          execIRStmtWithInternals contract fuel state (.expr expr) =
-            match execIRStmt fuel state (.expr expr) with
+          execIRStmtWithInternals contract fuel state (.exprStmt expr) =
+            match execIRStmt fuel state (.exprStmt expr) with
             | .continue next => .continue next
             | .return value next => .return value next
             | .stop next => .stop next
@@ -3784,14 +3784,14 @@ theorem execIRStmtsWithInternals_eq_execIRStmts_of_exprCompatibility
               rw [execIRStmtsWithInternals, execIRStmts, hhead]
               cases hstep : execIRStmt fuel state (.assign name value) <;>
                 simp only [ih]
-      | expr value rest hrest ih =>
+      | exprStmt value rest hrest ih =>
           cases fuel with
           | zero =>
               simp only [execIRStmtsWithInternals, execIRStmts]
           | succ fuel =>
               have hhead := hexpr hinternal fuel state value
               rw [execIRStmtsWithInternals, execIRStmts, hhead]
-              cases hstep : execIRStmt fuel state (.expr value) <;>
+              cases hstep : execIRStmt fuel state (.exprStmt value) <;>
                 simp only [ih]
       | if_ cond body rest hbody hrest ihBody ihRest =>
           cases fuel with
@@ -3942,8 +3942,8 @@ theorem execIRStmtWithInternals_eq_execIRStmt_of_exprCompatibility
     (hexpr :
       contract.internalFunctions = [] →
         ∀ fuel state expr,
-          execIRStmtWithInternals contract fuel state (.expr expr) =
-            match execIRStmt fuel state (.expr expr) with
+          execIRStmtWithInternals contract fuel state (.exprStmt expr) =
+            match execIRStmt fuel state (.exprStmt expr) with
             | .continue next => .continue next
             | .return value next => .return value next
             | .stop next => .stop next
@@ -3969,7 +3969,7 @@ end
 
 /-- The remaining single-statement helper-free conservative-extension seam is now
 packaged as an explicit one-field interface: the real semantic work sits in
-`YulStmt.expr`, while `if`, `block`, stmt-list, function, dispatch, and
+`YulStmt.exprStmt`, while `if`, `block`, stmt-list, function, dispatch, and
 contract transport are already derivable compositionally on the same
 legacy-compatible subset. -/
 structure InterpretIRWithInternalsZeroConservativeExtensionStmtSubgoals
@@ -3977,8 +3977,8 @@ structure InterpretIRWithInternalsZeroConservativeExtensionStmtSubgoals
   exprCompatibility :
     contract.internalFunctions = [] →
       ∀ fuel state expr,
-        execIRStmtWithInternals contract fuel state (.expr expr) =
-          match execIRStmt fuel state (.expr expr) with
+        execIRStmtWithInternals contract fuel state (.exprStmt expr) =
+          match execIRStmt fuel state (.exprStmt expr) with
           | .continue next => .continue next
           | .return value next => .return value next
           | .stop next => .stop next
@@ -4066,16 +4066,16 @@ theorem execIRStmtsWithInternals_eq_execIRStmts_of_stmtCompatibility
           rw [execIRStmtsWithInternals, execIRStmts, hhead]
           cases hstep : execIRStmt fuel state (.assign name value) <;>
             simp only [ih]
-  | expr value rest hrest ih =>
+  | exprStmt value rest hrest ih =>
       cases fuel with
       | zero =>
           simp only [execIRStmtsWithInternals, execIRStmts]
       | succ fuel =>
           have hhead :=
-            hstmt hinternal fuel state (.expr value)
-              (LegacyCompatibleExternalStmtList.expr value [] LegacyCompatibleExternalStmtList.nil)
+            hstmt hinternal fuel state (.exprStmt value)
+              (LegacyCompatibleExternalStmtList.exprStmt value [] LegacyCompatibleExternalStmtList.nil)
           rw [execIRStmtsWithInternals, execIRStmts, hhead]
-          cases hstep : execIRStmt fuel state (.expr value) <;>
+          cases hstep : execIRStmt fuel state (.exprStmt value) <;>
             simp only [ih]
   | if_ cond body rest hbody hrest ihBody ihRest =>
       cases fuel with
@@ -4971,7 +4971,7 @@ private theorem foldl_setParamVars_field_preservation {f : IRState → α}
 
 @[simp] theorem execIRFunction_single_stop
     (fn : IRFunction) (args : List Nat) (initialState : IRState)
-    (hBody : fn.body = [YulStmt.expr (YulExpr.call "stop" [])]) :
+    (hBody : fn.body = [YulStmt.exprStmt (YulExpr.call "stop" [])]) :
     execIRFunction fn args initialState =
       { success := true
         returnValue := none
@@ -4986,8 +4986,8 @@ theorem execIRFunction_store0_calldataload4_stop_of_args_cons
     (arg : Nat) (rest : List Nat)
     (hBody : fn.body = [
       YulStmt.let_ "value" (YulExpr.call "calldataload" [YulExpr.lit 4]),
-      YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "value"]),
-      YulStmt.expr (YulExpr.call "stop" [])])
+      YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "value"]),
+      YulStmt.exprStmt (YulExpr.call "stop" [])])
     (hArgs : tx.args = arg :: rest) :
     execIRFunction fn tx.args (applyIRTransactionContext tx initialState) =
       { success := true
@@ -5003,9 +5003,9 @@ theorem execIRFunction_store0_calldataload4_stop_of_args_cons
   have hbody : ∀ (n : Nat) (s : IRState), 3 ≤ n →
       execIRStmts (n + 1) s
         [YulStmt.let_ "value" (YulExpr.call "calldataload" [YulExpr.lit 4]),
-         YulStmt.expr (YulExpr.call "sstore"
+         YulStmt.exprStmt (YulExpr.call "sstore"
             [YulExpr.lit 0, YulExpr.ident "value"]),
-         YulStmt.expr (YulExpr.call "stop" [])] =
+         YulStmt.exprStmt (YulExpr.call "stop" [])] =
           .stop
             { s.setVar "value" (Compiler.Proofs.YulGeneration.calldataloadWord
                 s.selector s.calldata 4) with
@@ -5018,9 +5018,9 @@ theorem execIRFunction_store0_calldataload4_stop_of_args_cons
       IRState.setVar]
   have hsize : 3 ≤ sizeOf
       ([YulStmt.let_ "value" (YulExpr.call "calldataload" [YulExpr.lit 4]),
-        YulStmt.expr (YulExpr.call "sstore"
+        YulStmt.exprStmt (YulExpr.call "sstore"
           [YulExpr.lit 0, YulExpr.ident "value"]),
-        YulStmt.expr (YulExpr.call "stop" [])] : List YulStmt) := by
+        YulStmt.exprStmt (YulExpr.call "stop" [])] : List YulStmt) := by
     decide
   unfold execIRFunction
   simp only [hBody, hArgs]
@@ -5035,9 +5035,9 @@ theorem execIRFunction_mstore0_calldataload4_return32_of_args_cons
     (fn : IRFunction) (tx : IRTransaction) (initialState : IRState)
     (arg : Nat) (rest : List Nat)
     (hBody : fn.body = [
-      YulStmt.expr (YulExpr.call "mstore"
+      YulStmt.exprStmt (YulExpr.call "mstore"
         [YulExpr.lit 0, YulExpr.call "calldataload" [YulExpr.lit 4]]),
-      YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])])
+      YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])])
     (hArgs : tx.args = arg :: rest) :
     execIRFunction fn tx.args (applyIRTransactionContext tx initialState) =
       { success := true
@@ -5047,9 +5047,9 @@ theorem execIRFunction_mstore0_calldataload4_return32_of_args_cons
         events := initialState.events } := by
   have hbody : ∀ (n : Nat) (s : IRState), 2 ≤ n →
       execIRStmts (n + 1) s
-        [YulStmt.expr (YulExpr.call "mstore"
+        [YulStmt.exprStmt (YulExpr.call "mstore"
             [YulExpr.lit 0, YulExpr.call "calldataload" [YulExpr.lit 4]]),
-         YulStmt.expr (YulExpr.call "return"
+         YulStmt.exprStmt (YulExpr.call "return"
             [YulExpr.lit 0, YulExpr.lit 32])] =
           .return (Compiler.Proofs.YulGeneration.calldataloadWord
               s.selector s.calldata 4)
@@ -5062,9 +5062,9 @@ theorem execIRFunction_mstore0_calldataload4_return32_of_args_cons
     simp +decide only [execIRStmts, execIRStmt, evalIRExpr,
       evalIRCall_calldataload_singleton, Option.bind_some, ↓reduceIte]
   have hsize : 2 ≤ sizeOf
-      ([YulStmt.expr (YulExpr.call "mstore"
+      ([YulStmt.exprStmt (YulExpr.call "mstore"
           [YulExpr.lit 0, YulExpr.call "calldataload" [YulExpr.lit 4]]),
-        YulStmt.expr (YulExpr.call "return"
+        YulStmt.exprStmt (YulExpr.call "return"
           [YulExpr.lit 0, YulExpr.lit 32])] : List YulStmt) := by
     decide
   unfold execIRFunction
@@ -5086,10 +5086,10 @@ theorem execIRFunction_mstore0_calldataload_aligned_return32
     (fn : IRFunction) (tx : IRTransaction) (initialState : IRState)
     (idx : Nat)
     (hBody : fn.body = [
-      YulStmt.expr (YulExpr.call "mstore"
+      YulStmt.exprStmt (YulExpr.call "mstore"
         [YulExpr.lit 0,
          YulExpr.call "calldataload" [YulExpr.lit (4 + 32 * idx)]]),
-      YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])]) :
+      YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])]) :
     execIRFunction fn tx.args (applyIRTransactionContext tx initialState) =
       { success := true
         returnValue := some (tx.args.getD idx 0 % Compiler.Constants.evmModulus)
@@ -5098,10 +5098,10 @@ theorem execIRFunction_mstore0_calldataload_aligned_return32
         events := initialState.events } := by
   have hbody : ∀ (n : Nat) (s : IRState), 2 ≤ n →
       execIRStmts (n + 1) s
-        [YulStmt.expr (YulExpr.call "mstore"
+        [YulStmt.exprStmt (YulExpr.call "mstore"
             [YulExpr.lit 0,
              YulExpr.call "calldataload" [YulExpr.lit (4 + 32 * idx)]]),
-         YulStmt.expr (YulExpr.call "return"
+         YulStmt.exprStmt (YulExpr.call "return"
             [YulExpr.lit 0, YulExpr.lit 32])] =
           .return (Compiler.Proofs.YulGeneration.calldataloadWord
               s.selector s.calldata (4 + 32 * idx))
@@ -5114,16 +5114,16 @@ theorem execIRFunction_mstore0_calldataload_aligned_return32
     simp +decide only [execIRStmts, execIRStmt, evalIRExpr,
       evalIRCall_calldataload_singleton, Option.bind_some, ↓reduceIte]
   have hsize : 2 ≤ sizeOf
-      ([YulStmt.expr (YulExpr.call "mstore"
+      ([YulStmt.exprStmt (YulExpr.call "mstore"
           [YulExpr.lit 0,
            YulExpr.call "calldataload" [YulExpr.lit (4 + 32 * idx)]]),
-        YulStmt.expr (YulExpr.call "return"
+        YulStmt.exprStmt (YulExpr.call "return"
           [YulExpr.lit 0, YulExpr.lit 32])] : List YulStmt) := by
     have hlen := yulStmtList_length_le_sizeOf
-      ([YulStmt.expr (YulExpr.call "mstore"
+      ([YulStmt.exprStmt (YulExpr.call "mstore"
           [YulExpr.lit 0,
            YulExpr.call "calldataload" [YulExpr.lit (4 + 32 * idx)]]),
-        YulStmt.expr (YulExpr.call "return"
+        YulStmt.exprStmt (YulExpr.call "return"
           [YulExpr.lit 0, YulExpr.lit 32])] : List YulStmt)
     simpa using hlen
   unfold execIRFunction
@@ -5137,9 +5137,9 @@ theorem execIRFunction_mstore0_calldataload_aligned_return32
 theorem execIRFunction_mstore0_sload0_return32
     (fn : IRFunction) (tx : IRTransaction) (initialState : IRState)
     (hBody : fn.body = [
-      YulStmt.expr (YulExpr.call "mstore"
+      YulStmt.exprStmt (YulExpr.call "mstore"
         [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 0]]),
-      YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])]) :
+      YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])]) :
     execIRFunction fn tx.args (applyIRTransactionContext tx initialState) =
       { success := true
         returnValue := some ((initialState.storage (IRStorageSlot.ofNat 0)).toNat)
@@ -5148,9 +5148,9 @@ theorem execIRFunction_mstore0_sload0_return32
         events := initialState.events } := by
   have hbody : ∀ (n : Nat) (s : IRState), 2 ≤ n →
       execIRStmts (n + 1) s
-        [YulStmt.expr (YulExpr.call "mstore"
+        [YulStmt.exprStmt (YulExpr.call "mstore"
             [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 0]]),
-         YulStmt.expr (YulExpr.call "return"
+         YulStmt.exprStmt (YulExpr.call "return"
             [YulExpr.lit 0, YulExpr.lit 32])] =
           .return ((s.storage (IRStorageSlot.ofNat 0)).toNat)
             { s with memory := fun o =>
@@ -5161,9 +5161,9 @@ theorem execIRFunction_mstore0_sload0_return32
       Compiler.Proofs.abstractLoadStorageOrMapping,
       Option.bind_some, ↓reduceIte]
   have hsize : 2 ≤ sizeOf
-      ([YulStmt.expr (YulExpr.call "mstore"
+      ([YulStmt.exprStmt (YulExpr.call "mstore"
           [YulExpr.lit 0, YulExpr.call "sload" [YulExpr.lit 0]]),
-        YulStmt.expr (YulExpr.call "return"
+        YulStmt.exprStmt (YulExpr.call "return"
           [YulExpr.lit 0, YulExpr.lit 32])] : List YulStmt) := by
     decide
   unfold execIRFunction
@@ -5177,8 +5177,8 @@ theorem execIRFunction_mstore0_lit_return32
     (fn : IRFunction) (tx : IRTransaction) (initialState : IRState)
     (value : Nat)
     (hBody : fn.body = [
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit value]),
-      YulStmt.expr (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])]) :
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit value]),
+      YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])]) :
     execIRFunction fn tx.args (applyIRTransactionContext tx initialState) =
       { success := true
         returnValue := some value
@@ -5187,20 +5187,20 @@ theorem execIRFunction_mstore0_lit_return32
         events := initialState.events } := by
   have hbody : ∀ (n : Nat) (s : IRState), 2 ≤ n →
       execIRStmts (n + 1) s
-        [YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit value]),
-         YulStmt.expr (YulExpr.call "return"
+        [YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit value]),
+         YulStmt.exprStmt (YulExpr.call "return"
             [YulExpr.lit 0, YulExpr.lit 32])] =
           .return value { s with memory := fun o => if o = 0 then value else s.memory o } := by
     intro n s hn
     obtain ⟨k, rfl⟩ : ∃ k, n = k + 2 := ⟨n - 2, by omega⟩
     simp +decide only [execIRStmts, execIRStmt, evalIRExpr, ↓reduceIte]
   have hsize : 2 ≤ sizeOf
-      ([YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit value]),
-        YulStmt.expr (YulExpr.call "return"
+      ([YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit value]),
+        YulStmt.exprStmt (YulExpr.call "return"
           [YulExpr.lit 0, YulExpr.lit 32])] : List YulStmt) := by
     have hlen := yulStmtList_length_le_sizeOf
-      ([YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit value]),
-        YulStmt.expr (YulExpr.call "return"
+      ([YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.lit value]),
+        YulStmt.exprStmt (YulExpr.call "return"
           [YulExpr.lit 0, YulExpr.lit 32])] : List YulStmt)
     simpa using hlen
   unfold execIRFunction
@@ -5390,10 +5390,10 @@ theorem execIRStmtsWithInternals_singleton_letMany_call_internal
     contract fuel state names func args helper argVals state' hargs hfind
 
 /-- Combined characterization for `Stmt.internalCall` (void calls) at the IR level:
-when `.expr (.call func args)` executes with args evaluating to `argVals` and
+when `.exprStmt (.call func args)` executes with args evaluating to `argVals` and
 `func` resolving to an internal helper, the result is determined by
 `execIRInternalFunctionWithInternals`.  The `.values` case always yields
-`.continue` because `.expr` discards the return values. -/
+`.continue` because `.exprStmt` discards the return values. -/
 theorem execIRStmtWithInternals_expr_call_internal
     (contract : IRContract) (fuel : Nat) (state : IRState)
     (func : String) (args : List YulExpr)
@@ -5405,13 +5405,13 @@ theorem execIRStmtWithInternals_expr_call_internal
     (hrevert : func ≠ "revert")
     (hreturn : func ≠ "return")
     (hlog : isYulLogName func = false) :
-    execIRStmtWithInternals contract (fuel + 2) state (.expr (.call func args)) =
+    execIRStmtWithInternals contract (fuel + 2) state (.exprStmt (.call func args)) =
       match execIRInternalFunctionWithInternals contract fuel state' helper argVals with
       | .values _ state'' => .continue state''
       | .stop state'' => .stop state''
       | .return value' state'' => .return value' state''
       | .revert state'' => .revert state'' := by
-  -- The `.expr (.call func args)` case in execIRStmtWithInternals dispatches
+  -- The `.exprStmt (.call func args)` case in execIRStmtWithInternals dispatches
   -- through the builtin string matching before reaching the generic `.call`
   -- catch-all. We case-split on arg count to guide simp through the pattern tree.
   rw [show fuel + 2 = (fuel + 1) + 1 from by omega]
@@ -5432,7 +5432,7 @@ theorem execIRStmtWithInternals_expr_call_internal
         simp [execIRStmtWithInternals, evalIRCallWithInternals, hargs, hlog, hfind]
 
 /-- End-to-end singleton list characterization for `Stmt.internalCall` (void calls):
-when `compiledIR = [.expr (.call func args)]` with args evaluating to `argVals`
+when `compiledIR = [.exprStmt (.call func args)]` with args evaluating to `argVals`
 and `func` resolving to an internal helper, the list execution result is determined
 by `execIRInternalFunctionWithInternals`.  This is the IR-side half of the
 `CompiledStmtStepWithHelpersAndHelperIR.preserves` goal for `Stmt.internalCall`. -/
@@ -5448,7 +5448,7 @@ theorem execIRStmtsWithInternals_singleton_expr_call_internal
     (hreturn : func ≠ "return")
     (hlog : isYulLogName func = false) :
     execIRStmtsWithInternals contract (fuel + 3) state
-      [YulStmt.expr (YulExpr.call func args)] =
+      [YulStmt.exprStmt (YulExpr.call func args)] =
       match execIRInternalFunctionWithInternals contract fuel state' helper argVals with
       | .values _ state'' => .continue state''
       | .stop state'' => .stop state''
@@ -5592,7 +5592,7 @@ theorem compileStmt_internalCallAssign_shape
     exact hok.symm
 
 /-- Compilation of `Stmt.internalCall` produces exactly
-`[.expr (.call (internalFunctionYulName functionName) argExprs)]`
+`[.exprStmt (.call (internalFunctionYulName functionName) argExprs)]`
 when argument compilation succeeds. -/
 theorem compileStmt_internalCall_shape
     {fields : List CompilationModel.Field} {scope : List String}
@@ -5602,7 +5602,7 @@ theorem compileStmt_internalCall_shape
       (CompilationModel.Stmt.internalCall functionName args) = Except.ok compiledIR) :
     ∃ argExprs,
       CompilationModel.compileExprList fields .calldata args = Except.ok argExprs ∧
-      compiledIR = [YulStmt.expr
+      compiledIR = [YulStmt.exprStmt
         (YulExpr.call (CompilationModel.internalFunctionYulName functionName) argExprs)] := by
   simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork, bind, Except.bind] at hok
   match hargs : CompilationModel.compileExprListWithInternals fields .calldata [] args with
@@ -5690,7 +5690,7 @@ theorem execIRStmtsWithInternals_of_internalCallAssign_compile
 helper function is found in the runtime contract, the compiled IR's list-level
 execution reduces to `execIRInternalFunctionWithInternals` applied to the
 evaluated arguments.  The `.values` case always yields `.continue` because
-the `.expr` handler discards return values. -/
+the `.exprStmt` handler discards return values. -/
 theorem execIRStmtsWithInternals_of_internalCall_compile
     {fields : List CompilationModel.Field} {scope : List String}
     {functionName : String}
@@ -5711,7 +5711,7 @@ theorem execIRStmtsWithInternals_of_internalCall_compile
     (hmstore : CompilationModel.internalFunctionYulName functionName ≠ "mstore")
     (hrevert : CompilationModel.internalFunctionYulName functionName ≠ "revert")
     (hreturn : CompilationModel.internalFunctionYulName functionName ≠ "return") :
-    compiledIR = [YulStmt.expr
+    compiledIR = [YulStmt.exprStmt
       (YulExpr.call (CompilationModel.internalFunctionYulName functionName) argExprs)] ∧
     execIRStmtsWithInternals contract (fuel + 3) state compiledIR =
       match execIRInternalFunctionWithInternals contract fuel state' helper argVals with
@@ -5780,8 +5780,8 @@ private def shortCalldataRegressionContract : IRContract :=
         ret := .unit
         payable := false
         body := [
-          YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "value"]),
-          YulStmt.expr (YulExpr.call "stop" [])
+          YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "value"]),
+          YulStmt.exprStmt (YulExpr.call "stop" [])
         ] }
     ]
     usesMapping := false }

--- a/Compiler/Proofs/IRGeneration/ParamLoading.lean
+++ b/Compiler/Proofs/IRGeneration/ParamLoading.lean
@@ -336,7 +336,7 @@ private theorem exec_minInputSizeCheck_supported_noop
     execIRStmt (Nat.succ fuel) state
       (YulStmt.if_ (YulExpr.call "lt"
         [YulExpr.call "calldatasize" [], YulExpr.lit (4 + 32 * params.length)])
-        [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]) =
+        [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]) =
       .continue state := by
   have hrhs_lt_modulus : 4 + 32 * params.length < Compiler.Constants.evmModulus := by
     omega
@@ -568,7 +568,7 @@ theorem exec_genParamLoads_supported
       execIRStmt (body.length + 1) state
         (YulStmt.if_ (YulExpr.call "lt"
           [YulExpr.call "calldatasize" [], YulExpr.lit (4 + 32 * params.length)])
-          [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]) =
+          [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]) =
         .continue state :=
     exec_minInputSizeCheck_supported_noop (fuel := body.length) state params hsupported
       hcalldataSizeFits hlen
@@ -580,7 +580,7 @@ theorem exec_genParamLoads_supported
     execIRStmts_cons_of_execIRStmt_continue state state
       (YulStmt.if_ (YulExpr.call "lt"
         [YulExpr.call "calldatasize" [], YulExpr.lit (4 + 32 * params.length)])
-        [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])])
+        [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])])
       body hguard
   have hbody' :
       execIRStmts (body.length + 1) state body =
@@ -606,7 +606,7 @@ theorem exec_genParamLoads_supported_then_extraFuel
       execIRStmt (body.length + rest.length + extraFuel + 1) state
         (YulStmt.if_ (YulExpr.call "lt"
           [YulExpr.call "calldatasize" [], YulExpr.lit (4 + 32 * params.length)])
-          [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]) =
+          [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]) =
         .continue state :=
     exec_minInputSizeCheck_supported_noop (fuel := body.length + rest.length + extraFuel) state params hsupported
       hcalldataSizeFits hlen
@@ -619,7 +619,7 @@ theorem exec_genParamLoads_supported_then_extraFuel
     execIRStmts_cons_of_execIRStmt_continue_extraFuel extraFuel state state
       (YulStmt.if_ (YulExpr.call "lt"
         [YulExpr.call "calldatasize" [], YulExpr.lit (4 + 32 * params.length)])
-        [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])])
+        [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])])
       (body ++ rest) (by simpa [body] using hguard)
   have hbody' :
       execIRStmts ((body ++ rest).length + extraFuel + 1) state (body ++ rest) =

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -2790,6 +2790,7 @@ structure SupportedSpecSurface (spec : CompilationModel) : Prop where
   noExternals : spec.externals = []
   noAdtTypes : spec.adtTypes = []
   noCheckedArithmetic : contractUsesCheckedArithmetic spec = false
+  noTemplateIntrinsics : templateIntrinsicItems spec = []
   noFallback :
     ∀ fn ∈ spec.functions, fn.name != "fallback"
   noReceive :
@@ -2805,6 +2806,7 @@ structure SupportedSpecSurfaceWithScalarEvents (spec : CompilationModel) : Prop 
   noExternals : spec.externals = []
   noAdtTypes : spec.adtTypes = []
   noCheckedArithmetic : contractUsesCheckedArithmetic spec = false
+  noTemplateIntrinsics : templateIntrinsicItems spec = []
   noFallback :
     ∀ fn ∈ spec.functions, fn.name != "fallback"
   noReceive :
@@ -7180,6 +7182,17 @@ def counter_supported_spec : SupportedSpec counterSupportedSpecModel
         noCheckedArithmetic := by
           simp [contractUsesCheckedArithmetic, counterSupportedSpecModel,
             stmtListMayUseCheckedArithmetic, stmtMayUseCheckedArithmetic]
+        noTemplateIntrinsics := by
+          rw [templateIntrinsicItems, counterSupportedSpecModel]
+          simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+          unfold collectTemplateIntrinsicsFromStmts
+          simp only [List.flatMap_cons, List.flatMap_nil]
+          rw [collectTemplateIntrinsicsFromStmt.eq_def]
+          simp only [Stmt.directMetadata, Stmt.childLists, List.attach_nil,
+            List.flatMap_nil, List.append_nil]
+          simp only [List.flatMap_cons, List.flatMap_nil]
+          rw [collectTemplateIntrinsicsFromExpr.eq_def]
+          rfl
         noFallback := counter_noFallback
         noReceive := counter_noReceive }
     constructor := by
@@ -7268,6 +7281,17 @@ def simpleStorage_supported_spec : SupportedSpec simpleStorageSupportedSpecModel
         noCheckedArithmetic := by
           simp [contractUsesCheckedArithmetic, simpleStorageSupportedSpecModel,
             stmtListMayUseCheckedArithmetic, stmtMayUseCheckedArithmetic]
+        noTemplateIntrinsics := by
+          rw [templateIntrinsicItems, simpleStorageSupportedSpecModel]
+          simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+          unfold collectTemplateIntrinsicsFromStmts
+          simp only [List.flatMap_cons, List.flatMap_nil]
+          rw [collectTemplateIntrinsicsFromStmt.eq_def]
+          simp only [Stmt.directMetadata, Stmt.childLists, List.attach_nil,
+            List.flatMap_nil, List.append_nil]
+          simp only [List.flatMap_cons, List.flatMap_nil]
+          rw [collectTemplateIntrinsicsFromExpr.eq_def]
+          rfl
         noFallback := simpleStorage_noFallback
         noReceive := simpleStorage_noReceive }
     constructor := by

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBodyClosure/Base.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBodyClosure/Base.lean
@@ -85,7 +85,7 @@ private theorem bridgedStraightStmt_storageStore_lit
     (isTransient : Bool) (slot : Nat) (valueExpr : YulExpr)
     (hValue : BridgedExpr valueExpr) :
     BridgedStraightStmt
-      (YulStmt.expr
+      (YulStmt.exprStmt
         (YulExpr.call (if isTransient then "tstore" else "sstore")
           [YulExpr.lit slot, valueExpr])) := by
   cases isTransient
@@ -98,7 +98,7 @@ private theorem bridgedStraightStmt_storageStore_mapping
     (hBase : BridgedExpr baseExpr) (hKey : BridgedExpr keyExpr)
     (hValue : BridgedExpr valueExpr) :
     BridgedStraightStmt
-      (YulStmt.expr
+      (YulStmt.exprStmt
         (YulExpr.call (if isTransient then "tstore" else "sstore")
           [YulExpr.call "mappingSlot" [baseExpr, keyExpr], valueExpr])) := by
   cases isTransient
@@ -113,7 +113,7 @@ private theorem bridgedStraightStmt_storageStore_add
     (hLeft : BridgedExpr leftExpr) (hRight : BridgedExpr rightExpr)
     (hValue : BridgedExpr valueExpr) :
     BridgedStraightStmt
-      (YulStmt.expr
+      (YulStmt.exprStmt
         (YulExpr.call (if isTransient then "tstore" else "sstore")
           [YulExpr.call "add" [leftExpr, rightExpr], valueExpr])) := by
   cases isTransient
@@ -159,7 +159,7 @@ private theorem bridgedStraightStmt_fieldStorageStore_mapping
     (hBase : BridgedExpr baseExpr) (hKey : BridgedExpr keyExpr)
     (hValue : BridgedExpr valueExpr) :
     BridgedStraightStmt
-      (YulStmt.expr
+      (YulStmt.exprStmt
         (YulExpr.call
           (match findFieldWithResolvedSlot fields field with
            | some (f, _) => if f.isTransient = true then "tstore" else "sstore"
@@ -182,7 +182,7 @@ private theorem bridgedStraightStmt_fieldStorageStore_lit
     (slot : Nat) (valueExpr : YulExpr)
     (hValue : BridgedExpr valueExpr) :
     BridgedStraightStmt
-      (YulStmt.expr
+      (YulStmt.exprStmt
         (YulExpr.call
           (match findFieldWithResolvedSlot fields field with
            | some (f, _) => if f.isTransient = true then "tstore" else "sstore"
@@ -205,7 +205,7 @@ private theorem bridgedStraightStmt_fieldStorageStore_add
     (hLeft : BridgedExpr leftExpr) (hRight : BridgedExpr rightExpr)
     (hValue : BridgedExpr valueExpr) :
     BridgedStraightStmt
-      (YulStmt.expr
+      (YulStmt.exprStmt
         (YulExpr.call
           (match findFieldWithResolvedSlot fields field with
            | some (f, _) => if f.isTransient = true then "tstore" else "sstore"
@@ -229,7 +229,7 @@ private theorem bridgedStraightStmt_maybeFieldStorageStore_add
     (hLeft : BridgedExpr leftExpr) (hRight : BridgedExpr rightExpr)
     (hValue : BridgedExpr valueExpr) :
     BridgedStraightStmt
-      (YulStmt.expr
+      (YulStmt.exprStmt
         (YulExpr.call
           (if allowTransient then
             match findFieldWithResolvedSlot fields field with
@@ -251,7 +251,7 @@ private theorem bridgedStraightStmt_maybeFieldStorageStore_mapping
     (hBase : BridgedExpr baseExpr) (hKey : BridgedExpr keyExpr)
     (hValue : BridgedExpr valueExpr) :
     BridgedStraightStmt
-      (YulStmt.expr
+      (YulStmt.exprStmt
         (YulExpr.call
           (if allowTransient then
             match findFieldWithResolvedSlot fields field with
@@ -379,7 +379,7 @@ private theorem bridgedExpr_iszero_ident (name : String) :
 /-- `revert(0, 0)` as a straight-line (non-recursive) predicate witness. -/
 private theorem bridgedStraightStmt_revert_zero :
     BridgedStraightStmt
-      (YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])) :=
+      (YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])) :=
   BridgedStraightStmt.expr_revert (YulExpr.lit 0) (YulExpr.lit 0)
 
 /-- `lt(calldatasize(), lit n)` as a `BridgedExpr`. Exposed here at the public
@@ -1443,7 +1443,7 @@ private theorem revertWithMessage_chunks_noFuncDefs
     Native.yulStmtsContainFuncDef
       (chunks.map
         (fun chunkAndIdx =>
-          YulStmt.expr (YulExpr.call "mstore"
+          YulStmt.exprStmt (YulExpr.call "mstore"
             [YulExpr.lit (68 + chunkAndIdx.2 * 32),
               YulExpr.hex (wordFromBytes chunkAndIdx.1)]))) = false := by
   induction chunks with
@@ -2752,7 +2752,7 @@ encoding, which is out of scope for this increment.
 private theorem sigStores_bridged (sigBytes : List UInt8) :
     ∀ s ∈ (chunkBytes32 sigBytes).zipIdx.map
         (fun (chunk, idx) =>
-          YulStmt.expr (YulExpr.call "mstore" [
+          YulStmt.exprStmt (YulExpr.call "mstore" [
             YulExpr.call "add" [YulExpr.ident "__err_ptr", YulExpr.lit (idx * 32)],
             YulExpr.hex (wordFromBytes chunk)])),
       BridgedStmt s := by
@@ -2773,7 +2773,7 @@ private theorem sigStores_noFuncDefs (sigBytes : List UInt8) :
     Native.yulStmtsContainFuncDef
       ((chunkBytes32 sigBytes).zipIdx.map
         (fun (chunk, idx) =>
-          YulStmt.expr (YulExpr.call "mstore" [
+          YulStmt.exprStmt (YulExpr.call "mstore" [
             YulExpr.call "add" [YulExpr.ident "__err_ptr", YulExpr.lit (idx * 32)],
             YulExpr.hex (wordFromBytes chunk)]))) = false := by
   induction (chunkBytes32 sigBytes).zipIdx with
@@ -2797,7 +2797,7 @@ private theorem revertWithCustomError_zero_bridged
         ([YulStmt.let_ "__err_ptr" (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])] ++
           ((chunkBytes32 (bytesFromString (errorSignature errorDef))).zipIdx.map
             (fun (chunk, idx) =>
-              YulStmt.expr (YulExpr.call "mstore" [
+              YulStmt.exprStmt (YulExpr.call "mstore" [
                 YulExpr.call "add" [YulExpr.ident "__err_ptr", YulExpr.lit (idx * 32)],
                 YulExpr.hex (wordFromBytes chunk)]))) ++
           [YulStmt.let_ "__err_hash"
@@ -2806,10 +2806,10 @@ private theorem revertWithCustomError_zero_bridged
             YulStmt.let_ "__err_selector"
               (YulExpr.call "shl" [YulExpr.lit selectorShift,
                 YulExpr.call "shr" [YulExpr.lit selectorShift, YulExpr.ident "__err_hash"]]),
-            YulStmt.expr (YulExpr.call "mstore"
+            YulStmt.exprStmt (YulExpr.call "mstore"
               [YulExpr.lit 0, YulExpr.ident "__err_selector"]),
             YulStmt.let_ "__err_tail" (YulExpr.lit 0)] ++
-          [YulStmt.expr (YulExpr.call "revert"
+          [YulStmt.exprStmt (YulExpr.call "revert"
             [YulExpr.lit 0,
               YulExpr.call "add" [YulExpr.lit 4, YulExpr.ident "__err_tail"]])])] := by
     unfold revertWithCustomError
@@ -2887,7 +2887,7 @@ private theorem revertWithCustomError_zero_noFuncDefs
         ([YulStmt.let_ "__err_ptr" (YulExpr.call "mload" [YulExpr.lit freeMemoryPointer])] ++
           ((chunkBytes32 (bytesFromString (errorSignature errorDef))).zipIdx.map
             (fun (chunk, idx) =>
-              YulStmt.expr (YulExpr.call "mstore" [
+              YulStmt.exprStmt (YulExpr.call "mstore" [
                 YulExpr.call "add" [YulExpr.ident "__err_ptr", YulExpr.lit (idx * 32)],
                 YulExpr.hex (wordFromBytes chunk)]))) ++
           [YulStmt.let_ "__err_hash"
@@ -2896,10 +2896,10 @@ private theorem revertWithCustomError_zero_noFuncDefs
             YulStmt.let_ "__err_selector"
               (YulExpr.call "shl" [YulExpr.lit selectorShift,
                 YulExpr.call "shr" [YulExpr.lit selectorShift, YulExpr.ident "__err_hash"]]),
-            YulStmt.expr (YulExpr.call "mstore"
+            YulStmt.exprStmt (YulExpr.call "mstore"
               [YulExpr.lit 0, YulExpr.ident "__err_selector"]),
             YulStmt.let_ "__err_tail" (YulExpr.lit 0)] ++
-          [YulStmt.expr (YulExpr.call "revert"
+          [YulStmt.exprStmt (YulExpr.call "revert"
             [YulExpr.lit 0,
               YulExpr.call "add" [YulExpr.lit 4, YulExpr.ident "__err_tail"]])])] := by
     unfold revertWithCustomError
@@ -3799,7 +3799,7 @@ theorem BridgedSourceExternalStructuredBodyWithErrorsStmts_of_structured
 /-! ## Source statement body closure: direct `rawLog` emissions
 
 `Stmt.rawLog topics dataOffset dataSize` compiles (when `topics.length ≤ 4`)
-to a single `YulStmt.expr (YulExpr.call s!"log{topics.length}" args)` where
+to a single `YulStmt.exprStmt (YulExpr.call s!"log{topics.length}" args)` where
 `args = [offsetExpr, sizeExpr] ++ topicExprs`. Given bridged source
 hypotheses on all three components, every argument is `BridgedExpr`
 (topics via `compileExprList_bridgedSource`; offset/size via
@@ -5918,7 +5918,7 @@ def BridgedSourceReturnValuesExternalStmts (stmts : List Stmt) : Prop :=
   ∀ stmt ∈ stmts, BridgedSourceReturnValuesExternalStmt stmt
 
 /-- Every element of `compiled.zipIdx.map (fun (v, idx) =>
-YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit (idx * 32), v]))` is a
+YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit (idx * 32), v]))` is a
 `BridgedStmt` when each `compiled` element is `BridgedExpr`. Proved by
 induction on `compiled` with the `zipIdx` starting offset generalized. -/
 private theorem zipIdx_mstores_bridgedStmts :
@@ -5926,7 +5926,7 @@ private theorem zipIdx_mstores_bridgedStmts :
       (∀ e ∈ compiled, BridgedExpr e) →
       BridgedStmts
         ((compiled.zipIdx startIdx).map (fun p =>
-          YulStmt.expr (YulExpr.call "mstore"
+          YulStmt.exprStmt (YulExpr.call "mstore"
             [YulExpr.lit (p.2 * 32), p.1]))) := by
   intro compiled
   induction compiled with
@@ -5955,7 +5955,7 @@ private theorem zipIdx_mstores_noFuncDefs :
     ∀ (compiled : List YulExpr) (startIdx : Nat),
       Native.yulStmtsContainFuncDef
         ((compiled.zipIdx startIdx).map (fun p =>
-          YulStmt.expr (YulExpr.call "mstore"
+          YulStmt.exprStmt (YulExpr.call "mstore"
             [YulExpr.lit (p.2 * 32), p.1]))) = false := by
   intro compiled
   induction compiled with
@@ -7279,7 +7279,7 @@ private theorem bridgedStraightStmts_multiSlot_sstore_mapping
     (slots : List Nat) :
     BridgedStraightStmts
       (slots.map fun slot =>
-        Compiler.Yul.YulStmt.expr
+        Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call "sstore" [
             Compiler.Yul.YulExpr.call "mappingSlot"
               [Compiler.Yul.YulExpr.lit slot,
@@ -7305,7 +7305,7 @@ private theorem yulStmtsContainFuncDef_multiSlot_sstore_mapping
     (slots : List Nat) :
     Native.yulStmtsContainFuncDef
       (slots.map fun slot =>
-        Compiler.Yul.YulStmt.expr
+        Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call "sstore" [
             Compiler.Yul.YulExpr.call "mappingSlot"
               [Compiler.Yul.YulExpr.lit slot,
@@ -7351,7 +7351,7 @@ private theorem compileMappingSlotWrite_multiSlot_bridged
     exact BridgedStmt.straight _ (BridgedStraightStmt.let_ _ _ hValue)
   have hStoreFor : ∀ slot : Nat,
       BridgedStmt
-        (Compiler.Yul.YulStmt.expr
+        (Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call
             (if allowTransient then
               match findFieldWithResolvedSlot fields field with
@@ -7613,7 +7613,7 @@ private theorem bridgedStraightStmts_multiSlot_sstore_mapping2
     (slots : List Nat) :
     BridgedStraightStmts
       (slots.map fun slot =>
-        Compiler.Yul.YulStmt.expr
+        Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call "sstore" [
             Compiler.Yul.YulExpr.call "mappingSlot"
               [Compiler.Yul.YulExpr.call "mappingSlot"
@@ -7654,7 +7654,7 @@ private theorem yulStmtsContainFuncDef_multiSlot_sstore_mapping2
     (slots : List Nat) :
     Native.yulStmtsContainFuncDef
       (slots.map fun slot =>
-        Compiler.Yul.YulStmt.expr
+        Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call "sstore" [
             Compiler.Yul.YulExpr.call "mappingSlot"
               [Compiler.Yul.YulExpr.call "mappingSlot"
@@ -8617,7 +8617,7 @@ private theorem bridgedStraightStmts_multiSlot_sstore_mapping_add
     (slots : List Nat) (wordOffset : Nat) :
     BridgedStraightStmts
       (slots.map fun slot =>
-        Compiler.Yul.YulStmt.expr
+        Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call "sstore" [
             Compiler.Yul.YulExpr.call "add" [
               Compiler.Yul.YulExpr.call "mappingSlot"
@@ -8658,7 +8658,7 @@ private theorem yulStmtsContainFuncDef_multiSlot_sstore_mapping_add
     (slots : List Nat) (wordOffset : Nat) :
     Native.yulStmtsContainFuncDef
       (slots.map fun slot =>
-        Compiler.Yul.YulStmt.expr
+        Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call "sstore" [
             Compiler.Yul.YulExpr.call "add" [
               Compiler.Yul.YulExpr.call "mappingSlot"
@@ -8707,7 +8707,7 @@ private theorem compileMappingSlotWrite_multiSlot_nonzero_bridged
     exact BridgedStmt.straight _ (BridgedStraightStmt.let_ _ _ hValue)
   have hStoreFor : ∀ slot : Nat,
       BridgedStmt
-        (Compiler.Yul.YulStmt.expr
+        (Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call
             (if allowTransient then
               match findFieldWithResolvedSlot fields field with
@@ -8920,7 +8920,7 @@ private theorem bridgedStraightStmts_multiSlot_sstore_mapping2_add
     (slots : List Nat) (wordOffset : Nat) :
     BridgedStraightStmts
       (slots.map fun slot =>
-        Compiler.Yul.YulStmt.expr
+        Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call "sstore" [
             Compiler.Yul.YulExpr.call "add" [
               Compiler.Yul.YulExpr.call "mappingSlot" [
@@ -8978,7 +8978,7 @@ private theorem yulStmtsContainFuncDef_multiSlot_sstore_mapping2_add
     (slots : List Nat) (wordOffset : Nat) :
     Native.yulStmtsContainFuncDef
       (slots.map fun slot =>
-        Compiler.Yul.YulStmt.expr
+        Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call "sstore" [
             Compiler.Yul.YulExpr.call "add" [
               Compiler.Yul.YulExpr.call "mappingSlot" [
@@ -10146,7 +10146,7 @@ private theorem bridgedStmt_packedInnerBlock_wordOffsetZero
           Compiler.Yul.YulExpr.ident "__compat_slot_word",
           Compiler.Yul.YulExpr.call "not" [
             Compiler.Yul.YulExpr.lit (packedShiftedMaskNat packed)]]),
-      Compiler.Yul.YulStmt.expr (
+      Compiler.Yul.YulStmt.exprStmt (
         Compiler.Yul.YulExpr.call (if isTransient then "tstore" else "sstore") [
           Compiler.Yul.YulExpr.call "mappingSlot" [
             Compiler.Yul.YulExpr.lit slot,
@@ -10239,7 +10239,7 @@ private theorem bridgedStmt_packedInnerBlock_wordOffsetZero_field
           Compiler.Yul.YulExpr.ident "__compat_slot_word",
           Compiler.Yul.YulExpr.call "not" [
             Compiler.Yul.YulExpr.lit (packedShiftedMaskNat packed)]]),
-      Compiler.Yul.YulStmt.expr (
+      Compiler.Yul.YulStmt.exprStmt (
         Compiler.Yul.YulExpr.call
           (match findFieldWithResolvedSlot fields field with
            | some (f, _) => if f.isTransient = true then "tstore" else "sstore"
@@ -10279,7 +10279,7 @@ private theorem bridgedStmts_slotsMap_packedInnerBlock_wordOffsetZero
             Compiler.Yul.YulExpr.ident "__compat_slot_word",
             Compiler.Yul.YulExpr.call "not" [
               Compiler.Yul.YulExpr.lit (packedShiftedMaskNat packed)]]),
-        Compiler.Yul.YulStmt.expr (
+        Compiler.Yul.YulStmt.exprStmt (
           Compiler.Yul.YulExpr.call "sstore" [
             Compiler.Yul.YulExpr.call "mappingSlot" [
               Compiler.Yul.YulExpr.lit slot,
@@ -10310,7 +10310,7 @@ private theorem yulStmtsContainFuncDef_slotsMap_packedInnerBlock_wordOffsetZero
             Compiler.Yul.YulExpr.ident "__compat_slot_word",
             Compiler.Yul.YulExpr.call "not" [
               Compiler.Yul.YulExpr.lit (packedShiftedMaskNat packed)]]),
-        Compiler.Yul.YulStmt.expr (
+        Compiler.Yul.YulStmt.exprStmt (
           Compiler.Yul.YulExpr.call "sstore" [
             Compiler.Yul.YulExpr.call "mappingSlot" [
               Compiler.Yul.YulExpr.lit slot,
@@ -10524,7 +10524,7 @@ private theorem bridgedStmt_packedInnerBlock_wordOffsetNonzero
           Compiler.Yul.YulExpr.ident "__compat_slot_word",
           Compiler.Yul.YulExpr.call "not" [
             Compiler.Yul.YulExpr.lit (packedShiftedMaskNat packed)]]),
-      Compiler.Yul.YulStmt.expr (
+      Compiler.Yul.YulStmt.exprStmt (
         Compiler.Yul.YulExpr.call (if isTransient then "tstore" else "sstore") [
           Compiler.Yul.YulExpr.call "add" [
             Compiler.Yul.YulExpr.call "mappingSlot" [
@@ -10636,7 +10636,7 @@ private theorem bridgedStmt_packedInnerBlock_wordOffsetNonzero_field
           Compiler.Yul.YulExpr.ident "__compat_slot_word",
           Compiler.Yul.YulExpr.call "not" [
             Compiler.Yul.YulExpr.lit (packedShiftedMaskNat packed)]]),
-      Compiler.Yul.YulStmt.expr (
+      Compiler.Yul.YulStmt.exprStmt (
         Compiler.Yul.YulExpr.call
           (match findFieldWithResolvedSlot fields field with
            | some (f, _) => if f.isTransient = true then "tstore" else "sstore"
@@ -10680,7 +10680,7 @@ private theorem bridgedStmts_slotsMap_packedInnerBlock_wordOffsetNonzero
             Compiler.Yul.YulExpr.ident "__compat_slot_word",
             Compiler.Yul.YulExpr.call "not" [
               Compiler.Yul.YulExpr.lit (packedShiftedMaskNat packed)]]),
-        Compiler.Yul.YulStmt.expr (
+        Compiler.Yul.YulStmt.exprStmt (
           Compiler.Yul.YulExpr.call (if isTransient then "tstore" else "sstore") [
             Compiler.Yul.YulExpr.call "add" [
               Compiler.Yul.YulExpr.call "mappingSlot" [
@@ -10715,7 +10715,7 @@ private theorem yulStmtsContainFuncDef_slotsMap_packedInnerBlock_wordOffsetNonze
             Compiler.Yul.YulExpr.ident "__compat_slot_word",
             Compiler.Yul.YulExpr.call "not" [
               Compiler.Yul.YulExpr.lit (packedShiftedMaskNat packed)]]),
-        Compiler.Yul.YulStmt.expr (
+        Compiler.Yul.YulStmt.exprStmt (
           Compiler.Yul.YulExpr.call "sstore" [
             Compiler.Yul.YulExpr.call "add" [
               Compiler.Yul.YulExpr.call "mappingSlot" [

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgePredicates.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgePredicates.lean
@@ -58,34 +58,34 @@ inductive BridgedStraightStmt : Compiler.Yul.YulStmt → Prop
       (hBase : BridgedExpr baseExpr) (hKey : BridgedExpr keyExpr)
       (hVal : BridgedExpr valExpr) :
       BridgedStraightStmt
-        (.expr (.call "sstore" [.call "mappingSlot" [baseExpr, keyExpr], valExpr]))
+        (.exprStmt (.call "sstore" [.call "mappingSlot" [baseExpr, keyExpr], valExpr]))
   | expr_sstore_lit (slot : Nat) (valExpr : Compiler.Yul.YulExpr)
       (hVal : BridgedExpr valExpr) :
-      BridgedStraightStmt (.expr (.call "sstore" [.lit slot, valExpr]))
+      BridgedStraightStmt (.exprStmt (.call "sstore" [.lit slot, valExpr]))
   | expr_sstore_ident (slotName : String) (valExpr : Compiler.Yul.YulExpr)
       (hVal : BridgedExpr valExpr) :
-      BridgedStraightStmt (.expr (.call "sstore" [.ident slotName, valExpr]))
+      BridgedStraightStmt (.exprStmt (.call "sstore" [.ident slotName, valExpr]))
   | expr_sstore_add (leftExpr rightExpr valExpr : Compiler.Yul.YulExpr)
       (hLeft : BridgedExpr leftExpr) (hRight : BridgedExpr rightExpr)
       (hVal : BridgedExpr valExpr) :
       BridgedStraightStmt
-        (.expr (.call "sstore" [.call "add" [leftExpr, rightExpr], valExpr]))
+        (.exprStmt (.call "sstore" [.call "add" [leftExpr, rightExpr], valExpr]))
   | expr_mstore (offsetExpr valExpr : Compiler.Yul.YulExpr)
       (hOffset : BridgedExpr offsetExpr) (hVal : BridgedExpr valExpr) :
-      BridgedStraightStmt (.expr (.call "mstore" [offsetExpr, valExpr]))
+      BridgedStraightStmt (.exprStmt (.call "mstore" [offsetExpr, valExpr]))
   | expr_tstore (offsetExpr valExpr : Compiler.Yul.YulExpr)
       (hOffset : BridgedExpr offsetExpr) (hVal : BridgedExpr valExpr) :
-      BridgedStraightStmt (.expr (.call "tstore" [offsetExpr, valExpr]))
-  | expr_stop : BridgedStraightStmt (.expr (.call "stop" []))
+      BridgedStraightStmt (.exprStmt (.call "tstore" [offsetExpr, valExpr]))
+  | expr_stop : BridgedStraightStmt (.exprStmt (.call "stop" []))
   | expr_return (offsetExpr sizeExpr : Compiler.Yul.YulExpr)
       (hOffset : BridgedExpr offsetExpr) (hSize : BridgedExpr sizeExpr) :
-      BridgedStraightStmt (.expr (.call "return" [offsetExpr, sizeExpr]))
+      BridgedStraightStmt (.exprStmt (.call "return" [offsetExpr, sizeExpr]))
   | expr_revert (offsetExpr sizeExpr : Compiler.Yul.YulExpr) :
-      BridgedStraightStmt (.expr (.call "revert" [offsetExpr, sizeExpr]))
+      BridgedStraightStmt (.exprStmt (.call "revert" [offsetExpr, sizeExpr]))
   | expr_log (func : String) (args : List Compiler.Yul.YulExpr)
       (hLog : isYulLogName func = true)
       (hArgs : ∀ arg ∈ args, BridgedExpr arg) :
-      BridgedStraightStmt (.expr (.call func args))
+      BridgedStraightStmt (.exprStmt (.call func args))
   | funcDef (name : String) (params rets : List String)
       (body : List Compiler.Yul.YulStmt) :
       BridgedStraightStmt (.funcDef name params rets body)
@@ -130,7 +130,7 @@ theorem BridgedStraightStmts_map_mstore
     (hPairs : ∀ p ∈ pairs, BridgedExpr p.1 ∧ BridgedExpr p.2) :
     BridgedStraightStmts
       (pairs.map fun p =>
-        Compiler.Yul.YulStmt.expr
+        Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call "mstore" [p.1, p.2])) := by
   induction pairs with
   | nil => exact BridgedStraightStmts_nil
@@ -148,7 +148,7 @@ theorem BridgedStraightStmts_map_tstore
     (hPairs : ∀ p ∈ pairs, BridgedExpr p.1 ∧ BridgedExpr p.2) :
     BridgedStraightStmts
       (pairs.map fun p =>
-        Compiler.Yul.YulStmt.expr
+        Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call "tstore" [p.1, p.2])) := by
   induction pairs with
   | nil => exact BridgedStraightStmts_nil
@@ -201,7 +201,7 @@ inductive BridgedStmt : Compiler.Yul.YulStmt → Prop
       (calleeBody : List Compiler.Yul.YulStmt)
       (hArgs : ∀ arg ∈ args, BridgedExpr arg)
       (hCallee : ∀ stmt ∈ calleeBody, BridgedStmt stmt) :
-      BridgedStmt (.expr (.call funcName args))
+      BridgedStmt (.exprStmt (.call funcName args))
   /-- User-function call with `letMany` binding of return values. Mirrors
   `userCallExpr` for the multi-value-bind shape. -/
   | userCallBind (resultVars : List String) (funcName : String)
@@ -322,7 +322,7 @@ theorem bridgedStraightStmt_log_of_bridged_args
     (func : String) (args : List Compiler.Yul.YulExpr)
     (hLog : isYulLogName func = true)
     (hArgs : ∀ arg ∈ args, BridgedExpr arg) :
-    BridgedStraightStmt (.expr (.call func args)) :=
+    BridgedStraightStmt (.exprStmt (.call func args)) :=
   BridgedStraightStmt.expr_log func args hLog hArgs
 
 theorem bridgedStmt_of_bridgedStraightStmt {stmt : Compiler.Yul.YulStmt}
@@ -333,7 +333,7 @@ theorem bridgedStmt_log_of_bridged_args
     (func : String) (args : List Compiler.Yul.YulExpr)
     (hLog : isYulLogName func = true)
     (hArgs : ∀ arg ∈ args, BridgedExpr arg) :
-    BridgedStmt (.expr (.call func args)) :=
+    BridgedStmt (.exprStmt (.call func args)) :=
   bridgedStmt_of_bridgedStraightStmt
     (bridgedStraightStmt_log_of_bridged_args func args hLog hArgs)
 
@@ -385,7 +385,7 @@ theorem bridgedStmt_mstore_of_bridged_args
     (offsetExpr valExpr : Compiler.Yul.YulExpr)
     (hOffset : BridgedExpr offsetExpr) (hVal : BridgedExpr valExpr) :
     BridgedStmt
-      (.expr (Compiler.Yul.YulExpr.call "mstore" [offsetExpr, valExpr])) :=
+      (.exprStmt (Compiler.Yul.YulExpr.call "mstore" [offsetExpr, valExpr])) :=
   bridgedStmt_of_bridgedStraightStmt
     (BridgedStraightStmt.expr_mstore offsetExpr valExpr hOffset hVal)
 
@@ -393,7 +393,7 @@ theorem bridgedStmt_tstore_of_bridged_args
     (offsetExpr valExpr : Compiler.Yul.YulExpr)
     (hOffset : BridgedExpr offsetExpr) (hVal : BridgedExpr valExpr) :
     BridgedStmt
-      (.expr (Compiler.Yul.YulExpr.call "tstore" [offsetExpr, valExpr])) :=
+      (.exprStmt (Compiler.Yul.YulExpr.call "tstore" [offsetExpr, valExpr])) :=
   bridgedStmt_of_bridgedStraightStmt
     (BridgedStraightStmt.expr_tstore offsetExpr valExpr hOffset hVal)
 
@@ -402,7 +402,7 @@ theorem bridgedStmt_sstore_mapping_of_bridged_args
     (hBase : BridgedExpr baseExpr) (hKey : BridgedExpr keyExpr)
     (hVal : BridgedExpr valExpr) :
     BridgedStmt
-      (.expr (Compiler.Yul.YulExpr.call "sstore"
+      (.exprStmt (Compiler.Yul.YulExpr.call "sstore"
         [Compiler.Yul.YulExpr.call "mappingSlot" [baseExpr, keyExpr], valExpr])) :=
   bridgedStmt_of_bridgedStraightStmt
     (BridgedStraightStmt.expr_sstore_mapping baseExpr keyExpr valExpr hBase hKey hVal)
@@ -410,14 +410,14 @@ theorem bridgedStmt_sstore_mapping_of_bridged_args
 theorem bridgedStmt_sstore_lit_of_bridged_val
     (slot : Nat) (valExpr : Compiler.Yul.YulExpr) (hVal : BridgedExpr valExpr) :
     BridgedStmt
-      (.expr (Compiler.Yul.YulExpr.call "sstore" [.lit slot, valExpr])) :=
+      (.exprStmt (Compiler.Yul.YulExpr.call "sstore" [.lit slot, valExpr])) :=
   bridgedStmt_of_bridgedStraightStmt
     (BridgedStraightStmt.expr_sstore_lit slot valExpr hVal)
 
 theorem bridgedStmt_sstore_ident_of_bridged_val
     (slotName : String) (valExpr : Compiler.Yul.YulExpr) (hVal : BridgedExpr valExpr) :
     BridgedStmt
-      (.expr (Compiler.Yul.YulExpr.call "sstore" [.ident slotName, valExpr])) :=
+      (.exprStmt (Compiler.Yul.YulExpr.call "sstore" [.ident slotName, valExpr])) :=
   bridgedStmt_of_bridgedStraightStmt
     (BridgedStraightStmt.expr_sstore_ident slotName valExpr hVal)
 
@@ -426,26 +426,26 @@ theorem bridgedStmt_sstore_add_of_bridged_args
     (hLeft : BridgedExpr leftExpr) (hRight : BridgedExpr rightExpr)
     (hVal : BridgedExpr valExpr) :
     BridgedStmt
-      (.expr (Compiler.Yul.YulExpr.call "sstore"
+      (.exprStmt (Compiler.Yul.YulExpr.call "sstore"
         [Compiler.Yul.YulExpr.call "add" [leftExpr, rightExpr], valExpr])) :=
   bridgedStmt_of_bridgedStraightStmt
     (BridgedStraightStmt.expr_sstore_add leftExpr rightExpr valExpr hLeft hRight hVal)
 
 theorem bridgedStmt_stop :
-    BridgedStmt (Compiler.Yul.YulStmt.expr (Compiler.Yul.YulExpr.call "stop" [])) :=
+    BridgedStmt (Compiler.Yul.YulStmt.exprStmt (Compiler.Yul.YulExpr.call "stop" [])) :=
   bridgedStmt_of_bridgedStraightStmt BridgedStraightStmt.expr_stop
 
 theorem bridgedStmt_return_of_bridged_args
     (offsetExpr sizeExpr : Compiler.Yul.YulExpr)
     (hOffset : BridgedExpr offsetExpr) (hSize : BridgedExpr sizeExpr) :
     BridgedStmt
-      (.expr (Compiler.Yul.YulExpr.call "return" [offsetExpr, sizeExpr])) :=
+      (.exprStmt (Compiler.Yul.YulExpr.call "return" [offsetExpr, sizeExpr])) :=
   bridgedStmt_of_bridgedStraightStmt
     (BridgedStraightStmt.expr_return offsetExpr sizeExpr hOffset hSize)
 
 theorem bridgedStmt_revert (offsetExpr sizeExpr : Compiler.Yul.YulExpr) :
     BridgedStmt
-      (.expr (Compiler.Yul.YulExpr.call "revert" [offsetExpr, sizeExpr])) :=
+      (.exprStmt (Compiler.Yul.YulExpr.call "revert" [offsetExpr, sizeExpr])) :=
   bridgedStmt_of_bridgedStraightStmt
     (BridgedStraightStmt.expr_revert offsetExpr sizeExpr)
 
@@ -508,7 +508,7 @@ theorem BridgedStmts_map_mstore
     (hPairs : ∀ p ∈ pairs, BridgedExpr p.1 ∧ BridgedExpr p.2) :
     BridgedStmts
       (pairs.map fun p =>
-        Compiler.Yul.YulStmt.expr
+        Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call "mstore" [p.1, p.2])) :=
   BridgedStmts_of_BridgedStraightStmts
     (BridgedStraightStmts_map_mstore pairs hPairs)
@@ -644,21 +644,21 @@ theorem BridgedStmts_map_tstore
     (hPairs : ∀ p ∈ pairs, BridgedExpr p.1 ∧ BridgedExpr p.2) :
     BridgedStmts
       (pairs.map fun p =>
-        Compiler.Yul.YulStmt.expr
+        Compiler.Yul.YulStmt.exprStmt
           (Compiler.Yul.YulExpr.call "tstore" [p.1, p.2])) :=
   BridgedStmts_of_BridgedStraightStmts
     (BridgedStraightStmts_map_tstore pairs hPairs)
 
 theorem bridgedStmt_revert_zero :
     BridgedStmt
-      (Compiler.Yul.YulStmt.expr
+      (Compiler.Yul.YulStmt.exprStmt
         (Compiler.Yul.YulExpr.call "revert"
           [Compiler.Yul.YulExpr.lit 0, Compiler.Yul.YulExpr.lit 0])) :=
   bridgedStmt_revert (Compiler.Yul.YulExpr.lit 0) (Compiler.Yul.YulExpr.lit 0)
 
 theorem BridgedStmts_singleton_revert_zero :
     BridgedStmts
-      [Compiler.Yul.YulStmt.expr
+      [Compiler.Yul.YulStmt.exprStmt
         (Compiler.Yul.YulExpr.call "revert"
           [Compiler.Yul.YulExpr.lit 0, Compiler.Yul.YulExpr.lit 0])] :=
   BridgedStmts_singleton bridgedStmt_revert_zero
@@ -708,13 +708,13 @@ theorem BridgedStmts_cons_letMany
 
 theorem BridgedStmts_singleton_stop :
     BridgedStmts
-      [Compiler.Yul.YulStmt.expr (Compiler.Yul.YulExpr.call "stop" [])] :=
+      [Compiler.Yul.YulStmt.exprStmt (Compiler.Yul.YulExpr.call "stop" [])] :=
   BridgedStmts_singleton bridgedStmt_stop
 
 theorem BridgedStmts_cons_stop {stmts : List Compiler.Yul.YulStmt}
     (hStmts : BridgedStmts stmts) :
     BridgedStmts
-      (Compiler.Yul.YulStmt.expr (Compiler.Yul.YulExpr.call "stop" []) :: stmts) :=
+      (Compiler.Yul.YulStmt.exprStmt (Compiler.Yul.YulExpr.call "stop" []) :: stmts) :=
   BridgedStmts_cons bridgedStmt_stop hStmts
 
 theorem BridgedStmts_singleton_leave :
@@ -729,7 +729,7 @@ theorem BridgedStmts_cons_leave {stmts : List Compiler.Yul.YulStmt}
 theorem BridgedStmts_singleton_return
     (offsetExpr sizeExpr : Compiler.Yul.YulExpr)
     (hOffset : BridgedExpr offsetExpr) (hSize : BridgedExpr sizeExpr) :
-    BridgedStmts [.expr (.call "return" [offsetExpr, sizeExpr])] :=
+    BridgedStmts [.exprStmt (.call "return" [offsetExpr, sizeExpr])] :=
   BridgedStmts_singleton
     (bridgedStmt_return_of_bridged_args offsetExpr sizeExpr hOffset hSize)
 
@@ -737,25 +737,25 @@ theorem BridgedStmts_cons_return
     (offsetExpr sizeExpr : Compiler.Yul.YulExpr)
     (hOffset : BridgedExpr offsetExpr) (hSize : BridgedExpr sizeExpr)
     {stmts : List Compiler.Yul.YulStmt} (hStmts : BridgedStmts stmts) :
-    BridgedStmts (.expr (.call "return" [offsetExpr, sizeExpr]) :: stmts) :=
+    BridgedStmts (.exprStmt (.call "return" [offsetExpr, sizeExpr]) :: stmts) :=
   BridgedStmts_cons
     (bridgedStmt_return_of_bridged_args offsetExpr sizeExpr hOffset hSize) hStmts
 
 theorem BridgedStmts_singleton_revert
     (offsetExpr sizeExpr : Compiler.Yul.YulExpr) :
-    BridgedStmts [.expr (.call "revert" [offsetExpr, sizeExpr])] :=
+    BridgedStmts [.exprStmt (.call "revert" [offsetExpr, sizeExpr])] :=
   BridgedStmts_singleton (bridgedStmt_revert offsetExpr sizeExpr)
 
 theorem BridgedStmts_cons_revert
     (offsetExpr sizeExpr : Compiler.Yul.YulExpr)
     {stmts : List Compiler.Yul.YulStmt} (hStmts : BridgedStmts stmts) :
-    BridgedStmts (.expr (.call "revert" [offsetExpr, sizeExpr]) :: stmts) :=
+    BridgedStmts (.exprStmt (.call "revert" [offsetExpr, sizeExpr]) :: stmts) :=
   BridgedStmts_cons (bridgedStmt_revert offsetExpr sizeExpr) hStmts
 
 theorem BridgedStmts_singleton_mstore
     (offsetExpr valExpr : Compiler.Yul.YulExpr)
     (hOffset : BridgedExpr offsetExpr) (hVal : BridgedExpr valExpr) :
-    BridgedStmts [.expr (.call "mstore" [offsetExpr, valExpr])] :=
+    BridgedStmts [.exprStmt (.call "mstore" [offsetExpr, valExpr])] :=
   BridgedStmts_singleton
     (bridgedStmt_mstore_of_bridged_args offsetExpr valExpr hOffset hVal)
 
@@ -763,14 +763,14 @@ theorem BridgedStmts_cons_mstore
     (offsetExpr valExpr : Compiler.Yul.YulExpr)
     (hOffset : BridgedExpr offsetExpr) (hVal : BridgedExpr valExpr)
     {stmts : List Compiler.Yul.YulStmt} (hStmts : BridgedStmts stmts) :
-    BridgedStmts (.expr (.call "mstore" [offsetExpr, valExpr]) :: stmts) :=
+    BridgedStmts (.exprStmt (.call "mstore" [offsetExpr, valExpr]) :: stmts) :=
   BridgedStmts_cons
     (bridgedStmt_mstore_of_bridged_args offsetExpr valExpr hOffset hVal) hStmts
 
 theorem BridgedStmts_singleton_tstore
     (offsetExpr valExpr : Compiler.Yul.YulExpr)
     (hOffset : BridgedExpr offsetExpr) (hVal : BridgedExpr valExpr) :
-    BridgedStmts [.expr (.call "tstore" [offsetExpr, valExpr])] :=
+    BridgedStmts [.exprStmt (.call "tstore" [offsetExpr, valExpr])] :=
   BridgedStmts_singleton
     (bridgedStmt_tstore_of_bridged_args offsetExpr valExpr hOffset hVal)
 
@@ -778,33 +778,33 @@ theorem BridgedStmts_cons_tstore
     (offsetExpr valExpr : Compiler.Yul.YulExpr)
     (hOffset : BridgedExpr offsetExpr) (hVal : BridgedExpr valExpr)
     {stmts : List Compiler.Yul.YulStmt} (hStmts : BridgedStmts stmts) :
-    BridgedStmts (.expr (.call "tstore" [offsetExpr, valExpr]) :: stmts) :=
+    BridgedStmts (.exprStmt (.call "tstore" [offsetExpr, valExpr]) :: stmts) :=
   BridgedStmts_cons
     (bridgedStmt_tstore_of_bridged_args offsetExpr valExpr hOffset hVal) hStmts
 
 theorem BridgedStmts_singleton_sstore_lit
     (slot : Nat) (valExpr : Compiler.Yul.YulExpr) (hVal : BridgedExpr valExpr) :
-    BridgedStmts [.expr (.call "sstore" [.lit slot, valExpr])] :=
+    BridgedStmts [.exprStmt (.call "sstore" [.lit slot, valExpr])] :=
   BridgedStmts_singleton
     (bridgedStmt_sstore_lit_of_bridged_val slot valExpr hVal)
 
 theorem BridgedStmts_cons_sstore_lit
     (slot : Nat) (valExpr : Compiler.Yul.YulExpr) (hVal : BridgedExpr valExpr)
     {stmts : List Compiler.Yul.YulStmt} (hStmts : BridgedStmts stmts) :
-    BridgedStmts (.expr (.call "sstore" [.lit slot, valExpr]) :: stmts) :=
+    BridgedStmts (.exprStmt (.call "sstore" [.lit slot, valExpr]) :: stmts) :=
   BridgedStmts_cons
     (bridgedStmt_sstore_lit_of_bridged_val slot valExpr hVal) hStmts
 
 theorem BridgedStmts_singleton_sstore_ident
     (slotName : String) (valExpr : Compiler.Yul.YulExpr) (hVal : BridgedExpr valExpr) :
-    BridgedStmts [.expr (.call "sstore" [.ident slotName, valExpr])] :=
+    BridgedStmts [.exprStmt (.call "sstore" [.ident slotName, valExpr])] :=
   BridgedStmts_singleton
     (bridgedStmt_sstore_ident_of_bridged_val slotName valExpr hVal)
 
 theorem BridgedStmts_cons_sstore_ident
     (slotName : String) (valExpr : Compiler.Yul.YulExpr) (hVal : BridgedExpr valExpr)
     {stmts : List Compiler.Yul.YulStmt} (hStmts : BridgedStmts stmts) :
-    BridgedStmts (.expr (.call "sstore" [.ident slotName, valExpr]) :: stmts) :=
+    BridgedStmts (.exprStmt (.call "sstore" [.ident slotName, valExpr]) :: stmts) :=
   BridgedStmts_cons
     (bridgedStmt_sstore_ident_of_bridged_val slotName valExpr hVal) hStmts
 
@@ -813,7 +813,7 @@ theorem BridgedStmts_singleton_sstore_mapping
     (hBase : BridgedExpr baseExpr) (hKey : BridgedExpr keyExpr)
     (hVal : BridgedExpr valExpr) :
     BridgedStmts
-      [.expr (.call "sstore" [.call "mappingSlot" [baseExpr, keyExpr], valExpr])] :=
+      [.exprStmt (.call "sstore" [.call "mappingSlot" [baseExpr, keyExpr], valExpr])] :=
   BridgedStmts_singleton
     (bridgedStmt_sstore_mapping_of_bridged_args
       baseExpr keyExpr valExpr hBase hKey hVal)
@@ -824,7 +824,7 @@ theorem BridgedStmts_cons_sstore_mapping
     (hVal : BridgedExpr valExpr)
     {stmts : List Compiler.Yul.YulStmt} (hStmts : BridgedStmts stmts) :
     BridgedStmts
-      (.expr (.call "sstore" [.call "mappingSlot" [baseExpr, keyExpr], valExpr])
+      (.exprStmt (.call "sstore" [.call "mappingSlot" [baseExpr, keyExpr], valExpr])
         :: stmts) :=
   BridgedStmts_cons
     (bridgedStmt_sstore_mapping_of_bridged_args
@@ -834,7 +834,7 @@ theorem BridgedStmts_singleton_log
     (func : String) (args : List Compiler.Yul.YulExpr)
     (hLog : isYulLogName func = true)
     (hArgs : ∀ arg ∈ args, BridgedExpr arg) :
-    BridgedStmts [.expr (.call func args)] :=
+    BridgedStmts [.exprStmt (.call func args)] :=
   BridgedStmts_singleton
     (bridgedStmt_log_of_bridged_args func args hLog hArgs)
 
@@ -843,7 +843,7 @@ theorem BridgedStmts_cons_log
     (hLog : isYulLogName func = true)
     (hArgs : ∀ arg ∈ args, BridgedExpr arg)
     {stmts : List Compiler.Yul.YulStmt} (hStmts : BridgedStmts stmts) :
-    BridgedStmts (.expr (.call func args) :: stmts) :=
+    BridgedStmts (.exprStmt (.call func args) :: stmts) :=
   BridgedStmts_cons
     (bridgedStmt_log_of_bridged_args func args hLog hArgs) hStmts
 

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanCallClosure.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanCallClosure.lean
@@ -5,7 +5,7 @@
   families that are currently carved out of `compileStmtList_always_bridged`:
 
   - `internalCall` — Verity helper invoked as a statement, compiles to
-    `YulStmt.expr (YulExpr.call <internal_name> args)`.
+    `YulStmt.exprStmt (YulExpr.call <internal_name> args)`.
   - `internalCallAssign` — same with multi-value binding, compiles to
     `YulStmt.letMany names (YulExpr.call <internal_name> args)`.
   - `externalCallBind` — typed external contract call, compiles to either
@@ -61,7 +61,7 @@ inductive BridgedUserFunctionCall
       (hFn : (BridgedFunctionTable.lookup table funcName).isSome) :
       BridgedUserFunctionCall table (.call funcName args)
 
-/-- Statement-level closure: a `YulStmt.expr (.call <user_fn> args)` invocation
+/-- Statement-level closure: a `YulStmt.exprStmt (.call <user_fn> args)` invocation
 where args satisfy `BridgedExpr` and the callee resolves in `table`. Captures
 the compiled shape of `Stmt.internalCall` and the no-result variant of
 `Stmt.externalCallBind`. -/
@@ -69,7 +69,7 @@ inductive BridgedUserFunctionCallExpr
     (table : BridgedFunctionTable) : YulStmt → Prop
   | mk (funcName : String) (args : List YulExpr)
       (hCall : BridgedUserFunctionCall table (.call funcName args)) :
-      BridgedUserFunctionCallExpr table (.expr (.call funcName args))
+      BridgedUserFunctionCallExpr table (.exprStmt (.call funcName args))
 
 /-- Statement-level closure: a `YulStmt.letMany names (.call <user_fn> args)`
 binding where args satisfy `BridgedExpr` and the callee resolves in `table`.
@@ -363,7 +363,7 @@ theorem compileStmtList_internalCall_bridged
 /-! ## Phase 2.3: source-level closure for `Stmt.externalCallBind`
 
 `Stmt.externalCallBind resultVars externalName args` compiles to either
-`YulStmt.expr (YulExpr.call externalName argExprs)` (when `resultVars = []`)
+`YulStmt.exprStmt (YulExpr.call externalName argExprs)` (when `resultVars = []`)
 or `YulStmt.letMany resultVars (YulExpr.call externalName argExprs)`.  In
 both shapes the callee is the literal `externalName` (no `internal_` prefix)
 and resolves directly in the function table. -/
@@ -381,7 +381,7 @@ inductive BridgedSourceExternalCallBindStmt
 
 /-- Phase 2.3: compiling a source `Stmt.externalCallBind` with bridged
 arguments and a callee that resolves in `table` yields a `BridgedStmts`
-output. Branches on whether `resultVars` is empty (the `.expr` shape) or
+output. Branches on whether `resultVars` is empty (the `.exprStmt` shape) or
 not (the `.letMany` shape). -/
 theorem compileStmt_externalCallBind_bridged
     {table : BridgedFunctionTable}

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness/Base.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness/Base.lean
@@ -9425,7 +9425,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_call_of_b
         Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call func args)) = .ok (native, finalSwitchId))
+        (.exprStmt (.call func args)) = .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
       (some
@@ -11370,7 +11370,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_stop
     (nativeStmt : EvmYul.Yul.Ast.Stmt)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "stop" [])) = .ok (native, finalSwitchId))
+        (.exprStmt (.call "stop" [])) = .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
       (some
@@ -11398,7 +11398,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_log0
         Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "log0" args)) = .ok (native, finalSwitchId))
+        (.exprStmt (.call "log0" args)) = .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native)
     (hShape :
       ∀ fuel state,
@@ -11443,7 +11443,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_log1
         Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "log1" args)) = .ok (native, finalSwitchId))
+        (.exprStmt (.call "log1" args)) = .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native)
     (hShape :
       ∀ fuel state,
@@ -11488,7 +11488,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_log2
         Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "log2" args)) = .ok (native, finalSwitchId))
+        (.exprStmt (.call "log2" args)) = .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native)
     (hShape :
       ∀ fuel state,
@@ -11533,7 +11533,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_log3
         Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "log3" args)) = .ok (native, finalSwitchId))
+        (.exprStmt (.call "log3" args)) = .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native)
     (hShape :
       ∀ fuel state,
@@ -11578,7 +11578,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_log4
         Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "log4" args)) = .ok (native, finalSwitchId))
+        (.exprStmt (.call "log4" args)) = .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native)
     (hShape :
       ∀ fuel state,
@@ -11623,7 +11623,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_log0_of_n
         Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "log0" args)) = .ok (native, finalSwitchId))
+        (.exprStmt (.call "log0" args)) = .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
       (some
@@ -11655,7 +11655,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_log1_of_n
         Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "log1" args)) = .ok (native, finalSwitchId))
+        (.exprStmt (.call "log1" args)) = .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
       (some
@@ -11687,7 +11687,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_log2_of_n
         Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "log2" args)) = .ok (native, finalSwitchId))
+        (.exprStmt (.call "log2" args)) = .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
       (some
@@ -11719,7 +11719,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_log3_of_n
         Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "log3" args)) = .ok (native, finalSwitchId))
+        (.exprStmt (.call "log3" args)) = .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
       (some
@@ -11751,7 +11751,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_log4_of_n
         Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "log4" args)) = .ok (native, finalSwitchId))
+        (.exprStmt (.call "log4" args)) = .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
       (some
@@ -11782,7 +11782,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_mstore
     (hVal : Compiler.Proofs.YulGeneration.Backends.BridgedExpr valExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "mstore" [offsetExpr, valExpr])) =
+        (.exprStmt (.call "mstore" [offsetExpr, valExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native)
     (hShape :
@@ -11833,7 +11833,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_mstore_of
     (hVal : Compiler.Proofs.YulGeneration.Backends.BridgedExpr valExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "mstore" [offsetExpr, valExpr])) =
+        (.exprStmt (.call "mstore" [offsetExpr, valExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
@@ -11871,7 +11871,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_mstore8
     (hVal : Compiler.Proofs.YulGeneration.Backends.BridgedExpr valExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "mstore8" [offsetExpr, valExpr])) =
+        (.exprStmt (.call "mstore8" [offsetExpr, valExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native)
     (hShape :
@@ -11922,7 +11922,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_mstore8_o
     (hVal : Compiler.Proofs.YulGeneration.Backends.BridgedExpr valExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "mstore8" [offsetExpr, valExpr])) =
+        (.exprStmt (.call "mstore8" [offsetExpr, valExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
@@ -11960,7 +11960,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_sstore
     (hVal : Compiler.Proofs.YulGeneration.Backends.BridgedExpr valExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "sstore" [slotExpr, valExpr])) =
+        (.exprStmt (.call "sstore" [slotExpr, valExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native)
     (hShape :
@@ -12011,7 +12011,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_sstore_of
     (hVal : Compiler.Proofs.YulGeneration.Backends.BridgedExpr valExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "sstore" [slotExpr, valExpr])) =
+        (.exprStmt (.call "sstore" [slotExpr, valExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
@@ -12049,7 +12049,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_tstore
     (hVal : Compiler.Proofs.YulGeneration.Backends.BridgedExpr valExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "tstore" [slotExpr, valExpr])) =
+        (.exprStmt (.call "tstore" [slotExpr, valExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native)
     (hShape :
@@ -12100,7 +12100,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_tstore_of
     (hVal : Compiler.Proofs.YulGeneration.Backends.BridgedExpr valExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "tstore" [slotExpr, valExpr])) =
+        (.exprStmt (.call "tstore" [slotExpr, valExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
@@ -12138,7 +12138,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_return
     (hSize : Compiler.Proofs.YulGeneration.Backends.BridgedExpr sizeExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "return" [offsetExpr, sizeExpr])) =
+        (.exprStmt (.call "return" [offsetExpr, sizeExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native)
     (hShape :
@@ -12189,7 +12189,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_return_of
     (hSize : Compiler.Proofs.YulGeneration.Backends.BridgedExpr sizeExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "return" [offsetExpr, sizeExpr])) =
+        (.exprStmt (.call "return" [offsetExpr, sizeExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
@@ -12227,7 +12227,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_revert
     (hSize : Compiler.Proofs.YulGeneration.Backends.BridgedExpr sizeExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "revert" [offsetExpr, sizeExpr])) =
+        (.exprStmt (.call "revert" [offsetExpr, sizeExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native)
     (hShape :
@@ -12278,7 +12278,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_revert_of
     (hSize : Compiler.Proofs.YulGeneration.Backends.BridgedExpr sizeExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "revert" [offsetExpr, sizeExpr])) =
+        (.exprStmt (.call "revert" [offsetExpr, sizeExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
@@ -12317,7 +12317,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_calldatac
     (hSize : Compiler.Proofs.YulGeneration.Backends.BridgedExpr sizeExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "calldatacopy" [destOffset, sourceOffset, sizeExpr])) =
+        (.exprStmt (.call "calldatacopy" [destOffset, sourceOffset, sizeExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native)
     (hShape :
@@ -12371,7 +12371,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_returndat
     (hSize : Compiler.Proofs.YulGeneration.Backends.BridgedExpr sizeExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "returndatacopy" [destOffset, sourceOffset, sizeExpr])) =
+        (.exprStmt (.call "returndatacopy" [destOffset, sourceOffset, sizeExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native)
     (hShape :
@@ -12425,7 +12425,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_calldatac
     (hSize : Compiler.Proofs.YulGeneration.Backends.BridgedExpr sizeExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "calldatacopy" [destOffset, sourceOffset, sizeExpr])) =
+        (.exprStmt (.call "calldatacopy" [destOffset, sourceOffset, sizeExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
@@ -12465,7 +12465,7 @@ theorem NativeStmtPreservesWord_lowerStmtGroupNativeWithSwitchIds_expr_returndat
     (hSize : Compiler.Proofs.YulGeneration.Backends.BridgedExpr sizeExpr)
     (hLower :
       Backends.lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId
-        (.expr (.call "returndatacopy" [destOffset, sourceOffset, sizeExpr])) =
+        (.exprStmt (.call "returndatacopy" [destOffset, sourceOffset, sizeExpr])) =
           .ok (native, finalSwitchId))
     (hMem : nativeStmt ∈ native) :
     NativeStmtPreservesWord name expected nativeStmt
@@ -12508,72 +12508,72 @@ inductive NativePreservableStraightStmt : YulStmt → Prop
       (hArgs :
         ∀ arg, arg ∈ args →
           Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg) :
-      NativePreservableStraightStmt (.expr (.call func args))
+      NativePreservableStraightStmt (.exprStmt (.call func args))
   | expr_sstore (slotExpr valExpr : YulExpr)
       (hSlot : Compiler.Proofs.YulGeneration.Backends.BridgedExpr slotExpr)
       (hVal : Compiler.Proofs.YulGeneration.Backends.BridgedExpr valExpr) :
-      NativePreservableStraightStmt (.expr (.call "sstore" [slotExpr, valExpr]))
+      NativePreservableStraightStmt (.exprStmt (.call "sstore" [slotExpr, valExpr]))
   | expr_tstore (slotExpr valExpr : YulExpr)
       (hSlot : Compiler.Proofs.YulGeneration.Backends.BridgedExpr slotExpr)
       (hVal : Compiler.Proofs.YulGeneration.Backends.BridgedExpr valExpr) :
-      NativePreservableStraightStmt (.expr (.call "tstore" [slotExpr, valExpr]))
+      NativePreservableStraightStmt (.exprStmt (.call "tstore" [slotExpr, valExpr]))
   | expr_mstore (offsetExpr valExpr : YulExpr)
       (hOffset : Compiler.Proofs.YulGeneration.Backends.BridgedExpr offsetExpr)
       (hVal : Compiler.Proofs.YulGeneration.Backends.BridgedExpr valExpr) :
-      NativePreservableStraightStmt (.expr (.call "mstore" [offsetExpr, valExpr]))
+      NativePreservableStraightStmt (.exprStmt (.call "mstore" [offsetExpr, valExpr]))
   | expr_mstore8 (offsetExpr valExpr : YulExpr)
       (hOffset : Compiler.Proofs.YulGeneration.Backends.BridgedExpr offsetExpr)
       (hVal : Compiler.Proofs.YulGeneration.Backends.BridgedExpr valExpr) :
-      NativePreservableStraightStmt (.expr (.call "mstore8" [offsetExpr, valExpr]))
+      NativePreservableStraightStmt (.exprStmt (.call "mstore8" [offsetExpr, valExpr]))
   | expr_stop :
-      NativePreservableStraightStmt (.expr (.call "stop" []))
+      NativePreservableStraightStmt (.exprStmt (.call "stop" []))
   | expr_return (offsetExpr sizeExpr : YulExpr)
       (hOffset : Compiler.Proofs.YulGeneration.Backends.BridgedExpr offsetExpr)
       (hSize : Compiler.Proofs.YulGeneration.Backends.BridgedExpr sizeExpr) :
       NativePreservableStraightStmt
-        (.expr (.call "return" [offsetExpr, sizeExpr]))
+        (.exprStmt (.call "return" [offsetExpr, sizeExpr]))
   | expr_revert (offsetExpr sizeExpr : YulExpr)
       (hOffset : Compiler.Proofs.YulGeneration.Backends.BridgedExpr offsetExpr)
       (hSize : Compiler.Proofs.YulGeneration.Backends.BridgedExpr sizeExpr) :
       NativePreservableStraightStmt
-        (.expr (.call "revert" [offsetExpr, sizeExpr]))
+        (.exprStmt (.call "revert" [offsetExpr, sizeExpr]))
   | expr_log0 (args : List YulExpr)
       (hArgs :
         ∀ arg, arg ∈ args →
           Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg) :
-      NativePreservableStraightStmt (.expr (.call "log0" args))
+      NativePreservableStraightStmt (.exprStmt (.call "log0" args))
   | expr_log1 (args : List YulExpr)
       (hArgs :
         ∀ arg, arg ∈ args →
           Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg) :
-      NativePreservableStraightStmt (.expr (.call "log1" args))
+      NativePreservableStraightStmt (.exprStmt (.call "log1" args))
   | expr_log2 (args : List YulExpr)
       (hArgs :
         ∀ arg, arg ∈ args →
           Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg) :
-      NativePreservableStraightStmt (.expr (.call "log2" args))
+      NativePreservableStraightStmt (.exprStmt (.call "log2" args))
   | expr_log3 (args : List YulExpr)
       (hArgs :
         ∀ arg, arg ∈ args →
           Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg) :
-      NativePreservableStraightStmt (.expr (.call "log3" args))
+      NativePreservableStraightStmt (.exprStmt (.call "log3" args))
   | expr_log4 (args : List YulExpr)
       (hArgs :
         ∀ arg, arg ∈ args →
           Compiler.Proofs.YulGeneration.Backends.BridgedExpr arg) :
-      NativePreservableStraightStmt (.expr (.call "log4" args))
+      NativePreservableStraightStmt (.exprStmt (.call "log4" args))
   | expr_calldatacopy (destOffset sourceOffset sizeExpr : YulExpr)
       (hDest : Compiler.Proofs.YulGeneration.Backends.BridgedExpr destOffset)
       (hSource : Compiler.Proofs.YulGeneration.Backends.BridgedExpr sourceOffset)
       (hSize : Compiler.Proofs.YulGeneration.Backends.BridgedExpr sizeExpr) :
       NativePreservableStraightStmt
-        (.expr (.call "calldatacopy" [destOffset, sourceOffset, sizeExpr]))
+        (.exprStmt (.call "calldatacopy" [destOffset, sourceOffset, sizeExpr]))
   | expr_returndatacopy (destOffset sourceOffset sizeExpr : YulExpr)
       (hDest : Compiler.Proofs.YulGeneration.Backends.BridgedExpr destOffset)
       (hSource : Compiler.Proofs.YulGeneration.Backends.BridgedExpr sourceOffset)
       (hSize : Compiler.Proofs.YulGeneration.Backends.BridgedExpr sizeExpr) :
       NativePreservableStraightStmt
-        (.expr (.call "returndatacopy" [destOffset, sourceOffset, sizeExpr]))
+        (.exprStmt (.call "returndatacopy" [destOffset, sourceOffset, sizeExpr]))
 
 /-- Mapping-free straight statements whose lowered native form preserves a
 marker word for the actual runtime contract.
@@ -12600,66 +12600,66 @@ inductive NativeMappingFreePreservableStraightStmt : YulStmt → Prop
       (hName : Compiler.Proofs.YulGeneration.Backends.allowedExprCallName func)
       (hNoMapping : func ≠ "mappingSlot")
       (hArgs : ∀ arg, arg ∈ args → NativeMappingFreeBridgedExpr arg) :
-      NativeMappingFreePreservableStraightStmt (.expr (.call func args))
+      NativeMappingFreePreservableStraightStmt (.exprStmt (.call func args))
   | expr_sstore (slotExpr valExpr : YulExpr)
       (hSlot : NativeMappingFreeBridgedExpr slotExpr)
       (hVal : NativeMappingFreeBridgedExpr valExpr) :
       NativeMappingFreePreservableStraightStmt
-        (.expr (.call "sstore" [slotExpr, valExpr]))
+        (.exprStmt (.call "sstore" [slotExpr, valExpr]))
   | expr_tstore (slotExpr valExpr : YulExpr)
       (hSlot : NativeMappingFreeBridgedExpr slotExpr)
       (hVal : NativeMappingFreeBridgedExpr valExpr) :
       NativeMappingFreePreservableStraightStmt
-        (.expr (.call "tstore" [slotExpr, valExpr]))
+        (.exprStmt (.call "tstore" [slotExpr, valExpr]))
   | expr_mstore (offsetExpr valExpr : YulExpr)
       (hOffset : NativeMappingFreeBridgedExpr offsetExpr)
       (hVal : NativeMappingFreeBridgedExpr valExpr) :
       NativeMappingFreePreservableStraightStmt
-        (.expr (.call "mstore" [offsetExpr, valExpr]))
+        (.exprStmt (.call "mstore" [offsetExpr, valExpr]))
   | expr_mstore8 (offsetExpr valExpr : YulExpr)
       (hOffset : NativeMappingFreeBridgedExpr offsetExpr)
       (hVal : NativeMappingFreeBridgedExpr valExpr) :
       NativeMappingFreePreservableStraightStmt
-        (.expr (.call "mstore8" [offsetExpr, valExpr]))
+        (.exprStmt (.call "mstore8" [offsetExpr, valExpr]))
   | expr_stop :
-      NativeMappingFreePreservableStraightStmt (.expr (.call "stop" []))
+      NativeMappingFreePreservableStraightStmt (.exprStmt (.call "stop" []))
   | expr_return (offsetExpr sizeExpr : YulExpr)
       (hOffset : NativeMappingFreeBridgedExpr offsetExpr)
       (hSize : NativeMappingFreeBridgedExpr sizeExpr) :
       NativeMappingFreePreservableStraightStmt
-        (.expr (.call "return" [offsetExpr, sizeExpr]))
+        (.exprStmt (.call "return" [offsetExpr, sizeExpr]))
   | expr_revert (offsetExpr sizeExpr : YulExpr)
       (hOffset : NativeMappingFreeBridgedExpr offsetExpr)
       (hSize : NativeMappingFreeBridgedExpr sizeExpr) :
       NativeMappingFreePreservableStraightStmt
-        (.expr (.call "revert" [offsetExpr, sizeExpr]))
+        (.exprStmt (.call "revert" [offsetExpr, sizeExpr]))
   | expr_log0 (args : List YulExpr)
       (hArgs : ∀ arg, arg ∈ args → NativeMappingFreeBridgedExpr arg) :
-      NativeMappingFreePreservableStraightStmt (.expr (.call "log0" args))
+      NativeMappingFreePreservableStraightStmt (.exprStmt (.call "log0" args))
   | expr_log1 (args : List YulExpr)
       (hArgs : ∀ arg, arg ∈ args → NativeMappingFreeBridgedExpr arg) :
-      NativeMappingFreePreservableStraightStmt (.expr (.call "log1" args))
+      NativeMappingFreePreservableStraightStmt (.exprStmt (.call "log1" args))
   | expr_log2 (args : List YulExpr)
       (hArgs : ∀ arg, arg ∈ args → NativeMappingFreeBridgedExpr arg) :
-      NativeMappingFreePreservableStraightStmt (.expr (.call "log2" args))
+      NativeMappingFreePreservableStraightStmt (.exprStmt (.call "log2" args))
   | expr_log3 (args : List YulExpr)
       (hArgs : ∀ arg, arg ∈ args → NativeMappingFreeBridgedExpr arg) :
-      NativeMappingFreePreservableStraightStmt (.expr (.call "log3" args))
+      NativeMappingFreePreservableStraightStmt (.exprStmt (.call "log3" args))
   | expr_log4 (args : List YulExpr)
       (hArgs : ∀ arg, arg ∈ args → NativeMappingFreeBridgedExpr arg) :
-      NativeMappingFreePreservableStraightStmt (.expr (.call "log4" args))
+      NativeMappingFreePreservableStraightStmt (.exprStmt (.call "log4" args))
   | expr_calldatacopy (destOffset sourceOffset sizeExpr : YulExpr)
       (hDest : NativeMappingFreeBridgedExpr destOffset)
       (hSource : NativeMappingFreeBridgedExpr sourceOffset)
       (hSize : NativeMappingFreeBridgedExpr sizeExpr) :
       NativeMappingFreePreservableStraightStmt
-        (.expr (.call "calldatacopy" [destOffset, sourceOffset, sizeExpr]))
+        (.exprStmt (.call "calldatacopy" [destOffset, sourceOffset, sizeExpr]))
   | expr_returndatacopy (destOffset sourceOffset sizeExpr : YulExpr)
       (hDest : NativeMappingFreeBridgedExpr destOffset)
       (hSource : NativeMappingFreeBridgedExpr sourceOffset)
       (hSize : NativeMappingFreeBridgedExpr sizeExpr) :
       NativeMappingFreePreservableStraightStmt
-        (.expr (.call "returndatacopy" [destOffset, sourceOffset, sizeExpr]))
+        (.exprStmt (.call "returndatacopy" [destOffset, sourceOffset, sizeExpr]))
 
 def NativeMappingFreePreservableStraightStmts (stmts : List YulStmt) : Prop :=
   ∀ stmt, stmt ∈ stmts → NativeMappingFreePreservableStraightStmt stmt
@@ -12718,28 +12718,28 @@ def NativeMappingFreeSideConditionForBridgedStraightStmt :
       targets ≠ [] ∧ NativeMappingFreeBridgedExpr value
   | .assign _ value =>
       NativeMappingFreeSideConditionForBridgedExpr value
-  | .expr (.call "sstore" [.call "mappingSlot" _, _]) => False
-  | .expr (.call "sstore" [.lit _, valExpr]) =>
+  | .exprStmt (.call "sstore" [.call "mappingSlot" _, _]) => False
+  | .exprStmt (.call "sstore" [.lit _, valExpr]) =>
       NativeMappingFreeSideConditionForBridgedExpr valExpr
-  | .expr (.call "sstore" [.ident _, valExpr]) =>
+  | .exprStmt (.call "sstore" [.ident _, valExpr]) =>
       NativeMappingFreeSideConditionForBridgedExpr valExpr
-  | .expr (.call "sstore" [.call "add" [leftExpr, rightExpr], valExpr]) =>
+  | .exprStmt (.call "sstore" [.call "add" [leftExpr, rightExpr], valExpr]) =>
       NativeMappingFreeSideConditionForBridgedExpr leftExpr ∧
         NativeMappingFreeSideConditionForBridgedExpr rightExpr ∧
         NativeMappingFreeSideConditionForBridgedExpr valExpr
-  | .expr (.call "mstore" [offsetExpr, valExpr]) =>
+  | .exprStmt (.call "mstore" [offsetExpr, valExpr]) =>
       NativeMappingFreeSideConditionForBridgedExpr offsetExpr ∧
         NativeMappingFreeSideConditionForBridgedExpr valExpr
-  | .expr (.call "tstore" [offsetExpr, valExpr]) =>
+  | .exprStmt (.call "tstore" [offsetExpr, valExpr]) =>
       NativeMappingFreeSideConditionForBridgedExpr offsetExpr ∧
         NativeMappingFreeSideConditionForBridgedExpr valExpr
-  | .expr (.call "return" [offsetExpr, sizeExpr]) =>
+  | .exprStmt (.call "return" [offsetExpr, sizeExpr]) =>
       NativeMappingFreeSideConditionForBridgedExpr offsetExpr ∧
         NativeMappingFreeSideConditionForBridgedExpr sizeExpr
-  | .expr (.call "revert" [offsetExpr, sizeExpr]) =>
+  | .exprStmt (.call "revert" [offsetExpr, sizeExpr]) =>
       NativeMappingFreeBridgedExpr offsetExpr ∧
         NativeMappingFreeBridgedExpr sizeExpr
-  | .expr (.call func args) =>
+  | .exprStmt (.call func args) =>
       Compiler.Proofs.YulGeneration.isYulLogName func = true →
         ∀ arg, arg ∈ args → NativeMappingFreeSideConditionForBridgedExpr arg
   | .«leave» => False
@@ -12913,7 +12913,7 @@ def NativePreservableSideConditionForBridgedStraightStmt :
   | .letMany targets value =>
       targets ≠ [] ∧
         Compiler.Proofs.YulGeneration.Backends.BridgedExpr value
-  | .expr (.call "revert" [offsetExpr, sizeExpr]) =>
+  | .exprStmt (.call "revert" [offsetExpr, sizeExpr]) =>
       Compiler.Proofs.YulGeneration.Backends.BridgedExpr offsetExpr ∧
         Compiler.Proofs.YulGeneration.Backends.BridgedExpr sizeExpr
   | .«leave» => False

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeLowering.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeLowering.lean
@@ -159,7 +159,7 @@ mutual
     | .let_ name value => name :: yulExprIdentifierNames value
     | .letMany names value => names ++ yulExprIdentifierNames value
     | .assign name value => name :: yulExprIdentifierNames value
-    | .expr e => yulExprIdentifierNames e
+    | .exprStmt e => yulExprIdentifierNames e
     | .if_ cond body => yulExprIdentifierNames cond ++ yulStmtsIdentifierNames body
     | .for_ init cond post body =>
         yulStmtsIdentifierNames init ++
@@ -184,7 +184,7 @@ def collectYulStmtWriteNames
 
 mutual
 def yulStmtWriteNames : YulStmt → List String
-  | .comment _ | .expr _ | .leave => []
+  | .comment _ | .exprStmt _ | .leave => []
   | .let_ name _ => [name]
   | .letMany names _ => names
   | .assign name _ => [name]
@@ -388,7 +388,7 @@ def lowerStmtGroupNativeWithSwitchIds
   | .let_ name value => pure ([.Let [name] (some (lowerExprNative value))], nextSwitchId)
   | .letMany names value => pure ([.Let names (some (lowerExprNative value))], nextSwitchId)
   | .assign name value => pure ([lowerAssignNative name value], nextSwitchId)
-  | .expr e => pure ([.ExprStmtCall (lowerExprNative e)], nextSwitchId)
+  | .exprStmt e => pure ([.ExprStmtCall (lowerExprNative e)], nextSwitchId)
   | .leave => pure ([.Leave], nextSwitchId)
   | .if_ cond body => do
       let (body', nextSwitchId) ← lowerStmtsNativeWithSwitchIds reservedNames nextSwitchId body
@@ -688,7 +688,7 @@ theorem lowerSwitchCasesNativeWithSwitchIds_length_eq
     (reservedNames : List String)
     (nextSwitchId : Nat)
     (e : YulExpr) :
-    lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId (.expr e) =
+    lowerStmtGroupNativeWithSwitchIds reservedNames nextSwitchId (.exprStmt e) =
       .ok ([.ExprStmtCall (lowerExprNative e)], nextSwitchId) :=
   lowerStmtGroupNativeWithSwitchIds.eq_5 reservedNames nextSwitchId e
 

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativePrimOps.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativePrimOps.lean
@@ -2309,7 +2309,7 @@ theorem nativeMappingSlotFunctionDefinition_exec_revivable
     native statement used by the selector-miss execution lemma. -/
 theorem lowerStmtsNative_revert_zero_zero :
     Backends.lowerStmtsNative
-      [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])] =
+      [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])] =
       .ok [nativeRevertZeroZeroStmt] := by
   simp [Backends.lowerStmtsNative, Backends.lowerStmtsNativeWithSwitchIds,
     nativeRevertZeroZeroStmt, Backends.lowerExprNative,

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeState.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeState.lean
@@ -286,7 +286,7 @@ theorem lowerStmtGroupNativeWithSwitchIds_ok_of_yulStmtContainsFuncDef_false
   | let_ name value => simp
   | letMany names value => simp
   | assign name value => simp
-  | expr e => simp
+  | exprStmt e => simp
   | «leave» => simp
   | if_ cond body =>
       have hBody : yulStmtsContainFuncDef body = false := by

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeState.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeState.lean
@@ -72,7 +72,7 @@ mutual
     | .let_ _ value => yulExprLiteralStorageReadSlots value
     | .letMany _ value => yulExprLiteralStorageReadSlots value
     | .assign _ value => yulExprLiteralStorageReadSlots value
-    | .expr e => yulExprLiteralStorageReadSlots e
+    | .exprStmt e => yulExprLiteralStorageReadSlots e
     | .if_ cond body =>
         yulExprLiteralStorageReadSlots cond ++ yulStmtsLiteralStorageReadSlots body
     | .for_ init cond post body =>
@@ -132,7 +132,7 @@ mutual
     | .let_ _ value => yulExprUsesBuiltinExceptFunctions builtin functionNames value
     | .letMany _ value => yulExprUsesBuiltinExceptFunctions builtin functionNames value
     | .assign _ value => yulExprUsesBuiltinExceptFunctions builtin functionNames value
-    | .expr e => yulExprUsesBuiltinExceptFunctions builtin functionNames e
+    | .exprStmt e => yulExprUsesBuiltinExceptFunctions builtin functionNames e
     | .if_ cond body =>
         yulExprUsesBuiltinExceptFunctions builtin functionNames cond ||
           yulStmtsUseBuiltinExceptFunctions builtin functionNames body
@@ -164,7 +164,7 @@ mutual
     | .let_ _ value => yulExprCalledFunctions value
     | .letMany _ value => yulExprCalledFunctions value
     | .assign _ value => yulExprCalledFunctions value
-    | .expr e => yulExprCalledFunctions e
+    | .exprStmt e => yulExprCalledFunctions e
     | .if_ cond body => yulExprCalledFunctions cond ++ yulStmtsCalledFunctions body
     | .for_ init cond post body =>
         yulStmtsCalledFunctions init ++
@@ -223,7 +223,7 @@ mutual
           | some stmts => yulStmtsContainFuncDef stmts
           | none => false
     | .block stmts => yulStmtsContainFuncDef stmts
-    | .comment _ | .let_ _ _ | .letMany _ _ | .assign _ _ | .expr _ | .leave => false
+    | .comment _ | .let_ _ _ | .letMany _ _ | .assign _ _ | .exprStmt _ | .leave => false
 
   def yulStmtsContainFuncDef : List YulStmt → Bool
     | [] => false
@@ -1232,7 +1232,7 @@ theorem lowerStmtsNativeWithSwitchIds_switchCaseBody_payable_eq
       (Yul.YulExpr.call "lt"
         [Yul.YulExpr.call "calldatasize" [],
          Yul.YulExpr.lit (4 + fn.params.length * 32)])
-      [YulStmt.expr (Yul.YulExpr.call "revert" [Yul.YulExpr.lit 0,
+      [YulStmt.exprStmt (Yul.YulExpr.call "revert" [Yul.YulExpr.lit 0,
         Yul.YulExpr.lit 0])]
       fn.body afterComment next hAfterComment with
     ⟨guardBody, bodyStart, bodyNative, hAfterCommentShape, _hGuard,
@@ -1284,7 +1284,7 @@ theorem lowerStmtsNativeWithSwitchIds_switchCaseBody_nonpayable_eq
   rcases lowerStmtsNativeWithSwitchIds_if_head_eq
       reservedNames n0
       (Yul.YulExpr.call "callvalue" [])
-      [YulStmt.expr (Yul.YulExpr.call "revert" [Yul.YulExpr.lit 0,
+      [YulStmt.exprStmt (Yul.YulExpr.call "revert" [Yul.YulExpr.lit 0,
         Yul.YulExpr.lit 0])]
       (Compiler.CodegenCommon.calldatasizeGuard fn.params.length :: fn.body)
       afterComment next hAfterComment with
@@ -1295,7 +1295,7 @@ theorem lowerStmtsNativeWithSwitchIds_switchCaseBody_nonpayable_eq
       (Yul.YulExpr.call "lt"
         [Yul.YulExpr.call "calldatasize" [],
          Yul.YulExpr.lit (4 + fn.params.length * 32)])
-      [YulStmt.expr (Yul.YulExpr.call "revert" [Yul.YulExpr.lit 0,
+      [YulStmt.exprStmt (Yul.YulExpr.call "revert" [Yul.YulExpr.lit 0,
         Yul.YulExpr.lit 0])]
       fn.body afterCallvalue next hAfterCallvalue with
     ⟨calldataGuardBody, bodyStart, bodyNative, hAfterCallvalueShape,
@@ -1409,7 +1409,7 @@ without advancing the native switch counter. -/
 theorem lowerStmtsNativeWithSwitchIds_revert_zero_zero
     (reservedNames : List String) (n : Nat) :
     Backends.lowerStmtsNativeWithSwitchIds reservedNames n
-        [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])] =
+        [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])] =
       .ok ([nativeRevertZeroZeroStmt], n) := by
   simp [Backends.lowerStmtsNativeWithSwitchIds, nativeRevertZeroZeroStmt,
     Backends.lowerExprNative, Backends.lookupRuntimePrimOp]
@@ -1456,7 +1456,7 @@ theorem lowerStmtsNativeWithSwitchIds_switchCaseBody_payable_revert_eq
       (Yul.YulExpr.call "lt"
         [Yul.YulExpr.call "calldatasize" [],
          Yul.YulExpr.lit (4 + fn.params.length * 32)])
-      [YulStmt.expr (Yul.YulExpr.call "revert" [Yul.YulExpr.lit 0,
+      [YulStmt.exprStmt (Yul.YulExpr.call "revert" [Yul.YulExpr.lit 0,
         Yul.YulExpr.lit 0])]
       fn.body afterComment next hAfterComment with
     ⟨guardBody, bodyStart, bodyNative, hAfterCommentShape, hGuard,
@@ -1534,7 +1534,7 @@ theorem lowerStmtsNativeWithSwitchIds_switchCaseBody_nonpayable_revert_eq
   rcases lowerStmtsNativeWithSwitchIds_if_head_eq
       reservedNames n0
       (Yul.YulExpr.call "callvalue" [])
-      [YulStmt.expr (Yul.YulExpr.call "revert" [Yul.YulExpr.lit 0,
+      [YulStmt.exprStmt (Yul.YulExpr.call "revert" [Yul.YulExpr.lit 0,
         Yul.YulExpr.lit 0])]
       (Compiler.CodegenCommon.calldatasizeGuard fn.params.length :: fn.body)
       afterComment next hAfterComment with
@@ -1545,7 +1545,7 @@ theorem lowerStmtsNativeWithSwitchIds_switchCaseBody_nonpayable_revert_eq
       (Yul.YulExpr.call "lt"
         [Yul.YulExpr.call "calldatasize" [],
          Yul.YulExpr.lit (4 + fn.params.length * 32)])
-      [YulStmt.expr (Yul.YulExpr.call "revert" [Yul.YulExpr.lit 0,
+      [YulStmt.exprStmt (Yul.YulExpr.call "revert" [Yul.YulExpr.lit 0,
         Yul.YulExpr.lit 0])]
       fn.body afterCallvalue next hAfterCallvalue with
     ⟨calldataGuardBody, bodyStart, bodyNative, hAfterCallvalueShape,
@@ -1726,7 +1726,7 @@ theorem lowerStmtsNativeWithSwitchIds_singleton_switch_revert_default_eq
     (inner : List EvmYul.Yul.Ast.Stmt) (next : Nat)
     (h : Backends.lowerStmtsNativeWithSwitchIds reservedNames n0
             [YulStmt.switch expr cases
-              (some [YulStmt.expr (YulExpr.call "revert"
+              (some [YulStmt.exprStmt (YulExpr.call "revert"
                 [YulExpr.lit 0, YulExpr.lit 0])])] = .ok (inner, next)) :
     ∃ (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)),
       inner = [Backends.lowerNativeSwitchBlock expr
@@ -1758,7 +1758,7 @@ theorem lowerStmtsNativeWithSwitchIds_singleton_switch_revert_default_eq_sourceL
     (inner : List EvmYul.Yul.Ast.Stmt) (next : Nat)
     (h : Backends.lowerStmtsNativeWithSwitchIds reservedNames n0
             [YulStmt.switch expr cases
-              (some [YulStmt.expr (YulExpr.call "revert"
+              (some [YulStmt.exprStmt (YulExpr.call "revert"
                 [YulExpr.lit 0, YulExpr.lit 0])])] = .ok (inner, next)) :
     ∃ (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) (midN : Nat),
       inner = [Backends.lowerNativeSwitchBlock expr
@@ -2218,9 +2218,9 @@ theorem lowerFunctionDefinitionNativeWithReserved_mappingSlotFuncAt_zero_body
     (globalReservedNames : List String) :
     Backends.lowerFunctionDefinitionNativeWithReserved
       globalReservedNames ["baseSlot", "key"] ["slot"]
-      [YulStmt.expr
+      [YulStmt.exprStmt
         (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.ident "key"]),
-       YulStmt.expr
+       YulStmt.exprStmt
         (YulExpr.call "mstore"
           [YulExpr.lit (0 + 32), YulExpr.ident "baseSlot"]),
        YulStmt.assign "slot"
@@ -2279,8 +2279,8 @@ theorem lowerRuntimeContractNative_emitYul_mapping_noInternals_noFallback_noRece
         Backends.lowerStmtsNativeWithSwitchIds
         (Backends.yulStmtsIdentifierNames
           [YulStmt.funcDef "mappingSlot" ["baseSlot", "key"] ["slot"]
-              [YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.ident "key"]),
-                YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 32, YulExpr.ident "baseSlot"]),
+              [YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.ident "key"]),
+                YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 32, YulExpr.ident "baseSlot"]),
                 YulStmt.assign "slot" (YulExpr.call "keccak256" [YulExpr.lit 0, YulExpr.lit 64])],
             Compiler.CodegenCommon.initFreeMemoryPointer,
             Compiler.CodegenCommon.buildSwitch contract.functions none none])

--- a/Compiler/Proofs/YulGeneration/RuntimeTypes.lean
+++ b/Compiler/Proofs/YulGeneration/RuntimeTypes.lean
@@ -75,7 +75,7 @@ These are `Bool`-valued so compiler-generated fragments can discharge them
 automatically via `rfl`. -/
 mutual
 def yulStmtLoopFree : YulStmt → Bool
-  | .comment _ | .let_ _ _ | .letMany _ _ | .assign _ _ | .expr _ | .leave => true
+  | .comment _ | .let_ _ _ | .letMany _ _ | .assign _ _ | .exprStmt _ | .leave => true
   | .if_ _ body => yulStmtsLoopFree body
   | .for_ _ _ _ _ => false
   | .switch _ cases defaultCase =>

--- a/Compiler/TypedIRLowering.lean
+++ b/Compiler/TypedIRLowering.lean
@@ -59,20 +59,20 @@ where
   lowerTStmt : TStmt → List YulStmt
     | .let_ dst rhs => [.let_ (tVarName dst) (lowerTExpr rhs)]
     | .assign dst rhs => [.assign (tVarName dst) (lowerTExpr rhs)]
-    | .setStorage slot value => [.expr (.call "sstore" [.lit slot, lowerTExpr value])]
-    | .setStorageAddr slot value => [.expr (.call "sstore" [.lit slot, lowerTExpr value])]
-    | .setStorageWord slot value => [.expr (.call "sstore" [.lit slot, lowerTExpr value])]
+    | .setStorage slot value => [.exprStmt (.call "sstore" [.lit slot, lowerTExpr value])]
+    | .setStorageAddr slot value => [.exprStmt (.call "sstore" [.lit slot, lowerTExpr value])]
+    | .setStorageWord slot value => [.exprStmt (.call "sstore" [.lit slot, lowerTExpr value])]
     | .setMapping slot key value =>
-        [ .expr (.call "sstore"
+        [ .exprStmt (.call "sstore"
             [.call "mappingSlot" [.lit slot, lowerTExpr key], lowerTExpr value])
         ]
     | .setMapping2 slot key1 key2 value =>
         let innerSlot := .call "mappingSlot" [.lit slot, lowerTExpr key1]
-        [ .expr (.call "sstore"
+        [ .exprStmt (.call "sstore"
             [.call "mappingSlot" [innerSlot, lowerTExpr key2], lowerTExpr value])
         ]
     | .setMappingUint slot key value =>
-        [ .expr (.call "sstore"
+        [ .exprStmt (.call "sstore"
             [.call "mappingSlot" [.lit slot, lowerTExpr key], lowerTExpr value])
         ]
     | .if_ cond thenBranch elseBranch =>
@@ -84,24 +84,24 @@ where
             [(1, lowerTStmts thenBranch)]
             (some (lowerTStmts elseBranch))
         ]
-    | .stop => [.expr (.call "stop" [])]
+    | .stop => [.exprStmt (.call "stop" [])]
     | .returnUint value =>
-        [ .expr (.call "mstore" [.lit 0, lowerTExpr value])
-        , .expr (.call "return" [.lit 0, .lit 32])
+        [ .exprStmt (.call "mstore" [.lit 0, lowerTExpr value])
+        , .exprStmt (.call "return" [.lit 0, .lit 32])
         ]
     | .returnAddr value =>
-        [ .expr (.call "mstore" [.lit 0, lowerTExpr value])
-        , .expr (.call "return" [.lit 0, .lit 32])
+        [ .exprStmt (.call "mstore" [.lit 0, lowerTExpr value])
+        , .exprStmt (.call "return" [.lit 0, .lit 32])
         ]
-    | .expr value => [.expr (lowerTExpr value)]
+    | .exprStmt value => [.exprStmt (lowerTExpr value)]
     | .emit eventName topics =>
-        [ .expr (.call s!"log{topics.length + 1}"
+        [ .exprStmt (.call s!"log{topics.length + 1}"
             ([.lit 0, .lit 0, .lit (typedEventNameTopicWord eventName)] ++ topics.map lowerTExpr))
         ]
     | .rawLog topics dataOffset dataSize =>
-        [ .expr (.call s!"log{topics.length}" ([lowerTExpr dataOffset, lowerTExpr dataSize] ++ topics.map lowerTExpr))
+        [ .exprStmt (.call s!"log{topics.length}" ([lowerTExpr dataOffset, lowerTExpr dataSize] ++ topics.map lowerTExpr))
         ]
-    | .revert _reason => [.expr (.call "revert" [.lit 0, .lit 0])]
+    | .revert _reason => [.exprStmt (.call "revert" [.lit 0, .lit 0])]
 
 /-- Lower a typed IR block into Yul statements for the existing IR/Yul backend. -/
 def lowerTBlock (block : TBlock) : List YulStmt :=

--- a/Compiler/Yul/PatchFramework.lean
+++ b/Compiler/Yul/PatchFramework.lean
@@ -330,9 +330,9 @@ private def rewriteStmtOnce
   | .assign name value =>
       let (value', hits) := rewriteExprOnce orderedExprRules ctx value
       applyStmtRulesToCandidate orderedStmtRules ctx (.assign name value') hits
-  | .expr expr =>
+  | .exprStmt expr =>
       let (expr', hits) := rewriteExprOnce orderedExprRules ctx expr
-      applyStmtRulesToCandidate orderedStmtRules ctx (.expr expr') hits
+      applyStmtRulesToCandidate orderedStmtRules ctx (.exprStmt expr') hits
   | .leave =>
       applyStmtRulesToCandidate orderedStmtRules ctx .leave []
   | .if_ cond body =>

--- a/Compiler/Yul/PatchRulesCatalog/Base.lean
+++ b/Compiler/Yul/PatchRulesCatalog/Base.lean
@@ -237,7 +237,7 @@ partial def callNamesInStmt : YulStmt → List String
   | .let_ _ value => callNamesInExpr value
   | .letMany _ value => callNamesInExpr value
   | .assign _ value => callNamesInExpr value
-  | .expr value => callNamesInExpr value
+  | .exprStmt value => callNamesInExpr value
   | .leave => []
   | .if_ cond body =>
       unionUniqueStrings (callNamesInExpr cond) (callNamesInStmts body)
@@ -263,7 +263,7 @@ partial def callNamesInStmts : List YulStmt → List String
 
 private partial def callNamesInStmtNoFuncDefs : YulStmt → List String
   | .comment _ => []
-  | .expr expr => callNamesInExpr expr
+  | .exprStmt expr => callNamesInExpr expr
   | .let_ _ expr => callNamesInExpr expr
   | .letMany _ expr => callNamesInExpr expr
   | .assign _ expr => callNamesInExpr expr
@@ -416,7 +416,7 @@ partial def renameCallsInStmt (renames : List (String × String)) : YulStmt → 
   | .let_ name value => .let_ name (renameCallsInExpr renames value)
   | .letMany names value => .letMany names (renameCallsInExpr renames value)
   | .assign name value => .assign name (renameCallsInExpr renames value)
-  | .expr value => .expr (renameCallsInExpr renames value)
+  | .exprStmt value => .exprStmt (renameCallsInExpr renames value)
   | .leave => .leave
   | .if_ cond body =>
       .if_ (renameCallsInExpr renames cond) (renameCallsInStmts renames body)
@@ -496,7 +496,7 @@ private partial def outlineDispatchCasesInStmt
     | .let_ name value => (.let_ name value, [], knownDefs)
     | .letMany names value => (.letMany names value, [], knownDefs)
     | .assign name value => (.assign name value, [], knownDefs)
-    | .expr value => (.expr value, [], knownDefs)
+    | .exprStmt value => (.exprStmt value, [], knownDefs)
     | .leave => (.leave, [], knownDefs)
     | .if_ cond body =>
         let (body', defs, knownDefs') := outlineDispatchCasesInStmts knownDefs body
@@ -533,7 +533,7 @@ private partial def outlineDispatchCasesInStmt
                       else
                         let defs' := appendUniqueHelperDef nestedMerged helperName restBody
                         let known' := appendUniqueString knownWithNested helperName
-                        rewriteCases rest known' ((tag, [.expr (.call helperName [])]) :: accCases) defs'
+                        rewriteCases rest known' ((tag, [.exprStmt (.call helperName [])]) :: accCases) defs'
                   | none =>
                       rewriteCases rest knownWithNested ((tag, body') :: accCases) nestedMerged
               | _ =>
@@ -600,7 +600,7 @@ private partial def inlineDispatchWrapperCallsInStmt
     | .let_ name value => (.let_ name value, 0)
     | .letMany names value => (.letMany names value, 0)
     | .assign name value => (.assign name value, 0)
-    | .expr value => (.expr value, 0)
+    | .exprStmt value => (.exprStmt value, 0)
     | .leave => (.leave, 0)
     | .if_ cond body =>
         let (body', rewritten) := inlineDispatchWrapperCallsInStmts helpers body
@@ -614,7 +614,7 @@ private partial def inlineDispatchWrapperCallsInStmt
         let rewriteCase := fun (entry : Nat × List YulStmt) =>
           let (tag, body) := entry
           match body with
-          | [.expr (.call helperName [])] =>
+          | [.exprStmt (.call helperName [])] =>
               if helperName.startsWith "fun_" then
                 match helperBodyForName? helpers helperName with
                 | some helperBody => ((tag, helperBody), 1)

--- a/Compiler/Yul/PrettyPrint.lean
+++ b/Compiler/Yul/PrettyPrint.lean
@@ -39,7 +39,7 @@ def ppStmt (indent : Nat) : YulStmt → List String
       [s!"{indentStr indent}let {", ".intercalate names} := {ppExpr value}"]
   | YulStmt.assign name value =>
       [s!"{indentStr indent}{name} := {ppExpr value}"]
-  | YulStmt.expr e =>
+  | YulStmt.exprStmt e =>
       [s!"{indentStr indent}{ppExpr e}"]
   | YulStmt.leave =>
       [s!"{indentStr indent}leave"]

--- a/Contracts/Smoke/MultiArgIntrinsicSmoke.lean
+++ b/Contracts/Smoke/MultiArgIntrinsicSmoke.lean
@@ -15,11 +15,15 @@
   arities, real Yul opcodes / builtins, and proper refinement obligations.
 -/
 import Contracts.Common
+import Compiler.CompilationModel
+import Compiler.CompilationModel.ExpressionCompile
 
 namespace Contracts.Smoke
 
 open Verity hiding pure bind
 open Verity.EVM.Uint256
+open Compiler.Yul
+open Compiler.CompilationModel
 
 -- Two-argument intrinsic: returns the sum (toy semantics).
 verity_intrinsic addPair (a : Uint256, b : Uint256) : Uint256
@@ -81,5 +85,142 @@ verity_intrinsic addViaBuiltinArityMismatch (a : Uint256, b : Uint256, c : Uint2
         min_fork := osaka;
         semantics := (fun a b c => Verity.Core.Uint256.ofNat ((a.val + b.val + c.val) % (2 ^ 256)));
         obligation [add_via_builtin_mismatch := assumed "negative coverage; never elaborated"]
+
+-- Four-argument template intrinsic: the body is typed Yul AST and intentionally
+-- unchecked by Verity beyond arity/shape. The explicit assumed obligation marks
+-- the refinement proof that consumers must discharge or continue to trust.
+verity_intrinsic entryPointPackInnerCalldata (sender : Uint256, gasLimit : Uint256, callDataOffset : Uint256, callDataLength : Uint256) : Uint256
+  where pure;
+        yul := [template (sender, gasLimit, callDataOffset, callDataLength) -> packed := [
+          yulcall mstore(0, sender),
+          let head := add(sender, gasLimit),
+          packed := add(head, add(callDataOffset, callDataLength))
+        ]];
+        min_fork := osaka;
+        semantics := (fun sender gasLimit callDataOffset callDataLength =>
+          Verity.Core.Uint256.ofNat ((sender.val + gasLimit.val + callDataOffset.val + callDataLength.val) % (2 ^ 256)));
+        obligation [entry_point_pack_template_refines_yul := assumed "template Yul body is unchecked; ERC-4337 consumer must prove or trust this lowering"]
+
+example :
+    (entryPointPackInnerCalldata
+      (Verity.Core.Uint256.ofNat 1)
+      (Verity.Core.Uint256.ofNat 2)
+      (Verity.Core.Uint256.ofNat 3)
+      (Verity.Core.Uint256.ofNat 4)).val = 10 := by
+  native_decide
+
+private def templateLowering : Verity.Core.Intrinsics.YulLowering :=
+  Verity.Core.Intrinsics.YulLowering.template
+    ["sender", "gasLimit", "callDataOffset", "callDataLength"]
+    "packed"
+    [
+      YulStmt.exprStmt
+        (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.ident "sender"]),
+      YulStmt.let_ "head"
+        (YulExpr.call "add" [YulExpr.ident "sender", YulExpr.ident "gasLimit"]),
+      YulStmt.assign "packed"
+        (YulExpr.call "add" [
+          YulExpr.ident "head",
+          YulExpr.call "add" [YulExpr.ident "callDataOffset", YulExpr.ident "callDataLength"]
+        ])
+    ]
+
+def templateIntrinsicCompilesToHelperCall : Bool :=
+  match Compiler.CompilationModel.compileExpr [] .calldata
+      (Compiler.CompilationModel.Expr.intrinsic
+        "entryPointPackInnerCalldata"
+        templateLowering
+        Verity.Core.Intrinsics.HardFork.osaka
+        [ Compiler.CompilationModel.Expr.param "sender"
+        , Compiler.CompilationModel.Expr.param "gasLimit"
+        , Compiler.CompilationModel.Expr.param "callDataOffset"
+        , Compiler.CompilationModel.Expr.param "callDataLength"
+        ]) with
+  | .ok (YulExpr.call "__verity_intrinsic_template_entryPointPackInnerCalldata"
+      [YulExpr.ident "sender", YulExpr.ident "gasLimit", YulExpr.ident "callDataOffset", YulExpr.ident "callDataLength"]) => true
+  | _ => false
+
+example : templateIntrinsicCompilesToHelperCall = true := by
+  native_decide
+
+private def templateIntrinsicModel : CompilationModel := {
+  name := "TemplateIntrinsicModel"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "pack"
+      params := [
+        { name := "sender", ty := ParamType.uint256 },
+        { name := "gasLimit", ty := ParamType.uint256 },
+        { name := "callDataOffset", ty := ParamType.uint256 },
+        { name := "callDataLength", ty := ParamType.uint256 }
+      ]
+      returnType := some FieldType.uint256
+      body := [
+        Stmt.return
+          (Expr.intrinsic
+            "entryPointPackInnerCalldata"
+            templateLowering
+            Verity.Core.Intrinsics.HardFork.osaka
+            [ Expr.param "sender"
+            , Expr.param "gasLimit"
+            , Expr.param "callDataOffset"
+            , Expr.param "callDataLength"
+            ])
+      ]
+    }
+  ]
+}
+
+def templateIntrinsicCompilationEmitsHelper : Bool :=
+  match Compiler.CompilationModel.compile templateIntrinsicModel [0] with
+  | .ok contract =>
+      contract.internalFunctions.any fun
+        | YulStmt.funcDef "__verity_intrinsic_template_entryPointPackInnerCalldata"
+            ["sender", "gasLimit", "callDataOffset", "callDataLength"]
+            ["packed"]
+            [
+              YulStmt.exprStmt
+                (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.ident "sender"]),
+              YulStmt.let_ "head"
+                (YulExpr.call "add" [YulExpr.ident "sender", YulExpr.ident "gasLimit"]),
+              YulStmt.assign "packed"
+                (YulExpr.call "add" [
+                  YulExpr.ident "head",
+                  YulExpr.call "add" [YulExpr.ident "callDataOffset", YulExpr.ident "callDataLength"]
+                ])
+            ] => true
+        | _ => false
+  | .error _ => false
+
+example : templateIntrinsicCompilationEmitsHelper = true := by
+  native_decide
+
+/--
+error: verity_intrinsic `template` parameter 'wrongName' does not match declared parameter 'gasLimit'
+-/
+#guard_msgs in
+verity_intrinsic entryPointPackTemplateParamMismatch (sender : Uint256, gasLimit : Uint256) : Uint256
+  where pure;
+        yul := [template (sender, wrongName) -> packed := []];
+        min_fork := osaka;
+        semantics := (fun sender gasLimit => Verity.Core.Uint256.ofNat ((sender.val + gasLimit.val) % (2 ^ 256)));
+        obligation [entry_point_pack_template_mismatch := assumed "negative coverage; never elaborated"]
+
+def templateIntrinsicRejectsWrongArity : Bool :=
+  match Compiler.CompilationModel.compileExpr [] .calldata
+      (Compiler.CompilationModel.Expr.intrinsic
+        "entryPointPackInnerCalldata"
+        templateLowering
+        Verity.Core.Intrinsics.HardFork.osaka
+        [ Compiler.CompilationModel.Expr.param "sender"
+        , Compiler.CompilationModel.Expr.param "gasLimit"
+        , Compiler.CompilationModel.Expr.param "callDataOffset"
+        ]) with
+  | .error "Compilation error: intrinsic entryPointPackInnerCalldata template expects 4 arg(s), got 3" => true
+  | _ => false
+
+example : templateIntrinsicRejectsWrongArity = true := by
+  native_decide
 
 end Contracts.Smoke

--- a/Contracts/TypedIRTests.lean
+++ b/Contracts/TypedIRTests.lean
@@ -30,7 +30,7 @@ private def tVarIdNamed? (vars : List TVar) (name : String) : Option Nat :=
 
 private def returnedWordName? : List Compiler.Yul.YulStmt → Option String
   | [] => none
-  | .expr (.call "mstore" [.lit 0, .ident name]) :: .expr (.call "return" [.lit 0, .lit 32]) :: _ =>
+  | .exprStmt (.call "mstore" [.lit 0, .ident name]) :: .exprStmt (.call "return" [.lit 0, .lit 32]) :: _ =>
       some name
   | _ :: rest => returnedWordName? rest
 
@@ -150,8 +150,8 @@ def compileChainidLoweringShapeOk : Bool :=
       contains rendered "returnUint" &&
       contains rendered "chainid" &&
       match lowerTStmts st.2.body.toList with
-      | [ .expr (.call "mstore" [.lit 0, .call "chainid" []])
-        , .expr (.call "return" [.lit 0, .lit 32]) ] => true
+      | [ .exprStmt (.call "mstore" [.lit 0, .call "chainid" []])
+        , .exprStmt (.call "return" [.lit 0, .lit 32]) ] => true
       | _ => false
   | .error _ => false
 
@@ -298,7 +298,7 @@ def compileRawLogLoweringShapeOk : Bool :=
         (Compiler.CompilationModel.Expr.literal 64)]).run {} with
   | .ok st =>
       match lowerTStmts st.2.body.toList with
-      | [.expr (.call "log2" [.lit 0, .lit 64, .lit 1, .lit 2])] => true
+      | [.exprStmt (.call "log2" [.lit 0, .lit 64, .lit 1, .lit 2])] => true
       | _ => false
   | .error _ => false
 
@@ -345,7 +345,7 @@ def compileEmitLoweringShapeOk : Bool :=
         [Compiler.CompilationModel.Expr.literal 1, Compiler.CompilationModel.Expr.literal 2]]).run {} with
   | .ok st =>
       match lowerTStmts st.2.body.toList with
-      | [.expr (.call "log3" [.lit 0, .lit 0, .lit _, .lit 1, .lit 2])] => true
+      | [.exprStmt (.call "log3" [.lit 0, .lit 0, .lit _, .lit 1, .lit 2])] => true
       | _ => false
   | .error _ => false
 
@@ -362,8 +362,8 @@ def compileEmitEncodesDistinctTopic0 : Bool :=
         ]]).run {} with
   | .ok st1, .ok st2 =>
       match lowerTStmts st1.2.body.toList, lowerTStmts st2.2.body.toList with
-      | [.expr (.call "log3" [.lit 0, .lit 0, .lit t1, .lit 1, .lit 2])],
-        [.expr (.call "log3" [.lit 0, .lit 0, .lit t2, .lit 1, .lit 2])] => t1 != t2
+      | [.exprStmt (.call "log3" [.lit 0, .lit 0, .lit t1, .lit 1, .lit 2])],
+        [.exprStmt (.call "log3" [.lit 0, .lit 0, .lit t2, .lit 1, .lit 2])] => t1 != t2
       | _, _ => false
   | _, _ => false
 
@@ -547,19 +547,19 @@ example :
 /-- Lowering emits `log2` for typed raw logs with two topics. -/
 example :
     lowerTStmts [TStmt.rawLog [TExpr.uintLit 1, TExpr.uintLit 2] (TExpr.uintLit 0) (TExpr.uintLit 64)] =
-      [.expr (.call "log2" [.lit 0, .lit 64, .lit 1, .lit 2])] := by
+      [.exprStmt (.call "log2" [.lit 0, .lit 64, .lit 1, .lit 2])] := by
   rfl
 
 /-- Lowering emits `log0` when the topic list is empty. -/
 example :
     lowerTStmts [TStmt.rawLog [] (TExpr.uintLit 0) (TExpr.uintLit 32)] =
-      [.expr (.call "log0" [.lit 0, .lit 32])] := by
+      [.exprStmt (.call "log0" [.lit 0, .lit 32])] := by
   rfl
 
 /-- Lowering emits `log3` for typed `emit` with two indexed args. -/
 example :
     lowerTStmts [TStmt.emit "Transfer" [TExpr.uintLit 1, TExpr.uintLit 2]] =
-      [.expr (.call "log3" [.lit 0, .lit 0, .lit (typedEventNameTopicWord "Transfer"), .lit 1, .lit 2])] := by
+      [.exprStmt (.call "log3" [.lit 0, .lit 0, .lit (typedEventNameTopicWord "Transfer"), .lit 1, .lit 2])] := by
   rfl
 
 def counterTmp : TVar := { id := 10, ty := .uint256 }
@@ -578,7 +578,7 @@ def counterIncrementTBlock : TBlock where
 def counterIncrementIR : List YulStmt :=
   [ .let_ "tmp" (.call "sload" [.lit 0])
   , .assign "tmp" (.call "add" [.ident "tmp", .lit 1])
-  , .expr (.call "sstore" [.lit 0, .ident "tmp"])
+  , .exprStmt (.call "sstore" [.lit 0, .ident "tmp"])
   ]
 
 def counterTypedInitWorld : Verity.ContractState :=
@@ -638,7 +638,7 @@ def simpleStorageStoreTBlock : TBlock where
 
 /-- Existing untyped IR program equivalent to `simpleStorageStoreTBlock`. -/
 def simpleStorageStoreIR : List YulStmt :=
-  [ .expr (.call "sstore" [.lit 0, .ident "value"]) ]
+  [ .exprStmt (.call "sstore" [.lit 0, .ident "value"]) ]
 
 def simpleStorageTypedInitWorld : Verity.ContractState :=
   { «storage» := fun i => if i = 0 then 5 else 0
@@ -1571,8 +1571,8 @@ def compiledAddressHelpersSmokeGetDelegateBody : Bool :=
       match block.params, lowerTStmts block.body with
       | [ownerParam],
         [ .let_ delegateName delegateRead
-        , .expr (.call "mstore" [.lit 0, .ident delegateName'])
-        , .expr (.call "return" [.lit 0, .lit 32])
+        , .exprStmt (.call "mstore" [.lit 0, .ident delegateName'])
+        , .exprStmt (.call "return" [.lit 0, .lit 32])
         ] =>
             isMappingLoadExpr 0 (tVarName ownerParam) delegateRead &&
             delegateName' == delegateName
@@ -1632,8 +1632,8 @@ def compiledAddressHelpersSmokeGetOwnerForIdBody : Bool :=
       match block.params, lowerTStmts block.body with
       | [tokenParam],
         [ .let_ ownerName ownerRead
-        , .expr (.call "mstore" [.lit 0, .ident ownerName'])
-        , .expr (.call "return" [.lit 0, .lit 32])
+        , .exprStmt (.call "mstore" [.lit 0, .ident ownerName'])
+        , .exprStmt (.call "return" [.lit 0, .lit 32])
         ] =>
             isMappingLoadExpr 1 (tVarName tokenParam) ownerRead &&
             ownerName' == ownerName
@@ -3081,14 +3081,14 @@ example : erc20MintNonOwnerAgreement = true := by
 /-- Recognize the lowered owner-existence guard emitted from `not (owner == 0)`. -/
 def isOwnerExistsSwitch (ownerName : String) : Compiler.Yul.YulStmt → Bool
   | .switch (.call "iszero" [.call "eq" [.ident ownerName', .lit 0]])
-      [(1, [])] (some [.expr (.call "revert" [.lit 0, .lit 0])]) =>
+      [(1, [])] (some [.exprStmt (.call "revert" [.lit 0, .lit 0])]) =>
       ownerName' == ownerName
   | _ => false
 
 /-- Recognize the lowered owner-match guard emitted from `addrToUint(ownerAddr) == ownerWord`. -/
 def isOwnerMatchSwitch (ownerAddrName ownerWordName : String) : Compiler.Yul.YulStmt → Bool
   | .switch (.call "eq" [.ident ownerAddrName', .ident ownerWordName'])
-      [(1, [])] (some [.expr (.call "revert" [.lit 0, .lit 0])]) =>
+      [(1, [])] (some [.exprStmt (.call "revert" [.lit 0, .lit 0])]) =>
       ownerAddrName' == ownerAddrName && ownerWordName' == ownerWordName
   | _ => false
 
@@ -3103,8 +3103,8 @@ def compiledERC721GetApprovedHasExpectedBody : Bool :=
         [ .let_ ownerWordName ownerRead
         , ownerExistsGuard
         , .let_ approvedWordName approvalRead
-        , .expr (.call "mstore" [.lit 0, .ident approvedWordName'])
-        , .expr (.call "return" [.lit 0, .lit 32])
+        , .exprStmt (.call "mstore" [.lit 0, .ident approvedWordName'])
+        , .exprStmt (.call "return" [.lit 0, .lit 32])
         ] =>
             let tokenName := tVarName tokenIdParam
             isMappingLoadExpr 4 tokenName ownerRead &&
@@ -3178,9 +3178,9 @@ def compiledERC721ApproveHasExpectedBody : Bool :=
         , ownerExistsGuard
         , .let_ ownerAddrName (.ident senderWordName')
         , ownerMatchGuard
-        , .expr (.call "sstore"
+        , .exprStmt (.call "sstore"
             [.call "mappingSlot" [.lit 5, .ident tokenName'], .ident approvedName'])
-        , .expr (.call "stop" [])
+        , .exprStmt (.call "stop" [])
         ] =>
             let tokenName := tVarName tokenIdParam
             let approvedName := tVarName approvedParam

--- a/Verity/Core/Free/TypedIR.lean
+++ b/Verity/Core/Free/TypedIR.lean
@@ -65,7 +65,7 @@ inductive TStmt where
   | stop
   | returnUint (value : TExpr .uint256)
   | returnAddr (value : TExpr .address)
-  | expr (value : TExpr .unit)
+  | exprStmt (value : TExpr .unit)
   | emit (eventName : String) (topics : List (TExpr .uint256))
   | rawLog (topics : List (TExpr .uint256)) (dataOffset dataSize : TExpr .uint256)
   | revert (reason : String)
@@ -248,7 +248,7 @@ def evalTStmtFuel : Nat → TExecState → TStmt → TExecResult
   | Nat.succ _, s, .stop => .ok s
   | Nat.succ _, s, .returnUint _ => .ok s
   | Nat.succ _, s, .returnAddr _ => .ok s
-  | Nat.succ _, s, .expr value =>
+  | Nat.succ _, s, .exprStmt value =>
       let _ := evalTExpr s value
       .ok s
   | Nat.succ _, s, .emit eventName topics =>

--- a/Verity/Core/Intrinsics.lean
+++ b/Verity/Core/Intrinsics.lean
@@ -1,3 +1,5 @@
+import Verity.Core.Model.Yul.Ast
+
 /-!
 Verity.Core.Intrinsics
 
@@ -8,6 +10,8 @@ See docs/INTRINSICS.md and plan.md for usage and trust model.
 -/
 
 namespace Verity.Core.Intrinsics
+
+open Compiler.Yul
 
 /-- Hard fork levels used for `min_fork` guards on intrinsics.
 
@@ -83,23 +87,35 @@ inductive YulLowering where
   | verbatim (inArity outArity : Nat) (opcodeHex : String)
   /-- Named Yul builtin (for opcodes Yul names but Verity does not surface as first-class). -/
   | builtin (name : String)
+  /-- Multi-statement expression-position Yul template.
+
+      This first implementation intentionally supports one expression output:
+      it lowers to a generated Yul helper function with `params` as inputs and
+      `output` as its single return variable. The `body` is already-typed Yul
+      AST supplied by the intrinsic declaration, so Verity does not parse or
+      verify the template body beyond arity/shape checks. -/
+  | template (params : List String) (output : String) (body : List YulStmt)
   deriving Repr, BEq
 
 def YulLowering.inputArity : YulLowering → Option Nat
   | .verbatim inArity _ _ => some inArity
   | .builtin _ => none
+  | .template params _ _ => some params.length
 
 def YulLowering.outputArity : YulLowering → Option Nat
   | .verbatim _ outArity _ => some outArity
   | .builtin _ => none
+  | .template _ _ _ => some 1
 
 def YulLowering.callName : YulLowering → String
   | .verbatim inArity outArity _ => s!"verbatim_{inArity}i_{outArity}o"
   | .builtin name => name
+  | .template .. => "__verity_intrinsic_template"
 
 def YulLowering.hexLiteral? : YulLowering → Option String
   | .verbatim _ _ opcodeHex => some s!"hex\"{opcodeHex}\""
   | .builtin _ => none
+  | .template .. => none
 
 def yulBuiltinArity? (name : String) : Option (Nat × Nat) :=
   match name with
@@ -135,10 +151,20 @@ def yulBuiltinArity? (name : String) : Option (Nat × Nat) :=
 def YulLowering.inputArity? : YulLowering → Option Nat
   | .verbatim inArity _ _ => some inArity
   | .builtin name => (yulBuiltinArity? name).map Prod.fst
+  | .template params _ _ => some params.length
 
 def YulLowering.outputArity? : YulLowering → Option Nat
   | .verbatim _ outArity _ => some outArity
   | .builtin name => (yulBuiltinArity? name).map Prod.snd
+  | .template _ _ _ => some 1
+
+def YulLowering.templateHelperName (intrinsicName : String) : String :=
+  s!"__verity_intrinsic_template_{intrinsicName}"
+
+def YulLowering.templateFuncDef? (intrinsicName : String) : YulLowering → Option YulStmt
+  | .template params output body =>
+      some (YulStmt.funcDef (templateHelperName intrinsicName) params [output] body)
+  | _ => none
 
 @[simp] theorem YulLowering.callName_verbatim
     (inArity outArity : Nat) (opcodeHex : String) :

--- a/Verity/Core/Model/ECM.lean
+++ b/Verity/Core/Model/ECM.lean
@@ -224,30 +224,30 @@ def revertWithMessage (message : String) : List YulStmt :=
   let len := bytes.length
   let paddedLen := ((len + 31) / 32) * 32
   let header := [
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit len])
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
+    YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit len])
   ]
   let dataStmts :=
     (chunkBytes32 bytes).zipIdx.map fun (chunk, idx) =>
       let offset := 68 + idx * 32
       let word := wordFromBytes chunk
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit offset, YulExpr.hex word])
+      YulStmt.exprStmt (YulExpr.call "mstore" [YulExpr.lit offset, YulExpr.hex word])
   let totalSize := 68 + paddedLen
-  header ++ dataStmts ++ [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit totalSize])]
+  header ++ dataStmts ++ [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit totalSize])]
 
 /-- Copy dynamic data (calldata or memory) to a destination offset.
     Uses calldatacopy or a memory loop depending on `isDynamicFromCalldata`. -/
 def dynamicCopyData (ctx : CompilationContext)
     (destOffset sourceOffset len : YulExpr) : List YulStmt :=
   if ctx.isDynamicFromCalldata then
-    [YulStmt.expr (YulExpr.call "calldatacopy" [destOffset, sourceOffset, len])]
+    [YulStmt.exprStmt (YulExpr.call "calldatacopy" [destOffset, sourceOffset, len])]
   else
     [YulStmt.for_
       [YulStmt.let_ "__copy_i" (YulExpr.lit 0)]
       (YulExpr.call "lt" [YulExpr.ident "__copy_i", len])
       [YulStmt.assign "__copy_i" (YulExpr.call "add" [YulExpr.ident "__copy_i", YulExpr.lit 32])]
-      [YulStmt.expr (YulExpr.call "mstore" [
+      [YulStmt.exprStmt (YulExpr.call "mstore" [
         YulExpr.call "add" [destOffset, YulExpr.ident "__copy_i"],
         YulExpr.call "mload" [YulExpr.call "add" [sourceOffset, YulExpr.ident "__copy_i"]]
       ])]]

--- a/Verity/Core/Model/Types.lean
+++ b/Verity/Core/Model/Types.lean
@@ -463,7 +463,7 @@ partial def yulStmtScopeEffects : YulStmt → StmtScopeEffects
   | .assign name value =>
       { assignNames := [name]
         storageWrites := if yulExprWritesStorage value then ["<raw-yul-storage-write>"] else [] }
-  | .expr expr =>
+  | .exprStmt expr =>
       { storageWrites := if yulExprWritesStorage expr then ["<raw-yul-storage-write>"] else [] }
   | .if_ cond body =>
       let bodyEffects := yulStmtListScopeEffects body
@@ -530,7 +530,7 @@ partial def yulExprListContainsExternalCall : List YulExpr → Bool
 partial def yulStmtContainsExternalCall : YulStmt → Bool
   | .comment _ | .leave =>
       false
-  | .let_ _ value | .letMany _ value | .assign _ value | .expr value =>
+  | .let_ _ value | .letMany _ value | .assign _ value | .exprStmt value =>
       yulExprContainsExternalCall value
   | .if_ cond body =>
       yulExprContainsExternalCall cond || yulStmtListContainsExternalCall body
@@ -656,7 +656,7 @@ namespace UnsafeYulFragment
 def rawRevert (offset size : YulExpr) (obligation : LocalObligation)
     (label : String := obligation.name) : UnsafeYulFragment := {
   label := label
-  stmts := [YulStmt.expr (YulExpr.call "revert" [offset, size])]
+  stmts := [YulStmt.exprStmt (YulExpr.call "revert" [offset, size])]
   obligations := [obligation]
   contracts := [UnsafeYulContract.rawRevert obligation.name obligation.obligation]
   mechanics := [.rawRevert]

--- a/Verity/Core/Model/Yul/Ast.lean
+++ b/Verity/Core/Model/Yul/Ast.lean
@@ -6,7 +6,7 @@ inductive YulExpr
   | str (s : String)
   | ident (name : String)
   | call (func : String) (args : List YulExpr)
-  deriving Repr
+  deriving Repr, BEq
 
 namespace YulExpr
 
@@ -26,14 +26,14 @@ inductive YulStmt
   | let_ (name : String) (value : YulExpr)
   | letMany (names : List String) (value : YulExpr)
   | assign (name : String) (value : YulExpr)
-  | expr (e : YulExpr)
+  | exprStmt (e : YulExpr)
   | leave
   | if_ (cond : YulExpr) (body : List YulStmt)
   | for_ (init : List YulStmt) (cond : YulExpr) (post : List YulStmt) (body : List YulStmt)
   | switch (expr : YulExpr) (cases : List (Nat × List YulStmt)) (default : Option (List YulStmt))
   | block (stmts : List YulStmt)
   | funcDef (name : String) (params : List String) (rets : List String) (body : List YulStmt)
-  deriving Repr
+  deriving Repr, BEq
 
 structure YulObject where
   name : String

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -14,6 +14,39 @@ open Lean.Elab.Command
 
 set_option hygiene false
 
+partial def parseIntrinsicTemplateExpr (stx : TSyntax `verityIntrinsicTemplateExpr) :
+    CommandElabM Compiler.Yul.YulExpr := do
+  match stx with
+  | `(verityIntrinsicTemplateExpr| $func:ident ( $[$args:verityIntrinsicTemplateExpr],* )) => do
+      pure <| Compiler.Yul.YulExpr.call (toString func.getId)
+        (← args.toList.mapM parseIntrinsicTemplateExpr)
+  | `(verityIntrinsicTemplateExpr| $name:ident) =>
+      pure <| Compiler.Yul.YulExpr.ident (toString name.getId)
+  | `(verityIntrinsicTemplateExpr| $n:num) =>
+      pure <| Compiler.Yul.YulExpr.lit n.getNat
+  | `(verityIntrinsicTemplateExpr| $s:str) =>
+      pure <| Compiler.Yul.YulExpr.str s.getString
+  | _ =>
+      throwErrorAt stx "unsupported intrinsic template expression"
+
+def parseIntrinsicTemplateStmt (stx : TSyntax `verityIntrinsicTemplateStmt) :
+    CommandElabM Compiler.Yul.YulStmt := do
+  match stx with
+  | `(verityIntrinsicTemplateStmt| let $name:ident := $value:verityIntrinsicTemplateExpr) =>
+      pure <| Compiler.Yul.YulStmt.let_ (toString name.getId) (← parseIntrinsicTemplateExpr value)
+  | `(verityIntrinsicTemplateStmt| $name:ident := $value:verityIntrinsicTemplateExpr) =>
+      pure <| Compiler.Yul.YulStmt.assign (toString name.getId) (← parseIntrinsicTemplateExpr value)
+  | `(verityIntrinsicTemplateStmt| yulcall $func:ident ( $[$args:verityIntrinsicTemplateExpr],* )) =>
+      pure <| Compiler.Yul.YulStmt.exprStmt
+        (Compiler.Yul.YulExpr.call (toString func.getId)
+          (← args.toList.mapM parseIntrinsicTemplateExpr))
+  | `(verityIntrinsicTemplateStmt| comment $text:str) =>
+      pure <| Compiler.Yul.YulStmt.comment text.getString
+  | `(verityIntrinsicTemplateStmt| leave) =>
+      pure Compiler.Yul.YulStmt.leave
+  | _ =>
+      throwErrorAt stx "unsupported intrinsic template statement"
+
 @[command_elab verityContractCmd]
 def elabVerityContract : CommandElab := fun stx => do
   let parsed ← parseContractSyntax stx
@@ -190,8 +223,21 @@ def elabVerityIntrinsic : CommandElab := fun stx => do
                   throwErrorAt yul s!"verity_intrinsic `builtin \"{builtinName}\"` expects {inArity} input(s) but {paramNames.size} parameter(s) were declared"
             | none => pure ()
             pure <| Verity.Core.Intrinsics.YulLowering.builtin builtinName
+        | `(verityIntrinsicYul| [template ( $[$templateParams:ident],* ) -> $output:ident := [ $[$body:verityIntrinsicTemplateStmt],* ]]) =>
+            if templateParams.size != paramNames.size then
+              throwErrorAt yul s!"verity_intrinsic `template` input arity {templateParams.size} does not match the {paramNames.size} declared parameter(s)"
+            for pair in templateParams.zip paramNames do
+              let templateParam := toString pair.1.getId
+              let declaredParam := toString pair.2.getId
+              unless templateParam == declaredParam do
+                throwErrorAt pair.1 s!"verity_intrinsic `template` parameter '{templateParam}' does not match declared parameter '{declaredParam}'"
+            let bodyStmts ← body.toList.mapM parseIntrinsicTemplateStmt
+            pure <| Verity.Core.Intrinsics.YulLowering.template
+              (templateParams.toList.map (fun p => toString p.getId))
+              (toString output.getId)
+              bodyStmts
         | _ =>
-            throwErrorAt yul "expected `verbatim <inputs> <outputs> (hex \"...\")` or `builtin \"...\"`"
+            throwErrorAt yul "expected `verbatim <inputs> <outputs> (hex \"...\")`, `builtin \"...\"`, or `[template (<params>) -> <output> := [<statements>]]`"
       let minFork ←
         match Verity.Core.Intrinsics.HardFork.parse? (toString fork.getId) with
         | some parsed => pure parsed

--- a/Verity/Macro/Executable.lean
+++ b/Verity/Macro/Executable.lean
@@ -31,6 +31,73 @@ def hardForkTermFromIdent (fork : TSyntax `ident) : CommandElabM Term := do
       throwErrorAt fork
         s!"unknown fork '{toString fork.getId}' (expected cancun, prague, osaka, or fusaka alias)"
 
+partial def yulExprTerm : Compiler.Yul.YulExpr → CommandElabM Term
+  | .lit n => `(Compiler.Yul.YulExpr.lit $(natTerm n))
+  | .hex n => `(Compiler.Yul.YulExpr.hex $(natTerm n))
+  | .str s => `(Compiler.Yul.YulExpr.str $(strTerm s))
+  | .ident name => `(Compiler.Yul.YulExpr.ident $(strTerm name))
+  | .call func args => do
+      let argTerms ← args.mapM yulExprTerm
+      `(Compiler.Yul.YulExpr.call $(strTerm func) [ $[$argTerms.toArray],* ])
+
+partial def yulStmtTerm : Compiler.Yul.YulStmt → CommandElabM Term
+  | .comment text => `(Compiler.Yul.YulStmt.comment $(strTerm text))
+  | .let_ name value => do
+      let valueTerm ← yulExprTerm value
+      `(Compiler.Yul.YulStmt.let_ $(strTerm name) $valueTerm)
+  | .letMany names value => do
+      let nameTerms := names.map strTerm
+      let valueTerm ← yulExprTerm value
+      `(Compiler.Yul.YulStmt.letMany [ $[$nameTerms.toArray],* ] $valueTerm)
+  | .assign name value => do
+      let valueTerm ← yulExprTerm value
+      `(Compiler.Yul.YulStmt.assign $(strTerm name) $valueTerm)
+  | .exprStmt expr => do
+      let exprTerm ← yulExprTerm expr
+      `(Compiler.Yul.YulStmt.exprStmt $exprTerm)
+  | .leave => `(Compiler.Yul.YulStmt.leave)
+  | .if_ cond body => do
+      let condTerm ← yulExprTerm cond
+      let bodyTerms ← body.mapM yulStmtTerm
+      `(Compiler.Yul.YulStmt.if_ $condTerm [ $[$bodyTerms.toArray],* ])
+  | .for_ init cond post body => do
+      let initTerms ← init.mapM yulStmtTerm
+      let condTerm ← yulExprTerm cond
+      let postTerms ← post.mapM yulStmtTerm
+      let bodyTerms ← body.mapM yulStmtTerm
+      `(Compiler.Yul.YulStmt.for_
+          [ $[$initTerms.toArray],* ]
+          $condTerm
+          [ $[$postTerms.toArray],* ]
+          [ $[$bodyTerms.toArray],* ])
+  | .switch expr cases default => do
+      let exprTerm ← yulExprTerm expr
+      let caseTerms ← cases.mapM fun (tag, body) => do
+        let bodyTerms ← body.mapM yulStmtTerm
+        `(($(natTerm tag), [ $[$bodyTerms.toArray],* ]))
+      let defaultTerm ←
+        match default with
+        | none => `(none)
+        | some body => do
+            let bodyTerms ← body.mapM yulStmtTerm
+            `(some [ $[$bodyTerms.toArray],* ])
+      `(Compiler.Yul.YulStmt.switch
+          $exprTerm
+          [ $[$caseTerms.toArray],* ]
+          $defaultTerm)
+  | .block stmts => do
+      let stmtTerms ← stmts.mapM yulStmtTerm
+      `(Compiler.Yul.YulStmt.block [ $[$stmtTerms.toArray],* ])
+  | .funcDef name params rets body => do
+      let paramTerms := params.map strTerm
+      let retTerms := rets.map strTerm
+      let bodyTerms ← body.mapM yulStmtTerm
+      `(Compiler.Yul.YulStmt.funcDef
+          $(strTerm name)
+          [ $[$paramTerms.toArray],* ]
+          [ $[$retTerms.toArray],* ]
+          [ $[$bodyTerms.toArray],* ])
+
 def yulLoweringTerm (lowering : Verity.Core.Intrinsics.YulLowering) : CommandElabM Term := do
   match lowering with
   | .verbatim inArity outArity opcodeHex =>
@@ -38,5 +105,12 @@ def yulLoweringTerm (lowering : Verity.Core.Intrinsics.YulLowering) : CommandEla
           $(natTerm inArity) $(natTerm outArity) $(strTerm opcodeHex))
   | .builtin name =>
       `(Verity.Core.Intrinsics.YulLowering.builtin $(strTerm name))
+  | .template params output body => do
+      let paramTerms := params.map strTerm
+      let bodyTerms ← body.mapM yulStmtTerm
+      `(Verity.Core.Intrinsics.YulLowering.template
+          [ $[$paramTerms.toArray],* ]
+          $(strTerm output)
+          [ $[$bodyTerms.toArray],* ])
 
 end Verity.Macro

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -38,6 +38,8 @@ declare_syntax_cat verityRoleDecl
 declare_syntax_cat verityFunction
 declare_syntax_cat verityIntrinsicClause
 declare_syntax_cat verityIntrinsicYul
+declare_syntax_cat verityIntrinsicTemplateExpr
+declare_syntax_cat verityIntrinsicTemplateStmt
 declare_syntax_cat verityIntrinsicObligation
 
 syntax ident " : " term " := " "slot" num : verityStorageField
@@ -166,8 +168,19 @@ syntax &"min_fork" " := " ident : verityIntrinsicClause
 syntax &"semantics" " := " term : verityIntrinsicClause
 syntax &"obligation" "[" sepBy(verityIntrinsicObligation, ",") "]" : verityIntrinsicClause
 
+syntax (priority := high) ident "(" sepBy(verityIntrinsicTemplateExpr, ",") ")" : verityIntrinsicTemplateExpr
+syntax ident : verityIntrinsicTemplateExpr
+syntax num : verityIntrinsicTemplateExpr
+syntax str : verityIntrinsicTemplateExpr
+syntax "let " ident " := " verityIntrinsicTemplateExpr : verityIntrinsicTemplateStmt
+syntax ident " := " verityIntrinsicTemplateExpr : verityIntrinsicTemplateStmt
+syntax "yulcall " ident "(" sepBy(verityIntrinsicTemplateExpr, ",") ")" : verityIntrinsicTemplateStmt
+syntax "comment " str : verityIntrinsicTemplateStmt
+syntax "leave" : verityIntrinsicTemplateStmt
+
 syntax ident num num "(" ident str ")" : verityIntrinsicYul
 syntax ident str : verityIntrinsicYul
+syntax "[" &"template" "(" sepBy(ident, ",") ")" " -> " ident " := " "[" sepBy(verityIntrinsicTemplateStmt, ",") "]" "]" : verityIntrinsicYul
 syntax ident " := " ident str : verityIntrinsicObligation
 
 syntax (name := verityIntrinsicCmd)

--- a/artifacts/evmyullean_native_lowering_report.json
+++ b/artifacts/evmyullean_native_lowering_report.json
@@ -146,7 +146,9 @@
     "xor"
   ],
   "missing_expr_cases": [],
-  "missing_stmt_cases": [],
+  "missing_stmt_cases": [
+    "expr"
+  ],
   "native_context_bridge_lemmas": [
     "add",
     "addmod",
@@ -198,7 +200,7 @@
     "assign",
     "block",
     "comment",
-    "expr",
+    "exprStmt",
     "for_",
     "if_",
     "leave",


### PR DESCRIPTION
## Summary
- add `YulLowering.template` for one-output expression-position Yul templates
- lower template intrinsics through generated helper functions and collect helpers during contract compilation
- add `verity_intrinsic` template syntax plus smoke coverage for helper calls, helper emission, arity checks, and parameter-name checks
- rename Yul expression statements from `expr` to `exprStmt` to avoid parser ambiguity after making Yul AST available to core intrinsics

Fixes #2049.

## Verification
- `lake build Contracts.Smoke.MultiArgIntrinsicSmoke Compiler.CompilationModel.Dispatch Compiler.CompilationModel.ExpressionCompile Verity.Macro.Elaborate Verity.Macro.Executable Compiler.Proofs.IRGeneration.IRInterpreter`
- `git diff --check`

## Notes
- `lake build Contracts.TypedIRTests` currently fails before reaching this change because `Contracts.Legacy.SpecAliases.lean` is missing from the worktree.
- A full `Compiler.CompilationModelFeatureTest` run was not used as the final gate because it ran for more than 10 minutes in this workspace; the dedicated smoke target now covers the new helper-emission path directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide mechanical AST rename touches most codegen paths; incorrect missed sites would break compilation. Template helper collection runs on every contract compile and must stay consistent with expression lowering.
> 
> **Overview**
> Adds **Yul template intrinsics**: expression uses compile to a call to a generated `__verity_intrinsic_template_*` helper, and contract compilation walks constructor/function bodies to collect template intrinsics, dedupe them (erroring on conflicting bodies), and prepend emitted helper `funcDef`s to `internalFunctions`.
> 
> Renames side-effect Yul statements from **`YulStmt.expr` to `YulStmt.exprStmt`** across the compiler, tests, and gas/linker/patch passes so the Yul AST can be used from core intrinsics without parser ambiguity. Pattern matches and smoke tests are updated accordingly; intrinsic **template** syntax and smoke coverage live in macro/elaborate paths referenced by the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e664513216bfdef5bcc210336d69aa931056b487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->