### PR TITLE
docs: replace README metrics table with durable verification status section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,11 @@
 
 **Verity** is a formally verified smart contract compiler written in [Lean 4](https://lean-lang.org/). You write contracts in an embedded DSL, state what they should do, prove those properties hold, and compile to EVM bytecode. The compiler itself is proven to preserve semantics across three verified layers. Full documentation lives at [**veritylang.com**](https://veritylang.com).
 
-<!-- BEGIN GENERATED STATS -->
-| Metric | Value |
-|--------|-------|
-| Theorems | 300 (300 proven, 0 sorry) |
-| Axioms | 0 |
-| Foundry tests | 522 (239 property) |
-| Verified contracts | 13 |
-| Core EDSL | 830 lines |
-| Lean | 4.22.0 |
-<!-- END GENERATED STATS -->
+## Verification status
 
-Every number above is extracted from the codebase and verified on every commit. `0 sorry` means no proof is left incomplete. `0 axioms` means no unproven assumptions remain in the compiler stack.
+All proofs are machine-checked by the Lean kernel. CI rebuilds the proof development on every commit, and repository checks enforce that no proof is left incomplete (no `sorry`) and that the compiler proof stack carries 0 axioms (see [AXIOMS.md](AXIOMS.md)). Verification is scoped rather than total: the generic compiler theorems cover an explicitly documented fragment of the language, and the precise boundary between what is proven and what is trusted is maintained in [TRUST_ASSUMPTIONS.md](TRUST_ASSUMPTIONS.md).
+
+A detailed proof inventory — theorem status, per-contract results, and test coverage — is regenerated from the codebase and tracked in [docs/VERIFICATION_STATUS.md](docs/VERIFICATION_STATUS.md). All checks are reproducible locally (see [Quick start](#quick-start)).
 
 ## What is verified
 

--- a/scripts/consolidation-inventory.md
+++ b/scripts/consolidation-inventory.md
@@ -64,7 +64,7 @@ drift mode unless noted.
 | generate_print_axioms.py | `PrintAxioms.lean` ↔ all theorem decls | lean-grep | regen + `--check` | property_utils |
 | check_proof_length.py | proof line limits (soft 30 / hard 50, allowlist) | lean-grep | exit | property_utils |
 | check_issue_1060_integrity.py | `artifacts/issue_1060_progress.json` ledger schema + repo facts | artifact + repo | exit | — |
-| update_doc_numbers.py --check | README.md + docs-site/public/llms.txt metric markers ↔ verification_status.json | artifact + doc-grep | regen + `--check` | — |
+| update_doc_numbers.py --check | docs-site/public/llms.txt metric markers ↔ verification_status.json | artifact + doc-grep | regen + `--check` | — |
 | (unittest discover `test_*.py`) | unit coverage of the above checkers | — | exit | — |
 
 ### 1.2 CI-only (workflows, not `make check`)

--- a/scripts/update_doc_numbers.py
+++ b/scripts/update_doc_numbers.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """Update hardcoded numbers in documentation files from verification_status.json.
 
-Replaces the block between <!-- BEGIN GENERATED STATS --> and <!-- END GENERATED STATS -->
-in README.md, and the quick-facts block in docs-site/public/llms.txt.
+Replaces the quick-facts block in docs-site/public/llms.txt.
 """
 
 from __future__ import annotations
@@ -19,47 +18,6 @@ ARTIFACT = ROOT / "artifacts" / "verification_status.json"
 def load_artifact() -> dict:
     with open(ARTIFACT) as f:
         return json.load(f)
-
-
-def update_readme(data: dict) -> bool:
-    readme = ROOT / "README.md"
-    text = readme.read_text(encoding="utf-8")
-
-    theorems = data["theorems"]
-    proofs = data["proofs"]
-    tests = data["tests"]
-    codebase = data["codebase"]
-    toolchain = data["toolchain"]
-
-    lean_version = toolchain["lean"].split(":")[-1].lstrip("v")
-    contract_count = len(theorems["per_contract"])
-
-    block = (
-        "<!-- BEGIN GENERATED STATS -->\n"
-        "| Metric | Value |\n"
-        "|--------|-------|\n"
-        f"| Theorems | {theorems['total']} ({theorems['proven']} proven, {proofs['sorry']} sorry) |\n"
-        f"| Axioms | {proofs['axioms']} |\n"
-        f"| Foundry tests | {tests['foundry_functions']} ({tests['property_functions']} property) |\n"
-        f"| Verified contracts | {contract_count} |\n"
-        f"| Core EDSL | {codebase['core_lines']} lines |\n"
-        f"| Lean | {lean_version} |\n"
-        "<!-- END GENERATED STATS -->"
-    )
-
-    pattern = re.compile(
-        r"<!-- BEGIN GENERATED STATS -->.*?<!-- END GENERATED STATS -->",
-        re.DOTALL,
-    )
-    if not pattern.search(text):
-        print("WARNING: README.md missing GENERATED STATS markers", file=sys.stderr)
-        return False
-
-    new_text = pattern.sub(block, text)
-    if new_text != text:
-        readme.write_text(new_text, encoding="utf-8")
-        return True
-    return False
 
 
 def update_llms_txt(data: dict) -> bool:
@@ -120,25 +78,6 @@ def main() -> None:
     if check_mode:
         errors: list[str] = []
 
-        # Check README
-        readme = ROOT / "README.md"
-        text = readme.read_text(encoding="utf-8")
-        pattern = re.compile(
-            r"<!-- BEGIN GENERATED STATS -->.*?<!-- END GENERATED STATS -->",
-            re.DOTALL,
-        )
-        match = pattern.search(text)
-        if not match:
-            errors.append("README.md: missing GENERATED STATS markers")
-        else:
-            block = match.group(0)
-            total = data["theorems"]["total"]
-            if f"| Theorems | {total} " not in block:
-                errors.append(f"README.md: theorem count mismatch (expected {total})")
-            axioms = data["proofs"]["axioms"]
-            if f"| Axioms | {axioms} |" not in block:
-                errors.append(f"README.md: axiom count mismatch (expected {axioms})")
-
         # Check llms.txt
         llms = ROOT / "docs-site" / "public" / "llms.txt"
         if llms.exists():
@@ -163,8 +102,6 @@ def main() -> None:
         print("update_doc_numbers: all generated blocks are in sync")
     else:
         changed = []
-        if update_readme(data):
-            changed.append("README.md")
         if update_llms_txt(data):
             changed.append("llms.txt")
         if changed:


### PR DESCRIPTION
## Summary

- Removes the auto-generated metrics table (`<!-- GENERATED STATS -->` block: theorem/axiom/test/line counts) and the "Every number above is extracted from the codebase..." sentence from the README. These numbers went stale between regenerations and read as marketing rather than research documentation.
- Replaces them with a short **Verification status** section written to stay accurate over time:
  - all proofs are machine-checked by the Lean kernel; CI rebuilds the proof development on every commit, with repository checks enforcing no incomplete proofs (`sorry`) and 0 axioms in the compiler proof stack;
  - an explicit statement that verification is **scoped rather than total** — the generic compiler theorems cover a documented fragment, with the proven/trusted boundary maintained in `TRUST_ASSUMPTIONS.md`;
  - pointers to `docs/VERIFICATION_STATUS.md` (regenerated proof inventory), `AXIOMS.md`, and the Quick start for reproducing checks locally.
- Drops the README stats-block generation/checking from `scripts/update_doc_numbers.py` so `make check` stays green without the markers (the `llms.txt` quick-facts block is still generated and checked), and updates the corresponding line in `scripts/consolidation-inventory.md`.

Detailed, current numbers remain available where they are actually maintained: `docs/VERIFICATION_STATUS.md` and the live verification-status badge.

## Checks run

- `make check` — full CI-equivalent suite, all checks passed (includes `update_doc_numbers.py --check`, `docsync.py --check --only layer2_boundary` / `layer2_boundary_catalog`, `check_verify_sync.py`, and the scripts unittest suite)
- `python3 -m unittest discover -s scripts` — passed
- README link/anchor validation — all local links and the `#quick-start` anchor resolve
- Verified docsync-required README phrases ("...zero axioms", "0 axioms", dispatch-bridge sentence) are preserved

## Test plan

- [ ] CI `verify.yml` checks job passes
- [ ] Review rendered README on the PR branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doc-sync script scope only; no compiler, proof, or runtime behavior changes.
> 
> **Overview**
> Replaces the README’s auto-generated **metrics table** (`<!-- BEGIN GENERATED STATS -->`) and the line claiming every number is extracted on every commit with a **Verification status** section that stays accurate without frequent regeneration: Lean kernel checking, CI rebuilds, `sorry`/0-axiom enforcement, scoped verification, and links to `AXIOMS.md`, `TRUST_ASSUMPTIONS.md`, and `docs/VERIFICATION_STATUS.md`.
> 
> **`update_doc_numbers.py`** no longer writes or `--check`s the README stats block; it only syncs the quick-facts block in `docs-site/public/llms.txt` from `verification_status.json`. **`consolidation-inventory.md`** reflects that narrower scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 819f8c521ac0b69f16d3ebdc3328d92878d499c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->