### PR TITLE
proof: bridge function exec with internals

### DIFF
--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -1041,6 +1041,62 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir
       (hbind := hbind)
   simpa [hhelperIR] using hlegacy
 
+/-- Direct helper-aware compiled-side wrapper for the generic function theorem.
+This consumes the exact helper-aware body/IR goal and executes the compiled
+function through `execIRFunctionWithInternals` directly, leaving only the
+generated ABI parameter-load prefix disjointness as an explicit compiled-side
+premise. -/
+theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (hHelperProofs : SourceSemantics.SupportedSpecHelperProofs model selectors hSupported)
+    (hvalidateInputs : validateCompileInputs model selectors = Except.ok ())
+    (runtimeContract : IRContract)
+    (fn : FunctionSpec)
+    (sel : Nat)
+    (returns : List ParamType)
+    (bodyStmts : List YulStmt)
+    (irFn : IRFunction)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (htxNormalized : Function.TxContextNormalized tx)
+    (bindings : List (String × Nat))
+    (extraFuel : Nat)
+    (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
+    (hfn : fn ∈ selectorDispatchedFunctions model)
+    (hvalidate : validateFunctionSpec fn = Except.ok ())
+    (hreturns : functionReturns fn = Except.ok returns)
+    (hbodyCompile :
+      compileStmtList model.fields model.events model.errors .calldata [] false
+        (fn.params.map (·.name)) [] fn.body = Except.ok bodyStmts)
+    (hcompileFn :
+      compileFunctionSpec model.fields model.events model.errors [] sel fn = Except.ok irFn)
+    (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
+    (hcompiledBodyFuel :
+      (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
+        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body)
+    (hbodyCorrect :
+      SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
+        runtimeContract model fn bodyStmts hSupported.helperFuel tx initialWorld
+        (ParamLoading.applyBindingsToIRState
+          (Function.prebindRawArgs
+            (FunctionBody.initialIRStateForTx model tx initialWorld) fn.params)
+          bindings)
+        bindings extraFuel)
+    (hparamDisjoint :
+      YulStmtListCallsDisjointFromInternalTable runtimeContract
+        (genParamLoads fn.params)) :
+    FunctionBody.sourceResultMatchesIRResult
+      (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
+      (execIRFunctionWithInternals runtimeContract 0 irFn tx.args
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  exact Function.supported_function_correct_with_helper_proofs_body_goal_with_internals
+    model selectors hSupported hHelperProofs hvalidateInputs runtimeContract
+    fn sel returns bodyStmts irFn tx initialWorld bindings hfn hvalidate hreturns
+    hbodyCompile hcompileFn hbind htxNormalized extraFuel hcompiledBodyFuel
+    hbodyCorrect hparamDisjoint hcalldataSizeFits
+
 /-- Structured helper-aware compiled-side wrapper for the generic function
 theorem. This replaces the raw function-level conservative-extension equality
 premise by the compiled-body disjointness witness that proves it. -/

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -439,6 +439,139 @@ theorem exec_compiledFunctionIR_of_body_extraFuel
   rw [hprefix', hbody]
   rfl
 
+theorem execIRStmtsWithInternals_append_of_prefix_continue :
+    ∀ (contract : IRContract) (pre rest : List YulStmt) (fuel : Nat)
+      (state state' : IRState),
+      execIRStmtsWithInternals contract (pre.length + fuel) state pre = .continue state' →
+      execIRStmtsWithInternals contract (pre.length + fuel) state (pre ++ rest) =
+        execIRStmtsWithInternals contract fuel state' rest
+  | contract, [], rest, fuel, state, state', hprefix => by
+      simp only [List.length_nil, zero_add, execIRStmtsWithInternals] at hprefix
+      cases hprefix
+      simp
+  | contract, stmt :: pre, rest, fuel, state, state', hprefix => by
+      have hprefixNorm :
+          execIRStmtsWithInternals contract (Nat.succ (pre.length + fuel))
+            state (stmt :: pre) = .continue state' := by
+        simpa [List.length_cons, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using hprefix
+      simp only [List.length_cons, List.cons_append]
+      rw [show Nat.succ pre.length + fuel = Nat.succ (pre.length + fuel) by omega]
+      rw [execIRStmtsWithInternals]
+      cases hstep : execIRStmtWithInternals contract (pre.length + fuel) state stmt with
+      | «continue» next =>
+          have htail :
+              execIRStmtsWithInternals contract (pre.length + fuel) next pre =
+                .continue state' := by
+            simpa [execIRStmtsWithInternals, hstep] using hprefixNorm
+          exact execIRStmtsWithInternals_append_of_prefix_continue
+            contract pre rest fuel next state' htail
+      | «return» value next =>
+          simp [execIRStmtsWithInternals, hstep] at hprefixNorm
+      | stop next =>
+          simp [execIRStmtsWithInternals, hstep] at hprefixNorm
+      | revert next =>
+          simp [execIRStmtsWithInternals, hstep] at hprefixNorm
+      | «leave» next =>
+          simp [execIRStmtsWithInternals, hstep] at hprefixNorm
+
+theorem exec_genParamLoads_supported_then_extraFuel_withInternals
+    (runtimeContract : IRContract)
+    (state : IRState) (params : List Param) (bindings : List (String × Nat))
+    (rest : List YulStmt) (extraFuel : Nat)
+    (hsupported : ∀ param ∈ params, SupportedExternalParamType param.ty)
+    (hcalldataSizeFits : 4 + state.calldata.length * 32 < Compiler.Constants.evmModulus)
+    (hbind : SourceSemantics.bindSupportedParams params state.calldata = some bindings)
+    (hparamDisjoint :
+      YulStmtListCallsDisjointFromInternalTable runtimeContract (genParamLoads params)) :
+    execIRStmtsWithInternals runtimeContract
+        ((genParamLoads params).length + rest.length + extraFuel + 1) state
+        (genParamLoads params ++ rest) =
+      execIRStmtsWithInternals runtimeContract
+        (rest.length + extraFuel + 1)
+        (ParamLoading.applyBindingsToIRState state bindings) rest := by
+  let tailFuel := rest.length + extraFuel + 1
+  have hlegacyPrefix :
+      execIRStmts ((genParamLoads params).length + tailFuel) state (genParamLoads params) =
+        .continue (ParamLoading.applyBindingsToIRState state bindings) := by
+    have hlegacy :=
+      ParamLoading.exec_genParamLoads_supported_then_extraFuel
+        (state := state) (params := params) (bindings := bindings)
+        (rest := []) (extraFuel := rest.length + extraFuel)
+        hsupported hcalldataSizeFits hbind
+    simpa [tailFuel] using hlegacy
+  have hprefix :
+      execIRStmtsWithInternals runtimeContract ((genParamLoads params).length + tailFuel)
+          state (genParamLoads params) =
+        .continue (ParamLoading.applyBindingsToIRState state bindings) := by
+    have hcompat :=
+      execIRStmtsWithInternals_eq_execIRStmts_of_callsDisjoint
+        runtimeContract ((genParamLoads params).length + tailFuel)
+        state (genParamLoads params) hparamDisjoint
+    rw [hcompat, hlegacyPrefix]
+  have happend :=
+    execIRStmtsWithInternals_append_of_prefix_continue runtimeContract
+      (genParamLoads params) rest tailFuel state
+      (ParamLoading.applyBindingsToIRState state bindings) hprefix
+  simpa [tailFuel, List.length_append, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using happend
+
+theorem exec_compiledFunctionIR_withInternals_of_body_extraFuel
+    (runtimeContract : IRContract)
+    (state : IRState) (selector : Nat) (spec : FunctionSpec)
+    (returns : List ParamType) (bodyStmts : List YulStmt)
+    (bindings : List (String × Nat)) (tailResult : IRExecResultWithInternals)
+    (extraFuel : Nat)
+    (hsupported : ∀ param ∈ spec.params, SupportedExternalParamType param.ty)
+    (hcalldataSizeFits : 4 + state.calldata.length * 32 < Compiler.Constants.evmModulus)
+    (hbind : SourceSemantics.bindSupportedParams spec.params state.calldata = some bindings)
+    (hparamDisjoint :
+      YulStmtListCallsDisjointFromInternalTable runtimeContract (genParamLoads spec.params))
+    (hbody :
+      execIRStmtsWithInternals runtimeContract (bodyStmts.length + extraFuel + 1)
+        (ParamLoading.applyBindingsToIRState (prebindRawArgs state spec.params) bindings)
+        bodyStmts = tailResult) :
+    execIRStmtsWithInternals runtimeContract
+        ((genParamLoads spec.params ++ bodyStmts).length + extraFuel + 1)
+        (prebindRawArgs state spec.params)
+        (compiledFunctionIR selector spec returns bodyStmts).body =
+      tailResult := by
+  let preboundState := prebindRawArgs state spec.params
+  have hbind' :
+      SourceSemantics.bindSupportedParams spec.params preboundState.calldata = some bindings := by
+    simpa [preboundState] using hbind
+  have hcalldataSizeFits' :
+      4 + preboundState.calldata.length * 32 < Compiler.Constants.evmModulus := by
+    simpa [preboundState] using hcalldataSizeFits
+  have hprefix :
+      execIRStmtsWithInternals runtimeContract
+          ((genParamLoads spec.params).length + bodyStmts.length + extraFuel + 1)
+          preboundState (genParamLoads spec.params ++ bodyStmts) =
+        execIRStmtsWithInternals runtimeContract
+          (bodyStmts.length + extraFuel + 1)
+          (ParamLoading.applyBindingsToIRState preboundState bindings)
+          bodyStmts := by
+    simpa [preboundState, Nat.add_assoc] using
+      exec_genParamLoads_supported_then_extraFuel_withInternals
+        (runtimeContract := runtimeContract)
+        (state := preboundState)
+        (params := spec.params)
+        (bindings := bindings)
+        (rest := bodyStmts)
+        (extraFuel := extraFuel)
+        hsupported hcalldataSizeFits' hbind' hparamDisjoint
+  calc
+    execIRStmtsWithInternals runtimeContract
+        ((genParamLoads spec.params ++ bodyStmts).length + extraFuel + 1)
+        (prebindRawArgs state spec.params)
+        (compiledFunctionIR selector spec returns bodyStmts).body
+        =
+      execIRStmtsWithInternals runtimeContract
+        (bodyStmts.length + extraFuel + 1)
+        (ParamLoading.applyBindingsToIRState preboundState bindings)
+        bodyStmts := by
+          simpa [preboundState, compiledFunctionIR, List.length_append, Nat.add_assoc,
+            Nat.add_left_comm, Nat.add_comm] using hprefix
+    _ = tailResult := hbody
+
 theorem interpretFunction_eq_execResultToIRResult_of_body
     (model : CompilationModel) (fn : FunctionSpec)
     (tx : IRTransaction) (initialWorld : Verity.ContractState)
@@ -2149,6 +2282,138 @@ theorem supported_function_correct_with_helper_proofs_body_goal_and_helper_ir
       bodyStmts irFn tx initialWorld bindings hfn hvalidate hreturns hbodyCompile
       hcompile hbind htxNormalized extraFuel hcompiledBodyFuel hlegacyBody hcalldataSizeFits
   simpa [hhelperIR] using hlegacy
+
+/-- Direct helper-aware function theorem for compiled bodies that already prove
+the exact `execIRStmtsWithInternals` preservation goal. This is the function
+level analogue of the legacy param-load/body execution bridge: the generated
+ABI param-load prefix runs first under `WithInternals`, then execution continues
+with the helper-aware compiled body. -/
+theorem supported_function_correct_with_helper_proofs_body_goal_with_internals
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (_hHelperProofs : SourceSemantics.SupportedSpecHelperProofs model selectors hSupported)
+    (_hvalidateInputs : validateCompileInputs model selectors = Except.ok ())
+    (runtimeContract : IRContract)
+    (fn : FunctionSpec)
+    (selector : Nat)
+    (returns : List ParamType)
+    (bodyStmts : List YulStmt)
+    (irFn : IRFunction)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (bindings : List (String × Nat))
+    (hfn : fn ∈ selectorDispatchedFunctions model)
+    (hvalidate : validateFunctionSpec fn = Except.ok ())
+    (hreturns : functionReturns fn = Except.ok returns)
+    (hbodyCompile :
+      compileStmtList model.fields model.events model.errors .calldata [] false
+        (fn.params.map (·.name)) [] fn.body = Except.ok bodyStmts)
+    (hcompile :
+      compileFunctionSpec model.fields model.events model.errors [] selector fn = Except.ok irFn)
+    (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
+    (_htxNormalized : TxContextNormalized tx)
+    (extraFuel : Nat)
+    (hcompiledBodyFuel :
+      (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
+        sizeOf (compiledFunctionIR selector fn returns bodyStmts).body)
+    (hbodyCorrect :
+      SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
+        runtimeContract
+        model fn bodyStmts hSupported.helperFuel tx initialWorld
+        (ParamLoading.applyBindingsToIRState
+          (prebindRawArgs
+            (FunctionBody.initialIRStateForTx model tx initialWorld) fn.params)
+          bindings)
+        bindings extraFuel)
+    (hparamDisjoint :
+      YulStmtListCallsDisjointFromInternalTable runtimeContract (genParamLoads fn.params))
+    (hcalldataSizeFits : TxCalldataSizeFitsEvm tx) :
+    FunctionBody.sourceResultMatchesIRResult
+      (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
+      (execIRFunctionWithInternals runtimeContract 0 irFn tx.args
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
+  rcases hbodyCorrect with ⟨sourceResult, irExec, hsource, hbodyExec, hmatch⟩
+  have hcompiled := compileFunctionSpec_ok_of_components model.fields model.events model.errors
+      selector fn returns bodyStmts hvalidate hreturns hbodyCompile
+  have hirFn : irFn = compiledFunctionIR selector fn returns bodyStmts := by
+    rw [hcompile] at hcompiled
+    injection hcompiled
+  have hrollbackStorage :
+        initialState.storage = fun s =>
+          Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+            (SourceSemantics.encodeStorage model
+              (SourceSemantics.withTransactionContext initialWorld tx) s.toNat) := by
+    funext s
+    simp [initialState, FunctionBody.initialIRStateForTx,
+      FunctionBody.encodeStorage_withTransactionContext]
+  have hrollbackEvents :
+      initialState.events =
+        SourceSemantics.encodeEvents
+          (SourceSemantics.withTransactionContext initialWorld tx).events := by
+    simp [initialState, FunctionBody.initialIRStateForTx]
+  have hsourceMatch :
+      FunctionBody.sourceResultMatchesIRResult
+        (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
+        (FunctionBody.irResultOfExecResultWithInternals initialState irExec) := by
+    have hpack :=
+      interpretFunctionWithHelpers_eq_execResultToIRResultWithInternals_of_body
+        (model := model)
+        (fn := fn)
+        (helperFuel := hSupported.helperFuel)
+        (tx := tx)
+        (initialWorld := initialWorld)
+        (sourceResult := sourceResult)
+        (rollback := initialState)
+        (irResult := irExec)
+        (bindings := bindings)
+        hbind hsource hrollbackStorage hrollbackEvents hmatch
+    simpa [supportedSourceFunctionSemantics] using hpack
+  subst hirFn
+  have hcompiledBodyFuel' :
+      (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
+        sizeOf (genParamLoads fn.params ++ bodyStmts) := by
+    simpa [compiledFunctionIR] using hcompiledBodyFuel
+  have hcompiledExec :
+      execIRStmtsWithInternals runtimeContract
+          (sizeOf (genParamLoads fn.params ++ bodyStmts) + 1)
+          (prebindRawArgs initialState fn.params)
+          (genParamLoads fn.params ++ bodyStmts) =
+        irExec := by
+    have hprefix :=
+      exec_compiledFunctionIR_withInternals_of_body_extraFuel
+        (runtimeContract := runtimeContract)
+        (state := initialState)
+        (selector := selector)
+        (spec := fn)
+        (returns := returns)
+        (bodyStmts := bodyStmts)
+        (bindings := bindings)
+        (tailResult := irExec)
+        (extraFuel := extraFuel)
+        (hSupported.selectorFunctionParamsSupported hfn)
+        hcalldataSizeFits hbind hparamDisjoint hbodyExec
+    have hfuel :
+        (genParamLoads fn.params ++ bodyStmts).length + extraFuel + 1 =
+          sizeOf (genParamLoads fn.params ++ bodyStmts) + 1 := by
+      omega
+    rw [← hfuel]
+    simpa [compiledFunctionIR] using hprefix
+  have hfunctionExec :
+      execIRFunctionWithInternals runtimeContract 0
+          (compiledFunctionIR selector fn returns bodyStmts) tx.args initialState =
+        FunctionBody.irResultOfExecResultWithInternals initialState irExec := by
+    have hstateWithParams :
+        List.foldl (fun s x => s.setVar x.1.name x.2) initialState
+            ((List.map Param.toIRParam fn.params).zip tx.args) =
+          prebindRawArgs initialState fn.params := by
+      simp [prebindRawArgs, initialState, FunctionBody.initialIRStateForTx]
+    rw [execIRFunctionWithInternals]
+    simp [compiledFunctionIR, hstateWithParams]
+    rw [hcompiledExec]
+    rfl
+  simpa [initialState, hfunctionExec] using hsourceMatch
 
 /-- Structured exact helper-aware function/IR wrapper under compiled-body
 disjointness. The exact helper-aware body theorem can now be reused all the way

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1875,6 +1875,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_except_mapping_writes_stmtSafety
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir
+  Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_bodyCallsDisjoint
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
   -- Compiler.Proofs.IRGeneration.Contract.scalar_events_contract_function_callback  -- private
@@ -2055,6 +2056,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Function.compileConstructor_ok_components
   Compiler.Proofs.IRGeneration.Function.exec_compiledFunctionIR_of_body
   Compiler.Proofs.IRGeneration.Function.exec_compiledFunctionIR_of_body_extraFuel
+  Compiler.Proofs.IRGeneration.Function.execIRStmtsWithInternals_append_of_prefix_continue
+  Compiler.Proofs.IRGeneration.Function.exec_genParamLoads_supported_then_extraFuel_withInternals
+  Compiler.Proofs.IRGeneration.Function.exec_compiledFunctionIR_withInternals_of_body_extraFuel
   Compiler.Proofs.IRGeneration.Function.interpretFunction_eq_execResultToIRResult_of_body
   Compiler.Proofs.IRGeneration.Function.interpretFunctionWithHelpers_eq_execResultToIRResultWithInternals_of_body
   Compiler.Proofs.IRGeneration.Function.runtimeStateMatchesIR_applyBindingsToIRState
@@ -2085,6 +2089,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_scalar_events_body_goal_fuel  -- private
   Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_scalar_events_body_goal
   Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_helper_proofs_body_goal_and_helper_ir
+  Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_helper_proofs_body_goal_with_internals
   Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_helper_proofs_body_goal_and_helper_ir_of_bodyCallsDisjoint
   -- Compiler.Proofs.IRGeneration.Function.function_body_scopeNamesPresent_of_bindSupportedParams  -- private
   -- Compiler.Proofs.IRGeneration.Function.function_body_state_runtime_of_bindSupportedParams  -- private
@@ -5910,4 +5915,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5540 theorems/lemmas (3835 public, 1705 private, 0 sorry'd)
+-- Total: 5545 theorems/lemmas (3840 public, 1705 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -134,6 +134,19 @@ ALLOWLIST: set[str] = {
     "selectedUserBodyClosureAndMatchedFresh_of_compile_ok_supported_switchFresh",
     # --- Helper-aware result packaging bridge ---
     "interpretFunctionWithHelpers_eq_execResultToIRResultWithInternals_of_body",
+    # #2080 phase 21 function-level WithInternals bridge: threads generated ABI
+    # param-load execution into the helper-aware compiled body while preserving
+    # the exact fuel equality needed by `execIRFunctionWithInternals`.
+    "exec_compiledFunctionIR_withInternals_of_body_extraFuel",
+    # #2080 phase 21 direct helper-aware function theorem: packages source
+    # helper semantics, the exact helper-IR body goal, function compilation
+    # shape, rollback state, and param-prefix execution into the final
+    # `execIRFunctionWithInternals` result.
+    "supported_function_correct_with_helper_proofs_body_goal_with_internals",
+    # #2080 phase 21 contract-level consumer: exposes the direct helper-aware
+    # function theorem through the contract proof API while keeping the
+    # generated param-load disjointness premise explicit.
+    "compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal",
     # First concrete letVar statement-head adapter (#2080 phase 10): threads a
     # single compositional-expression existential through source execution, IR
     # fuel alignment, and four scope/runtime invariant re-establishment steps


### PR DESCRIPTION
## Base / dependency

Stacked on `paloma/issue-2080-function-withinternals-bridge` / PR #2115, which is still open and clean at PR creation time. This continues the #2080 L2 proof-tier stack after phase 20.

Do not merge until predecessor stack is merged/green.

## Summary

- Add the `execIRStmtsWithInternals` append/prefix bridge needed to run generated ABI param loads before helper-aware compiled bodies.
- Add `exec_genParamLoads_supported_then_extraFuel_withInternals` and `exec_compiledFunctionIR_withInternals_of_body_extraFuel`, with the generated param-load prefix disjointness kept explicit.
- Add the direct function-level theorem `supported_function_correct_with_helper_proofs_body_goal_with_internals`, consuming `SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal` and producing preservation against `execIRFunctionWithInternals` directly.
- Add a contract-level API consumer wrapper `compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal`.
- Refresh `PrintAxioms.lean` and proof-length metadata for the new bridge theorems.

## Validation

- `lean-slot lake build Compiler.Proofs.IRGeneration.FunctionShape Compiler.Proofs.IRGeneration.Function` - passed
- `lean-slot lake build Compiler.Proofs.IRGeneration.Function` - passed
- `lean-slot lake build Compiler.Proofs.IRGeneration.Contract` - passed
- `lean-slot lake build Compiler.Proofs.HelperStepProofs` - passed
- `python3 scripts/generate_print_axioms.py --check` - passed
- `python3 scripts/check_proof_length.py` - passed
- `git diff --check` - passed
- Touched proof-file scan found no new `sorry`, `admit`, or `axiom` declarations; matches are comments/generated audit text only.

## Remaining #2080 gate

This PR exposes the first direct function-level `execIRFunctionWithInternals` path for exact helper-aware body goals. Whole-contract dispatch still needs a follow-up retarget that supplies the generated param-load disjointness/naming invariant and threads this direct function theorem through selector dispatch instead of the existing conservative-extension wrappers.

Refs #2080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to Lean correctness proofs and audit metadata; no compiler runtime, auth, or execution semantics outside the proof layer.
> 
> **Overview**
> Adds **#2080 phase 21** proof infrastructure so helper-aware function correctness can be stated against **`execIRFunctionWithInternals`** when callers already discharge the exact helper-IR body goal, instead of a manual conservative-extension equality.
> 
> New execution lemmas thread **generated ABI `genParamLoads`** under `execIRStmtsWithInternals` (prefix/append, param-load bridge, compiled-function fuel alignment). **`supported_function_correct_with_helper_proofs_body_goal_with_internals`** packages source semantics, compilation shape, and that body goal into **`sourceResultMatchesIRResult`** for `execIRFunctionWithInternals`. **`compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal`** exposes the same on the contract API, with **`YulStmtListCallsDisjointFromInternalTable` on `genParamLoads`** as the remaining explicit premise.
> 
> **`PrintAxioms.lean`** and **`scripts/check_proof_length.py`** are updated for the new public theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95f99ddc4f13db3b41a87c1f6b696b8a5ec11f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->