### PR TITLE
proof: evaluate short mappingChain reads

### DIFF
--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -67,7 +67,8 @@ theorem denote_evalExpr_eq (fields : List Field) (s : DenoteState) :
       Denote.evalExpr sourceOracle fields s e =
         SourceSemantics.evalExpr fields (toRuntimeState s) e
   | .literal _ | .param _ | .immutable _ | .constructorArg _ | .storage _ | .storageAddr _
-  | .mappingChain .. | .localVar _ | .storageArrayLength _ | .dynamicBytesEq ..
+  | .mappingChain _ [] | .mappingChain _ (_ :: _ :: _ :: _) | .localVar _
+  | .storageArrayLength _ | .dynamicBytesEq ..
   | .memoryArrayLength _ | .memoryArrayElement .. | .paramDynamicMemberLength ..
   | .paramDynamicMemberDataOffset .. | .paramDynamicMemberElement ..
   | .paramDynamicStaticComposite .. | .paramDynamicHeadWord ..
@@ -81,7 +82,8 @@ theorem denote_evalExpr_eq (fields : List Field) (s : DenoteState) :
   | .returndataSize => rfl
   | .bitNot a | .logicalNot a | .mload a | .tload a | .calldataload a
   | .mapping _ a | .mappingWord _ a _ | .mappingPackedWord _ a _ _
-  | .mappingUint _ a | .structMember _ a _ | .storageArrayElement _ a
+  | .mappingUint _ a | .mappingChain _ [a] | .structMember _ a _
+  | .storageArrayElement _ a
   | .arrayElementDynamicWord _ a _
   | .arrayElementDynamicDataOffset _ a
   | .arrayElementDynamicMemberLength _ a _
@@ -93,6 +95,7 @@ theorem denote_evalExpr_eq (fields : List Field) (s : DenoteState) :
   | .lt a b | .slt a b | .le a b | .logicalAnd a b | .logicalOr a b
   | .ceilDiv a b | .wMulDown a b | .wDivUp a b | .min a b | .max a b
   | .keccak256 a b | .mapping2 _ a b | .mapping2Word _ a b _
+  | .mappingChain _ [a, b]
   | .structMember2 _ a b _ =>
       bindAgree (denote_evalExpr_eq fields s a) fun _ =>
         bindAgree (denote_evalExpr_eq fields s b) fun _ => rfl

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -1314,8 +1314,22 @@ def evalExpr (fields : List Field) (state : RuntimeState) : Expr → Option Nat
           let outerSlot := Compiler.Proofs.abstractMappingSlot innerSlot key2Val
           some (readFieldWord state.world field (wordNormalize (outerSlot + wordOffset))).val
       | none => none
-  -- mappingChain: deferred — requires List Expr recursion infrastructure
-  -- | .mappingChain field keys => ...
+  | .mappingChain field [key] => do
+      let keyVal ← evalExpr fields state key
+      match findFieldWithResolvedSlot fields field with
+      | some (field, slot) =>
+          some (readFieldWord state.world field (Compiler.Proofs.abstractMappingSlot slot keyVal)).val
+      | none => none
+  | .mappingChain field [key1, key2] => do
+      let key1Val ← evalExpr fields state key1
+      let key2Val ← evalExpr fields state key2
+      match findFieldWithResolvedSlot fields field with
+      | some (field, slot) =>
+          let innerSlot := Compiler.Proofs.abstractMappingSlot slot key1Val
+          some (readFieldWord state.world field (Compiler.Proofs.abstractMappingSlot innerSlot key2Val)).val
+      | none => none
+  -- Longer mappingChain reads remain deferred until the evaluator has shared
+  -- list-recursion infrastructure for arbitrary key lists.
   | .structMember field key memberName => do
       let keyVal ← evalExpr fields state key
       match findFieldWithResolvedSlot fields field, findStructMembers fields field with
@@ -2114,6 +2128,32 @@ private theorem evalExpr_mapping2
     (field : String)
     (key1 key2 : Expr) :
     evalExpr fields state (.mapping2 field key1 key2) = (do
+      let key1Val ← evalExpr fields state key1
+      let key2Val ← evalExpr fields state key2
+      match findFieldWithResolvedSlot fields field with
+      | some (field, slot) =>
+          let innerSlot := Compiler.Proofs.abstractMappingSlot slot key1Val
+          some (readFieldWord state.world field (Compiler.Proofs.abstractMappingSlot innerSlot key2Val)).val
+      | none => none) := rfl
+
+private theorem evalExpr_mappingChain_singleton
+    (fields : List Field)
+    (state : RuntimeState)
+    (field : String)
+    (key : Expr) :
+    evalExpr fields state (.mappingChain field [key]) = (do
+      let keyVal ← evalExpr fields state key
+      match findFieldWithResolvedSlot fields field with
+      | some (field, slot) =>
+          some (readFieldWord state.world field (Compiler.Proofs.abstractMappingSlot slot keyVal)).val
+      | none => none) := rfl
+
+private theorem evalExpr_mappingChain_pair
+    (fields : List Field)
+    (state : RuntimeState)
+    (field : String)
+    (key1 key2 : Expr) :
+    evalExpr fields state (.mappingChain field [key1, key2]) = (do
       let key1Val ← evalExpr fields state key1
       let key2Val ← evalExpr fields state key2
       match findFieldWithResolvedSlot fields field with

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3401,6 +3401,8 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_structMember  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_storageArrayElement  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mapping2  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mappingChain_singleton  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mappingChain_pair  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mapping2Word  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_structMember2  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_ceilDiv  -- private
@@ -5828,4 +5830,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5458 theorems/lemmas (3758 public, 1700 private, 0 sorry'd)
+-- Total: 5460 theorems/lemmas (3758 public, 1702 private, 0 sorry'd)

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -879,7 +879,21 @@ def evalExpr (oracle : DenoteOracle) (fields : List Field) (state : DenoteState)
           let outerSlot := oracle.mappingSlot innerSlot key2Val
           some (readFieldWord state.world field (wordNormalize (outerSlot + wordOffset))).val
       | none => none
-  -- mappingChain reads: deferred, exactly as in SourceSemantics.
+  | .mappingChain field [key] => do
+      let keyVal ← evalExpr oracle fields state key
+      match findFieldWithResolvedSlot fields field with
+      | some (field, slot) =>
+          some (readFieldWord state.world field (oracle.mappingSlot slot keyVal)).val
+      | none => none
+  | .mappingChain field [key1, key2] => do
+      let key1Val ← evalExpr oracle fields state key1
+      let key2Val ← evalExpr oracle fields state key2
+      match findFieldWithResolvedSlot fields field with
+      | some (field, slot) =>
+          let innerSlot := oracle.mappingSlot slot key1Val
+          some (readFieldWord state.world field (oracle.mappingSlot innerSlot key2Val)).val
+      | none => none
+  -- Longer mappingChain reads: deferred, exactly as in SourceSemantics.
   | .structMember field key memberName => do
       let keyVal ← evalExpr oracle fields state key
       match findFieldWithResolvedSlot fields field, findStructMembers fields field with

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -55,7 +55,8 @@ semantic definition.
 Exactly the constructs `SourceSemantics` itself maps to `none`/`.revert`:
 dynamic memory-array expressions (`memoryArrayLength`, `memoryArrayElement`,
 `arrayElementDynamic*`, `paramDynamic*`), `forkIfAtLeast`, `mappingChain`
-reads (writes are supported), and every `Expr`/`Stmt` constructor not listed
+reads with zero or three-plus keys (one/two-key reads and writes are
+supported), and every `Expr`/`Stmt` constructor not listed
 in the arms below (raw calls, ABI re-encoding returns, ECM, unsafe Yul,
 `matchAdt`, internal calls — internal-call semantics live in the separate
 `*WithHelpers` interpreters and are not part of this fragment).


### PR DESCRIPTION
## Summary
- add source semantics for one-key and two-key `Expr.mappingChain` reads, matching the existing `mapping` / `mapping2` slot bridge behavior
- mirror the new short-chain cases in `Verity.Core.Model.Denote`
- extend `DenoteAgreement` so the denotational evaluator remains checked against `SourceSemantics`

Refs #2081.

## Validation
- `lean-slot lake build Compiler.Proofs.IRGeneration.SourceSemantics`
- `lean-slot lake build Compiler.Proofs.IRGeneration.DenoteAgreement`
- `git diff --check`
- `rg -n "\\bsorry\\b|\\badmit\\b|^\\s*axiom\\b" Compiler/Proofs/IRGeneration/SourceSemantics.lean Verity/Core/Model/Denote.lean Compiler/Proofs/IRGeneration/DenoteAgreement.lean`

## Remaining blockers
- Arbitrary 3+ key `mappingChain` reads are still deferred; they need shared list-recursion infrastructure for evaluating arbitrary key lists without restructuring the large evaluator unsafely.
- The coarse unsupported-state/helper surfaces still classify mapping-chain/storage surfaces conservatively; this PR only removes a local semantic gap for the one-key and two-key bridge cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-layer semantic extensions only; no runtime auth or IO. Remaining gap for 3+ key reads is unchanged and documented.
> 
> **Overview**
> Implements **one-key and two-key** `Expr.mappingChain` **read** semantics in `SourceSemantics`, aligned with existing `mapping` / `mapping2` slot hashing via `abstractMappingSlot`. The denotation interpreter in `Verity.Core.Model.Denote` mirrors the same cases (oracle `mappingSlot` instead of `abstractMappingSlot`).
> 
> **`DenoteAgreement`** splits the old catch-all `mappingChain` arm: empty lists and **three-or-more** keys stay unsupported (`rfl`); singleton and pair reads use `bindAgree` like other keyed expressions. Private `evalExpr_mappingChain_singleton` / `_pair` `rfl` lemmas and `PrintAxioms` entries track the new proof surface.
> 
> Documentation now states that only **0- and 3+-key** chain reads remain outside the denotation fragment; **1- and 2-key** reads are in scope. Arbitrary longer chains are still explicitly deferred pending list-recursion infrastructure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 692253e5fbbfdb63c123b8a2bda2efebd0ecf3c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->