### PR TITLE
fix: release nonreentrant lock before EVM return/stop, not as dead code after (#2075)

### DIFF
--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -227,6 +227,67 @@ def nonReentrantGuardPrologue (fields : List Field) (lockField : String) :
         YulStmt.exprStmt (YulExpr.call "tstore" [lockSlot, YulExpr.lit 1])
       pure [revertOnReentry, acquire]
 
+/-- Sound under-approximation of "this Yul halts the EVM call frame on every
+    exit" — i.e. control never falls through to a following statement. Only
+    returns `true` when it can prove halting: a halting builtin
+    (`return`/`stop`/`revert`/`invalid`/`selfdestruct`), a `block` whose body
+    halts, or a `switch` with a `default` where every branch halts. Everything
+    else (including `if` without a guaranteed-halting counterpart and `for`) is
+    treated as possibly falling through. Used to decide whether the guarded body
+    still needs a trailing fall-through lock release (#2075). -/
+mutual
+partial def yulFrameHalts : YulStmt → Bool
+  | .exprStmt (.call f _) =>
+      f == "return" || f == "stop" || f == "revert" || f == "invalid" || f == "selfdestruct"
+  | .block stmts => yulFrameHaltsList stmts
+  | .switch _ cases (some dflt) =>
+      yulFrameHaltsList dflt && cases.all (fun c => yulFrameHaltsList c.2)
+  | _ => false
+
+partial def yulFrameHaltsList : List YulStmt → Bool
+  | [] => false
+  | [s] => yulFrameHalts s
+  | _ :: rest => yulFrameHaltsList rest
+end
+
+/-- Splice `release` immediately before every reachable EVM-frame `return`/`stop`
+    in a guarded entrypoint body, recursing through `if`/`for`/`switch`/`block`.
+
+    Internal-helper `funcDef` bodies are deliberately left untouched: a helper's
+    `leave` (and its internal `return` lowering, which becomes `__ret := …;
+    leave`) returns into the still-running guarded body, not the EVM frame, so
+    releasing the lock there would clear it mid-execution. Only the top-level
+    frame-halting `return`/`stop` opcodes clear the lock (#2075). -/
+mutual
+partial def spliceLockRelease (release : YulStmt) : YulStmt → List YulStmt
+  | s@(.exprStmt (.call f _)) =>
+      if f == "return" || f == "stop" then [release, s] else [s]
+  | .if_ cond body => [.if_ cond (spliceLockReleaseList release body)]
+  | .for_ init cond post body =>
+      [.for_ (spliceLockReleaseList release init) cond
+             (spliceLockReleaseList release post)
+             (spliceLockReleaseList release body)]
+  | .switch e cases dflt =>
+      [.switch e
+        (cases.map (fun c => (c.1, spliceLockReleaseList release c.2)))
+        (dflt.map (spliceLockReleaseList release))]
+  | .block stmts => [.block (spliceLockReleaseList release stmts)]
+  | s => [s]
+
+partial def spliceLockReleaseList (release : YulStmt) : List YulStmt → List YulStmt
+  | [] => []
+  | s :: rest => spliceLockRelease release s ++ spliceLockReleaseList release rest
+end
+
+/-- Clear the transient lock on every successful exit of a guarded body: splice
+    `release` before each reachable `return`/`stop`, and keep a single trailing
+    `release` only when the body can fall off the end (no guaranteed halt). A
+    reverting exit rolls back the acquire, so no release is spliced before
+    `revert`. Fixes the dead-code-after-return leak in #2075. -/
+def applyLockReleaseOnExits (release : YulStmt) (body : List YulStmt) : List YulStmt :=
+  let released := spliceLockReleaseList release body
+  if yulFrameHaltsList body then released else released ++ [release]
+
 /-- Wrap an already-compiled `IRFunction` with the `nonreentrant(lockField)`
     guard prologue (#1893) when the source `FunctionSpec` carries the
     annotation. The prologue is inserted **after** parameter loading and
@@ -247,17 +308,19 @@ def attachNonReentrantGuard (fields : List Field) (spec : FunctionSpec)
       let guardStmts ← nonReentrantGuardPrologue fields lockField
       let paramLoadCount := (genParamLoads spec.params).length
       let (prefixLoads, suffix) := irFn.body.splitAt paramLoadCount
-      -- Release the transient lock on normal exit so that a second top-level
-      -- call to the same nonreentrant function in the same tx is allowed
-      -- (the guard only protects against reentrancy *during* execution).
-      -- Early returns/reverts inside the body may leave the lock set until
-      -- tx end (transient), but this fixes the "never clears" case for the
-      -- common fall-through path.
+      -- Release the transient lock on every *successful* exit so a later
+      -- top-level call to a same-lock nonreentrant entry in the same tx is
+      -- allowed (the guard only protects against reentrancy *during*
+      -- execution). The release is spliced before each reachable `return`/
+      -- `stop` — not merely appended after the body — because on the EVM those
+      -- opcodes halt the frame, so an appended release is dead code and the
+      -- lock would stay set for the rest of the tx (#2075). Reverting exits
+      -- roll back the acquire, so they need no release.
       let releaseSlot := match findFieldWithResolvedSlot fields lockField with
         | some (_, s) => s
         | none => 0   -- unreachable after prologue validation
       let release := YulStmt.exprStmt (YulExpr.call "tstore" [YulExpr.lit releaseSlot, YulExpr.lit 0])
-      pure { irFn with body := prefixLoads ++ guardStmts ++ suffix ++ [release] }
+      pure { irFn with body := prefixLoads ++ guardStmts ++ applyLockReleaseOnExits release suffix }
 
 private def compileSpecialEntrypoint (fields : List Field) (events : List EventDef)
     (errors : List ErrorDef) (adtTypes : List AdtTypeDef := [])
@@ -276,7 +339,7 @@ private def compileSpecialEntrypoint (fields : List Field) (events : List EventD
           | some (_, s) => s
           | none => 0
         let release := YulStmt.exprStmt (YulExpr.call "tstore" [YulExpr.lit releaseSlot, YulExpr.lit 0])
-        pure (guardStmts ++ bodyChunks ++ [release])
+        pure (guardStmts ++ applyLockReleaseOnExits release bodyChunks)
   pure {
     payable := spec.isPayable
     body := guardedBody

--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -227,14 +227,14 @@ def nonReentrantGuardPrologue (fields : List Field) (lockField : String) :
         YulStmt.exprStmt (YulExpr.call "tstore" [lockSlot, YulExpr.lit 1])
       pure [revertOnReentry, acquire]
 
-/-- Sound under-approximation of "this Yul halts the EVM call frame on every
-    exit" — i.e. control never falls through to a following statement. Only
-    returns `true` when it can prove halting: a halting builtin
-    (`return`/`stop`/`revert`/`invalid`/`selfdestruct`), a `block` whose body
-    halts, or a `switch` with a `default` where every branch halts. Everything
-    else (including `if` without a guaranteed-halting counterpart and `for`) is
-    treated as possibly falling through. Used to decide whether the guarded body
-    still needs a trailing fall-through lock release (#2075). -/
+/- Sound under-approximation of "this Yul halts the EVM call frame on every
+   exit" — i.e. control never falls through to a following statement. Only
+   returns `true` when it can prove halting: a halting builtin
+   (`return`/`stop`/`revert`/`invalid`/`selfdestruct`), a `block` whose body
+   halts, or a `switch` with a `default` where every branch halts. Everything
+   else (including `if` without a guaranteed-halting counterpart and `for`) is
+   treated as possibly falling through. Used to decide whether the guarded body
+   still needs a trailing fall-through lock release (#2075). -/
 mutual
 partial def yulFrameHalts : YulStmt → Bool
   | .exprStmt (.call f _) =>
@@ -250,14 +250,14 @@ partial def yulFrameHaltsList : List YulStmt → Bool
   | _ :: rest => yulFrameHaltsList rest
 end
 
-/-- Splice `release` immediately before every reachable EVM-frame `return`/`stop`
-    in a guarded entrypoint body, recursing through `if`/`for`/`switch`/`block`.
+/- Splice `release` immediately before every reachable EVM-frame `return`/`stop`
+   in a guarded entrypoint body, recursing through `if`/`for`/`switch`/`block`.
 
-    Internal-helper `funcDef` bodies are deliberately left untouched: a helper's
-    `leave` (and its internal `return` lowering, which becomes `__ret := …;
-    leave`) returns into the still-running guarded body, not the EVM frame, so
-    releasing the lock there would clear it mid-execution. Only the top-level
-    frame-halting `return`/`stop` opcodes clear the lock (#2075). -/
+   Internal-helper `funcDef` bodies are deliberately left untouched: a helper's
+   `leave` (and its internal `return` lowering, which becomes `__ret := …;
+   leave`) returns into the still-running guarded body, not the EVM frame, so
+   releasing the lock there would clear it mid-execution. Only the top-level
+   frame-halting `return`/`stop` opcodes clear the lock (#2075). -/
 mutual
 partial def spliceLockRelease (release : YulStmt) : YulStmt → List YulStmt
   | s@(.exprStmt (.call f _)) =>

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -7070,12 +7070,12 @@ private def twoEntrySpec : CompilationModel := {
   functions := [
     { name := "foo"
       params := []
-      returnType := some ParamType.uint256
+      returnType := some FieldType.uint256
       nonReentrantLock := some "lock"
       body := [Stmt.return (Expr.literal 1)] },
     { name := "bar"
       params := []
-      returnType := some ParamType.uint256
+      returnType := some FieldType.uint256
       nonReentrantLock := some "lock"
       body := [Stmt.return (Expr.literal 2)] }
   ]

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -7018,4 +7018,101 @@ def nonreentrantCompileAcceptedAtDefaultFork : Bool :=
 
 end NonreentrantForkCompatibilitySmoke
 
+/-! ## Issue #2075: nonreentrant lock release before every reachable `return`/`stop`
+
+The `nonreentrant(lock)` guard used to append a single lock release *after* the
+compiled body. On the EVM `return`/`stop` halt the call frame, so that appended
+release was dead code whenever the body ended in (or branched to) a
+`return`/`stop` — the normal case for any function that returns a value. The
+transient lock therefore stayed set for the rest of the transaction, and a
+later same-lock guarded entry in the same transaction wrongly reverted as
+reentrant (e.g. ERC-4337 `validateUserOp` + execute sharing one lock).
+
+The fix (`applyLockReleaseOnExits`) splices the release immediately before every
+reachable `return`/`stop`, recursing through `if`/`for`/`switch`/`block`, keeps
+a trailing release only for a body that falls off the end, and never rewrites
+internal-helper `funcDef` bodies or `leave` (a helper's `leave` returns into the
+still-running guarded frame, not the EVM frame). Reverting exits are left
+untouched because the revert rolls back the acquire. -/
+namespace NonreentrantReleaseBeforeReturn
+
+open Compiler.Yul
+
+private def rel : YulStmt :=
+  YulStmt.exprStmt (YulExpr.call "tstore" [YulExpr.lit 0, YulExpr.lit 0])
+private def ret : YulStmt :=
+  YulStmt.exprStmt (YulExpr.call "return" [YulExpr.lit 0, YulExpr.lit 32])
+private def stp : YulStmt :=
+  YulStmt.exprStmt (YulExpr.call "stop" [])
+private def rev : YulStmt :=
+  YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+private def work : YulStmt :=
+  YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit 1, YulExpr.lit 7])
+
+/-- A release precedes the first EVM `return` (not appended dead after it). -/
+private def releaseBeforeReturn (yul : String) : Bool :=
+  match yul.splitOn "return(0, 32)" with
+  | before :: _ :: _ => contains before "tstore(0, 0)"
+  | _ => false
+
+/-- No dead lock release survives after the final EVM `return`. -/
+private def noReleaseAfterLastReturn (yul : String) : Bool :=
+  match (yul.splitOn "return(0, 32)").getLast? with
+  | some tail => !contains tail "tstore(0, 0)"
+  | none => true
+
+/-- Two external entrypoints guarded by the *same* lock slot, each ending in a
+    `return` — the exact shape that broke: `foo()` then `bar()` in one tx. -/
+private def twoEntrySpec : CompilationModel := {
+  name := "TwoNonreentrantEntries"
+  fields := [{ name := "lock", ty := FieldType.uint256, «slot» := some 0 }]
+  «constructor» := none
+  functions := [
+    { name := "foo"
+      params := []
+      returnType := some ParamType.uint256
+      nonReentrantLock := some "lock"
+      body := [Stmt.return (Expr.literal 1)] },
+    { name := "bar"
+      params := []
+      returnType := some ParamType.uint256
+      nonReentrantLock := some "lock"
+      body := [Stmt.return (Expr.literal 2)] }
+  ]
+}
+
+#eval! do
+  -- Unit-level: the IR transform on hand-built bodies.
+  expectTrue "#2075 release spliced before a trailing return"
+    (applyLockReleaseOnExits rel [work, ret] == [work, rel, ret])
+  expectTrue "#2075 release spliced before a trailing stop"
+    (applyLockReleaseOnExits rel [work, stp] == [work, rel, stp])
+  expectTrue "#2075 fall-through body keeps exactly one trailing release"
+    (applyLockReleaseOnExits rel [work] == [work, rel])
+  expectTrue "#2075 release spliced inside a branch, trailing release kept for the untaken path"
+    (applyLockReleaseOnExits rel [YulStmt.if_ (YulExpr.ident "c") [ret], work]
+      == [YulStmt.if_ (YulExpr.ident "c") [rel, ret], work, rel])
+  expectTrue "#2075 release spliced into every switch branch, no trailing release when all halt"
+    (applyLockReleaseOnExits rel
+        [YulStmt.switch (YulExpr.ident "s") [(0, [ret])] (some [stp])]
+      == [YulStmt.switch (YulExpr.ident "s") [(0, [rel, ret])] (some [rel, stp])])
+  expectTrue "#2075 reverting exit is left untouched (acquire rolls back)"
+    (applyLockReleaseOnExits rel [work, rev] == [work, rev])
+  expectTrue "#2075 internal-helper funcDef/leave bodies are never rewritten"
+    (applyLockReleaseOnExits rel
+        [YulStmt.funcDef "helper" [] ["r"] [ret, YulStmt.leave], work]
+      == [YulStmt.funcDef "helper" [] ["r"] [ret, YulStmt.leave], work, rel])
+  -- End-to-end: two same-lock guarded entries compile with the corrected shape.
+  let yul ← expectCompileToYul "two same-lock nonreentrant entries compile" twoEntrySpec
+  expectTrue "#2075 guard still checks the transient lock on entry (reentrancy still reverts)"
+    (contains yul "tload(0)" && contains yul "tstore(0, 1)")
+  expectTrue "#2075 lock release is spliced before the return, not dead after it"
+    (releaseBeforeReturn yul)
+  expectTrue "#2075 each guarded return clears the lock (two entries → two releases)"
+    (countOccurrences yul "tstore(0, 0)" == 2)
+  expectTrue "#2075 no dead lock release remains after the final return"
+    (noReleaseAfterLastReturn yul)
+
+end NonreentrantReleaseBeforeReturn
+
 end Compiler.CompilationModelFeatureTest


### PR DESCRIPTION
## Summary

Fixes #2075.

The `nonreentrant(lock)` guard acquired the transient lock at entry and appended a **single** lock release (`tstore(lock, 0)`) **after** the compiled body:

```yul
tstore(lock, 1)
// … body …
return(ptr, len)   // EVM halts here
tstore(lock, 0)    // dead code — never reached → lock stays set
```

On the EVM, `return`/`stop` halt the call frame immediately, so the appended release is **unreachable dead code** whenever the body ends in (or branches to) a `return`/`stop` — the normal case for any function that returns a value. The transient lock therefore stayed set for the rest of the transaction. EIP-1153 clears transient storage at end-of-transaction, so there is no cross-transaction leak, but a contract with **two or more entries guarded by the same lock slot invoked in one transaction** finds the lock still set on the second entry and reverts it as reentrant even though it is an ordinary top-level call (ERC-4337 `validateUserOp` + execute sharing one lock, multicall over guarded entries, batched calls).

## Fix

New IR transform `applyLockReleaseOnExits` (in `Compiler/CompilationModel/Dispatch.lean`):

- Splices the lock release **immediately before every reachable `return`/`stop`**, recursing through `if` / `for` / `switch` / `block`.
- Keeps a **single trailing release** only for a body that falls off the end with no explicit halt (`yulFrameHaltsList` decides this soundly).
- Leaves internal-helper `funcDef` bodies and `leave` **untouched** — a helper's `leave` (and its internal `return` lowering `__ret := …; leave`) returns into the still-running guarded frame, not the EVM frame, so releasing there would clear the lock mid-execution.
- Does **not** splice before `revert`: a reverting exit rolls back the acquire anyway.

Applied on both wrapped code paths: the normal entrypoint path (`attachNonReentrantGuard`) and the special-entrypoint (fallback/receive) path (`compileSpecialEntrypoint`).

Resulting shape:

```yul
tstore(lock, 1)
// … body …
tstore(lock, 0)
return(ptr, len)
```

The `if eq(tload(lock), 1) { revert }` reentry check at entry is unchanged, so reentrancy **during** the body still reverts.

## Tests

`Compiler/CompilationModelFeatureTest.lean`, section `NonreentrantReleaseBeforeReturn`:

- Structural unit tests on the transform: release spliced before trailing `return`/`stop`; fall-through body keeps exactly one trailing release; release spliced inside `if` branches (trailing kept for the untaken path); spliced into every `switch` branch (no trailing when all branches halt); reverting exit untouched; internal-helper `funcDef`/`leave` never rewritten.
- End-to-end: compiles a contract with two `nonreentrant` entries sharing one lock slot, each ending in `return`, and asserts (a) the `tload`/`tstore` entry guard is preserved, (b) a release is spliced **before** the return (not dead after it), (c) two returns → two releases, (d) no dead release remains after the final return.

## Test plan

- [ ] `lean-slot lake build Compiler.CompilationModelFeatureTest` — typechecks the transform and runs the `#eval!` regression assertions.
- [ ] No new `sorry`/`admit`/`axiom`; the only existing proof about the guard (`attachNonReentrantGuard_eq_of_none`, the lock-free identity case) is unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reentrancy guard codegen on all nonreentrant entrypoints and special entrypoints; behavior is security-sensitive but narrowly scoped with regression tests.
> 
> **Overview**
> Fixes **#2075**: `nonreentrant(lock)` no longer appends a single `tstore(lock, 0)` after the guarded body, which was **dead code** whenever the body ended in `return`/`stop` because those opcodes halt the EVM frame. The transient lock could then stay set for the rest of the transaction and block a later top-level call to another entry sharing the same lock.
> 
> **`Dispatch.lean`** adds `yulFrameHalts` / `yulFrameHaltsList`, `spliceLockRelease` / `applyLockReleaseOnExits`: splice release **before** each reachable `return`/`stop` (through `if`/`for`/`switch`/`block`), add a trailing release only when the body may fall through, skip `revert`, and do not rewrite internal `funcDef`/`leave`. **`attachNonReentrantGuard`** and **`compileSpecialEntrypoint`** now wrap the user body with `applyLockReleaseOnExits` instead of `suffix ++ [release]`.
> 
> **`CompilationModelFeatureTest.lean`** adds `NonreentrantReleaseBeforeReturn` with structural `#eval!` tests and an end-to-end compile of two same-lock guarded entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d3951f020c9b5cc6b574de26180a01297375976. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->