### PR TITLE
proof: add expression helper context bridge

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -390,6 +390,155 @@ world-preservation evidence to the corresponding compiled Yul expression
 evaluation under `evalIRCallWithInternals`.
 -/
 
+/-- Compiled-helper lookup specialized to helper-aware Yul expression calls.
+This is the expression-context counterpart of the statement-call shape lemmas
+for `execIRStmtsWithInternals`: after the argument expressions evaluate, the
+call dispatches through the internal helper table supplied by
+`SupportedCompiledInternalHelperWitness`. -/
+theorem evalIRCallWithInternals_of_compiledHelperWitness
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {calleeName : String}
+    (compiledHelper :
+      SupportedCompiledInternalHelperWitness spec runtimeContract calleeName)
+    (state : IRState)
+    (irFuel : Nat)
+    {argExprs : List YulExpr}
+    {argVals : List Nat}
+    {state' : IRState}
+    (hargs :
+      evalIRExprsWithInternals runtimeContract (irFuel + 1) state argExprs =
+        .values argVals state') :
+    ∃ helper,
+      findInternalFunction? runtimeContract
+        (CompilationModel.internalFunctionYulName calleeName) = some helper ∧
+      evalIRCallWithInternals runtimeContract (irFuel + 1) state
+          (CompilationModel.internalFunctionYulName calleeName) argExprs =
+        execIRInternalFunctionWithInternals runtimeContract irFuel state' helper argVals := by
+  have hcalleeName : compiledHelper.sourceWitness.callee.name = calleeName :=
+    compiledHelper.sourceWitness.nameEq
+  have hfindSome :
+      (findInternalFunction? runtimeContract
+        (CompilationModel.internalFunctionYulName calleeName)).isSome = true := by
+    simpa [hcalleeName] using
+      (findInternalFunction?_of_compileInternalFunction_mem
+        compiledHelper.compileOk
+        compiledHelper.presentInRuntime)
+  cases hfind : findInternalFunction? runtimeContract
+      (CompilationModel.internalFunctionYulName calleeName) with
+  | none =>
+      simp [hfind] at hfindSome
+  | some helper =>
+      refine ⟨helper, rfl, ?_⟩
+      simp [evalIRCallWithInternals, hargs, hfind]
+
+/-- Per-callee expression-context helper bridge. It binds together the source
+summary evidence used by `evalExprWithHelpers` and the compiled-helper witness
+used by `evalIRCallWithInternals`. The remaining non-closed obligation is still
+compositional expression compilation: callers must prove that their compiled
+Yul argument expressions evaluate to the same `argVals` in the corresponding IR
+state. -/
+structure ExprInternalHelperCallContextBridge
+    (runtimeContract : IRContract)
+    (spec : CompilationModel)
+    (calleeName : String) where
+  sourceWitness :
+    SupportedInternalHelperWitness spec calleeName
+  summarySound :
+    SourceSemantics.InternalHelperSummarySound
+      spec sourceWitness.callee sourceWitness.summary.contract
+  sourcePreservesWorld :
+    InternalHelperSummaryPreservesWorldOnSuccess sourceWitness.summary.contract
+  compiledHelper :
+    SupportedCompiledInternalHelperWitness spec runtimeContract calleeName
+  irCall :
+    ∀ (state : IRState) (irFuel : Nat)
+      {argExprs : List YulExpr} {argVals : List Nat} {state' : IRState},
+      evalIRExprsWithInternals runtimeContract (irFuel + 1) state argExprs =
+          .values argVals state' →
+      ∃ helper,
+        findInternalFunction? runtimeContract
+          (CompilationModel.internalFunctionYulName calleeName) = some helper ∧
+        evalIRCallWithInternals runtimeContract (irFuel + 1) state
+            (CompilationModel.internalFunctionYulName calleeName) argExprs =
+          execIRInternalFunctionWithInternals runtimeContract irFuel state' helper argVals
+
+/-- Construct the per-callee expression-context bridge from the current supported
+helper inventory: source summary soundness, expression-call world preservation,
+and the compiled runtime helper table. -/
+def exprInternalHelperCallContextBridge_of_supportedEvidence
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fn : FunctionSpec}
+    (hHelpers : SupportedBodyHelperInterface spec fn)
+    (hSummaries : SourceSemantics.SupportedBodyHelperSummariesSound spec fn hHelpers)
+    (hRuntime : SupportedRuntimeHelperTableInterface spec runtimeContract)
+    {calleeName : String}
+    (hmem : calleeName ∈ exprHelperCallNames fn) :
+    ExprInternalHelperCallContextBridge runtimeContract spec calleeName := by
+  let hcall : calleeName ∈ helperCallNames fn :=
+    exprHelperCallNames_subset_helperCallNames hmem
+  let witness := hHelpers.summaryOfCall hcall
+  refine
+    { sourceWitness := witness
+      summarySound :=
+        SourceSemantics.SupportedBodyHelperInterface.summarySoundOfCall
+          hHelpers hSummaries hcall
+      sourcePreservesWorld := hHelpers.exprSummaryPreservesWorld hmem
+      compiledHelper := hRuntime.compiledOfCall hHelpers hcall
+      irCall := ?_ }
+  intro state irFuel argExprs argVals state' hargs
+  exact
+    evalIRCallWithInternals_of_compiledHelperWitness
+      (runtimeContract := runtimeContract)
+      (spec := spec)
+      (calleeName := calleeName)
+      (hRuntime.compiledOfCall hHelpers hcall)
+      state
+      irFuel
+      hargs
+
+/-- Source half of the expression-context bridge for an expression-position
+helper call. It simultaneously exposes the `evalExprWithHelpers` reduction, the
+`InternalHelperSummaryContract.post` fact for the underlying
+`interpretInternalFunctionFuel`, and the world-preservation consequence used by
+expression contexts. -/
+theorem exprInternalHelperCallContextBridge_sourceEvidence
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {calleeName : String}
+    {args : List Expr}
+    (hctx : ExprInternalHelperCallContextBridge runtimeContract spec calleeName)
+    (hnodup : (spec.functions.map (·.name)).Nodup)
+    {fuel : Nat}
+    {state : SourceSemantics.RuntimeState}
+    {argVals : List Nat}
+    (hargs :
+      SourceSemantics.evalExprListWithHelpers spec fields (fuel + 1) state args =
+        some argVals) :
+    let result :=
+      SourceSemantics.interpretInternalFunctionFuel
+        spec fuel hctx.sourceWitness.callee state.world argVals
+    SourceSemantics.evalExprWithHelpers spec fields (fuel + 1) state
+        (Expr.internalCall calleeName args) =
+          (if result.success then result.returnValue else none) ∧
+      hctx.sourceWitness.summary.contract.post fuel state.world argVals
+        result.success result.returnValue result.world ∧
+      (result.success = true → result.world = state.world) := by
+  intro result
+  refine ⟨?_, ?_, ?_⟩
+  · simp +zetaDelta [
+      SourceSemantics.evalExprWithHelpers_internalCall_of_witness
+        hctx.sourceWitness hnodup,
+      hargs]
+  · exact hctx.summarySound fuel state.world argVals
+  · intro hsuccess
+    exact SourceSemantics.helperSummaryPreservesWorldOnSuccess
+      hctx.sourcePreservesWorld
+      (hpost := hctx.summarySound fuel state.world argVals)
+      hsuccess
+
 /-- Expression-helper statement-head bridge. Future helper-summary induction
 should construct this for each statement head whose helper work appears in
 expression position. The semantic payload is the exact helper-aware source/IR

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -4479,6 +4479,56 @@ theorem evalExprWithHelpers_internalCall_of_witness
         if hresult.success then hresult.returnValue else none) := by
   simpa [evalExprWithHelpers, findUniqueInternalFunction?_of_witness witness hnodup]
 
+/-- Version of `evalExprWithHelpers_internalCall_obeys_summary` that takes a
+`SupportedInternalHelperWitness` instead of the private
+`findUniqueInternalFunction?` hypothesis. This is the source-expression helper
+summary seam consumed by expression-context helper-call bridge proofs. -/
+theorem evalExprWithHelpers_internalCall_obeys_summary_of_witness
+    {spec : CompilationModel}
+    {fields : List Field}
+    {fuel : Nat}
+    {state : RuntimeState}
+    {calleeName : String}
+    {args : List Expr}
+    (witness : SupportedInternalHelperWitness spec calleeName)
+    (hnodup : (spec.functions.map (·.name)).Nodup)
+    (hsound : InternalHelperSummarySound spec witness.callee witness.summary.contract)
+    {argVals : List Nat}
+    (hargs : evalExprListWithHelpers spec fields fuel state args = some argVals) :
+    let result := interpretInternalFunctionFuel spec fuel witness.callee state.world argVals
+    witness.summary.contract.post fuel state.world argVals
+      result.success result.returnValue result.world :=
+  evalExprWithHelpers_internalCall_obeys_summary
+    (hfind := findUniqueInternalFunction?_of_witness witness hnodup)
+    (hsound := hsound)
+    (hargs := hargs)
+
+/-- Source-side world-preservation consequence for expression-position helper
+calls, packaged with public supported-helper witnesses. -/
+theorem evalExprWithHelpers_internalCall_preserves_world_of_witness
+    {spec : CompilationModel}
+    {fields : List Field}
+    {fuel : Nat}
+    {state : RuntimeState}
+    {calleeName : String}
+    {args : List Expr}
+    (witness : SupportedInternalHelperWitness spec calleeName)
+    (hnodup : (spec.functions.map (·.name)).Nodup)
+    (hsound : InternalHelperSummarySound spec witness.callee witness.summary.contract)
+    (hpreserve : InternalHelperSummaryPreservesWorldOnSuccess witness.summary.contract)
+    {argVals : List Nat}
+    (hargs : evalExprListWithHelpers spec fields fuel state args = some argVals) :
+    let result := interpretInternalFunctionFuel spec fuel witness.callee state.world argVals
+    result.success = true → result.world = state.world := by
+  intro result hsuccess
+  exact helperSummaryPreservesWorldOnSuccess hpreserve
+    (hpost := evalExprWithHelpers_internalCall_obeys_summary_of_witness
+      (witness := witness)
+      (hnodup := hnodup)
+      (hsound := hsound)
+      (hargs := hargs))
+    hsuccess
+
 theorem SupportedBodyHelperInterface.summarySoundOfCall
     {spec : CompilationModel}
     {fn : FunctionSpec}

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1784,6 +1784,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterface_cons_internalCallAssign_of_assignHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterface_of_assignHeadStepBridges
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterface_of_perCalleeAssignBridgeCatalog
+  Compiler.Proofs.HelperStepProofs.evalIRCallWithInternals_of_compiledHelperWitness
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCallContextBridge_sourceEvidence
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_cons_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_of_exprHeadStepBridges
@@ -3451,6 +3453,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmtWithHelpers_internalCallAssign_obeys_summary_of_witness
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmtWithHelpers_internalCall_of_witness
   Compiler.Proofs.IRGeneration.SourceSemantics.evalExprWithHelpers_internalCall_of_witness
+  Compiler.Proofs.IRGeneration.SourceSemantics.evalExprWithHelpers_internalCall_obeys_summary_of_witness
+  Compiler.Proofs.IRGeneration.SourceSemantics.evalExprWithHelpers_internalCall_preserves_world_of_witness
   Compiler.Proofs.IRGeneration.SourceSemantics.SupportedBodyHelperInterface.summarySoundOfCall
   Compiler.Proofs.IRGeneration.SourceSemantics.SupportedBodyHelperInterface.exprCallSummaryPreservesWorld
   Compiler.Proofs.IRGeneration.SourceSemantics.SupportedHelperSummaryProofCatalog.soundOfWitness
@@ -5837,4 +5841,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5467 theorems/lemmas (3765 public, 1702 private, 0 sorry'd)
+-- Total: 5471 theorems/lemmas (3769 public, 1702 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- add public source-side expression helper witness lemmas for `evalExprWithHelpers_internalCall`: witness-based summary postcondition and world-preservation consequence
- add an expression-context helper bridge in `HelperStepProofs.lean` that packages source summary soundness, expression-call world preservation, compiled helper table evidence, and the compiled Yul `evalIRCallWithInternals` dispatch shape
- regenerate `PrintAxioms.lean`

References #2080.

## Proof status
This advances the phase-3 expression-position adapter from a pure statement-head boundary witness to a semantic expression-context bridge layer:

- Source side: `exprInternalHelperCallContextBridge_sourceEvidence` exposes the `evalExprWithHelpers` reduction for `Expr.internalCall`, the corresponding `InternalHelperSummaryContract.post` fact for `interpretInternalFunctionFuel`, and the world-preservation consequence needed by expression contexts.
- Compiled IR side: `evalIRCallWithInternals_of_compiledHelperWitness` connects `SupportedCompiledInternalHelperWitness` to helper-aware Yul expression-call dispatch through `evalIRCallWithInternals` after argument evaluation.
- Inventory assembly: `exprInternalHelperCallContextBridge_of_supportedEvidence` packages `SupportedBodyHelperInterface`, summary soundness, `exprCallsPreserveWorld`, and `SupportedRuntimeHelperTableInterface` into the per-callee expression-context bridge.

This is non-vacuous for the per-callee expression helper call bridge, but it does not fully close `StmtListExprInternalHelperStepInterface`: the remaining architecture gap is the compositional expression compiler theorem that proves compiled Yul argument/expression contexts evaluate to the same `argVals`/state expected by this bridge and lifts that through arbitrary statement heads. Existing helper-surface-closed fast paths and `SupportedStmtList.helperSurfaceClosed` are unchanged.

## Validation
- `lake env lean Compiler/Proofs/IRGeneration/SourceSemantics.lean` (passed)
- `lake env lean Compiler/Proofs/HelperStepProofs.lean` (passed)
- `lean-slot lake build Compiler.Proofs.HelperStepProofs` (passed; Spark offload denied for this mission path, built locally)
- `python3 scripts/generate_print_axioms.py --check` (passed)
- `rg -n "\\bsorry\\b|\\badmit\\b|\\baxiom\\b" Compiler/Proofs/IRGeneration/SourceSemantics.lean Compiler/Proofs/HelperStepProofs.lean` (no matches)
- `make check` (passed)

## Next blocker / dispatch recommendation
Prove the expression compiler/context theorem that turns per-call bridge evidence into statement-head `ExprInternalHelperHeadStepBridge` values: it needs to relate `SourceSemantics.evalExprWithHelpers` and `evalIRExprWithInternals` for expression contexts containing internal helper calls, threading helper-world preservation and argument evaluation through `compileExprWithInternals` / statement compilation shapes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in compiler verification modules with no runtime or auth changes; remaining gap is explicitly documented architecture, not partial unsafe closure.
> 
> **Overview**
> Adds **expression-position internal helper** proof infrastructure so source `evalExprWithHelpers` and compiled `evalIRCallWithInternals` can be linked per callee before full statement-head closure.
> 
> In **SourceSemantics**, new witness-based lemmas expose summary **postconditions** and **world preservation** for `Expr.internalCall` under `evalExprWithHelpers`, without relying on private lookup hypotheses.
> 
> In **HelperStepProofs**, **`evalIRCallWithInternals_of_compiledHelperWitness`** shows that after Yul args evaluate, helper-aware calls dispatch through the runtime internal table; **`ExprInternalHelperCallContextBridge`** bundles source summary soundness, world preservation, compiled helper witnesses, and that IR dispatch shape; **`exprInternalHelperCallContextBridge_of_supportedEvidence`** builds bridges from the supported helper inventory; **`exprInternalHelperCallContextBridge_sourceEvidence`** packages the source-side reduction, contract post, and preservation facts.
> 
> **PrintAxioms** is regenerated (+4 public theorems). **`StmtListExprInternalHelperStepInterface`** is still open: a compositional expression-compiler theorem is needed to lift per-call bridges to **`ExprInternalHelperHeadStepBridge`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6526713c530348f243d1729658d149b75924ae05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->