### PR TITLE
proof: package expression helper context head

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -695,6 +695,76 @@ theorem exprInternalHelperCallContextBridge_compileExprWithInternals_internalCal
   · exact evalIRExprWithInternals_call_of_dispatch
       runtimeContract irFuel state state' calleeName argExprs helper argVals hirDispatch
 
+/-- Expression-context payload that combines outer expression correspondence
+with the exact phase-5 helper-head evidence. The remaining blocker is the
+recursive non-call `Expr` theorem that constructs this package for contexts. -/
+def ExprInternalHelperCompositionalContextResult
+    (runtimeContract : IRContract)
+    (spec : CompilationModel)
+    (fields : List Field)
+    (expr : Expr)
+    (exprIR : YulExpr)
+    (helperFuel irFuel : Nat)
+    (runtime headRuntime : SourceSemantics.RuntimeState)
+    (state headState finalState : IRState)
+    (value : Nat) : Prop :=
+  CompilationModel.compileExprWithInternals fields .calldata spec.functions expr =
+      Except.ok exprIR ∧
+    SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime expr =
+      some value ∧
+    evalIRExprWithInternals runtimeContract (irFuel + 1) state exprIR =
+      .value value finalState ∧
+    FunctionBody.runtimeStateMatchesIR fields headRuntime headState ∧
+    ∃ (calleeName : String) (args : List Expr)
+        (hctx : ExprInternalHelperCallContextBridge runtimeContract spec calleeName)
+        (argVals : List Nat) (argExprs : List YulExpr) (argState : IRState),
+      ExprInternalHelperCompiledCallContextResult runtimeContract spec fields
+        calleeName args hctx helperFuel irFuel headRuntime headState argState
+        argVals argExprs
+
+/-- Direct-head base case for the compositional expression-context payload. -/
+theorem exprInternalHelperCompositionalContextResult_internalCall_head
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {calleeName : String} {args : List Expr}
+    (hctx : ExprInternalHelperCallContextBridge runtimeContract spec calleeName)
+    (hnodup : (spec.functions.map (·.name)).Nodup)
+    {helperFuel irFuel : Nat} {runtime : SourceSemantics.RuntimeState}
+    {state argState finalState : IRState} {argVals : List Nat}
+    {argExprs : List YulExpr} {value : Nat}
+    (hruntime : FunctionBody.runtimeStateMatchesIR fields runtime state)
+    (hsourceArgs :
+      SourceSemantics.evalExprListWithHelpers spec fields (helperFuel + 1) runtime args =
+        some argVals)
+    (hcompileArgs :
+      CompilationModel.compileInternalCallArgs fields .calldata spec.functions calleeName args =
+        Except.ok argExprs)
+    (hirArgs :
+      evalIRExprsWithInternals runtimeContract (irFuel + 1) state argExprs =
+        .values argVals argState)
+    (hsourceValue :
+      SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime
+          (Expr.internalCall calleeName args) =
+        some value)
+    (hirValue :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) state
+          (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs) =
+        .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      (Expr.internalCall calleeName args)
+      (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs)
+      helperFuel irFuel runtime runtime state state finalState value := by
+  unfold ExprInternalHelperCompositionalContextResult
+  refine ⟨?_, hsourceValue, hirValue, hruntime, ?_⟩
+  · exact compileExprWithInternals_internalCall_shape hcompileArgs
+  · refine ⟨calleeName, args, hctx, argVals, argExprs, argState, ?_⟩
+    exact
+      exprInternalHelperCallContextBridge_compileExprWithInternals_internalCall
+        (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+        (calleeName := calleeName) (args := args) hctx hnodup
+        (helperFuel := helperFuel) (irFuel := irFuel) (runtime := runtime)
+        (state := state) (state' := argState) (argVals := argVals)
+        (argExprs := argExprs) hsourceArgs hcompileArgs hirArgs
+
 /-- Expression-helper statement-head bridge. Future helper-summary induction
 should construct this for each statement head whose helper work appears in
 expression position. The semantic payload is the exact helper-aware source/IR

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1789,6 +1789,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.compileExprWithInternals_internalCall_shape
   Compiler.Proofs.HelperStepProofs.evalIRExprWithInternals_call_of_dispatch
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCallContextBridge_compileExprWithInternals_internalCall
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_internalCall_head
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_cons_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_of_exprHeadStepBridges
@@ -5844,4 +5845,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5474 theorems/lemmas (3772 public, 1702 private, 0 sorry'd)
+-- Total: 5475 theorems/lemmas (3773 public, 1702 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- add `ExprInternalHelperCompositionalContextResult`, a small expression-context payload that combines outer expression compile/evaluation correspondence with the phase-5 helper-head package
- add the direct `Expr.internalCall` head base theorem that reuses `exprInternalHelperCallContextBridge_compileExprWithInternals_internalCall` and carries source arg evaluation, compiled Yul arg evaluation to the same `argVals`, helper summary/world evidence, helper dispatch, and source/compiled state relation
- regenerate `PrintAxioms.lean`

References #2080.

## Base / dependency
#2099 is merged, so this PR targets `main` directly. It is not stacked.

## Proof status
This is a non-vacuous base-case handoff for the compositional expression-context theorem: the new result shape records the outer expression compile/evaluation facts while preserving the exact phase-5 helper-head evidence. The direct-head theorem constructs that package for `Expr.internalCall`.

This does not fully close arbitrary non-call expression contexts or `StmtListExprInternalHelperStepInterface`. The remaining proof/API blocker is the recursive expression compiler theorem over non-call `Expr` constructors that constructs `ExprInternalHelperCompositionalContextResult` for parent contexts and then a statement-head bridge for the expression-bearing `Stmt` cases.

## Validation
- `lean-slot lake build Compiler.Proofs.HelperStepProofs` (passed; Spark offload denied for this mission path, built locally)
- `lake env lean Compiler/Proofs/HelperStepProofs.lean` (passed)
- `python3 scripts/generate_print_axioms.py --check` (passed)
- `python3 scripts/check_proof_length.py` (passed)
- `rg -n "\\bsorry\\b|\\badmit\\b|\\baxiom\\b" Compiler/Proofs/HelperStepProofs.lean` (no matches)
- `make check` (passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof-only additions with no changes to compilation or runtime semantics; risk is limited to proof maintenance and axiom inventory accuracy.
> 
> **Overview**
> Adds **`ExprInternalHelperCompositionalContextResult`**, a proof obligation that ties outer expression compile/source-eval/IR-eval agreement to the existing phase-5 helper-head package (`ExprInternalHelperCompiledCallContextResult`). The intended follow-on is a recursive theorem over non-call `Expr` constructors that fills this shape for parent contexts.
> 
> Proves the **direct head base case** for `Expr.internalCall` via `exprInternalHelperCompositionalContextResult_internalCall_head`, reusing `exprInternalHelperCallContextBridge_compileExprWithInternals_internalCall` plus compile shape, arg evaluation, and value correspondence hypotheses. **`PrintAxioms.lean`** is regenerated to register the new public theorem.
> 
> This does **not** close arbitrary expression contexts or `StmtListExprInternalHelperStepInterface`; it is scaffolding for the compositional expression proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0990f8fbfcfe2c2c9a5573bb29368f26845600fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->