### PR TITLE
feat(Intrinsics): multi-statement Yul template intrinsic lowering (#2049)

### DIFF
--- a/Compiler/CompilationModel/ExpressionCompile.lean
+++ b/Compiler/CompilationModel/ExpressionCompile.lean
@@ -591,7 +591,7 @@ def compileExprWithInternals (fields : List Field)
           if args.length != inArity then
             throw s!"Compilation error: intrinsic {name} builtin {builtinName} expects {inArity} arg(s), got {args.length}"
           pure (YulExpr.call builtinName argExprs)
-      | .template params _output _body =>
+      | .template params _output _body _obligations =>
           if args.length != params.length then
             throw s!"Compilation error: intrinsic {name} template expects {params.length} arg(s), got {args.length}"
           pure (YulExpr.call (Verity.Core.Intrinsics.YulLowering.templateHelperName name) argExprs)

--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -20,6 +20,33 @@ private def dedupLocalObligations (items : List LocalObligation) : List LocalObl
     (fun acc item => if acc.any (fun prev => prev.name = item.name) then acc else acc ++ [item])
     []
 
+private def proofStatusFromIntrinsicString : String → Compiler.ProofStatus
+  | "proved" => .proved
+  | "unchecked" => .unchecked
+  | _ => .assumed
+
+private def intrinsicTemplateObligation
+    (entry : String × String × String) : LocalObligation :=
+  { name := entry.1
+    proofStatus := proofStatusFromIntrinsicString entry.2.1
+    obligation := entry.2.2 }
+
+private def collectTemplateIntrinsicObligationsFromExpr (expr : Expr) :
+    List LocalObligation :=
+  let here :=
+    match expr with
+    | .intrinsic _ (.template _ _ _ obligations) _ _ =>
+        obligations.map intrinsicTemplateObligation
+    | _ => []
+  here ++ expr.children.attach.flatMap (fun ⟨child, hchild⟩ =>
+    have := Expr.children_sizeOf_lt expr child hchild
+    collectTemplateIntrinsicObligationsFromExpr child)
+termination_by sizeOf expr
+
+private def collectTemplateIntrinsicObligationsFromMetadata
+    (md : StmtMetadata) : List LocalObligation :=
+  md.subexpressions.flatMap collectTemplateIntrinsicObligationsFromExpr
+
 private def dedupEcmModules (items : List ECM.ExternalCallModule) : List ECM.ExternalCallModule :=
   items.foldl (fun acc item => if acc.contains item then acc else acc ++ [item]) []
 
@@ -717,7 +744,10 @@ private def collectLocalObligationsFromStmts
     (obligations : List LocalObligation)
     (stmts : List Stmt) : List LocalObligation :=
   dedupLocalObligations
-    (obligations ++ Stmt.foldList (fun acc _ md => acc ++ md.localObligations) [] stmts)
+    (obligations ++ Stmt.foldList
+      (fun acc _ md =>
+        acc ++ md.localObligations ++ collectTemplateIntrinsicObligationsFromMetadata md)
+      [] stmts)
 
 private def collectConstructorLocalObligations (spec : CompilationModel) : List LocalObligation :=
   match spec.constructor with

--- a/Contracts/Smoke/MultiArgIntrinsicSmoke.lean
+++ b/Contracts/Smoke/MultiArgIntrinsicSmoke.lean
@@ -17,6 +17,7 @@
 import Contracts.Common
 import Compiler.CompilationModel
 import Compiler.CompilationModel.ExpressionCompile
+import Compiler.CompilationModel.TrustSurface
 
 namespace Contracts.Smoke
 
@@ -99,7 +100,7 @@ verity_intrinsic entryPointPackInnerCalldata (sender : Uint256, gasLimit : Uint2
         min_fork := osaka;
         semantics := (fun sender gasLimit callDataOffset callDataLength =>
           Verity.Core.Uint256.ofNat ((sender.val + gasLimit.val + callDataOffset.val + callDataLength.val) % (2 ^ 256)));
-        obligation [entry_point_pack_template_refines_yul := assumed "template Yul body is unchecked; ERC-4337 consumer must prove or trust this lowering"]
+        obligation [entrypoint_inner_calldata_layout := assumed "template Yul body is unchecked; ERC-4337 consumer must prove or trust this lowering"]
 
 example :
     (entryPointPackInnerCalldata
@@ -124,6 +125,8 @@ private def templateLowering : Verity.Core.Intrinsics.YulLowering :=
           YulExpr.call "add" [YulExpr.ident "callDataOffset", YulExpr.ident "callDataLength"]
         ])
     ]
+    [("entrypoint_inner_calldata_layout", "assumed",
+      "template Yul body is unchecked; ERC-4337 consumer must prove or trust this lowering")]
 
 def templateIntrinsicCompilesToHelperCall : Bool :=
   match Compiler.CompilationModel.compileExpr [] .calldata
@@ -196,6 +199,13 @@ def templateIntrinsicCompilationEmitsHelper : Bool :=
 example : templateIntrinsicCompilationEmitsHelper = true := by
   native_decide
 
+def templateIntrinsicTrustReportSurfacesObligation : Bool :=
+  match Compiler.CompilationModel.collectLocalObligations templateIntrinsicModel with
+  | [{ name := "entrypoint_inner_calldata_layout", proofStatus := .assumed, .. }] => true
+  | _ => false
+
+#guard templateIntrinsicTrustReportSurfacesObligation
+
 /--
 error: verity_intrinsic `template` parameter 'wrongName' does not match declared parameter 'gasLimit'
 -/
@@ -206,6 +216,28 @@ verity_intrinsic entryPointPackTemplateParamMismatch (sender : Uint256, gasLimit
         min_fork := osaka;
         semantics := (fun sender gasLimit => Verity.Core.Uint256.ofNat ((sender.val + gasLimit.val) % (2 ^ 256)));
         obligation [entry_point_pack_template_mismatch := assumed "negative coverage; never elaborated"]
+
+/--
+error: verity_intrinsic parameter 'sender' must have type Uint256; got Bool
+-/
+#guard_msgs in
+verity_intrinsic entryPointPackTemplateNonUintParam (sender : Bool, gasLimit : Uint256) : Uint256
+  where pure;
+        yul := [template (sender, gasLimit) -> packed := []];
+        min_fork := osaka;
+        semantics := (fun sender gasLimit => Verity.Core.Uint256.ofNat 0);
+        obligation [entry_point_pack_template_non_uint := assumed "negative coverage; never elaborated"]
+
+/--
+error: verity_intrinsic return type must be Uint256; got Bool
+-/
+#guard_msgs in
+verity_intrinsic entryPointPackTemplateNonUintReturn (sender : Uint256, gasLimit : Uint256) : Bool
+  where pure;
+        yul := [template (sender, gasLimit) -> packed := []];
+        min_fork := osaka;
+        semantics := (fun sender gasLimit => true);
+        obligation [entry_point_pack_template_non_uint_return := assumed "negative coverage; never elaborated"]
 
 def templateIntrinsicRejectsWrongArity : Bool :=
   match Compiler.CompilationModel.compileExpr [] .calldata

--- a/Verity/Core/Intrinsics.lean
+++ b/Verity/Core/Intrinsics.lean
@@ -94,18 +94,22 @@ inductive YulLowering where
       `output` as its single return variable. The `body` is already-typed Yul
       AST supplied by the intrinsic declaration, so Verity does not parse or
       verify the template body beyond arity/shape checks. -/
-  | template (params : List String) (output : String) (body : List YulStmt)
+  | template
+      (params : List String)
+      (output : String)
+      (body : List YulStmt)
+      (obligations : List (String × String × String) := [])
   deriving Repr, BEq
 
 def YulLowering.inputArity : YulLowering → Option Nat
   | .verbatim inArity _ _ => some inArity
   | .builtin _ => none
-  | .template params _ _ => some params.length
+  | .template params _ _ _ => some params.length
 
 def YulLowering.outputArity : YulLowering → Option Nat
   | .verbatim _ outArity _ => some outArity
   | .builtin _ => none
-  | .template _ _ _ => some 1
+  | .template _ _ _ _ => some 1
 
 def YulLowering.callName : YulLowering → String
   | .verbatim inArity outArity _ => s!"verbatim_{inArity}i_{outArity}o"
@@ -151,18 +155,18 @@ def yulBuiltinArity? (name : String) : Option (Nat × Nat) :=
 def YulLowering.inputArity? : YulLowering → Option Nat
   | .verbatim inArity _ _ => some inArity
   | .builtin name => (yulBuiltinArity? name).map Prod.fst
-  | .template params _ _ => some params.length
+  | .template params _ _ _ => some params.length
 
 def YulLowering.outputArity? : YulLowering → Option Nat
   | .verbatim _ outArity _ => some outArity
   | .builtin name => (yulBuiltinArity? name).map Prod.snd
-  | .template _ _ _ => some 1
+  | .template _ _ _ _ => some 1
 
 def YulLowering.templateHelperName (intrinsicName : String) : String :=
   s!"__verity_intrinsic_template_{intrinsicName}"
 
 def YulLowering.templateFuncDef? (intrinsicName : String) : YulLowering → Option YulStmt
-  | .template params output body =>
+  | .template params output body _ =>
       some (YulStmt.funcDef (templateHelperName intrinsicName) params [output] body)
   | _ => none
 

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -47,6 +47,24 @@ def parseIntrinsicTemplateStmt (stx : TSyntax `verityIntrinsicTemplateStmt) :
   | _ =>
       throwErrorAt stx "unsupported intrinsic template statement"
 
+private def cleanTypeSyntaxString (ty : Term) : String :=
+  String.mk <| (toString ty).toList.filter (fun c => c != '`')
+
+private def isUint256TypeSyntax (ty : Term) : Bool :=
+  let rendered := cleanTypeSyntaxString ty
+  rendered == "Uint256" ||
+    rendered == "Verity.Uint256" ||
+    rendered == "Verity.Core.Uint256" ||
+    rendered.endsWith ".Uint256"
+
+private def parseIntrinsicProofStatus (status : Ident) : CommandElabM String := do
+  let rendered := toString status.getId
+  match rendered with
+  | "proved" | "assumed" | "unchecked" => pure rendered
+  | _ =>
+      throwErrorAt status
+        "unsupported proof status for verity_intrinsic obligation; expected proved, assumed, or unchecked"
+
 @[command_elab verityContractCmd]
 def elabVerityContract : CommandElab := fun stx => do
   let parsed ← parseContractSyntax stx
@@ -203,6 +221,19 @@ def elabVerityIntrinsic : CommandElab := fun stx => do
         throwErrorAt pureKw "verity_intrinsic currently supports only pure intrinsics"
       if paramNames.size == 0 then
         throwErrorAt stx "verity_intrinsic requires at least one parameter"
+      for pair in paramNames.zip paramTypes do
+        unless isUint256TypeSyntax pair.2 do
+          throwErrorAt pair.2
+            s!"verity_intrinsic parameter '{toString pair.1.getId}' must have type Uint256; got {cleanTypeSyntaxString pair.2}"
+      unless isUint256TypeSyntax retTy do
+        throwErrorAt retTy s!"verity_intrinsic return type must be Uint256; got {cleanTypeSyntaxString retTy}"
+      let parsedObligations ← obligations.mapM fun obligation => do
+        match obligation with
+        | `(verityIntrinsicObligation| $obligationName:ident := $status:ident $message:str) => do
+            let statusString ← parseIntrinsicProofStatus status
+            pure (toString obligationName.getId, statusString, message.getString)
+        | _ =>
+            throwErrorAt obligation "expected obligation entry `<name> := assumed \"reason\"`"
       let yulLowering ←
         match yul with
         | `(verityIntrinsicYul| verbatim $inArity:num $outArity:num (hex $opcode:str)) =>
@@ -236,19 +267,19 @@ def elabVerityIntrinsic : CommandElab := fun stx => do
               (templateParams.toList.map (fun p => toString p.getId))
               (toString output.getId)
               bodyStmts
+              parsedObligations.toList
         | _ =>
             throwErrorAt yul "expected `verbatim <inputs> <outputs> (hex \"...\")`, `builtin \"...\"`, or `[template (<params>) -> <output> := [<statements>]]`"
+      match yulLowering.outputArity? with
+      | some 1 => pure ()
+      | some outArity =>
+          throwErrorAt yul s!"verity_intrinsic lowering must produce exactly 1 output word, got {outArity}"
+      | none => pure ()
       let minFork ←
         match Verity.Core.Intrinsics.HardFork.parse? (toString fork.getId) with
         | some parsed => pure parsed
         | none => throwErrorAt fork
             s!"unknown intrinsic min_fork '{toString fork.getId}' (expected cancun, prague, osaka, or fusaka alias)"
-      let parsedObligations ← obligations.mapM fun obligation => do
-        match obligation with
-        | `(verityIntrinsicObligation| $obligationName:ident := $status:ident $message:str) =>
-            pure (toString obligationName.getId, toString status.getId, message.getString)
-        | _ =>
-            throwErrorAt obligation "expected obligation entry `<name> := assumed \"reason\"`"
       let nameStr := toString name.getId
       let paramNameStrs : List String := paramNames.toList.map (fun id => toString id.getId)
       let paramTypeStrs : List String := paramTypes.toList.map toString

--- a/Verity/Macro/Executable.lean
+++ b/Verity/Macro/Executable.lean
@@ -105,12 +105,15 @@ def yulLoweringTerm (lowering : Verity.Core.Intrinsics.YulLowering) : CommandEla
           $(natTerm inArity) $(natTerm outArity) $(strTerm opcodeHex))
   | .builtin name =>
       `(Verity.Core.Intrinsics.YulLowering.builtin $(strTerm name))
-  | .template params output body => do
+  | .template params output body obligations => do
       let paramTerms := params.map strTerm
       let bodyTerms ← body.mapM yulStmtTerm
+      let obligationTerms ← obligations.mapM fun (name, status, message) =>
+        `(( $(strTerm name), $(strTerm status), $(strTerm message) ))
       `(Verity.Core.Intrinsics.YulLowering.template
           [ $[$paramTerms.toArray],* ]
           $(strTerm output)
-          [ $[$bodyTerms.toArray],* ])
+          [ $[$bodyTerms.toArray],* ]
+          [ $[$obligationTerms.toArray],* ])
 
 end Verity.Macro


### PR DESCRIPTION
## Summary
Closes #2049. Adds a **multi-statement typed Yul `template`** lowering mode to `verity_intrinsic`, on top of the single-statement `builtin`/`verbatim` surface landed in #2050. This unblocks ERC-4337 `EntryPoint._executeUserOp`/`innerHandleOp` calldata packing.

**Stacked on #2050** — base is `task/2049-intrinsic-template`. Land bottom-up: merge #2050 first, then this PR auto-retargets to `main`.

## What it does
- New `YulLowering.template (params) (output) (body) (obligations)` arm. A template intrinsic emits a genuine helper **function definition** `__verity_intrinsic_template_<name>` (params in declaration order, one return var, the raw typed multi-statement Yul body) and compiles call sites to `call __verity_intrinsic_template_<name>(args)` — the correct hoist-to-function pattern since Yul expressions can't hold statements.
- Strict validation: arity, every param must be `Uint256`, return must be `Uint256`, lowering must produce exactly one output word. Param-name mismatch, wrong arity, and non-`Uint256` param/return are all rejected at elaboration.
- The unchecked template body is surfaced as an explicit **`assumed` trust obligation** (`entrypoint_inner_calldata_layout`) through the trust-surface report path (`collectLocalObligations`) — the trusted base is not silently widened.

## Test coverage (`Contracts/Smoke/MultiArgIntrinsicSmoke.lean`)
- `templateIntrinsicCompilationEmitsHelper` (`native_decide`): asserts the compiled contract emits the helper `funcDef` with the exact **3-statement** body (`mstore(0, sender)`, `let head := add(sender, gasLimit)`, `packed := add(head, add(callDataOffset, callDataLength))`) referencing **all four** parameters.
- `templateIntrinsicTrustReportSurfacesObligation` (`#guard`): the `assumed` obligation surfaces in the trust report.
- Negative coverage (`#guard_msgs`): param-name mismatch, non-`Uint256` param, non-`Uint256` return, wrong arity.

## Verification
`lake build && lake build PrintAxioms` — both exit 0 (PrintAxioms compiles the `Compiler.Proofs.*` proof graph, CI-equivalent). No stray axioms beyond the one declared obligation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes intrinsic elaboration, trust-surface obligation collection, and the `YulLowering.template` shape; incorrect wiring could hide assumed template Yul or reject valid declarations, but impact is scoped to the intrinsic/compiler pipeline with smoke tests.
> 
> **Overview**
> Extends **multi-statement Yul `template`** intrinsics so declared **`obligation`** entries are stored on `YulLowering.template` (fourth field) and threaded through macro elaboration and executable term generation, not only on the top-level `IntrinsicDecl`.
> 
> **Trust reporting** walks intrinsic expressions in statement metadata and merges template obligations into **`collectLocalObligations`**, so assumed/unchecked template bodies (e.g. `entrypoint_inner_calldata_layout`) appear in trust reports without silently widening the trusted base.
> 
> **Elaboration** is tightened: every parameter and the return type must be **`Uint256`** (syntax-checked), obligation proof statuses must be **`proved` / `assumed` / `unchecked`**, and lowering **output arity** must be exactly one word. Template obligations are attached when building the template lowering from the `verity_intrinsic` clause.
> 
> Smoke coverage adds a **`#guard`** that `collectLocalObligations` surfaces the template obligation, plus **`#guard_msgs`** for non-`Uint256` param/return. The compile path’s template match gains an `_obligations` binder (obligations are not used at Yul emission, only in trust collection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2351d90d7f24141f2dddecf29654ee7a72cde1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->