### PR TITLE
proof: make scope lift helper-world parametric

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -1774,6 +1774,76 @@ theorem stmtListGenericWithHelpersAndHelperIRWithInternals_cons_of_exprHeadStepB
     ⟨compiledIR, hstep⟩
   exact .cons hstep hrest
 
+/-- Build the spec-functions expression-helper list interface from a
+`WithInternals` expression-head bridge at the current head. -/
+theorem stmtListExprInternalHelperStepInterfaceWithInternals_cons_of_exprHeadStepBridgeWithInternals
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {stmt : Stmt}
+    {rest : List Stmt}
+    (hbridge :
+      ExprInternalHelperHeadStepBridgeWithInternals runtimeContract spec fields stmt)
+    (hrest :
+      StmtListExprInternalHelperStepInterfaceWithInternals
+        runtimeContract
+        spec
+        fields
+        (stmtNextScope scope stmt)
+        rest) :
+    StmtListExprInternalHelperStepInterfaceWithInternals
+      runtimeContract
+      spec
+      fields
+      scope
+      (stmt :: rest) := by
+  rcases
+      compiledStmtStepWithHelpersAndHelperIRWithInternals_of_exprHeadStepBridgeWithInternals
+        (runtimeContract := runtimeContract)
+        (spec := spec)
+        (fields := fields)
+        (scope := scope)
+        (stmt := stmt)
+        hbridge with
+    ⟨compiledIR, hstep⟩
+  refine .cons ?_ hrest
+  intro _
+  exact ⟨compiledIR, hstep⟩
+
+/-- Assemble the spec-functions expression-helper interface from exact
+`WithInternals` bridges for each expression-helper head in the list. -/
+theorem stmtListExprInternalHelperStepInterfaceWithInternals_of_exprHeadStepBridgesWithInternals
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {stmts : List Stmt}
+    (hbridge :
+      ∀ {stmt : Stmt},
+        stmt ∈ stmts →
+        stmtTouchesExprInternalHelperSurface stmt = true →
+        ExprInternalHelperHeadStepBridgeWithInternals runtimeContract spec fields stmt) :
+    StmtListExprInternalHelperStepInterfaceWithInternals
+      runtimeContract spec fields scope stmts := by
+  induction stmts generalizing scope with
+  | nil =>
+      exact .nil
+  | cons stmt rest ih =>
+      refine .cons ?_ ?_
+      · intro hexpr
+        exact
+          compiledStmtStepWithHelpersAndHelperIRWithInternals_of_exprHeadStepBridgeWithInternals
+            (runtimeContract := runtimeContract)
+            (spec := spec)
+            (fields := fields)
+            (scope := scope)
+            (stmt := stmt)
+            (hbridge (by simp) hexpr)
+      · apply ih
+        intro stmt' hmem hexpr
+        exact hbridge (List.mem_cons_of_mem _ hmem) hexpr
+
 /-- Whole-list exact-scope assembler for statement lists whose heads all have
 spec-functions bridges.  This is intentionally a narrow scaffold: mixed
 helper-free/direct/residual list assembly still targets the legacy
@@ -1785,28 +1855,30 @@ theorem stmtListGenericWithHelpersAndHelperIRWithInternals_of_exprHeadStepBridge
     {fields : List Field}
     {scope : List String}
     {stmts : List Stmt}
+    (hsurface :
+      ∀ stmt ∈ stmts, stmtTouchesExprInternalHelperSurface stmt = true)
     (hbridge :
       ∀ {stmt : Stmt},
         stmt ∈ stmts →
         ExprInternalHelperHeadStepBridgeWithInternals runtimeContract spec fields stmt) :
     StmtListGenericWithHelpersAndHelperIRWithInternals
       runtimeContract spec fields scope stmts := by
-  induction stmts generalizing scope with
-  | nil =>
-      exact .nil
-  | cons stmt rest ih =>
-      exact
-        stmtListGenericWithHelpersAndHelperIRWithInternals_cons_of_exprHeadStepBridgeWithInternals
+  exact
+    stmtListGenericWithHelpersAndHelperIRWithInternals_of_exprInternalHelperStepInterfaceWithInternals
+      (runtimeContract := runtimeContract)
+      (spec := spec)
+      (fields := fields)
+      (scope := scope)
+      (stmts := stmts)
+      (hexpr :=
+        stmtListExprInternalHelperStepInterfaceWithInternals_of_exprHeadStepBridgesWithInternals
           (runtimeContract := runtimeContract)
           (spec := spec)
           (fields := fields)
           (scope := scope)
-          (stmt := stmt)
-          (rest := rest)
-          (hbridge (by simp))
-          (ih (scope := stmtNextScope scope stmt)
-            (fun {stmt'} hmem =>
-              hbridge (List.mem_cons_of_mem _ hmem)))
+          (stmts := stmts)
+          (fun {stmt} hmem _ => hbridge hmem))
+      (hallExpr := hsurface)
 
 /-- Non-vacuous list witness for a statement list whose head contains
 expression-position helper work. The head proof comes from the expression-head

--- a/Compiler/Proofs/IRGeneration/FunctionBody/Stmt.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody/Stmt.lean
@@ -202,6 +202,44 @@ theorem compileStmtList_cons_eq_ok
   simpa [bind, Except.bind, Pure.pure, Except.pure,
     compileStmtListWithFork_cancun_eq_compileStmtList, htail]
 
+theorem compileStmtList_cons_eq_ok_with_internals
+    (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
+    (dynamicSource : DynamicDataSource) (internalRetNames : List String)
+    (isInternal : Bool) (inScopeNames : List String)
+    (adtTypes : List AdtTypeDef) (stmt : Stmt) (rest : List Stmt)
+    (internalFunctions : List FunctionSpec)
+    (headIR tailIR : List YulStmt)
+    (hhead :
+      CompilationModel.compileStmt fields events errors dynamicSource
+        internalRetNames isInternal inScopeNames adtTypes stmt internalFunctions =
+          Except.ok headIR)
+    (htail :
+      CompilationModel.compileStmtList fields events errors dynamicSource
+        internalRetNames isInternal (collectStmtNames stmt ++ inScopeNames) adtTypes
+          rest internalFunctions =
+          Except.ok tailIR) :
+    CompilationModel.compileStmtList fields events errors dynamicSource
+      internalRetNames isInternal inScopeNames adtTypes (stmt :: rest) internalFunctions =
+        Except.ok (headIR ++ tailIR) := by
+  unfold CompilationModel.compileStmtList
+  unfold CompilationModel.compileStmtListWithFork
+  rw [show
+    CompilationModel.compileStmtWithFork fields events errors dynamicSource
+      internalRetNames isInternal inScopeNames adtTypes Verity.Core.Intrinsics.HardFork.cancun
+      stmt internalFunctions =
+    CompilationModel.compileStmt fields events errors dynamicSource
+      internalRetNames isInternal inScopeNames adtTypes stmt internalFunctions from rfl,
+    hhead]
+  simpa [bind, Except.bind, Pure.pure, Except.pure,
+    show
+      CompilationModel.compileStmtListWithFork fields events errors dynamicSource
+        internalRetNames isInternal (collectStmtNames stmt ++ inScopeNames) adtTypes
+        Verity.Core.Intrinsics.HardFork.cancun rest internalFunctions =
+      CompilationModel.compileStmtList fields events errors dynamicSource
+        internalRetNames isInternal (collectStmtNames stmt ++ inScopeNames) adtTypes
+        rest internalFunctions from rfl,
+    htail]
+
 theorem compileStmtListWithFork_nil_eq_ok
     (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
     (dynamicSource : DynamicDataSource) (internalRetNames : List String)
@@ -264,6 +302,55 @@ theorem compileStmtList_cons_ok_inv
       cases htail : CompilationModel.compileStmtList
           fields events errors .calldata [] false
             (collectStmtNames stmt ++ inScopeNames) adtTypes rest with
+      | error err =>
+          simp [compileStmtListWithFork_cancun_eq_compileStmtList, htail] at hcompile
+          cases hcompile
+      | ok tailIR =>
+          simp [compileStmtListWithFork_cancun_eq_compileStmtList, htail] at hcompile
+          injection hcompile with hbody
+          subst hbody
+          refine ⟨headIR, tailIR, ?_, ?_, rfl⟩
+          · simpa [hhead]
+          · simpa [htail]
+
+theorem compileStmtList_cons_ok_inv_with_internals
+    {fields : List Field}
+    {events : List EventDef}
+    {errors : List ErrorDef}
+    {inScopeNames : List String}
+    {adtTypes : List AdtTypeDef}
+    {stmt : Stmt}
+    {rest : List Stmt}
+    {internalFunctions : List FunctionSpec}
+    {bodyIR : List YulStmt}
+    (hcompile :
+      CompilationModel.compileStmtList
+        fields events errors .calldata [] false inScopeNames adtTypes (stmt :: rest) internalFunctions =
+          Except.ok bodyIR) :
+    ∃ headIR tailIR,
+      CompilationModel.compileStmt
+        fields events errors .calldata [] false inScopeNames adtTypes
+          stmt internalFunctions = Except.ok headIR ∧
+      CompilationModel.compileStmtList
+        fields events errors .calldata [] false (collectStmtNames stmt ++ inScopeNames)
+          adtTypes rest internalFunctions = Except.ok tailIR ∧
+      bodyIR = headIR ++ tailIR := by
+  rw [CompilationModel.compileStmtList] at hcompile
+  unfold CompilationModel.compileStmtListWithFork at hcompile
+  cases hhead : CompilationModel.compileStmt
+      fields events errors .calldata [] false inScopeNames adtTypes stmt internalFunctions with
+  | error err =>
+      rw [compileStmtWithFork_cancun_eq_compileStmt
+        fields events errors .calldata [] false inScopeNames adtTypes stmt internalFunctions,
+        hhead] at hcompile
+      cases hcompile
+  | ok headIR =>
+      rw [compileStmtWithFork_cancun_eq_compileStmt
+        fields events errors .calldata [] false inScopeNames adtTypes stmt internalFunctions,
+        hhead] at hcompile
+      cases htail : CompilationModel.compileStmtList
+          fields events errors .calldata [] false
+            (collectStmtNames stmt ++ inScopeNames) adtTypes rest internalFunctions with
       | error err =>
           simp [compileStmtListWithFork_cancun_eq_compileStmtList, htail] at hcompile
           cases hcompile
@@ -1147,19 +1234,20 @@ private theorem compileStmt_ok_any_scope_with_surface_aux
     (n : Nat)
     (fields : List Field)
     (events : List EventDef)
-    (errors : List ErrorDef) :
+    (errors : List ErrorDef)
+    (internalFunctions : List FunctionSpec) :
     (∀ (stmt : Stmt) (scope1 scope2 : List String),
       sizeOf stmt < n →
-      (∃ ir, CompilationModel.compileStmt fields events errors .calldata [] false scope1 [] stmt =
-        Except.ok ir) →
-      ∃ ir', CompilationModel.compileStmt fields events errors .calldata [] false scope2 [] stmt =
-        Except.ok ir') ∧
+      (∃ ir, CompilationModel.compileStmt fields events errors .calldata [] false scope1 []
+        stmt internalFunctions = Except.ok ir) →
+      ∃ ir', CompilationModel.compileStmt fields events errors .calldata [] false scope2 []
+        stmt internalFunctions = Except.ok ir') ∧
     (∀ (stmts : List Stmt) (scope1 scope2 : List String),
       sizeOf stmts < n →
-      (∃ ir, CompilationModel.compileStmtList fields events errors .calldata [] false scope1 [] stmts =
-        Except.ok ir) →
-      ∃ ir', CompilationModel.compileStmtList fields events errors .calldata [] false scope2 [] stmts =
-        Except.ok ir') := by
+      (∃ ir, CompilationModel.compileStmtList fields events errors .calldata [] false scope1 []
+        stmts internalFunctions = Except.ok ir) →
+      ∃ ir', CompilationModel.compileStmtList fields events errors .calldata [] false scope2 []
+        stmts internalFunctions = Except.ok ir') := by
   induction n with
   | zero => exact ⟨fun _ _ _ h => absurd h (Nat.not_lt_zero _),
                     fun _ _ _ h => absurd h (Nat.not_lt_zero _)⟩
@@ -1170,17 +1258,18 @@ private theorem compileStmt_ok_any_scope_with_surface_aux
       | ite cond thenBranch elseBranch =>
           rcases hok with ⟨ir, hir⟩
           simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork, bind, Except.bind] at hir ⊢
-          cases hcond : CompilationModel.compileExprWithInternals fields .calldata [] cond with
+          cases hcond :
+              CompilationModel.compileExprWithInternals fields .calldata internalFunctions cond with
           | error e => simp [hcond] at hir
           | ok condIR =>
             simp only [hcond] at hir ⊢
             cases hthen1 : CompilationModel.compileStmtList
-                fields events errors .calldata [] false scope1 [] thenBranch with
+                fields events errors .calldata [] false scope1 [] thenBranch internalFunctions with
             | error e => simp [compileStmtListWithFork_cancun_eq_compileStmtList, hthen1] at hir
             | ok thenIR1 =>
               simp [compileStmtListWithFork_cancun_eq_compileStmtList, hthen1] at hir
               cases helse1 : CompilationModel.compileStmtList
-                  fields events errors .calldata [] false scope1 [] elseBranch with
+                  fields events errors .calldata [] false scope1 [] elseBranch internalFunctions with
               | error e => simp [compileStmtListWithFork_cancun_eq_compileStmtList, helse1] at hir
               | ok elseIR1 =>
                 rcases ih.2 thenBranch scope1 scope2
@@ -1194,13 +1283,15 @@ private theorem compileStmt_ok_any_scope_with_surface_aux
       | forEach varName count body =>
           rcases hok with ⟨ir, hir⟩
           simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork, bind, Except.bind] at hir ⊢
-          cases hcount : CompilationModel.compileExprWithInternals fields .calldata [] count with
+          cases hcount :
+              CompilationModel.compileExprWithInternals fields .calldata internalFunctions count with
           | error e => simp [hcount] at hir
           | ok countIR =>
             simp only [hcount] at hir ⊢
             cases hbody1 : CompilationModel.compileStmtList
                 fields events errors .calldata [] false
-                (CompilationModel.forEachBodyScope scope1 varName count body) [] body with
+                (CompilationModel.forEachBodyScope scope1 varName count body) [] body
+                internalFunctions with
             | error e => simp [compileStmtListWithFork_cancun_eq_compileStmtList, hbody1] at hir
             | ok bodyIR1 =>
               rcases ih.2 body (CompilationModel.forEachBodyScope scope1 varName count body)
@@ -1213,13 +1304,15 @@ private theorem compileStmt_ok_any_scope_with_surface_aux
           rcases hok with ⟨ir, hir⟩
           simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
             bind, Except.bind] at hir ⊢
-          cases hbitmap : CompilationModel.compileExprWithInternals fields .calldata [] bitmap with
+          cases hbitmap :
+              CompilationModel.compileExprWithInternals fields .calldata internalFunctions bitmap with
           | error e => simp [hbitmap] at hir
           | ok bitmapIR =>
             simp only [hbitmap] at hir ⊢
             cases hbody1 : CompilationModel.compileStmtList
                 fields events errors .calldata [] false
-                (CompilationModel.forEachSetBitFallbackBodyScope scope1 varName bitmap body) [] body with
+                (CompilationModel.forEachSetBitFallbackBodyScope scope1 varName bitmap body) [] body
+                internalFunctions with
             | error e => simp [compileStmtListWithFork_cancun_eq_compileStmtList, hbody1] at hir
             | ok bodyIR1 =>
               rcases ih.2 body
@@ -1257,16 +1350,18 @@ private theorem compileStmt_ok_any_scope_with_surface_aux
               Pure.pure, Except.pure]⟩
         | cons s ss =>
             rcases hok with ⟨ir, hir⟩
-            rcases compileStmtList_cons_ok_inv (fields := fields) (events := events)
+            rcases compileStmtList_cons_ok_inv_with_internals
+                (fields := fields) (events := events)
                 (errors := errors) (inScopeNames := scope1) (adtTypes := [])
-                (stmt := s) (rest := ss) hir with
+                (stmt := s) (rest := ss) (internalFunctions := internalFunctions) hir with
               ⟨headIR1, tailIR1, hs1, hss1, _⟩
             rcases ih.1 s scope1 scope2 (by simp [List.cons.sizeOf_spec] at hlt; omega)
                 ⟨headIR1, hs1⟩ with ⟨headIR2, hs2⟩
             rcases ih.2 ss (collectStmtNames s ++ scope1) (collectStmtNames s ++ scope2)
                 (by simp [List.cons.sizeOf_spec] at hlt; omega) ⟨tailIR1, hss1⟩
               with ⟨tailIR2, hss2⟩
-            exact ⟨_, compileStmtList_cons_eq_ok _ _ _ _ _ _ _ _ _ _ _ _ hs2 hss2⟩
+            exact ⟨_, compileStmtList_cons_eq_ok_with_internals
+              _ _ _ _ _ _ _ _ _ _ internalFunctions _ _ hs2 hss2⟩
 
 theorem compileStmt_ok_any_scope_with_surface
     {fields : List Field}
@@ -1278,7 +1373,24 @@ theorem compileStmt_ok_any_scope_with_surface
       fields events errors .calldata [] false scope1 [] stmt = Except.ok ir) :
     ∃ ir', CompilationModel.compileStmt
       fields events errors .calldata [] false scope2 [] stmt = Except.ok ir' :=
-  (compileStmt_ok_any_scope_with_surface_aux (sizeOf stmt + 1) fields events errors).1
+  (compileStmt_ok_any_scope_with_surface_aux (sizeOf stmt + 1) fields events errors []).1
+    stmt scope1 scope2 (Nat.lt_succ_of_le (Nat.le_refl _)) hok
+
+theorem compileStmt_ok_any_scope_with_surface_with_internals
+    {fields : List Field}
+    {events : List EventDef}
+    {errors : List ErrorDef}
+    {internalFunctions : List FunctionSpec}
+    {scope1 scope2 : List String}
+    {stmt : Stmt}
+    (hok : ∃ ir, CompilationModel.compileStmt
+      fields events errors .calldata [] false scope1 [] stmt internalFunctions =
+        Except.ok ir) :
+    ∃ ir', CompilationModel.compileStmt
+      fields events errors .calldata [] false scope2 [] stmt internalFunctions =
+        Except.ok ir' :=
+  (compileStmt_ok_any_scope_with_surface_aux
+    (sizeOf stmt + 1) fields events errors internalFunctions).1
     stmt scope1 scope2 (Nat.lt_succ_of_le (Nat.le_refl _)) hok
 
 theorem compileStmtList_ok_any_scope_with_surface
@@ -1291,7 +1403,24 @@ theorem compileStmtList_ok_any_scope_with_surface
       fields events errors .calldata [] false scope1 [] stmts = Except.ok ir) :
     ∃ ir', CompilationModel.compileStmtList
       fields events errors .calldata [] false scope2 [] stmts = Except.ok ir' :=
-  (compileStmt_ok_any_scope_with_surface_aux (sizeOf stmts + 1) fields events errors).2
+  (compileStmt_ok_any_scope_with_surface_aux (sizeOf stmts + 1) fields events errors []).2
+    stmts scope1 scope2 (Nat.lt_succ_of_le (Nat.le_refl _)) hok
+
+theorem compileStmtList_ok_any_scope_with_surface_with_internals
+    {fields : List Field}
+    {events : List EventDef}
+    {errors : List ErrorDef}
+    {internalFunctions : List FunctionSpec}
+    {scope1 scope2 : List String}
+    {stmts : List Stmt}
+    (hok : ∃ ir, CompilationModel.compileStmtList
+      fields events errors .calldata [] false scope1 [] stmts internalFunctions =
+        Except.ok ir) :
+    ∃ ir', CompilationModel.compileStmtList
+      fields events errors .calldata [] false scope2 [] stmts internalFunctions =
+        Except.ok ir' :=
+  (compileStmt_ok_any_scope_with_surface_aux
+    (sizeOf stmts + 1) fields events errors internalFunctions).2
     stmts scope1 scope2 (Nat.lt_succ_of_le (Nat.le_refl _)) hok
 
 theorem compileStmtList_ok_any_scope

--- a/Compiler/Proofs/IRGeneration/GenericInduction/InterfaceAssembly.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/InterfaceAssembly.lean
@@ -859,6 +859,38 @@ theorem
                     (fun s hmem => hheads s (List.mem_cons_of_mem stmt hmem))
                     htailDisjoint)
 
+/-- Spec-functions-aware expression-helper list bridge. Expression-helper heads
+supplied by the `WithInternals` interface assemble directly into the
+`StmtListGenericWithHelpersAndHelperIRWithInternals` seam, avoiding the legacy
+default-empty `compileStmt` witness used by `StmtListExprInternalHelperStepInterface`.
+
+This theorem is intentionally narrow: every head in the list must be an
+expression-position helper head. Mixed helper-free/direct/structural lists still
+need their own `WithInternals` interfaces before the legacy assembly path can be
+removed. -/
+theorem
+    stmtListGenericWithHelpersAndHelperIRWithInternals_of_exprInternalHelperStepInterfaceWithInternals
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {stmts : List Stmt}
+    (hexpr :
+      StmtListExprInternalHelperStepInterfaceWithInternals
+        runtimeContract spec fields scope stmts)
+    (hallExpr :
+      ∀ stmt ∈ stmts, stmtTouchesExprInternalHelperSurface stmt = true) :
+    StmtListGenericWithHelpersAndHelperIRWithInternals
+      runtimeContract spec fields scope stmts := by
+  induction hexpr with
+  | nil =>
+      exact .nil
+  | @cons scope stmt rest hhead htail ih =>
+      rcases hhead (hallExpr stmt List.mem_cons_self) with ⟨compiledIR, hcompiled⟩
+      exact .cons hcompiled
+        (ih (fun stmt' hmem =>
+          hallExpr stmt' (List.mem_cons_of_mem stmt hmem)))
+
 /-- Exact helper-aware list bridge with the helper-positive work split cleanly:
 genuine internal-helper heads are supplied through a narrow helper-specific
 interface, while residual coarse helper-surface heads are tracked separately so

--- a/Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean
@@ -693,6 +693,27 @@ inductive StmtListExprInternalHelperStepInterface
         runtimeContract spec fields (stmtNextScope scope stmt) rest →
       StmtListExprInternalHelperStepInterface runtimeContract spec fields scope (stmt :: rest)
 
+/-- Spec-functions-aware exact step interface for expression-position internal
+helper heads. This mirrors `StmtListExprInternalHelperStepInterface`, but the
+head proof records `compileStmt ... spec.functions`, so consumers can assemble
+the `WithInternals` list seam without passing through the legacy default-empty
+compile shape. -/
+inductive StmtListExprInternalHelperStepInterfaceWithInternals
+    (runtimeContract : IRContract)
+    (spec : CompilationModel)
+    (fields : List Field) : List String → List Stmt → Prop where
+  | nil {scope : List String} :
+      StmtListExprInternalHelperStepInterfaceWithInternals runtimeContract spec fields scope []
+  | cons {scope : List String} {stmt : Stmt} {rest : List Stmt} :
+      (stmtTouchesExprInternalHelperSurface stmt = true →
+        ∃ compiledIR,
+          CompiledStmtStepWithHelpersAndHelperIRWithInternals
+            runtimeContract spec fields scope stmt compiledIR) →
+      StmtListExprInternalHelperStepInterfaceWithInternals
+        runtimeContract spec fields (stmtNextScope scope stmt) rest →
+      StmtListExprInternalHelperStepInterfaceWithInternals
+        runtimeContract spec fields scope (stmt :: rest)
+
 /-- Exact step interface for structural heads whose helper burden is recursive
 transport through nested bodies (`ite` / `forEach`) rather than direct helper
 summary consumption at the head itself. -/

--- a/Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean
@@ -460,16 +460,7 @@ inductive StmtListGenericWithHelpersAndHelperIRWithInternals
         runtimeContract spec fields scope (stmt :: rest)
 
 /-- Exact-scope compile reconstruction for the spec-functions-aware helper IR
-list seam.
-
-This is intentionally weaker than
-`compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIR`: it does not try
-to retarget compilation to a larger `inScopeNames`.  The current scope-lifting
-lemma in `FunctionBody` is hardcoded to the default empty internal-function
-world, so arbitrary-scope reconstruction for `spec.functions` still needs a
-new `internalFunctions`-parametric
-`compileStmt_ok_any_scope_with_surface`/`compileStmtList_ok_any_scope_with_surface`
-API. -/
+list seam. -/
 theorem compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIRWithInternals_exact
     {runtimeContract : IRContract}
     {spec : CompilationModel}
@@ -494,6 +485,52 @@ theorem compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIRWithInternals
         compileStmtList_cons_eq_ok_with_internals
           fields spec.events spec.errors .calldata [] false scope [] stmt rest
           spec.functions compiledIR tailIR hstep.compileOk htail⟩
+
+/-- Scope-lifted compile reconstruction for the spec-functions-aware helper IR
+list seam.
+
+This is the `spec.functions` counterpart of
+`compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIR`: each exact head
+compile is first retargeted to the caller-provided scope with the
+internal-functions-parametric scope theorem, then the list is reconstructed
+under that same helper world. -/
+theorem compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIRWithInternals
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope inScopeNames : List String}
+    {stmts : List Stmt}
+    (hgeneric :
+      StmtListGenericWithHelpersAndHelperIRWithInternals
+        runtimeContract spec fields scope stmts)
+    (hincluded : FunctionBody.scopeNamesIncluded scope inScopeNames) :
+    ∃ bodyIR,
+      CompilationModel.compileStmtList
+        fields spec.events spec.errors .calldata [] false inScopeNames [] stmts spec.functions =
+          Except.ok bodyIR := by
+  induction hgeneric generalizing inScopeNames with
+  | nil =>
+      exact ⟨[], by
+        simp [CompilationModel.compileStmtList, CompilationModel.compileStmtListWithFork,
+          Pure.pure, Except.pure]⟩
+  | cons hstep _hrest ih =>
+      rcases FunctionBody.compileStmt_ok_any_scope_with_surface_with_internals
+          (scope2 := inScopeNames)
+          (internalFunctions := spec.functions)
+          ⟨_, hstep.compileOk⟩ with
+        ⟨headIR, hhead⟩
+      rcases ih (inScopeNames := collectStmtNames _ ++ inScopeNames)
+          (by
+            intro name hmem
+            simp [stmtNextScope] at hmem
+            rcases hmem with h | h
+            · exact List.mem_append_left _ h
+            · exact List.mem_append_right _ (hincluded name h))
+        with ⟨tailIR, htail⟩
+      exact ⟨headIR ++ tailIR,
+        compileStmtList_cons_eq_ok_with_internals
+          fields spec.events spec.errors .calldata [] false inScopeNames [] _ _
+          spec.functions headIR tailIR hhead htail⟩
 
 /-- Compiled-side compatibility witness for lifting existing helper-free generic
 statement proofs into the exact helper-aware compiled induction seam. This

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2334,9 +2334,11 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.FunctionBody.compileStmtListWithFork_cancun_eq_compileStmtList
   Compiler.Proofs.IRGeneration.FunctionBody.compileStmtList_nil_eq_ok
   Compiler.Proofs.IRGeneration.FunctionBody.compileStmtList_cons_eq_ok
+  Compiler.Proofs.IRGeneration.FunctionBody.compileStmtList_cons_eq_ok_with_internals
   Compiler.Proofs.IRGeneration.FunctionBody.compileStmtListWithFork_nil_eq_ok
   Compiler.Proofs.IRGeneration.FunctionBody.compileStmtListWithFork_cons_eq_ok
   Compiler.Proofs.IRGeneration.FunctionBody.compileStmtList_cons_ok_inv
+  Compiler.Proofs.IRGeneration.FunctionBody.compileStmtList_cons_ok_inv_with_internals
   Compiler.Proofs.IRGeneration.FunctionBody.runtimeStateMatchesIR_setBothMemory
   Compiler.Proofs.IRGeneration.FunctionBody.runtimeStateMatchesIR_updateMemoryEvents
   Compiler.Proofs.IRGeneration.FunctionBody.runtimeStateMatchesIR_setTransientStorage
@@ -2372,7 +2374,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.FunctionBody.compileStmt_ok_any_scope
   -- Compiler.Proofs.IRGeneration.FunctionBody.compileStmt_ok_any_scope_with_surface_aux  -- private
   Compiler.Proofs.IRGeneration.FunctionBody.compileStmt_ok_any_scope_with_surface
+  Compiler.Proofs.IRGeneration.FunctionBody.compileStmt_ok_any_scope_with_surface_with_internals
   Compiler.Proofs.IRGeneration.FunctionBody.compileStmtList_ok_any_scope_with_surface
+  Compiler.Proofs.IRGeneration.FunctionBody.compileStmtList_ok_any_scope_with_surface_with_internals
   Compiler.Proofs.IRGeneration.FunctionBody.compileStmtList_ok_any_scope
   Compiler.Proofs.IRGeneration.FunctionBody.compileStmtList_cons_ok_of_compileStmt_ok_with_surface
   Compiler.Proofs.IRGeneration.FunctionBody.compileStmtList_cons_ok_of_compileStmt_ok
@@ -2865,6 +2869,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.compileStmtList_ok_of_stmtListGenericCore_early
   Compiler.Proofs.IRGeneration.compileStmtList_cons_eq_ok_with_internals
   Compiler.Proofs.IRGeneration.compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIRWithInternals_exact
+  Compiler.Proofs.IRGeneration.compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIRWithInternals
 
   -- Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
   Compiler.Proofs.IRGeneration.exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false
@@ -5869,4 +5874,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5499 theorems/lemmas (3797 public, 1702 private, 0 sorry'd)
+-- Total: 5504 theorems/lemmas (3802 public, 1702 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1812,6 +1812,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIRWithInternals_of_exprHeadStepBridgeWithInternals
   Compiler.Proofs.HelperStepProofs.stmtListGenericWithHelpersAndHelperIRWithInternals_cons_of_exprHeadStepBridgeWithInternals
+  Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterfaceWithInternals_cons_of_exprHeadStepBridgeWithInternals
+  Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterfaceWithInternals_of_exprHeadStepBridgesWithInternals
   Compiler.Proofs.HelperStepProofs.stmtListGenericWithHelpersAndHelperIRWithInternals_of_exprHeadStepBridges
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_cons_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_of_exprHeadStepBridges
@@ -5874,4 +5876,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5504 theorems/lemmas (3802 public, 1702 private, 0 sorry'd)
+-- Total: 5506 theorems/lemmas (3804 public, 1702 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

Continues #2080 after phase 13 / #2107.

This PR is stacked on #2107 and targets `paloma/issue-2080-spec-functions-stmt-list`. It should be reviewed/merged after the existing #2102 -> #2107 chain lands.

- make the `FunctionBody.compileStmt_ok_any_scope_with_surface` induction parametric over `internalFunctions`
- add public `*_with_internals` wrappers for statement and statement-list scope lifting
- add `compileStmtList` cons reconstruction/inversion helpers under an arbitrary internal helper world
- compose the new parametric scope lift with the phase-13 exact statement-list seam, producing `compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIRWithInternals`
- regenerate `PrintAxioms.lean`

## Proof status

The internal-functions-parametric any-scope path now works for the `StmtListGenericWithHelpersAndHelperIRWithInternals` seam: exact `spec.functions` head compiles can be retargeted to the caller-provided scope and reconstructed as a compiled statement list under the same `spec.functions` world.

This does not close every legacy/default-empty consumer yet. The next dispatch should retarget remaining consumers of `StmtListGenericWithHelpersAndHelperIR` / helper-free compiled compatibility in `InterfaceAssembly` and adjacent call sites to the `WithInternals` witness where expression helper payloads enter, then continue removing default-empty seams that still rely on helper-free compatibility or `runtimeContract.internalFunctions = []`-style assumptions.

## Validation

- `lake env lean Compiler/Proofs/IRGeneration/FunctionBody/Stmt.lean && lake env lean Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean` passed
- `lean-slot lake build Compiler.Proofs.IRGeneration.FunctionBody.Stmt` passed; Spark offload attempted and fell back locally after HTTP 403 (`host_dir does not belong to this mission or an ancestor`)
- `lean-slot lake build Compiler.Proofs.IRGeneration.GenericInduction.ResultRelation` passed with the same Spark 403 fallback
- `lean-slot lake build Compiler.Proofs.HelperStepProofs` passed with the same Spark 403 fallback
- `lean-slot lake build Compiler.Proofs.IRGeneration.FunctionBody.Stmt Compiler.Proofs.IRGeneration.GenericInduction.ResultRelation Compiler.Proofs.HelperStepProofs` passed with the same Spark 403 fallback
- `python3 scripts/lean_lint.py --only lean_hygiene` passed: 0 debug commands in proofs, 0 allowUnsafeReducibility, 0 sorry, 0 native_decide in proofs
- `python3 scripts/lean_lint.py --only proof_length` passed
- `python3 scripts/generate_print_axioms.py --check` passed
- `lean-slot lake build PrintAxioms` passed with the same Spark 403 fallback
- `lake env lean PrintAxioms.lean > axiom-report-raw.log 2>&1` passed
- `make check` passed fully: `Ran 607 tests in 308.106s`, `OK`, `All checks passed.`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are confined to Lean proof infrastructure around compilation and helper-aware IR seams; mistakes could weaken verified compile/scope claims but do not touch runtime execution paths directly.
> 
> **Overview**
> Makes **statement compilation proofs** respect an arbitrary internal-helper world (`spec.functions`) instead of assuming an empty helper table, and wires that through the **WithInternals** statement-list seam.
> 
> **FunctionBody** now threads `internalFunctions` through the `compileStmt_ok_any_scope_with_surface` induction (including `compileExprWithInternals` and list compilation). It adds `*_with_internals` scope-lift lemmas for single statements and lists, plus `compileStmtList` cons **reconstruction** and **inversion** under that same helper world. Existing entry points still call the aux lemma with `[]`.
> 
> **ResultRelation** introduces `StmtListExprInternalHelperStepInterfaceWithInternals` and **`compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIRWithInternals`**, which lifts exact-scope generic witnesses to a caller `inScopeNames` by retargeting each head compile via the new scope API and rebuilding the list with `spec.functions`.
> 
> **InterfaceAssembly** adds assembly from the WithInternals expression-helper list interface into `StmtListGenericWithHelpersAndHelperIRWithInternals`. **HelperStepProofs** adds matching cons/whole-list builders for expression-helper bridges and refactors `stmtListGenericWithHelpersAndHelperIRWithInternals_of_exprHeadStepBridges` to route through that path (with an explicit “all heads are expression-helper surface” hypothesis). **PrintAxioms** is regenerated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a29959d951d4b84e11be66ff3f468a53de5f3086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->