### PR TITLE
proof: bridge add expression helper constructor

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -794,6 +794,39 @@ theorem exprInternalHelperCompositionalContextResult_of_outer_facts
   rcases hhead with ⟨_, _, _, hmatches, hpayload⟩
   exact ⟨hcompile, hsource, hir, hmatches, hpayload⟩
 
+/-- Variant of `exprInternalHelperCompositionalContextResult_of_outer_facts`
+where the helper-head IR expression starts from an intermediate state rather
+than the parent expression's entry state.  This is the shape needed for
+right-hand siblings: the left sibling may have already advanced IR state before
+the helper-bearing right expression is evaluated, while source expression
+evaluation still uses the same source runtime. -/
+theorem exprInternalHelperCompositionalContextResult_of_outer_facts_threaded_head
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {headExpr expr : Expr} {headExprIR exprIR : YulExpr}
+    {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {parentState headEntryState headState headFinalState finalState : IRState}
+    {headValue value : Nat}
+    (hhead :
+      ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+        headExpr headExprIR helperFuel irFuel runtime headRuntime headEntryState
+        headState headFinalState headValue)
+    (hcompile :
+      CompilationModel.compileExprWithInternals fields .calldata spec.functions expr =
+        Except.ok exprIR)
+    (hsource :
+      SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime expr =
+        some value)
+    (hir :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) parentState exprIR =
+        .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      expr exprIR helperFuel irFuel runtime headRuntime parentState headState
+      finalState value := by
+  unfold ExprInternalHelperCompositionalContextResult at hhead ⊢
+  rcases hhead with ⟨_, _, _, hmatches, hpayload⟩
+  exact ⟨hcompile, hsource, hir, hmatches, hpayload⟩
+
 /-- Unary non-call expression-context lift.  This is the common shape for
 constructors such as `bitNot`, `logicalNot`, `mload`, `tload`, `calldataload`,
 and single-child dynamic-array helpers once their outer facts are proved. -/
@@ -909,6 +942,109 @@ theorem exprInternalHelperCompositionalContextResult_binary_right_context
       (runtime := runtime) (headRuntime := headRuntime)
       (state := state) (headState := headState)
       hright hcompile hsource hir
+
+/-- Binary non-call expression-context lift when the helper payload is in the
+right child and the left sibling has already advanced the IR state.  This is the
+threaded counterpart of `exprInternalHelperCompositionalContextResult_binary_right_context`
+and is the reusable shape for source/IR expression compiler lemmas over sibling
+constructors. -/
+theorem exprInternalHelperCompositionalContextResult_binary_right_threaded_context
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {left right : Expr} {leftIR rightIR : YulExpr}
+    {mkExpr : Expr → Expr → Expr} {mkIR : YulExpr → YulExpr → YulExpr}
+    {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {parentState rightEntryState headState rightFinalState finalState : IRState}
+    {rightValue value : Nat}
+    (hright :
+      ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+        right rightIR helperFuel irFuel runtime headRuntime rightEntryState headState
+        rightFinalState rightValue)
+    (hcompile :
+      CompilationModel.compileExprWithInternals fields .calldata spec.functions
+          (mkExpr left right) =
+        Except.ok (mkIR leftIR rightIR))
+    (hsource :
+      SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime
+          (mkExpr left right) =
+        some value)
+    (hir :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) parentState
+          (mkIR leftIR rightIR) =
+        .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      (mkExpr left right) (mkIR leftIR rightIR) helperFuel irFuel runtime
+      headRuntime parentState headState finalState value := by
+  exact
+    exprInternalHelperCompositionalContextResult_of_outer_facts_threaded_head
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (headExpr := right) (headExprIR := rightIR)
+      (helperFuel := helperFuel) (irFuel := irFuel)
+      (runtime := runtime) (headRuntime := headRuntime)
+      (parentState := parentState) (headEntryState := rightEntryState)
+      (headState := headState)
+      hright hcompile hsource hir
+
+/-- Successful two-argument IR expression evaluation with explicit
+left-to-right state threading. -/
+theorem evalIRExprsWithInternals_pair_of_values
+    (runtimeContract : IRContract)
+    (fuel : Nat)
+    (state leftState finalState : IRState)
+    (leftIR rightIR : YulExpr)
+    (leftValue rightValue : Nat)
+    (hleft :
+      evalIRExprWithInternals runtimeContract fuel state leftIR =
+        .value leftValue leftState)
+    (hright :
+      evalIRExprWithInternals runtimeContract fuel leftState rightIR =
+        .value rightValue finalState) :
+    evalIRExprsWithInternals runtimeContract fuel state [leftIR, rightIR] =
+      .values [leftValue, rightValue] finalState := by
+  simp [evalIRExprsWithInternals, hleft, hright]
+
+/-- Helper-aware compiled IR evaluation for a pure two-argument Yul builtin,
+with the sibling state threading exposed by
+`evalIRExprsWithInternals_pair_of_values`.  Constructor-specific source/compile
+lemmas can use this to discharge the IR side for binary non-call expression
+contexts after proving the source value computes to the same builtin result. -/
+theorem evalIRExprWithInternals_binary_builtin_of_values
+    (runtimeContract : IRContract)
+    (fuel : Nat)
+    (state leftState finalState : IRState)
+    (func : String)
+    (leftIR rightIR : YulExpr)
+    (leftValue rightValue value : Nat)
+    (hleft :
+      evalIRExprWithInternals runtimeContract fuel state leftIR =
+        .value leftValue leftState)
+    (hright :
+      evalIRExprWithInternals runtimeContract fuel leftState rightIR =
+        .value rightValue finalState)
+    (hfind : findInternalFunction? runtimeContract func = none)
+    (hnotTload : func ≠ "tload")
+    (hnotMload : func ≠ "mload")
+    (hnotKeccak : func ≠ "keccak256")
+    (hbuiltin :
+      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext
+          finalState.storage finalState.sender finalState.msgValue finalState.thisAddress
+          finalState.blockTimestamp finalState.blockNumber finalState.chainId
+          finalState.blobBaseFee finalState.txOrigin finalState.selector
+          finalState.calldata func [leftValue, rightValue] =
+        some value) :
+    evalIRExprWithInternals runtimeContract fuel state
+        (YulExpr.call func [leftIR, rightIR]) =
+      .value value finalState := by
+  have hargs :
+      evalIRExprsWithInternals runtimeContract fuel state [leftIR, rightIR] =
+        .values [leftValue, rightValue] finalState :=
+    evalIRExprsWithInternals_pair_of_values runtimeContract fuel state leftState finalState
+      leftIR rightIR leftValue rightValue hleft hright
+  simp [evalIRExprWithInternals_call,
+    evalIRCallWithInternals_of_builtin runtimeContract fuel state func
+      [leftIR, rightIR] [leftValue, rightValue] finalState hargs hfind
+      hnotTload hnotMload hnotKeccak,
+    hbuiltin]
 
 /-- Expression-helper statement-head bridge. Future helper-summary induction
 should construct this for each statement head whose helper work appears in

--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -1046,6 +1046,124 @@ theorem evalIRExprWithInternals_binary_builtin_of_values
       hnotTload hnotMload hnotKeccak,
     hbuiltin]
 
+/-- `Nat` values coerced to `Uint256` may be normalized before or after the
+coercion when using the EVM modulus. -/
+theorem uint256_ofNat_evmModulus_mod (value : Nat) :
+    Verity.Core.Uint256.ofNat value =
+      Verity.Core.Uint256.ofNat (value % Compiler.Constants.evmModulus) := by
+  ext
+  simp [Verity.Core.Uint256.ofNat, Verity.Core.Uint256.modulus,
+    Verity.Core.UINT256_MODULUS, Compiler.Constants.evmModulus]
+
+/-- Shared source/Yul value for the `Expr.add` constructor. -/
+def exprAddValue (leftValue rightValue : Nat) : Nat :=
+  (Verity.Core.Uint256.add
+    (Verity.Core.Uint256.ofNat (leftValue % Compiler.Constants.evmModulus))
+    (Verity.Core.Uint256.ofNat (rightValue % Compiler.Constants.evmModulus))).val
+
+/-- Constructor-specific compiler shape for `Expr.add` once both children have
+already compiled. -/
+theorem compileExprWithInternals_add_of_children
+    {fields : List Field} {internalFunctions : List FunctionSpec}
+    {left right : Expr} {leftIR rightIR : YulExpr}
+    (hcompileLeft :
+      CompilationModel.compileExprWithInternals fields .calldata internalFunctions left =
+        Except.ok leftIR)
+    (hcompileRight :
+      CompilationModel.compileExprWithInternals fields .calldata internalFunctions right =
+        Except.ok rightIR) :
+    CompilationModel.compileExprWithInternals fields .calldata internalFunctions
+        (Expr.add left right) =
+      Except.ok (YulExpr.call "add" [leftIR, rightIR]) := by
+  simp only [CompilationModel.compileExprWithInternals, hcompileLeft, hcompileRight,
+    CompilationModel.yulBinOp]
+  rfl
+
+/-- Constructor-specific source semantics for `Expr.add` once both child source
+values are known. -/
+theorem evalExprWithHelpers_add_of_values
+    (spec : CompilationModel) (fields : List Field)
+    (fuel : Nat) (runtime : SourceSemantics.RuntimeState)
+    {left right : Expr} {leftValue rightValue : Nat}
+    (hsourceLeft :
+      SourceSemantics.evalExprWithHelpers spec fields fuel runtime left =
+        some leftValue)
+    (hsourceRight :
+      SourceSemantics.evalExprWithHelpers spec fields fuel runtime right =
+        some rightValue) :
+    SourceSemantics.evalExprWithHelpers spec fields fuel runtime (Expr.add left right) =
+      some (exprAddValue leftValue rightValue) := by
+  simp [SourceSemantics.evalExprWithHelpers, hsourceLeft, hsourceRight,
+    exprAddValue, Verity.Core.Uint256.add]
+  conv_lhs =>
+    rw [uint256_ofNat_evmModulus_mod leftValue,
+      uint256_ofNat_evmModulus_mod rightValue]
+
+/-- Constructor-specific builtin semantics for the compiled Yul `add` call. -/
+theorem evalBuiltinCallWithEvmYulLeanContext_add_of_values
+    (state : IRState) (leftValue rightValue : Nat) :
+    Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext
+        state.storage state.sender state.msgValue state.thisAddress
+        state.blockTimestamp state.blockNumber state.chainId state.blobBaseFee
+        state.txOrigin state.selector state.calldata "add" [leftValue, rightValue] =
+      some (exprAddValue leftValue rightValue) := by
+  simp [Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
+    exprAddValue, Verity.Core.Uint256.add, Verity.Core.Uint256.ofNat,
+    Verity.Core.Uint256.modulus, Verity.Core.UINT256_MODULUS,
+    Compiler.Constants.evmModulus, Nat.add_mod]
+
+/-- Constructor-specific right-child bridge for `Expr.add`.
+
+This is the first non-call expression constructor that discharges its own
+source, compile, and IR facts using the threaded binary API.  The left operand
+is evaluated first in IR and may advance the state; the helper-bearing right
+operand is then evaluated from that intermediate state, while source evaluation
+continues from the original runtime. -/
+theorem exprInternalHelperCompositionalContextResult_add_right_threaded
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {left right : Expr} {leftIR rightIR : YulExpr} {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {parentState rightEntryState headState rightFinalState finalState : IRState}
+    {leftValue rightValue : Nat}
+    (hright : ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      right rightIR helperFuel irFuel runtime headRuntime rightEntryState headState rightFinalState rightValue)
+    (hcompileLeft :
+      CompilationModel.compileExprWithInternals fields .calldata spec.functions left =
+        Except.ok leftIR)
+    (hsourceLeft : SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime left =
+      some leftValue)
+    (hirLeft :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) parentState leftIR =
+        .value leftValue rightEntryState)
+    (hirRight :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) rightEntryState rightIR =
+        .value rightValue finalState)
+    (hfindAdd : findInternalFunction? runtimeContract "add" = none) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields (Expr.add left right)
+      (YulExpr.call "add" [leftIR, rightIR]) helperFuel irFuel runtime headRuntime
+      parentState headState finalState (exprAddValue leftValue rightValue) := by
+  let value := exprAddValue leftValue rightValue
+  have hrightFacts := hright
+  unfold ExprInternalHelperCompositionalContextResult at hrightFacts
+  rcases hrightFacts with ⟨hcompileRight, hsourceRight, _, _, _⟩
+  let hcompile := compileExprWithInternals_add_of_children hcompileLeft hcompileRight
+  let hsource := evalExprWithHelpers_add_of_values spec fields (helperFuel + 1) runtime
+    hsourceLeft hsourceRight
+  let hbuiltin := evalBuiltinCallWithEvmYulLeanContext_add_of_values finalState leftValue rightValue
+  let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
+    parentState rightEntryState finalState "add" leftIR rightIR leftValue rightValue value
+    hirLeft hirRight hfindAdd (by decide) (by decide) (by decide) hbuiltin
+  exact
+    exprInternalHelperCompositionalContextResult_binary_right_threaded_context
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (left := left) (right := right) (leftIR := leftIR) (rightIR := rightIR)
+      (mkExpr := Expr.add) (mkIR := fun a b => YulExpr.call "add" [a, b])
+      (helperFuel := helperFuel) (irFuel := irFuel)
+      (runtime := runtime) (headRuntime := headRuntime)
+      (parentState := parentState) (rightEntryState := rightEntryState)
+      (headState := headState)
+      hright hcompile hsource hir
+
 /-- Expression-helper statement-head bridge. Future helper-summary induction
 should construct this for each statement head whose helper work appears in
 expression position. The semantic payload is the exact helper-aware source/IR

--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -765,6 +765,151 @@ theorem exprInternalHelperCompositionalContextResult_internalCall_head
         (state := state) (state' := argState) (argVals := argVals)
         (argExprs := argExprs) hsourceArgs hcompileArgs hirArgs
 
+theorem exprInternalHelperCompositionalContextResult_of_outer_facts
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {headExpr expr : Expr} {headExprIR exprIR : YulExpr}
+    {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state headState headFinalState finalState : IRState}
+    {headValue value : Nat}
+    (hhead :
+      ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+        headExpr headExprIR helperFuel irFuel runtime headRuntime state headState
+        headFinalState headValue)
+    (hcompile :
+      CompilationModel.compileExprWithInternals fields .calldata spec.functions expr =
+        Except.ok exprIR)
+    (hsource :
+      SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime expr =
+        some value)
+    (hir :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) state exprIR =
+        .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      expr exprIR helperFuel irFuel runtime headRuntime state headState finalState value := by
+  -- Blocker: a fully automatic theorem over every non-call `Expr` constructor
+  -- still needs a uniform helper-aware source/IR expression compiler lemma,
+  -- including sequential IR state threading for sibling expressions.
+  unfold ExprInternalHelperCompositionalContextResult at hhead ⊢
+  rcases hhead with ⟨_, _, _, hmatches, hpayload⟩
+  exact ⟨hcompile, hsource, hir, hmatches, hpayload⟩
+
+/-- Unary non-call expression-context lift.  This is the common shape for
+constructors such as `bitNot`, `logicalNot`, `mload`, `tload`, `calldataload`,
+and single-child dynamic-array helpers once their outer facts are proved. -/
+theorem exprInternalHelperCompositionalContextResult_unary_context
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {child : Expr} {childIR : YulExpr}
+    {mkExpr : Expr → Expr} {mkIR : YulExpr → YulExpr}
+    {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state headState childFinalState finalState : IRState}
+    {childValue value : Nat}
+    (hchild :
+      ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+        child childIR helperFuel irFuel runtime headRuntime state headState
+        childFinalState childValue)
+    (hcompile :
+      CompilationModel.compileExprWithInternals fields .calldata spec.functions
+          (mkExpr child) =
+        Except.ok (mkIR childIR))
+    (hsource :
+      SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime
+          (mkExpr child) =
+        some value)
+    (hir :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) state (mkIR childIR) =
+        .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      (mkExpr child) (mkIR childIR) helperFuel irFuel runtime headRuntime state
+      headState finalState value := by
+  exact
+    exprInternalHelperCompositionalContextResult_of_outer_facts
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (headExpr := child) (headExprIR := childIR)
+      (helperFuel := helperFuel) (irFuel := irFuel)
+      (runtime := runtime) (headRuntime := headRuntime)
+      (state := state) (headState := headState)
+      hchild hcompile hsource hir
+
+/-- Binary non-call expression-context lift when the helper payload is in the
+left child.  Sibling evaluation state threading is intentionally part of the
+outer `hir` fact supplied by the caller. -/
+theorem exprInternalHelperCompositionalContextResult_binary_left_context
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {left right : Expr} {leftIR rightIR : YulExpr}
+    {mkExpr : Expr → Expr → Expr} {mkIR : YulExpr → YulExpr → YulExpr}
+    {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state headState leftFinalState finalState : IRState}
+    {leftValue value : Nat}
+    (hleft :
+      ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+        left leftIR helperFuel irFuel runtime headRuntime state headState
+        leftFinalState leftValue)
+    (hcompile :
+      CompilationModel.compileExprWithInternals fields .calldata spec.functions
+          (mkExpr left right) =
+        Except.ok (mkIR leftIR rightIR))
+    (hsource :
+      SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime
+          (mkExpr left right) =
+        some value)
+    (hir :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) state
+          (mkIR leftIR rightIR) =
+        .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      (mkExpr left right) (mkIR leftIR rightIR) helperFuel irFuel runtime
+      headRuntime state headState finalState value := by
+  exact
+    exprInternalHelperCompositionalContextResult_of_outer_facts
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (headExpr := left) (headExprIR := leftIR)
+      (helperFuel := helperFuel) (irFuel := irFuel)
+      (runtime := runtime) (headRuntime := headRuntime)
+      (state := state) (headState := headState)
+      hleft hcompile hsource hir
+
+/-- Binary non-call expression-context lift when the helper payload is in the
+right child.  This preserves the helper head while the caller supplies the
+already-established outer facts for the whole parent expression. -/
+theorem exprInternalHelperCompositionalContextResult_binary_right_context
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {left right : Expr} {leftIR rightIR : YulExpr}
+    {mkExpr : Expr → Expr → Expr} {mkIR : YulExpr → YulExpr → YulExpr}
+    {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state headState rightFinalState finalState : IRState}
+    {rightValue value : Nat}
+    (hright :
+      ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+        right rightIR helperFuel irFuel runtime headRuntime state headState
+        rightFinalState rightValue)
+    (hcompile :
+      CompilationModel.compileExprWithInternals fields .calldata spec.functions
+          (mkExpr left right) =
+        Except.ok (mkIR leftIR rightIR))
+    (hsource :
+      SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime
+          (mkExpr left right) =
+        some value)
+    (hir :
+      evalIRExprWithInternals runtimeContract (irFuel + 1) state
+          (mkIR leftIR rightIR) =
+        .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      (mkExpr left right) (mkIR leftIR rightIR) helperFuel irFuel runtime
+      headRuntime state headState finalState value := by
+  exact
+    exprInternalHelperCompositionalContextResult_of_outer_facts
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (headExpr := right) (headExprIR := rightIR)
+      (helperFuel := helperFuel) (irFuel := irFuel)
+      (runtime := runtime) (headRuntime := headRuntime)
+      (state := state) (headState := headState)
+      hright hcompile hsource hir
+
 /-- Expression-helper statement-head bridge. Future helper-summary induction
 should construct this for each statement head whose helper work appears in
 expression position. The semantic payload is the exact helper-aware source/IR

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1790,6 +1790,10 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.evalIRExprWithInternals_call_of_dispatch
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCallContextBridge_compileExprWithInternals_internalCall
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_internalCall_head
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_of_outer_facts
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_unary_context
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_binary_left_context
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_binary_right_context
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_cons_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_of_exprHeadStepBridges
@@ -5845,4 +5849,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5475 theorems/lemmas (3773 public, 1702 private, 0 sorry'd)
+-- Total: 5479 theorems/lemmas (3777 public, 1702 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1798,6 +1798,11 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_binary_right_threaded_context
   Compiler.Proofs.HelperStepProofs.evalIRExprsWithInternals_pair_of_values
   Compiler.Proofs.HelperStepProofs.evalIRExprWithInternals_binary_builtin_of_values
+  Compiler.Proofs.HelperStepProofs.uint256_ofNat_evmModulus_mod
+  Compiler.Proofs.HelperStepProofs.compileExprWithInternals_add_of_children
+  Compiler.Proofs.HelperStepProofs.evalExprWithHelpers_add_of_values
+  Compiler.Proofs.HelperStepProofs.evalBuiltinCallWithEvmYulLeanContext_add_of_values
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_add_right_threaded
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_cons_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_of_exprHeadStepBridges
@@ -5853,4 +5858,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5483 theorems/lemmas (3781 public, 1702 private, 0 sorry'd)
+-- Total: 5488 theorems/lemmas (3786 public, 1702 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1791,9 +1791,13 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCallContextBridge_compileExprWithInternals_internalCall
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_internalCall_head
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_of_outer_facts
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_of_outer_facts_threaded_head
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_unary_context
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_binary_left_context
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_binary_right_context
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_binary_right_threaded_context
+  Compiler.Proofs.HelperStepProofs.evalIRExprsWithInternals_pair_of_values
+  Compiler.Proofs.HelperStepProofs.evalIRExprWithInternals_binary_builtin_of_values
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_cons_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_of_exprHeadStepBridges
@@ -5849,4 +5853,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5479 theorems/lemmas (3777 public, 1702 private, 0 sorry'd)
+-- Total: 5483 theorems/lemmas (3781 public, 1702 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- add constructor-specific `Expr.add` source, compile, and Yul builtin value facts for helper-aware expression proofs
- add `exprInternalHelperCompositionalContextResult_add_right_threaded`, a non-vacuous right-child bridge that uses the phase-8 threaded binary API after the left operand advances the IR state
- regenerate `PrintAxioms.lean`

References #2080.

## Base / dependency
This PR is stacked on #2102 because #2102 is still open. Base branch: `paloma/issue-2080-helper-aware-expr-compiler`.

#2102 is itself stacked on #2101, which is also still open, so this keeps the chain intact:
`main` <- #2101 (`paloma/issue-2080-expression-recursive-context`) <- #2102 (`paloma/issue-2080-helper-aware-expr-compiler`) <- this PR.

## Proof status
This slice proves one concrete non-call expression constructor non-vacuously: `Expr.add` with the helper payload in the right operand. The proof derives the parent compile fact, source value fact, and compiled Yul `add` value fact, then feeds the result through `exprInternalHelperCompositionalContextResult_binary_right_threaded_context`.

The helper payload invariants from the child expression are preserved unchanged: the same source helper `argVals`, compiled argument evaluation to the same `argVals`, helper-world evidence, helper dispatch, and source/compiled head-state relation are carried through the threaded bridge.

The full statement-head lift through `ExprInternalHelperHeadStepBridge` remains blocked on per-statement head adapters that connect expression-result assignment/statement compilation shapes to `stmtStepMatchesIRExecWithInternals`. The next dispatch should clone this constructor pattern for more binary constructors and then build an exact head bridge for one expression-bearing statement form.

## Validation
- `lake env lean Compiler/Proofs/HelperStepProofs.lean` (passed)
- `lean-slot lake build Compiler.Proofs.HelperStepProofs` (passed; Spark offload denied for this mission path, built locally)
- `python3 scripts/generate_print_axioms.py --check` (passed)
- `python3 scripts/check_proof_length.py` (passed)
- `rg -n "\\bsorry\\b|\\badmit\\b|\\baxiom\\b" Compiler/Proofs/HelperStepProofs.lean` (no matches)
- `make check` (passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in `HelperStepProofs.lean` with no runtime or compiler behavior changes; risk is limited to proof maintenance and axiom catalog accuracy.
> 
> **Overview**
> Adds the first **non-call** expression constructor proof for helper-aware compositional context: **`Expr.add`** when the helper payload sits in the **right** operand.
> 
> New lemmas wire **compile** (`YulExpr.call "add"`), **source** evaluation (`exprAddValue` via `Uint256.add` with EVM modulus), and **Yul builtin** `add` semantics, plus `uint256_ofNat_evmModulus_mod` so source and IR agree on modular normalization. **`exprInternalHelperCompositionalContextResult_add_right_threaded`** assembles those facts and discharges IR evaluation through the existing threaded binary builtin API (`evalIRExprWithInternals_binary_builtin_of_values` → `exprInternalHelperCompositionalContextResult_binary_right_threaded_context`), modeling left-then-right IR state threading while source stays on the original runtime.
> 
> **`PrintAxioms.lean`** is regenerated to export the five new public theorems (theorem count 5483 → 5488).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e168b30d900a7a98114fa1e75f0a99baa68b467d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->