### PR TITLE
proof(#2080): naming-invariant param-load disjointness contract seam

### DIFF
--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -1097,6 +1097,64 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     hbodyCompile hcompileFn hbind htxNormalized extraFuel hcompiledBodyFuel
     hbodyCorrect hparamDisjoint hcalldataSizeFits
 
+/-- Packaged helper-aware compiled-side wrapper that discharges the ABI
+parameter-load prefix disjointness from the runtime contract's internal-table
+naming invariant, rather than taking it as an opaque premise. This is the
+selector-dispatch consumer seam: once the whole-contract theorem establishes
+`InternalTableNamesInternalPrefixed` for the compiled runtime contract, each
+per-function correctness obligation feeds straight into
+`execIRFunctionWithInternals` without the `genParamLoads` disjointness witness
+having to be supplied by hand. Param supportedness comes from `SupportedSpec`. -/
+theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (hHelperProofs : SourceSemantics.SupportedSpecHelperProofs model selectors hSupported)
+    (hvalidateInputs : validateCompileInputs model selectors = Except.ok ())
+    (runtimeContract : IRContract)
+    (fn : FunctionSpec)
+    (sel : Nat)
+    (returns : List ParamType)
+    (bodyStmts : List YulStmt)
+    (irFn : IRFunction)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (htxNormalized : Function.TxContextNormalized tx)
+    (bindings : List (String × Nat))
+    (extraFuel : Nat)
+    (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
+    (hfn : fn ∈ selectorDispatchedFunctions model)
+    (hvalidate : validateFunctionSpec fn = Except.ok ())
+    (hreturns : functionReturns fn = Except.ok returns)
+    (hbodyCompile :
+      compileStmtList model.fields model.events model.errors .calldata [] false
+        (fn.params.map (·.name)) [] fn.body = Except.ok bodyStmts)
+    (hcompileFn :
+      compileFunctionSpec model.fields model.events model.errors [] sel fn = Except.ok irFn)
+    (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
+    (hcompiledBodyFuel :
+      (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
+        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body)
+    (hbodyCorrect :
+      SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
+        runtimeContract model fn bodyStmts hSupported.helperFuel tx initialWorld
+        (ParamLoading.applyBindingsToIRState
+          (Function.prebindRawArgs
+            (FunctionBody.initialIRStateForTx model tx initialWorld) fn.params)
+          bindings)
+        bindings extraFuel)
+    (hinv : InternalTableNamesInternalPrefixed runtimeContract) :
+    FunctionBody.sourceResultMatchesIRResult
+      (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
+      (execIRFunctionWithInternals runtimeContract 0 irFn tx.args
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
+  compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal
+    model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
+    bodyStmts irFn tx initialWorld htxNormalized bindings extraFuel hcalldataSizeFits hfn
+    hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
+    (Function.genParamLoads_callsDisjoint_of_internalNamesPrefixed runtimeContract fn.params
+      (supported_params_of_supportedSpec model selectors hSupported fn hfn) hinv)
+
 /-- Structured helper-aware compiled-side wrapper for the generic function
 theorem. This replaces the raw function-level conservative-extension equality
 premise by the compiled-body disjointness witness that proves it. -/

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -2858,6 +2858,138 @@ private theorem genParamLoads_scalar_legacy
   simp [genParamLoads, genParamLoadsFrom]
   exact .if_ _ _ _ (.exprStmt _ _ .nil) hbody
 
+/-- Disjointness of a single scalar param-load (with the `calldataload` word
+loader used by `genParamLoads`) from a runtime contract's internal-function
+table. Every EVM/Yul builtin emitted by `genScalarLoad`
+(`calldataload`, `and`, `iszero`) is assumed absent from the table; the
+generated statement introduces no other calls. -/
+private theorem genScalarLoad_calldataload_callsDisjoint
+    (runtimeContract : IRContract) (name : String) (ty : ParamType) (offset : Nat)
+    (hsupported : SupportedExternalParamType ty)
+    (hcd : findInternalFunction? runtimeContract "calldataload" = none)
+    (hand : findInternalFunction? runtimeContract "and" = none)
+    (hiszero : findInternalFunction? runtimeContract "iszero" = none) :
+    YulStmtListCallsDisjointFromInternalTable runtimeContract
+      (genScalarLoad (fun pos => YulExpr.call "calldataload" [pos]) name ty offset) := by
+  have hload : yulExprCallsDisjointFromInternalTable runtimeContract
+      (YulExpr.call "calldataload" [YulExpr.lit offset]) := by
+    simp only [yulExprCallsDisjointFromInternalTable]
+    refine ⟨hcd, ?_⟩
+    intro arg harg
+    simp only [List.mem_singleton] at harg
+    subst harg
+    simp only [yulExprCallsDisjointFromInternalTable]
+  cases ty <;> simp only [SupportedExternalParamType] at hsupported ⊢
+  all_goals
+    first
+    | exact .let_ _ _ [] hload .nil
+    | (refine .let_ _ _ [] ?_ .nil
+       simp only [yulExprCallsDisjointFromInternalTable]
+       refine ⟨hand, ?_⟩
+       intro arg harg
+       simp only [List.mem_cons, List.not_mem_nil, or_false] at harg
+       rcases harg with h1 | h2
+       · subst h1; exact hload
+       · subst h2; simp only [yulExprCallsDisjointFromInternalTable])
+    | (refine .let_ _ _ [] ?_ .nil
+       simp only [yulExprCallsDisjointFromInternalTable]
+       refine ⟨hiszero, ?_⟩
+       intro arg harg
+       simp only [List.mem_singleton] at harg
+       subst harg
+       simp only [yulExprCallsDisjointFromInternalTable]
+       refine ⟨hiszero, ?_⟩
+       intro arg2 harg2
+       simp only [List.mem_singleton] at harg2
+       subst harg2
+       exact hload)
+
+/-- Disjointness of the whole param-load body (the recursive `genSingleParamLoad`
+sequence used by `genParamLoads`) from a runtime contract's internal-function
+table, given the three scalar-load builtins are absent. Recurses over the
+supported scalar params, appending per-param disjointness. -/
+private theorem genParamLoadBodyFrom_calldataload_callsDisjoint
+    (runtimeContract : IRContract)
+    (hcd : findInternalFunction? runtimeContract "calldataload" = none)
+    (hand : findInternalFunction? runtimeContract "and" = none)
+    (hiszero : findInternalFunction? runtimeContract "iszero" = none)
+    (sizeExpr : YulExpr) (headSize baseOffset : Nat) :
+    ∀ (params : List Param) (headOffset : Nat),
+      (∀ param ∈ params, SupportedExternalParamType param.ty) →
+        YulStmtListCallsDisjointFromInternalTable runtimeContract
+          (genParamLoadBodyFrom (fun pos => YulExpr.call "calldataload" [pos])
+            sizeExpr headSize baseOffset params headOffset)
+  | [], _, _ => .nil
+  | param :: rest, headOffset, hsupported => by
+      have htail := genParamLoadBodyFrom_calldataload_callsDisjoint runtimeContract
+        hcd hand hiszero sizeExpr headSize baseOffset rest
+        (headOffset + paramHeadSize param.ty)
+        (by intro p hp; exact hsupported p (by simp [hp]))
+      have hhead_sup : SupportedExternalParamType param.ty := hsupported param (by simp)
+      have hhead := genScalarLoad_calldataload_callsDisjoint runtimeContract
+        param.name param.ty headOffset hhead_sup hcd hand hiszero
+      cases hty : param.ty <;>
+        simp only [SupportedExternalParamType, hty] at hhead_sup <;>
+        simpa only [genParamLoadBodyFrom, genSingleParamLoad, hty]
+          using yulStmtListCallsDisjoint_append hhead htail
+
+/-- Disjointness of the full `genParamLoads` output (min-input-size guard plus
+the param-load body) from a runtime contract's internal-function table, given
+that none of the six EVM/Yul builtins it emits (`calldataload`, `calldatasize`,
+`lt`, `revert`, `and`, `iszero`) collide with an internal helper. -/
+private theorem genParamLoads_callsDisjoint_of_builtins
+    (runtimeContract : IRContract) (params : List Param)
+    (hsupported : ∀ param ∈ params, SupportedExternalParamType param.ty)
+    (hcd : findInternalFunction? runtimeContract "calldataload" = none)
+    (hcdsize : findInternalFunction? runtimeContract "calldatasize" = none)
+    (hlt : findInternalFunction? runtimeContract "lt" = none)
+    (hrevert : findInternalFunction? runtimeContract "revert" = none)
+    (hand : findInternalFunction? runtimeContract "and" = none)
+    (hiszero : findInternalFunction? runtimeContract "iszero" = none) :
+    YulStmtListCallsDisjointFromInternalTable runtimeContract (genParamLoads params) := by
+  have hbody := genParamLoadBodyFrom_calldataload_callsDisjoint runtimeContract
+    hcd hand hiszero (YulExpr.call "calldatasize" [])
+    ((params.map (fun p => paramHeadSize p.ty)).foldl (· + ·) 0) 4 params 4 hsupported
+  simp only [genParamLoads, genParamLoadsFrom]
+  refine .if_ _ _ _ ?_ ?_ hbody
+  · simp only [yulExprCallsDisjointFromInternalTable]
+    refine ⟨hlt, ?_⟩
+    intro arg harg
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at harg
+    rcases harg with h1 | h2
+    · subst h1
+      simp only [yulExprCallsDisjointFromInternalTable]
+      exact ⟨hcdsize, by intro a ha; simp at ha⟩
+    · subst h2; simp only [yulExprCallsDisjointFromInternalTable]
+  · refine .exprStmt _ _ ?_ .nil
+    simp only [yulExprCallsDisjointFromInternalTable]
+    refine ⟨hrevert, ?_⟩
+    intro arg harg
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at harg
+    rcases harg with h1 | h2
+    · subst h1; simp only [yulExprCallsDisjointFromInternalTable]
+    · subst h2; simp only [yulExprCallsDisjointFromInternalTable]
+
+/-- Package `genParamLoads` disjointness directly from the runtime contract's
+internal-table naming invariant. Because every helper name begins with
+`internalFunctionPrefix` (`"internal_"`), none of the six builtins emitted by the
+param-load prologue — whose names are not `internal_`-prefixed — can resolve to a
+helper. This is the forward-compatible replacement for the
+`internalFunctions = []` disjointness route: it does not require the internal
+table to be empty. -/
+theorem genParamLoads_callsDisjoint_of_internalNamesPrefixed
+    (runtimeContract : IRContract) (params : List Param)
+    (hsupported : ∀ param ∈ params, SupportedExternalParamType param.ty)
+    (hinv : InternalTableNamesInternalPrefixed runtimeContract) :
+    YulStmtListCallsDisjointFromInternalTable runtimeContract (genParamLoads params) :=
+  genParamLoads_callsDisjoint_of_builtins runtimeContract params hsupported
+    (findInternalFunction?_eq_none_of_not_internalPrefixed runtimeContract "calldataload" hinv (by decide))
+    (findInternalFunction?_eq_none_of_not_internalPrefixed runtimeContract "calldatasize" hinv (by decide))
+    (findInternalFunction?_eq_none_of_not_internalPrefixed runtimeContract "lt" hinv (by decide))
+    (findInternalFunction?_eq_none_of_not_internalPrefixed runtimeContract "revert" hinv (by decide))
+    (findInternalFunction?_eq_none_of_not_internalPrefixed runtimeContract "and" hinv (by decide))
+    (findInternalFunction?_eq_none_of_not_internalPrefixed runtimeContract "iszero" hinv (by decide))
+
 private theorem compiledStmt_scalar_events_callsDisjoint
     (runtimeContract : IRContract) (hinternal : runtimeContract.internalFunctions = [])
     {fields : List Field} {spec : CompilationModel} {scope : List String}

--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -2171,6 +2171,37 @@ noncomputable def interpretIRWithInternals
     findInternalFunction? contract name = none := by
   simp [findInternalFunction?, hinternal]
 
+/-- Naming invariant for a runtime contract's internal-function table: every
+decoded helper's name begins with `internalFunctionPrefix`. Compiled contracts
+satisfy this because helpers are emitted via `internalFunctionYulName`, which
+prepends the prefix. Phrasing the invariant via `String.data.take` avoids any
+dependence on defeq of `internalFunctionYulName` (which appends to an opaque
+tail). -/
+def InternalTableNamesInternalPrefixed (contract : IRContract) : Prop :=
+  ∀ d ∈ contract.internalFunctions.filterMap irInternalFunctionDefOfStmt?,
+    d.name.data.take CompilationModel.internalFunctionPrefix.data.length =
+      CompilationModel.internalFunctionPrefix.data
+
+/-- A name that is not `internal_`-prefixed cannot resolve to any helper in a
+contract whose internal table satisfies the naming invariant. This is the
+forward-compatible generalization of
+`findInternalFunction?_eq_none_of_internalFunctions_nil`: it discharges the
+`findInternalFunction? ... = none` obligation for a concrete non-prefixed name
+(e.g. an EVM/Yul builtin) without requiring the internal table to be empty. -/
+theorem findInternalFunction?_eq_none_of_not_internalPrefixed
+    (contract : IRContract) (name : String)
+    (hinv : InternalTableNamesInternalPrefixed contract)
+    (hname : name.data.take CompilationModel.internalFunctionPrefix.data.length ≠
+        CompilationModel.internalFunctionPrefix.data) :
+    findInternalFunction? contract name = none := by
+  simp only [findInternalFunction?]
+  rw [List.find?_eq_none]
+  intro d hd hpred
+  have hdname : d.name = name := by simpa using hpred
+  have hdtake := hinv d hd
+  rw [hdname] at hdtake
+  exact hname hdtake
+
 /-- The first compiled-side helper retarget theorem only needs the current
 helper-free runtime-contract shape: no internal helpers and legacy-compatible
 external bodies. Encoding that shape as a proposition keeps the remaining

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1876,6 +1876,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal
+  Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_bodyCallsDisjoint
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
   -- Compiler.Proofs.IRGeneration.Contract.scalar_events_contract_function_callback  -- private
@@ -2103,6 +2104,10 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Function.genScalarLoad_legacy  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoadBodyFrom_scalar_legacy  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoads_scalar_legacy  -- private
+  -- Compiler.Proofs.IRGeneration.Function.genScalarLoad_calldataload_callsDisjoint  -- private
+  -- Compiler.Proofs.IRGeneration.Function.genParamLoadBodyFrom_calldataload_callsDisjoint  -- private
+  -- Compiler.Proofs.IRGeneration.Function.genParamLoads_callsDisjoint_of_builtins  -- private
+  Compiler.Proofs.IRGeneration.Function.genParamLoads_callsDisjoint_of_internalNamesPrefixed
   -- Compiler.Proofs.IRGeneration.Function.compiledStmt_scalar_events_callsDisjoint  -- private
   -- Compiler.Proofs.IRGeneration.Function.compileStmtList_scalar_events_callsDisjoint  -- private
   -- Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_scalar_events_state_runtime  -- private
@@ -3182,6 +3187,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.IRState.withTx_events
   Compiler.Proofs.IRGeneration.execIRFunction_continue_extract_eq
   Compiler.Proofs.IRGeneration.findInternalFunction?_eq_none_of_internalFunctions_nil
+  Compiler.Proofs.IRGeneration.findInternalFunction?_eq_none_of_not_internalPrefixed
   Compiler.Proofs.IRGeneration.legacyCompatibleExternalBodies_of_legacyCompatibleRuntimeContract
   Compiler.Proofs.IRGeneration.evalIRExprWithInternals_eq_evalIRExpr_of_no_internal
   Compiler.Proofs.IRGeneration.evalIRExprsWithInternals_eq_evalIRExprs_of_no_internal
@@ -5915,4 +5921,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5545 theorems/lemmas (3840 public, 1705 private, 0 sorry'd)
+-- Total: 5551 theorems/lemmas (3843 public, 1708 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -147,6 +147,12 @@ ALLOWLIST: set[str] = {
     # function theorem through the contract proof API while keeping the
     # generated param-load disjointness premise explicit.
     "compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal",
+    # #2080 selector-dispatch consumer seam: same signature-dominated wrapper as
+    # its `_of_body_goal` sibling, but discharges the generated param-load
+    # disjointness premise from the runtime contract's internal-table naming
+    # invariant instead of taking it as an opaque hypothesis. Body is a single
+    # term application; the >50 lines are entirely the mirrored premise list.
+    "compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed",
     # First concrete letVar statement-head adapter (#2080 phase 10): threads a
     # single compositional-expression existential through source execution, IR
     # fuel alignment, and four scope/runtime invariant re-establishment steps


### PR DESCRIPTION
## Base / dependency (stacked)

- **Base branch:** `paloma/issue-2080-function-exec-withinternals` (head of **PR #2116**).
- **Stack:** #2116 → `paloma/issue-2080-function-withinternals-bridge`. #2116 is OPEN, MERGEABLE, all checks green at time of writing.
- **Do not merge until predecessor stack (#2116 and below) is merged/green.**

## Summary

Threads the L2 param-load prefix-disjointness fact through to the selector-dispatch consumer seam, reducing reliance on conservative-extension / default-empty helper-world wrappers.

- **IRInterpreter.lean:** add `InternalTableNamesInternalPrefixed` (contract invariant: every internal-table entry's name carries the `internal_` prefix) and `findInternalFunction?_eq_none_of_not_internalPrefixed` (a non-prefixed name never resolves in the internal table).
- **Function.lean:** prove `genParamLoads` call-disjointness from the internal table out of per-builtin `findInternalFunction? = none` facts (`genScalarLoad` / `genParamLoadBodyFrom` recursion + `minInputSizeCheck`), then package it as `genParamLoads_callsDisjoint_of_internalNamesPrefixed`, which supplies those facts from the naming invariant via `by decide` on each builtin's non-`internal_` prefix.
- **Contract.lean:** add `compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed` — same premises as its `_of_body_goal` sibling except it discharges the `hparamDisjoint` premise from `InternalTableNamesInternalPrefixed` (param supportedness comes from `SupportedSpec` via `supported_params_of_supportedSpec`). Each per-function obligation now feeds straight into `execIRFunctionWithInternals` without an opaque disjointness witness.

The naming-invariant route (rather than `internalFunctions = []`) is deliberately forward-compatible with non-empty helper tables — the direction #2080 wants to move.

## Validation

All run via `lean-slot` (host-wide gate, Spark offload), from `verity/`:

- `lean-slot lake build PrintAxioms` → **Build completed successfully.** Whole-tree axiom gate (PrintAxioms imports every top-level theorem to `#print axioms`); Contract.lean's new theorem and all downstream modules compile. Every printed axiom is standard (`propext`, `Classical.choice`, `Quot.sound`) — no `sorryAx`.
- Individual green builds this slice: `IRInterpreter`, `Function`, `Contract`.
- `python3 scripts/generate_print_axioms.py --check` → **OK: PrintAxioms.lean is up to date.**
- `python3 scripts/check_proof_length.py` → **passed** (the signature-dominated wrapper is allowlisted with justification; body is a single term application).
- `git diff --check` → clean.
- No new `sorry` / `admit` / `axiom` in any touched proof file.

## Next slice (not in this PR — kept narrow)

Whole-contract dispatch integration: establish `InternalTableNamesInternalPrefixed` for the compiled runtime contract from the compilation pipeline, and supply the per-function body-preservation goal, so the whole-contract theorem consumes this seam across all selector-dispatched functions and fully retires the default-empty helper-world wrapper.

Refs #2080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof-only changes with no runtime or auth logic; risk is limited to proof maintenance and axiom/theorem registration consistency.
> 
> **Overview**
> Adds a **forward-compatible** proof path so `genParamLoads` ABI prefix code cannot collide with internal helpers when the runtime table is **non-empty**, as long as every helper name carries the `internal_` prefix.
> 
> **IRInterpreter:** introduces `InternalTableNamesInternalPrefixed` and `findInternalFunction?_eq_none_of_not_internalPrefixed` so non-prefixed names (EVM/Yul builtins) never resolve in the internal table.
> 
> **Function:** proves `genParamLoads` call-disjointness from per-builtin `findInternalFunction? = none` lemmas, then packages it as `genParamLoads_callsDisjoint_of_internalNamesPrefixed` using the naming invariant.
> 
> **Contract:** adds `compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed`, mirroring the existing `_of_body_goal` wrapper but replacing opaque `hparamDisjoint` with `InternalTableNamesInternalPrefixed` (param support from `SupportedSpec`).
> 
> **Tooling:** registers new theorems in `PrintAxioms.lean` and allowlists the long signature-only contract wrapper in `check_proof_length.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5759254451ec8c9de60df77024512ddd1689e570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->