### PR TITLE
Add runtime-sized dynamic CodeData ABI payloads

### DIFF
--- a/Compiler/ABI/Frame.lean
+++ b/Compiler/ABI/Frame.lean
@@ -32,6 +32,7 @@ structure FrameLayout where
   headWords : Nat
   hasDynamic : Bool
   mode : FramePassMode
+  runtimeSize : Option YulExpr := none
   deriving Repr, BEq
 
 def spillThresholdWords : Nat := 4
@@ -57,6 +58,11 @@ def layout (fields : List FrameField) : FrameLayout :=
     hasDynamic
     mode := if shouldPassByPointer fields then .pointer else .inlineWords }
 
+def runtimeSizedLayout (fields : List FrameField) (size : YulExpr) : FrameLayout :=
+  { layout fields with
+    mode := .pointer
+    runtimeSize := some size }
+
 def fieldSourceSupported (field : FrameField) : Bool :=
   match field.source with
   | .memory | .code | .storage => true
@@ -68,6 +74,19 @@ def fieldLayoutSupported (field : FrameField) : Bool :=
 
 def layoutSourcesSupported (l : FrameLayout) : Bool :=
   l.fields.all fieldLayoutSupported
+
+def fieldRuntimeLayoutSupported (field : FrameField) : Bool :=
+  match field.source with
+  | .memory | .calldata | .code => true
+  | .storage => !isDynamicParamType field.ty
+
+def layoutRuntimeSourcesSupported (l : FrameLayout) : Bool :=
+  l.fields.all fieldRuntimeLayoutSupported
+
+def layoutHasRuntimeSize (l : FrameLayout) : Bool :=
+  match l.runtimeSize with
+  | some _ => true
+  | none => false
 
 def dynamicTailWords (field : FrameField) : Nat :=
   1 + (field.tailBytes + 31) / 32
@@ -81,6 +100,14 @@ def frameSizeBytes (l : FrameLayout) : Nat :=
 def frameAllocBytes (l : FrameLayout) : Nat :=
   l.fields.foldl (fun acc field => acc + fieldPayloadWords field * 32) 0
 
+def frameSizeExpr (l : FrameLayout) : YulExpr :=
+  match l.runtimeSize with
+  | some size => size
+  | none => YulExpr.lit (frameSizeBytes l)
+
+def frameAllocExpr (l : FrameLayout) : YulExpr :=
+  frameSizeExpr l
+
 def ptrName (base : String) : String :=
   "__abi_frame_" ++ base
 
@@ -91,7 +118,15 @@ def allocateFrame (base : String) (l : FrameLayout) : List YulStmt :=
   [ YulStmt.let_ (ptrName base) (YulExpr.call "mload" [YulExpr.lit 64])
   , YulStmt.exprStmt (YulExpr.call "mstore"
       [ YulExpr.lit 64
-      , YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit (frameAllocBytes l)] ])]
+      , YulExpr.call "add" [YulExpr.ident (ptrName base), frameAllocExpr l] ])]
+
+def allocateFrameWithPrefix (base : String) (prefixBytes : Nat) (l : FrameLayout) : List YulStmt :=
+  [ YulStmt.let_ (ptrName base) (YulExpr.call "mload" [YulExpr.lit 64])
+  , YulStmt.exprStmt (YulExpr.call "mstore"
+      [ YulExpr.lit 64
+      , YulExpr.call "add"
+          [ YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit prefixBytes]
+          , frameAllocExpr l ] ])]
 
 def sourceBaseName (field : FrameField) : String :=
   if field.sourceBase.isEmpty then field.name else field.sourceBase
@@ -165,6 +200,49 @@ private def spillDynamicField (base : String) (headOffsetWords tailOffsetWords :
         YulStmt.exprStmt (YulExpr.call "mstore"
           [dest, YulExpr.call "mload" [dynamicTailByteOffset field idx]])
 
+private def copyRuntimeMemoryPayload (base : String) (prefixBytes : Nat) (field : FrameField) (size : YulExpr) :
+    List YulStmt :=
+  let destBase := YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit prefixBytes]
+  let srcBase := YulExpr.ident (sourceBaseName field)
+  [ YulStmt.for_
+      [YulStmt.let_ "__abi_frame_copy_i" (YulExpr.lit 0)]
+      (YulExpr.call "lt" [YulExpr.ident "__abi_frame_copy_i", size])
+      [YulStmt.assign "__abi_frame_copy_i"
+        (YulExpr.call "add" [YulExpr.ident "__abi_frame_copy_i", YulExpr.lit 32])]
+      [YulStmt.exprStmt (YulExpr.call "mstore"
+        [ YulExpr.call "add" [destBase, YulExpr.ident "__abi_frame_copy_i"]
+        , YulExpr.call "mload" [YulExpr.call "add" [srcBase, YulExpr.ident "__abi_frame_copy_i"]] ])] ]
+
+private def copyRuntimeCalldataPayload (base : String) (prefixBytes : Nat) (field : FrameField) (size : YulExpr) :
+    List YulStmt :=
+  [YulStmt.exprStmt (YulExpr.call "calldatacopy"
+    [ YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit prefixBytes]
+    , YulExpr.ident (sourceBaseName field)
+    , size ])]
+
+private def copyRuntimeCodePayload (base : String) (prefixBytes : Nat) (field : FrameField) (size : YulExpr) :
+    List YulStmt :=
+  [YulStmt.exprStmt (YulExpr.call "extcodecopy"
+    [ YulExpr.ident (sourceBaseName field)
+    , YulExpr.call "add" [YulExpr.ident (ptrName base), YulExpr.lit prefixBytes]
+    , YulExpr.lit field.sourceOffset
+    , size ])]
+
+def copyRuntimePayloadToMemory (base : String) (prefixBytes : Nat) (l : FrameLayout) : Except String (List YulStmt) := do
+  let size ←
+    match l.runtimeSize with
+    | some size => pure size
+    | none => throw s!"ABI frame '{base}' has no runtime payload size"
+  match l.fields with
+  | [field] =>
+      match field.source with
+      | .memory => pure (copyRuntimeMemoryPayload base prefixBytes field size)
+      | .calldata => pure (copyRuntimeCalldataPayload base prefixBytes field size)
+      | .code => pure (copyRuntimeCodePayload base prefixBytes field size)
+      | .storage => throw s!"ABI frame '{base}' cannot runtime-copy dynamic storage payloads"
+  | _ =>
+      throw s!"ABI frame '{base}' runtime payload copy expects exactly one pre-encoded field"
+
 partial def spillFieldsAbi (base : String) (headOffsetWords tailOffsetWords : Nat) : List FrameField → List YulStmt
   | [] => []
   | field :: rest =>
@@ -183,7 +261,11 @@ def spillPayloadToMemory (base : String) (l : FrameLayout) : List YulStmt :=
   allocateFrame base l ++ spillFieldsAbi base 0 l.headWords l.fields
 
 def pointerArgs (base : String) (l : FrameLayout) : List YulExpr :=
-  [YulExpr.ident (ptrName base), YulExpr.lit (frameSizeBytes l)]
+  [YulExpr.ident (ptrName base), frameSizeExpr l]
+
+def pointerArgsWithPrefix (base : String) (prefixBytes : Nat) (l : FrameLayout) : List YulExpr :=
+  [ YulExpr.ident (ptrName base)
+  , YulExpr.call "add" [YulExpr.lit prefixBytes, frameSizeExpr l] ]
 
 def inlinePayloadToScratch (words : List YulExpr) : List YulStmt :=
   words.zipIdx.map fun (word, idx) =>
@@ -210,6 +292,11 @@ def materializePayloadToMemory (base : String) (l : FrameLayout) : List YulStmt 
       (spillPayloadToMemory base l, pointerArgs base l)
   | .inlineWords =>
       (inlinePayloadToScratch (inlineArgs l), [YulExpr.lit 0, YulExpr.lit (frameSizeBytes l)])
+
+def materializeRuntimePayloadToMemoryWithPrefix (base : String) (prefixBytes : Nat) (l : FrameLayout) :
+    Except String (List YulStmt × List YulExpr) := do
+  let copy ← copyRuntimePayloadToMemory base prefixBytes l
+  pure (allocateFrameWithPrefix base prefixBytes l ++ copy, pointerArgsWithPrefix base prefixBytes l)
 
 def containsDynamicArrayOrBytes (l : FrameLayout) : Bool :=
   l.fields.any fun field =>

--- a/Compiler/ABI/FrameTest.lean
+++ b/Compiler/ABI/FrameTest.lean
@@ -32,6 +32,11 @@ private def dynamicStorageFields : List FrameField :=
 private def dynamicMemoryFields : List FrameField :=
   [ { name := "payload", ty := .bytes, source := .memory, sourceOffset := 32, tailBytes := 64 } ]
 
+private def runtimeDynamicMemoryLayout : FrameLayout :=
+  runtimeSizedLayout
+    [ { name := "payload", ty := .bytes, source := .memory, sourceBase := "payloadPtr" } ]
+    (YulExpr.ident "payloadSize")
+
 private def unpaddedDynamicFields : List FrameField :=
   [ { name := "payload", ty := .bytes, source := .calldata, tailBytes := 33 } ]
 
@@ -62,6 +67,10 @@ private def hasExtcodecopy : List YulStmt → Bool :=
     (!layoutSourcesSupported (layout dynamicStorageFields))
   assert "dynamic memory tails are rejected until runtime-sized ABI frames exist"
     (!layoutSourcesSupported (layout dynamicMemoryFields))
+  assert "runtime-sized dynamic memory layout records caller-provided size"
+    (frameSizeExpr runtimeDynamicMemoryLayout == YulExpr.ident "payloadSize")
+  assert "runtime-sized dynamic memory layout is source-supported for CodeData-style copies"
+    (layoutRuntimeSourcesSupported runtimeDynamicMemoryLayout)
   assert "dynamic source frame is pointer mode" (srcLayout.mode == FramePassMode.pointer)
   assert "code source spills through extcodecopy" (hasExtcodecopy (spillPayloadToMemory "src" srcLayout))
   let inlineNames := (inlineArgs (layout inlineFields)).filterMap calldataLoadName?

--- a/Compiler/Modules/CodeData.lean
+++ b/Compiler/Modules/CodeData.lean
@@ -25,12 +25,74 @@ def trustSurface : List String :=
   [ "CREATE2 address derivation is trusted at the EVM boundary"
   , "SSTORE2 pointer code layout is trusted as code-as-data"
   , "extcodecopy reads immutable deployed code bytes into caller-owned memory"
-  , "ABI frame layout is typed by Compiler.ABI.Frame before write/read lowering" ]
+  , "ABI frame layout is typed by Compiler.ABI.Frame before write/read lowering"
+  , "Runtime-sized dynamic ABI payload copies preserve the caller-provided byte extent" ]
+
+def sstore2PrefixBytes : Nat := 1
+
+def sstore2PrefixOffset : YulExpr := YulExpr.lit sstore2PrefixBytes
+
+def sstore2RuntimeSize (payloadSize : YulExpr) : YulExpr :=
+  YulExpr.call "add" [sstore2PrefixOffset, payloadSize]
+
+def codeDataPayloadSupported (payload : FrameLayout) : Bool :=
+  if layoutHasRuntimeSize payload then
+    layoutRuntimeSourcesSupported payload
+  else
+    !payload.hasDynamic && layoutSourcesSupported payload
+
+private def copyMemorySlice (dest src size : YulExpr) : List YulStmt :=
+  [ YulStmt.for_
+      [YulStmt.let_ "__codedata_copy_i" (YulExpr.lit 0)]
+      (YulExpr.call "lt" [YulExpr.ident "__codedata_copy_i", size])
+      [YulStmt.assign "__codedata_copy_i"
+        (YulExpr.call "add" [YulExpr.ident "__codedata_copy_i", YulExpr.lit 32])]
+      [YulStmt.exprStmt (YulExpr.call "mstore"
+        [ YulExpr.call "add" [dest, YulExpr.ident "__codedata_copy_i"]
+        , YulExpr.call "mload" [YulExpr.call "add" [src, YulExpr.ident "__codedata_copy_i"]] ])] ]
+
+private def materializeStaticSstore2Payload (base : String) (payload : FrameLayout) :
+    Except String (List YulStmt × List YulExpr) := do
+  let (payloadPrelude, payloadArgs) := materializePayloadToMemory (base ++ "_payload") payload
+  let payloadOffset ←
+    match payloadArgs with
+    | [offset, _size] => pure offset
+    | _ => throw "CodeData write expected a memory payload pointer and size"
+  let payloadSize ←
+    match payloadArgs with
+    | [_offset, size] => pure size
+    | _ => throw "CodeData write expected a memory payload pointer and size"
+  let ptr := YulExpr.ident (ptrName base)
+  let dest := YulExpr.call "add" [ptr, sstore2PrefixOffset]
+  pure
+    ( payloadPrelude ++
+      [ YulStmt.let_ (ptrName base) (YulExpr.call "mload" [YulExpr.lit 64])
+      , YulStmt.exprStmt (YulExpr.call "mstore"
+          [ YulExpr.lit 64
+          , YulExpr.call "add" [ptr, sstore2RuntimeSize payloadSize] ])
+      , YulStmt.exprStmt (YulExpr.call "mstore8" [ptr, YulExpr.lit 0]) ] ++
+      copyMemorySlice dest payloadOffset payloadSize
+    , [ptr, sstore2RuntimeSize payloadSize] )
+
+private def materializeDynamicSstore2Payload (base : String) (payload : FrameLayout) :
+    Except String (List YulStmt × List YulExpr) := do
+  let (prelude, args) ← materializeRuntimePayloadToMemoryWithPrefix base sstore2PrefixBytes payload
+  pure
+    ( prelude ++
+      [YulStmt.exprStmt (YulExpr.call "mstore8" [YulExpr.ident (ptrName base), YulExpr.lit 0])]
+    , args )
+
+def materializeSstore2Payload (base : String) (payload : FrameLayout) :
+    Except String (List YulStmt × List YulExpr) :=
+  if layoutHasRuntimeSize payload then
+    materializeDynamicSstore2Payload base payload
+  else
+    materializeStaticSstore2Payload base payload
 
 def writeTyped (resultVar base : String) (write : CodeDataWrite) : Except String (List YulStmt) := do
-  if !layoutSourcesSupported write.payload then
+  if !codeDataPayloadSupported write.payload then
     throw "CodeData write payload has unsupported frame source"
-  let (prelude, payloadArgs) := materializePayloadToMemory base write.payload
+  let (prelude, payloadArgs) ← materializeSstore2Payload base write.payload
   let initcodeOffset ←
     match payloadArgs with
     | [offset, _size] => pure offset
@@ -44,7 +106,7 @@ def writeTyped (resultVar base : String) (write : CodeDataWrite) : Except String
   pure (prelude ++ deploy)
 
 def readTyped (read : CodeDataRead) : Except String (List YulStmt) := do
-  if !layoutSourcesSupported read.payload then
+  if !codeDataPayloadSupported read.payload then
     throw "CodeData read payload has unsupported frame source"
   (Compiler.Modules.Create2SSTORE2.readCodeModule).compile {}
     [read.pointer, read.destOffset, read.codeOffset, read.size]

--- a/Compiler/Modules/CodeDataTest.lean
+++ b/Compiler/Modules/CodeDataTest.lean
@@ -20,7 +20,48 @@ private def payload := layout
 private def deployUsesPayloadBuffer : List YulStmt → Bool :=
   fun stmts => stmts.any fun stmt =>
     match stmt with
-    | .let_ _ (.call "create2" [_value, .ident "__abi_frame_sstore2", .lit 160, _salt]) => true
+    | .let_ _ (.call "create2"
+        [ _value
+        , .ident "__abi_frame_sstore2"
+        , .call "add" [.lit 1, .lit 160]
+        , _salt ]) => true
+    | _ => false
+
+private def writesSstore2Prefix (base : String) : List YulStmt → Bool :=
+  fun stmts => stmts.any fun stmt =>
+    match stmt with
+    | .exprStmt (.call "mstore8" [.ident ptr, .lit 0]) => ptr == ptrName base
+    | _ => false
+
+private def readSkipsSstore2Prefix : List YulStmt → Bool :=
+  fun stmts => stmts.any fun stmt =>
+    match stmt with
+    | .exprStmt (.call "extcodecopy" [_ptr, _dest, .lit 1, _size]) => true
+    | _ => false
+
+private def deployUsesRuntimeSize (base sizeName : String) : List YulStmt → Bool :=
+  fun stmts => stmts.any fun stmt =>
+    match stmt with
+    | .let_ _ (.call "create2"
+        [ _value
+        , .ident ptr
+        , .call "add" [.lit 1, .ident size]
+        , _salt ]) =>
+          ptr == ptrName base && size == sizeName
+    | _ => false
+
+private def copiesRuntimeMemoryPayload (sourceName sizeName : String) : List YulStmt → Bool :=
+  fun stmts => stmts.any fun stmt =>
+    match stmt with
+    | .for_ _ (.call "lt" [.ident "__abi_frame_copy_i", .ident size]) _ body =>
+        size == sizeName &&
+          body.any (fun bodyStmt =>
+            match bodyStmt with
+            | .exprStmt (.call "mstore"
+                [ _
+                , .call "mload" [.call "add" [.ident source, .ident "__abi_frame_copy_i"]] ]) =>
+                  source == sourceName
+            | _ => false)
     | _ => false
 
 private def returnCodeDataHasExtentGuard : List YulStmt → Bool
@@ -50,11 +91,13 @@ private def emptyPayload := layout []
 private def shortPayload := layout
   [ { name := "word", ty := .uint256, source := .memory } ]
 
--- Dynamic payload (#1967): `layoutSourcesSupported` must reject dynamic
--- types so callers get a clear failure mode rather than corrupt code-as-
--- data shapes.
-private def dynamicPayload := layout
-  [ { name := "blob", ty := .bytes, source := .memory } ]
+-- Dynamic CodeData payload (#2023): callers can pass a pre-encoded
+-- runtime-sized ABI payload such as `abi.encode(market)`. The ParamType stays
+-- attached to the frame for typed read/write/return/id reasoning, while the
+-- byte extent is supplied by the caller at runtime.
+private def dynamicPayload := runtimeSizedLayout
+  [ { name := "market", ty := .tuple [.address, .address, .bytes], source := .memory, sourceBase := "marketAbi" } ]
+  (YulExpr.ident "marketSize")
 
 #eval! do
   let write : CodeDataWrite :=
@@ -72,7 +115,11 @@ private def dynamicPayload := layout
     | .error err => throw (IO.userError err)
   assert "typed roundtrip has create2 and extcodecopy" (hasCreate2AndExtcodecopy roundtrip)
   assert "typed write deploys the materialized payload buffer" (deployUsesPayloadBuffer roundtrip)
-  assert "trust surface is explicit" (trustSurface.length == 4)
+  assert "typed write materializes observable SSTORE2 STOP prefix"
+    (writesSstore2Prefix "sstore2" roundtrip)
+  assert "typed read skips observable SSTORE2 prefix byte"
+    (readSkipsSstore2Prefix roundtrip)
+  assert "trust surface is explicit" (trustSurface.length == 5)
   let returnCodeData ←
     match compileStmt [] [] [] .calldata [] false [] [] (Stmt.returnCodeData (Expr.param "ptr")) with
     | .ok stmts => pure stmts
@@ -114,18 +161,34 @@ private def dynamicPayload := layout
     (hasCreate2AndExtcodecopy shortRoundtrip)
   assert "short-payload layout has exactly one head word"
     (shortPayload.headWords == 1)
-  -- Dynamic-payload rejection (#1967): the typed surface must fail closed
-  -- when a field carries a dynamic ABI type. SSTORE2-style code-as-data is
-  -- only sound for static layouts; the diagnostic must surface that.
+  -- Dynamic runtime-sized payload (#2023): typed CodeData accepts a
+  -- pre-encoded ABI payload, stores `STOP ++ payload`, and uses the caller's
+  -- runtime byte length for the CREATE2 slice.
   let dynamicWrite : CodeDataWrite :=
     { salt := YulExpr.ident "salt", payload := dynamicPayload }
-  let dynamicResult :=
-    Compiler.Modules.CodeData.writeTyped "dynamicPtr" "dynamic" dynamicWrite
-  assert "dynamic payload write is rejected (typed surface stays static-only)"
-    (match dynamicResult with
-     | .ok _ => false
-     | .error _ => true)
+  let dynamicRead : CodeDataRead :=
+    { pointer := YulExpr.ident "ptr"
+      destOffset := YulExpr.ident "dest"
+      codeOffset := YulExpr.lit 1
+      size := YulExpr.ident "marketSize"
+      payload := dynamicPayload }
+  let dynamicRoundtrip ←
+    match roundtripShape "dynamicPtr" "dynamic" dynamicWrite dynamicRead with
+    | .ok stmts => pure stmts
+    | .error err => throw (IO.userError s!"dynamic payload roundtrip failed: {err}")
+  assert "dynamic CodeData roundtrip emits create2 + extcodecopy"
+    (hasCreate2AndExtcodecopy dynamicRoundtrip)
+  assert "dynamic CodeData writes SSTORE2 prefix"
+    (writesSstore2Prefix "dynamic" dynamicRoundtrip)
+  assert "dynamic CodeData create2 uses runtime payload size plus prefix"
+    (deployUsesRuntimeSize "dynamic" "marketSize" dynamicRoundtrip)
+  assert "dynamic CodeData copies the runtime-sized ABI payload"
+    (copiesRuntimeMemoryPayload "marketAbi" "marketSize" dynamicRoundtrip)
+  assert "dynamic CodeData read skips SSTORE2 prefix"
+    (readSkipsSstore2Prefix dynamicRoundtrip)
   assert "dynamic payload layout flags hasDynamic"
     dynamicPayload.hasDynamic
+  assert "dynamic payload layout records runtime byte size"
+    (layoutHasRuntimeSize dynamicPayload)
 
 end Compiler.Modules.CodeDataTest

--- a/docs/EXTERNAL_CALL_MODULES.md
+++ b/docs/EXTERNAL_CALL_MODULES.md
@@ -305,21 +305,24 @@ and routes through the underlying ECMs:
 
 - `Compiler.Modules.CodeData.writeTyped resultVar base write` — typed
   write. The `write : CodeDataWrite` carries a `FrameLayout` payload, an
-  optional ETH value, and a salt. Fails closed if the layout contains
-  any dynamic field (`Frame.layoutSourcesSupported` is the gate); this
-  is intentional because SSTORE2-style code-as-data is only sound for
-  static layouts.
+  optional ETH value, and a salt. Static payloads are ABI-materialized
+  from their typed fields. Runtime-sized payloads are accepted when the
+  layout carries `runtimeSize`; the payload is treated as a pre-encoded
+  ABI byte slice, copied from memory/calldata/code, and deployed as
+  `SSTORE2_PREFIX ++ abiPayload`.
 - `Compiler.Modules.CodeData.readTyped read` — typed read. Lowers to the
   underlying `extcodecopy` ECM after a matching layout-sources check.
+  SSTORE2 payload reads use code offset `1`, matching the observable
+  prefix byte written by `writeTyped`.
 - `Compiler.Modules.CodeData.roundtripShape resultVar base write read` —
   combined write+read, useful for tests and Midnight-style
   `toId`/`toMarket`/`touchMarket` round-trip patterns.
 
 Coverage in `Compiler.Modules.CodeDataTest` exercises the typed surface
 on (a) the full multi-field blob+meta payload, (b) an empty payload (no
-fields), (c) a one-word short payload, and (d) a dynamic payload — the
-last must be rejected with an explicit error so callers never silently
-store ABI-encoded dynamic tails into pointer code.
+fields), (c) a one-word short payload, and (d) a dynamic runtime-sized
+payload over `ParamType` with an observable `STOP ++ abi.encode(...)`
+byte layout.
 
 ### Packed Hashing Helpers
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,6 +123,11 @@ Recent progress for low-level calls + returndata handling (`#622`):
 - Raw `Expr.externalCall` interop names for low-level/builtin opcodes remain fail-fast rejected, preserving explicit migration diagnostics while the first-class surface continues to expand.
 
 Recent progress for dynamic ABI-shaped parameters:
+- Typed CodeData now has a runtime-sized ABI payload path for SSTORE2-style
+  code-as-data: `Frame.runtimeSizedLayout` keeps the `ParamType` attached,
+  `CodeData.writeTyped` deploys the observable `STOP ++ abi.encode(...)`
+  byte layout, `CodeData.readTyped` reads from code offset `1`, and
+  `Stmt.returnCodeData` returns the runtime payload after that prefix.
 - `verity_contract` now accepts dynamic array parameters whose element type is a static tuple of ABI words, e.g. `Array (Tuple [Uint256, Uint256, Int256])`, on tuple destructuring and tuple-return `arrayElement` paths. Those paths lower to checked word reads with the tuple element stride, which covers Solidity memory arrays of small fixed-size structs such as `CurveCut[]`; plain scalar `arrayElement` remains limited to single-word static element arrays.
 - `verity_contract` now accepts named `struct` declarations for function parameters as ABI tuple aliases. Executable contracts get Lean structures and field projection syntax, while the compilation model keeps the existing tuple ABI lowering. Nested static struct fields are supported for parameter field reads, covering the #1750 TermMax-style `config.feeConfig.borrowTakerFeeRatio` shape.
 - `verity_contract` now supports explicit storage layout trees with


### PR DESCRIPTION
## Summary

- add `Frame.runtimeSizedLayout` and runtime-size metadata for typed ABI frames
- allow `Compiler.Modules.CodeData` to store runtime-sized ABI payloads as observable `SSTORE2_PREFIX ++ abiPayload`
- keep CodeData read/return behavior aligned on payload offset `1`, with tests covering dynamic ParamType payloads
- document the new CodeData surface in `docs/EXTERNAL_CALL_MODULES.md` and `docs/ROADMAP.md`

## Verification

- `LEAN_NUM_THREADS=1 LAKE_JOBS=1 lake build Compiler.Modules.CodeDataTest`
- `LEAN_NUM_THREADS=1 LAKE_JOBS=1 lake build`
- consumer parity in `/workspaces/morpho-verity`: `LEAN_NUM_THREADS=1 LAKE_JOBS=1 lake build`
- consumer Midnight smoke: `LEAN_NUM_THREADS=1 LAKE_JOBS=1 lake build Morpho.Compiler.MidnightCreate2CodeReadSmoke`

## Notes

- #2000 dynamic event support is already in the current main ancestry; this PR keeps the CodeData changes scoped to the co-located ABI frame/runtime payload surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CREATE2 initcode sizing and SSTORE2 byte layout for dynamic payloads; mistakes could corrupt deployed code-as-data, though behavior is covered by new compile-time tests and static paths are refactored rather than replaced.
> 
> **Overview**
> **Runtime-sized ABI frames** extend `FrameLayout` with optional `runtimeSize`, `runtimeSizedLayout`, and Yul helpers that allocate/copy using a caller-supplied byte length instead of static `frameSizeBytes`. Pointer args and memory materialization now go through `frameSizeExpr` / `materializeRuntimePayloadToMemoryWithPrefix`, with runtime copies from memory, calldata, or code (single pre-encoded field).
> 
> **CodeData** accepts layouts that carry `runtimeSize`: static payloads still ABI-materialize field-by-field with an explicit **1-byte SSTORE2 STOP prefix**; runtime payloads copy the pre-encoded slice after that prefix and pass **prefix + payload size** into CREATE2. Support checks use `codeDataPayloadSupported` / `layoutRuntimeSourcesSupported` instead of rejecting all dynamic layouts. Tests now cover dynamic roundtrips (prefix write, runtime CREATE2 size, memory copy, read at offset 1) and static paths assert the same prefix behavior.
> 
> Docs describe the new write/read contract and roadmap notes the path for patterns like `abi.encode(market)` with typed `ParamType` retained on the frame.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42ee61106c17c1fe4f6f444ba09ba07ff06e024a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->