### PR TITLE
proof: add direct assign helper bridge witnesses

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -216,6 +216,128 @@ theorem stmtListDirectInternalHelperCallStepInterface_of_callHeadStepBridges
           (args := args)
           (hbridge hmem))
 
+/-!
+## Direct assign internal-helper calls
+
+These constructors mirror the direct void-call bridge above for
+`Stmt.internalCallAssign`. They keep the statement-return-binding proof seam
+callee-local, so future rank-decreasing helper induction can provide one
+`DirectInternalHelperAssignHeadStepBridge` per callee and reuse the mechanical
+list assembly here.
+-/
+
+/-- Build a helper-aware singleton compiled-step proof for a direct
+helper-return-binding call from the exact assign-head bridge. -/
+theorem compiledStmtStepWithHelpersAndHelperIR_internalCallAssign_of_assignHeadStepBridge
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {names : List String}
+    {calleeName : String}
+    {args : List Expr}
+    (hbridge :
+      DirectInternalHelperAssignHeadStepBridge runtimeContract spec fields calleeName) :
+    ∃ compiledIR,
+      CompiledStmtStepWithHelpersAndHelperIR
+        runtimeContract
+        spec
+        fields
+        scope
+        (Stmt.internalCallAssign names calleeName args)
+        compiledIR := by
+  rcases hbridge.compile (scope := scope) (names := names) (args := args) with
+    ⟨compiledIR, hcompile⟩
+  obtain ⟨argExprs, hargCompile, _⟩ := compileStmt_internalCallAssign_shape hcompile
+  have hcompileSpec :
+      CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
+        (Stmt.internalCallAssign names calleeName args) = Except.ok compiledIR := by
+    simpa [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork] using hcompile
+  refine ⟨compiledIR, ?_⟩
+  exact
+    compiledStmtStepWithHelpersAndHelperIR_internalCallAssign
+      hcompileSpec
+      hargCompile
+      (hbridge.bridge
+        (scope := scope)
+        (names := names)
+        (args := args)
+        (compiledIR := compiledIR)
+        (argExprs := argExprs)
+        hcompile
+        hargCompile)
+
+/-- Non-vacuous list witness for a statement list headed by
+`Stmt.internalCallAssign`. -/
+theorem stmtListDirectInternalHelperAssignStepInterface_cons_internalCallAssign_of_assignHeadStepBridge
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {names : List String}
+    {calleeName : String}
+    {args : List Expr}
+    {rest : List Stmt}
+    (hbridge :
+      DirectInternalHelperAssignHeadStepBridge runtimeContract spec fields calleeName)
+    (hrest :
+      StmtListDirectInternalHelperAssignStepInterface
+        runtimeContract
+        spec
+        fields
+        (stmtNextScope scope (Stmt.internalCallAssign names calleeName args))
+        rest) :
+    StmtListDirectInternalHelperAssignStepInterface
+      runtimeContract
+      spec
+      fields
+      scope
+      (Stmt.internalCallAssign names calleeName args :: rest) := by
+  rcases
+      compiledStmtStepWithHelpersAndHelperIR_internalCallAssign_of_assignHeadStepBridge
+        (runtimeContract := runtimeContract)
+        (spec := spec)
+        (fields := fields)
+        (scope := scope)
+        (names := names)
+        (calleeName := calleeName)
+        (args := args)
+        hbridge with
+    ⟨compiledIR, hstep⟩
+  exact stmtListDirectInternalHelperAssignStepInterface_cons_internalCallAssign
+    (compiledIR := compiledIR) hstep hrest
+
+/-- Assemble the direct helper-return-binding list interface from per-callee
+assign bridges for helper names that occur in the statement list. -/
+theorem stmtListDirectInternalHelperAssignStepInterface_of_assignHeadStepBridges
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {stmts : List Stmt}
+    (hbridge :
+      ∀ {calleeName : String},
+        calleeName ∈ (stmtListInternalHelperCallNames stmts).eraseDups →
+        DirectInternalHelperAssignHeadStepBridge runtimeContract spec fields calleeName) :
+    StmtListDirectInternalHelperAssignStepInterface runtimeContract spec fields scope stmts := by
+  exact
+    stmtListDirectInternalHelperAssignStepInterface_of_internalCallAssignSteps_of_helperCallNames
+      (runtimeContract := runtimeContract)
+      (spec := spec)
+      (fields := fields)
+      (scope := scope)
+      (stmts := stmts)
+      (fun {scope} {names} {calleeName} {args} hmem =>
+        compiledStmtStepWithHelpersAndHelperIR_internalCallAssign_of_assignHeadStepBridge
+          (runtimeContract := runtimeContract)
+          (spec := spec)
+          (fields := fields)
+          (scope := scope)
+          (names := names)
+          (calleeName := calleeName)
+          (args := args)
+          (hbridge hmem))
+
 /-- For helper-surface-closed statement lists, the four narrow helper-step
 interfaces are all trivially satisfied. This is the entry point for contracts
 that do not use internal helpers at all. -/

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1780,6 +1780,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_internalCall_of_callHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperCallStepInterface_cons_internalCall_of_callHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperCallStepInterface_of_callHeadStepBridges
+  Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_internalCallAssign_of_assignHeadStepBridge
+  Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterface_cons_internalCallAssign_of_assignHeadStepBridge
+  Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterface_of_assignHeadStepBridges
   Compiler.Proofs.HelperStepProofs.allHelperInterfacesSatisfied_of_helperSurfaceClosed
   Compiler.Proofs.HelperStepProofs.fullHelperAwareListWitness_of_allInterfaces
   Compiler.Proofs.HelperStepProofs.fullHelperAwareListWitness_of_allInterfaces_disjoint
@@ -5828,4 +5831,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5458 theorems/lemmas (3758 public, 1700 private, 0 sorry'd)
+-- Total: 5461 theorems/lemmas (3761 public, 1700 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- add non-vacuous `Stmt.internalCallAssign` helper-step construction from `DirectInternalHelperAssignHeadStepBridge`
- add list-level cons and per-callee bridge assembly helpers for `StmtListDirectInternalHelperAssignStepInterface`
- refresh `PrintAxioms.lean` for the three new public proof theorems

Refs #2080.

## Validation
- `lean-slot lake build Compiler.Proofs.HelperStepProofs`
- `lean-slot lake build PrintAxioms`
- `git diff --check`
- `rg -n "\\bsorry\\b|\\badmit\\b|^\\s*axiom\\b" Compiler/Proofs/HelperStepProofs.lean PrintAxioms.lean` (only the generated `0 sorry'd` count line in `PrintAxioms.lean`)
- `python3 scripts/lean_lint.py --only proof_length`
- `make check`

## Remaining work
This mirrors the merged direct void-call bridge slice for helper-return bindings. Issue #2080 still needs the expression-position and structural helper interfaces, plus the end-to-end derivation of these bridge objects from supported helper-summary/rank evidence before the `stmtTouchesUnsupportedHelperSurface` gate can be removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only scaffolding reusing existing GenericInduction assembly; no runtime, auth, or compiler behavior changes.
> 
> **Overview**
> Adds the **assign-call** counterpart to the existing direct void-call helper bridge in `HelperStepProofs.lean`: three theorems that turn per-callee `DirectInternalHelperAssignHeadStepBridge` evidence into `CompiledStmtStepWithHelpersAndHelperIR` for `Stmt.internalCallAssign`, cons-style list witnesses, and full `StmtListDirectInternalHelperAssignStepInterface` assembly over helper names in the statement list.
> 
> `PrintAxioms.lean` registers those three public theorems and bumps the tracked lemma count by three.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faa739ac58cf931262ec9f3d8cfd5f931f976b85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->