### PR TITLE
proof: bridge function internals body compile

### DIFF
--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -1,4 +1,5 @@
 import Compiler.CompilationModel.Dispatch
+import Compiler.Proofs.IRGeneration.FunctionShape
 import Compiler.Proofs.IRGeneration.FunctionBody
 import Compiler.Proofs.IRGeneration.GenericInduction
 import Compiler.Proofs.IRGeneration.GenericInduction.EventBridge
@@ -2225,6 +2226,218 @@ theorem supported_function_correct_with_helper_proofs_body_goal_and_helper_ir_of
         (FunctionBody.initialIRStateForTx model tx initialWorld)
         hfnBodyDisjoint)
       hcalldataSizeFits
+
+private theorem function_body_scopeNamesPresent_of_bindSupportedParams
+    (fn : FunctionSpec)
+    (tx : IRTransaction)
+    (bindings : List (String × Nat))
+    (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings) :
+    FunctionBody.scopeNamesPresent (fn.params.map (·.name)) bindings := by
+  intro name hmem
+  have hmemBindings : name ∈ bindings.map Prod.fst := by
+    rw [ParamLoading.bindSupportedParams_names hbind]
+    simpa using hmem
+  exact lookupBinding?_some_of_mem bindings name hmemBindings
+
+private theorem function_body_state_runtime_of_bindSupportedParams
+    (model : CompilationModel)
+    (fn : FunctionSpec)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (bindings : List (String × Nat))
+    (htxNormalized : TxContextNormalized tx)
+    (hcalldataSizeFits : TxCalldataSizeFitsEvm tx) :
+    FunctionBody.runtimeStateMatchesIR
+      (SourceSemantics.effectiveFields model)
+      { world := SourceSemantics.withTransactionContext initialWorld tx
+        bindings := []
+        selector := tx.functionSelector }
+      (ParamLoading.applyBindingsToIRState
+        (prebindRawArgs
+          (FunctionBody.initialIRStateForTx model tx initialWorld) fn.params)
+        bindings) := by
+  let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
+  have hpreboundRuntime :
+      FunctionBody.runtimeStateMatchesIR
+        (SourceSemantics.effectiveFields model)
+        { world := SourceSemantics.withTransactionContext initialWorld tx
+          bindings := []
+          selector := tx.functionSelector }
+        (prebindRawArgs initialState fn.params) := by
+    simpa [initialState] using
+      runtimeStateMatchesIR_prebindRawArgs
+        (state := initialState)
+        (runtime := { world := SourceSemantics.withTransactionContext initialWorld tx,
+                      bindings := [],
+                      selector := tx.functionSelector })
+        (fields := SourceSemantics.effectiveFields model)
+        (params := fn.params)
+        (initialIRStateForTx_matches_runtime model tx initialWorld htxNormalized
+          hcalldataSizeFits)
+  exact runtimeStateMatchesIR_applyBindingsToIRState
+    (state := prebindRawArgs initialState fn.params)
+    (runtime := { world := SourceSemantics.withTransactionContext initialWorld tx,
+                  bindings := [],
+                  selector := tx.functionSelector })
+    (fields := SourceSemantics.effectiveFields model)
+    (bindings := bindings)
+    hpreboundRuntime
+
+private theorem function_body_state_bindings_of_bindSupportedParams
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (fn : FunctionSpec)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (bindings : List (String × Nat))
+    (hfn : fn ∈ selectorDispatchedFunctions model)
+    (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings) :
+    FunctionBody.bindingsExactlyMatchIRVars bindings
+      (ParamLoading.applyBindingsToIRState
+        (prebindRawArgs
+          (FunctionBody.initialIRStateForTx model tx initialWorld) fn.params)
+        bindings) := by
+  let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
+  have hinitBindings :
+      FunctionBody.bindingsExactlyMatchIRVars [] initialState := by
+    simpa [initialState] using
+      FunctionBody.bindingsExactlyMatchIRVars_nil_initialIRStateForTx model tx initialWorld
+  have hparamNamesNodup :
+      (fn.params.map (·.name)).Nodup :=
+    hSupported.selectorFunctionParamNamesNodup hfn
+  exact supported_function_param_state_exact
+    initialState fn.params bindings hinitBindings hparamNamesNodup hbind
+
+/-- Function-level bridge from helper-aware `compileFunctionSpec` facts to the
+mixed `WithInternals` body consumer.
+
+The compile fact is reconstructed in the `model.functions` helper world and is
+then threaded directly into the split-interface body theorem introduced for the
+mixed helper-IR path. This packages the state/binding plumbing that callers
+otherwise had to rebuild before they could consume
+`supported_function_body_correct_from_exact_state_generic_split_helper_steps_and_helper_ir_with_internals`.
+-/
+theorem supported_function_body_with_internals_goal_of_compileFunctionSpec_with_internals
+    (runtimeContract : IRContract)
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (fn : FunctionSpec)
+    (selector : Nat)
+    (irFn : IRFunction)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (bindings : List (String × Nat))
+    (hfn : fn ∈ selectorDispatchedFunctions model)
+    (hcompile :
+      compileFunctionSpec model.fields model.events model.errors model.adtTypes
+        selector fn .cancun model.functions = Except.ok irFn)
+    (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
+    (htxNormalized : TxContextNormalized tx)
+    (hcalldataSizeFits : TxCalldataSizeFitsEvm tx)
+    (hfuelPos : 0 < hSupported.helperFuel)
+    (hhelperFree :
+      StmtListHelperFreeStepInterfaceWithInternals
+        runtimeContract model (SourceSemantics.effectiveFields model)
+        (fn.params.map (·.name)) fn.body)
+    (hcall :
+      StmtListDirectInternalHelperCallStepInterfaceWithInternals
+        runtimeContract model (SourceSemantics.effectiveFields model)
+        (fn.params.map (·.name)) fn.body)
+    (hassign :
+      StmtListDirectInternalHelperAssignStepInterfaceWithInternals
+        runtimeContract model (SourceSemantics.effectiveFields model)
+        (fn.params.map (·.name)) fn.body)
+    (hexpr :
+      StmtListExprInternalHelperStepInterfaceWithInternals
+        runtimeContract model (SourceSemantics.effectiveFields model)
+        (fn.params.map (·.name)) fn.body)
+    (hstruct :
+      StmtListStructuralInternalHelperStepInterfaceWithInternals
+        runtimeContract model (SourceSemantics.effectiveFields model)
+        (fn.params.map (·.name)) fn.body)
+    (hresidual :
+      StmtListResidualHelperSurfaceStepInterfaceWithInternals
+        runtimeContract model (SourceSemantics.effectiveFields model)
+        (fn.params.map (·.name)) fn.body) :
+    ∃ returns bodyStmts extraFuel,
+      irFn = compiledFunctionIR selector fn returns bodyStmts ∧
+      SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
+        runtimeContract
+        model fn bodyStmts hSupported.helperFuel tx initialWorld
+        (ParamLoading.applyBindingsToIRState
+          (prebindRawArgs
+            (FunctionBody.initialIRStateForTx model tx initialWorld) fn.params)
+          bindings)
+        bindings extraFuel := by
+  classical
+  let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
+  rcases FunctionShape.compileFunctionSpec_ok_components_with_internals
+      model.fields model.events model.errors model.adtTypes model.functions
+      selector fn irFn hcompile with
+    ⟨returns, bodyStmts, _hvalidate, _hreturns, hbodyCompile, hirFn⟩
+  have hirFnLocal : irFn = compiledFunctionIR selector fn returns bodyStmts := by
+    simpa [FunctionShape.compiledFunctionIR, compiledFunctionIR] using hirFn
+  let extraFuel := sizeOf irFn.body - irFn.body.length
+  have hbodyExtraFuelLower :
+      sizeOf bodyStmts - bodyStmts.length ≤ extraFuel := by
+    dsimp [extraFuel]
+    rw [hirFnLocal]
+    simpa [compiledFunctionIR] using
+      yulStmtList_extraFuel_append_ge (genParamLoads fn.params) bodyStmts
+  have hscope :
+      FunctionBody.scopeNamesPresent (fn.params.map (·.name)) bindings := by
+    exact function_body_scopeNamesPresent_of_bindSupportedParams fn tx bindings hbind
+  have hbounded : FunctionBody.bindingsBounded bindings :=
+    FunctionBody.bindingsBounded_of_bindSupportedParams hbind
+  have hbodyStateRuntime :
+      FunctionBody.runtimeStateMatchesIR
+        (SourceSemantics.effectiveFields model)
+        { world := SourceSemantics.withTransactionContext initialWorld tx
+          bindings := []
+          selector := tx.functionSelector }
+        (ParamLoading.applyBindingsToIRState
+          (prebindRawArgs initialState fn.params) bindings) := by
+    simpa [initialState] using
+      function_body_state_runtime_of_bindSupportedParams
+        model fn tx initialWorld bindings htxNormalized hcalldataSizeFits
+  have hbodyStateBindings :
+      FunctionBody.bindingsExactlyMatchIRVars bindings
+        (ParamLoading.applyBindingsToIRState
+          (prebindRawArgs initialState fn.params) bindings) := by
+    simpa [initialState] using
+      function_body_state_bindings_of_bindSupportedParams
+        model selectors hSupported fn tx initialWorld bindings hfn hbind
+  have hbodyCorrect :
+      SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
+        runtimeContract
+        model fn bodyStmts hSupported.helperFuel tx initialWorld
+        (ParamLoading.applyBindingsToIRState
+          (prebindRawArgs initialState fn.params) bindings)
+        bindings extraFuel :=
+    supported_function_body_correct_from_exact_state_generic_split_helper_steps_and_helper_ir_with_internals
+      runtimeContract model fn bodyStmts hSupported.helperFuel tx initialWorld
+      (ParamLoading.applyBindingsToIRState
+        (prebindRawArgs initialState fn.params) bindings)
+      bindings extraFuel hbodyExtraFuelLower
+      hfuelPos
+      (by simpa [SourceSemantics.effectiveFields] using hSupported.normalizedFields)
+      hSupported.noEvents
+      hSupported.noErrors
+      hSupported.noAdtTypes
+      hhelperFree
+      hcall
+      hassign
+      hexpr
+      hstruct
+      hresidual
+      hbodyCompile
+      hscope
+      hbounded
+      hbodyStateRuntime
+      hbodyStateBindings
+  exact ⟨returns, bodyStmts, extraFuel, hirFnLocal, hbodyCorrect⟩
 
 /-- Scalar-event sibling of the helper-aware body-goal wrapper. -/
 theorem supported_function_correct_with_scalar_events_body_goal_and_helper_ir

--- a/Compiler/Proofs/IRGeneration/FunctionShape.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionShape.lean
@@ -50,6 +50,44 @@ theorem compileFunctionSpec_ok_components
         refine ⟨returns, bodyStmts, ?_⟩
         exact ⟨by simp, by simp, by simpa [compileStmtList] using hbody, hEq.symm⟩
 
+/-- Parametric function-shape bridge for helper-aware compilation.  This is the
+same shape fact as `compileFunctionSpec_ok_components`, but it preserves the
+caller-provided ADT and internal-helper environments through to the body compile
+fact instead of specializing them to the legacy empty helper world. -/
+theorem compileFunctionSpec_ok_components_with_internals
+    (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
+    (adtTypes : List AdtTypeDef) (internalFunctions : List FunctionSpec)
+    (selector : Nat) (spec : FunctionSpec) (irFn : IRFunction)
+    (hcompile :
+      compileFunctionSpec fields events errors adtTypes selector spec .cancun internalFunctions =
+        Except.ok irFn) :
+    ∃ returns bodyStmts,
+      validateFunctionSpec spec = Except.ok () ∧
+      functionReturns spec = Except.ok returns ∧
+      compileStmtList fields events errors .calldata [] false
+        (spec.params.map (·.name)) adtTypes spec.body internalFunctions =
+          Except.ok bodyStmts ∧
+      irFn = compiledFunctionIR selector spec returns bodyStmts := by
+  unfold CompilationModel.compileFunctionSpec at hcompile
+  cases hvalidate : validateFunctionSpec spec
+  · rw [hvalidate] at hcompile
+    cases hcompile
+  case ok _ =>
+    cases hreturns : functionReturns spec
+    · rw [hvalidate, hreturns] at hcompile
+      cases hcompile
+    case ok returns =>
+      cases hbody :
+          compileStmtListWithFork fields events errors .calldata [] false
+            (spec.params.map (·.name)) adtTypes .cancun spec.body internalFunctions
+      · rw [hvalidate, hreturns, hbody] at hcompile
+        cases hcompile
+      case ok bodyStmts =>
+        rw [hvalidate, hreturns, hbody] at hcompile
+        injection hcompile with hEq
+        refine ⟨returns, bodyStmts, ?_⟩
+        exact ⟨by simp, by simp, by simpa [compileStmtList] using hbody, hEq.symm⟩
+
 end FunctionShape
 
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2086,6 +2086,10 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_scalar_events_body_goal
   Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_helper_proofs_body_goal_and_helper_ir
   Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_helper_proofs_body_goal_and_helper_ir_of_bodyCallsDisjoint
+  -- Compiler.Proofs.IRGeneration.Function.function_body_scopeNamesPresent_of_bindSupportedParams  -- private
+  -- Compiler.Proofs.IRGeneration.Function.function_body_state_runtime_of_bindSupportedParams  -- private
+  -- Compiler.Proofs.IRGeneration.Function.function_body_state_bindings_of_bindSupportedParams  -- private
+  Compiler.Proofs.IRGeneration.Function.supported_function_body_with_internals_goal_of_compileFunctionSpec_with_internals
   Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_scalar_events_body_goal_and_helper_ir
   Compiler.Proofs.IRGeneration.Function.stmtListHelperFreeNonEventStepInterface_of_helperFreeStepInterface
   Compiler.Proofs.IRGeneration.Function.stmtListHelperFreeCompiledCallsDisjoint_of_internalFunctions_nil
@@ -2534,6 +2538,7 @@ end Verity.AxiomAudit
 
   -- Compiler/Proofs/IRGeneration/FunctionShape.lean
   Compiler.Proofs.IRGeneration.FunctionShape.compileFunctionSpec_ok_components
+  Compiler.Proofs.IRGeneration.FunctionShape.compileFunctionSpec_ok_components_with_internals
 
   -- Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
   Compiler.Proofs.IRGeneration.compiledStmtStepWithHelpersAndHelperIR_internalCallAssign
@@ -5905,4 +5910,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5535 theorems/lemmas (3833 public, 1702 private, 0 sorry'd)
+-- Total: 5540 theorems/lemmas (3835 public, 1705 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -329,6 +329,9 @@ ALLOWLIST: set[str] = {
     "supported_function_correct_with_helper_proofs_body_goal",
     "supported_function_correct_with_helper_proofs_body_goal_and_helper_ir",
     "supported_function_correct_with_helper_proofs_body_goal_and_helper_ir_of_bodyCallsDisjoint",
+    # Issue #2080: interface-heavy bridge from function compile facts into the
+    # split WithInternals body consumer; state/binding plumbing is factored.
+    "supported_function_body_with_internals_goal_of_compileFunctionSpec_with_internals",
     "compileFunctionSpec_correct_generic_with_helper_proofs",
     "compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir",
     "compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_bodyCallsDisjoint",


### PR DESCRIPTION
## Base / dependency

Stacked on #2114 (`paloma/issue-2080-helper-ir-withinternals`), which is still open/mergeable/green. Do not merge until predecessor stack is merged/green.

## Summary

- Add a parametric `compileFunctionSpec` shape bridge that preserves caller-provided ADT/internal-helper environments through to the body `compileStmtList` fact.
- Add a function-level bridge that reconstructs the `model.functions` body compile fact from helper-aware function compilation and threads the split `WithInternals` body consumer into the function proof path.
- Refresh `PrintAxioms.lean` and add a proof-length allowlist entry for the interface-heavy bridge after factoring the state/binding plumbing into private helpers.

## Validation

- `lean-slot lake build Compiler.Proofs.IRGeneration.FunctionShape Compiler.Proofs.IRGeneration.Function` passed.
- `lean-slot lake build Compiler.Proofs.IRGeneration.Function` passed after decomposition.
- `lean-slot lake build Compiler.Proofs.HelperStepProofs` passed.
- `lean-slot lake build Compiler.Proofs.IRGeneration.Contract` passed.
- `python3 scripts/generate_print_axioms.py --check` passed.
- `python3 scripts/check_proof_length.py` passed.
- `git diff --check` passed.
- No `sorry`, `admit`, or `axiom` in touched proof files.

Refs #2080

## Remaining #2080 gate

The full function-level retarget still needs the compiled-side `execIRFunctionWithInternals` param-loading/function execution bridge, so whole-contract dispatch can consume the helper-rich function theorem without falling back through default-empty helper-world/conservative-extension wrappers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, machine-checked proof lemmas in IR generation only; no runtime or auth behavior changes.
> 
> **Overview**
> Adds proof infrastructure for **#2080** so function-level correctness can use **helper-rich** `compileFunctionSpec` facts instead of the legacy empty ADT/helper world.
> 
> **`FunctionShape.compileFunctionSpec_ok_components_with_internals`** mirrors the existing `compileFunctionSpec_ok_components` decomposition but threads caller **`adtTypes`** and **`internalFunctions`** through to the body `compileStmtList` success fact.
> 
> **`supported_function_body_with_internals_goal_of_compileFunctionSpec_with_internals`** is the main entry: from a successful helper-aware compile plus the split `WithInternals` step interfaces, it produces **`SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal`** with param binding state already wired. Three **private** lemmas factor out scope names, runtime IR alignment, and binding equality from `bindSupportedParams`.
> 
> **`PrintAxioms.lean`** and **`scripts/check_proof_length.py`** are updated for the new public theorem and allowlist entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e600a54f67ef66e754f2bbcab8be15d9a1719d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->