### PR TITLE
C2: add view/storage lens proof entry point

### DIFF
--- a/Compiler.lean
+++ b/Compiler.lean
@@ -30,6 +30,7 @@ import Compiler.Yul.PatchRules
 import Compiler.Keccak.SpongeProperties
 import Compiler.Proofs.KeccakBound
 import Compiler.Proofs.MappingSlot
+import Compiler.Proofs.StorageLens
 import Compiler.Proofs.IRGeneration.Expr
 import Compiler.Proofs.IRGeneration.SupportedFragment
 import Compiler.Proofs.IRGeneration.Contract

--- a/Compiler/Proofs/StorageLens.lean
+++ b/Compiler/Proofs/StorageLens.lean
@@ -79,7 +79,7 @@ theorem word_read_store_other
     (word readSlot).read
       (abstractStoreStorageOrMapping storage writeSlot value) =
     (word readSlot).read storage := by
-  simp [word, abstractLoadStorageOrMapping, abstractStoreStorageOrMapping, h]
+  simp [word, abstractLoadStorageOrMapping, h]
 
 end ViewLens
 

--- a/Compiler/Proofs/StorageLens.lean
+++ b/Compiler/Proofs/StorageLens.lean
@@ -1,0 +1,150 @@
+import Compiler.Proofs.MappingSlot
+
+namespace Compiler.Proofs
+
+open Compiler.Proofs.IRGeneration (IRStorageSlot IRStorageWord)
+
+/-!
+Proof-facing storage lenses.
+
+This module is the first C2 part 2 entry point.  It keeps the lens surface
+small: a `ViewLens` observes through a source without mutation, while a
+`StorageLens` additionally carries the write half needed by later frame and
+composition proofs.
+-/
+
+/-- Proof-side flat storage carrier. -/
+abbrev Storage : Type := IRStorageSlot → IRStorageWord
+
+/--
+Read-only lens from `σ` to `α`.
+
+The `slotOffset` and `decode` fields record the storage-observation shape used
+by concrete storage views.  Generic views can still provide any `read` function;
+composition proofs only rely on `read`.
+-/
+structure ViewLens (σ : Type) (α : Type) where
+  slotOffset : Nat
+  decode : IRStorageWord → α
+  read : σ → α
+
+/-- Read-write lens from `σ` to `α`. -/
+structure StorageLens (σ : Type) (α : Type) where
+  slotOffset : Nat
+  decode : IRStorageWord → α
+  encode : α → IRStorageWord
+  read : σ → α
+  write : α → σ → σ
+
+namespace ViewLens
+
+/-- Read one resolved storage word. -/
+def word (slot : Nat) : ViewLens Storage IRStorageWord :=
+  { slotOffset := slot
+    decode := id
+    read := fun storage => abstractLoadStorageOrMapping storage slot }
+
+/-- Read and decode one resolved storage word. -/
+def wordDecoded (slot : Nat) (decode : IRStorageWord → α) : ViewLens Storage α :=
+  { slotOffset := slot
+    decode := decode
+    read := fun storage => decode (abstractLoadStorageOrMapping storage slot) }
+
+/-- Read one Solidity mapping word using the shared mapping-slot model. -/
+def mappingWord (baseSlot key : Nat) : ViewLens Storage IRStorageWord :=
+  word (solidityMappingSlot baseSlot key)
+
+/-- Read and decode one Solidity mapping word using the shared mapping-slot model. -/
+def mappingWordDecoded
+    (baseSlot key : Nat) (decode : IRStorageWord → α) : ViewLens Storage α :=
+  wordDecoded (solidityMappingSlot baseSlot key) decode
+
+@[simp] theorem word_read (slot : Nat) (storage : Storage) :
+    (word slot).read storage = abstractLoadStorageOrMapping storage slot := rfl
+
+@[simp] theorem wordDecoded_read
+    (slot : Nat) (decode : IRStorageWord → α) (storage : Storage) :
+    (wordDecoded slot decode).read storage =
+      decode (abstractLoadStorageOrMapping storage slot) := rfl
+
+@[simp] theorem mappingWord_read (baseSlot key : Nat) (storage : Storage) :
+    (mappingWord baseSlot key).read storage =
+      abstractLoadStorageOrMapping storage (solidityMappingSlot baseSlot key) := rfl
+
+/-- A flat-slot write to a projected-distinct slot preserves a word view. -/
+theorem word_read_store_other
+    (storage : Storage)
+    (readSlot writeSlot value : Nat)
+    (h : IRStorageSlot.ofNat readSlot ≠ IRStorageSlot.ofNat writeSlot) :
+    (word readSlot).read
+      (abstractStoreStorageOrMapping storage writeSlot value) =
+    (word readSlot).read storage := by
+  simp [word, abstractLoadStorageOrMapping, abstractStoreStorageOrMapping, h]
+
+end ViewLens
+
+namespace StorageLens
+
+/-- The identity storage lens, useful as the root of storage-view composition. -/
+def idStorage : StorageLens Storage Storage :=
+  { slotOffset := 0
+    decode := fun word _ => word
+    encode := fun storage => storage (IRStorageSlot.ofNat 0)
+    read := id
+    write := fun replacement _ => replacement }
+
+/-- Read-write lens for one resolved storage word. -/
+def word (slot : Nat) : StorageLens Storage IRStorageWord :=
+  { slotOffset := slot
+    decode := id
+    encode := id
+    read := fun storage => abstractLoadStorageOrMapping storage slot
+    write := fun value storage =>
+      fun s => if s = IRStorageSlot.ofNat slot then value else storage s }
+
+/-- Project the read half of a storage lens as a view lens. -/
+def toViewLens (sl : StorageLens σ α) : ViewLens σ α :=
+  { slotOffset := sl.slotOffset
+    decode := sl.decode
+    read := sl.read }
+
+@[simp] theorem toViewLens_read (sl : StorageLens σ α) (s : σ) :
+    sl.toViewLens.read s = sl.read s := rfl
+
+@[simp] theorem word_read (slot : Nat) (storage : Storage) :
+    (word slot).read storage = abstractLoadStorageOrMapping storage slot := rfl
+
+@[simp] theorem word_write (slot : Nat) (value : IRStorageWord) (storage : Storage) :
+    (word slot).write value storage =
+      (fun s => if s = IRStorageSlot.ofNat slot then value else storage s) := rfl
+
+end StorageLens
+
+/-- Compose a read-only view through the read half of a storage lens. -/
+def view_lens_comp (vl : ViewLens τ α) (sl : StorageLens σ τ) (s : σ) : α :=
+  vl.read (sl.read s)
+
+/--
+Composing a view lens with a storage lens is observationally the same as
+reading the storage lens focus and then reading the view.
+-/
+@[simp] theorem view_lens_comp_correct
+    (vl : ViewLens τ α) (sl : StorageLens σ τ) (s : σ) :
+    view_lens_comp vl sl s = vl.read (sl.read s) := rfl
+
+/-- Project the read-only view carried by a read-write storage lens. -/
+def view_lens_of_storage_lens (sl : StorageLens σ α) : ViewLens σ α :=
+  sl.toViewLens
+
+/-- The projected view lens observes exactly the storage lens read. -/
+@[simp] theorem view_lens_of_storage_lens_correct
+    (sl : StorageLens σ α) (s : σ) :
+    (view_lens_of_storage_lens sl).read s = sl.read s := rfl
+
+/-- Composing with a projected storage lens view is the same as nested reads. -/
+@[simp] theorem view_lens_comp_of_storage_lens_correct
+    (outer : StorageLens τ α) (inner : StorageLens σ τ) (s : σ) :
+    view_lens_comp (view_lens_of_storage_lens outer) inner s =
+      outer.read (inner.read s) := rfl
+
+end Compiler.Proofs

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -72,6 +72,7 @@ import Compiler.Proofs.IRGeneration.SupportedSpec
 import Compiler.Proofs.KeccakBound
 import Compiler.Proofs.MappingSlot
 import Compiler.Proofs.StorageBounds
+import Compiler.Proofs.StorageLens
 import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBodyClosure.Base
 import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBodyClosure.Generic
 import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBodyClosure.Safe
@@ -3767,6 +3768,18 @@ end Verity.AxiomAudit
   Compiler.Proofs.StorageBounds.writeStorageArray_storage_unchanged
   Compiler.Proofs.StorageBounds.writeStorageArray_events_unchanged
 
+  -- Compiler/Proofs/StorageLens.lean
+  Compiler.Proofs.ViewLens.word_read
+  Compiler.Proofs.ViewLens.wordDecoded_read
+  Compiler.Proofs.ViewLens.mappingWord_read
+  Compiler.Proofs.ViewLens.word_read_store_other
+  Compiler.Proofs.StorageLens.toViewLens_read
+  Compiler.Proofs.StorageLens.word_read
+  Compiler.Proofs.StorageLens.word_write
+  Compiler.Proofs.view_lens_comp_correct
+  Compiler.Proofs.view_lens_of_storage_lens_correct
+  Compiler.Proofs.view_lens_comp_of_storage_lens_correct
+
   -- Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBodyClosure/Base.lean
   -- Compiler.Proofs.YulGeneration.Backends.compileStmtWithFork_cancun_eq_compileStmt  -- private
   -- Compiler.Proofs.YulGeneration.Backends.compileStmtListWithFork_cancun_eq_compileStmtList  -- private
@@ -5795,4 +5808,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5431 theorems/lemmas (3735 public, 1696 private, 0 sorry'd)
+-- Total: 5441 theorems/lemmas (3745 public, 1696 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- Adds `Compiler/Proofs/StorageLens.lean`, the C2 (storage lens part 2) proof entry point: read-only `ViewLens` and read-write `StorageLens` over the flat `Storage := IRStorageSlot → IRStorageWord` model, with `word`/`wordDecoded`/`mappingWord` constructors, a `word_read_store_other` frame lemma, and view/storage-lens composition lemmas.
- Wires the new module into `Compiler.lean` (lib root aggregator) and regenerates `PrintAxioms.lean` (additive: +1 import, +10 public theorems in the axiom-audit manifest).

## Notes
- The lens module is authored by Thomas Marchand (cherry-picked from `feat/c2-view-lens` onto current `main`); the follow-up commit adds the axiom-audit wiring and drops one redundant simp argument so the file builds warning-free (Lean warning baseline stays at 0).

## Verification
- `lake build` — exit 0
- `lake build PrintAxioms` — exit 0
- `python3 scripts/generate_print_axioms.py --check` — up to date
- `python3 scripts/check_axioms.py` — PASS (only Lean builtins; 0 undocumented axioms)
- StorageLens.lean: 0 `sorry` / 0 `admit`, 0 warnings

## Test plan
- [ ] CI `verify.yml` green (build, PrintAxioms, warning regression, axiom audit)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New proof infrastructure only; reuses existing MappingSlot load/store abstractions with no runtime or security behavior changes.
> 
> **Overview**
> Introduces **`Compiler/Proofs/StorageLens.lean`**, the C2 part 2 proof entry for storage observation and updates over flat `Storage` (`IRStorageSlot → IRStorageWord`).
> 
> The module adds **`ViewLens`** (read-only) and **`StorageLens`** (read/write with encode/decode), plus constructors for resolved words, decoded words, and Solidity mapping slots via `solidityMappingSlot`. It includes **`word_read_store_other`** (writes to a distinct slot preserve an unrelated word view) and simp lemmas for **`view_lens_comp`**, projecting storage lenses to views, and nested read composition.
> 
> **`Compiler.lean`** and **`PrintAxioms.lean`** import the module and list ten new public theorems in the axiom audit manifest (+10 in the total count).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39f0b100b107753ed6fb0ef7299d8756b4a4e1e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->