### PR TITLE
Collapse supported native fragment bridge

### DIFF
--- a/Compiler/Proofs/EndToEnd/Base.lean
+++ b/Compiler/Proofs/EndToEnd/Base.lean
@@ -5212,6 +5212,43 @@ private theorem stmtListTouchesUnsupportedStateSurfaceExceptMappingWrites_append
       simp [stmtListTouchesUnsupportedStateSurfaceExceptMappingWrites, ih,
         Bool.or_assoc]
 
+private theorem stmtTouchesUnsupportedStateSurface_eq_false_of_mem
+    {stmt : CompilationModel.Stmt} {stmts : List CompilationModel.Stmt}
+    (hState : stmtListTouchesUnsupportedStateSurface stmts = false)
+    (hmem : stmt ∈ stmts) :
+    stmtTouchesUnsupportedStateSurface stmt = false := by
+  induction stmts with
+  | nil =>
+      simp at hmem
+  | cons head rest ih =>
+      simp only [stmtListTouchesUnsupportedStateSurface, Bool.or_eq_false_iff] at hState
+      simp only [List.mem_cons] at hmem
+      rcases hmem with rfl | hmem
+      · exact hState.1
+      · exact ih hState.2 hmem
+
+private theorem stmtMappingWriteSlotSafe_of_stateSurfaceClosed
+    {fields : List CompilationModel.Field} {stmt : CompilationModel.Stmt}
+    (hState : stmtTouchesUnsupportedStateSurface stmt = false) :
+    StmtMappingWriteSlotSafe fields stmt := by
+  cases stmt <;>
+    simp [StmtMappingWriteSlotSafe, stmtTouchesUnsupportedStateSurface] at hState ⊢
+
+private theorem stmtMappingWriteSlotSafe_of_supported_stateClosed
+    {spec : CompilationModel.CompilationModel} {selectors : List Nat}
+    (hSupported : SupportedSpec spec selectors) :
+    ∀ entry, entry ∈ SourceSemantics.selectorFunctionPairs spec selectors →
+      ∀ stmt, stmt ∈ entry.1.body →
+        StmtMappingWriteSlotSafe spec.fields stmt := by
+  intro entry hentry stmt hmem
+  have hfn : entry.1 ∈ selectorDispatchedFunctions spec := by
+    simpa [SourceSemantics.selectorFunctionPairs] using
+      (List.of_mem_zip hentry).1
+  exact stmtMappingWriteSlotSafe_of_stateSurfaceClosed
+    (stmtTouchesUnsupportedStateSurface_eq_false_of_mem
+      (hSupported.supportedFunctionOfSelectorDispatched hfn).body.state.surfaceClosed
+      hmem)
+
 private theorem stmtListTouchesUnsupportedEffectSurface_append
     (pfx sfx : List CompilationModel.Stmt) :
     stmtListTouchesUnsupportedEffectSurface (pfx ++ sfx) =
@@ -6879,8 +6916,9 @@ theorem generatedRuntimeNativeFragment_of_compile_ok_supported
     (hSupported : SupportedSpec spec selectors) :
     Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeNativeFragment
       (Compiler.emitYul irContract).runtimeCode = true :=
-  generatedRuntimeNativeFragment_of_compile_ok_supported_safeBodies
-    hCompile hSupported (generatedRuntimeSafeBodies_of_supported hSupported)
+  generatedRuntimeNativeFragment_of_compile_ok_supported_except_mapping_writes_stmt_safety
+    hCompile hSupported.exceptMappingWrites
+    (stmtMappingWriteSlotSafe_of_supported_stateClosed hSupported)
 
 /-- Supported compiler output passes the native generated-runtime fragment
 validator. -/

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1078,6 +1078,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.EndToEnd.supportedFunctionSupportedStmtList_of_supported
   -- Compiler.Proofs.EndToEnd.stmtListTouchesUnsupportedStateSurface_append  -- private
   -- Compiler.Proofs.EndToEnd.stmtListTouchesUnsupportedStateSurfaceExceptMappingWrites_append  -- private
+  -- Compiler.Proofs.EndToEnd.stmtTouchesUnsupportedStateSurface_eq_false_of_mem  -- private
+  -- Compiler.Proofs.EndToEnd.stmtMappingWriteSlotSafe_of_stateSurfaceClosed  -- private
+  -- Compiler.Proofs.EndToEnd.stmtMappingWriteSlotSafe_of_supported_stateClosed  -- private
   -- Compiler.Proofs.EndToEnd.stmtListTouchesUnsupportedEffectSurface_append  -- private
   -- Compiler.Proofs.EndToEnd.stmtListTouchesUnsupportedCallSurface_append  -- private
   Compiler.Proofs.EndToEnd.supportedStmtList_safe_of_state_effect_closed
@@ -5822,4 +5825,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5452 theorems/lemmas (3755 public, 1697 private, 0 sorry'd)
+-- Total: 5455 theorems/lemmas (3755 public, 1700 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

- derive mapping-write slot-safety automatically for `SupportedSpec` bodies whose original state surface is closed
- make `generatedRuntimeNativeFragment_of_compile_ok_supported` delegate through the post-#2069 `SupportedSpec.exceptMappingWrites` bridge
- regenerate `PrintAxioms.lean` for the added private proof helpers

## C3 slice

This collapses one more end-to-end/native proof wrapper onto the wider `SupportedSpecExceptMappingWrites` theorem surface without admitting any new programs. The plain `SupportedSpec` path now reuses the mapping-write native-fragment theorem with a safety witness derived from its stricter state gate.

## Validation

- `lean-slot lake build Compiler.Proofs.EndToEnd.Base`
- `lean-slot lake build PrintAxioms`
- `git diff --check`

No new `sorry`; `PrintAxioms.lean` reports `0 sorry'd`. No new axioms were introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof-only refactor with no executable or spec-admission changes; theorem statements for callers stay the same.
> 
> **Overview**
> Refactors the end-to-end proof so **`generatedRuntimeNativeFragment_of_compile_ok_supported`** no longer goes through **`generatedRuntimeNativeFragment_of_compile_ok_supported_safeBodies`** and **`generatedRuntimeSafeBodies_of_supported`**. It now calls **`generatedRuntimeNativeFragment_of_compile_ok_supported_except_mapping_writes_stmt_safety`** with **`hSupported.exceptMappingWrites`** and a mapping-write slot-safety witness derived inside the proof.
> 
> Three **private** lemmas in **`Base.lean`** supply that witness: membership implies a statement does not touch unsupported state surface; closed state surface implies **`StmtMappingWriteSlotSafe`**; and **`SupportedSpec`** selector-dispatched bodies get slot safety from their stricter state gate. **`PrintAxioms.lean`** is regenerated to list those helpers and bump the private theorem count (5452 → 5455).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79938d8ac3390647774552980de3afb255944de1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->