### PR TITLE
proof: add structural WithInternals head witnesses

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -2214,6 +2214,78 @@ theorem stmtListStructuralInternalHelperStepInterfaceWithInternals_cons_of_compi
   intro _
   exact ⟨compiledIR, hstep⟩
 
+/-- Concrete `WithInternals` structural witness for an `ite` head. The caller
+supplies the exact spec-functions compiled-step proof for the recursive
+statement form, and this packages it into the structural helper interface
+without falling back to the legacy empty-helper compiler world. -/
+theorem stmtListStructuralInternalHelperStepInterfaceWithInternals_cons_ite_of_compiledStep
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {cond : Expr}
+    {thenBranch elseBranch : List Stmt}
+    {compiledIR : List YulStmt}
+    {rest : List Stmt}
+    (hstep :
+      CompiledStmtStepWithHelpersAndHelperIRWithInternals
+        runtimeContract spec fields scope
+          (Stmt.ite cond thenBranch elseBranch) compiledIR)
+    (hrest :
+      StmtListStructuralInternalHelperStepInterfaceWithInternals
+        runtimeContract spec fields
+          (stmtNextScope scope (Stmt.ite cond thenBranch elseBranch)) rest) :
+    StmtListStructuralInternalHelperStepInterfaceWithInternals
+      runtimeContract spec fields scope
+      (Stmt.ite cond thenBranch elseBranch :: rest) := by
+  exact
+    stmtListStructuralInternalHelperStepInterfaceWithInternals_cons_of_compiledStep
+      (runtimeContract := runtimeContract)
+      (spec := spec)
+      (fields := fields)
+      (scope := scope)
+      (stmt := Stmt.ite cond thenBranch elseBranch)
+      (compiledIR := compiledIR)
+      (rest := rest)
+      hstep
+      hrest
+
+/-- Concrete `WithInternals` structural witness for a `forEach` head. The exact
+head step compiles against `spec.functions`, so the recursive structural case
+can participate in the phase-17 mixed-list assembly route directly. -/
+theorem stmtListStructuralInternalHelperStepInterfaceWithInternals_cons_forEach_of_compiledStep
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {varName : String}
+    {count : Expr}
+    {body : List Stmt}
+    {compiledIR : List YulStmt}
+    {rest : List Stmt}
+    (hstep :
+      CompiledStmtStepWithHelpersAndHelperIRWithInternals
+        runtimeContract spec fields scope
+          (Stmt.forEach varName count body) compiledIR)
+    (hrest :
+      StmtListStructuralInternalHelperStepInterfaceWithInternals
+        runtimeContract spec fields
+          (stmtNextScope scope (Stmt.forEach varName count body)) rest) :
+    StmtListStructuralInternalHelperStepInterfaceWithInternals
+      runtimeContract spec fields scope
+      (Stmt.forEach varName count body :: rest) := by
+  exact
+    stmtListStructuralInternalHelperStepInterfaceWithInternals_cons_of_compiledStep
+      (runtimeContract := runtimeContract)
+      (spec := spec)
+      (fields := fields)
+      (scope := scope)
+      (stmt := Stmt.forEach varName count body)
+      (compiledIR := compiledIR)
+      (rest := rest)
+      hstep
+      hrest
+
 /-- Assemble the spec-functions structural-helper interface from exact
 `WithInternals` head steps for the structural-helper heads that occur in the
 statement list. -/

--- a/Compiler/Proofs/IRGeneration/GenericInduction/InterfaceAssembly.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/InterfaceAssembly.lean
@@ -1048,6 +1048,34 @@ theorem
         (ih (fun stmt' hmem =>
           hallDirect stmt' (List.mem_cons_of_mem stmt hmem)))
 
+/-- Spec-functions-aware structural-helper list bridge. Structural helper heads
+supplied by the `WithInternals` interface assemble directly into the
+`StmtListGenericWithHelpersAndHelperIRWithInternals` seam. This is intentionally
+narrow: every head in the list must be a recursive structural helper head. -/
+theorem
+    stmtListGenericWithHelpersAndHelperIRWithInternals_of_structuralInternalHelperStepInterfaceWithInternals
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {stmts : List Stmt}
+    (hstruct :
+      StmtListStructuralInternalHelperStepInterfaceWithInternals
+        runtimeContract spec fields scope stmts)
+    (hallStructural :
+      ∀ stmt ∈ stmts, stmtTouchesStructuralInternalHelperSurface stmt = true) :
+    StmtListGenericWithHelpersAndHelperIRWithInternals
+      runtimeContract spec fields scope stmts := by
+  induction hstruct with
+  | nil =>
+      exact .nil
+  | @cons scope stmt rest hhead htail ih =>
+      rcases hhead (hallStructural stmt List.mem_cons_self) with
+        ⟨compiledIR, hcompiled⟩
+      exact .cons hcompiled
+        (ih (fun stmt' hmem =>
+          hallStructural stmt' (List.mem_cons_of_mem stmt hmem)))
+
 /-- Spec-functions-aware mixed helper-list bridge. Helper-free heads and
 helper-positive heads both provide exact `compileStmt ... spec.functions`
 witnesses, so the assembled list lands directly in

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1824,6 +1824,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_cons_of_exprHeadStepBridge
   Compiler.Proofs.HelperStepProofs.stmtListExprInternalHelperStepInterface_of_exprHeadStepBridges
   Compiler.Proofs.HelperStepProofs.stmtListStructuralInternalHelperStepInterfaceWithInternals_cons_of_compiledStep
+  Compiler.Proofs.HelperStepProofs.stmtListStructuralInternalHelperStepInterfaceWithInternals_cons_ite_of_compiledStep
+  Compiler.Proofs.HelperStepProofs.stmtListStructuralInternalHelperStepInterfaceWithInternals_cons_forEach_of_compiledStep
   Compiler.Proofs.HelperStepProofs.stmtListStructuralInternalHelperStepInterfaceWithInternals_of_structuralHeadStepsWithInternals
   Compiler.Proofs.HelperStepProofs.fullHelperAwareListWitnessWithInternals_of_allInterfaces
   Compiler.Proofs.HelperStepProofs.allHelperInterfacesSatisfied_of_helperSurfaceClosed
@@ -5899,4 +5901,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5529 theorems/lemmas (3827 public, 1702 private, 0 sorry'd)
+-- Total: 5531 theorems/lemmas (3829 public, 1702 private, 0 sorry'd)


### PR DESCRIPTION
## Base / dependency

Stacked on PR #2112 (`paloma/issue-2080-structural-withinternals`). Do not merge until predecessor stack is merged/green.

Predecessor stack observed before PR creation:
- #2108 open, mergeable
- #2111 open, mergeable
- #2112 open, mergeable, checks green

## Summary

- Adds a structural-only `StmtListGenericWithHelpersAndHelperIRWithInternals` assembly bridge for lists whose heads are all structural helper-recursive heads.
- Adds concrete `WithInternals` structural head witnesses for `Stmt.ite` and `Stmt.forEach`, packaging exact `CompiledStmtStepWithHelpersAndHelperIRWithInternals` head steps into the phase-17 structural interface without falling back to the legacy/default-empty helper-world list seam.
- Regenerates `PrintAxioms.lean` for the two new public theorem names.

## Validation

- `lean-slot lake build Compiler.Proofs.HelperStepProofs` - passed
- `lean-slot lake build Compiler.Proofs.IRGeneration.GenericInduction.InterfaceAssembly` - passed
- `python3 scripts/generate_print_axioms.py --check` - passed
- `python3 scripts/check_proof_length.py` - passed (`5729 proofs scanned`; no new proofs exceed hard limit)
- `git diff --check` - passed
- `rg -n "\b(sorry|admit|axiom)\b" Compiler/Proofs/HelperStepProofs.lean Compiler/Proofs/IRGeneration/GenericInduction/InterfaceAssembly.lean` - no matches

## Remaining #2080 interface/gate

This narrows the structural recursive-head packaging, but it does not yet prove full structural `ite`/`forEach` preservation from nested `StmtListGenericWithHelpersAndHelperIRWithInternals` bodies. The next gate remains adding/using the `WithInternals` execution sibling for the helper-IR generic list theorem so body-level/function-level preservation can consume the mixed `WithInternals` list witness directly and continue reducing reliance on `SupportedStmtList.helperSurfaceClosed`.

Refs #2080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof-only additions (inductive packaging and thin wrappers); no compiler runtime, auth, or execution semantics changes.
> 
> **Overview**
> Extends the phase-17 **WithInternals** helper-proof plumbing so structural recursive heads (`Stmt.ite`, `Stmt.forEach`) can be wired without the legacy empty-internal-functions compile path.
> 
> **HelperStepProofs** adds two thin lemmas that take an exact `CompiledStmtStepWithHelpersAndHelperIRWithInternals` head step and a structural tail witness, then build `StmtListStructuralInternalHelperStepInterfaceWithInternals` for `ite :: rest` and `forEach :: rest` (both delegate to the existing `cons_of_compiledStep` lemma).
> 
> **InterfaceAssembly** adds `stmtListGenericWithHelpersAndHelperIRWithInternals_of_structuralInternalHelperStepInterfaceWithInternals`, mirroring the expression- and direct-helper list bridges: when every statement in the list is a structural helper head, the structural interface inductively assembles into `StmtListGenericWithHelpersAndHelperIRWithInternals`.
> 
> **PrintAxioms.lean** is regenerated to register the two new public theorem names (+2 public lemmas in the inventory).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cbc08ae74c19decfec6ccbbecd0a915b4216621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->