### PR TITLE
proof: route expr helper lists through WithInternals assembly

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -1774,6 +1774,76 @@ theorem stmtListGenericWithHelpersAndHelperIRWithInternals_cons_of_exprHeadStepB
     ⟨compiledIR, hstep⟩
   exact .cons hstep hrest
 
+/-- Build the spec-functions expression-helper list interface from a
+`WithInternals` expression-head bridge at the current head. -/
+theorem stmtListExprInternalHelperStepInterfaceWithInternals_cons_of_exprHeadStepBridgeWithInternals
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {stmt : Stmt}
+    {rest : List Stmt}
+    (hbridge :
+      ExprInternalHelperHeadStepBridgeWithInternals runtimeContract spec fields stmt)
+    (hrest :
+      StmtListExprInternalHelperStepInterfaceWithInternals
+        runtimeContract
+        spec
+        fields
+        (stmtNextScope scope stmt)
+        rest) :
+    StmtListExprInternalHelperStepInterfaceWithInternals
+      runtimeContract
+      spec
+      fields
+      scope
+      (stmt :: rest) := by
+  rcases
+      compiledStmtStepWithHelpersAndHelperIRWithInternals_of_exprHeadStepBridgeWithInternals
+        (runtimeContract := runtimeContract)
+        (spec := spec)
+        (fields := fields)
+        (scope := scope)
+        (stmt := stmt)
+        hbridge with
+    ⟨compiledIR, hstep⟩
+  refine .cons ?_ hrest
+  intro _
+  exact ⟨compiledIR, hstep⟩
+
+/-- Assemble the spec-functions expression-helper interface from exact
+`WithInternals` bridges for each expression-helper head in the list. -/
+theorem stmtListExprInternalHelperStepInterfaceWithInternals_of_exprHeadStepBridgesWithInternals
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {stmts : List Stmt}
+    (hbridge :
+      ∀ {stmt : Stmt},
+        stmt ∈ stmts →
+        stmtTouchesExprInternalHelperSurface stmt = true →
+        ExprInternalHelperHeadStepBridgeWithInternals runtimeContract spec fields stmt) :
+    StmtListExprInternalHelperStepInterfaceWithInternals
+      runtimeContract spec fields scope stmts := by
+  induction stmts generalizing scope with
+  | nil =>
+      exact .nil
+  | cons stmt rest ih =>
+      refine .cons ?_ ?_
+      · intro hexpr
+        exact
+          compiledStmtStepWithHelpersAndHelperIRWithInternals_of_exprHeadStepBridgeWithInternals
+            (runtimeContract := runtimeContract)
+            (spec := spec)
+            (fields := fields)
+            (scope := scope)
+            (stmt := stmt)
+            (hbridge (by simp) hexpr)
+      · apply ih
+        intro stmt' hmem hexpr
+        exact hbridge (List.mem_cons_of_mem _ hmem) hexpr
+
 /-- Whole-list exact-scope assembler for statement lists whose heads all have
 spec-functions bridges.  This is intentionally a narrow scaffold: mixed
 helper-free/direct/residual list assembly still targets the legacy
@@ -1785,28 +1855,30 @@ theorem stmtListGenericWithHelpersAndHelperIRWithInternals_of_exprHeadStepBridge
     {fields : List Field}
     {scope : List String}
     {stmts : List Stmt}
+    (hsurface :
+      ∀ stmt ∈ stmts, stmtTouchesExprInternalHelperSurface stmt = true)
     (hbridge :
       ∀ {stmt : Stmt},
         stmt ∈ stmts →
         ExprInternalHelperHeadStepBridgeWithInternals runtimeContract spec fields stmt) :
     StmtListGenericWithHelpersAndHelperIRWithInternals
       runtimeContract spec fields scope stmts := by
-  induction stmts generalizing scope with
-  | nil =>
-      exact .nil
-  | cons stmt rest ih =>
-      exact
-        stmtListGenericWithHelpersAndHelperIRWithInternals_cons_of_exprHeadStepBridgeWithInternals
+  exact
+    stmtListGenericWithHelpersAndHelperIRWithInternals_of_exprInternalHelperStepInterfaceWithInternals
+      (runtimeContract := runtimeContract)
+      (spec := spec)
+      (fields := fields)
+      (scope := scope)
+      (stmts := stmts)
+      (hexpr :=
+        stmtListExprInternalHelperStepInterfaceWithInternals_of_exprHeadStepBridgesWithInternals
           (runtimeContract := runtimeContract)
           (spec := spec)
           (fields := fields)
           (scope := scope)
-          (stmt := stmt)
-          (rest := rest)
-          (hbridge (by simp))
-          (ih (scope := stmtNextScope scope stmt)
-            (fun {stmt'} hmem =>
-              hbridge (List.mem_cons_of_mem _ hmem)))
+          (stmts := stmts)
+          (fun {stmt} hmem _ => hbridge hmem))
+      (hallExpr := hsurface)
 
 /-- Non-vacuous list witness for a statement list whose head contains
 expression-position helper work. The head proof comes from the expression-head

--- a/Compiler/Proofs/IRGeneration/GenericInduction/InterfaceAssembly.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/InterfaceAssembly.lean
@@ -859,6 +859,38 @@ theorem
                     (fun s hmem => hheads s (List.mem_cons_of_mem stmt hmem))
                     htailDisjoint)
 
+/-- Spec-functions-aware expression-helper list bridge. Expression-helper heads
+supplied by the `WithInternals` interface assemble directly into the
+`StmtListGenericWithHelpersAndHelperIRWithInternals` seam, avoiding the legacy
+default-empty `compileStmt` witness used by `StmtListExprInternalHelperStepInterface`.
+
+This theorem is intentionally narrow: every head in the list must be an
+expression-position helper head. Mixed helper-free/direct/structural lists still
+need their own `WithInternals` interfaces before the legacy assembly path can be
+removed. -/
+theorem
+    stmtListGenericWithHelpersAndHelperIRWithInternals_of_exprInternalHelperStepInterfaceWithInternals
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {stmts : List Stmt}
+    (hexpr :
+      StmtListExprInternalHelperStepInterfaceWithInternals
+        runtimeContract spec fields scope stmts)
+    (hallExpr :
+      ∀ stmt ∈ stmts, stmtTouchesExprInternalHelperSurface stmt = true) :
+    StmtListGenericWithHelpersAndHelperIRWithInternals
+      runtimeContract spec fields scope stmts := by
+  induction hexpr with
+  | nil =>
+      exact .nil
+  | @cons scope stmt rest hhead htail ih =>
+      rcases hhead (hallExpr stmt List.mem_cons_self) with ⟨compiledIR, hcompiled⟩
+      exact .cons hcompiled
+        (ih (fun stmt' hmem =>
+          hallExpr stmt' (List.mem_cons_of_mem stmt hmem)))
+
 /-- Exact helper-aware list bridge with the helper-positive work split cleanly:
 genuine internal-helper heads are supplied through a narrow helper-specific
 interface, while residual coarse helper-surface heads are tracked separately so

--- a/Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean
@@ -693,6 +693,27 @@ inductive StmtListExprInternalHelperStepInterface
         runtimeContract spec fields (stmtNextScope scope stmt) rest →
       StmtListExprInternalHelperStepInterface runtimeContract spec fields scope (stmt :: rest)
 
+/-- Spec-functions-aware exact step interface for expression-position internal
+helper heads. This mirrors `StmtListExprInternalHelperStepInterface`, but the
+head proof records `compileStmt ... spec.functions`, so consumers can assemble
+the `WithInternals` list seam without passing through the legacy default-empty
+compile shape. -/
+inductive StmtListExprInternalHelperStepInterfaceWithInternals
+    (runtimeContract : IRContract)
+    (spec : CompilationModel)
+    (fields : List Field) : List String → List Stmt → Prop where
+  | nil {scope : List String} :
+      StmtListExprInternalHelperStepInterfaceWithInternals runtimeContract spec fields scope []
+  | cons {scope : List String} {stmt : Stmt} {rest : List Stmt} :
+      (stmtTouchesExprInternalHelperSurface stmt = true →
+        ∃ compiledIR,
+          CompiledStmtStepWithHelpersAndHelperIRWithInternals
+            runtimeContract spec fields scope stmt compiledIR) →
+      StmtListExprInternalHelperStepInterfaceWithInternals
+        runtimeContract spec fields (stmtNextScope scope stmt) rest →
+      StmtListExprInternalHelperStepInterfaceWithInternals
+        runtimeContract spec fields scope (stmt :: rest)
+
 /-- Exact step interface for structural heads whose helper burden is recursive
 transport through nested bodies (`ite` / `forEach`) rather than direct helper
 summary consumption at the head itself. -/

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1812,6 +1812,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIR_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIRWithInternals_of_exprHeadStepBridgeWithInternals
   Compiler.Proofs.HelperStepProofs.stmtListGenericWithHelpersAndHelperIRWithInternals_cons_of_exprHeadStepBridgeWithInternals
+  Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterfaceWithInternals_cons_of_exprHeadStepBridgeWithInternals
+  Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterfaceWithInternals_of_exprHeadStepBridgesWithInternals
   Compiler.Proofs.HelperStepProofs.stmtListGenericWithHelpersAndHelperIRWithInternals_of_exprHeadStepBridges
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_cons_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_of_exprHeadStepBridges
@@ -5874,4 +5876,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5504 theorems/lemmas (3802 public, 1702 private, 0 sorry'd)
+-- Total: 5506 theorems/lemmas (3804 public, 1702 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

Refs #2080.

Stacked on #2108 (`paloma/issue-2080-parametric-scope-lift`). Do not merge until predecessor stack is merged/green.

This phase-15 slice retargets the expression-helper list assembly path toward the `WithInternals` witness seam:

- adds `StmtListExprInternalHelperStepInterfaceWithInternals`, whose heads carry `CompiledStmtStepWithHelpersAndHelperIRWithInternals` and therefore record `compileStmt ... spec.functions`
- adds an `InterfaceAssembly` bridge from that spec-functions-aware expression-helper interface into `StmtListGenericWithHelpersAndHelperIRWithInternals`
- routes the existing all-expression-head helper bridge assembler in `HelperStepProofs` through the new `WithInternals` interface assembly instead of recursively constructing the list witness directly
- refreshes `PrintAxioms.lean`

## Validation

- `lean-slot lake build Compiler.Proofs.IRGeneration.GenericInduction.ResultRelation Compiler.Proofs.IRGeneration.GenericInduction.InterfaceAssembly Compiler.Proofs.HelperStepProofs` passed
- `lean-slot lake build Compiler.Proofs.HelperStepProofs` passed
- `python3 scripts/generate_print_axioms.py --check` passed
- `python3 scripts/check_proof_length.py` passed
- `rg -n "^\\s*(sorry|admit|axiom)\\b|:=\\s*by\\s+sorry\\b|by\\s+admit\\b" Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean Compiler/Proofs/IRGeneration/GenericInduction/InterfaceAssembly.lean Compiler/Proofs/HelperStepProofs.lean` found no matches
- `git diff --check` passed

## Remaining #2080 Interface/Gate Work

This is intentionally narrow: it moves the expression-helper all-head list path onto `WithInternals`, but mixed lists still need `WithInternals` interfaces for helper-free heads, direct helper calls/assigns, structural helper recursion, and residual helper-surface heads before the legacy/default-empty `StmtListGenericWithHelpersAndHelperIR` assemblers can be removed.

The broad `SupportedStmtList.helperSurfaceClosed` gate remains until those mixed-list `WithInternals` interfaces and the direct/structural helper summary proofs are available.

## Next Slice

Add `WithInternals` variants for the split direct helper interfaces (`StmtListDirectInternalHelperCallStepInterface` and `StmtListDirectInternalHelperAssignStepInterface`) and start packaging the direct helper summary bridge proofs into `CompiledStmtStepWithHelpersAndHelperIRWithInternals`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor along an existing helper-induction seam; no runtime, auth, or data-path changes. Residual risk is localized to correctness of the new Lean wiring for expression-helper lists.
> 
> **Overview**
> Introduces a **spec-functions-aware** expression-helper list interface (`StmtListExprInternalHelperStepInterfaceWithInternals`) whose heads carry `CompiledStmtStepWithHelpersAndHelperIRWithInternals`, so compile witnesses use `compileStmt … spec.functions` instead of the legacy default-empty internal-function path.
> 
> Adds an **InterfaceAssembly** bridge from that interface into `StmtListGenericWithHelpersAndHelperIRWithInternals`, and **retargets** the all-expression-head assembler in `HelperStepProofs` to build the `WithInternals` list witness via the new interface plus that bridge (replacing direct recursive `cons` on the generic list).
> 
> Also adds small **cons / list** lemmas to package per-head `ExprInternalHelperHeadStepBridgeWithInternals` into the new interface, and updates **PrintAxioms** for the new theorems.
> 
> Scope stays **narrow**: lists where every statement is an expression-position helper head. Mixed helper-free, direct, and structural lists still use legacy assembly until further `WithInternals` interfaces land.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20f35a72c5c9077af1358f07f7d7d80f0c90138a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->