### PR TITLE
Remove unused trace helpers

### DIFF
--- a/Verity/Trace.lean
+++ b/Verity/Trace.lean
@@ -20,8 +20,6 @@ We provide:
 * `count_le_one_under_pairwise_distinct` — at most one matching event
   when the source list of events generators are pairwise distinct on the
   key.
-* `count_ge_one_when_member_emitted` — at least one matching event when
-  a known emitter is in the source list with non-empty contribution.
 
 Downstream contracts instantiate with their concrete `Event`, `Key`,
 and `matchEvent` predicate.
@@ -31,11 +29,6 @@ and `matchEvent` predicate.
 def countMatching {Event Key : Type}
     (matchEvent : Key → Event → Bool) (key : Key) (trace : List Event) : Nat :=
   (trace.filter (matchEvent key)).length
-
-/-- Pairwise distinctness on a key-extraction function. -/
-def Pairwise.distinctOn {α Key : Type} [DecidableEq Key]
-    (keyOf : α → Key) (xs : List α) : Prop :=
-  List.Pairwise (fun a b => keyOf a ≠ keyOf b) xs
 
 /-! ## Generic at-most-once theorem
 
@@ -72,23 +65,6 @@ theorem emitLoop_event_origin {α Event : Type}
         exact ⟨x, List.mem_cons_of_mem _ hx, hex⟩
     · obtain ⟨x, hx, hex⟩ := ih he
       exact ⟨x, List.mem_cons_of_mem _ hx, hex⟩
-
-/-- If `x ∈ xs` and `emit x = some e`, then `e ∈ emitLoop emit xs`. -/
-theorem emitLoop_contains_emitted_event {α Event : Type}
-    (emit : α → Option Event) (xs : List α) (x : α) (hMem : x ∈ xs)
-    (e : Event) (hEmit : emit x = some e) :
-    e ∈ emitLoop emit xs := by
-  induction xs with
-  | nil => cases hMem
-  | cons hd rest ih =>
-    simp only [emitLoop]
-    rcases List.mem_cons.mp hMem with hEq | hTail
-    · subst hEq
-      rw [hEmit]
-      exact List.mem_cons_self ..
-    · split
-      · exact List.mem_cons_of_mem _ (ih hTail)
-      · exact ih hTail
 
 /-- **At-most-once**: if all events emitted from `xs` are pairwise
     distinct on a matching key, the trace contains at most one match. -/


### PR DESCRIPTION
Summary:
- Removed 2 unused definitions from `Verity.Trace`: `Pairwise.distinctOn` and `emitLoop_contains_emitted_event`.
- Removed the stale module-doc bullet for an unimplemented/absent `count_ge_one_when_member_emitted` helper.
- No behavior change; this pass only trims unreferenced trace helpers and documentation.

Verification:
- `lake build` clean.
- `lake test` not run: this repo reports `error: verity: no test driver configured`.
- `scripts/run_morpho_midnight_parity.sh` not run: file is absent from this checkout.
- `scripts/run_morpho_blue_parity.sh` not run: file is absent from this checkout.

Audit notes:
- `lean4lean` and `lean-lsp` were not available, so unused-definition detection was conservative textual reference checking plus build validation.
- Intrinsics pass found the generic intrinsic surface and builtin registry in active use; no intrinsic removals were made in this pass.
- Stale remote branch inventory found 495 `origin/*` branches with last commit on or before 2026-04-25, excluding protected active branches named in the task. Most are unmerged, so this PR does not delete remote refs.
- Protected/active branches were not touched: `feat-1999`, `feat-1995`, `feat-2023`, `feat/erc4337`, `spine-c2`.
- Proven fragment theorem files were not edited.

Risk:
- Low. `Verity.Trace` appears to be a reusable utility surface, so downstream users could theoretically import these names even though this repo has no references. If that public API compatibility matters, this is the one thing to review before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7a79a30f4672beb80ee2ff9990eb786e6e9f095a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->