### PR TITLE
docs: seed parity gap maps and roadmap log

### DIFF
--- a/docs/parity/README.md
+++ b/docs/parity/README.md
@@ -9,9 +9,9 @@ events, errors, modifiers, functions) with one of:
 - ❌ requires a new EDSL feature (feature named)
 
 The maps are used to (a) prioritize feature work in issue
-[#1724](https://github.com/lfglabs-dev/verity/issues/1724) and (b) drive the
-nightly `contracts-smoke` CI job that compiles each reference contract through
-Verity and asserts no rows regress.
+[#1724](https://github.com/lfglabs-dev/verity/issues/1724) and (b) drive a
+planned nightly `contracts-smoke` CI job (not yet implemented) that will
+compile each reference contract through Verity and assert no rows regress.
 
 ## Contents
 
@@ -38,5 +38,4 @@ Lido, flashloan callback for Morpho) come next.
 ## Updating a map
 
 Any PR that changes a `verity_contract` construct row (adds support, changes
-signature, deletes) MUST update the corresponding row in these files. This is
-gate 7 in the roadmap agent's merge checklist.
+signature, deletes) MUST update the corresponding row in these files.

--- a/docs/parity/README.md
+++ b/docs/parity/README.md
@@ -1,0 +1,42 @@
+# Solidity parity gap maps
+
+Per-contract gap maps between production Solidity and the `verity_contract`
+EDSL. Each file lists every top-level construct (state variables, structs,
+events, errors, modifiers, functions) with one of:
+
+- ✅ expressible in `verity_contract` today
+- 🚧 expressible with a workaround (workaround noted)
+- ❌ requires a new EDSL feature (feature named)
+
+The maps are used to (a) prioritize feature work in issue
+[#1724](https://github.com/lfglabs-dev/verity/issues/1724) and (b) drive the
+nightly `contracts-smoke` CI job that compiles each reference contract through
+Verity and asserts no rows regress.
+
+## Contents
+
+- [`lido.md`](lido.md) — Lido StakingRouter v3 (Solidity 0.8.25 / 0.4.24)
+- [`erc4337.md`](erc4337.md) — ERC-4337 v0.9 EntryPoint stack (eth-infinitism
+  reference implementation)
+- [`morpho.md`](morpho.md) — Morpho Blue singleton (`morpho-org/morpho-blue`)
+
+## Convergent findings
+
+Across all three contracts (423 constructs scored), the same top-3 missing
+EDSL features dominate:
+
+| Rank | Feature | Lido hits | 4337 hits | Morpho hits |
+|---|---|---:|---:|---:|
+| 1 | Narrow uints (`uint128`, `uint64`, `uint48`, `uint32`, `uint16`) | ~45 | 22 | ~15 |
+| 2 | `abi.encode` / `encodePacked` / `encodeCall` codec | 6+ | 9 | 3 |
+| 3 | First-class modifiers + inheritance (`is X, Y`) | ~30 | 8 | 4 |
+
+Landing these three lands every reference contract north of 70% ✅ in one
+wave; individual contract-specific gaps (EIP-712 for 4337/Morpho, `enum` for
+Lido, flashloan callback for Morpho) come next.
+
+## Updating a map
+
+Any PR that changes a `verity_contract` construct row (adds support, changes
+signature, deletes) MUST update the corresponding row in these files. This is
+gate 7 in the roadmap agent's merge checklist.

--- a/docs/parity/erc4337.md
+++ b/docs/parity/erc4337.md
@@ -1,0 +1,370 @@
+# ERC-4337 EntryPoint × Verity EDSL — parity gap map
+
+Scope: Solidity ↔ `verity_contract` EDSL coverage for the ERC-4337 v0.9
+EntryPoint stack the harness in
+[`lfglabs-dev/erc4337-verity`](https://github.com/lfglabs-dev/erc4337-verity)
+targets. That repo carries only Python glue, adapters, and a submodule at
+`upstream/account-abstraction/` pinned to
+[`eth-infinitism/account-abstraction@b36a1ed5`](https://github.com/eth-infinitism/account-abstraction/tree/b36a1ed52ae00da6f8a4c8d50181e2877e4fa410)
+(tag `v0.9.0`), so this document scores that pinned commit as the source of
+truth.
+
+Files scored (all under `contracts/`):
+
+| File | LOC | Role |
+| --- | --- | --- |
+| `core/EntryPoint.sol` | 1013 | Singleton entrypoint (>500 LOC → storage-layout + designated entrypoints only) |
+| `core/StakeManager.sol` | 148 | Stake/deposit accounting mixed into EntryPoint |
+| `core/NonceManager.sol` | 40 | 2-D nonce mapping |
+| `core/BaseAccount.sol` | 166 | Abstract account base |
+| `core/BasePaymaster.sol` | 144 | Abstract paymaster base |
+| `core/UserOperationLib.sol` | 231 | Packing, hashing, offsets |
+| `accounts/SimpleAccount.sol` | 127 | Reference singleton account |
+| `interfaces/IEntryPoint.sol` | 261 | Errors, events, structs |
+| `interfaces/IStakeManager.sol` | 120 | Errors, events, `DepositInfo` |
+| `interfaces/IPaymaster.sol` | 63 | `PostOpMode` enum, paymaster ABI |
+| `interfaces/PackedUserOperation.sol` | 46 | Wire struct |
+
+Legend: ✅ expressible in `verity_contract` today · 🚧 expressible with a
+workaround (noted) · ❌ needs new EDSL work. Tracked in verity issue
+[#2071](https://github.com/lfglabs-dev/verity/issues/2071); related umbrella
+issues [#1724](https://github.com/lfglabs-dev/verity/issues/1724),
+[#1982](https://github.com/lfglabs-dev/verity/issues/1982),
+[#2002](https://github.com/lfglabs-dev/verity/issues/2002),
+[#2060](https://github.com/lfglabs-dev/verity/issues/2060).
+
+## PackedUserOperation.sol
+
+| Construct | Signature | Verity | Notes |
+| --- | --- | --- | --- |
+| struct field | `address sender` | ✅ | |
+| struct field | `uint256 nonce` | ✅ | |
+| struct field | `bytes initCode` | 🚧 | Only via `calldata`; storage `bytes` still ❌ (see #1982). |
+| struct field | `bytes callData` | 🚧 | Same. |
+| struct field | `bytes32 accountGasLimits` (packed 2×uint128) | ✅ | Word storage OK; unpacking below is ❌. |
+| struct field | `uint256 preVerificationGas` | ✅ | |
+| struct field | `bytes32 gasFees` (packed 2×uint128) | ✅ | |
+| struct field | `bytes paymasterAndData` | 🚧 | calldata-only. |
+| struct field | `bytes signature` | 🚧 | calldata-only. |
+| top-level struct type | `struct PackedUserOperation { ... }` (as calldata param) | 🚧 | Modelled as calldata bag; top-level *storage* struct still ❌. |
+
+## interfaces/IStakeManager.sol
+
+| Construct | Signature | Verity | Notes |
+| --- | --- | --- | --- |
+| error | `InvalidUnstakeDelay(uint256,uint256)` | ✅ | |
+| error | `InvalidStake(uint256,uint256)` | ✅ | |
+| error | `NotStaked(uint256,uint256,bool)` | ✅ | |
+| error | `InsufficientDeposit(uint256,uint256)` | ✅ | |
+| error | `StakeNotUnlocked(uint256,uint256)` | ✅ | |
+| error | `WithdrawalNotDue(uint256,uint256)` | ✅ | |
+| error | `StakeWithdrawalFailed(address,address,uint256,bytes)` | 🚧 | `bytes` in composite payload — needs #1982 codec. |
+| error | `DepositWithdrawalFailed(address,address,uint256,bytes)` | 🚧 | Same. |
+| event | `Deposited(address indexed, uint256)` | ✅ | |
+| event | `Withdrawn(address indexed, address, uint256)` | ✅ | |
+| event | `StakeLocked(address indexed, uint256, uint256)` | ✅ | |
+| event | `StakeUnlocked(address indexed, uint256)` | ✅ | |
+| event | `StakeWithdrawn(address indexed, address, uint256)` | ✅ | |
+| struct | `DepositInfo { uint256; bool; uint112; uint32; uint48 }` | ❌ | Needs `uint112`, `uint32`, `uint48` + top-level packed storage struct (#2060). |
+| struct | `StakeInfo { uint256, uint256 }` | ✅ | |
+| fn | `getDepositInfo(address) view returns (DepositInfo)` | ❌ | Depends on struct above. |
+| fn | `balanceOf(address) view returns (uint256)` | ✅ | |
+| fn | `depositTo(address) payable` | ✅ | |
+| fn | `addStake(uint32) payable` | ❌ | `uint32` parameter unsupported. |
+| fn | `unlockStake()` | ✅ | |
+| fn | `withdrawStake(address payable)` | ✅ | `payable` on address is a no-op at type level. |
+| fn | `withdrawTo(address payable, uint256)` | ✅ | |
+
+## core/StakeManager.sol (concrete abstract)
+
+| Construct | Signature | Verity | Notes |
+| --- | --- | --- | --- |
+| storage | `mapping(address => DepositInfo) private deposits` | ❌ | Value type is packed struct (#2060). Workaround: split into parallel `mapping(address => uint256)`. |
+| fn | `getDepositInfo(address) view returns (DepositInfo)` | ❌ | See struct. |
+| fn | `_getStakeInfo(address) view returns (StakeInfo)` | 🚧 | Model as two-return `uint256`s. |
+| fn | `balanceOf(address) view returns (uint256)` | ✅ | |
+| receive | `receive() external payable` | ❌ | No `receive/fallback` — must expose an explicit `depositTo` entrypoint. |
+| fn | `_incrementDeposit(address, uint256) returns (uint256)` | ✅ | |
+| fn | `_tryDecrementDeposit(address, uint256) returns (bool)` | ✅ | |
+| fn | `depositTo(address)` payable | ✅ | |
+| fn | `addStake(uint32)` payable | ❌ | `uint32` arg. |
+| fn | `unlockStake()` | 🚧 | Uses `uint48(block.timestamp)` cast — needs `uint48`; workaround: `uint256`. |
+| fn | `withdrawStake(address payable)` | 🚧 | `.call{value}()`: OK in EDSL, no proof; `transfer/send` remain ❌. |
+| fn | `withdrawTo(address payable, uint256)` | 🚧 | Same. |
+
+## core/NonceManager.sol
+
+| Construct | Signature | Verity | Notes |
+| --- | --- | --- | --- |
+| storage | `mapping(address => mapping(uint192 => uint256)) public nonceSequenceNumber` | ❌ | `mapping2` supported, but *key type `uint192`* is ❌. Workaround: `uint256` key + truncate. |
+| fn | `getNonce(address, uint192) view returns (uint256)` | ❌ | `uint192` arg. |
+| fn | `incrementNonce(uint192)` | ❌ | Same. |
+| fn | `_validateAndUpdateNonce(address, uint256) returns (bool)` | ❌ | Uses `uint192(nonce >> 64)` and `uint64(nonce)` casts. |
+
+## interfaces/IEntryPoint.sol
+
+| Construct | Signature | Verity | Notes |
+| --- | --- | --- | --- |
+| event | `UserOperationEvent(bytes32 idx, address idx, address idx, uint256, bool, uint256, uint256)` | ✅ | |
+| event | `AccountDeployed(bytes32 idx, address idx, address, address)` | ✅ | |
+| event | `IgnoredInitCode(bytes32 idx, address idx, address)` | ✅ | |
+| event | `EIP7702AccountInitialized(bytes32 idx, address idx, address idx)` | ✅ | |
+| event | `UserOperationRevertReason(bytes32 idx, address idx, uint256, bytes)` | 🚧 | `bytes` payload. |
+| event | `PostOpRevertReason(bytes32 idx, address idx, uint256, bytes)` | 🚧 | |
+| event | `UserOperationPrefundTooLow(bytes32 idx, address idx, uint256)` | ✅ | |
+| event | `BeforeExecution()` | ✅ | |
+| event | `SignatureAggregatorChanged(address idx)` | ✅ | |
+| error | `FailedOp(uint256, string)` | ❌ | Composite error with storage/memory `string`. Workaround: use `bytes32` code. |
+| error | `InvalidBeneficiary(address)` | ✅ | |
+| error | `FailedSendToBeneficiary(address, uint256, bytes)` | 🚧 | |
+| error | `InternalFunction()` | ✅ | |
+| error | `InvalidPaymasterData(uint256)` | ✅ | |
+| error | `InvalidPaymaster(address)` | ✅ | |
+| error | `FailedOpWithRevert(uint256, string, bytes)` | ❌ | `string` + `bytes` — needs full composite codec (#1982). |
+| error | `PostOpReverted(bytes)` | 🚧 | |
+| error | `SignatureValidationFailed(address)` | ✅ | |
+| error | `SenderAddressResult(address)` | ✅ | |
+| error | `DelegateAndRevert(bool, bytes)` | 🚧 | |
+| struct | `UserOpsPerAggregator { PackedUserOperation[]; IAggregator; bytes }` | 🚧 | Only in calldata; storage form ❌. |
+| struct | `ReturnInfo { 4× uint256, bytes }` | 🚧 | |
+| fn | `handleOps(PackedUserOperation[] calldata, address payable)` | 🚧 | Body gaps drive the score; signature-wise fine. |
+| fn | `handleAggregatedOps(UserOpsPerAggregator[] calldata, address payable)` | 🚧 | |
+| fn | `getUserOpHash(PackedUserOperation calldata) view returns (bytes32)` | ❌ | Body needs EIP-712 domain separator + typed-data hash (#2002). |
+| fn | `getCurrentUserOpHash() view returns (bytes32)` | ✅ | |
+| fn | `getSenderAddress(bytes memory)` | ❌ | Requires `CREATE`/`CREATE2` codepath. |
+| fn | `delegateAndRevert(address, bytes calldata)` | ❌ | `delegatecall` compile OK; the always-revert with `bytes` isn't provable. |
+| fn | `senderCreator() view returns (ISenderCreator)` | 🚧 | Immutable of a contract type; treat as `address`. |
+
+## interfaces/IPaymaster.sol
+
+| Construct | Signature | Verity | Notes |
+| --- | --- | --- | --- |
+| enum | `PostOpMode { opSucceeded, opReverted, postOpReverted }` | ❌ | No `enum`. Workaround: `uint8` constants. |
+| fn | `validatePaymasterUserOp(PackedUserOperation calldata, bytes32, uint256) returns (bytes, uint256)` | 🚧 | `bytes` return only lands as raw memory. |
+| fn | `postOp(PostOpMode, bytes calldata, uint256, uint256)` | ❌ | Enum arg. |
+
+## core/BasePaymaster.sol
+
+| Construct | Signature | Verity | Notes |
+| --- | --- | --- | --- |
+| storage | `IEntryPoint internal immutable _entryPoint` | 🚧 | As `address` immutable. |
+| const | `PAYMASTER_VALIDATION_GAS_OFFSET = 20` (uint256) | ✅ | |
+| const | `PAYMASTER_POSTOP_GAS_OFFSET = 36` | ✅ | |
+| const | `PAYMASTER_DATA_OFFSET = 52` | ✅ | |
+| error | `NotFromEntryPoint(address,address,address)` | ✅ | |
+| error | `ERC165Error(address, bytes4)` | ❌ | `bytes4` payload. |
+| error | `MustOverride()` | ✅ | |
+| inheritance | `is IPaymaster, Stakeable` (via `Ownable2Step`) | ❌ | No `is X, Y`. |
+| constructor | `constructor(IEntryPoint, address) Ownable(owner)` | ❌ | Parent-constructor call + inheritance. |
+| fn | `entryPoint() public view returns (IEntryPoint)` | 🚧 | Return as `address`. |
+| fn | `_validateEntryPointInterface(IEntryPoint) internal` | ❌ | Uses `type(IEntryPoint).interfaceId` (`bytes4`) + `IERC165(...).supportsInterface`. |
+| fn | `validatePaymasterUserOp(...) external` | 🚧 | Body dispatches to internal template; template itself is ❌ (abstract). |
+| fn | `_validatePaymasterUserOp(...) internal virtual` | ❌ | Abstract → no `virtual`/override slot in EDSL. |
+| fn | `postOp(PostOpMode,...) external` | ❌ | Enum arg. |
+| fn | `_postOp(...) internal virtual` | ❌ | Abstract + enum. |
+| fn | `deposit() public payable` | ✅ | |
+| fn | `withdrawTo(address payable, uint256) public onlyOwner` | ❌ | Modifier system + inherited `Ownable`. |
+| fn | `getDeposit() public view returns (uint256)` | ✅ | |
+| fn | `_requireFromEntryPoint() internal` | ✅ | |
+
+## core/BaseAccount.sol
+
+| Construct | Signature | Verity | Notes |
+| --- | --- | --- | --- |
+| struct (calldata) | `Call { address, uint256, bytes }` | 🚧 | Calldata-only. |
+| error | `ExecuteError(uint256, bytes)` | 🚧 | `bytes` payload. |
+| error | `NotFromEntryPoint(address,address,address)` | ✅ | |
+| fn | `getNonce() view returns (uint256)` | ✅ | |
+| fn (abstract) | `entryPoint() view returns (IEntryPoint)` | 🚧 | |
+| fn | `execute(address,uint256,bytes calldata)` | 🚧 | Low-level `call` (no proof coverage). |
+| fn | `executeBatch(Call[] calldata)` | 🚧 | Bounded `for` OK. |
+| fn | `validateUserOp(PackedUserOperation calldata, bytes32, uint256) returns (uint256)` | ✅ | |
+| fn | `_requireFromEntryPoint() internal virtual` | ✅ | |
+| fn | `_requireForExecute() internal virtual` | ✅ | |
+| fn (internal abstract) | `_validateSignature(PackedUserOperation calldata, bytes32) returns (uint256)` | ❌ | Virtual template requires first-class modifiers/overrides. |
+| fn (internal virtual view) | `_validateNonce(uint256)` | ✅ | |
+| fn (internal virtual) | `_payPrefund(uint256)` | 🚧 | Low-level `call{value:...}`. |
+
+## accounts/SimpleAccount.sol
+
+| Construct | Signature | Verity | Notes |
+| --- | --- | --- | --- |
+| storage | `address public owner` | ✅ | |
+| storage | `IEntryPoint private immutable _entryPoint` | 🚧 | As `address`. |
+| event | `SimpleAccountInitialized(IEntryPoint indexed, address indexed)` | ✅ | |
+| modifier | `onlyOwner()` | ❌ | Only `nonReentrant` supported (#2076). Workaround: inline `require`. |
+| error | `NotOwner(address,address,address)` | ✅ | |
+| error | `NotOwnerOrEntryPoint(address,address,address,address)` | ✅ | |
+| inheritance | `is BaseAccount, TokenCallbackHandler, UUPSUpgradeable, Initializable` | ❌ | No multi-inheritance. |
+| fn (public view override) | `entryPoint() returns (IEntryPoint)` | 🚧 | |
+| receive | `receive() external payable {}` | ❌ | |
+| constructor | `constructor(IEntryPoint) { … _disableInitializers() }` | ❌ | Inheritance init. |
+| fn (internal view) | `_onlyOwner()` | ✅ | |
+| fn (public initializer) | `initialize(address)` | ❌ | `initializer` modifier from OZ. |
+| fn (internal virtual) | `_initialize(address)` | ✅ | |
+| fn (internal view override) | `_requireForExecute()` | ✅ | |
+| fn (internal override virtual) | `_validateSignature(...)` | ❌ | `ECDSA.recover` on typed-data hash → EIP-712 flow (#2002). |
+| fn (public view) | `getDeposit() returns (uint256)` | ✅ | |
+| fn (public payable) | `addDeposit()` | ✅ | |
+| fn (public virtual onlyOwner) | `withdrawDepositTo(address payable, uint256)` | ❌ | Depends on modifier system. |
+| fn (internal view override) | `_authorizeUpgrade(address)` | ❌ | UUPS override slot. |
+
+## core/UserOperationLib.sol
+
+| Construct | Signature | Verity | Notes |
+| --- | --- | --- | --- |
+| error | `InvalidPaymasterSignatureLength(uint256,uint256)` | ✅ | |
+| const | 6× uint256 offsets (`PAYMASTER_*_OFFSET`, `PAYMASTER_SIG_MAGIC_LEN`, `PAYMASTER_SUFFIX_LEN`) | ✅ | |
+| const | `PAYMASTER_SIG_MAGIC = bytes8(0x22e325a297439656)` | ❌ | `bytes8` unsupported. Workaround: `bytes32` masked. |
+| const | `MIN_PAYMASTER_DATA_WITH_SUFFIX_LEN` | ✅ | |
+| const | `PACKED_USEROP_TYPEHASH = keccak256("...")` | 🚧 | Landed via `keccak256_lit` (#1978). |
+| fn | `gasPrice(userOp) view returns (uint256)` | 🚧 | Uses `unpackUints` — packing math OK as `uint256 >> 128`. |
+| fn | `encode(userOp, bytes32) pure returns (bytes)` | ❌ | `abi.encode` of 8 args. |
+| fn | `unpackUints(bytes32) pure returns (uint256,uint256)` | ✅ | Bitshift form. |
+| fn | `unpackHigh128(bytes32) pure returns (uint256)` | ✅ | |
+| fn | `unpackLow128(bytes32) pure returns (uint256)` | ❌ | `uint128(uint256(packed))` narrowing. Workaround: `packed & (2**128-1)`. |
+| fn | `unpackMaxPriorityFeePerGas(userOp)` | ✅ | |
+| fn | `unpackMaxFeePerGas(userOp)` | ❌ | Via `unpackLow128`. |
+| fn | `unpackVerificationGasLimit(userOp)` | ✅ | |
+| fn | `unpackCallGasLimit(userOp)` | ❌ | Via `unpackLow128`. |
+| fn | `unpackPaymasterVerificationGasLimit(userOp)` | ❌ | `bytes16` cast on calldata slice. |
+| fn | `unpackPostOpGasLimit(userOp)` | ❌ | Same. |
+| fn | `unpackPaymasterStaticFields(bytes calldata)` | ❌ | `bytes20`/`bytes16` slice casts. |
+| fn | `getPaymasterSignatureLength(bytes calldata) returns (uint256)` | ❌ | `bytes8`/`bytes2` casts + `uint16`. |
+| fn | `getSignedPaymasterData / getPaymasterSignature / getPaymasterSignatureWithLength` | 🚧 | Depend on above. |
+| fn | `encodePaymasterSignature(bytes calldata) returns (bytes)` | ❌ | `abi.encodePacked` + `uint16`. |
+| fn | `hash(PackedUserOperation calldata, bytes32) returns (bytes32)` | ❌ | Wraps `encode`. |
+
+## core/EntryPoint.sol — storage + designated entrypoints
+
+Full file 1013 LOC; storage layout is scored comprehensively, only the
+designated entrypoints (`handleOps`, `handleAggregatedOps`,
+`_validatePrepayment`, `_executeUserOp`, `depositTo` [inherited],
+`getUserOpHash`) are scored at body granularity. (`simulateValidation` lives
+in `EntryPointSimulations.sol`, out of the pinned scope.)
+
+### Storage / constants
+
+| Construct | Signature | Verity | Notes |
+| --- | --- | --- | --- |
+| const | `INNER_GAS_OVERHEAD = 10000` (uint256) | ✅ | |
+| const | `INNER_OUT_OF_GAS = hex"deaddead"` (bytes32) | ✅ | |
+| const | `INNER_REVERT_LOW_PREFUND = hex"deadaa51"` (bytes32) | ✅ | |
+| const | `REVERT_REASON_MAX_LEN = 2048` (uint256) | ✅ | |
+| const | `UNUSED_GAS_PENALTY_PERCENT = 10` (uint256) | ✅ | |
+| const | `PENALTY_GAS_THRESHOLD = 40000` (uint256) | ✅ | |
+| const | `VALIDITY_BLOCK_RANGE_FLAG = 0x800000000000` (uint48) | ❌ | `uint48` type. Workaround: `uint256` const. |
+| const | `VALIDITY_BLOCK_RANGE_MASK = 0x7fffffffffff` (uint48) | ❌ | Same. |
+| storage | `SenderCreator private immutable _senderCreator = new SenderCreator()` | ❌ | `new` (CREATE) inside a state init. |
+| const | `DOMAIN_NAME = "ERC4337"` (string) | ❌ | `string` constant. Workaround: `bytes32`. |
+| const | `DOMAIN_VERSION = "1"` (string) | ❌ | Same. |
+| storage | `bytes32 transient private currentUserOpHash` | ✅ | Transient supported. |
+| error | `Reentrancy()` | ✅ | |
+| modifier | `nonReentrant()` (`tx.origin == msg.sender && msg.sender.code.length == 0`) | 🚧 | Slot is available (#2076) but custom impl uses `tx.origin`; needs verifier hook. |
+| inheritance | `is IEntryPoint, StakeManager, NonceManager, ERC165, EIP712` | ❌ | 5-way inheritance. |
+| struct (memory) | `MemoryUserOp` (10 fields) | 🚧 | Memory-only; flatten to multi-return. |
+| struct (memory) | `UserOpInfo { MemoryUserOp, bytes32, uint256, uint256, uint256 }` | 🚧 | Nested — flatten. |
+| constructor | `constructor() EIP712(DOMAIN_NAME, DOMAIN_VERSION)` | ❌ | Parent ctor + EIP-712 (#2002). |
+
+### Designated entrypoints (function-body scoring)
+
+| Fn | Visibility / Mut | Verity | Body notes |
+| --- | --- | --- | --- |
+| `handleOps(PackedUserOperation[] calldata ops, address payable beneficiary)` | external virtual `nonReentrant` | 🚧 | Signature OK; body uses bounded `for` (✅), `new UserOpInfo[](opslen)` memory alloc (🚧), calls `_iterateValidationPhase`/`_executeUserOp`/`_compensate`. |
+| `handleAggregatedOps(UserOpsPerAggregator[] calldata, address payable)` | external virtual `nonReentrant` | ❌ | `try/catch` around `aggregator.validateSignatures` (❌). |
+| `_validatePrepayment(uint256, PackedUserOperation calldata, UserOpInfo memory) returns (uint256, uint256)` | internal virtual | 🚧 | Calls `getUserOpHash` (❌ EIP-712) and packs 7 gas values with `|` (✅). `require(maxGasValues <= type(uint120).max, ...)` (`uint120` ❌; workaround `2**120 - 1`). |
+| `_executeUserOp(uint256, PackedUserOperation calldata, UserOpInfo memory) returns (uint256)` | internal virtual | ❌ | `abi.encodeCall` (❌), inline assembly with `call`/returndata (🚧), `bytes4` `methodSig` matching (❌). |
+| `depositTo(address)` (inherited) | public virtual payable | ✅ | Straight-line. |
+| `getUserOpHash(PackedUserOperation calldata) view returns (bytes32)` | public view | ❌ | `MessageHashUtils.toTypedDataHash(getDomainSeparatorV4(), userOp.hash(...))` — full EIP-712 (#2002). |
+| `simulateValidation` | — | n/a | In `EntryPointSimulations.sol`, out of pinned scope. |
+
+### Other EntryPoint functions (signature-level only)
+
+| Fn | Verity | Blocking construct |
+| --- | --- | --- |
+| `getCurrentUserOpHash() view returns (bytes32)` | ✅ | Reads transient. |
+| `getSenderAddress(bytes calldata)` | ❌ | Calls factory. Depends on CREATE. |
+| `senderCreator() view returns (ISenderCreator)` | 🚧 | Return as `address`. |
+| `delegateAndRevert(address, bytes calldata)` | ❌ | `.delegatecall` + revert-with-`bytes`. |
+| `getPackedUserOpTypeHash() pure returns (bytes32)` | 🚧 | `keccak256_lit` (#1978). |
+| `getDomainSeparatorV4() view returns (bytes32)` | ❌ | EIP-712 domain (#2002). |
+| `supportsInterface(bytes4) view returns (bool)` | ❌ | `bytes4` arg + `type(...).interfaceId`. |
+| `_compensate(address payable, uint256)` | 🚧 | Low-level `.call{value}`. |
+| `_emitUserOperationEvent` | ✅ | |
+| `_emitPrefundTooLow` | ✅ | |
+| `_iterateValidationPhase(...)` | 🚧 | Bounded `for` + internal calls. |
+| `innerHandleOp(bytes, UserOpInfo, bytes calldata) returns (uint256)` | ❌ | 63/64 gas math + inline assembly revert + enum `PostOpMode`. |
+| `_copyUserOpToMemory` | ❌ | Memory struct writes + `unpackUints` chain. |
+| `_getRequiredPrefund` | ✅ | Pure sum × mul. |
+| `_createSenderIfNeeded` | ❌ | `senderCreator().createSender{gas:...}(initCode)`. |
+| `_validateAccountPrepayment` | 🚧 | Straight-line branching. |
+| `_callValidateUserOp` | ❌ | Inline assembly `call` + `returndatasize` + `abi.encodeCall`. |
+| `_validatePaymasterPrepayment` | 🚧 | |
+| `_callValidatePaymasterUserOp` | ❌ | Heavy inline assembly + `abi.encodeCall`. |
+| `_validateAccountAndPaymasterValidationData` | 🚧 | |
+| `_getValidationData(uint256) returns (address, bool, bool)` | ❌ | Reads `uint48` `validAfter/validUntil` + masks. |
+| `_postExecution` | ❌ | `try/catch` around `IPaymaster(paymaster).postOp{gas:...}` + enum. |
+| `_getUserOpGasPrice` | ✅ | |
+| `_getOffsetOfMemoryBytes` / `_getMemoryBytesFromOffset` | 🚧 | Pure inline-asm identity. |
+| `_getFreePtr` / `_restoreFreePtr` | ❌ | Direct free-pointer manipulation. |
+| `_getUnusedGasPenalty` | ✅ | Pure arithmetic. |
+
+## Cross-reference to open verity tickets
+
+| Verity ticket | Covers |
+| --- | --- |
+| [#2071](https://github.com/lfglabs-dev/verity/issues/2071) | Umbrella tracker for this parity work. |
+| [#2002](https://github.com/lfglabs-dev/verity/issues/2002) | EIP-712 typed-hash + ecrecover flow. |
+| [#2060](https://github.com/lfglabs-dev/verity/issues/2060) | Packed storage lowering. |
+| [#1982](https://github.com/lfglabs-dev/verity/issues/1982) | Dynamic ABI codec + storage `bytes`/`string` + typed CodeData. |
+| [#1724](https://github.com/lfglabs-dev/verity/issues/1724) | General Solidity-feature parity umbrella. |
+| [#1993](https://github.com/lfglabs-dev/verity/issues/1993) | Automatic checked-arithmetic obligations. |
+| #1978 *(merged)* | `keccak256_lit` — unblocked `PACKED_USEROP_TYPEHASH`. |
+| #2076 *(merged)* | `nonReentrant` lock release — partially unblocks EntryPoint's modifier. |
+| #1969 *(merged)* | ERC-4337 frame primitives in EVM/Trace core. |
+| #1576 *(merged)* | Receive/fallback macro entrypoints. |
+
+## Summary
+
+Total scored constructs: **~175** (11 struct fields · 21 errors · 13 events ·
+14 storage/constant slots · 4 modifiers · ~88 functions · 6 structs · 1 enum ·
+5 inheritance headers · 2 constructors · 2 receives · plus 8 designated
+EntryPoint bodies scored separately).
+
+| Bucket | Count | Share |
+| --- | --- | --- |
+| ✅ expressible today | 75 | 43 % |
+| 🚧 expressible with workaround | 42 | 24 % |
+| ❌ needs new EDSL work | 58 | 33 % |
+
+### Top 5 missing EDSL features (weighted by usage)
+
+| Rank | Feature | Sites hit | Blocked constructs |
+| --- | --- | --- | --- |
+| 1 | Sub-256 integer types (`uint128`, `uint120`, `uint112`, `uint64`, `uint48`, `uint32`, `uint192`, `uint16`) | 22 | `DepositInfo`, all nonce math, `_validatePrepayment` uint120 guard, `_getValidationData`, `addStake`, `getNonce`, `unpackLow128`. |
+| 2 | Full `abi.encode` / `abi.encodePacked` / `abi.encodeCall` / `abi.encodeWithSelector` codec | 9 | `UserOperationLib.encode`, `_callValidateUserOp`, `_callValidatePaymasterUserOp`, `_executeUserOp` inner call. |
+| 3 | Inheritance (`is X, Y`) + parent constructors + `virtual`/`override`/first-class modifier system | 8 | `EntryPoint is …`, `SimpleAccount is …`, `BasePaymaster is …`, `onlyOwner`, `initializer`, `_authorizeUpgrade`. |
+| 4 | Fixed-width byte types (`bytes4`, `bytes8`, `bytes16`, `bytes20`, `bytes2`) | 7 | Interface-id checks, `unpackPaymaster*`, `methodSig` dispatch, `PAYMASTER_SIG_MAGIC`. |
+| 5 | EIP-712 typed-data hash + domain separator (#2002) | 5 | `getUserOpHash`, `_validateSignature`, `getDomainSeparatorV4`, `getPackedUserOpTypeHash` chain. |
+
+Runner-ups: `try/catch` (3 sites), `receive/fallback` (2 sites), `enum`
+(`PostOpMode` propagates to ~6 fn signatures), storage `bytes`/`string`,
+`CREATE`/`CREATE2`.
+
+### Suggested next 3 PRs to unblock 4337
+
+1. **Packed sub-256 integer type support and bit-width casts** — Minimum
+   viable: `uint128`, `uint64`, `uint48`, `uint32`, `uint192`, `uint120` plus
+   `uint64(x)`, `uint128(uint256(x))`, and `bytes32 → uintN` packing/unpacking
+   used across `UserOperationLib` and `NonceManager`.
+2. **ABI codec surface (`abi.encode`, `abi.encodePacked`, `abi.encodeCall`,
+   `abi.encodeWithSelector`) with proof coverage** — pinned to the shape used
+   by `UserOperationLib.encode` and the two `_callValidate*` helpers.
+3. **EIP-712 typed-data hash + `ecrecover` (#2002)** — makes `getUserOpHash`,
+   `getDomainSeparatorV4`, and `SimpleAccount._validateSignature` provable
+   end-to-end, unblocks the harness's differential test against upstream
+   Hardhat.
+
+After those three land, the residual gap is dominated by modifier/inheritance
+and the `bytes4` family — good candidates for a second-wave batch, alongside
+`try/catch` and `receive/fallback` reuse from #1576.

--- a/docs/parity/lido.md
+++ b/docs/parity/lido.md
@@ -1,0 +1,372 @@
+# Lido StakingRouter v3 — Verity EDSL parity gap map
+
+**Status:** draft — best-effort. The Solidity source is NOT in
+`lfglabs-dev/lido-srv3-proof-closure` (that repo is a LaTeX report package).
+The Solidity mapped here lives in the upstream Lido monorepo `lidofinance/core`
+at the exact revision named in the report's `content/05-reproducibility.tex`:
+
+- Repo: `lidofinance/core` (branch: `develop`, PR
+  [#1811 — Staking Router V3](https://github.com/lidofinance/core/pull/1811))
+- Commit: `d088bbc2deac9913b68036d73d35c37aa6279b90`
+- Files mapped (from the report's own "Source anchor examples" list):
+  - `contracts/0.8.25/sr/StakingRouter.sol` (~1158 loc)
+  - `contracts/0.8.25/sr/SRLib.sol` (~932 loc, external library)
+  - `contracts/0.8.25/sr/SRStorage.sol`, `SRTypes.sol`, `SRUtils.sol`, `ISRBase.sol`
+  - `contracts/0.8.25/TopUpGateway.sol` (~424 loc)
+  - `contracts/0.8.9/oracle/AccountingOracle.sol` (~917 loc)
+  - `contracts/0.4.24/Lido.sol` (~1558 loc, buffer / reserve / `withdrawDepositableEther`)
+
+**Support matrix legend** (from
+[verity #1724](https://github.com/lfglabs-dev/verity/issues/1724)):
+
+- ✅ expressible today in `verity_contract`
+- 🚧 expressible with a workaround (noted)
+- ❌ requires a new EDSL feature (feature name noted)
+
+**Verity type baseline used below.** ✅: `uint256`, `int256`, `uint8`,
+`address`, `bytes32`, `bool`, single mapping, `mapping2`, simple events, custom
+errors with scalar payloads, `require`, bounded `for`, `if/else`, ternary,
+low-level `call`/`staticcall`/`delegatecall` (no proof coverage). ❌:
+`uint128/64/32/24/16`, `int128`, `bytes4/20`, `enum`, storage `string`/`bytes`,
+top-level `struct` as storage root, `mapping` depth ≥ 3 (no proof),
+inheritance, modifiers as first class, `abi.encode`/`abi.encodePacked`,
+`try/catch`, `while`, `break/continue`, `CREATE`/`CREATE2`, `transfer`/`send`,
+`receive`/`fallback`.
+
+The report itself scopes to six accounting properties (SRV3-P1 … P6).
+Constructs outside that scope are still listed so gaps can be counted honestly.
+
+---
+
+## 1. `contracts/0.8.25/sr/SRTypes.sol`
+
+### 1.1 Enums
+
+| Construct | Signature | Status | Notes / needed feature |
+|---|---|---|---|
+| enum `StakingModuleStatus` | `{Active, DepositsPaused, Stopped}` | ❌ | `enum` — workaround: encode as `Uint8` (SRTypes docs literally say "stored as `uint8` to avoid problems") |
+
+### 1.2 Interfaces (referenced, not implemented)
+
+| Construct | Signature | Status | Notes |
+|---|---|---|---|
+| `interface ILido` | `getDepositableEther() view returns (uint256)`, `withdrawDepositableEther(uint256,uint256)` | 🚧 | External-call interface. Verity has no `interface` decl but the calls can be modeled with typed low-level `call` — no proof coverage |
+| `interface IAccountingOracle` | `getProcessingState() returns (9-tuple)`, `getLastProcessingRefSlot()` | 🚧 | 9-value return tuple — Verity has partial multi-return; no destructuring assignment |
+
+### 1.3 Structs (used as storage or in mappings)
+
+| Struct | Fields (widths) | Status | Feature gap |
+|---|---|---|---|
+| `StakingModuleConfig` (calldata only) | 7× `uint256` | ✅ | Fits Tuple encoding |
+| `StakingModule` (legacy, in storage during migration) | `uint24,address,uint16,uint16,uint16,uint8,string,uint64,uint256,uint256,uint16,uint64,uint64,uint8,uint64` | ❌ | `uint24`, `uint16`, `uint64`, `uint8`, storage `string`, storage struct root |
+| `ModuleStateConfig` (1 storage slot, packed) | `address,uint16,uint16,uint16,uint16,StakingModuleStatus(enum),uint8` | ❌ | packed `uint16`+`enum`+`uint8` in one slot — needs `uint16`, `enum`, packed-field support |
+| `ModuleStateDeposits` (1 slot) | 4× `uint64` | ❌ | `uint64` |
+| `ModuleStateAccounting` (1 slot) | 2× `uint64` | ❌ | `uint64` |
+| `RouterStateAccounting` (1 slot) | `uint64` | ❌ | `uint64` |
+| `ModuleState` (top-level storage struct) | `config, deposits, accounting, string name` | ❌ | storage `string`, nested storage structs |
+| `RouterState` (top-level storage struct) | `mapping(uint256=>ModuleState), EnumerableSet.UintSet, RouterStateAccounting, bytes32, uint24 lastModuleId` | ❌ | top-level struct storage root, `uint24`, EnumerableSet library-typed storage |
+| `StakingModuleSummary` (memory) | 3× `uint256` | ✅ | Tuple/return |
+| `NodeOperatorSummary` (memory) | 8× `uint256` | ✅ | Tuple/return |
+| `StakingModuleDigest` (memory return) | 2 uint256 + `StakingModule` + `StakingModuleSummary` | ❌ | nested struct memory returns |
+| `NodeOperatorDigest` (memory return) | `uint256, bool, NodeOperatorSummary` | 🚧 | Flatten to tuple |
+| `ValidatorsCountsCorrection` (memory) | 4× `uint256` | ✅ | Tuple |
+| `ValidatorExitData` (memory) | `uint256, uint256, bytes` | 🚧 | `bytes` ABI-only in Verity; OK if only calldata/memory |
+
+---
+
+## 2. `contracts/0.8.25/sr/ISRBase.sol` (events + errors)
+
+### 2.1 Events
+
+| Event | Signature | Status | Notes |
+|---|---|---|---|
+| `StakingModuleAdded` | `(uint256 indexed, address, string, address)` | 🚧 | indexed dynamic events are supported; `string` in payload is ABI-only |
+| `StakingModuleShareLimitSet` | `(uint256 indexed, uint256, uint256, address)` | ✅ | |
+| `StakingModuleFeesSet` | `(uint256 indexed, uint256, uint256, address)` | ✅ | |
+| `StakingModuleMaxDepositsPerBlockSet` | `(uint256 indexed, uint256, address)` | ✅ | |
+| `StakingModuleMinDepositBlockDistanceSet` | `(uint256 indexed, uint256, address)` | ✅ | |
+| `StakingModuleStatusSet` | `(uint256 indexed, StakingModuleStatus, address)` | ❌ | enum payload — workaround: emit as `uint8` |
+| `WithdrawalCredentialsSet` | `(bytes32, address)` | ✅ | |
+| `StakingRouterETHDeposited` | `(uint256 indexed, uint256)` | ✅ | |
+| `DepositableEthReceived` | `(uint256)` | ✅ | |
+| `ExitedAndStuckValidatorsCountsUpdateFailed` | `(uint256 indexed, bytes)` | 🚧 | dynamic `bytes` event supported |
+| `RewardsMintedReportFailed` | `(uint256 indexed, bytes)` | 🚧 | same |
+| `StakingModuleExitedValidatorsIncompleteReporting` | `(uint256 indexed, uint256)` | ✅ | |
+| `WithdrawalsCredentialsChangeFailed` | `(uint256 indexed, bytes)` | 🚧 | dynamic `bytes` |
+| `StakingModuleExitNotificationFailed` | `(uint256 indexed, uint256 indexed, bytes)` | 🚧 | dynamic `bytes` |
+
+### 2.2 Errors (custom, scalar payloads unless noted)
+
+| Error | Payload | Status |
+|---|---|---|
+| `InvalidAmountGwei`, `NotAuthorized`, `ZeroAddress`, `ZeroArgument`, `ArraysLengthMismatch`, `OracleExtraDataNotSubmitted` | none | ✅ |
+| `InvalidReportData` | `(uint256)` | ✅ |
+| `ReportedExitedValidatorsExceedDeposited` | `(uint256, uint256)` | ✅ |
+| `UnexpectedCurrentValidatorsCount` | `(uint256, uint256)` | ✅ |
+| `UnexpectedFinalExitedValidatorsCount` | `(uint256, uint256)` | ✅ |
+| `UnrecoverableModuleError`, `ExitedValidatorsCountCannotDecrease`, `DirectETHTransfer`, `ModuleReturnExceedTarget`, `StakingModuleStatusTheSame`, `EmptyKeysList`, `WrongPubkeyLength`, `AmountNotAlignedToGwei`, `AllocationExceedsLimit`, `ZeroDeposits`, `StakingModuleAddressExists`, `StakingModulesLimitExceeded`, `StakingModuleWrongName`, `StakingModuleUnregistered`, `StakingModuleNotActive`, `WrongWithdrawalCredentialsType`, `InvalidPriorityExitShareThreshold`, `InvalidMinDepositBlockDistance`, `InvalidMaxDepositPerBlockValue`, `InvalidStakeShareLimit`, `InvalidFeeSum`, `InconsistentFeeSum` | none | ✅ |
+| `UnexpectedModuleId` | `(uint256, uint256)` | ✅ |
+
+---
+
+## 3. `contracts/0.8.25/sr/StakingRouter.sol`
+
+### 3.1 Top-level construct
+
+| Construct | Status | Feature gap |
+|---|---|---|
+| `contract StakingRouter is ISRBase, AccessControlEnumerableUpgradeable` | ❌ | inheritance (`is X, Y`) — no Verity equivalent; must flatten |
+
+### 3.2 State constants & immutables
+
+| Var | Type | Status | Notes |
+|---|---|---|---|
+| 9× `bytes32 public constant *_ROLE = keccak256(...)` | `bytes32` | ✅ | keccak of literal string OK |
+| `FEE_PRECISION_POINTS` | `uint256 constant` | ✅ | |
+| `PUBKEY_LENGTH` | `uint64 constant` | ❌ | `uint64` — workaround: `uint256` |
+| `DEPOSIT_CONTRACT`, `LIDO`, `LIDO_LOCATOR` | `I* immutable` | 🚧 | Verity has immutables for scalars; `interface` type as `address` |
+| `MAX_EFFECTIVE_BALANCE_WC_TYPE_01/02` | `uint256 immutable` | ✅ | |
+
+### 3.3 Constructor & initializers
+
+| Function | Signature | Status | Notes |
+|---|---|---|---|
+| `constructor(address,address,address,uint256,uint256)` | — | ✅ | Verity supports constructor + immutable init |
+| `initialize(address _admin, bytes32 _wc) external reinitializer(4)` | — | ❌ | `reinitializer(4)` modifier — modifier system missing |
+| `finalizeUpgrade_v4() external reinitializer(4)` | — | ❌ | modifier + inline delete of legacy role storage |
+
+### 3.4 Functions (grouped)
+
+For brevity: `external onlyRole(X)` in every management function collapses into
+"❌ modifier system".
+
+| Function (signature abbreviated) | Visibility / mut. | Status | Notes / gap |
+|---|---|---|---|
+| `INITIAL_DEPOSIT_SIZE() view returns (uint256)` | external | ✅ | |
+| `TOTAL_BASIS_POINTS() pure returns (uint256)` | external | ✅ | |
+| `MAX_STAKING_MODULES_COUNT() pure returns (uint256)` | external | ✅ | |
+| `MAX_STAKING_MODULE_NAME_LENGTH() pure returns (uint256)` | external | ✅ | |
+| `_getStorageRoleMembersOld() private pure returns (mapping storage $)` | private pure | ❌ | inline assembly + returning `mapping storage` — needs storage-pointer + assembly |
+| `addStakingModule(string calldata,address,StakingModuleConfig calldata)` | external, `onlyRole` | 🚧 | body OK once modifier lowered |
+| `updateStakingModule(uint256,uint256×6)` | external, `onlyRole` | 🚧 | 7 scalar args |
+| `updateAllStakingModulesFees(uint256[] calldata,uint256[] calldata)` | external | 🚧 | calldata arrays OK, bounded for |
+| `updateModuleShares(uint256, uint16, uint16)` | external | ❌ | `uint16` params |
+| `updateTargetValidatorsLimits(uint256, uint256, uint256, uint256)` | external | 🚧 | forwards to module via `call` |
+| `reportRewardsMinted(uint256[], uint256[])` | external | 🚧 | SRV3-P4/P5 core path |
+| `updateExitedValidatorsCountByStakingModule(uint256[], uint256[])` | external | 🚧 | |
+| `reportValidatorBalancesByStakingModule(uint256[], uint256[])` | external | 🚧 | SRV3-P3 core path; writes `uint64` balance sums — needs `uint64` |
+| `validateReportValidatorBalancesByStakingModule(uint256[], uint256[])` | external view | ✅ | pure array validation |
+| `reportStakingModuleExitedValidatorsCountByNodeOperator(uint256, bytes, bytes)` | external | 🚧 | `bytes` calldata OK |
+| `unsafeSetExitedValidatorsCount(uint256,uint256,bool,ValidatorsCountsCorrection)` | external | 🚧 | struct-by-value calldata (tuple) |
+| `onValidatorsCountsByNodeOperatorReportingFinished()` | external | 🚧 | walk `for` over modules |
+| `decreaseStakingModuleVettedKeysCountByNodeOperator(uint256, bytes, bytes)` | external | 🚧 | delegates to module (call) |
+| `reportValidatorExitDelay(uint256,uint256,uint256,bytes,uint256)` | external | 🚧 | |
+| `onValidatorExitTriggered(ValidatorExitData[] calldata,uint256,uint256)` | external | 🚧 | struct array |
+| `getStakingModules() view returns (StakingModule[])` | external | ❌ | returns array of legacy struct with narrow ints + `string` |
+| `getStakingModuleStateConfig / …StateDeposits / …StateAccounting(uint256)` | external view | ❌ | returns packed narrow-int structs |
+| `getStakingModuleIds() view returns (uint256[])` | external | ✅ | |
+| `getStakingModule(uint256) view returns (StakingModule)` | external | ❌ | same struct |
+| `getStakingModulesCount() view returns (uint256)` | external | ✅ | |
+| `hasStakingModule(uint256) view returns (bool)` | public | ✅ | |
+| `getStakingModuleStatus(uint256) view returns (StakingModuleStatus)` | public | ❌ | enum return |
+| `getContractVersion() view returns (uint256)` | external | ✅ | |
+| `getStakingModuleSummary` / `getNodeOperatorSummary` | external view | ✅ | scalar tuple returns |
+| `getAllStakingModuleDigests / getStakingModuleDigests(uint256[])` | external view | ❌ | nested-struct memory arrays |
+| `getAllNodeOperatorDigests / getNodeOperatorDigests(...)` | external view | 🚧 | flatten to tuple[] |
+| `setStakingModuleStatus(uint256, StakingModuleStatus)` | external `onlyRole` | ❌ | enum arg |
+| `getStakingModuleIsStopped / IsDepositsPaused / IsActive` | external view returns (bool) | ❌ | derived from enum status |
+| `getStakingModuleNonce / LastDepositBlock / MinDepositBlockDistance / MaxDepositsPerBlock` | external view returns (uint256) | 🚧 | value stored as `uint64`; cast up |
+| `getStakingModuleActiveValidatorsCount(uint256) view returns (uint256, uint256)` | external | ✅ | |
+| `getStakingModuleWithdrawalCredentials(uint256) view returns (bytes32)` | external | ✅ | |
+| `getStakingModuleMaxDepositsCount(uint256, uint256) view returns (uint256)` | external | ✅ | |
+| `canDeposit(uint256) view returns (bool)` | external | ✅ | |
+| `receiveDepositableEther() external payable` | external payable | ❌ | payable function needs `receive`/`fallback`/payable modeling (partial) |
+| `topUp(uint256, IStakingModuleV2.TopUpsData calldata, bytes calldata)` | external, `onlyRole`, calls out | 🚧 | ABI arrays OK; per-key allocation loop; `abi.encodePacked` on `bytes32 wc` (❌); modifier ❌ |
+| `_validateTopUpInputs(uint256, uint256, uint256[] calldata) internal pure` | internal pure | ✅ | |
+| `getStakingFeeAggregateDistribution() view returns (uint96 total, uint96 mod, uint96 treas, uint256 prec)` | external | ❌ | `uint96` × 3 |
+| `getStakingRewardsDistribution() view returns (address[], uint256[], uint96[], uint96 totalFee, uint256 prec)` | external | ❌ | `uint96` × 2 + `uint96[]` (SRV3-P5 anchor) |
+| `getModuleValidatorsBalance(uint256) view returns (uint256)` | external | 🚧 | Wraps `uint64` internal store |
+| `getTotalModulesValidatorsBalance() view returns (uint256)` | external | 🚧 | Same |
+| `_computeModuleFee(uint256, uint256, uint256, uint16) view returns (uint256)` | internal | ❌ | `uint16` arg |
+| `getTotalFeeE4Precision() view returns (uint16)` | external | ❌ | `uint16` return |
+| `getStakingFeeAggregateDistributionE4Precision() view returns (uint16, uint16, uint16)` | external | ❌ | `uint16` returns |
+| `getDepositAllocations(uint256, bool) view returns (uint256[])` | external | ✅ | |
+| `deposit(uint256, bytes calldata) external` | external | 🚧 | SRV3-P2 core path; body uses `address(this).balance` (❌), `abi.encodePacked` (❌), external `call` (🚧); enum comparison ❌ |
+| `setWithdrawalCredentials(bytes32) external onlyRole` | external | 🚧 | modifier + notifying loop |
+| `getWithdrawalCredentials() public view returns (bytes32)` | public view | ✅ | |
+| `_setWithdrawalCredentials(bytes32) internal` | internal | ✅ | |
+| `_getWithdrawalCredentialsWithType(uint8) internal view returns (bytes32)` | internal | ✅ | |
+| `_updateModuleLastDepositState(uint256, uint256) internal` | internal | 🚧 | writes `uint64 lastDepositBlock` — needs `uint64` |
+| `_getModuleDepositAllocation(uint256, uint256, bool) view returns (uint256)` | internal | ✅ | |
+| `_getStakingModuleNodeOperatorsCount / …Active…Count(IStakingModule) internal view` | internal | 🚧 | external `staticcall` |
+| `_getStakingModuleNodeOperatorIds(IStakingModule, uint256, uint256) view returns (uint256[])` | internal | 🚧 | staticcall |
+| `_getStakingModuleNodeOperatorIsActive(IStakingModule, uint256) view returns (bool)` | internal | 🚧 | staticcall |
+| `_getModuleState / _getModuleStateCompat / _getStakingModuleSummary / …Struct / _getNodeOperatorSummary` | internal view | 🚧/❌ | Compat variants build legacy struct with narrow ints |
+| `_getAccountingOracle / _getTopUpGateway / _getDepositSecurityModule() internal view returns (address)` | internal | ✅ | via locator staticcall |
+| `_checkAppAuth(address)` | internal view | ✅ | |
+| `_getConfig() private view returns (SRLib.Config)` | private | ✅ | |
+| `_toE4Precision(uint256, uint256) pure returns (uint16)` | internal pure | ❌ | `uint16` return |
+
+### 3.5 Modifiers used but not declared here
+
+- `onlyRole(bytes32)` (from OZ AccessControl) — used on ~20 external funcs — ❌ modifier system + inheritance
+- `reinitializer(4)` — used on `initialize`, `finalizeUpgrade_v4` — ❌ modifier system
+
+---
+
+## 4. `contracts/0.8.25/sr/SRLib.sol` (external library)
+
+Library used through `using X for Y` — Verity has no library concept; would
+inline.
+
+| Construct | Status | Feature gap |
+|---|---|---|
+| `library SRLib` | ❌ | `library` decl — must inline |
+| `struct Config { uint256, uint256 }` | ✅ | scalar tuple |
+| `struct ModuleParamsCache { uint256, uint256, uint16, StakingModuleStatus(enum), uint8 }` | ❌ | `uint16` + enum |
+| `_migrateStorage(uint256)` | ❌ | `keccak256` of literal (✅), `delete` on storage slot (❌), `abi.encode`/`abi.encodePacked` (❌), inline assembly slot compute (❌), builds/writes `uint64` fields + `uint24 lastModuleId` (❌), storage `string name` (❌) |
+| `_getStorageStakingModulesMapping / _getStorageStakingIndicesMapping` | ❌ | returns `mapping storage` via inline assembly |
+| `_addModule(address, string calldata, StakingModuleConfig calldata) returns (uint256)` | ❌ | writes storage `string name`, `uint24 lastModuleId++`, packs `ModuleStateConfig` |
+| `_validateShareParams(uint256, uint256) pure` | ✅ | |
+| `_updateModuleParams(uint256, uint256×6)` | ❌ | writes `uint16` fields into packed slot |
+| `_requireConsistentFeeSum(uint256, uint256, uint256) view` | ✅ | bounded `for` + `require` |
+| `_updateAllModuleFees(uint256[] calldata, uint256[] calldata)` | ❌ | writes packed `uint16` fields |
+| `_updateModuleShares(uint256, uint256, uint256)` | ❌ | writes packed `uint16` fields |
+| `_setModuleStatus(uint256, StakingModuleStatus) returns (bool)` | ❌ | enum arg + writes enum-in-packed-struct |
+| `_getStakingModuleSummary(IStakingModule) view returns (uint256, uint256, uint256)` | 🚧 | staticcall (no proof) |
+| `_getDepositAllocations(Config calldata, uint256, bool) view returns (uint256, uint256[])` | ✅ | SRV3-P2 anchor — pure array/loop |
+| `_getModuleDepositAllocation(uint256, uint256, bool) view returns (uint256)` | ✅ | |
+| `_getModulesAllocationAndCapacity(Config calldata, uint256, bool) view returns (uint256[], ModuleParamsCache[])` | ❌ | `ModuleParamsCache[]` contains `uint16` + enum |
+| `_reportValidatorExitDelay(uint256, uint256, uint256, bytes calldata, uint256)` | 🚧 | forwarded call |
+| `_onValidatorExitTriggered(ValidatorExitData[] calldata, uint256, uint256)` | 🚧 | |
+| `_reportRewardsMinted(uint256[] calldata, uint256[] calldata)` | 🚧 | SRV3-P4/P5 anchor: try/catch pattern via low-level `call` + `returndataSize` |
+| `_onValidatorsCountsByNodeOperatorReportingFinished()` | 🚧 | loop + call |
+| `_decreaseStakingModuleVettedKeysCountByNodeOperator / _reportStakingModuleOperatorExitedValidators / _updateExitedValidatorsCountByStakingModule` | ❌ | Read/write `uint64 exitedValidatorsCount` |
+| `_unsafeSetExitedValidatorsCount(...)` | ❌ | Same `uint64` gap |
+| `_validateReportValidatorBalancesByStakingModule(uint256[], uint256[]) view` | ✅ | SRV3-P3 anchor |
+| `_reportValidatorBalancesByStakingModule(uint256[], uint256[])` | ❌ | SRV3-P3 write path: writes `uint64 validatorsBalanceGwei` |
+| `_updateModuleLastDepositState(uint256)` | ❌ | writes `uint64 lastDepositBlock/At` |
+| `_notifyStakingModulesOfWithdrawalCredentialsChange()` | 🚧 | loop + low-level `call` |
+| `_checkOperatorsReportData(bytes calldata, bytes calldata) internal pure` | 🚧 | slicing `bytes calldata` via assembly `calldataload` |
+
+---
+
+## 5. `contracts/0.8.25/sr/SRStorage.sol` (thin storage-slot helper library)
+
+| Construct | Status | Feature gap |
+|---|---|---|
+| `library SRStorage` | ❌ | `library` |
+| `bytes32 constant ROUTER_STORAGE_POSITION = keccak256(abi.encode(uint256(keccak256(abi.encodePacked("..."))) - 1)) & ~bytes32(uint256(0xff))` | ❌ | ERC-7201 slot derivation uses `abi.encode` + `abi.encodePacked` |
+| `getRouterState() pure returns (RouterState storage $)` | ❌ | inline assembly `$.slot := _position` + top-level struct storage root |
+| All `getModuleState`, `addModuleId`, `getModulesCount`, `getModuleIdInnerPosition`, `isModuleExists` | ❌ | OZ `EnumerableSet.UintSet` — 3-deep mapping style; Verity lacks `mappingChain` proof |
+
+---
+
+## 6. `contracts/0.8.25/TopUpGateway.sol`
+
+| Construct | Status | Feature gap |
+|---|---|---|
+| `struct Storage { uint64, uint32, uint32, uint16, uint16, uint64, uint64 }` (packed one-slot) | ❌ | `uint64`, `uint32`, `uint16` |
+| `bytes32 constant GATEWAY_STORAGE_POSITION` (ERC-7201) | ❌ | `abi.encode/Packed` |
+| `uint256 constant PUBKEY_LENGTH = 48` | ✅ | |
+| `uint256 constant FAR_FUTURE_EPOCH = type(uint64).max` | ❌ | `type(T).max` unavailable in EDSL |
+| `uint256 immutable SLOTS_PER_EPOCH` | ✅ | |
+| Roles `TOP_UP_ROLE`, `MANAGE_LIMITS_ROLE` | ✅ | |
+| `constructor(uint64, uint256)` | ❌ | `uint64` arg |
+| `topUp(TopUpsData calldata, ...)` | 🚧 | modifier `onlyRole` ❌; body reads `bytes32 wc` via external `staticcall`; uses `abi.encodePacked` on pubkey concat (❌) |
+| `_verifyValidatorState(...)` | ❌ | EIP-4788 beacon root proof — Merkle/SSZ (out of scope) |
+| `_computeTopUpLimit(Validator, uint64) view returns (uint256)` | ❌ | `uint64` arg |
+| `_gatewayStorage() pure returns (Storage storage $)` | ❌ | inline asm + packed narrow-int storage struct |
+| Events: `MaxValidatorsPerTopUpChanged / MinBlockDistanceChanged / LastTopUpChanged / MaxRootAgeChanged / TopUpBalanceLimitsChanged` | ✅ | |
+| Errors `ZeroValue`, `TooLargeValue`, `RootIsTooOld`, `RootPrecedesLastTopUp`, `WrongArrayLength` | ✅ | |
+| Error `ZeroArgument(string argument)` | ❌ | dynamic `string` payload |
+
+---
+
+## 7. `contracts/0.8.9/oracle/AccountingOracle.sol` (SRv3 balance-check path only)
+
+| Construct | Status | Feature gap |
+|---|---|---|
+| `contract AccountingOracle is BaseOracle` | ❌ | inheritance |
+| `initialize(...)` / `finalizeUpgrade_v5(uint256)` | ❌ | modifiers |
+| `submitReportData(ReportData calldata, uint256)` | ❌ | large calldata struct with nested fields |
+| `_checkStakingRouterModuleBalances(sanityChecker, data, timeElapsed)` (SRV3-P3 P4 anchor) | 🚧 | staticcall + bounded loop |
+| `_normalizeStakingRouterValidatorBalancesToWei(uint256[])` | ✅ | pure multiplication |
+| `_processStakingRouterExitedValidatorsByModule / …ValidatorBalancesByModule` | 🚧 | forwarded external calls |
+| `_processExtraDataItems / _processExtraDataItem(bytes calldata, ExtraDataIterState)` | ❌ | slices `bytes calldata` via assembly `calldataload`, packs `bytes4` selectors, `while`-style |
+| `_storageExtraDataProcessingState() pure returns (StorageExtraDataProcessingState storage r)` | ❌ | assembly slot pointer + storage struct |
+| Storage struct `StorageExtraDataProcessingState` (packed) | ❌ | contains `uint64` fields |
+| Events + errors (~15, mostly scalar) | ✅ | |
+
+---
+
+## 8. `contracts/0.4.24/Lido.sol` (buffer / reserve / withdraw path only)
+
+Solidity 0.4.24 dialect — Verity targets 0.8.x — the accounting logic would
+have to be re-expressed.
+
+| Construct | Status | Feature gap |
+|---|---|---|
+| `contract Lido is Versioned, StETHPermit, AragonApp` (multiple inheritance) | ❌ | inheritance (deep) |
+| `bytes32 constant BUFFERED_ETHER_POSITION` — packed slot `uint128 depositedPostReport | uint128 bufferedEther` | ❌ | `uint128`, packed 2×`uint128` |
+| `bytes32 constant DEPOSITS_RESERVE_POSITION` (single `uint256` slot) | ✅ | ERC-1967 unstructured storage |
+| `struct BufferedEtherAllocation { uint256 total, unfinalizedStETH, unreserved, depositsReserve, withdrawalsReserve }` (memory only) | ✅ | scalar tuple |
+| `event DepositsReserveSet(uint256)` | ✅ | |
+| `event ExternalBadDebtInternalized(uint256)` | ✅ | |
+| `_getBufferedEtherAllocation() internal view returns (BufferedEtherAllocation)` (SRV3-P1 anchor) | ✅ | pure `min` arithmetic |
+| `getDepositsReserve() external view returns (uint256)` | ✅ | |
+| `getDepositableEther() external view returns (uint256)` | ✅ | |
+| `withdrawDepositableEther(uint256, uint256) external` (SRV3-P1 anchor) | ❌ | writes `uint128 depositedPostReport` (packed) + 2300-gas `transfer`. Requires `uint128` + `transfer` |
+| `receive() external payable` / `fallback()` | ❌ | receive/fallback |
+| `_getBufferedEther() internal view returns (uint256)` (extracts low 128 bits) | ❌ | `uint128` + bitmask extraction |
+| `_setBufferedEther(uint256) internal` | ❌ | `uint128` packed write |
+
+---
+
+## Summary
+
+**Total top-level constructs counted:** 176
+
+| Category | ✅ | 🚧 | ❌ | Total |
+|---|---:|---:|---:|---:|
+| Structs / Enums | 5 | 2 | 12 | 19 |
+| State variables & constants | 12 | 3 | 8 | 23 |
+| Events | 9 | 5 | 1 | 15 |
+| Errors | 30 | 0 | 1 | 31 |
+| Functions (external + internal + library) | 21 | 27 | 32 | 80 |
+| Contract-level (inheritance, receive/fallback, modifiers-used) | 0 | 0 | 8 | 8 |
+| **Total** | **77 (43.8%)** | **37 (21.0%)** | **62 (35.2%)** | **176** |
+
+Only the SRv3-P1…P6 accounting core skews friendlier: ~55 % ✅ / 30 % 🚧 /
+15 % ❌ — the ❌ items are concentrated in **`uint64` balance storage** and
+**`enum` status gating**.
+
+### Top 3 missing EDSL features weighted by usage count
+
+1. **Narrow unsigned integer widths** (`uint64`, `uint16`, `uint32`, `uint24`,
+   `uint96`, `uint128`) — hit in almost every storage struct and both SRV3
+   core writes. **~45 distinct construct hits.** Blocks P3 write path and P1
+   write path outright.
+2. **`enum` support** — `StakingModuleStatus` in status gating (SRV3-P6),
+   setters, getters, events, storage packing, args. **~14 construct hits.**
+   Workaround exists (`Uint8`) but propagates through every signature and the
+   packed slot.
+3. **Modifier system + inheritance** — `onlyRole`, `reinitializer`, `is
+   ISRBase, AccessControlEnumerableUpgradeable`. **~30 construct hits.** No
+   in-block workaround today; must flatten.
+
+Runner-ups: storage `string`, top-level storage structs, `abi.encode` /
+`abi.encodePacked`, inline-assembly storage pointer resolution.
+
+### Verdict on the six P0 properties
+
+- **SRV3-P1 (reserve separation)** — math ✅; write side (`withdrawDepositableEther`, packed `uint128|uint128` slot) ❌ until `uint128`.
+- **SRV3-P2 (exact 32 ETH pull)** — allocation math ✅; `deposit()` body ❌/🚧 (`abi.encodePacked(wc)`, beacon deposit).
+- **SRV3-P3 (module-balance conservation)** — validation ✅; accepted-report write writes `uint64 validatorsBalanceGwei`. Blocked on `uint64`.
+- **SRV3-P4 (report-before-reward)** — expressible once `uint64` reads exist.
+- **SRV3-P5 (bounded rewards / fee alignment)** — invariant ✅; types (`uint96 totalFee`, `uint96[]`) ❌.
+- **SRV3-P6 (status gates)** — depends on `enum StakingModuleStatus`; ❌ / 🚧 with `Uint8` shim.
+
+**Net:** three of six properties can be *stated* today with modest workarounds
+(P2, P4, P5 partial). P1, P3, P6 will not close without the top-3 EDSL
+features.

--- a/docs/parity/morpho.md
+++ b/docs/parity/morpho.md
@@ -1,0 +1,259 @@
+# Morpho Blue → Verity EDSL parity gap map
+
+## Preamble
+
+**Target:** `Th0rgal/morpho-verity@master`, which vendors
+`morpho-org/morpho-blue@0427acea` as a git submodule at `./morpho-blue/`. The
+project itself is Lean (Yul is only in build artifacts). Solidity sources are
+therefore analyzed from the upstream submodule `morpho-org/morpho-blue/src/`.
+
+**Scope.** Morpho Blue is a single ~550 LOC singleton (`Morpho.sol`) plus five
+pure libraries (`MathLib`, `SharesMathLib`, `MarketParamsLib`, `UtilsLib`,
+`SafeTransferLib`), a constants file, an events library, and a string-based
+errors library. **MetaMorpho is out of scope** — it lives in a separate repo
+(`morpho-org/metamorpho`) and `morpho-verity` does not vendor it. The
+periphery view-only library `MorphoLib.sol` uses `extSloads` bit-tricks; per
+the project's `MORPH_BLUE_MAPPING.md`, the Verity port replaces it with direct
+storage projections and is therefore excluded from the parity target.
+
+**Verity EDSL support model.**
+- ✅ expressible today in `verity_contract`.
+- 🚧 expressible with a documented workaround.
+- ❌ needs a new EDSL feature (named in the row).
+
+**Key EDSL constraints that dominate Morpho parity:**
+1. No `uint128` / `uint64` etc. — Morpho's `Market` and `Position` are 100%
+   `uint128` for packing.
+2. No top-level storage `struct` — Morpho storage is dominated by `mapping(Id
+   => Market)` and `mapping(Id => mapping(address => Position))`.
+3. No mapping-of-mapping-of-mapping with proofs (2 max) — `position[id][user]`
+   is fine (mapping2), and `MarketParams` inside `idToMarketParams[id]` is a
+   struct-in-mapping.
+4. No inheritance, no first-class modifiers, no `abi.encode`, no `try/catch`,
+   no callback (`onMorphoSupply`, `onMorphoRepay`, `onMorphoSupplyCollateral`,
+   `onMorphoLiquidate`, `onMorphoFlashLoan`) trust-boundary primitive.
+
+Rows marked 🚧 with "packed struct in mapping (#1976)" assume the EDSL packs
+the `uint128` fields itself; the developer still writes them as `uint128`,
+which is ❌ standalone. Where both apply, the deeper blocker is surfaced.
+
+Total constructs counted: **72**.
+
+---
+
+## 1. `src/Morpho.sol` (555 LOC, singleton)
+
+### 1.1 Immutables & storage
+
+| # | Construct | Solidity | Verity status | Note |
+|---|-----------|----------|---------------|------|
+| 1 | Immutable | `bytes32 public immutable DOMAIN_SEPARATOR` | 🚧 | `bytes32` ✅ but immutable not first-class; store in constructor-initialized slot. |
+| 2 | Storage | `address public owner` | ✅ | |
+| 3 | Storage | `address public feeRecipient` | ✅ | |
+| 4 | Storage | `mapping(Id => mapping(address => Position)) public position` | ❌ | Storage `struct Position` + `uint128` fields → **packed struct in mapping (#1976)** + `mapping2` ✅ + `uint128` ❌. Blocker: `uint128`. |
+| 5 | Storage | `mapping(Id => Market) public market` | ❌ | `Market` = 6× `uint128` packed into 2 slots. Needs **`uint128` + packed struct in mapping (#1976)**. |
+| 6 | Storage | `mapping(address => bool) public isIrmEnabled` | ✅ | |
+| 7 | Storage | `mapping(uint256 => bool) public isLltvEnabled` | ✅ | |
+| 8 | Storage | `mapping(address => mapping(address => bool)) public isAuthorized` | ✅ | |
+| 9 | Storage | `mapping(address => uint256) public nonce` | ✅ | |
+| 10 | Storage | `mapping(Id => MarketParams) public idToMarketParams` | 🚧 | `Id` is `bytes32` ✅. `MarketParams` = 4×`address` + `uint256` — no packing needed. **struct-in-mapping (#1976)**. |
+
+### 1.2 Types (from `IMorpho.sol`, used pervasively)
+
+| # | Construct | Solidity | Verity status | Note |
+|---|-----------|----------|---------------|------|
+| 11 | User type | `type Id is bytes32;` | 🚧 | `bytes32` ✅; the newtype wrapper is sugar the frontend can inline. |
+| 12 | Struct | `MarketParams { address loanToken, collateralToken, oracle, irm; uint256 lltv; }` | 🚧 | All fields ✅; memory struct usage needs **local-struct** or manual field passing. |
+| 13 | Struct | `Position { uint256 supplyShares; uint128 borrowShares; uint128 collateral; }` | ❌ | `uint128` fields → **`uint128`** required. |
+| 14 | Struct | `Market { uint128 totalSupplyAssets, totalSupplyShares, totalBorrowAssets, totalBorrowShares, lastUpdate, fee; }` | ❌ | 100% `uint128` → **`uint128`** required. |
+| 15 | Struct | `Authorization { address authorizer, authorized; bool isAuthorized; uint256 nonce, deadline; }` | 🚧 | Memory only; all fields ✅ if flattened. |
+| 16 | Struct | `Signature { uint8 v; bytes32 r, s; }` | ✅ | |
+
+### 1.3 Constructor & modifier
+
+| # | Construct | Solidity | Verity status | Note |
+|---|-----------|----------|---------------|------|
+| 17 | Constructor | `constructor(address newOwner)` | ✅ | `keccak256(abi.encode(...))` inside → 🚧 (see row 20). |
+| 18 | Modifier | `modifier onlyOwner()` | ❌ | **First-class modifiers** not in EDSL — inline `require(msg.sender == owner)`. |
+| 19 | Inheritance | `contract Morpho is IMorphoStaticTyping` | ❌ | **Inheritance** not supported. Match the ABI structurally. |
+| 20 | Call | `keccak256(abi.encode(DOMAIN_TYPEHASH, block.chainid, address(this)))` | ❌ | **`abi.encode`** not supported. |
+
+### 1.4 Owner functions
+
+| # | Function | Solidity | Verity status | Note |
+|---|----------|----------|---------------|------|
+| 21 | `setOwner(address) external onlyOwner` | ✅ | Inline modifier. |
+| 22 | `enableIrm(address) external onlyOwner` | ✅ | |
+| 23 | `enableLltv(uint256) external onlyOwner` | ✅ | |
+| 24 | `setFee(MarketParams, uint256) external onlyOwner` | 🚧 | Blocked only by `market[id].fee = uint128(newFee)` cast → **`uint128`**. |
+| 25 | `setFeeRecipient(address) external onlyOwner` | ✅ | |
+
+### 1.5 Market creation
+
+| # | Function | Solidity | Verity status | Note |
+|---|----------|----------|---------------|------|
+| 26 | `createMarket(MarketParams) external` | ❌ | `market[id].lastUpdate = uint128(block.timestamp)` and `idToMarketParams[id] = marketParams` need **`uint128`** and **struct-in-mapping**; `IIrm(...).borrowRate(...)` is low-level ✅ once storage blockers land. |
+
+### 1.6 Core entrypoints
+
+| # | Function | Solidity | Verity status | Note |
+|---|----------|----------|---------------|------|
+| 27 | `supply(MarketParams, uint256, uint256, address, bytes) external returns (uint256, uint256)` | ❌ | Reads/writes `market[id].totalSupplyAssets/Shares` (`uint128`), + callback `IMorphoSupplyCallback(msg.sender).onMorphoSupply` — **flashloan/reentrant callback pattern** not in EDSL. |
+| 28 | `withdraw(MarketParams, uint256, uint256, address, address) external returns (uint256, uint256)` | ❌ | Same `uint128` field arithmetic. |
+| 29 | `borrow(MarketParams, uint256, uint256, address, address) external returns (uint256, uint256)` | ❌ | `uint128` arithmetic; `_isHealthy` call ✅ shape-wise. |
+| 30 | `repay(MarketParams, uint256, uint256, address, bytes) external returns (uint256, uint256)` | ❌ | Same `uint128` blockers + `onMorphoRepay` callback ❌. |
+| 31 | `supplyCollateral(MarketParams, uint256, address, bytes) external` | ❌ | `position[id][onBehalf].collateral += assets.toUint128()`; `onMorphoSupplyCollateral` callback ❌. |
+| 32 | `withdrawCollateral(MarketParams, uint256, address, address) external` | ❌ | `uint128` cast on `collateral`. |
+| 33 | `liquidate(MarketParams, address, uint256, uint256, bytes) external returns (uint256, uint256)` | ❌ | Heaviest: `uint128` arithmetic on both `market[id]` and `position[id][borrower]`, `onMorphoLiquidate` callback ❌, oracle `IOracle(...).price()` ✅, math (`wMulDown`/`wDivUp`/`mulDivUp`/`mulDivDown`) ✅. |
+| 34 | `flashLoan(address, uint256, bytes) external` | ❌ | Pure **flashloan callback pattern** — `onMorphoFlashLoan` sandwiched between `safeTransfer` and `safeTransferFrom`. |
+
+### 1.7 Authorization
+
+| # | Function | Solidity | Verity status | Note |
+|---|----------|----------|---------------|------|
+| 35 | `setAuthorization(address, bool) external` | ✅ | `mapping2` write + event. |
+| 36 | `setAuthorizationWithSig(Authorization, Signature) external` | ❌ | `abi.encode(AUTHORIZATION_TYPEHASH, authorization)` ❌ + `bytes.concat("\x19\x01", ...)` ❌ + `ecrecover` (not on ✅ list). |
+| 37 | `_isSenderAuthorized(address) internal view returns (bool)` | ✅ | Pure boolean. |
+
+### 1.8 Interest accrual & health
+
+| # | Function | Solidity | Verity status | Note |
+|---|----------|----------|---------------|------|
+| 38 | `accrueInterest(MarketParams) external` | 🚧 | Requires `market[id].lastUpdate` (`uint128`). |
+| 39 | `_accrueInterest(MarketParams, Id) internal` | ❌ | Reads/writes 5 `uint128` fields; `wTaylorCompounded`, `wMulDown` ✅; `IIrm.borrowRate` ✅. |
+| 40 | `_isHealthy(MarketParams, Id, address) internal view returns (bool)` | ❌ | Reads `position[id][borrower].borrowShares` (`uint128`). |
+| 41 | `_isHealthy(MarketParams, Id, address, uint256) internal view returns (bool)` | ❌ | `uint256(position[id][borrower].borrowShares).toAssetsUp(...)` needs `uint128` field read. Math ✅. |
+
+### 1.9 Storage view
+
+| # | Function | Solidity | Verity status | Note |
+|---|----------|----------|---------------|------|
+| 42 | `extSloads(bytes32[]) external view returns (bytes32[])` | ❌ | Inline `assembly { sload }` over a calldata array. Verity has no **raw `sload` opcode / dynamic bytes32 return**. Workaround: expose typed getters. |
+
+---
+
+## 2. Libraries
+
+### 2.1 `MathLib.sol`
+
+| # | Function | Verity | Note |
+|---|----------|--------|------|
+| 43 | `wMulDown(uint256, uint256)` | ✅ | Native proven op. |
+| 44 | `wDivDown(uint256, uint256)` | ✅ | Implied by `mulDivDown(x, WAD, y)`. |
+| 45 | `wDivUp(uint256, uint256)` | ✅ | Native proven op. |
+| 46 | `mulDivDown(uint256, uint256, uint256)` | ✅ | Native proven op. |
+| 47 | `mulDivUp(uint256, uint256, uint256)` | ✅ | Native proven op. |
+| 48 | `wTaylorCompounded(uint256, uint256)` | ✅ | Composable; Taylor is manual. |
+
+### 2.2 `SharesMathLib.sol`
+
+| # | Function | Verity | Note |
+|---|----------|--------|------|
+| 49 | `toSharesDown` | ✅ | Pure `mulDivDown`. |
+| 50 | `toAssetsDown` | ✅ | Pure `mulDivDown`. |
+| 51 | `toSharesUp` | ✅ | Pure `mulDivUp`. |
+| 52 | `toAssetsUp` | ✅ | Pure `mulDivUp`. |
+| 53 | Constant `VIRTUAL_SHARES = 1e6` | ✅ | |
+| 54 | Constant `VIRTUAL_ASSETS = 1` | ✅ | |
+
+### 2.3 `MarketParamsLib.sol`
+
+| # | Function | Verity | Note |
+|---|----------|--------|------|
+| 55 | `id(MarketParams memory) → Id` via `assembly { keccak256(marketParams, 160) }` | 🚧 | Result is `keccak256` of 5 contiguous 32-byte words. EDSL can express as `keccak256(loanToken, collateralToken, oracle, irm, lltv)` if a **fixed-arity keccak of ABI-encoded words** helper is added; else `abi.encode` ❌. |
+
+### 2.4 `UtilsLib.sol`
+
+| # | Function | Verity | Note |
+|---|----------|--------|------|
+| 56 | `exactlyOneZero(uint256, uint256)` | ✅ | |
+| 57 | `min(uint256, uint256)` | ✅ | Ternary. |
+| 58 | `toUint128(uint256)` | ❌ | Returns **`uint128`**. |
+| 59 | `zeroFloorSub(uint256, uint256)` | ✅ | |
+
+### 2.5 `SafeTransferLib.sol`
+
+| # | Function | Verity | Note |
+|---|----------|--------|------|
+| 60 | `safeTransfer(IERC20, address, uint256)` | 🚧 | Uses `abi.encodeCall` ❌ + returndata decode ❌; Verity port replaces with an **ECM primitive** (see `MORPH_BLUE_MAPPING.md`). |
+| 61 | `safeTransferFrom(IERC20, address, address, uint256)` | 🚧 | Same ECM pattern. |
+
+### 2.6 `ConstantsLib.sol`
+
+| # | Constant | Verity | Note |
+|---|----------|--------|------|
+| 62 | `MAX_FEE = 0.25e18` | ✅ | |
+| 63 | `ORACLE_PRICE_SCALE = 1e36` | ✅ | |
+| 64 | `LIQUIDATION_CURSOR = 0.3e18` | ✅ | |
+| 65 | `MAX_LIQUIDATION_INCENTIVE_FACTOR = 1.15e18` | ✅ | |
+| 66 | `DOMAIN_TYPEHASH = keccak256("EIP712Domain(...)")` | ✅ | Compile-time. |
+| 67 | `AUTHORIZATION_TYPEHASH = keccak256("Authorization(...)")` | ✅ | Compile-time. |
+
+### 2.7 `ErrorsLib.sol`
+
+All 21 error identifiers are `string internal constant` used as `require`
+reason strings.
+
+| # | Construct | Verity | Note |
+|---|-----------|--------|------|
+| 68 | 21× `string internal constant NAME` | 🚧 | Storage `string` ❌, but these are **library constants**, not storage — inline as literal reason strings at each `require`. Or convert to custom errors (✅). |
+
+### 2.8 `EventsLib.sol` — 18 events
+
+| # | Event | Verity | Note |
+|---|-------|--------|------|
+| 69 | `SetOwner`, `SetFee`, `SetFeeRecipient`, `EnableIrm`, `EnableLltv`, `Supply`, `Withdraw`, `Borrow`, `Repay`, `SupplyCollateral`, `WithdrawCollateral`, `FlashLoan`, `SetAuthorization`, `IncrementNonce`, `AccrueInterest` | ✅ | Fields all `address`/`uint256`/`bool`/`Id (bytes32)` — events with proofs supported. |
+| 70 | `CreateMarket(Id indexed id, MarketParams marketParams)` | 🚧 | Non-indexed **struct payload** in event. Emit as 5 flat fields until struct-in-event is supported. |
+| 71 | `Liquidate(Id, address, address, 5×uint256)` | ✅ | Flat scalar payload. |
+
+### 2.9 Interface files (`IMorpho.sol`, `IIrm.sol`, `IOracle.sol`, `IMorphoCallbacks.sol`, `IERC20.sol`)
+
+| # | Construct | Verity | Note |
+|---|-----------|--------|------|
+| 72 | External interfaces used via low-level `call`/`staticcall` (`IIrm.borrowRate`, `IOracle.price`, `IERC20.transfer/transferFrom`, 5× callback interfaces) | ✅ / ❌ | Static/low-level calls ✅ for IRM+Oracle+ERC20; **the 5 callback interfaces** need the **flashloan/callback trust-boundary** ❌. |
+
+---
+
+## 3. Summary
+
+**Counted constructs: 72**
+
+| Bucket | Count | % |
+|--------|-------|---|
+| ✅ expressible today | 34 | 47% |
+| 🚧 workaround exists | 13 | 18% |
+| ❌ needs new EDSL feature | 25 | 35% |
+
+### Top 5 missing EDSL features (weighted by usage in Morpho)
+
+| Rank | Feature | Directly blocks | Why it dominates |
+|------|---------|-----------------|------------------|
+| 1 | **`uint128` scalar type** | rows 4, 5, 13, 14, 24, 26, 27–33, 38–41, 58 (~15 constructs) | Every write to `Market` or `Position` casts to `uint128`; nothing accrual/health/liquidation-related compiles without it. |
+| 2 | **Packed struct storage in `mapping` (#1976 completion for 6×`uint128`)** | rows 4, 5, 10, 26 | `Market` packs 6 `uint128`s into 2 slots; `Position` packs `uint128+uint128` into 1 slot; #1976 support needs to cover 6-field packing to match Solidity's layout used by `extSloads`. |
+| 3 | **Callback / re-entrant trust boundary (`onMorpho*`)** | rows 27, 30, 31, 33, 34, 72 | 5 of 8 core entrypoints run user-supplied code mid-execution. `flashLoan` is nothing but this pattern. |
+| 4 | **`abi.encode` / `abi.encodePacked` / `bytes.concat`** | rows 17, 20, 36, 55 | EIP-712 paths and the market-id keccak use ABI encoding. Alternative: "keccak of typed tuple" primitive. |
+| 5 | **`ecrecover` precompile** | row 36 | `setAuthorizationWithSig` needs it; unlocks any future meta-tx feature. |
+
+### Recommended "next 3 PRs to unblock Morpho"
+
+1. **PR-A: `uint128` scalar + packed-mapping storage (Market & Position
+   layouts).** Land `uint128` arithmetic + widen #1976 packed-struct support
+   to 6 fields with the exact slot layout Solidity uses. Immediately unblocks
+   `createMarket`, `_accrueInterest`, `supply`, `withdraw`, `borrow`, `repay`,
+   `supplyCollateral`, `withdrawCollateral`, `_isHealthy` — reduces ❌ from
+   25 → ~9.
+2. **PR-B: Callback trust-boundary primitive (`onMorpho*` pattern).** A
+   `verity_contract` construct that models "emit event → external `call` to
+   caller → resume with post-state assertion" as an ECM trust boundary —
+   reuses the existing ECM pattern already used by `SafeTransferLib` in the
+   Verity port. Unblocks `flashLoan`, `supply`, `repay`, `supplyCollateral`,
+   `liquidate`.
+3. **PR-C: EIP-712 helpers — `abi.encode`-of-tuple + `ecrecover`.** Even a
+   narrow `keccak256_of_words(bytes32, ...)` plus `ecrecover(bytes32, uint8,
+   bytes32, bytes32)` closes `setAuthorizationWithSig`, the constructor's
+   `DOMAIN_SEPARATOR`, and `MarketParamsLib.id`.
+
+After these three PRs, `>90%` of Morpho Blue's Solidity would map
+line-by-line into `verity_contract`. Remaining ❌ items (inheritance,
+first-class modifiers, `extSloads` raw `sload` array) are cosmetic or
+replaceable with typed getters and do not block correctness parity.

--- a/docs/roadmap/log.md
+++ b/docs/roadmap/log.md
@@ -1,0 +1,27 @@
+# Roadmap log
+
+Chronological record of merges, closes, and cross-track decisions driven by the
+roadmap agent. One line per event, newest last.
+
+Format: `YYYY-MM-DD | <ref> | <track> | <one-sentence outcome>`
+
+Tracks:
+- **T1** — Fix CI
+- **T2** — Prevent #2074/#2075-class regressions
+- **T3** — Extend the proven fragment (issue #1723)
+- **T4** — Refactor proofs into a lemma library
+- **T5** — Prune the issue tracker
+- **T6** — Faithful Solidity representation of Lido / ERC-4337 / Morpho
+
+## Log
+
+- 2026-07-02 | PR #2078 | T1 | Hardened `issue-intake-guard.yml` against
+  script injection via `findings` output (env-var read instead of inline
+  string interpolation).
+- 2026-07-02 | PR (this) | T6 | Seeded `docs/parity/{lido,erc4337,morpho}.md`
+  gap maps: Lido 44% ✅, ERC-4337 43% ✅, Morpho 47% ✅. Convergent top-3
+  missing EDSL features across all three contracts: narrow uints
+  (`uint128`/`uint64`/`uint48`), `abi.encode*` codec, first-class modifiers +
+  inheritance.
+- 2026-07-02 | PR (this) | T5 | Created `docs/roadmap/log.md` reporting
+  infrastructure.


### PR DESCRIPTION
## Summary

Non-destructive prep for the six-track roadmap workstream. Three artifacts:

- **`docs/parity/{lido,erc4337,morpho}.md`** — per-contract Solidity ↔
  `verity_contract` gap maps for the three reference contracts, mapping every
  top-level construct to ✅ / 🚧 / ❌. **423 constructs scored total.** Draft
  status; the maps will be updated with each PR touching the corresponding
  construct row.
- **`docs/parity/README.md`** — overview + convergent finding: the same top-3
  missing EDSL features (narrow uints, `abi.encode*` codec, first-class
  modifiers + inheritance) dominate all three contracts. Landing those three
  moves every reference contract north of 70% ✅ in one wave.
- **`docs/roadmap/log.md`** — chronological log of merges / closes /
  cross-track decisions.

## Headline numbers

| Contract | Source | ✅ | 🚧 | ❌ |
| --- | --- | ---: | ---: | ---: |
| Lido StakingRouter v3 | `lidofinance/core@d088bbc2` | 44% | 21% | 35% |
| ERC-4337 v0.9 EntryPoint | `eth-infinitism/account-abstraction@b36a1ed5` | 43% | 24% | 33% |
| Morpho Blue | `morpho-org/morpho-blue@0427acea` | 47% | 18% | 35% |

## Notes

- No source, proof, macro, or CI code changed. Docs only.
- The `lfglabs-dev/lido-srv3-proof-closure` repo is TeX-only; the Lido map
  points at the exact upstream Lido commit named in its
  `content/05-reproducibility.tex`.
- `Th0rgal/morpho-verity` vendors `morpho-blue` as a submodule; the Morpho
  map is scored against that submodule commit. MetaMorpho is out of scope
  (separate repo, not vendored).

Refs #1724, #1723, #2071.

## Test plan

- [ ] `Verify proofs` green (docs-only change).
- [ ] `docs/parity/README.md` renders correctly on the repo's default view.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, proof, or CI behavior impact.
> 
> **Overview**
> Adds **documentation-only** prep for roadmap track T6 (faithful Lido / ERC-4337 / Morpho representation): no compiler, proof, or CI code changes.
> 
> **`docs/parity/`** introduces an overview plus three per-contract gap maps that score Solidity top-level constructs against `verity_contract` as ✅ / 🚧 / ❌ (~423 constructs total). Each map pins an upstream commit, links to tracking issues (#1724, #2071, etc.), and includes contract-specific summaries and suggested next PRs. **`docs/parity/README.md`** states that PRs touching EDSL construct support must update the matching rows, and describes a **planned** (not yet implemented) nightly `contracts-smoke` job to guard against regressions.
> 
> **`docs/roadmap/log.md`** adds a chronological log format for six roadmap tracks (T1–T6) and seeds entries for this PR plus prior work (e.g. PR #2078).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6654101e9bfa940fceb3f07f0ac25b2d0a247470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->