### PR TITLE
proof: thread helper expr context through siblings

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -794,6 +794,39 @@ theorem exprInternalHelperCompositionalContextResult_of_outer_facts
   rcases hhead with ⟨_, _, _, hmatches, hpayload⟩
   exact ⟨hcompile, hsource, hir, hmatches, hpayload⟩
 
+/-- Variant of `exprInternalHelperCompositionalContextResult_of_outer_facts`
+where the helper-head IR expression starts from an intermediate state rather
+than the parent expression's entry state.  This is the shape needed for
+right-hand siblings: the left sibling may have already advanced IR state before
+the helper-bearing right expression is evaluated, while source expression
+evaluation still uses the same source runtime. -/
+theorem exprInternalHelperCompositionalContextResult_of_outer_facts_threaded_head
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {headExpr expr : Expr} {headExprIR exprIR : YulExpr}
+    {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {parentState headEntryState headState headFinalState finalState : IRState}
+    {headValue value : Nat}
+    (hhead :
+      ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+        headExpr headExprIR helperFuel irFuel runtime headRuntime headEntryState
+        headState headFinalState headValue)
+    (hcompile :
+      CompilationModel.compileExprWithInternals fields .calldata spec.functions expr =
+        Except.ok exprIR)
+    (hsource :
+      SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime expr =
+        some value)
+    (hir :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) parentState exprIR =
+        .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      expr exprIR helperFuel irFuel runtime headRuntime parentState headState
+      finalState value := by
+  unfold ExprInternalHelperCompositionalContextResult at hhead ⊢
+  rcases hhead with ⟨_, _, _, hmatches, hpayload⟩
+  exact ⟨hcompile, hsource, hir, hmatches, hpayload⟩
+
 /-- Unary non-call expression-context lift.  This is the common shape for
 constructors such as `bitNot`, `logicalNot`, `mload`, `tload`, `calldataload`,
 and single-child dynamic-array helpers once their outer facts are proved. -/
@@ -909,6 +942,109 @@ theorem exprInternalHelperCompositionalContextResult_binary_right_context
       (runtime := runtime) (headRuntime := headRuntime)
       (state := state) (headState := headState)
       hright hcompile hsource hir
+
+/-- Binary non-call expression-context lift when the helper payload is in the
+right child and the left sibling has already advanced the IR state.  This is the
+threaded counterpart of `exprInternalHelperCompositionalContextResult_binary_right_context`
+and is the reusable shape for source/IR expression compiler lemmas over sibling
+constructors. -/
+theorem exprInternalHelperCompositionalContextResult_binary_right_threaded_context
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {left right : Expr} {leftIR rightIR : YulExpr}
+    {mkExpr : Expr → Expr → Expr} {mkIR : YulExpr → YulExpr → YulExpr}
+    {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {parentState rightEntryState headState rightFinalState finalState : IRState}
+    {rightValue value : Nat}
+    (hright :
+      ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+        right rightIR helperFuel irFuel runtime headRuntime rightEntryState headState
+        rightFinalState rightValue)
+    (hcompile :
+      CompilationModel.compileExprWithInternals fields .calldata spec.functions
+          (mkExpr left right) =
+        Except.ok (mkIR leftIR rightIR))
+    (hsource :
+      SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime
+          (mkExpr left right) =
+        some value)
+    (hir :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) parentState
+          (mkIR leftIR rightIR) =
+        .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      (mkExpr left right) (mkIR leftIR rightIR) helperFuel irFuel runtime
+      headRuntime parentState headState finalState value := by
+  exact
+    exprInternalHelperCompositionalContextResult_of_outer_facts_threaded_head
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (headExpr := right) (headExprIR := rightIR)
+      (helperFuel := helperFuel) (irFuel := irFuel)
+      (runtime := runtime) (headRuntime := headRuntime)
+      (parentState := parentState) (headEntryState := rightEntryState)
+      (headState := headState)
+      hright hcompile hsource hir
+
+/-- Successful two-argument IR expression evaluation with explicit
+left-to-right state threading. -/
+theorem evalIRExprsWithInternals_pair_of_values
+    (runtimeContract : IRContract)
+    (fuel : Nat)
+    (state leftState finalState : IRState)
+    (leftIR rightIR : YulExpr)
+    (leftValue rightValue : Nat)
+    (hleft :
+      evalIRExprWithInternals runtimeContract fuel state leftIR =
+        .value leftValue leftState)
+    (hright :
+      evalIRExprWithInternals runtimeContract fuel leftState rightIR =
+        .value rightValue finalState) :
+    evalIRExprsWithInternals runtimeContract fuel state [leftIR, rightIR] =
+      .values [leftValue, rightValue] finalState := by
+  simp [evalIRExprsWithInternals, hleft, hright]
+
+/-- Helper-aware compiled IR evaluation for a pure two-argument Yul builtin,
+with the sibling state threading exposed by
+`evalIRExprsWithInternals_pair_of_values`.  Constructor-specific source/compile
+lemmas can use this to discharge the IR side for binary non-call expression
+contexts after proving the source value computes to the same builtin result. -/
+theorem evalIRExprWithInternals_binary_builtin_of_values
+    (runtimeContract : IRContract)
+    (fuel : Nat)
+    (state leftState finalState : IRState)
+    (func : String)
+    (leftIR rightIR : YulExpr)
+    (leftValue rightValue value : Nat)
+    (hleft :
+      evalIRExprWithInternals runtimeContract fuel state leftIR =
+        .value leftValue leftState)
+    (hright :
+      evalIRExprWithInternals runtimeContract fuel leftState rightIR =
+        .value rightValue finalState)
+    (hfind : findInternalFunction? runtimeContract func = none)
+    (hnotTload : func ≠ "tload")
+    (hnotMload : func ≠ "mload")
+    (hnotKeccak : func ≠ "keccak256")
+    (hbuiltin :
+      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext
+          finalState.storage finalState.sender finalState.msgValue finalState.thisAddress
+          finalState.blockTimestamp finalState.blockNumber finalState.chainId
+          finalState.blobBaseFee finalState.txOrigin finalState.selector
+          finalState.calldata func [leftValue, rightValue] =
+        some value) :
+    evalIRExprWithInternals runtimeContract fuel state
+        (YulExpr.call func [leftIR, rightIR]) =
+      .value value finalState := by
+  have hargs :
+      evalIRExprsWithInternals runtimeContract fuel state [leftIR, rightIR] =
+        .values [leftValue, rightValue] finalState :=
+    evalIRExprsWithInternals_pair_of_values runtimeContract fuel state leftState finalState
+      leftIR rightIR leftValue rightValue hleft hright
+  simp [evalIRExprWithInternals_call,
+    evalIRCallWithInternals_of_builtin runtimeContract fuel state func
+      [leftIR, rightIR] [leftValue, rightValue] finalState hargs hfind
+      hnotTload hnotMload hnotKeccak,
+    hbuiltin]
 
 /-- Expression-helper statement-head bridge. Future helper-summary induction
 should construct this for each statement head whose helper work appears in

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1791,9 +1791,13 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCallContextBridge_compileExprWithInternals_internalCall
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_internalCall_head
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_of_outer_facts
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_of_outer_facts_threaded_head
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_unary_context
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_binary_left_context
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_binary_right_context
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_binary_right_threaded_context
+  Compiler.Proofs.HelperStepProofs.evalIRExprsWithInternals_pair_of_values
+  Compiler.Proofs.HelperStepProofs.evalIRExprWithInternals_binary_builtin_of_values
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_cons_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_of_exprHeadStepBridges
@@ -5849,4 +5853,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5479 theorems/lemmas (3777 public, 1702 private, 0 sorry'd)
+-- Total: 5483 theorems/lemmas (3781 public, 1702 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- add `exprInternalHelperCompositionalContextResult_of_outer_facts_threaded_head`, a threaded variant of the phase-7 payload adapter where the helper-head IR expression starts from an intermediate sibling state instead of the parent entry state
- add `exprInternalHelperCompositionalContextResult_binary_right_threaded_context` so right-hand binary expression contexts can preserve the same helper-head payload after the left sibling advances IR state
- add small IR helpers for non-call binary expression compiler lemmas: `evalIRExprsWithInternals_pair_of_values` exposes left-to-right argument-state threading, and `evalIRExprWithInternals_binary_builtin_of_values` packages pure two-argument builtin evaluation once constructor-specific source/compile/value facts are supplied
- regenerate `PrintAxioms.lean`

References #2080.

## Base / dependency
This PR is stacked on #2101 because #2101 is still open. Base branch: `paloma/issue-2080-expression-recursive-context`.

## Proof status
This is a compiling, non-vacuous API bridge for the remaining helper-aware source/IR expression compiler lemma. It does not close the full recursive non-call `Expr` theorem or `StmtListExprInternalHelperStepInterface`, but it removes the key right-sibling state-shape gap: the helper payload can now be lifted from an IR state reached after evaluating an earlier sibling while the parent expression result is evaluated from the original IR state.

The statement-head lift remains blocked on constructor-specific source/compile/value facts for expression-bearing statement heads. The next dispatch should use these threaded adapters to prove concrete binary constructor cases, then consume them through `ExprInternalHelperHeadStepBridge`.

## Validation
- `lake env lean Compiler/Proofs/HelperStepProofs.lean` (passed)
- `lean-slot lake build Compiler.Proofs.HelperStepProofs` (passed; Spark offload denied for this mission path, built locally)
- `python3 scripts/generate_print_axioms.py --check` (passed)
- `python3 scripts/check_proof_length.py` (passed)
- `rg -n "\\bsorry\\b|\\badmit\\b|\\baxiom\\b" Compiler/Proofs/HelperStepProofs.lean` (no matches)
- `make check` (passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only API additions in HelperStepProofs with no runtime or compiler behavior changes; risk is limited to proof maintenance if downstream lemmas misuse the new state parameters.
> 
> **Overview**
> Adds **threaded** compositional lifting lemmas so helper-aware expression proofs can treat the parent IR evaluation as starting from the original state while the helper-bearing subexpression is checked from an **intermediate state** after an earlier sibling (e.g. left operand) has run.
> 
> Introduces `exprInternalHelperCompositionalContextResult_of_outer_facts_threaded_head` and `exprInternalHelperCompositionalContextResult_binary_right_threaded_context` as the reusable adapters for right-hand binary contexts. Also adds `evalIRExprsWithInternals_pair_of_values` and `evalIRExprWithInternals_binary_builtin_of_values` to package left-to-right argument evaluation and pure two-argument builtin IR calls for upcoming constructor-specific lemmas.
> 
> `PrintAxioms.lean` is regenerated to register the four new public theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c8a92a70423d3979a6dc6a9e0a299f43b309a88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->