### PR TITLE
proof(#2080): derive contract naming invariant from compiled internal table

### DIFF
--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -1155,6 +1155,71 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (Function.genParamLoads_callsDisjoint_of_internalNamesPrefixed runtimeContract fn.params
       (supported_params_of_supportedSpec model selectors hSupported fn hfn) hinv)
 
+/-- Whole-contract-facing consumer seam. Rather than taking the runtime
+contract's naming invariant `InternalTableNamesInternalPrefixed` as an opaque
+premise, this variant derives it from the structural compilation fact that every
+statement in the runtime internal table is a `compileInternalFunction` output.
+This is the concrete step that threads PR #2117's `WithInternals` selector seam
+into the whole-contract dispatch path: once the dispatch proof exhibits the
+internal table as compiled internal helpers, the per-function obligation flows
+into `execIRFunctionWithInternals` with no hand-supplied disjointness witness and
+no `internalFunctions = []` default-empty helper-world assumption. -/
+theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compiledInternalTable
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (hHelperProofs : SourceSemantics.SupportedSpecHelperProofs model selectors hSupported)
+    (hvalidateInputs : validateCompileInputs model selectors = Except.ok ())
+    (runtimeContract : IRContract)
+    (fn : FunctionSpec)
+    (sel : Nat)
+    (returns : List ParamType)
+    (bodyStmts : List YulStmt)
+    (irFn : IRFunction)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (htxNormalized : Function.TxContextNormalized tx)
+    (bindings : List (String × Nat))
+    (extraFuel : Nat)
+    (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
+    (hfn : fn ∈ selectorDispatchedFunctions model)
+    (hvalidate : validateFunctionSpec fn = Except.ok ())
+    (hreturns : functionReturns fn = Except.ok returns)
+    (hbodyCompile :
+      compileStmtList model.fields model.events model.errors .calldata [] false
+        (fn.params.map (·.name)) [] fn.body = Except.ok bodyStmts)
+    (hcompileFn :
+      compileFunctionSpec model.fields model.events model.errors [] sel fn = Except.ok irFn)
+    (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
+    (hcompiledBodyFuel :
+      (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
+        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body)
+    (hbodyCorrect :
+      SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
+        runtimeContract model fn bodyStmts hSupported.helperFuel tx initialWorld
+        (ParamLoading.applyBindingsToIRState
+          (Function.prebindRawArgs
+            (FunctionBody.initialIRStateForTx model tx initialWorld) fn.params)
+          bindings)
+        bindings extraFuel)
+    (hcompiledTable : ∀ stmt ∈ runtimeContract.internalFunctions,
+        ∃ (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
+          (adtTypes : List AdtTypeDef) (spec : FunctionSpec)
+          (targetFork : Verity.Core.Intrinsics.HardFork)
+          (internalFunctions : List FunctionSpec),
+          compileInternalFunction fields events errors adtTypes spec targetFork internalFunctions
+            = Except.ok stmt) :
+    FunctionBody.sourceResultMatchesIRResult
+      (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
+      (execIRFunctionWithInternals runtimeContract 0 irFn tx.args
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
+  compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed
+    model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
+    bodyStmts irFn tx initialWorld htxNormalized bindings extraFuel hcalldataSizeFits hfn
+    hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
+    (Function.InternalTableNamesInternalPrefixed_of_all_compiledInternal runtimeContract
+      hcompiledTable)
+
 /-- Structured helper-aware compiled-side wrapper for the generic function
 theorem. This replaces the raw function-level conservative-extension equality
 premise by the compiled-body disjointness witness that proves it. -/

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -2990,6 +2990,85 @@ theorem genParamLoads_callsDisjoint_of_internalNamesPrefixed
     (findInternalFunction?_eq_none_of_not_internalPrefixed runtimeContract "and" hinv (by decide))
     (findInternalFunction?_eq_none_of_not_internalPrefixed runtimeContract "iszero" hinv (by decide))
 
+/-- The Yul name emitted for a compiled internal helper begins with
+`internalFunctionPrefix` (`"internal_"`). This is the structural fact that lets
+the whole-contract dispatch proof discharge `InternalTableNamesInternalPrefixed`
+directly from the compilation pipeline rather than assuming an empty internal
+table. -/
+theorem internalFunctionYulName_take_prefix (name : String) :
+    (internalFunctionYulName name).data.take internalFunctionPrefix.data.length =
+      internalFunctionPrefix.data := by
+  have hdata : (internalFunctionYulName name).data =
+      internalFunctionPrefix.data ++ name.data := by
+    have ts : ∀ s : String, toString s = s := fun _ => rfl
+    simp only [internalFunctionYulName, ts, String.data_append, List.nil_append, List.append_nil]
+  rw [hdata]
+  simp
+
+/-- Every successful `compileInternalFunction` output is a `funcDef` whose Yul
+name is exactly `internalFunctionYulName spec.name`. Mirrors the case analysis of
+`compileInternalFunction_ok_components`, extracting only the emitted name. -/
+theorem compileInternalFunction_isFuncDef_internalNamed
+    (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
+    (adtTypes : List AdtTypeDef) (spec : FunctionSpec)
+    (targetFork : Verity.Core.Intrinsics.HardFork)
+    (internalFunctions : List FunctionSpec) (stmt : YulStmt)
+    (hcompile : compileInternalFunction fields events errors adtTypes spec targetFork
+        internalFunctions = Except.ok stmt) :
+    ∃ params rets body,
+      stmt = YulStmt.funcDef (internalFunctionYulName spec.name) params rets body := by
+  unfold compileInternalFunction at hcompile
+  cases hvalidate : validateFunctionSpec spec
+  · rw [hvalidate] at hcompile
+    cases hcompile
+  case ok _ =>
+    cases hreturns : functionReturns spec
+    · rw [hvalidate, hreturns] at hcompile
+      cases hcompile
+    case ok returns =>
+      rw [hvalidate, hreturns] at hcompile
+      simp only [bind, Except.bind] at hcompile
+      cases hbody :
+          compileStmtListWithFork fields events errors .calldata
+            (freshInternalRetNames returns
+              (internalFunctionYulParamNames spec.params ++ collectStmtListBindNames spec.body))
+            true
+            (internalFunctionYulParamNames spec.params ++
+              freshInternalRetNames returns
+                (internalFunctionYulParamNames spec.params ++ collectStmtListBindNames spec.body))
+            adtTypes targetFork spec.body internalFunctions
+      · rw [hbody] at hcompile
+        cases hcompile
+      case ok bodyStmts =>
+        rw [hbody] at hcompile
+        simp only [pure, Except.pure, Except.ok.injEq] at hcompile
+        exact ⟨_, _, _, hcompile.symm⟩
+
+/-- If every statement in a runtime contract's internal table is the output of
+`compileInternalFunction`, then the contract satisfies
+`InternalTableNamesInternalPrefixed`. This packages the compiled-internal naming
+invariant for consumption by the whole-contract dispatch seam. -/
+theorem InternalTableNamesInternalPrefixed_of_all_compiledInternal
+    (runtimeContract : IRContract)
+    (hcompiled : ∀ stmt ∈ runtimeContract.internalFunctions,
+        ∃ (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
+          (adtTypes : List AdtTypeDef) (spec : FunctionSpec)
+          (targetFork : Verity.Core.Intrinsics.HardFork)
+          (internalFunctions : List FunctionSpec),
+          compileInternalFunction fields events errors adtTypes spec targetFork internalFunctions
+            = Except.ok stmt) :
+    InternalTableNamesInternalPrefixed runtimeContract := by
+  intro d hd
+  rw [List.mem_filterMap] at hd
+  obtain ⟨stmt, hstmt, hdecode⟩ := hd
+  obtain ⟨fields, events, errors, adtTypes, spec, tf, ifs, hc⟩ := hcompiled stmt hstmt
+  obtain ⟨params, rets, body, hstmteq⟩ :=
+    compileInternalFunction_isFuncDef_internalNamed fields events errors adtTypes spec tf ifs stmt hc
+  subst hstmteq
+  simp only [irInternalFunctionDefOfStmt?_funcDef, Option.some.injEq] at hdecode
+  subst hdecode
+  exact internalFunctionYulName_take_prefix spec.name
+
 private theorem compiledStmt_scalar_events_callsDisjoint
     (runtimeContract : IRContract) (hinternal : runtimeContract.internalFunctions = [])
     {fields : List Field} {spec : CompilationModel} {scope : List String}

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1877,6 +1877,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed
+  Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compiledInternalTable
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_bodyCallsDisjoint
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
   -- Compiler.Proofs.IRGeneration.Contract.scalar_events_contract_function_callback  -- private
@@ -2108,6 +2109,9 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Function.genParamLoadBodyFrom_calldataload_callsDisjoint  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoads_callsDisjoint_of_builtins  -- private
   Compiler.Proofs.IRGeneration.Function.genParamLoads_callsDisjoint_of_internalNamesPrefixed
+  Compiler.Proofs.IRGeneration.Function.internalFunctionYulName_take_prefix
+  Compiler.Proofs.IRGeneration.Function.compileInternalFunction_isFuncDef_internalNamed
+  Compiler.Proofs.IRGeneration.Function.InternalTableNamesInternalPrefixed_of_all_compiledInternal
   -- Compiler.Proofs.IRGeneration.Function.compiledStmt_scalar_events_callsDisjoint  -- private
   -- Compiler.Proofs.IRGeneration.Function.compileStmtList_scalar_events_callsDisjoint  -- private
   -- Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_scalar_events_state_runtime  -- private
@@ -5921,4 +5925,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5551 theorems/lemmas (3843 public, 1708 private, 0 sorry'd)
+-- Total: 5555 theorems/lemmas (3847 public, 1708 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -153,6 +153,12 @@ ALLOWLIST: set[str] = {
     # invariant instead of taking it as an opaque hypothesis. Body is a single
     # term application; the >50 lines are entirely the mirrored premise list.
     "compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed",
+    # #2080 whole-contract dispatch seam: same signature-dominated wrapper as the
+    # `_of_internalNamesPrefixed` sibling, but derives the internal-table naming
+    # invariant from the structural compilation fact (every internal-table stmt is
+    # a `compileInternalFunction` output). Body is a single term application; the
+    # >50 lines are entirely the mirrored premise list.
+    "compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compiledInternalTable",
     # First concrete letVar statement-head adapter (#2080 phase 10): threads a
     # single compositional-expression existential through source execution, IR
     # fuel alignment, and four scope/runtime invariant re-establishment steps


### PR DESCRIPTION
## Summary

Threads the runtime contract's internal-table **naming invariant** into the whole-contract dispatch seam by *deriving* it from the structural compilation fact — every internal-table statement is a `compileInternalFunction` output — instead of taking `InternalTableNamesInternalPrefixed` as an opaque hypothesis.

Stacked on top of `paloma/issue-2080-selector-dispatch-withinternals` (PR #2117's `WithInternals` selector seam).

### New lemmas (`Compiler/Proofs/IRGeneration/Function.lean`)
- `internalFunctionYulName_take_prefix` — a compiled internal helper's Yul name carries the `internal_` prefix.
- `compileInternalFunction_isFuncDef_internalNamed` — a `compileInternalFunction` output is a `FunctionDefinition` whose name is `internal_`-prefixed.
- `InternalTableNamesInternalPrefixed_of_all_compiledInternal` — lifts the above to the whole runtime internal table.

### New consumer seam (`Compiler/Proofs/IRGeneration/Contract.lean`)
- `compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compiledInternalTable` — takes the structural "all internal-table stmts are compiled internal helpers" premise, derives the naming invariant, and delegates to the `_of_internalNamesPrefixed` sibling. The body is a single term application; the length is entirely the mirrored premise list (allowlisted in `check_proof_length.py`).

## Validation
- `lean-slot lake build Compiler.Proofs.IRGeneration.Function` — green
- `lean-slot lake build Compiler.Proofs.IRGeneration.Contract` — green (1144/1144, with the new seam)
- `lean-slot lake build Compiler.Proofs.HelperStepProofs` — green (1139/1139)
- `python3 scripts/generate_print_axioms.py --check` — OK (5551 -> 5555 theorems, 0 sorry'd)
- `python3 scripts/check_proof_length.py` — pass
- `git diff --check` — clean
- No new `sorry`/`admit`/`axiom` in touched proof files
- `lake build PrintAxioms` — running in CI (constructive proofs only; no new axioms expected)

## Test plan
- [ ] CI green (full `lake build`, PrintAxioms axiom footprint, proof-length gate)

Do not merge until the base PR lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof-only changes with no runtime or auth logic; risk is limited to proof maintenance and CI gates (PrintAxioms, proof length).
> 
> **Overview**
> Adds proof plumbing so whole-contract helper-aware correctness can assume **every runtime internal-table stmt came from `compileInternalFunction`**, instead of supplying `InternalTableNamesInternalPrefixed` by hand.
> 
> In **Function.lean**, three lemmas chain compilation shape to naming: `internalFunctionYulName_take_prefix`, `compileInternalFunction_isFuncDef_internalNamed`, and `InternalTableNamesInternalPrefixed_of_all_compiledInternal`.
> 
> In **Contract.lean**, `compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compiledInternalTable` mirrors the `_of_internalNamesPrefixed` wrapper but takes `hcompiledTable` and derives the naming invariant before delegating to `execIRFunctionWithInternals` (no manual param-load disjointness witness).
> 
> **PrintAxioms.lean** and **`check_proof_length.py`** register the new public theorem (+4 lemmas, allowlist entry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455906ff157b9b8d3f96612124c1eecaa03598d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->