### PR TITLE
proof: add direct void helper call interface witnesses

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -661,6 +661,7 @@ jobs:
           set -euo pipefail
           smoke_modules=(
             Contracts.BytesEqSmoke
+            Contracts.Smoke.ImmutableSmoke
             Contracts.Smoke.LowLevelTryCatchSmoke
             Contracts.Smoke.SelfBalanceSmoke
             Contracts.StringArrayErrorSmoke
@@ -705,6 +706,7 @@ jobs:
           set -euo pipefail
           smoke_modules=(
             Contracts.BytesEqSmoke
+            Contracts.Smoke.ImmutableSmoke
             Contracts.Smoke.LowLevelTryCatchSmoke
             Contracts.Smoke.SelfBalanceSmoke
             Contracts.StringArrayErrorSmoke

--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -66,6 +66,156 @@ open Compiler.CompilationModel
 open Compiler.Yul
 open Compiler.Proofs.IRGeneration
 
+/-!
+## Direct void internal-helper calls
+
+The constructors below are intentionally call-only: they prove the first
+non-vacuous `StmtListDirectInternalHelperCallStepInterface` witnesses while
+leaving the helper-surface-closed fast paths below unchanged.  The semantic
+payload is still supplied through `DirectInternalHelperCallHeadStepBridge`.
+That bridge is the current architecture's exact source/IR seam: source
+`execStmtWithHelpers` must be related to helper-aware compiled execution
+`execIRStmtsWithInternals` after compiling the argument list.
+
+Blocker for closing this from only `SupportedBodyHelperInterface` and
+`SupportedRuntimeHelperTableInterface`: the tree has source summary soundness
+(`InternalHelperSummarySound` for `interpretInternalFunctionFuel`) and IR
+helper lookup/dispatch lemmas, but it does not yet expose a theorem stating
+that executing a compiled internal helper body with
+`execIRInternalFunctionWithInternals` satisfies the same
+`InternalHelperSummaryContract.post` as the source helper.
+-/
+
+/-- Build a helper-aware singleton compiled-step proof for a direct void
+internal helper call from the exact call-head bridge.  This is non-vacuous:
+the `Stmt.internalCall` head is compiled and its helper-aware source/IR
+execution is consumed directly from `hbridge`. -/
+theorem compiledStmtStepWithHelpersAndHelperIR_internalCall_of_callHeadStepBridge
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {calleeName : String}
+    {args : List Expr}
+    (hbridge :
+      DirectInternalHelperCallHeadStepBridge runtimeContract spec fields calleeName) :
+    ∃ compiledIR,
+      CompiledStmtStepWithHelpersAndHelperIR
+        runtimeContract
+        spec
+        fields
+        scope
+        (Stmt.internalCall calleeName args)
+        compiledIR := by
+  rcases hbridge.compile (scope := scope) (args := args) with
+    ⟨compiledIR, hcompile⟩
+  obtain ⟨argExprs, hargCompile, _⟩ := compileStmt_internalCall_shape hcompile
+  have hcompileSpec :
+      CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
+        (Stmt.internalCall calleeName args) = Except.ok compiledIR := by
+    simpa [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork] using hcompile
+  refine ⟨compiledIR, ?_⟩
+  exact
+    compiledStmtStepWithHelpersAndHelperIR_internalCall
+      (runtimeContract := runtimeContract)
+      (spec := spec)
+      (fields := fields)
+      (scope := scope)
+      (calleeName := calleeName)
+      (args := args)
+      (compiledIR := compiledIR)
+      (argExprs := argExprs)
+      hcompileSpec
+      hargCompile
+      (hbridge.bridge
+        (scope := scope)
+        (args := args)
+        (compiledIR := compiledIR)
+        (argExprs := argExprs)
+        hcompile
+        hargCompile)
+
+/-- Non-vacuous list witness for a statement list headed by
+`Stmt.internalCall`.  The head proof comes from the call bridge; the tail remains
+the ordinary list interface at the post-head scope. -/
+theorem stmtListDirectInternalHelperCallStepInterface_cons_internalCall_of_callHeadStepBridge
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {calleeName : String}
+    {args : List Expr}
+    {rest : List Stmt}
+    (hbridge :
+      DirectInternalHelperCallHeadStepBridge runtimeContract spec fields calleeName)
+    (hrest :
+      StmtListDirectInternalHelperCallStepInterface
+        runtimeContract
+        spec
+        fields
+        (stmtNextScope scope (Stmt.internalCall calleeName args))
+        rest) :
+    StmtListDirectInternalHelperCallStepInterface
+      runtimeContract
+      spec
+      fields
+      scope
+      (Stmt.internalCall calleeName args :: rest) := by
+  rcases
+      compiledStmtStepWithHelpersAndHelperIR_internalCall_of_callHeadStepBridge
+        (runtimeContract := runtimeContract)
+        (spec := spec)
+        (fields := fields)
+        (scope := scope)
+        (calleeName := calleeName)
+        (args := args)
+        hbridge with
+    ⟨compiledIR, hstep⟩
+  exact
+    stmtListDirectInternalHelperCallStepInterface_cons_internalCall
+      (runtimeContract := runtimeContract)
+      (spec := spec)
+      (fields := fields)
+      (scope := scope)
+      (calleeName := calleeName)
+      (args := args)
+      (compiledIR := compiledIR)
+      (rest := rest)
+      hstep
+      hrest
+
+/-- Assemble the direct void-helper-call list interface from per-callee call
+bridges for the helper names that occur in this statement list.  This is the
+call-only counterpart of the broader direct-helper catalog assembly and does
+not require the assign-call half. -/
+theorem stmtListDirectInternalHelperCallStepInterface_of_callHeadStepBridges
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {stmts : List Stmt}
+    (hbridge :
+      ∀ {calleeName : String},
+        calleeName ∈ (stmtListInternalHelperCallNames stmts).eraseDups →
+        DirectInternalHelperCallHeadStepBridge runtimeContract spec fields calleeName) :
+    StmtListDirectInternalHelperCallStepInterface runtimeContract spec fields scope stmts := by
+  exact
+    stmtListDirectInternalHelperCallStepInterface_of_internalCallSteps_of_helperCallNames
+      (runtimeContract := runtimeContract)
+      (spec := spec)
+      (fields := fields)
+      (scope := scope)
+      (stmts := stmts)
+      (fun {scope} {calleeName} {args} hmem =>
+        compiledStmtStepWithHelpersAndHelperIR_internalCall_of_callHeadStepBridge
+          (runtimeContract := runtimeContract)
+          (spec := spec)
+          (fields := fields)
+          (scope := scope)
+          (calleeName := calleeName)
+          (args := args)
+          (hbridge hmem))
+
 /-- For helper-surface-closed statement lists, the four narrow helper-step
 interfaces are all trivially satisfied. This is the entry point for contracts
 that do not use internal helpers at all. -/

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1777,6 +1777,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.Frames.execStmtList_execution_summary_cons
 
   -- Compiler/Proofs/HelperStepProofs.lean
+  Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_internalCall_of_callHeadStepBridge
+  Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperCallStepInterface_cons_internalCall_of_callHeadStepBridge
+  Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperCallStepInterface_of_callHeadStepBridges
   Compiler.Proofs.HelperStepProofs.allHelperInterfacesSatisfied_of_helperSurfaceClosed
   Compiler.Proofs.HelperStepProofs.fullHelperAwareListWitness_of_allInterfaces
   Compiler.Proofs.HelperStepProofs.fullHelperAwareListWitness_of_allInterfaces_disjoint
@@ -5825,4 +5828,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5455 theorems/lemmas (3755 public, 1700 private, 0 sorry'd)
+-- Total: 5458 theorems/lemmas (3758 public, 1700 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- add call-only constructors for non-vacuous `StmtListDirectInternalHelperCallStepInterface` witnesses headed by `Stmt.internalCall`
- assemble the call interface from per-callee `DirectInternalHelperCallHeadStepBridge` witnesses while preserving existing helper-surface-closed fast paths
- refresh `PrintAxioms.lean` for the new public helper-step theorems

Refs #2080.

## Validation
- `lake env lean Compiler/Proofs/HelperStepProofs.lean`
- `lean-slot make verify` (remote offload refused because worktree is outside the current mission ancestry; local `lake build` completed successfully)
- `make check`
- `git diff --check`
- `rg -n "\\bsorry\\b|\\badmit\\b|^\\s*axiom\\b" Compiler/Proofs/HelperStepProofs.lean PrintAxioms.lean` (only generated `0 sorry'd` count line in `PrintAxioms.lean`)

## Blocker / follow-up
This proves the first direct-void-call witness non-vacuously when a `DirectInternalHelperCallHeadStepBridge` is available. Deriving that bridge only from `SupportedBodyHelperInterface` / `SupportedRuntimeHelperTableInterface` is still blocked by a missing API theorem connecting compiled IR helper execution (`execIRInternalFunctionWithInternals`) to the same `InternalHelperSummaryContract.post` established by source summary soundness for `interpretInternalFunctionFuel`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-layer additions only; no runtime or auth changes. CI smoke list expansion is low-risk compiler validation coverage.
> 
> **Overview**
> Adds **call-only Lean constructors** in `HelperStepProofs.lean` so `StmtListDirectInternalHelperCallStepInterface` can be satisfied non-vacuously for `Stmt.internalCall` when a per-callee `DirectInternalHelperCallHeadStepBridge` is available—singleton step proof, cons on a call-headed list, and whole-list assembly from bridges for all callee names in the list. Existing helper-surface-closed fast paths are unchanged; documentation notes that deriving bridges from supported-helper interfaces alone is still blocked on an IR/source `InternalHelperSummaryContract.post` alignment theorem.
> 
> **PrintAxioms.lean** registers the three new public theorems (5458 total lemmas). **verify.yml** includes `Contracts.Smoke.ImmutableSmoke` in unpatched and patched smoke Yul pre-build lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1f6aa4476284cd66bba8a4e2c685edf73e8bf46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->