### PR TITLE
C3: bridge SupportedSpec to mapping-write fragment

### DIFF
--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -2849,6 +2849,68 @@ structure SupportedSpecExceptMappingWrites
   functions :
     ∀ fn, fn ∈ spec.functions → SupportedFunctionExceptMappingWrites spec fn
 
+private theorem stmtTouchesUnsupportedStateSurfaceExceptMappingWrites_eq_false_of_stateSurface
+    {stmt : Stmt}
+    (hstate : stmtTouchesUnsupportedStateSurface stmt = false) :
+    stmtTouchesUnsupportedStateSurfaceExceptMappingWrites stmt = false := by
+  cases stmt <;>
+    simp [stmtTouchesUnsupportedStateSurfaceExceptMappingWrites,
+      stmtTouchesUnsupportedStateSurface] at hstate ⊢ <;>
+    try exact hstate
+
+theorem stmtListTouchesUnsupportedStateSurfaceExceptMappingWrites_eq_false_of_stateSurface
+    {stmts : List Stmt}
+    (hstate : stmtListTouchesUnsupportedStateSurface stmts = false) :
+    stmtListTouchesUnsupportedStateSurfaceExceptMappingWrites stmts = false := by
+  induction stmts with
+  | nil =>
+      simp [stmtListTouchesUnsupportedStateSurfaceExceptMappingWrites]
+  | cons stmt rest ih =>
+      have hsplit := Bool.or_eq_false_iff.mp hstate
+      simp [stmtListTouchesUnsupportedStateSurfaceExceptMappingWrites,
+        stmtTouchesUnsupportedStateSurfaceExceptMappingWrites_eq_false_of_stateSurface hsplit.1,
+        ih hsplit.2]
+
+def SupportedBodyStateInterface.exceptMappingWrites
+    {fn : FunctionSpec}
+    (hState : SupportedBodyStateInterface fn) :
+    SupportedBodyStateInterfaceExceptMappingWrites fn :=
+  { surfaceClosed :=
+      stmtListTouchesUnsupportedStateSurfaceExceptMappingWrites_eq_false_of_stateSurface
+        hState.surfaceClosed }
+
+def SupportedBodyInterface.exceptMappingWrites
+    {spec : CompilationModel} {fn : FunctionSpec}
+    (hBody : SupportedBodyInterface spec fn) :
+    SupportedBodyInterfaceExceptMappingWrites spec fn :=
+  { stmtList := hBody.stmtList
+    core := hBody.core
+    state := hBody.state.exceptMappingWrites
+    calls := hBody.calls
+    effects := hBody.effects
+    noLocalObligations := hBody.noLocalObligations }
+
+def SupportedFunction.exceptMappingWrites
+    {spec : CompilationModel} {fn : FunctionSpec}
+    (hSupported : SupportedFunction spec fn) :
+    SupportedFunctionExceptMappingWrites spec fn :=
+  { nonInternal := hSupported.nonInternal
+    nonSpecialEntrypoint := hSupported.nonSpecialEntrypoint
+    noNonReentrant := hSupported.noNonReentrant
+    params := hSupported.params
+    returns := hSupported.returns
+    body := hSupported.body.exceptMappingWrites }
+
+def SupportedSpec.exceptMappingWrites
+    {spec : CompilationModel} {selectors : List Nat}
+    (hSupported : SupportedSpec spec selectors) :
+    SupportedSpecExceptMappingWrites spec selectors :=
+  { invariants := hSupported.invariants
+    surface := hSupported.surface
+    constructor := hSupported.constructor
+    functions := fun fn hmem =>
+      (hSupported.functions fn hmem).exceptMappingWrites }
+
 theorem SupportedFunction.paramNamesNodup
     {spec : CompilationModel} {fn : FunctionSpec}
     (hSupported : SupportedFunction spec fn) :

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3553,6 +3553,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.exprHelperCallNames_subset_helperCallNames
   Compiler.Proofs.IRGeneration.SupportedConstructor.paramNamesNodup
   Compiler.Proofs.IRGeneration.SupportedConstructor.paramsSupported
+  -- Compiler.Proofs.IRGeneration.stmtTouchesUnsupportedStateSurfaceExceptMappingWrites_eq_false_of_stateSurface  -- private
+  Compiler.Proofs.IRGeneration.stmtListTouchesUnsupportedStateSurfaceExceptMappingWrites_eq_false_of_stateSurface
   Compiler.Proofs.IRGeneration.SupportedFunction.paramNamesNodup
   Compiler.Proofs.IRGeneration.SupportedFunction.paramsSupported
   Compiler.Proofs.IRGeneration.SupportedFunction.paramCalldataThreshold
@@ -5820,4 +5822,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5450 theorems/lemmas (3754 public, 1696 private, 0 sorry'd)
+-- Total: 5452 theorems/lemmas (3755 public, 1697 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

This is a narrow C3 slice for #1723. It closes the bridge from the original `SupportedSpec` fragment into the existing `SupportedSpecExceptMappingWrites` tier-2 consumer surface without weakening any gate.

The new proof shows that the existing full state-surface closure implies the weaker `ExceptMappingWrites` state-surface closure:

- `stmtTouchesUnsupportedStateSurfaceExceptMappingWrites_eq_false_of_stateSurface` (private)
- `stmtListTouchesUnsupportedStateSurfaceExceptMappingWrites_eq_false_of_stateSurface`
- `SupportedBodyStateInterface.exceptMappingWrites`
- `SupportedBodyInterface.exceptMappingWrites`
- `SupportedFunction.exceptMappingWrites`
- `SupportedSpec.exceptMappingWrites`

`PrintAxioms.lean` was regenerated so the new theorem and theorem counts remain in the audit surface. No new `sorry`, no new axioms, no trust gate deletion.

## Current gate audit

- `stmtTouchesUnsupported*`: the body surface is split across constructor raw calldata, core, state, effects, calls, helper, foreign, low-level, and contract surfaces in `Compiler/Proofs/IRGeneration/SupportedSpec.lean`. The only bridge closed here is `state -> stateExceptMappingWrites`; other statement surfaces still require their feature-specific proof bridges.
- `exprTouchesUnsupported*`: dynamic ABI and helper/accessor expressions remain excluded through the core/state/call/helper/foreign/low-level expression surfaces. Existing `SupportedSpec` consequences still prove usage-analysis exclusions such as `contractUsesParamDynamicHeadWord = false`, `contractUsesArrayElement = false`, `contractUsesStorageArrayElement = false`, and `contractUsesDynamicBytesEq = false`.
- `SupportedSpec`: still the narrow initial whole-contract witness: global invariants, restricted contract surface, constructor support through `SupportedConstructor`, and per-function `SupportedFunction`.
- `SupportedSpecExceptMappingWrites`: still keeps the same invariants/surface/constructor gates as `SupportedSpec`, but uses `SupportedFunctionExceptMappingWrites`; this PR adds a direct bridge from `SupportedSpec` into it.
- `SupportedFragment`: remains the statement-list fragment consumed by Yul body closure/back-end bridges; this PR does not expand its constructors.
- `SupportedBodyInterface`: remains split into `stmtList`, `core`, `state`, `calls`, `effects`, and `noLocalObligations`; this PR bridges only the `state` component into `SupportedBodyInterfaceExceptMappingWrites`.
- Dynamic ABI accessor surfaces: #2057 refinement is present on main, but current SupportedSpec usage proofs still exclude dynamic head words, array-element accessors, storage-array-element accessors, and dynamic-bytes equality from the generic fragment.
- Execution summary/frame consumers: `Compiler/Proofs/Frames.lean` exposes `ExecutionSummary` and frame rules, but generated-body consumers in `Compiler/Proofs/EndToEnd/Base.lean` still primarily consume `SupportedSpecExceptMappingWrites` and body closure bridges; this PR does not retarget them to summary output.

## Validation

Passed:

- `lean-slot lake build Compiler.Proofs.IRGeneration.SupportedSpec`
- `lean-slot lake build PrintAxioms`
- `scripts/refresh_verification_artifacts.sh`
- `make check`

Attempted broader requested build:

- `lean-slot lake build Verity Contracts Compiler PrintAxioms` failed in existing target `Compiler.Modules.CallsTest` because `self-delegate multicall bytes smoke spec` now fails input validation with: function `multicall` makes an external call but declares no reentrancy disposition. This is unrelated to the proof bridge in this PR; the focused proof targets and `make check` pass.

Zero new `sorry`; Lean hygiene in `make check` reports `0 sorry`. Zero new axioms; axiom registry remains synchronized with `0 source axioms`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof-only changes in IR generation supported-spec; no compiler runtime or trust-gate removal.
> 
> **Overview**
> Adds a **proof bridge** from full `SupportedSpec` into the existing `SupportedSpecExceptMappingWrites` tier without relaxing any gate.
> 
> New lemmas show that when the strict state-surface check is closed (`stmtListTouchesUnsupportedStateSurface = false`), the weaker **except-mapping-writes** state check is also closed. On top of that, **`exceptMappingWrites`** builders lift witnesses from `SupportedBodyStateInterface` through body, function, and whole-contract `SupportedSpec`.
> 
> **`PrintAxioms.lean`** is refreshed so the new list-level theorem stays in the audit registry and theorem counts update (+2 total, +1 public, +1 private). No new axioms or `sorry`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f98457120ef1cf2fecc650710cee01c66b28388b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->