### PR TITLE
Fix constructor immutables: patch runtime after datacopy (Fixes #2074)

### DIFF
--- a/Compiler/CodegenCommon.lean
+++ b/Compiler/CodegenCommon.lean
@@ -319,12 +319,87 @@ private def runtimeCodeWithEmitOptions (contract : IRContract) (options : YulEmi
   let switchStmt := buildSwitch contract.functions contract.fallbackEntrypoint contract.receiveEntrypoint sortCases
   mapping ++ internals ++ [initFreeMemoryPointer, switchStmt]
 
+/-- Temp variable name holding an immutable's pending value during the
+    constructor body, before it is patched into the copied runtime image. -/
+private def immTempName (name : String) : String := "__imm_" ++ name
+
+/- Collect immutable names assigned anywhere in the constructor body,
+   descending into control flow so conditionally/repeatedly set immutables are
+   all discovered. `Stmt.setImmutable` lowers each assignment to
+   `setimmutable(dataoffset("runtime"), "<name>", <value>)`. Fuel bounds the
+   traversal for termination (mirrors `optimizeCheckedArithmeticStmtsFuel`). -/
+mutual
+private def collectImmNamesStmt : Nat → YulStmt → List String
+  | 0, _ => []
+  | _fuel + 1, YulStmt.exprStmt (YulExpr.call "setimmutable"
+      [YulExpr.call "dataoffset" [YulExpr.str "runtime"], YulExpr.str name, _]) => [name]
+  | fuel + 1, YulStmt.if_ _ body => collectImmNamesStmts fuel body
+  | fuel + 1, YulStmt.for_ init _ post body =>
+      collectImmNamesStmts fuel init ++ collectImmNamesStmts fuel post
+        ++ collectImmNamesStmts fuel body
+  | fuel + 1, YulStmt.switch _ cases default =>
+      (cases.map (fun c => collectImmNamesStmts fuel c.2)).flatten
+        ++ (match default with
+            | some body => collectImmNamesStmts fuel body
+            | none => [])
+  | fuel + 1, YulStmt.block stmts => collectImmNamesStmts fuel stmts
+  | fuel + 1, YulStmt.funcDef _ _ _ body => collectImmNamesStmts fuel body
+  | _fuel + 1, _ => []
+
+private def collectImmNamesStmts : Nat → List YulStmt → List String
+  | 0, _ => []
+  | _fuel + 1, [] => []
+  | fuel + 1, s :: rest => collectImmNamesStmt fuel s ++ collectImmNamesStmts fuel rest
+end
+
+/- Rewrite each in-body `setimmutable(dataoffset("runtime"), name, value)` to
+   `__imm_<name> := value`, preserving position within control flow so the
+   last executed assignment wins. The actual `setimmutable(0, …)` calls are
+   emitted after `datacopy` in `deployCodeWithProfile`. -/
+mutual
+private def rewriteImmSettersStmt : Nat → YulStmt → YulStmt
+  | 0, stmt => stmt
+  | _fuel + 1, YulStmt.exprStmt (YulExpr.call "setimmutable"
+      [YulExpr.call "dataoffset" [YulExpr.str "runtime"], YulExpr.str name, value]) =>
+      YulStmt.assign (immTempName name) value
+  | fuel + 1, YulStmt.if_ cond body => YulStmt.if_ cond (rewriteImmSettersStmts fuel body)
+  | fuel + 1, YulStmt.for_ init cond post body =>
+      YulStmt.for_
+        (rewriteImmSettersStmts fuel init) cond
+        (rewriteImmSettersStmts fuel post) (rewriteImmSettersStmts fuel body)
+  | fuel + 1, YulStmt.switch expr cases default =>
+      YulStmt.switch expr
+        (cases.map (fun c => (c.1, rewriteImmSettersStmts fuel c.2)))
+        (default.map (rewriteImmSettersStmts fuel))
+  | fuel + 1, YulStmt.block stmts => YulStmt.block (rewriteImmSettersStmts fuel stmts)
+  | fuel + 1, YulStmt.funcDef name params rets body =>
+      YulStmt.funcDef name params rets (rewriteImmSettersStmts fuel body)
+  | _fuel + 1, stmt => stmt
+
+private def rewriteImmSettersStmts : Nat → List YulStmt → List YulStmt
+  | 0, stmts => stmts
+  | _fuel + 1, [] => []
+  | fuel + 1, s :: rest => rewriteImmSettersStmt fuel s :: rewriteImmSettersStmts fuel rest
+end
+
+/-- Deduplicate a list of strings, keeping first-occurrence order. -/
+private def dedupStrings (xs : List String) : List String :=
+  (xs.foldl (fun acc x => if acc.contains x then acc else x :: acc) []).reverse
+
 private def deployCodeWithProfile (contract : IRContract) (profile : BackendProfile)
     (mappingSlotScratchBase : Nat := 0) : List YulStmt :=
   let valueGuard := if contract.constructorPayable then [] else [callvalueGuard]
   let mapping := if contract.usesMapping then [mappingSlotFuncAt mappingSlotScratchBase] else []
   let internals := internalHelpersForProfile profile contract.internalFunctions
-  [initFreeMemoryPointer] ++ valueGuard ++ mapping ++ internals ++ contract.deploy ++ [yulDatacopy, yulReturnRuntime]
+  let fuel := yulStmtListFuel contract.deploy
+  let immNames := dedupStrings (collectImmNamesStmts fuel contract.deploy)
+  let immDecls := immNames.map (fun n => YulStmt.let_ (immTempName n) (YulExpr.lit 0))
+  let deployBody := rewriteImmSettersStmts fuel contract.deploy
+  let immPatches := immNames.map (fun n =>
+    YulStmt.exprStmt (YulExpr.call "setimmutable"
+      [YulExpr.lit 0, YulExpr.str n, YulExpr.ident (immTempName n)]))
+  [initFreeMemoryPointer] ++ valueGuard ++ mapping ++ internals
+    ++ immDecls ++ deployBody ++ [yulDatacopy] ++ immPatches ++ [yulReturnRuntime]
 
 private def deployCode (contract : IRContract) : List YulStmt :=
   deployCodeWithProfile contract .semantic

--- a/Compiler/Linker.lean
+++ b/Compiler/Linker.lean
@@ -244,7 +244,8 @@ private def yulBuiltins : List String :=
    "log0", "log1", "log2", "log3", "log4",
    "create", "create2", "call", "callcode", "delegatecall", "staticcall",
    "return", "revert", "selfdestruct", "invalid", "stop",
-   "datasize", "dataoffset", "datacopy"]
+   "datasize", "dataoffset", "datacopy",
+   "loadimmutable", "setimmutable"]
 
 private def isYulBuiltinCall (name : String) : Bool :=
   yulBuiltins.contains name || name.startsWith "verbatim_"

--- a/Contracts/Smoke/ImmutableSmoke.lean
+++ b/Contracts/Smoke/ImmutableSmoke.lean
@@ -1,0 +1,1 @@
+import Contracts.Smoke.Declarations

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -10,9 +10,9 @@
   "schema_version": 1,
   "tests": {
     "differential_total": 110000,
-    "foundry_functions": 522,
+    "foundry_functions": 525,
     "property_functions": 239,
-    "suites": 50
+    "suites": 51
   },
   "theorems": {
     "categories": 13,

--- a/scripts/check_builtin_list_sync.py
+++ b/scripts/check_builtin_list_sync.py
@@ -10,7 +10,8 @@ Expected differences:
   - yulBuiltins includes low-level call opcodes (call, staticcall, delegatecall,
     callcode) that CompilationModel tracks separately in `isLowLevelCallName`.
   - yulBuiltins includes Yul-object builtins (datasize, dataoffset, datacopy)
-    that are not EVM opcodes and not relevant to interop validation.
+    and immutable builtins (loadimmutable, setimmutable) that are not EVM
+    opcodes and not relevant to interop validation.
 """
 
 from __future__ import annotations
@@ -29,6 +30,7 @@ CONTRACT_SPEC = ROOT / "Compiler" / "CompilationModel.lean"
 # AND isLowLevelCallName. These are Yul-object builtins, not EVM opcodes.
 EXPECTED_LINKER_ONLY = {
     "datasize", "dataoffset", "datacopy",
+    "loadimmutable", "setimmutable",
 }
 
 

--- a/test/Issue2074ImmutableDeploy.t.sol
+++ b/test/Issue2074ImmutableDeploy.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "forge-std/Test.sol";
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title Issue2074ImmutableDeployTest
+ * @notice Regression test for lfglabs-dev/verity#2074.
+ * @dev Deploys a contract that has an `immutables` block via REAL creation
+ *      bytecode (EVM CREATE), then reads `loadimmutable`-backed views. Before
+ *      the fix, the constructor emitted `setimmutable` before `datacopy` (and
+ *      at the code offset `dataoffset("runtime")` instead of memory offset 0),
+ *      so the runtime image returned by `return(0, …)` was never patched and
+ *      every `loadimmutable` in the deployed code read `0`.
+ *
+ *      Contract under test: `ImmutableSmoke` (Contracts/Smoke/Declarations.lean)
+ *        immutables
+ *          seededSupply : Uint256 := (add seed offset)   -- offset = 2
+ *          treasury     : Address := ownerSeed
+ *        constructor (seed, ownerSeed) := setStorageAddr owner ownerSeed
+ *        view supplyCap()    := seededSupply
+ *        view treasuryAddr() := treasury
+ */
+contract Issue2074ImmutableDeployTest is Test, YulTestBase {
+    /// Deploy `ImmutableSmoke` from freshly compiled Yul, appending ABI-encoded
+    /// constructor args to the creation bytecode (real CREATE).
+    function _deployImmutableSmoke(bytes memory args) internal returns (address) {
+        _ensureVerityModuleYul("Contracts.Smoke.ImmutableSmoke", "ImmutableSmoke", _smokeYulDir());
+        string memory path = string.concat(_smokeYulDir(), "/ImmutableSmoke.yul");
+        bytes memory initCode = bytes.concat(_compileYul(path), args);
+        return _deploy(initCode);
+    }
+
+    // A plain immutable (treasury := ownerSeed) is read back verbatim.
+    function testImmutableAddressReadBack() public {
+        address ownerSeed = address(0xBEEF);
+        address target = _deployImmutableSmoke(abi.encode(uint256(1), ownerSeed));
+        require(target != address(0), "Deploy failed");
+
+        (bool ok, bytes memory ret) = target.staticcall(abi.encodeWithSignature("treasuryAddr()"));
+        require(ok, "treasuryAddr reverted");
+        assertEq(ret.length, 32, "treasuryAddr return length");
+        assertEq(abi.decode(ret, (address)), ownerSeed, "immutable address must survive deploy (not 0)");
+    }
+
+    // A computed immutable (seededSupply := seed + offset) is read back.
+    function testImmutableComputedReadBack() public {
+        uint256 seed = 40;
+        address target = _deployImmutableSmoke(abi.encode(seed, address(0xBEEF)));
+        require(target != address(0), "Deploy failed");
+
+        (bool ok, bytes memory ret) = target.staticcall(abi.encodeWithSignature("supplyCap()"));
+        require(ok, "supplyCap reverted");
+        assertEq(ret.length, 32, "supplyCap return length");
+        // offset constant is 2, so seededSupply == seed + 2.
+        assertEq(abi.decode(ret, (uint256)), seed + 2, "computed immutable must survive deploy (not 0)");
+    }
+
+    // Fuzzed: whatever constructor args are supplied, the deployed views echo them.
+    function testImmutablesFuzz(uint128 seed, address ownerSeed) public {
+        address target = _deployImmutableSmoke(abi.encode(uint256(seed), ownerSeed));
+        require(target != address(0), "Deploy failed");
+
+        (bool ok1, bytes memory r1) = target.staticcall(abi.encodeWithSignature("supplyCap()"));
+        require(ok1, "supplyCap reverted");
+        assertEq(abi.decode(r1, (uint256)), uint256(seed) + 2, "supplyCap == seed + offset");
+
+        (bool ok2, bytes memory r2) = target.staticcall(abi.encodeWithSignature("treasuryAddr()"));
+        require(ok2, "treasuryAddr reverted");
+        assertEq(abi.decode(r2, (address)), ownerSeed, "treasuryAddr == ownerSeed");
+    }
+}


### PR DESCRIPTION
## Summary

Constructor immutables were never written into a contract's deployed runtime, so every `loadimmutable("<name>")` in deployed code read `0`. Two independent defects, both fixed here:

1. **Order & offset (the reported bug).** `deployCodeWithProfile` emitted each `setimmutable(dataoffset("runtime"), name, value)` inside the constructor body — *before* `datacopy(0, …)` materializes the runtime image in memory, and at a code/data offset rather than memory offset `0`. So the patch targeted memory that wasn't there yet, at the wrong address. The runtime returned by `return(0, …)` was never patched.

   Fix (matches the standard solc deploy shape): predeclare `let __imm_<name> := 0` per immutable, rewrite each in-body `setimmutable(dataoffset("runtime"), name, value)` into `__imm_<name> := value` (last-executed-assignment-wins, preserved through control flow), then **after** `datacopy(0, …)` emit `setimmutable(0, "<name>", __imm_<name>)` for each immutable, then `return`.

2. **Linker prerequisite.** `loadimmutable`/`setimmutable` are solc Yul-dialect builtins but were missing from `yulBuiltins`, so `validateExternalReferences` rejected *any* immutable contract as an "Unresolved external reference" before it could be emitted. Added both to the builtin list.

### Emitted deploy code (ImmutableSmoke), after fix
```yul
let __imm_seededSupply := 0
let __imm_treasury := 0
...
__imm_seededSupply := add(seed, 2)
__imm_treasury := ownerSeed
sstore(0, and(ownerSeed, 0xff...ff))
datacopy(0, dataoffset("runtime"), datasize("runtime"))
setimmutable(0, "seededSupply", __imm_seededSupply)
setimmutable(0, "treasury", __imm_treasury)
return(0, datasize("runtime"))
```

## Files changed
- `Compiler/CodegenCommon.lean` — defer immutable patching past `datacopy`, target offset 0 (collect names, predeclare temps, rewrite setters, emit patches after copy).
- `Compiler/Linker.lean` — add `loadimmutable`/`setimmutable` to `yulBuiltins`.
- `Contracts/Smoke/ImmutableSmoke.lean` — thin re-export module so the existing `ImmutableSmoke` contract is compilable via `--module` (its canonical spec lives in `Contracts.Smoke.Declarations`).
- `test/Issue2074ImmutableDeploy.t.sol` — regression test.

## Validation
Regression test deploys `ImmutableSmoke` through **real creation bytecode (CREATE)** and reads `loadimmutable`-backed views:

```
FOUNDRY_PROFILE=difftest forge test --match-path test/Issue2074ImmutableDeploy.t.sol -vv

[PASS] testImmutableAddressReadBack()      (gas: 1189629)
[PASS] testImmutableComputedReadBack()     (gas: 1189475)
[PASS] testImmutablesFuzz(uint128,address) (runs: 256, μ: 1179354)
Suite result: ok. 3 passed; 0 failed; 0 skipped
```

- `lake build verity-compiler` succeeds.
- Non-immutable contracts (e.g. `Counter`) emit byte-identical deploy code — the new pass is a no-op when a contract has no immutables (verified: deploy tail is still plain `datacopy(0, …)` / `return(0, …)`).

## Acceptance criteria
- [x] A `CREATE`-deployed contract's `loadimmutable` reads the constructor-supplied value, not `0`.
- [x] Compiler builds.
- [x] A deploy-and-read-immutable test is added.

Fixes #2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deploy bytecode shape for immutable contracts (core codegen path); non-immutable deploy output should stay identical, but wrong ordering would break all immutable deployments.
> 
> **Overview**
> Fixes **#2074**: CREATE-deployed contracts no longer read `0` from every `loadimmutable`.
> 
> **Deploy codegen** (`deployCodeWithProfile`) now follows the solc-style sequence: declare `__imm_<name>` temps, rewrite in-constructor `setimmutable(dataoffset("runtime"), …)` into assignments to those temps (control-flow preserved), run **`datacopy`**, then emit **`setimmutable(0, …)`** from the temps, then `return`. Contracts without immutables are unchanged.
> 
> **Linker** adds `loadimmutable` / `setimmutable` to `yulBuiltins` so immutable Yul is not rejected as unresolved externals; the builtin sync script documents the same exception.
> 
> Adds **`ImmutableSmoke`** module wiring and a **Foundry** suite that CREATE-deploys and fuzz-reads immutable-backed views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d366427fe3c6997e1926e6e3e4aec7facaf9c0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->