### PR TITLE
proof: lift expression helper context payload

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -765,6 +765,151 @@ theorem exprInternalHelperCompositionalContextResult_internalCall_head
         (state := state) (state' := argState) (argVals := argVals)
         (argExprs := argExprs) hsourceArgs hcompileArgs hirArgs
 
+theorem exprInternalHelperCompositionalContextResult_of_outer_facts
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {headExpr expr : Expr} {headExprIR exprIR : YulExpr}
+    {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state headState headFinalState finalState : IRState}
+    {headValue value : Nat}
+    (hhead :
+      ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+        headExpr headExprIR helperFuel irFuel runtime headRuntime state headState
+        headFinalState headValue)
+    (hcompile :
+      CompilationModel.compileExprWithInternals fields .calldata spec.functions expr =
+        Except.ok exprIR)
+    (hsource :
+      SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime expr =
+        some value)
+    (hir :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) state exprIR =
+        .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      expr exprIR helperFuel irFuel runtime headRuntime state headState finalState value := by
+  -- Blocker: a fully automatic theorem over every non-call `Expr` constructor
+  -- still needs a uniform helper-aware source/IR expression compiler lemma,
+  -- including sequential IR state threading for sibling expressions.
+  unfold ExprInternalHelperCompositionalContextResult at hhead ⊢
+  rcases hhead with ⟨_, _, _, hmatches, hpayload⟩
+  exact ⟨hcompile, hsource, hir, hmatches, hpayload⟩
+
+/-- Unary non-call expression-context lift.  This is the common shape for
+constructors such as `bitNot`, `logicalNot`, `mload`, `tload`, `calldataload`,
+and single-child dynamic-array helpers once their outer facts are proved. -/
+theorem exprInternalHelperCompositionalContextResult_unary_context
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {child : Expr} {childIR : YulExpr}
+    {mkExpr : Expr → Expr} {mkIR : YulExpr → YulExpr}
+    {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state headState childFinalState finalState : IRState}
+    {childValue value : Nat}
+    (hchild :
+      ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+        child childIR helperFuel irFuel runtime headRuntime state headState
+        childFinalState childValue)
+    (hcompile :
+      CompilationModel.compileExprWithInternals fields .calldata spec.functions
+          (mkExpr child) =
+        Except.ok (mkIR childIR))
+    (hsource :
+      SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime
+          (mkExpr child) =
+        some value)
+    (hir :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) state (mkIR childIR) =
+        .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      (mkExpr child) (mkIR childIR) helperFuel irFuel runtime headRuntime state
+      headState finalState value := by
+  exact
+    exprInternalHelperCompositionalContextResult_of_outer_facts
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (headExpr := child) (headExprIR := childIR)
+      (helperFuel := helperFuel) (irFuel := irFuel)
+      (runtime := runtime) (headRuntime := headRuntime)
+      (state := state) (headState := headState)
+      hchild hcompile hsource hir
+
+/-- Binary non-call expression-context lift when the helper payload is in the
+left child.  Sibling evaluation state threading is intentionally part of the
+outer `hir` fact supplied by the caller. -/
+theorem exprInternalHelperCompositionalContextResult_binary_left_context
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {left right : Expr} {leftIR rightIR : YulExpr}
+    {mkExpr : Expr → Expr → Expr} {mkIR : YulExpr → YulExpr → YulExpr}
+    {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state headState leftFinalState finalState : IRState}
+    {leftValue value : Nat}
+    (hleft :
+      ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+        left leftIR helperFuel irFuel runtime headRuntime state headState
+        leftFinalState leftValue)
+    (hcompile :
+      CompilationModel.compileExprWithInternals fields .calldata spec.functions
+          (mkExpr left right) =
+        Except.ok (mkIR leftIR rightIR))
+    (hsource :
+      SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime
+          (mkExpr left right) =
+        some value)
+    (hir :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) state
+          (mkIR leftIR rightIR) =
+        .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      (mkExpr left right) (mkIR leftIR rightIR) helperFuel irFuel runtime
+      headRuntime state headState finalState value := by
+  exact
+    exprInternalHelperCompositionalContextResult_of_outer_facts
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (headExpr := left) (headExprIR := leftIR)
+      (helperFuel := helperFuel) (irFuel := irFuel)
+      (runtime := runtime) (headRuntime := headRuntime)
+      (state := state) (headState := headState)
+      hleft hcompile hsource hir
+
+/-- Binary non-call expression-context lift when the helper payload is in the
+right child.  This preserves the helper head while the caller supplies the
+already-established outer facts for the whole parent expression. -/
+theorem exprInternalHelperCompositionalContextResult_binary_right_context
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {left right : Expr} {leftIR rightIR : YulExpr}
+    {mkExpr : Expr → Expr → Expr} {mkIR : YulExpr → YulExpr → YulExpr}
+    {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state headState rightFinalState finalState : IRState}
+    {rightValue value : Nat}
+    (hright :
+      ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+        right rightIR helperFuel irFuel runtime headRuntime state headState
+        rightFinalState rightValue)
+    (hcompile :
+      CompilationModel.compileExprWithInternals fields .calldata spec.functions
+          (mkExpr left right) =
+        Except.ok (mkIR leftIR rightIR))
+    (hsource :
+      SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime
+          (mkExpr left right) =
+        some value)
+    (hir :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) state
+          (mkIR leftIR rightIR) =
+        .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      (mkExpr left right) (mkIR leftIR rightIR) helperFuel irFuel runtime
+      headRuntime state headState finalState value := by
+  exact
+    exprInternalHelperCompositionalContextResult_of_outer_facts
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (headExpr := right) (headExprIR := rightIR)
+      (helperFuel := helperFuel) (irFuel := irFuel)
+      (runtime := runtime) (headRuntime := headRuntime)
+      (state := state) (headState := headState)
+      hright hcompile hsource hir
+
 /-- Expression-helper statement-head bridge. Future helper-summary induction
 should construct this for each statement head whose helper work appears in
 expression position. The semantic payload is the exact helper-aware source/IR

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1790,6 +1790,10 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.evalIRExprWithInternals_call_of_dispatch
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCallContextBridge_compileExprWithInternals_internalCall
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_internalCall_head
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_of_outer_facts
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_unary_context
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_binary_left_context
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_binary_right_context
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_cons_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_of_exprHeadStepBridges
@@ -5845,4 +5849,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5475 theorems/lemmas (3773 public, 1702 private, 0 sorry'd)
+-- Total: 5479 theorems/lemmas (3777 public, 1702 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- add `exprInternalHelperCompositionalContextResult_of_outer_facts`, a proof adapter that lifts the phase-6 `ExprInternalHelperCompositionalContextResult` helper-head payload through an already-proved outer expression context
- add unary and binary non-call expression-context wrappers so constructor-specific proofs can preserve the same source helper `argVals`, compiled argument evaluation, helper-world evidence, helper dispatch, and source/compiled head-state relation
- regenerate `PrintAxioms.lean` for the four new public theorems

References #2080.

## Base / dependency
#2100 is merged, so this PR targets `main` directly. It is not stacked.

## Proof status
This is a compiling, non-vacuous API bridge for the recursive expression-context theorem: once a constructor-specific proof supplies the parent compile/source-eval/IR-eval facts, the adapter preserves the exact helper-head payload produced by phase 6.

This does not fully close arbitrary expression recursion or `StmtListExprInternalHelperStepInterface`. The remaining proof/API blocker is a uniform helper-aware source/IR expression compiler lemma for non-call `Expr` constructors, including sequential IR state threading for sibling expressions. The statement-head bridge should consume these adapters after that lemma is available.

## Validation
- `lake env lean Compiler/Proofs/HelperStepProofs.lean` (passed)
- `lean-slot lake build Compiler.Proofs.HelperStepProofs` (passed; Spark offload denied for this mission path, built locally)
- `python3 scripts/generate_print_axioms.py --check` (passed)
- `python3 scripts/check_proof_length.py` (passed)
- `rg -n "\\bsorry\\b|\\badmit\\b|\\baxiom\\b" Compiler/Proofs/HelperStepProofs.lean` (no matches)
- `make check` (passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof-only additions with no executable compiler or runtime behavior changes; risk is limited to proof API correctness and maintainability.
> 
> **Overview**
> Adds **proof adapters** in `HelperStepProofs.lean` so constructor-specific lemmas can reuse the phase-6 `ExprInternalHelperCompositionalContextResult` helper-head payload when the parent expression’s compile, source-eval, and IR-eval facts are already proved.
> 
> `exprInternalHelperCompositionalContextResult_of_outer_facts` copies the existing helper-world match and `ExprInternalHelperCompiledCallContextResult` witness from a child “head” into the parent result, given outer `hcompile` / `hsource` / `hir`. **Unary** and **binary left/right** wrappers (`…_unary_context`, `…_binary_left_context`, `…_binary_right_context`) instantiate that adapter for common non-call expression shapes; sibling IR state threading stays in the caller’s `hir` hypothesis.
> 
> `PrintAxioms.lean` is regenerated to list the four new public theorems (5479 total lemmas). Full automatic recursion over all non-call `Expr` constructors is still blocked on a uniform helper-aware expression compiler lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f90ac2772a928304dc202bd800ee1bb04558d2a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->