### PR TITLE
Expose transient computed-slot preimages (#1995)

### DIFF
--- a/Compiler/CompilationModel/LayoutReport.lean
+++ b/Compiler/CompilationModel/LayoutReport.lean
@@ -91,6 +91,9 @@ private def slotAliasRangeJson (range : SlotAliasRange) : String :=
     ("targetStart", jsonNat range.targetStart)
   ]
 
+private def fieldLocationKind (field : Field) : String :=
+  if field.isTransient then "transient" else "persistent"
+
 private def fieldJson (declaredField effectiveField : Field) (idx : Nat) : String :=
   let canonicalSlot := declaredField.slot.getD idx
   let effectiveAliasSlots := effectiveField.aliasSlots
@@ -102,7 +105,9 @@ private def fieldJson (declaredField effectiveField : Field) (idx : Nat) : Strin
     ("effectiveAliasSlots", jsonArray (effectiveAliasSlots.map jsonNat)),
     ("writeSlots", jsonArray ((canonicalSlot :: effectiveAliasSlots).map jsonNat)),
     ("type", fieldTypeJson declaredField.ty),
-    ("packedBits", jsonOption packedBitsJson declaredField.packedBits)
+    ("packedBits", jsonOption packedBitsJson declaredField.packedBits),
+    ("isTransient", if declaredField.isTransient then "true" else "false"),
+    ("locationKind", jsonString (fieldLocationKind declaredField))
   ]
 
 private def immutableJson (imm : ImmutableSpec) : String :=
@@ -165,6 +170,7 @@ private def storageFamilyJson (declaredField : Field) (idx : Nat) : String :=
   let canonicalSlot := declaredField.slot.getD idx
   jsonObject [
     ("name", jsonString declaredField.name),
+    ("locationKind", jsonString (fieldLocationKind declaredField)),
     ("kind", jsonString (familyKindString declaredField.ty)),
     ("rootSlot", jsonNat canonicalSlot),
     ("keccakPreimage", familyKeccakPreimage declaredField.ty canonicalSlot),

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -150,7 +150,8 @@ private def layoutReportSpec : CompilationModel := {
   fields := [
     layoutReportAdminField,
     layoutReportPausedField,
-    layoutReportBalancesField
+    layoutReportBalancesField,
+    layoutReportLiquidationLocksField
   ]
   reservedSlotRanges := [{ start := 20, end_ := 29 }]
   slotAliasRanges := [{ sourceStart := 5, sourceEnd := 6, targetStart := 100 }]
@@ -185,6 +186,13 @@ where
     let base : Field := { name := "balances", ty := FieldType.mappingTyped (.simple .address) }
     { base with
       «slot» := some 7
+    }
+
+  layoutReportLiquidationLocksField : Field :=
+    let base : Field := { name := "liquidationLocks", ty := FieldType.mappingTyped (.simple .bytes32) }
+    { base with
+      «slot» := some 8
+      isTransient := true
     }
 
 private def proxyLayoutBaselineSpec : CompilationModel := {
@@ -531,6 +539,7 @@ private def lowLevelOnlyTrustSurfaceSpec : CompilationModel := {
       params := [{ name := "target", ty := ParamType.address }]
       returnType := none
       returns := [ParamType.uint256]
+      reentrancyTrusted := true
       localObligations := [
         { name := "low_level_call_safety"
           obligation := "Callee behavior is assumption-backed"
@@ -1475,6 +1484,10 @@ unsafe def runTests : IO Unit := do
     throw (IO.userError "✗ layout report emits packed field metadata")
   if !contains layoutReport "\"kind\":\"mapping\",\"keys\":[\"address\"],\"valueKind\":\"uint256\"" then
     throw (IO.userError "✗ layout report emits mapping field type metadata")
+  if !contains layoutReport "\"name\":\"liquidationLocks\",\"declaredSlot\":8,\"canonicalSlot\":8" ||
+      !contains layoutReport "\"isTransient\":true,\"locationKind\":\"transient\"" ||
+      !contains layoutReport "\"name\":\"liquidationLocks\",\"locationKind\":\"transient\",\"kind\":\"mapping\",\"rootSlot\":8,\"keccakPreimage\":\"keccak256(key || slot=8) [keys: bytes32]\"" then
+    throw (IO.userError "✗ layout report emits transient computed-slot preimage metadata")
   if !contains layoutReport "\"reservedSlotRanges\":[{\"start\":20,\"end\":29}]" then
     throw (IO.userError "✗ layout report emits reserved slot ranges")
   if !contains layoutReport "\"slotAliasRanges\":[{\"sourceStart\":5,\"sourceEnd\":6,\"targetStart\":100}]" then
@@ -1927,9 +1940,10 @@ unsafe def runTests : IO Unit := do
   if !writtenLayoutReport then
     throw (IO.userError "✗ compileSpecsWithOptions writes layout report file")
   expectFileContains
-    "compileSpecsWithOptions layout report includes effective write slots"
+    "compileSpecsWithOptions layout report includes effective write slots and transient preimage metadata"
     layoutReportPath
-    ["\"contract\":\"LayoutReportSmoke\"", "\"writeSlots\":[5,50,100]", "\"writeSlots\":[6,101]"]
+    ["\"contract\":\"LayoutReportSmoke\"", "\"writeSlots\":[5,50,100]", "\"writeSlots\":[6,101]",
+      "\"name\":\"liquidationLocks\",\"locationKind\":\"transient\",\"kind\":\"mapping\",\"rootSlot\":8,\"keccakPreimage\":\"keccak256(key || slot=8) [keys: bytes32]\""]
 
   let layoutCompatibilityReportPath := s!"{layoutReportDir}/layout-compat-report.json"
   compileSpecsWithOptions

--- a/Contracts/Smoke/Storage.lean
+++ b/Contracts/Smoke/Storage.lean
@@ -34,6 +34,28 @@ example :
       if field.name == "lock" then field.isTransient else true) := by
   decide
 
+verity_contract TransientComputedLockSmoke where
+  storage
+    transient locks : Bytes32 → Uint256 := slot 1
+
+  function acquire (lockId : Bytes32) : Unit := do
+    setMappingN locks [lockId] 1
+
+  function release (lockId : Bytes32) : Unit := do
+    setMappingN locks [lockId] 0
+
+  function locked (lockId : Bytes32) : Uint256 := do
+    let current ← getMappingN locks [lockId]
+    return current
+
+example :
+    TransientComputedLockSmoke.spec.fields.any (fun field =>
+      field.name == "locks" && field.isTransient &&
+        match field.ty with
+        | Compiler.CompilationModel.FieldType.mappingTyped _ => true
+        | _ => false) := by
+  decide
+
 verity_contract MappingChainSmoke where
   storage
     approvals : Address → Address → Address → Uint256 := slot 0

--- a/artifacts/macro_property_tests/PropertyTransientComputedLockSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyTransientComputedLockSmoke.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyTransientComputedLockSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/Storage.lean
+ */
+contract PropertyTransientComputedLockSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("TransientComputedLockSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: acquire has no unexpected revert
+    function testAuto_Acquire_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("acquire(bytes32)", bytes32(uint256(0xBEEF))));
+        require(ok, "acquire reverted unexpectedly");
+    }
+    // Property 2: release has no unexpected revert
+    function testAuto_Release_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("release(bytes32)", bytes32(uint256(0xBEEF))));
+        require(ok, "release reverted unexpectedly");
+    }
+    // Property 3: TODO decode and assert `locked` result
+    function testTODO_Locked_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("locked(bytes32)", bytes32(uint256(0xBEEF))));
+        require(ok, "locked reverted unexpectedly");
+        assertEq(ret.length, 32, "locked ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/artifacts/storage_layout_report.json
+++ b/artifacts/storage_layout_report.json
@@ -8,6 +8,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 0,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "storedData",
           "packedBits": null,
           "type": {
@@ -26,6 +28,7 @@
         {
           "keccakPreimage": null,
           "kind": "scalar",
+          "locationKind": "persistent",
           "name": "storedData",
           "rootSlot": 0,
           "structWordRange": null
@@ -41,6 +44,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 0,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "count",
           "packedBits": null,
           "type": {
@@ -59,6 +64,7 @@
         {
           "keccakPreimage": null,
           "kind": "scalar",
+          "locationKind": "persistent",
           "name": "count",
           "rootSlot": 0,
           "structWordRange": null
@@ -74,6 +80,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 0,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "owner",
           "packedBits": null,
           "type": {
@@ -92,6 +100,7 @@
         {
           "keccakPreimage": null,
           "kind": "scalar",
+          "locationKind": "persistent",
           "name": "owner",
           "rootSlot": 0,
           "structWordRange": null
@@ -107,6 +116,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 0,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "balances",
           "packedBits": null,
           "type": {
@@ -129,6 +140,7 @@
         {
           "keccakPreimage": "keccak256(key || slot=0) [keys: address]",
           "kind": "mapping",
+          "locationKind": "persistent",
           "name": "balances",
           "rootSlot": 0,
           "structWordRange": null
@@ -144,6 +156,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 0,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "totalAssetsSlot",
           "packedBits": null,
           "type": {
@@ -158,6 +172,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 1,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "totalSupplySlot",
           "packedBits": null,
           "type": {
@@ -172,6 +188,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 2,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "shareBalancesSlot",
           "packedBits": null,
           "type": {
@@ -234,6 +252,7 @@
         {
           "keccakPreimage": null,
           "kind": "scalar",
+          "locationKind": "persistent",
           "name": "totalAssetsSlot",
           "rootSlot": 0,
           "structWordRange": null
@@ -241,6 +260,7 @@
         {
           "keccakPreimage": null,
           "kind": "scalar",
+          "locationKind": "persistent",
           "name": "totalSupplySlot",
           "rootSlot": 1,
           "structWordRange": null
@@ -248,6 +268,7 @@
         {
           "keccakPreimage": "keccak256(key || slot=2) [keys: address]",
           "kind": "mapping",
+          "locationKind": "persistent",
           "name": "shareBalancesSlot",
           "rootSlot": 2,
           "structWordRange": null
@@ -263,6 +284,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 0,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "owner",
           "packedBits": null,
           "type": {
@@ -277,6 +300,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 1,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "count",
           "packedBits": null,
           "type": {
@@ -309,6 +334,7 @@
         {
           "keccakPreimage": null,
           "kind": "scalar",
+          "locationKind": "persistent",
           "name": "owner",
           "rootSlot": 0,
           "structWordRange": null
@@ -316,6 +342,7 @@
         {
           "keccakPreimage": null,
           "kind": "scalar",
+          "locationKind": "persistent",
           "name": "count",
           "rootSlot": 1,
           "structWordRange": null
@@ -331,6 +358,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 0,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "ownerSlot",
           "packedBits": null,
           "type": {
@@ -345,6 +374,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 1,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "balancesSlot",
           "packedBits": null,
           "type": {
@@ -363,6 +394,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 2,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "totalSupplySlot",
           "packedBits": null,
           "type": {
@@ -421,6 +454,7 @@
         {
           "keccakPreimage": null,
           "kind": "scalar",
+          "locationKind": "persistent",
           "name": "ownerSlot",
           "rootSlot": 0,
           "structWordRange": null
@@ -428,6 +462,7 @@
         {
           "keccakPreimage": "keccak256(key || slot=1) [keys: address]",
           "kind": "mapping",
+          "locationKind": "persistent",
           "name": "balancesSlot",
           "rootSlot": 1,
           "structWordRange": null
@@ -435,6 +470,7 @@
         {
           "keccakPreimage": null,
           "kind": "scalar",
+          "locationKind": "persistent",
           "name": "totalSupplySlot",
           "rootSlot": 2,
           "structWordRange": null
@@ -450,6 +486,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 0,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "count",
           "packedBits": null,
           "type": {
@@ -468,6 +506,7 @@
         {
           "keccakPreimage": null,
           "kind": "scalar",
+          "locationKind": "persistent",
           "name": "count",
           "rootSlot": 0,
           "structWordRange": null
@@ -483,6 +522,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 0,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "ownerSlot",
           "packedBits": null,
           "type": {
@@ -497,6 +538,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 1,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "totalSupplySlot",
           "packedBits": null,
           "type": {
@@ -511,6 +554,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 2,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "balancesSlot",
           "packedBits": null,
           "type": {
@@ -529,6 +574,8 @@
           "declaredAliasSlots": [],
           "declaredSlot": 3,
           "effectiveAliasSlots": [],
+          "isTransient": false,
+          "locationKind": "persistent",
           "name": "allowancesSlot",
           "packedBits": null,
           "type": {
@@ -631,6 +678,7 @@
         {
           "keccakPreimage": null,
           "kind": "scalar",
+          "locationKind": "persistent",
           "name": "ownerSlot",
           "rootSlot": 0,
           "structWordRange": null
@@ -638,6 +686,7 @@
         {
           "keccakPreimage": null,
           "kind": "scalar",
+          "locationKind": "persistent",
           "name": "totalSupplySlot",
           "rootSlot": 1,
           "structWordRange": null
@@ -645,6 +694,7 @@
         {
           "keccakPreimage": "keccak256(key || slot=2) [keys: address]",
           "kind": "mapping",
+          "locationKind": "persistent",
           "name": "balancesSlot",
           "rootSlot": 2,
           "structWordRange": null
@@ -652,6 +702,7 @@
         {
           "keccakPreimage": "keccak256(innerKey || keccak256(outerKey || slot=3)) [keys: address, address]",
           "kind": "nestedMapping",
+          "locationKind": "persistent",
           "name": "allowancesSlot",
           "rootSlot": 3,
           "structWordRange": null

--- a/scripts/generate_macro_property_tests.py
+++ b/scripts/generate_macro_property_tests.py
@@ -52,6 +52,17 @@ INTERFACE_RE = re.compile(r"^\s*interface\s+([A-Za-z_][A-Za-z0-9_]*)\s+where\s*$
 STORAGE_RE = re.compile(
     rf"^\s*{_IDENT}\s*:\s*(.+?)\s*:=\s*slot\s+([0-9]+)\s*$",
 )
+STORAGE_MODIFIER_RE = re.compile(r"^(transient|persistent)\s+(.*)$")
+
+
+def _split_storage_modifier(text: str) -> tuple[str | None, str]:
+    """Strip a leading `transient`/`persistent` location modifier from a storage decl."""
+    m = STORAGE_MODIFIER_RE.match(text)
+    if m:
+        return m.group(1), m.group(2)
+    return None, text
+
+
 VALUE_BINDING_RE = re.compile(
     rf"^\s*{_IDENT}\s*:\s*(.+?)\s*:=\s*(.+?)\s*$",
 )
@@ -145,6 +156,7 @@ class ContractDecl:
     storage_slots: dict[str, int]
     source: Path
     storage_types: dict[str, str] = field(default_factory=dict)
+    transient_slots: frozenset[str] = frozenset()
     newtypes: dict[str, str] = field(default_factory=dict)
     constants: dict[str, ValueDecl] = field(default_factory=dict)
     immutables: dict[str, ValueDecl] = field(default_factory=dict)
@@ -289,6 +301,7 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
     current_name: str | None = None
     current_constructor: ConstructorDecl | None = None
     current_storage_slots: dict[str, int] = {}
+    current_transient_slots: set[str] = set()
     current_storage_types: dict[str, str] = {}
     current_newtypes: dict[str, str] = {}
     current_structs: dict[str, tuple[ParamDecl, ...]] = {}
@@ -335,7 +348,7 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
         current_body = []
 
     def flush_current() -> None:
-        nonlocal current_name, current_constructor, current_storage_slots, current_storage_types, current_newtypes, current_structs, current_constants, current_immutables, current_functions, in_types_block, in_storage_block, in_constants_block, in_immutables_block, pending_storage_lines, current_struct_block_comment
+        nonlocal current_name, current_constructor, current_storage_slots, current_transient_slots, current_storage_types, current_newtypes, current_structs, current_constants, current_immutables, current_functions, in_types_block, in_storage_block, in_constants_block, in_immutables_block, pending_storage_lines, current_struct_block_comment
         if current_name is None:
             return
         flush_struct()
@@ -347,6 +360,7 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
             storage_slots=dict(current_storage_slots),
             source=source,
             storage_types=dict(current_storage_types),
+            transient_slots=frozenset(current_transient_slots),
             newtypes=dict(current_newtypes),
             constants=dict(current_constants),
             immutables=dict(current_immutables),
@@ -354,6 +368,7 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
         current_name = None
         current_constructor = None
         current_storage_slots = {}
+        current_transient_slots = set()
         current_storage_types = {}
         current_newtypes = {}
         current_structs = {}
@@ -522,18 +537,24 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
 
         if in_storage_block:
             stripped = line.strip()
-            sm = STORAGE_RE.match(stripped)
+            modifier, decl_body = _split_storage_modifier(stripped)
+            sm = STORAGE_RE.match(decl_body)
             if sm:
                 current_storage_slots[sm.group(1)] = int(sm.group(3))
                 current_storage_types[sm.group(1)] = _normalize_type(sm.group(2))
+                if modifier == "transient":
+                    current_transient_slots.add(sm.group(1))
                 pending_storage_lines = []
                 continue
             if pending_storage_lines:
                 pending_storage_lines.append(stripped)
-                sm = STORAGE_RE.match(" ".join(pending_storage_lines))
+                joined_modifier, joined_body = _split_storage_modifier(" ".join(pending_storage_lines))
+                sm = STORAGE_RE.match(joined_body)
                 if sm:
                     current_storage_slots[sm.group(1)] = int(sm.group(3))
                     current_storage_types[sm.group(1)] = _normalize_type(sm.group(2))
+                    if joined_modifier == "transient":
+                        current_transient_slots.add(sm.group(1))
                     pending_storage_lines = []
                 continue
             if stripped:
@@ -2215,9 +2236,24 @@ def _infer_straight_line_non_unit_test(
     )
 
 
+def _reads_transient_slot(contract: ContractDecl, body: list[str]) -> bool:
+    """A read of a transient storage slot cannot be modelled by the persistent
+    ``vm.store`` equivalence tests this generator emits, so such functions are
+    skipped (they fall through to a no-revert TODO stub)."""
+    if not contract.transient_slots:
+        return False
+    for line in body:
+        read = _parse_read_accessor(line)
+        if read is not None and read.storage_name in contract.transient_slots:
+            return True
+    return False
+
+
 def _render_inferred_non_unit_test(contract: ContractDecl, fn: FunctionDecl, idx: int, encode_args: str) -> str | None:
     fn_camel = _fn_camel(fn.name)
     body = list(fn.body)
+    if _reads_transient_slot(contract, body):
+        return None
     ty = _normalize_type(fn.return_type)
     param_examples = _choose_param_examples(fn)
     constructor_examples = (


### PR DESCRIPTION
## Summary
- Add transient/persistent location metadata to layout report fields and storage families.
- Surface typed mapping slot preimages for transient computed slots, including keccak preimage strings.
- Add compile-driver coverage for a transient bytes32 liquidation-lock mapping and a source smoke for transient computed lock mappings.
- Keep low-level deny fixture past the CEI reentrancy gate by marking the low-level external-call fixture reentrancyTrusted.

## Verification
- lake build
- lake build Compiler.CompileDriverTest
- rg -n '\bsorry\b' Compiler/CompilationModel/LayoutReport.lean Compiler/CompileDriverTest.lean Contracts/Smoke/Storage.lean
- In /workspaces/morpho-verity: lake build
- In /workspaces/morpho-verity: lake build Morpho.Compiler.MidnightCreate2CodeReadSmoke && lake env lean Morpho/Compiler/MidnightCreate2CodeReadSmoke.lean

## Morpho parity note
- Updated /workspaces/morpho-verity/MORPHO_MIDNIGHT_MAPPING.md locally to document issue #1995 transient lock-slot mapping.
- Full ./scripts/run_morpho_blue_parity.sh did not reach the differential suite in this checkout: native artifact prep timed out twice compiling the 102 MB generated Compiler/Yul/PatchRules.c object, even with MORPHO_VERITY_PREP_TIMEOUT_SEC=2400 and MORPHO_VERITY_PARITY_PREFLIGHT_TIMEOUT_SEC=3600.
- Manual interpreter artifact generation succeeded, but solc --strict-assembly failed on the generated Morpho.yul with pre-existing duplicate __ite_cond names in the current dirty morpho-yul-identity checkout, so I could not produce a complete prepared artifact bundle locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reporting, tests, and generator changes only; no auth or payment paths. The reentrancyTrusted fixture change is test-only.
> 
> **Overview**
> **Layout JSON** now tags each field and storage family with **`isTransient`**, **`locationKind`** (`persistent` / `transient`), and keeps **keccak preimage strings** for computed slots (including transient mappings like `bytes32` keys).
> 
> **Tests and smoke**: compile-driver layout spec adds a transient **`liquidationLocks`** mapping with assertions on transient preimage metadata; **`TransientComputedLockSmoke`** in `Storage.lean` exercises transient **`Bytes32 → Uint256`** mapping locks; regenerated **`storage_layout_report.json`** and a **Foundry property stub** for the new contract.
> 
> **Tooling**: **`generate_macro_property_tests.py`** parses `transient`/`persistent` storage modifiers and **skips** persistent `vm.store` equivalence tests when a function reads transient slots.
> 
> **Fixture tweak**: **`LowLevelOnlyTrustSurface`** sets **`reentrancyTrusted := true`** so the low-level deny-path regression still passes the CEI reentrancy gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 285dfb4ff8a6151bcbc6c80d2fd747096b379b60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->