### PR TITLE
C2 storage lens part 2 scope

### DIFF
--- a/.fleet-blockers.md
+++ b/.fleet-blockers.md
@@ -1,0 +1,8 @@
+# Fleet Blockers
+
+No Verity language blocker encountered during this #1999 mission.
+
+Notes:
+- `panic(code)` is expressible today as Yul payload construction and helper calls.
+- The missing work is product/API surface, not a primitive that the language cannot encode.
+- Existing unrelated transient-storage changes were preserved in a stash and left out of this branch commit.

--- a/docs/C2_STORAGE_LENS_PART2_SCOPE.md
+++ b/docs/C2_STORAGE_LENS_PART2_SCOPE.md
@@ -1,0 +1,72 @@
+# C2 Storage Lens Part 2 Scope
+
+## Current State
+
+C1 and C2 part 1 are already landed, but this checkout has no committed
+`storage_lens`, `StorageLens`, or "storage lens" symbols under `Compiler/`,
+`Contracts/`, or `Compiler/Proofs/`. The C2 part 2 slice therefore needs a
+small proof-facing entry point before it can safely refactor compiler or layout
+surfaces.
+
+## Smallest Landable Part 2 Unit
+
+Pick one new lens type: `view_lens`.
+
+This is the smallest useful unit because a view lens can be introduced as a
+read-only projection over existing flat-storage and mapping-slot proof
+surfaces, without changing compiler lowering or taking ownership of the
+uncommitted transient layout work.
+
+## Proposed Shape
+
+The first implementation should live near the proof-facing storage model, most
+likely under `Compiler/Proofs/StorageLens.lean`, imported only by a focused test
+or proof file until the API is stable.
+
+Minimal API:
+
+```lean
+structure ViewLens (α : Type) where
+  read : (IRStorageSlot → IRStorageWord) → α
+```
+
+First concrete constructors:
+
+- `ViewLens.word slot`: reads one resolved storage slot.
+- `ViewLens.mappingWord baseSlot key`: reads through
+  `solidityMappingSlot baseSlot key`.
+
+The mapping constructor should reuse `Compiler.Proofs.MappingSlot` rather than
+introducing a second slot-derivation model.
+
+## First Proof/Test
+
+Land one theorem proving that a write to a different flat slot preserves a
+`ViewLens.word` read:
+
+```lean
+theorem ViewLens.word_read_store_other
+    (storage : IRStorageSlot → IRStorageWord)
+    (readSlot writeSlot value : Nat)
+    (h : readSlot ≠ writeSlot) :
+    (ViewLens.word readSlot).read
+      (abstractStoreStorageOrMapping storage writeSlot value) =
+    (ViewLens.word readSlot).read storage
+```
+
+This theorem is narrow, builds on `abstractStoreStorageOrMapping`, and gives C2
+part 2 a concrete proof artifact before broadening to mapping/non-alias
+certificates.
+
+## Not In This Unit
+
+- No compiler lowering changes.
+- No layout report changes.
+- No transient mapping semantics yet.
+- No global storage-lens import into Layer 2 or native Layer 3 proofs.
+
+## Follow-Up Slice
+
+After `ViewLens.word` lands, add `ViewLens.mappingWord` preservation using the
+finite non-alias certificate surface already present in
+`Compiler/Proofs/MappingSlot.lean`.


### PR DESCRIPTION
Original commit: https://github.com/lfglabs-dev/verity/commit/deeb6795

Adds the C2 storage lens part 2 scope note, preserving the completed mission commit as a standalone review branch separated from the later panic-surface work.

- [ ] Confirm scope boundaries for C2 storage lens follow-up.
- [ ] Check docs wording against current storage lens API.
- [ ] Decide next implementation slice after scope approval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only markdown documentation; no executable, compiler, or proof behavior changes.
> 
> **Overview**
> **Documentation-only PR** that records planning for C2 storage lens part 2 and a short fleet/mission note, without changing compiler, contracts, or proofs.
> 
> **`docs/C2_STORAGE_LENS_PART2_SCOPE.md`** defines the next landable slice: introduce a proof-facing **`ViewLens`** (likely in `Compiler/Proofs/StorageLens.lean`) as a read-only projection over existing flat-storage and mapping-slot proof APIs, reusing `Compiler.Proofs.MappingSlot` for mapping reads. It proposes initial constructors (`ViewLens.word`, later `ViewLens.mappingWord`), a first theorem **`ViewLens.word_read_store_other`** over `abstractStoreStorageOrMapping`, and explicit **out-of-scope** boundaries (no lowering, layout reports, transient mapping, or broad Layer 2/3 imports). A follow-up slice is **`ViewLens.mappingWord`** preservation via existing non-alias certificates in `MappingSlot.lean`.
> 
> **`.fleet-blockers.md`** states there was no Verity language blocker for mission #1999: `panic(code)` is already encodable via Yul/helpers and missing work is product/API surface; unrelated transient-storage edits were stashed and excluded from this branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deeb67959c50ccf865fa7b024386ccfe5015e0cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->