### PR TITLE
proof: lift expr helper result through let head

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -1192,11 +1192,165 @@ structure ExprInternalHelperHeadStepBridge
         FunctionBody.scopeNamesPresent scope runtime.bindings →
         FunctionBody.bindingsBounded runtime.bindings →
         FunctionBody.runtimeStateMatchesIR fields runtime state →
+        sizeOf compiledIR - compiledIR.length ≤ irFuel →
         stmtStepMatchesIRExecWithInternals fields
           (stmtNextScope scope stmt)
           (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime stmt)
           (execIRStmtsWithInternals runtimeContract
             (compiledIR.length + irFuel + 1) state compiledIR)
+
+/-- `Stmt.letVar` compiler shape when the bound expression has already been
+compiled through the helper-aware expression compiler. -/
+theorem compileStmt_letVar_of_compileExprWithInternals
+    {fields : List Field}
+    {events : List EventDef}
+    {errors : List ErrorDef}
+    {scope : List String}
+    {name : String}
+    {value : Expr}
+    {valueIR : YulExpr}
+    {internalFunctions : List FunctionSpec}
+    (hcompile :
+      CompilationModel.compileExprWithInternals fields .calldata internalFunctions value =
+        Except.ok valueIR) :
+    CompilationModel.compileStmt fields events errors .calldata [] false scope []
+        (Stmt.letVar name value) internalFunctions =
+      Except.ok [YulStmt.let_ name valueIR] := by
+  simp [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork, hcompile]
+
+/-- The first concrete expression-to-statement-head adapter for #2080.
+
+The expression compositional result supplies the source value, compiled
+expression value, and the helper-call payload introduced in phases 6-9.  The
+adapter adds only the `letVar` statement wrapper.  The statement-side compile
+shape remains explicit because `CompiledStmtStepWithHelpersAndHelperIR` still
+records the legacy `compileStmt ... stmt = ok ...` form with the default empty
+internal-function list, while the expression payload records
+`compileExprWithInternals ... spec.functions ...`.  Two post-expression facts
+also remain explicit because `ExprInternalHelperCompositionalContextResult`
+currently does not record them: the final IR state must still match the source
+runtime, and the old scope bindings must still agree in that final IR state. -/
+theorem exprInternalHelperHeadStepBridge_letVar_of_exprCompositionalResult
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {name : String}
+    {value : Expr}
+    {valueIR : YulExpr}
+    (hvalueCompileStmt :
+      CompilationModel.compileExprWithInternals fields .calldata [] value =
+        Except.ok valueIR)
+    (hvalue :
+      ∀ {scope : List String}
+        {runtime : SourceSemantics.RuntimeState}
+        {state : IRState}
+        {helperFuel irFuel : Nat},
+        0 < helperFuel →
+        0 < irFuel →
+        FunctionBody.bindingsExactlyMatchIRVarsOnScope scope runtime.bindings state →
+        FunctionBody.scopeNamesPresent scope runtime.bindings →
+        FunctionBody.bindingsBounded runtime.bindings →
+        FunctionBody.runtimeStateMatchesIR fields runtime state →
+        ∃ finalState valueNat,
+          ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+            value valueIR (helperFuel - 1) (irFuel - 1) runtime runtime state state
+            finalState valueNat ∧
+          FunctionBody.runtimeStateMatchesIR fields runtime finalState ∧
+          FunctionBody.bindingsExactlyMatchIRVarsOnScope scope runtime.bindings finalState ∧
+          valueNat < Compiler.Constants.evmModulus)
+    (hvalueNamesInScope :
+      ∀ {scope : List String}
+        {runtime : SourceSemantics.RuntimeState}
+        {state : IRState}
+        {helperFuel irFuel : Nat},
+        0 < helperFuel →
+        0 < irFuel →
+        FunctionBody.bindingsExactlyMatchIRVarsOnScope scope runtime.bindings state →
+        FunctionBody.scopeNamesPresent scope runtime.bindings →
+        FunctionBody.bindingsBounded runtime.bindings →
+        FunctionBody.runtimeStateMatchesIR fields runtime state →
+        ∀ {n : String}, n ∈ collectExprNames value → n ∈ scope) :
+    ExprInternalHelperHeadStepBridge runtimeContract spec fields (Stmt.letVar name value) := by
+  refine ⟨?_, ?_⟩
+  · intro scope
+    exact ⟨[YulStmt.let_ name valueIR],
+      compileStmt_letVar_of_compileExprWithInternals
+        (events := spec.events) (errors := spec.errors) (scope := scope)
+        (name := name) hvalueCompileStmt⟩
+  · intro scope compiledIR hcompile runtime state helperFuel irFuel hfuelPos
+      hexact hscope hbounded hruntime hslack
+    have hcompiledEq : compiledIR = [YulStmt.let_ name valueIR] := by
+      have hshape :=
+        compileStmt_letVar_of_compileExprWithInternals
+          (events := spec.events) (errors := spec.errors) (scope := scope)
+          (name := name) hvalueCompileStmt
+      exact Except.ok.inj (hcompile.symm.trans hshape)
+    subst hcompiledEq
+    have hirFuelPos : 0 < irFuel := by
+      have hsize : sizeOf [YulStmt.let_ name valueIR] ≥ 2 := by
+        simp
+      simp at hslack
+      omega
+    rcases hvalue (scope := scope) (runtime := runtime) (state := state)
+        (helperFuel := helperFuel) (irFuel := irFuel) hfuelPos hirFuelPos
+        hexact hscope hbounded hruntime with
+      ⟨finalState, valueNat, hresult, hfinalRuntime, hfinalExact, hvalueLt⟩
+    have hresultFacts := hresult
+    unfold ExprInternalHelperCompositionalContextResult at hresultFacts
+    rcases hresultFacts with ⟨_hcompileExpr, hsourceValue, hirValue, _, _helperPayload⟩
+    have hhelperFuelEq : helperFuel - 1 + 1 = helperFuel := by
+      omega
+    have hirFuelEq : irFuel - 1 + 1 = irFuel := by
+      omega
+    rw [hhelperFuelEq] at hsourceValue
+    rw [hirFuelEq] at hirValue
+    let runtime' : SourceSemantics.RuntimeState :=
+      { runtime with bindings := SourceSemantics.bindValue runtime.bindings name valueNat }
+    let state' : IRState := finalState.setVar name valueNat
+    have hsourceExec :
+        SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
+            (Stmt.letVar name value) =
+          .continue runtime' := by
+      simp [SourceSemantics.execStmtWithHelpers, hsourceValue, runtime']
+    have hirExec :
+        execIRStmtsWithInternals runtimeContract
+            ([YulStmt.let_ name valueIR].length + irFuel + 1) state
+            [YulStmt.let_ name valueIR] =
+          .continue state' := by
+      have houter :
+          [YulStmt.let_ name valueIR].length + irFuel + 1 =
+            Nat.succ (Nat.succ irFuel) := by
+        simp
+        omega
+      rw [houter]
+      simp only [execIRStmtsWithInternals]
+      simp [execIRStmtWithInternals, hirValue, state']
+    have hruntime' : FunctionBody.runtimeStateMatchesIR fields runtime' state' := by
+      exact FunctionBody.runtimeStateMatchesIR_setVar_bindValue hfinalRuntime name valueNat
+    have hexactBase : FunctionBody.bindingsExactlyMatchIRVarsOnScope
+        (name :: scope) runtime'.bindings state' :=
+      FunctionBody.bindingsExactlyMatchIRVarsOnScope_setVar_bindValue hfinalExact
+    have hnextIncl : FunctionBody.scopeNamesIncluded
+        (stmtNextScope scope (Stmt.letVar name value)) (name :: scope) := by
+      intro n hn
+      simp [stmtNextScope, collectStmtNames] at hn
+      rcases hn with rfl | hn | hn
+      · simp
+      · exact List.mem_cons_of_mem _
+          (hvalueNamesInScope hfuelPos hirFuelPos hexact hscope hbounded hruntime hn)
+      · exact List.mem_cons_of_mem _ hn
+    have hexact' : FunctionBody.bindingsExactlyMatchIRVarsOnScope
+        (stmtNextScope scope (Stmt.letVar name value)) runtime'.bindings state' :=
+      FunctionBody.bindingsExactlyMatchIRVarsOnScope_of_included hexactBase hnextIncl
+    have hbounded' : FunctionBody.bindingsBounded runtime'.bindings :=
+      FunctionBody.bindingsBounded_bindValue hbounded name valueNat hvalueLt
+    have hscopeBase : FunctionBody.scopeNamesPresent (name :: scope) runtime'.bindings :=
+      FunctionBody.scopeNamesPresent_cons_bindValue hscope
+    have hscope' : FunctionBody.scopeNamesPresent
+        (stmtNextScope scope (Stmt.letVar name value)) runtime'.bindings :=
+      FunctionBody.scopeNamesPresent_of_included hscopeBase hnextIncl
+    rw [hsourceExec, hirExec]
+    exact ⟨hruntime', hexact', hbounded', hscope'⟩
 
 /-- Build a helper-aware singleton statement proof for an expression-position
 helper head from the exact expression-head bridge. -/
@@ -1241,7 +1395,8 @@ theorem compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge
         hexact
         hscope
         hbounded
-        hruntime⟩
+        hruntime
+        hslack⟩
 
 /-- Non-vacuous list witness for a statement list whose head contains
 expression-position helper work. The head proof comes from the expression-head

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1803,6 +1803,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.evalExprWithHelpers_add_of_values
   Compiler.Proofs.HelperStepProofs.evalBuiltinCallWithEvmYulLeanContext_add_of_values
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_add_right_threaded
+  Compiler.Proofs.HelperStepProofs.compileStmt_letVar_of_compileExprWithInternals
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperHeadStepBridge_letVar_of_exprCompositionalResult
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_cons_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_of_exprHeadStepBridges
@@ -5858,4 +5860,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5488 theorems/lemmas (3786 public, 1702 private, 0 sorry'd)
+-- Total: 5490 theorems/lemmas (3788 public, 1702 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -134,6 +134,12 @@ ALLOWLIST: set[str] = {
     "selectedUserBodyClosureAndMatchedFresh_of_compile_ok_supported_switchFresh",
     # --- Helper-aware result packaging bridge ---
     "interpretFunctionWithHelpers_eq_execResultToIRResultWithInternals_of_body",
+    # First concrete letVar statement-head adapter (#2080 phase 10): threads a
+    # single compositional-expression existential through source execution, IR
+    # fuel alignment, and four scope/runtime invariant re-establishment steps
+    # that all share the locally-bound post-binding runtime'/state'. Splitting
+    # would duplicate the compositional-result unpacking plumbing in each part.
+    "exprInternalHelperHeadStepBridge_letVar_of_exprCompositionalResult",
     # ERC-4337 dynamic ABI view projection: mechanical destructuring of the
     # nine-field PackedUserOperation decoder to expose its four dynamic bytes
     # member bindings. Splitting would duplicate the same option-case spine.


### PR DESCRIPTION
Continues #2080 after phase 9 / #2103.

Stacking: this PR targets `paloma/issue-2080-constructor-expr-bridge` and depends on #2103, which remains stacked on #2102 and #2101.

## What changed
- Threads the existing statement fuel slack into `ExprInternalHelperHeadStepBridge`, so concrete statement-head adapters can line up `execIRStmtsWithInternals` fuel with expression evaluation fuel.
- Adds `compileStmt_letVar_of_compileExprWithInternals` for singleton `Stmt.letVar` compilation.
- Adds `exprInternalHelperHeadStepBridge_letVar_of_exprCompositionalResult`, the first concrete adapter from an `ExprInternalHelperCompositionalContextResult` into an `ExprInternalHelperHeadStepBridge` for an expression-bearing statement head.

## Non-vacuous status
This is a concrete statement-head lift for `Stmt.letVar`: the theorem consumes the phase 6-9 compositional expression payload, preserves the helper payload existential, evaluates source and helper-aware IR for the statement head, and proves the resulting `stmtStepMatchesIRExecWithInternals` continue case.

## Remaining proof/API gaps
The adapter keeps two obligations explicit instead of faking them:
- `CompiledStmtStepWithHelpersAndHelperIR.compileOk` still records the legacy `compileStmt ... stmt` shape with the default empty internal-function list, while expression helper payloads compile with `spec.functions`; callers must currently provide the statement-side compile shape separately.
- `ExprInternalHelperCompositionalContextResult` does not yet record post-expression IR/source state preservation or old-scope binding preservation, so the `letVar` adapter requires those facts explicitly.

Recommended next dispatch: close those two API gaps by enriching the expression compositional result with final-state relation facts and aligning helper-aware statement compilation witnesses with `spec.functions`; then instantiate this `letVar` bridge with the phase-9 `Expr.add` right-helper result.

## Validation
- `lean-slot lake build Compiler.Proofs.HelperStepProofs` passed.
- `rg -n "\\bsorry\\b|\\badmit\\b|\\baxiom\\b" Compiler/Proofs/HelperStepProofs.lean` found no matches.
- `git diff --check` passed.
- `lean-slot make check` was attempted, but the offloaded workspace used by `lean-slot` is not a git repository for `git ls-files`; it passed property manifest/coverage/sync and contract structure checks before failing in `scripts/check_paths.py` with `fatal: not a git repository`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof-only changes in helper-step infrastructure; no runtime, auth, or deployment impact. Residual API mismatches (empty vs `spec.functions` compile witnesses) are documented and left for follow-up.
> 
> **Overview**
> Continues **#2080** phase 10 by wiring expression-position helper proofs up to **statement heads**, starting with **`Stmt.letVar`**.
> 
> **`ExprInternalHelperHeadStepBridge`** now requires **IR fuel slack** (`sizeOf compiledIR - compiledIR.length ≤ irFuel`) so statement-head adapters can align `execIRStmtsWithInternals` fuel with inner expression evaluation. **`compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge`** forwards that hypothesis into the bridge.
> 
> New lemmas: **`compileStmt_letVar_of_compileExprWithInternals`** (singleton `let` compile shape from a helper-aware expression compile) and **`exprInternalHelperHeadStepBridge_letVar_of_exprCompositionalResult`**, which consumes an **`ExprInternalHelperCompositionalContextResult`** (plus explicit post-expression runtime/scope facts and name-in-scope side conditions) and proves source `execStmtWithHelpers` and IR execution both **continue** with the bound value while re-establishing scope/runtime invariants.
> 
> **`PrintAxioms.lean`** and **`scripts/check_proof_length.py`** register the new theorems (allowlist entry for the long `letVar` adapter proof).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d1e6d144ca6afac7849690db86ac1c0a83220f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->