### PR TITLE
chore: move layer2 boundary catalog check into docsync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ check: ## Run local CI-equivalent checks job (no Lean build, no solc)
 	python3 scripts/generate_layer2_boundary_catalog.py --check
 	python3 scripts/check_verification_status_doc.py
 	python3 scripts/docsync.py --check --only layer2_boundary
-	python3 scripts/check_layer2_boundary_catalog_sync.py
+	python3 scripts/docsync.py --check --only layer2_boundary_catalog
 	python3 scripts/generate_verify_sync_spec.py --check
 	python3 scripts/check_verify_sync.py
 	python3 scripts/check_bridge_coverage_sync.py

--- a/scripts/REFERENCE.md
+++ b/scripts/REFERENCE.md
@@ -18,13 +18,13 @@ This document is the long-form reference for script responsibilities.
 
 ## Artifacts and documentation consistency
 
-- `docsync.py`: schema-driven doc-sync engine (P7 consolidation). One declarative registry of artifact/doc bindings; run `python3 scripts/docsync.py --check [--only <entry>]` or `--list`. Migrated entries: `low_level_call_boundary`, `linear_memory_boundary`, `axiomatized_primitive_boundary`, `struct_mapping_surface`, `layer2_boundary`, `interpreter_feature_boundary_catalog`. The legacy `check_*_sync.py` paths below remain as thin shims.
+- `docsync.py`: schema-driven doc-sync engine (P7 consolidation). One declarative registry of artifact/doc bindings; run `python3 scripts/docsync.py --check [--only <entry>]` or `--list`. Migrated entries: `low_level_call_boundary`, `linear_memory_boundary`, `axiomatized_primitive_boundary`, `struct_mapping_surface`, `layer2_boundary`, `layer2_boundary_catalog`, `interpreter_feature_boundary_catalog`. The legacy `check_*_sync.py` paths below remain as thin shims.
 - `generate_verification_status.py`: refresh/check `artifacts/verification_status.json`.
 - `generate_layer2_boundary_catalog.py`: refresh/check `artifacts/layer2_boundary_catalog.json`.
 - `check_feature_ownership.py`: validate `artifacts/feature_ownership.json`, the major feature-surface ownership and proof-boundary registry.
 - `check_verification_status_doc.py`: keep `docs/VERIFICATION_STATUS.md` aligned with the artifact-backed live totals.
 - `check_layer2_boundary_sync.py`: shim for `docsync.py --only layer2_boundary` (Layer 2 proof-boundary claims across README/trust/docs/docs-site surfaces).
-- `check_layer2_boundary_catalog_sync.py`: keep Layer 2 docs aligned with the machine-readable boundary catalog.
+- `check_layer2_boundary_catalog_sync.py`: shim for `docsync.py --only layer2_boundary_catalog` (Layer 2 docs aligned with the machine-readable boundary catalog).
 - `verification_metrics.py`: shared metric collection and strict artifact validation.
 - `refresh_verification_artifacts.sh`: regenerate and validate the verification artifact.
 

--- a/scripts/check_layer2_boundary_catalog_sync.py
+++ b/scripts/check_layer2_boundary_catalog_sync.py
@@ -1,147 +1,26 @@
 #!/usr/bin/env python3
-"""Keep Layer 2 docs aligned with the machine-readable boundary catalog."""
+"""Deprecated shim: this checker now lives in scripts/docsync.py (entry `layer2_boundary_catalog`).
+
+Prefer `python3 scripts/docsync.py --check --only layer2_boundary_catalog`.
+This wrapper is kept so existing callers of this path keep working.
+"""
 
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
-CATALOG = ROOT / "artifacts" / "layer2_boundary_catalog.json"
-TARGET_FILES = {
-    "ROADMAP": ROOT / "docs" / "ROADMAP.md",
-    "VERIFICATION_STATUS": ROOT / "docs" / "VERIFICATION_STATUS.md",
-    "COMPILER_PROOFS_README": ROOT / "Compiler" / "Proofs" / "README.md",
-}
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
+from docsync import run_entry
 
-def normalize_ws(text: str) -> str:
-    return " ".join(text.split())
-
-
-def load_catalog(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def validate_catalog(catalog: dict) -> None:
-    target = catalog.get("theorem_target", {})
-    if target.get("intended_claim") != "proof_complete_macro_lowered_verity_contract_image":
-        raise ValueError("unexpected theorem target claim in Layer 2 boundary catalog")
-    if target.get("excludes_arbitrary_lean_compilation_models") is not True:
-        raise ValueError("Layer 2 boundary catalog must exclude arbitrary Lean-produced models")
-
-    helper = catalog.get("supported_spec_split", {}).get("helper_boundary", {})
-    if helper.get("current_fail_closed_gate") != "SupportedBodyInterface.stmtList":
-        raise ValueError("Layer 2 boundary catalog is missing the helper fail-closed gate")
-    if not helper.get("blocking_seams"):
-        raise ValueError("Layer 2 boundary catalog is missing helper blocking seams")
-
-
-def lean_name(ref: str) -> str:
-    return ref.rsplit(".", 1)[-1]
-
-
-def catalog_surface_snippets(catalog: dict) -> list[str]:
-    helper = catalog["supported_spec_split"]["helper_boundary"]
-    compat = helper["compiled_target_compatibility_subset"]
-    source_helper = helper["source_helper_goal_surface"]
-    compiled_target = helper["compiled_target_proof_surface"]
-
-    refs = [
-        compat["goal_surface"],
-        compat["dispatch_goal_surface"],
-        compat["goal_composition_surface"],
-        compat["goal_decomposition_surface"],
-        compat["interface_builder_surface"],
-        compat["stmt_subgoal_surface"],
-        compat["stmt_subgoal_closed_surface"],
-        compat["expr_stmt_dedicated_builtin_classifier"],
-        source_helper["direct_body_goal"],
-        source_helper["direct_body_goal_helper_ir"],
-        catalog["current_theorem"]["helper_ir_goal_ready_variant"],
-        catalog["current_theorem"]["helper_ir_closed_variant"],
-        compiled_target["source"],
-    ]
-    return [f"`{lean_name(ref)}`" for ref in refs]
-
-
-def common_boundary_snippets(catalog: dict) -> list[str]:
-    helper = catalog["supported_spec_split"]["helper_boundary"]
-    return [
-        "`artifacts/layer2_boundary_catalog.json`",
-        f"`{helper['current_fail_closed_gate']}`",
-        "total fuel-indexed helper-aware IR semantics",
-        "direct helper-free lemmas for `stop`, `mstore`, `revert`, `return`, and mapping-slot `sstore`",
-        "helper-free conservative-extension goal is now closed",
-        "[#1638]",
-        *catalog_surface_snippets(catalog),
-    ]
-
-
-def expected_snippets(catalog: dict) -> dict[str, list[str]]:
-    helper = catalog["supported_spec_split"]["helper_boundary"]
-    theorem_target = catalog["theorem_target"]
-    assert theorem_target["intended_claim"] == "proof_complete_macro_lowered_verity_contract_image"
-    assert helper["current_fail_closed_gate"] == "SupportedBodyInterface.stmtList"
-    common = common_boundary_snippets(catalog)
-    return {
-        "ROADMAP": [
-            *common,
-            "macro-lowered `verity_contract` image",
-            "`SupportedStmtList.helperSurfaceClosed`",
-            "`execIRFunctionWithInternals` / `interpretIRWithInternals`",
-            "conservative extension of `interpretIR`",
-        ],
-        "VERIFICATION_STATUS": [
-            *common,
-            "macro-lowered image of `verity_contract`",
-            "`SupportedBodyInterface.stmtList` gate",
-            "helper-aware body theorem does not yet consume helper-summary soundness/rank evidence",
-            "legacy-compatible external-body Yul subset",
-        ],
-        "COMPILER_PROOFS_README": [
-            *common,
-            "`SupportedSpec` split",
-            "`calls.helpers`",
-            "summary-soundness evidence",
-            "legacy-compatible external-body Yul subset",
-        ],
-    }
+ENTRY = "layer2_boundary_catalog"
 
 
 def main() -> int:
-    if not CATALOG.exists():
-        print(f"Missing: {CATALOG.relative_to(ROOT)}", file=sys.stderr)
-        return 1
-
-    try:
-        catalog = load_catalog(CATALOG)
-        validate_catalog(catalog)
-    except (json.JSONDecodeError, ValueError) as exc:
-        print(f"{CATALOG.relative_to(ROOT)}: {exc}", file=sys.stderr)
-        return 1
-
-    errors: list[str] = []
-    expected = expected_snippets(catalog)
-    for label, path in TARGET_FILES.items():
-        if not path.exists():
-            errors.append(f"Missing: {path.relative_to(ROOT)}")
-            continue
-        normalized = normalize_ws(path.read_text(encoding="utf-8"))
-        for snippet in expected[label]:
-            if normalize_ws(snippet) not in normalized:
-                errors.append(
-                    f"{path.relative_to(ROOT)} is out of sync with the Layer 2 boundary catalog: missing `{snippet}`"
-                )
-
-    if errors:
-        for error in errors:
-            print(error, file=sys.stderr)
-        return 1
-
-    print("layer2 boundary catalog sync passed: docs reference the machine-readable Layer 2 boundary")
-    return 0
+    return run_entry(ENTRY)
 
 
 if __name__ == "__main__":

--- a/scripts/consolidation-inventory.md
+++ b/scripts/consolidation-inventory.md
@@ -197,6 +197,7 @@ docsync directly:
 - [x] check_axiomatized_primitive_boundary_sync.py → `axiomatized_primitive_boundary` (Cluster B)
 - [x] check_struct_mapping_surface_sync.py → `struct_mapping_surface` (Cluster B)
 - [x] check_layer2_boundary_sync.py → `layer2_boundary` (Cluster A)
+- [x] check_layer2_boundary_catalog_sync.py → `layer2_boundary_catalog` (Cluster A)
 - [x] check_interpreter_feature_boundary_catalog_sync.py → `interpreter_feature_boundary_catalog` (Cluster A)
 
 Cluster C landed as `scripts/property_pipeline.py` (subcommands `check
@@ -237,7 +238,7 @@ walk can land later behind the same `lean_lint.py` interface without touching
 callers.
 
 Still pending from Cluster A: the verification-status trio +
-update_doc_numbers.py, layer2 catalog generator/checker, the EVMYulLean report
+update_doc_numbers.py, the layer2 catalog generator, the EVMYulLean report
 generators, builtin-bridge / feature-summary matrix checkers,
 generate_storage_layout_report.py, generate_print_axioms.py.
 `verify_sync_spec_source.py` pins the new docsync Makefile commands

--- a/scripts/docsync.py
+++ b/scripts/docsync.py
@@ -285,6 +285,138 @@ class CategoryNoteEntry:
         return 0
 
 
+@dataclass(frozen=True)
+class Layer2BoundaryCatalogEntry:
+    """Validate docs against the machine-readable Layer 2 boundary catalog."""
+
+    name: str
+    catalog_rel: str
+    targets: dict[str, str]
+    pass_message: str
+
+    def _load_catalog(self, root: Path) -> dict:
+        catalog_path = _rel(root, self.catalog_rel)
+        if not catalog_path.exists():
+            raise DocSyncError(f"Missing: {self.catalog_rel}")
+        try:
+            catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+            self._validate_catalog(catalog)
+            return catalog
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise DocSyncError(f"{self.catalog_rel}: {exc}") from exc
+
+    def _validate_catalog(self, catalog: dict) -> None:
+        target = catalog.get("theorem_target", {})
+        if target.get("intended_claim") != "proof_complete_macro_lowered_verity_contract_image":
+            raise ValueError("unexpected theorem target claim in Layer 2 boundary catalog")
+        if target.get("excludes_arbitrary_lean_compilation_models") is not True:
+            raise ValueError("Layer 2 boundary catalog must exclude arbitrary Lean-produced models")
+
+        helper = catalog.get("supported_spec_split", {}).get("helper_boundary", {})
+        if helper.get("current_fail_closed_gate") != "SupportedBodyInterface.stmtList":
+            raise ValueError("Layer 2 boundary catalog is missing the helper fail-closed gate")
+        if not helper.get("blocking_seams"):
+            raise ValueError("Layer 2 boundary catalog is missing helper blocking seams")
+
+    @staticmethod
+    def _lean_name(ref: str) -> str:
+        return ref.rsplit(".", 1)[-1]
+
+    def _catalog_surface_snippets(self, catalog: dict) -> list[str]:
+        helper = catalog["supported_spec_split"]["helper_boundary"]
+        compat = helper["compiled_target_compatibility_subset"]
+        source_helper = helper["source_helper_goal_surface"]
+        compiled_target = helper["compiled_target_proof_surface"]
+
+        refs = [
+            compat["goal_surface"],
+            compat["dispatch_goal_surface"],
+            compat["goal_composition_surface"],
+            compat["goal_decomposition_surface"],
+            compat["interface_builder_surface"],
+            compat["stmt_subgoal_surface"],
+            compat["stmt_subgoal_closed_surface"],
+            compat["expr_stmt_dedicated_builtin_classifier"],
+            source_helper["direct_body_goal"],
+            source_helper["direct_body_goal_helper_ir"],
+            catalog["current_theorem"]["helper_ir_goal_ready_variant"],
+            catalog["current_theorem"]["helper_ir_closed_variant"],
+            compiled_target["source"],
+        ]
+        return [f"`{self._lean_name(ref)}`" for ref in refs]
+
+    def _common_boundary_snippets(self, catalog: dict) -> list[str]:
+        helper = catalog["supported_spec_split"]["helper_boundary"]
+        return [
+            "`artifacts/layer2_boundary_catalog.json`",
+            f"`{helper['current_fail_closed_gate']}`",
+            "total fuel-indexed helper-aware IR semantics",
+            "direct helper-free lemmas for `stop`, `mstore`, `revert`, `return`, and mapping-slot `sstore`",
+            "helper-free conservative-extension goal is now closed",
+            "[#1638]",
+            *self._catalog_surface_snippets(catalog),
+        ]
+
+    def expected_snippets(self, catalog: dict) -> dict[str, list[str]]:
+        helper = catalog["supported_spec_split"]["helper_boundary"]
+        theorem_target = catalog["theorem_target"]
+        assert theorem_target["intended_claim"] == "proof_complete_macro_lowered_verity_contract_image"
+        assert helper["current_fail_closed_gate"] == "SupportedBodyInterface.stmtList"
+        common = self._common_boundary_snippets(catalog)
+        return {
+            "ROADMAP": [
+                *common,
+                "macro-lowered `verity_contract` image",
+                "`SupportedStmtList.helperSurfaceClosed`",
+                "`execIRFunctionWithInternals` / `interpretIRWithInternals`",
+                "conservative extension of `interpretIR`",
+            ],
+            "VERIFICATION_STATUS": [
+                *common,
+                "macro-lowered image of `verity_contract`",
+                "`SupportedBodyInterface.stmtList` gate",
+                "helper-aware body theorem does not yet consume helper-summary soundness/rank evidence",
+                "legacy-compatible external-body Yul subset",
+            ],
+            "COMPILER_PROOFS_README": [
+                *common,
+                "`SupportedSpec` split",
+                "`calls.helpers`",
+                "summary-soundness evidence",
+                "legacy-compatible external-body Yul subset",
+            ],
+        }
+
+    def check(self, root: Path) -> int:
+        try:
+            catalog = self._load_catalog(root)
+        except DocSyncError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+
+        errors: list[str] = []
+        expected = self.expected_snippets(catalog)
+        for label, rel_path in self.targets.items():
+            path = _rel(root, rel_path)
+            if not path.exists():
+                errors.append(f"Missing: {rel_path}")
+                continue
+            normalized = normalize_ws(path.read_text(encoding="utf-8"))
+            for snippet in expected[label]:
+                if normalize_ws(snippet) not in normalized:
+                    errors.append(
+                        f"{rel_path} is out of sync with the Layer 2 boundary catalog: missing `{snippet}`"
+                    )
+
+        if errors:
+            for error in errors:
+                print(error, file=sys.stderr)
+            return 1
+
+        print(self.pass_message)
+        return 0
+
+
 # ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
@@ -616,6 +748,20 @@ INTERPRETER_FEATURE_BOUNDARY_CATALOG = CategoryNoteEntry(
 )
 
 
+LAYER2_BOUNDARY_CATALOG = Layer2BoundaryCatalogEntry(
+    name="layer2_boundary_catalog",
+    catalog_rel="artifacts/layer2_boundary_catalog.json",
+    targets={
+        "ROADMAP": "docs/ROADMAP.md",
+        "VERIFICATION_STATUS": "docs/VERIFICATION_STATUS.md",
+        "COMPILER_PROOFS_README": "Compiler/Proofs/README.md",
+    },
+    pass_message=(
+        "layer2 boundary catalog sync passed: docs reference the machine-readable Layer 2 boundary"
+    ),
+)
+
+
 ENTRIES = {
     entry.name: entry
     for entry in (
@@ -624,6 +770,7 @@ ENTRIES = {
         AXIOMATIZED_PRIMITIVE_BOUNDARY,
         STRUCT_MAPPING_SURFACE,
         LAYER2_BOUNDARY,
+        LAYER2_BOUNDARY_CATALOG,
         INTERPRETER_FEATURE_BOUNDARY_CATALOG,
     )
 }

--- a/scripts/test_check_layer2_boundary_catalog_sync.py
+++ b/scripts/test_check_layer2_boundary_catalog_sync.py
@@ -12,7 +12,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-import check_layer2_boundary_catalog_sync as check
+import docsync
 
 
 class Layer2BoundaryCatalogSyncTests(unittest.TestCase):
@@ -100,7 +100,7 @@ class Layer2BoundaryCatalogSyncTests(unittest.TestCase):
         )
 
         catalog = json.loads(artifact.read_text(encoding="utf-8"))
-        expected = check.expected_snippets(catalog)
+        expected = docsync.get_entry("layer2_boundary_catalog").expected_snippets(catalog)
         docs = {
             label: "\n".join(snippets) + "\n" for label, snippets in expected.items()
         }
@@ -121,26 +121,11 @@ class Layer2BoundaryCatalogSyncTests(unittest.TestCase):
             root = Path(tmpdir)
             self._write_fixture_tree(root, good_docs=good_docs)
 
-            old_root = check.ROOT
-            old_catalog = check.CATALOG
-            old_targets = check.TARGET_FILES
-            check.ROOT = root
-            check.CATALOG = root / "artifacts" / "layer2_boundary_catalog.json"
-            check.TARGET_FILES = {
-                "ROADMAP": root / "docs" / "ROADMAP.md",
-                "VERIFICATION_STATUS": root / "docs" / "VERIFICATION_STATUS.md",
-                "COMPILER_PROOFS_README": root / "Compiler" / "Proofs" / "README.md",
-            }
-            try:
-                stdout = io.StringIO()
-                stderr = io.StringIO()
-                with redirect_stdout(stdout), redirect_stderr(stderr):
-                    rc = check.main()
-                return rc, stdout.getvalue() + stderr.getvalue()
-            finally:
-                check.ROOT = old_root
-                check.CATALOG = old_catalog
-                check.TARGET_FILES = old_targets
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                rc = docsync.run_entry("layer2_boundary_catalog", root=root)
+            return rc, stdout.getvalue() + stderr.getvalue()
 
     def test_matching_docs_pass(self) -> None:
         rc, output = self._run_check(good_docs=True)
@@ -156,7 +141,7 @@ class Layer2BoundaryCatalogSyncTests(unittest.TestCase):
         stdout = io.StringIO()
         stderr = io.StringIO()
         with redirect_stdout(stdout), redirect_stderr(stderr):
-            rc = check.main()
+            rc = docsync.run_entry("layer2_boundary_catalog")
         output = stdout.getvalue() + stderr.getvalue()
         self.assertEqual(rc, 0, output)
 

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -733,6 +733,7 @@
     "python3 scripts/docsync.py --check --only axiomatized_primitive_boundary",
     "python3 scripts/docsync.py --check --only struct_mapping_surface",
     "python3 scripts/docsync.py --check --only layer2_boundary",
+    "python3 scripts/docsync.py --check --only layer2_boundary_catalog",
     "python3 scripts/check_issue_templates.py",
     "python3 scripts/check_docs_workflow_sync.py",
     "python3 scripts/check_solc_pin.py",

--- a/scripts/verify_sync_spec_source.py
+++ b/scripts/verify_sync_spec_source.py
@@ -637,6 +637,8 @@ SPEC = {'check_only_paths': ['.github/workflows/**',
                                       'python3 scripts/docsync.py --check --only '
                                       'struct_mapping_surface',
                                       'python3 scripts/docsync.py --check --only layer2_boundary',
+                                      'python3 scripts/docsync.py --check --only '
+                                      'layer2_boundary_catalog',
                                       'python3 scripts/check_issue_templates.py',
                                       'python3 scripts/check_docs_workflow_sync.py',
                                       'python3 scripts/check_solc_pin.py',


### PR DESCRIPTION
## Summary
- move the Layer 2 boundary catalog docs check into the shared `docsync.py` registry
- keep `check_layer2_boundary_catalog_sync.py` as a compatibility shim
- update the Makefile/spec references and consolidation inventory for the migrated entry

## Test Plan
- `python3 scripts/docsync.py --check --only layer2_boundary_catalog`
- `python3 scripts/check_layer2_boundary_catalog_sync.py`
- `python3 -m unittest scripts.test_check_layer2_boundary_catalog_sync`
- `python3 scripts/generate_verify_sync_spec.py --check`
- `python3 scripts/check_verify_sync.py`
- `python3 scripts/docsync.py --check`
- `python3 -m unittest scripts.test_check_low_level_call_boundary_sync scripts.test_check_linear_memory_boundary_sync scripts.test_check_axiomatized_primitive_boundary_sync scripts.test_check_struct_mapping_surface_sync scripts.test_check_layer2_boundary_sync scripts.test_check_interpreter_feature_boundary_catalog_sync scripts.test_check_layer2_boundary_catalog_sync`
- `make check`

## Related Issues
Addresses part of #1987.
