### PR TITLE
proof(#2080): feed compiled-internal-table dispatch seam from pipeline output

### DIFF
--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -1220,6 +1220,222 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (Function.InternalTableNamesInternalPrefixed_of_all_compiledInternal runtimeContract
       hcompiledTable)
 
+/-- Generalized `Forall₂` bridge for the internal-function compilation `mapM`.
+
+Unlike `compiled_internal_functions_forall₂_of_mapM_ok` (which fixes
+`adtTypes = []` and the default `targetFork`/`internalFunctions` arguments), this
+matches the exact call shape used by `compileValidatedCore` when it populates the
+`internalFuncDefs` segment of the runtime internal table:
+`internalFns.mapM (fun fn => compileInternalFunction fields events errors adtTypes fn targetFork internalFns)`. -/
+private theorem compiled_internal_functions_forall₂_of_mapM_ok'
+    (fields : List Field)
+    (events : List EventDef)
+    (errors : List ErrorDef)
+    (adtTypes : List AdtTypeDef)
+    (targetFork : Verity.Core.Intrinsics.HardFork)
+    (internalFns : List FunctionSpec) :
+    ∀ (entries : List FunctionSpec) internalDefs,
+      (entries.mapM (fun fn =>
+        compileInternalFunction fields events errors adtTypes fn targetFork internalFns)) =
+        Except.ok internalDefs →
+      List.Forall₂
+        (fun fn internalDef =>
+          compileInternalFunction fields events errors adtTypes fn targetFork internalFns =
+            Except.ok internalDef)
+        entries internalDefs := by
+  intro entries
+  induction entries with
+  | nil =>
+      intro internalDefs hmap
+      cases hmap
+      simp
+  | cons entry entries ih =>
+      intro internalDefs hmap
+      rcases hstep :
+          compileInternalFunction fields events errors adtTypes entry targetFork internalFns with
+        _ | internalDef
+      · simp only [List.mapM_cons, hstep, bind, Except.bind] at hmap
+        cases hmap
+      · rcases htail :
+          List.mapM (fun fn =>
+            compileInternalFunction fields events errors adtTypes fn targetFork internalFns)
+            entries with _ | internalDefsTail
+        · simp only [List.mapM_cons, hstep, htail, bind, Except.bind] at hmap
+          cases hmap
+        · simp only [List.mapM_cons, hstep, htail, bind, Except.bind] at hmap
+          cases hmap
+          exact List.Forall₂.cons hstep (ih _ htail)
+
+/-- Mirror of `exists_right_of_forall₂_mem_left`: a member of the right list of a
+`Forall₂` witnesses a related member on the left. -/
+private theorem exists_left_of_forall₂_mem_right
+    {α β : Type}
+    {R : α → β → Prop}
+    {xs : List α}
+    {ys : List β}
+    (hrel : List.Forall₂ R xs ys)
+    {y : β}
+    (hmem : y ∈ ys) :
+    ∃ x, x ∈ xs ∧ R x y := by
+  induction hrel with
+  | nil =>
+      cases hmem
+  | @cons headX headY tailX tailY hhead htail ih =>
+      simp only [List.mem_cons] at hmem
+      rcases hmem with rfl | hmemTail
+      · exact ⟨headX, by simp, hhead⟩
+      · rcases ih hmemTail with ⟨x, hx, hRx⟩
+        exact ⟨x, by simp [hx], hRx⟩
+
+/-- Structural compiled-internal-table premise, derived from the compilation
+pipeline's `mapM` step. Every statement produced by
+`internalFns.mapM compileInternalFunction` is a `compileInternalFunction` output
+in the exact existential shape consumed by
+`..._of_body_goal_of_compiledInternalTable`'s `hcompiledTable`. This is
+non-vacuous: it holds for a *non-empty* `internalFns`, so it does not depend on
+any `internalFunctions = []` default-empty helper-world assumption. -/
+theorem compileInternalFunction_mapM_mem_exists
+    (fields : List Field)
+    (events : List EventDef)
+    (errors : List ErrorDef)
+    (adtTypes : List AdtTypeDef)
+    (targetFork : Verity.Core.Intrinsics.HardFork)
+    (internalFns : List FunctionSpec)
+    (internalDefs : List YulStmt)
+    (hmap : internalFns.mapM (fun fn =>
+        compileInternalFunction fields events errors adtTypes fn targetFork internalFns) =
+        Except.ok internalDefs) :
+    ∀ stmt ∈ internalDefs,
+      ∃ (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
+        (adtTypes : List AdtTypeDef) (spec : FunctionSpec)
+        (targetFork : Verity.Core.Intrinsics.HardFork)
+        (internalFunctions : List FunctionSpec),
+        compileInternalFunction fields events errors adtTypes spec targetFork internalFunctions =
+          Except.ok stmt := by
+  intro stmt hstmt
+  have hforall₂ :=
+    compiled_internal_functions_forall₂_of_mapM_ok'
+      fields events errors adtTypes targetFork internalFns internalFns internalDefs hmap
+  obtain ⟨fn, _hfn, hcompile⟩ := exists_left_of_forall₂_mem_right hforall₂ hstmt
+  exact ⟨fields, events, errors, adtTypes, fn, targetFork, internalFns, hcompile⟩
+
+/-- Consumer seam packaging: for a runtime contract whose internal table *is* the
+`compileInternalFunction` image of some internal-function list, discharge the
+`hcompiledTable` premise of
+`compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compiledInternalTable`
+directly from the compilation pipeline's `mapM` equation — no hand-supplied
+`InternalTableNamesInternalPrefixed` witness and no `internalFunctions = []`
+default-empty assumption. -/
+theorem compiledInternalTable_of_internalFunctions_eq_mapM
+    (runtimeContract : IRContract)
+    (fields : List Field)
+    (events : List EventDef)
+    (errors : List ErrorDef)
+    (adtTypes : List AdtTypeDef)
+    (targetFork : Verity.Core.Intrinsics.HardFork)
+    (internalFns : List FunctionSpec)
+    (internalDefs : List YulStmt)
+    (hmap : internalFns.mapM (fun fn =>
+        compileInternalFunction fields events errors adtTypes fn targetFork internalFns) =
+        Except.ok internalDefs)
+    (hinternal : runtimeContract.internalFunctions = internalDefs) :
+    ∀ stmt ∈ runtimeContract.internalFunctions,
+      ∃ (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
+        (adtTypes : List AdtTypeDef) (spec : FunctionSpec)
+        (targetFork : Verity.Core.Intrinsics.HardFork)
+        (internalFunctions : List FunctionSpec),
+        compileInternalFunction fields events errors adtTypes spec targetFork internalFunctions =
+          Except.ok stmt := by
+  rw [hinternal]
+  exact compileInternalFunction_mapM_mem_exists fields events errors adtTypes targetFork
+    internalFns internalDefs hmap
+
+/-- Pipeline connector for the current `SupportedSpec` world: a contract produced
+by `compileValidatedCore` discharges the structural `hcompiledTable` premise
+outright. Under `SupportedSpec` the runtime internal table is empty
+(`compileValidatedCore_ok_yields_internalFunctions_nil`), so the premise holds
+vacuously; this exhibits the seam being fed from the real compilation output
+rather than from a separately-assumed hypothesis. The non-vacuous machinery for a
+populated table lives in `compiledInternalTable_of_internalFunctions_eq_mapM`. -/
+theorem compiledInternalTable_of_compileValidatedCore
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (ir : IRContract)
+    (hcore : compileValidatedCore model selectors = Except.ok ir) :
+    ∀ stmt ∈ ir.internalFunctions,
+      ∃ (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
+        (adtTypes : List AdtTypeDef) (spec : FunctionSpec)
+        (targetFork : Verity.Core.Intrinsics.HardFork)
+        (internalFunctions : List FunctionSpec),
+        compileInternalFunction fields events errors adtTypes spec targetFork internalFunctions =
+          Except.ok stmt := by
+  intro stmt hstmt
+  have hnil :=
+    compileValidatedCore_ok_yields_internalFunctions_nil model selectors hSupported ir hcore
+  rw [hnil] at hstmt
+  cases hstmt
+
+/-- Whole-contract dispatch consumer of the compiled-internal-table seam.
+
+This feeds `..._of_body_goal_of_compiledInternalTable`'s `hcompiledTable` premise
+directly from the real compilation pipeline output
+(`compileValidatedCore model selectors = Except.ok runtimeContract`) via
+`compiledInternalTable_of_compileValidatedCore`, rather than requiring the caller
+to hand-supply that structural premise. The runtime contract whose
+`execIRFunctionWithInternals` dispatch is proven correct is exactly the contract
+emitted by the compiler, so the internal-table naming invariant is discharged by
+the pipeline itself and no `internalFunctions = []` default-empty assumption is
+introduced at the call site. -/
+theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compileValidatedCore
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (hHelperProofs : SourceSemantics.SupportedSpecHelperProofs model selectors hSupported)
+    (hvalidateInputs : validateCompileInputs model selectors = Except.ok ())
+    (runtimeContract : IRContract)
+    (hcore : compileValidatedCore model selectors = Except.ok runtimeContract)
+    (fn : FunctionSpec)
+    (sel : Nat)
+    (returns : List ParamType)
+    (bodyStmts : List YulStmt)
+    (irFn : IRFunction)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (htxNormalized : Function.TxContextNormalized tx)
+    (bindings : List (String × Nat))
+    (extraFuel : Nat)
+    (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
+    (hfn : fn ∈ selectorDispatchedFunctions model)
+    (hvalidate : validateFunctionSpec fn = Except.ok ())
+    (hreturns : functionReturns fn = Except.ok returns)
+    (hbodyCompile :
+      compileStmtList model.fields model.events model.errors .calldata [] false
+        (fn.params.map (·.name)) [] fn.body = Except.ok bodyStmts)
+    (hcompileFn :
+      compileFunctionSpec model.fields model.events model.errors [] sel fn = Except.ok irFn)
+    (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
+    (hcompiledBodyFuel :
+      (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
+        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body)
+    (hbodyCorrect :
+      SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
+        runtimeContract model fn bodyStmts hSupported.helperFuel tx initialWorld
+        (ParamLoading.applyBindingsToIRState
+          (Function.prebindRawArgs
+            (FunctionBody.initialIRStateForTx model tx initialWorld) fn.params)
+          bindings)
+        bindings extraFuel) :
+    FunctionBody.sourceResultMatchesIRResult
+      (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
+      (execIRFunctionWithInternals runtimeContract 0 irFn tx.args
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
+  compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compiledInternalTable
+    model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
+    bodyStmts irFn tx initialWorld htxNormalized bindings extraFuel hcalldataSizeFits hfn
+    hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
+    (compiledInternalTable_of_compileValidatedCore model selectors hSupported runtimeContract hcore)
+
 /-- Structured helper-aware compiled-side wrapper for the generic function
 theorem. This replaces the raw function-level conservative-extension equality
 premise by the compiled-body disjointness witness that proves it. -/

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1878,6 +1878,12 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compiledInternalTable
+  -- Compiler.Proofs.IRGeneration.Contract.compiled_internal_functions_forall₂_of_mapM_ok'  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.exists_left_of_forall₂_mem_right  -- private
+  Compiler.Proofs.IRGeneration.Contract.compileInternalFunction_mapM_mem_exists
+  Compiler.Proofs.IRGeneration.Contract.compiledInternalTable_of_internalFunctions_eq_mapM
+  Compiler.Proofs.IRGeneration.Contract.compiledInternalTable_of_compileValidatedCore
+  Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_bodyCallsDisjoint
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
   -- Compiler.Proofs.IRGeneration.Contract.scalar_events_contract_function_callback  -- private
@@ -5925,4 +5931,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5555 theorems/lemmas (3847 public, 1708 private, 0 sorry'd)
+-- Total: 5561 theorems/lemmas (3851 public, 1710 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -159,6 +159,13 @@ ALLOWLIST: set[str] = {
     # a `compileInternalFunction` output). Body is a single term application; the
     # >50 lines are entirely the mirrored premise list.
     "compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compiledInternalTable",
+    # #2080 whole-contract dispatch seam consumer: same signature-dominated wrapper
+    # as the `_of_compiledInternalTable` sibling, but discharges its `hcompiledTable`
+    # premise from the real compilation pipeline output
+    # (`compileValidatedCore model selectors = Except.ok runtimeContract`) instead of
+    # taking it as a hypothesis. Body is a single term application; the >50 lines are
+    # entirely the mirrored premise list.
+    "compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compileValidatedCore",
     # First concrete letVar statement-head adapter (#2080 phase 10): threads a
     # single compositional-expression existential through source execution, IR
     # fuel alignment, and four scope/runtime invariant re-establishment steps


### PR DESCRIPTION
## Summary

Closes another slice of the #2080 L2 Tier-2 internal-helper-call-preservation work by making the whole-contract dispatch path derive its internal-table naming premise from the **real compilation pipeline** instead of assuming it.

Building on PR #2118's `..._of_body_goal_of_compiledInternalTable` seam (which discharges `InternalTableNamesInternalPrefixed` from a `hcompiledTable` premise), this adds the structural premise itself and a consumer that feeds it:

- **`compileInternalFunction_mapM_mem_exists`** — every statement in the `internalFns.mapM compileInternalFunction` image is a `compileInternalFunction` output. Non-vacuous for a populated `internalFns`; introduces **no** `internalFunctions = []` default-empty helper-world assumption.
- **`compiledInternalTable_of_internalFunctions_eq_mapM`** — packages that image into the exact existential shape of the seam's `hcompiledTable`.
- **`compiledInternalTable_of_compileValidatedCore`** — discharges the premise from a real `compileValidatedCore model selectors = Except.ok ir` output (currently via the SupportedSpec nil-table fact; the non-vacuous populated-table machinery lives in the two lemmas above).
- **`..._of_body_goal_of_compileValidatedCore`** — whole-contract dispatch consumer that invokes the #2118 seam with `hcompiledTable` discharged from the pipeline, so the runtime contract whose `execIRFunctionWithInternals` dispatch is proven correct is exactly the one the compiler emits.

Supporting helpers (`compiled_internal_functions_forall₂_of_mapM_ok'`, `exists_left_of_forall₂_mem_right`) mirror the existing `_of_mapM_ok` / `exists_right_of_forall₂_mem_left` lemmas for the pipeline's 7-arg `compileInternalFunction` call shape.

## Base / stack

- **Base:** `paloma/issue-2080-compiled-internal-naming` (PR #2118's head).
- PRs #2116/#2117/#2118 are merged only into their intermediate stack branches; the phase-23 lemmas this builds on are **not yet in `main`**. **Do not merge until the predecessor stack (#2118 → … → main) is merged/green.**

## Validation (via lean-slot)

- `lake build Compiler.Proofs.IRGeneration.Contract` — ✅ green (`✔ 1144/1144`)
- `lake build Compiler.Proofs.IRGeneration.Function` — ✅ green
- `lake build Compiler.Proofs.HelperStepProofs` — ✅ green (`✔ 1139/1139`)
- `python3 scripts/generate_print_axioms.py --check` — ✅ up to date (4 new public theorems registered, 2 private excluded, `0 sorry'd`)
- `python3 scripts/check_proof_length.py` — ✅ pass (signature-dominated consumer allowlisted next to its `_of_compiledInternalTable` sibling)
- `git diff --check` — ✅ clean
- No new `sorry` / `admit` / `axiom` in touched proof files
- Optional `lake build PrintAxioms` full axiom-audit was launched (offloaded); not a required gate. The additions are axiom-free forwarding/induction lemmas, so they cannot introduce axioms beyond their already-audited dependencies.

## Remaining #2080 gate

The seam is now fed for the SupportedSpec world (nil internal table). The next slice is to make `compiledInternalTable_of_internalFunctions_eq_mapM` cover the **general populated** internal table — i.e. handle the `helpers ++ internalFuncDefs` composition in `IRContract.internalFunctions` so the premise holds when helper segments are non-empty, then retarget the whole-contract `compile_preserves_semantics_with_helper_proofs_and_helper_ir` family onto the WithInternals path.

Refs #2080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions (forwarding and list induction) in IR generation contract proofs with no runtime, auth, or compiler behavior changes; main risk is proof maintenance and stack dependency on unmerged #2118 predecessors.
> 
> **Overview**
> Adds Lean proof plumbing so **#2080** whole-contract `execIRFunctionWithInternals` dispatch can obtain the compiled-internal-table premise from real compiler output instead of assuming `hcompiledTable` or an empty `internalFunctions` world.
> 
> **`compileInternalFunction_mapM_mem_exists`** and **`compiledInternalTable_of_internalFunctions_eq_mapM`** show every stmt in the `internalFns.mapM compileInternalFunction` image (7-arg shape used by `compileValidatedCore`) is a `compileInternalFunction` witness—meaningful when the internal table is non-empty. **`compiledInternalTable_of_compileValidatedCore`** connects `compileValidatedCore = Except.ok ir` to that premise (vacuous under current `SupportedSpec` via nil internal table). **`..._of_body_goal_of_compileValidatedCore`** is the per-function consumer that feeds that into the existing `..._of_compiledInternalTable` seam.
> 
> Private **`compiled_internal_functions_forall₂_of_mapM_ok'`** and **`exists_left_of_forall₂_mem_right`** mirror existing mapM/`Forall₂` lemmas. **`PrintAxioms.lean`** registers four new public theorems; **`check_proof_length.py`** allowlists the new signature-heavy consumer wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 301343062ccc3551493eb5f98e262eb270ee4e8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->