### PR TITLE
proof: add spec-functions stmt helper witness

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -1702,32 +1702,46 @@ theorem compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge
         stmt
         compiledIR := by
   rcases hbridge.compile (scope := scope) with ⟨compiledIR, hcompile⟩
-  have hcompileSpec :
-      CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope [] stmt =
-        Except.ok compiledIR := by
-    exact hcompile
   refine ⟨compiledIR, ?_⟩
-  refine { compileOk := hcompileSpec, preserves := ?_ }
+  refine { compileOk := hcompile, preserves := ?_ }
   intro runtime state helperFuel extraFuel hfuelPos hexact hscope hbounded hruntime hslack
-  exact
-    ⟨_,
-      _,
-      rfl,
-      rfl,
-      hbridge.bridge
-        (scope := scope)
-        (compiledIR := compiledIR)
-        hcompile
-        runtime
-        state
-        helperFuel
-        extraFuel
-        hfuelPos
-        hexact
-        hscope
-        hbounded
-        hruntime
-        hslack⟩
+  exact ⟨_, _, rfl, rfl,
+    hbridge.bridge (scope := scope) (compiledIR := compiledIR) hcompile
+      runtime state helperFuel extraFuel hfuelPos hexact hscope hbounded hruntime hslack⟩
+
+/-- Spec-functions-aware singleton statement proof for an expression-position
+helper head.
+
+This is the mechanical composition point for the phase-11
+`ExprInternalHelperHeadStepBridgeWithInternals`/`Stmt.letVar` adapter.  It
+records the same `spec.functions` compile shape as the expression helper
+payload, avoiding the unsound conversion to the legacy default-empty internal
+function compiler argument.  The remaining generic-list blocker is an
+internal-functions-parametric analogue of the scope/list compilation lemmas
+used by `compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIR`. -/
+theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_of_exprHeadStepBridgeWithInternals
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {stmt : Stmt}
+    (hbridge :
+      ExprInternalHelperHeadStepBridgeWithInternals runtimeContract spec fields stmt) :
+    ∃ compiledIR,
+      CompiledStmtStepWithHelpersAndHelperIRWithInternals
+        runtimeContract
+        spec
+        fields
+        scope
+        stmt
+        compiledIR := by
+  rcases hbridge.compile (scope := scope) with ⟨compiledIR, hcompile⟩
+  refine ⟨compiledIR, ?_⟩
+  refine { compileOk := hcompile, preserves := ?_ }
+  intro runtime state helperFuel extraFuel hfuelPos hexact hscope hbounded hruntime hslack
+  exact ⟨_, _, rfl, rfl,
+    hbridge.bridge (scope := scope) (compiledIR := compiledIR) hcompile
+      runtime state helperFuel extraFuel hfuelPos hexact hscope hbounded hruntime hslack⟩
 
 /-- Non-vacuous list witness for a statement list whose head contains
 expression-position helper work. The head proof comes from the expression-head

--- a/Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean
@@ -193,6 +193,44 @@ structure CompiledStmtStepWithHelpersAndHelperIR
         stmtStepMatchesIRExecWithInternals
           fields (stmtNextScope scope stmt) sourceResult irExec
 
+/-- Spec-functions-aware variant of `CompiledStmtStepWithHelpersAndHelperIR`.
+
+The existing generic list induction still reconstructs statement-list
+compilation through the default empty internal-function compiler argument.
+Expression-position internal-helper payloads, however, compile through
+`spec.functions`.  This witness records that exact compile shape while keeping
+the same helper-aware source/IR preservation contract.  It is the narrow API
+needed by helper-expression statement heads until the list-level induction gets
+the corresponding internal-functions-parametric compile/scope lemmas. -/
+structure CompiledStmtStepWithHelpersAndHelperIRWithInternals
+    (runtimeContract : IRContract)
+    (spec : CompilationModel)
+    (fields : List Field)
+    (scope : List String)
+    (stmt : Stmt)
+    (compiledIR : List YulStmt) : Prop where
+  compileOk :
+    CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
+        stmt spec.functions =
+      Except.ok compiledIR
+  preserves :
+    ∀ (runtime : SourceSemantics.RuntimeState)
+      (state : IRState)
+      (helperFuel : Nat)
+      (extraFuel : Nat),
+      0 < helperFuel →
+      FunctionBody.bindingsExactlyMatchIRVarsOnScope scope runtime.bindings state →
+      FunctionBody.scopeNamesPresent scope runtime.bindings →
+      FunctionBody.bindingsBounded runtime.bindings →
+      FunctionBody.runtimeStateMatchesIR fields runtime state →
+      sizeOf compiledIR - compiledIR.length ≤ extraFuel →
+      ∃ sourceResult irExec,
+        SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime stmt = sourceResult ∧
+        execIRStmtsWithInternals runtimeContract
+          (compiledIR.length + extraFuel + 1) state compiledIR = irExec ∧
+        stmtStepMatchesIRExecWithInternals
+          fields (stmtNextScope scope stmt) sourceResult irExec
+
 /-- Any legacy generic statement-step proof remains valid for the helper-aware
 source semantics as long as the statement itself is helper-surface closed. This
 lets the existing helper-free library discharge the unchanged cases while the

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1810,6 +1810,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.exprInternalHelperHeadStepBridgeWithInternals_letVar_of_exprPostStateResult
   Compiler.Proofs.HelperStepProofs.exprInternalHelperHeadStepBridgeWithInternals_letVar_add_right_threaded
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge
+  Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIRWithInternals_of_exprHeadStepBridgeWithInternals
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_cons_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_of_exprHeadStepBridges
   Compiler.Proofs.HelperStepProofs.allHelperInterfacesSatisfied_of_helperSurfaceClosed
@@ -5864,4 +5865,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5494 theorems/lemmas (3792 public, 1702 private, 0 sorry'd)
+-- Total: 5495 theorems/lemmas (3793 public, 1702 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

Continues #2080 after phase 11 / #2105.

This PR is stacked on #2105 and targets `paloma/issue-2080-letvar-bridge-instantiation` because #2105 is not yet merged into `main`.

Changes:
- Add `CompiledStmtStepWithHelpersAndHelperIRWithInternals`, a spec-functions-aware generic statement head witness that records `compileStmt ... stmt spec.functions` while preserving the existing helper-aware source/IR execution contract.
- Add a mechanical wrapper from `ExprInternalHelperHeadStepBridgeWithInternals` to the new witness, so the phase-11 `Stmt.letVar` spec-functions bridge can be packaged without an unsound conversion to the legacy default-empty internal-function compile shape.
- Refresh `PrintAxioms.lean` for the new public theorem.

## Status / blocker

This composes the phase-11 `ExprInternalHelperHeadStepBridgeWithInternals` shape through a generic statement-head witness, but it does not yet close the full list-level generic induction path. The remaining API blocker is an internal-functions-parametric analogue of the compile/scope/list lemmas used by `compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIR`, so statement-list compilation can be reconstructed with `spec.functions` instead of the legacy default empty internal-function argument.

No helper payload invariant is weakened: source helper args, compiled arg evaluation, helper-world evidence, helper dispatch, and source/compiled state relation stay inside the existing expression bridge payload and preservation contract.

## Validation

- `lake env lean Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean`
- `lake env lean Compiler/Proofs/HelperStepProofs.lean`
- `lean-slot lake build Compiler.Proofs.HelperStepProofs`
  - Spark offload returned HTTP 403 for this worktree path, then `lean-slot` fell back to local build.
  - Local build completed successfully.
- `rg -n "^\\s*(sorry|admit|axiom)\\b|:=\\s*by\\s+sorry\\b|by\\s+admit\\b" Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean Compiler/Proofs/HelperStepProofs.lean`
  - no matches
- `python3 scripts/lean_lint.py --only proof_length`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only API additions and a local refactor in the compiler correctness layer; no runtime or auth changes, and existing helper preservation contracts are unchanged.
> 
> **Overview**
> Introduces **`CompiledStmtStepWithHelpersAndHelperIRWithInternals`**, mirroring the existing helper-aware statement step witness but with **`compileOk`** stating `compileStmt ... stmt spec.functions` instead of the legacy empty internal-function list. That aligns statement-head compilation with expression helper payloads that already compile through **`spec.functions`**.
> 
> Adds **`compiledStmtStepWithHelpersAndHelperIRWithInternals_of_exprHeadStepBridgeWithInternals`**, which mechanically packages **`ExprInternalHelperHeadStepBridgeWithInternals`** (e.g. phase-11 **`Stmt.letVar`**) into the new witness without forcing an unsound match to the old compile shape.
> 
> **`compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge`** is tightened to use the bridge’s compile proof directly. **`PrintAxioms.lean`** lists the new public theorem.
> 
> Full list-level generic induction with **`spec.functions`** is still blocked on internal-functions-parametric compile/scope/list lemmas analogous to **`compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIR`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f6e96c2237bb19d8d3883781649f82f9f5ed595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->