### PR TITLE
ci(intake-guard): read findings via env, not inline string interpolation

### DIFF
--- a/.github/workflows/issue-intake-guard.yml
+++ b/.github/workflows/issue-intake-guard.yml
@@ -38,9 +38,11 @@ jobs:
       - name: Comment and close invalid issue
         if: steps.validate.outputs.status != '0'
         uses: actions/github-script@v7
+        env:
+          FINDINGS: ${{ steps.validate.outputs.findings }}
         with:
           script: |
-            const findings = `${{ steps.validate.outputs.findings }}`.trim();
+            const findings = (process.env.FINDINGS || '').trim();
             const issue_number = context.issue.number;
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

- The `Comment and close invalid issue` step interpolates `steps.validate.outputs.findings` directly into the inline `github-script` body via `` `${{ steps.validate.outputs.findings }}` ``.
- A backtick or `${` in the validator output can break the JS template literal or execute injected code with `issues: write` permissions (a submitter can steer the validator's `findings.md` output).
- Fix: pass the value through `env.FINDINGS` and read it with `process.env.FINDINGS` inside the script — the same pattern GitHub recommends for untrusted context inputs.

Refs Track 1 (CI cleanup) of the roadmap.

## Test plan

- [ ] `Issue Intake Guard` workflow runs green on this PR (no invalid-issue path to exercise).
- [ ] After merge, the next auto-close on an invalid intake still comments + closes as before.
- [ ] Manually verify a payload containing `` ` `` and `${x}` in the findings no longer breaks the script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-step CI hardening with no product runtime impact; behavior should match the previous comment-and-close path when findings are benign.
> 
> **Overview**
> The **Issue Intake Guard** workflow no longer embeds `steps.validate.outputs.findings` inside the inline `github-script` body. Validator output (from issue title/body) is passed through **`env.FINDINGS`** and read with **`process.env.FINDINGS`**, so characters like backticks or `${` in findings cannot break the script or run injected code under **`issues: write`**.
> 
> Comment-and-close behavior for invalid issues is unchanged; only how findings reach the script is hardened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f74d2a3c626119d403770ead18dd4340a0a915d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->