### PR TITLE
proof: expose helper-return assign bridge catalog witness

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -217,17 +217,23 @@ theorem stmtListDirectInternalHelperCallStepInterface_of_callHeadStepBridges
           (hbridge hmem))
 
 /-!
-## Direct assign internal-helper calls
+## Direct helper-return-binding calls
 
-These constructors mirror the direct void-call bridge above for
-`Stmt.internalCallAssign`. They keep the statement-return-binding proof seam
-callee-local, so future rank-decreasing helper induction can provide one
-`DirectInternalHelperAssignHeadStepBridge` per callee and reuse the mechanical
-list assembly here.
+These constructors mirror the direct void-call witnesses above for
+`Stmt.internalCallAssign`.  They are intentionally still parameterised by
+`DirectInternalHelperAssignHeadStepBridge`: that bridge is the exact missing
+semantic seam for helper-return bindings, connecting source
+`execStmtWithHelpers` through `interpretInternalFunctionFuel` to helper-aware
+compiled execution through `execIRStmtsWithInternals` and
+`evalIRCallWithInternals`.  A closed bridge should be supplied by the later
+rank-decreasing helper-summary proof once the architecture exposes the needed
+compiled-helper summary lemma.
 -/
 
-/-- Build a helper-aware singleton compiled-step proof for a direct
-helper-return-binding call from the exact assign-head bridge. -/
+/-- Build a helper-aware singleton compiled-step proof for a direct helper
+return binding from the exact assign-head bridge.  This is non-vacuous: the
+`Stmt.internalCallAssign` head is compiled as a Yul `let` binding and its
+helper-aware source/IR execution is consumed directly from `hbridge`. -/
 theorem compiledStmtStepWithHelpersAndHelperIR_internalCallAssign_of_assignHeadStepBridge
     {runtimeContract : IRContract}
     {spec : CompilationModel}
@@ -268,7 +274,8 @@ theorem compiledStmtStepWithHelpersAndHelperIR_internalCallAssign_of_assignHeadS
         hargCompile)
 
 /-- Non-vacuous list witness for a statement list headed by
-`Stmt.internalCallAssign`. -/
+`Stmt.internalCallAssign`.  The head proof comes from the assign bridge; the
+tail remains the ordinary list interface at the post-head scope. -/
 theorem stmtListDirectInternalHelperAssignStepInterface_cons_internalCallAssign_of_assignHeadStepBridge
     {runtimeContract : IRContract}
     {spec : CompilationModel}
@@ -304,11 +311,14 @@ theorem stmtListDirectInternalHelperAssignStepInterface_cons_internalCallAssign_
         (args := args)
         hbridge with
     ⟨compiledIR, hstep⟩
-  exact stmtListDirectInternalHelperAssignStepInterface_cons_internalCallAssign
-    (compiledIR := compiledIR) hstep hrest
+  exact
+    stmtListDirectInternalHelperAssignStepInterface_cons_internalCallAssign
+      hstep
+      hrest
 
 /-- Assemble the direct helper-return-binding list interface from per-callee
-assign bridges for helper names that occur in the statement list. -/
+assign bridges for the helper names that occur in this statement list.  This is
+the assign-only counterpart of the broader direct-helper catalog assembly. -/
 theorem stmtListDirectInternalHelperAssignStepInterface_of_assignHeadStepBridges
     {runtimeContract : IRContract}
     {spec : CompilationModel}
@@ -337,6 +347,29 @@ theorem stmtListDirectInternalHelperAssignStepInterface_of_assignHeadStepBridges
           (calleeName := calleeName)
           (args := args)
           (hbridge hmem))
+
+/-- Assemble the direct helper-return-binding list interface for a function
+body from the per-callee assign bridge catalog used by the rank-decreasing
+helper-summary layer. -/
+theorem stmtListDirectInternalHelperAssignStepInterface_of_perCalleeAssignBridgeCatalog
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {fn : FunctionSpec}
+    (hbridge :
+      DirectInternalHelperPerCalleeAssignBridgeCatalog runtimeContract spec fields fn) :
+    StmtListDirectInternalHelperAssignStepInterface
+      runtimeContract spec fields scope fn.body := by
+  exact
+    stmtListDirectInternalHelperAssignStepInterface_of_assignHeadStepBridges
+      (runtimeContract := runtimeContract)
+      (spec := spec)
+      (fields := fields)
+      (scope := scope)
+      (stmts := fn.body)
+      (fun {calleeName} hmem =>
+        hbridge.assign (by simpa [helperCallNames] using hmem))
 
 /-- For helper-surface-closed statement lists, the four narrow helper-step
 interfaces are all trivially satisfied. This is the entry point for contracts

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1783,6 +1783,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_internalCallAssign_of_assignHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterface_cons_internalCallAssign_of_assignHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterface_of_assignHeadStepBridges
+  Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterface_of_perCalleeAssignBridgeCatalog
   Compiler.Proofs.HelperStepProofs.allHelperInterfacesSatisfied_of_helperSurfaceClosed
   Compiler.Proofs.HelperStepProofs.fullHelperAwareListWitness_of_allInterfaces
   Compiler.Proofs.HelperStepProofs.fullHelperAwareListWitness_of_allInterfaces_disjoint
@@ -5833,4 +5834,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5463 theorems/lemmas (3761 public, 1702 private, 0 sorry'd)
+-- Total: 5464 theorems/lemmas (3762 public, 1702 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

Advances #2080 for the helper-return-binding surface after #2090.

This PR keeps the existing `StmtListDirectInternalHelperAssignStepInterface` bridge witnesses and adds a function-body-level assembly theorem:

- `stmtListDirectInternalHelperAssignStepInterface_of_perCalleeAssignBridgeCatalog`

The new theorem converts the rank-induction-oriented `DirectInternalHelperPerCalleeAssignBridgeCatalog` into the statement-list assign interface for `fn.body`, reusing the existing per-callee bridge and helper-call-name seam. It does not weaken supported fragments, helper-surface gates, compiler behavior, or CI checks.

## Notes

The helper-return-binding witness is non-vacuous at the interface layer: it consumes `DirectInternalHelperAssignHeadStepBridge`, which compiles `Stmt.internalCallAssign` into the Yul `letMany` helper call and carries the exact source/IR execution bridge.

The proof is still parameterized by the assign-head bridge. Closing that bridge directly from helper summaries remains blocked on the same architectural API gap noted in the file: a compiled-helper execution summary lemma connecting `execIRInternalFunctionWithInternals` / `evalIRCallWithInternals` to `InternalHelperSummaryContract.post` for the helper body.

This PR intentionally does not remove `SupportedStmtList.helperSurfaceClosed` or the unsupported-helper-surface gate; expression-position helper calls and structural helper recursion remain open parts of #2080.

## Validation

- `lean-slot lake build Compiler.Proofs.HelperStepProofs` passed. Spark offload rejected this mission worktree path with HTTP 403, so `lean-slot` built locally.
- `python3 scripts/generate_print_axioms.py --check` passed.
- `python3 scripts/lean_lint.py --only proof_length` passed.
- `rg -n "\\b(sorry|admit|axiom)\\b" Compiler/Proofs/HelperStepProofs.lean; test $? -eq 1` passed.
- `make check` passed: 607 Python tests, all checks passed.
- `lean-slot make verify` passed before the final rebase. Spark offload rejected this mission worktree path with HTTP 403, so `lean-slot` built locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Lean proof scaffolding with no compiler, fragment, or runtime changes; the assign-head bridge remains an explicit parameter.
> 
> **Overview**
> Adds **`stmtListDirectInternalHelperAssignStepInterface_of_perCalleeAssignBridgeCatalog`**, which turns a **`DirectInternalHelperPerCalleeAssignBridgeCatalog`** (the rank-decreasing helper-summary assign inventory) into **`StmtListDirectInternalHelperAssignStepInterface`** for **`fn.body`**, by reusing the existing per-statement-list assign bridge assembly and mapping **`helperCallNames`** membership to catalog **`assign`** entries.
> 
> Documentation in the direct helper-return-binding section is tightened to name the assign-head bridge as the remaining semantic seam; the **`cons_internalCallAssign`** proof is slightly simplified. **`PrintAxioms.lean`** registers the new public theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 208d625bf1635243569822678757022f22456ed2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->