### PR TITLE
proof(#2080): split populated internal-table naming invariant over helper segment

### DIFF
--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -1350,6 +1350,78 @@ theorem compiledInternalTable_of_internalFunctions_eq_mapM
   exact compileInternalFunction_mapM_mem_exists fields events errors adtTypes targetFork
     internalFns internalDefs hmap
 
+/-- Structural distribution of the internal-table naming invariant over a
+segmented table. `compileValidatedCore` populates `internalFunctions` as
+`<prebuilt helper segments> ++ internalFuncDefs` (see `compileValidatedCore` in
+`Compiler/CompilationModel/Dispatch.lean`), so the whole-table
+`InternalTableNamesInternalPrefixed` obligation is exactly the conjunction of the
+same invariant restricted to each segment. Proving it via `List.mem_append`
+avoids any dependence on `filterMap`-append rewriting and keeps the two segment
+obligations independent, which is what lets a caller discharge the helper
+segment and the `internalFuncDefs` segment by different routes. -/
+theorem InternalTableNamesInternalPrefixed_of_internalFunctions_append
+    (contract : IRContract)
+    (helpers internalDefs : List YulStmt)
+    (hcontract : contract.internalFunctions = helpers ++ internalDefs)
+    (hhelpers : ∀ d ∈ helpers.filterMap irInternalFunctionDefOfStmt?,
+        d.name.data.take CompilationModel.internalFunctionPrefix.data.length =
+          CompilationModel.internalFunctionPrefix.data)
+    (hinternal : ∀ d ∈ internalDefs.filterMap irInternalFunctionDefOfStmt?,
+        d.name.data.take CompilationModel.internalFunctionPrefix.data.length =
+          CompilationModel.internalFunctionPrefix.data) :
+    InternalTableNamesInternalPrefixed contract := by
+  intro d hd
+  rw [hcontract, List.mem_filterMap] at hd
+  obtain ⟨stmt, hstmt, hdecode⟩ := hd
+  rw [List.mem_append] at hstmt
+  rcases hstmt with hstmt | hstmt
+  · exact hhelpers d (List.mem_filterMap.mpr ⟨stmt, hstmt, hdecode⟩)
+  · exact hinternal d (List.mem_filterMap.mpr ⟨stmt, hstmt, hdecode⟩)
+
+/-- Consumer seam for the *populated* internal table produced by the compilation
+pipeline. A runtime contract whose internal table is a prebuilt helper segment
+followed by the `compileInternalFunction` image of some internal-function list
+(`runtimeContract.internalFunctions = helpers ++ internalDefs` with
+`internalDefs` the `mapM` output) satisfies `InternalTableNamesInternalPrefixed`
+as soon as the helper segment is internal-prefixed: the `internalFuncDefs`
+segment is discharged structurally from the pipeline's `mapM` equation via
+`compileInternalFunction_mapM_mem_exists` +
+`Function.InternalTableNamesInternalPrefixed_of_all_compiledInternal`, and the
+two segments are combined by
+`InternalTableNamesInternalPrefixed_of_internalFunctions_append`.
+
+This is the non-empty-table analogue of
+`compiledInternalTable_of_compileValidatedCore`: it feeds the naming invariant
+consumed by
+`compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed`
+without any `internalFunctions = []` default-empty assumption, leaving only the
+helper-segment prefix obligation for a later slice. -/
+theorem InternalTableNamesInternalPrefixed_of_helpers_append_compiledInternalTable
+    (runtimeContract : IRContract)
+    (helpers : List YulStmt)
+    (fields : List Field)
+    (events : List EventDef)
+    (errors : List ErrorDef)
+    (adtTypes : List AdtTypeDef)
+    (targetFork : Verity.Core.Intrinsics.HardFork)
+    (internalFns : List FunctionSpec)
+    (internalDefs : List YulStmt)
+    (hmap : internalFns.mapM (fun fn =>
+        compileInternalFunction fields events errors adtTypes fn targetFork internalFns) =
+        Except.ok internalDefs)
+    (hcontract : runtimeContract.internalFunctions = helpers ++ internalDefs)
+    (hhelpers : ∀ d ∈ helpers.filterMap irInternalFunctionDefOfStmt?,
+        d.name.data.take CompilationModel.internalFunctionPrefix.data.length =
+          CompilationModel.internalFunctionPrefix.data) :
+    InternalTableNamesInternalPrefixed runtimeContract := by
+  refine InternalTableNamesInternalPrefixed_of_internalFunctions_append
+    runtimeContract helpers internalDefs hcontract hhelpers ?_
+  have hcompiled :=
+    compileInternalFunction_mapM_mem_exists fields events errors adtTypes targetFork
+      internalFns internalDefs hmap
+  exact Function.InternalTableNamesInternalPrefixed_of_all_compiledInternal
+    { runtimeContract with internalFunctions := internalDefs } hcompiled
+
 /-- Pipeline connector for the current `SupportedSpec` world: a contract produced
 by `compileValidatedCore` discharges the structural `hcompiledTable` premise
 outright. Under `SupportedSpec` the runtime internal table is empty

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1882,6 +1882,8 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Contract.exists_left_of_forall₂_mem_right  -- private
   Compiler.Proofs.IRGeneration.Contract.compileInternalFunction_mapM_mem_exists
   Compiler.Proofs.IRGeneration.Contract.compiledInternalTable_of_internalFunctions_eq_mapM
+  Compiler.Proofs.IRGeneration.Contract.InternalTableNamesInternalPrefixed_of_internalFunctions_append
+  Compiler.Proofs.IRGeneration.Contract.InternalTableNamesInternalPrefixed_of_helpers_append_compiledInternalTable
   Compiler.Proofs.IRGeneration.Contract.compiledInternalTable_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_bodyCallsDisjoint
@@ -5931,4 +5933,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5561 theorems/lemmas (3851 public, 1710 private, 0 sorry'd)
+-- Total: 5563 theorems/lemmas (3853 public, 1710 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

Tier-2 internal-helper-call preservation (proof/L2) for #2080. This slice
generalizes the compiled-internal-table naming machinery from the pure
`mapM`-image table to the **populated** table shape that
`compileValidatedCore` actually emits, namely
`<prebuilt helper segments> ++ internalFuncDefs`
(see `internalFunctions :=` in `Compiler/CompilationModel/Dispatch.lean`).

Two additions in `Compiler/Proofs/IRGeneration/Contract.lean`:

- **Reusable structural lemma** `InternalTableNamesInternalPrefixed_of_internalFunctions_append`:
  distributes `InternalTableNamesInternalPrefixed` over a segmented
  `helpers ++ internalDefs` internal table via `List.mem_append`, so the
  whole-table naming obligation splits into two independent per-segment
  obligations (helper segment + `internalFuncDefs` segment). Proved
  without any `filterMap`-append rewriting.

- **Consumer seam** `InternalTableNamesInternalPrefixed_of_helpers_append_compiledInternalTable`:
  for a contract whose internal table is `helpers ++ internalDefs` with
  `internalDefs` the `compileInternalFunction` `mapM` image, derives
  `InternalTableNamesInternalPrefixed` — discharging the `internalFuncDefs`
  segment structurally from the pipeline's `mapM` equation
  (`compileInternalFunction_mapM_mem_exists` +
  `Function.InternalTableNamesInternalPrefixed_of_all_compiledInternal`)
  and leaving only the helper-segment prefix obligation for a later slice.
  This is the non-empty-table analogue of
  `compiledInternalTable_of_compileValidatedCore`, feeding the naming
  invariant consumed by
  `..._of_body_goal_of_internalNamesPrefixed` with no
  `internalFunctions = []` default-empty assumption.

`PrintAxioms.lean` regenerated to register the two new public theorems
(0 sorry'd).

## Base / dependency / stack

- Base: `paloma/issue-2080-dispatch-compiled-internal-table` (PR #2119, still open).
- Stacked on #2119. **Do not merge until the predecessor stack (#2119) is merged/green.**

## Validation

- `lean-slot lake build Compiler.Proofs.IRGeneration.Contract` -> `✔ [1144/1144] Built ... Build completed successfully.`
- `python3 scripts/generate_print_axioms.py --check` -> `OK: PrintAxioms.lean is up to date.`
- `python3 scripts/check_proof_length.py` -> passed (no new proof over the 50-line hard limit).
- `git diff --check` -> clean.
- No new `sorry`/`admit`/`axiom` in touched proof files.

Refs #2080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in IR generation contract lemmas plus axiom index regeneration; no runtime or compilation behavior changes.
> 
> **Overview**
> Adds proof infrastructure so **`InternalTableNamesInternalPrefixed`** can be shown for the **populated** internal table shape `helpers ++ internalFuncDefs` that `compileValidatedCore` emits, not only a pure `mapM` image.
> 
> **`InternalTableNamesInternalPrefixed_of_internalFunctions_append`** splits the whole-table naming obligation into independent per-segment checks via `List.mem_append`, without `filterMap`-append rewriting.
> 
> **`InternalTableNamesInternalPrefixed_of_helpers_append_compiledInternalTable`** is the consumer seam: given `internalFunctions = helpers ++ internalDefs` and a successful `compileInternalFunction` `mapM`, it proves the invariant when the helper segment is already prefix-correct—the `internalDefs` side is discharged from existing `mapM` / compiled-internal lemmas. That feeds the same naming premise used by `..._of_body_goal_of_internalNamesPrefixed` without assuming an empty internal table.
> 
> **`PrintAxioms.lean`** registers both new public theorems (count 5561 → 5563).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8e8295950660508ea3b38853c71a258a037e408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->