### PR TITLE
proof: bridge expression helper compiler context

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -539,6 +539,162 @@ theorem exprInternalHelperCallContextBridge_sourceEvidence
       (hpost := hctx.summarySound fuel state.world argVals)
       hsuccess
 
+/-- Compiler shape for an expression-position internal helper call.  The
+argument expressions are the exact output of `compileInternalCallArgs`, which is
+more general than `compileExprListWithInternals`: internal helper parameters may
+expand direct forwarded source arguments into several Yul arguments. -/
+theorem compileExprWithInternals_internalCall_shape
+    {fields : List Field}
+    {dynamicSource : DynamicDataSource}
+    {internalFunctions : List FunctionSpec}
+    {calleeName : String}
+    {args : List Expr}
+    {argExprs : List YulExpr}
+    (hargs :
+      CompilationModel.compileInternalCallArgs fields dynamicSource internalFunctions calleeName args =
+        Except.ok argExprs) :
+    CompilationModel.compileExprWithInternals fields dynamicSource internalFunctions
+        (Expr.internalCall calleeName args) =
+      Except.ok
+        (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs) := by
+  simp [CompilationModel.compileExprWithInternals, hargs]
+
+/-- Result package for composing an expression-position internal helper call
+through source evaluation, expression compilation, compiled argument evaluation,
+and helper-aware IR dispatch.  It is factored out so the public theorem below
+stays below the proof-length gate while still exposing every piece of evidence
+needed by the later statement-head bridge. -/
+def ExprInternalHelperCompiledCallContextResult
+    (runtimeContract : IRContract)
+    (spec : CompilationModel)
+    (fields : List Field)
+    (calleeName : String)
+    (args : List Expr)
+    (hctx : ExprInternalHelperCallContextBridge runtimeContract spec calleeName)
+    (helperFuel irFuel : Nat)
+    (runtime : SourceSemantics.RuntimeState)
+    (state state' : IRState)
+    (argVals : List Nat)
+    (argExprs : List YulExpr) : Prop :=
+  let sourceResult :=
+    SourceSemantics.interpretInternalFunctionFuel
+      spec helperFuel hctx.sourceWitness.callee runtime.world argVals
+  ∃ helper,
+    CompilationModel.compileExprWithInternals fields .calldata spec.functions
+        (Expr.internalCall calleeName args) =
+      Except.ok
+        (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs) ∧
+    SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime
+        (Expr.internalCall calleeName args) =
+      (if sourceResult.success then sourceResult.returnValue else none) ∧
+    hctx.sourceWitness.summary.contract.post helperFuel runtime.world argVals
+      sourceResult.success sourceResult.returnValue sourceResult.world ∧
+    (sourceResult.success = true → sourceResult.world = runtime.world) ∧
+    findInternalFunction? runtimeContract
+      (CompilationModel.internalFunctionYulName calleeName) = some helper ∧
+    evalIRCallWithInternals runtimeContract (irFuel + 1) state
+        (CompilationModel.internalFunctionYulName calleeName) argExprs =
+      execIRInternalFunctionWithInternals runtimeContract irFuel state' helper argVals ∧
+    evalIRExprWithInternals runtimeContract (irFuel + 1) state
+        (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs) =
+      match execIRInternalFunctionWithInternals runtimeContract irFuel state' helper argVals with
+      | .values [value] state'' => .value value state''
+      | .values _ state'' => .revert state''
+      | .stop state'' => .stop state''
+      | .return value state'' => .return value state''
+      | .revert state'' => .revert state''
+
+/-- Lift an already-proved helper-aware call dispatch equality through
+`evalIRExprWithInternals` for the compiled call expression. -/
+theorem evalIRExprWithInternals_call_of_dispatch
+    (runtimeContract : IRContract)
+    (irFuel : Nat)
+    (state state' : IRState)
+    (calleeName : String)
+    (argExprs : List YulExpr)
+    (helper : IRInternalFunctionDef)
+    (argVals : List Nat)
+    (hirDispatch :
+      evalIRCallWithInternals runtimeContract (irFuel + 1) state
+          (CompilationModel.internalFunctionYulName calleeName) argExprs =
+        execIRInternalFunctionWithInternals runtimeContract irFuel state' helper argVals) :
+    evalIRExprWithInternals runtimeContract (irFuel + 1) state
+        (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs) =
+      match execIRInternalFunctionWithInternals runtimeContract irFuel state' helper argVals with
+      | .values [value] state'' => .value value state''
+      | .values _ state'' => .revert state''
+      | .stop state'' => .stop state''
+      | .return value state'' => .return value state''
+      | .revert state'' => .revert state'' := by
+  rw [evalIRExprWithInternals_call, hirDispatch]
+  cases execIRInternalFunctionWithInternals runtimeContract irFuel state' helper argVals with
+  | values values state'' =>
+      cases values with
+      | nil => rfl
+      | cons value rest => cases rest <;> rfl
+  | stop state'' => rfl
+  | «return» value state'' => rfl
+  | revert state'' => rfl
+
+/-- Compose the phase-4 per-callee expression helper bridge with the expression
+compiler at the helper-call head.  This theorem is the current non-vacuous
+compiler/context handoff: once callers prove that the compiled Yul argument
+context evaluates to the same helper argument values as source
+`evalExprListWithHelpers`, the bridge supplies source summary soundness,
+helper-world preservation on success, compiled helper lookup/dispatch through
+`evalIRCallWithInternals`, and the corresponding `evalIRExprWithInternals`
+shape for the compiled call expression.
+
+This intentionally remains at the `Expr.internalCall` head.  Lifting it through
+arbitrary parent expressions and then through statement heads still requires a
+separate compositional expression compiler theorem relating
+`evalExprWithHelpers` and `evalIRExprWithInternals` for non-call expression
+contexts while preserving the helper-world and argument-evaluation evidence. -/
+theorem exprInternalHelperCallContextBridge_compileExprWithInternals_internalCall
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {calleeName : String}
+    {args : List Expr}
+    (hctx : ExprInternalHelperCallContextBridge runtimeContract spec calleeName)
+    (hnodup : (spec.functions.map (·.name)).Nodup)
+    {helperFuel irFuel : Nat}
+    {runtime : SourceSemantics.RuntimeState}
+    {state state' : IRState}
+    {argVals : List Nat}
+    {argExprs : List YulExpr}
+    (hsourceArgs :
+      SourceSemantics.evalExprListWithHelpers spec fields (helperFuel + 1) runtime args =
+        some argVals)
+    (hcompileArgs :
+      CompilationModel.compileInternalCallArgs fields .calldata spec.functions calleeName args =
+        Except.ok argExprs)
+    (hirArgs :
+      evalIRExprsWithInternals runtimeContract (irFuel + 1) state argExprs =
+        .values argVals state') :
+    ExprInternalHelperCompiledCallContextResult runtimeContract spec fields
+      calleeName args hctx helperFuel irFuel runtime state state' argVals argExprs := by
+  unfold ExprInternalHelperCompiledCallContextResult
+  dsimp only
+  have hcompile :
+      CompilationModel.compileExprWithInternals fields .calldata spec.functions
+          (Expr.internalCall calleeName args) =
+        Except.ok
+          (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs) :=
+    compileExprWithInternals_internalCall_shape hcompileArgs
+  have hsource :=
+    exprInternalHelperCallContextBridge_sourceEvidence (runtimeContract := runtimeContract)
+      (spec := spec) (fields := fields) (calleeName := calleeName) (args := args)
+      hctx hnodup (fuel := helperFuel) (state := runtime) hsourceArgs
+  have hirCall := hctx.irCall state irFuel hirArgs
+  rcases hirCall with ⟨helper, hfind, hirDispatch⟩
+  refine ⟨helper, hcompile, ?_, ?_, ?_, hfind, hirDispatch, ?_⟩
+  · exact hsource.1
+  · exact hsource.2.1
+  · exact hsource.2.2
+  · exact evalIRExprWithInternals_call_of_dispatch
+      runtimeContract irFuel state state' calleeName argExprs helper argVals hirDispatch
+
 /-- Expression-helper statement-head bridge. Future helper-summary induction
 should construct this for each statement head whose helper work appears in
 expression position. The semantic payload is the exact helper-aware source/IR

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1786,6 +1786,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterface_of_perCalleeAssignBridgeCatalog
   Compiler.Proofs.HelperStepProofs.evalIRCallWithInternals_of_compiledHelperWitness
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCallContextBridge_sourceEvidence
+  Compiler.Proofs.HelperStepProofs.compileExprWithInternals_internalCall_shape
+  Compiler.Proofs.HelperStepProofs.evalIRExprWithInternals_call_of_dispatch
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCallContextBridge_compileExprWithInternals_internalCall
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_cons_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_of_exprHeadStepBridges
@@ -5841,4 +5844,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5471 theorems/lemmas (3769 public, 1702 private, 0 sorry'd)
+-- Total: 5474 theorems/lemmas (3772 public, 1702 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- add the compiler shape theorem for `Expr.internalCall` through `compileExprWithInternals` / `compileInternalCallArgs`
- add a compiled expression-call context result package that threads source `evalExprWithHelpers`, helper summary postcondition, helper-world preservation, compiled helper lookup, `evalIRCallWithInternals`, and `evalIRExprWithInternals`
- add the non-vacuous per-callee bridge theorem composing `ExprInternalHelperCallContextBridge` with compiled argument evaluation evidence at the helper-call head
- regenerate `PrintAxioms.lean`

References #2080.

## Base / dependency
#2097 is merged, so this PR targets `main` directly. It is not stacked.

## Proof status
This advances the remaining phase-4 blocker by adding the smallest expression compiler/context bridge currently supported by the architecture:

- `compileExprWithInternals_internalCall_shape` exposes the compiled Yul call produced for expression-position internal helpers using the exact `compileInternalCallArgs` path, including expanded/forwarded helper arguments.
- `exprInternalHelperCallContextBridge_compileExprWithInternals_internalCall` composes the phase-4 per-callee `ExprInternalHelperCallContextBridge` with source argument evaluation, compiled argument evaluation to the same `argVals`, source summary soundness, world preservation, helper runtime lookup, `evalIRCallWithInternals`, and the resulting `evalIRExprWithInternals` call expression shape.
- Existing helper-surface-closed and expression-surface-closed fast paths are unchanged.

This is non-vacuous at the `Expr.internalCall` head. It does not fully close arbitrary expression contexts or `StmtListExprInternalHelperStepInterface`: the remaining proof/API gap is the compositional theorem lifting this helper-call head result through non-call expression contexts and statement heads while proving the compiled Yul argument context evaluates to the source helper `argVals` and preserving the helper-world evidence.

## Validation
- `lean-slot lake build Compiler.Proofs.HelperStepProofs` (passed; Spark offload denied for this mission path, built locally)
- `python3 scripts/generate_print_axioms.py --check` (passed after regenerating `PrintAxioms.lean`)
- `rg -n "\\bsorry\\b|\\badmit\\b|\\baxiom\\b" Compiler/Proofs/HelperStepProofs.lean` (no matches)
- `make check` (passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in helper step proofs with no runtime or auth changes; scope is localized to compiler correctness lemmas.
> 
> **Overview**
> Adds the **phase-4 expression compiler/context handoff** for `Expr.internalCall` heads in `HelperStepProofs.lean`: a compile-shape lemma via `compileInternalCallArgs`, a bundled `ExprInternalHelperCompiledCallContextResult` predicate, and a bridge theorem that ties source `evalExprWithHelpers`, helper summary/world preservation, and IR `evalIRCallWithInternals` / `evalIRExprWithInternals` when source and compiled args agree on `argVals`.
> 
> Also adds **`evalIRExprWithInternals_call_of_dispatch`** to map internal-call dispatch equalities into full expression-evaluation outcomes, and updates **`PrintAxioms.lean`** (+3 listed lemmas).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3213e1e9cbf7e0d77a2b89b5f03ce15786d2efa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->