### PR TITLE
proof(#2080): reserved-name dispatch seam (replaces false internal_-prefix helper premise)

### DIFF
--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -1155,6 +1155,65 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (Function.genParamLoads_callsDisjoint_of_internalNamesPrefixed runtimeContract fn.params
       (supported_params_of_supportedSpec model selectors hSupported fn hfn) hinv)
 
+/-- Reserved-name variant of
+`compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed`.
+Takes the *true* `InternalTableNamesReserved` invariant — dischargeable from the
+real populated internal table via
+`InternalTableNamesReserved_of_helpers_append_compiledInternalTable` — and
+discharges the ABI parameter-load prefix disjointness through
+`Function.genParamLoads_callsDisjoint_of_reserved`. This is the per-function seam
+that lets the whole-contract `WithInternals` dispatch retarget consume a populated
+internal table containing non-`internal_` compiler helpers. -/
+theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_reserved
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (hHelperProofs : SourceSemantics.SupportedSpecHelperProofs model selectors hSupported)
+    (hvalidateInputs : validateCompileInputs model selectors = Except.ok ())
+    (runtimeContract : IRContract)
+    (fn : FunctionSpec)
+    (sel : Nat)
+    (returns : List ParamType)
+    (bodyStmts : List YulStmt)
+    (irFn : IRFunction)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (htxNormalized : Function.TxContextNormalized tx)
+    (bindings : List (String × Nat))
+    (extraFuel : Nat)
+    (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
+    (hfn : fn ∈ selectorDispatchedFunctions model)
+    (hvalidate : validateFunctionSpec fn = Except.ok ())
+    (hreturns : functionReturns fn = Except.ok returns)
+    (hbodyCompile :
+      compileStmtList model.fields model.events model.errors .calldata [] false
+        (fn.params.map (·.name)) [] fn.body = Except.ok bodyStmts)
+    (hcompileFn :
+      compileFunctionSpec model.fields model.events model.errors [] sel fn = Except.ok irFn)
+    (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
+    (hcompiledBodyFuel :
+      (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
+        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body)
+    (hbodyCorrect :
+      SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
+        runtimeContract model fn bodyStmts hSupported.helperFuel tx initialWorld
+        (ParamLoading.applyBindingsToIRState
+          (Function.prebindRawArgs
+            (FunctionBody.initialIRStateForTx model tx initialWorld) fn.params)
+          bindings)
+        bindings extraFuel)
+    (hinv : InternalTableNamesReserved runtimeContract) :
+    FunctionBody.sourceResultMatchesIRResult
+      (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
+      (execIRFunctionWithInternals runtimeContract 0 irFn tx.args
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
+  compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal
+    model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
+    bodyStmts irFn tx initialWorld htxNormalized bindings extraFuel hcalldataSizeFits hfn
+    hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
+    (Function.genParamLoads_callsDisjoint_of_reserved runtimeContract fn.params
+      (supported_params_of_supportedSpec model selectors hSupported fn hfn) hinv)
+
 /-- Whole-contract-facing consumer seam. Rather than taking the runtime
 contract's naming invariant `InternalTableNamesInternalPrefixed` as an opaque
 premise, this variant derives it from the structural compilation fact that every
@@ -1350,26 +1409,24 @@ theorem compiledInternalTable_of_internalFunctions_eq_mapM
   exact compileInternalFunction_mapM_mem_exists fields events errors adtTypes targetFork
     internalFns internalDefs hmap
 
-/-- Structural distribution of the internal-table naming invariant over a
-segmented table. `compileValidatedCore` populates `internalFunctions` as
+/-- Structural distribution of the reserved-name invariant over a segmented
+table. `compileValidatedCore` populates `internalFunctions` as
 `<prebuilt helper segments> ++ internalFuncDefs` (see `compileValidatedCore` in
 `Compiler/CompilationModel/Dispatch.lean`), so the whole-table
-`InternalTableNamesInternalPrefixed` obligation is exactly the conjunction of the
-same invariant restricted to each segment. Proving it via `List.mem_append`
-avoids any dependence on `filterMap`-append rewriting and keeps the two segment
-obligations independent, which is what lets a caller discharge the helper
-segment and the `internalFuncDefs` segment by different routes. -/
-theorem InternalTableNamesInternalPrefixed_of_internalFunctions_append
+`InternalTableNamesReserved` obligation is exactly the conjunction of the same
+invariant restricted to each segment. Proving it via `List.mem_append` avoids any
+dependence on `filterMap`-append rewriting and keeps the two segment obligations
+independent, which is what lets a caller discharge the helper segment and the
+`internalFuncDefs` segment by different routes. -/
+theorem InternalTableNamesReserved_of_internalFunctions_append
     (contract : IRContract)
     (helpers internalDefs : List YulStmt)
     (hcontract : contract.internalFunctions = helpers ++ internalDefs)
     (hhelpers : ∀ d ∈ helpers.filterMap irInternalFunctionDefOfStmt?,
-        d.name.data.take CompilationModel.internalFunctionPrefix.data.length =
-          CompilationModel.internalFunctionPrefix.data)
+        IsReservedInternalHelperName d.name)
     (hinternal : ∀ d ∈ internalDefs.filterMap irInternalFunctionDefOfStmt?,
-        d.name.data.take CompilationModel.internalFunctionPrefix.data.length =
-          CompilationModel.internalFunctionPrefix.data) :
-    InternalTableNamesInternalPrefixed contract := by
+        IsReservedInternalHelperName d.name) :
+    InternalTableNamesReserved contract := by
   intro d hd
   rw [hcontract, List.mem_filterMap] at hd
   obtain ⟨stmt, hstmt, hdecode⟩ := hd
@@ -1382,21 +1439,22 @@ theorem InternalTableNamesInternalPrefixed_of_internalFunctions_append
 pipeline. A runtime contract whose internal table is a prebuilt helper segment
 followed by the `compileInternalFunction` image of some internal-function list
 (`runtimeContract.internalFunctions = helpers ++ internalDefs` with
-`internalDefs` the `mapM` output) satisfies `InternalTableNamesInternalPrefixed`
-as soon as the helper segment is internal-prefixed: the `internalFuncDefs`
-segment is discharged structurally from the pipeline's `mapM` equation via
+`internalDefs` the `mapM` output) satisfies `InternalTableNamesReserved` as soon
+as the helper segment is reserved: the `internalFuncDefs` segment is discharged
+structurally from the pipeline's `mapM` equation via
 `compileInternalFunction_mapM_mem_exists` +
-`Function.InternalTableNamesInternalPrefixed_of_all_compiledInternal`, and the
-two segments are combined by
-`InternalTableNamesInternalPrefixed_of_internalFunctions_append`.
+`Function.InternalTableNamesInternalPrefixed_of_all_compiledInternal` +
+`InternalTableNamesReserved_of_internalPrefixed`, and the two segments are
+combined by `InternalTableNamesReserved_of_internalFunctions_append`.
 
-This is the non-empty-table analogue of
-`compiledInternalTable_of_compileValidatedCore`: it feeds the naming invariant
-consumed by
-`compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed`
-without any `internalFunctions = []` default-empty assumption, leaving only the
-helper-segment prefix obligation for a later slice. -/
-theorem InternalTableNamesInternalPrefixed_of_helpers_append_compiledInternalTable
+This replaces the false `internal_`-prefix helper-segment premise of the previous
+slice: real compiler helpers (`__verity_*`, `checked_*`, `panic_error_*`,
+template intrinsics) are reserved but *not* `internal_`-prefixed, so the helper
+premise here is dischargeable from the actual populated table. It feeds the
+reserved-name naming invariant consumed by
+`compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_reserved`
+without any `internalFunctions = []` default-empty assumption. -/
+theorem InternalTableNamesReserved_of_helpers_append_compiledInternalTable
     (runtimeContract : IRContract)
     (helpers : List YulStmt)
     (fields : List Field)
@@ -1411,16 +1469,17 @@ theorem InternalTableNamesInternalPrefixed_of_helpers_append_compiledInternalTab
         Except.ok internalDefs)
     (hcontract : runtimeContract.internalFunctions = helpers ++ internalDefs)
     (hhelpers : ∀ d ∈ helpers.filterMap irInternalFunctionDefOfStmt?,
-        d.name.data.take CompilationModel.internalFunctionPrefix.data.length =
-          CompilationModel.internalFunctionPrefix.data) :
-    InternalTableNamesInternalPrefixed runtimeContract := by
-  refine InternalTableNamesInternalPrefixed_of_internalFunctions_append
+        IsReservedInternalHelperName d.name) :
+    InternalTableNamesReserved runtimeContract := by
+  refine InternalTableNamesReserved_of_internalFunctions_append
     runtimeContract helpers internalDefs hcontract hhelpers ?_
   have hcompiled :=
     compileInternalFunction_mapM_mem_exists fields events errors adtTypes targetFork
       internalFns internalDefs hmap
-  exact Function.InternalTableNamesInternalPrefixed_of_all_compiledInternal
-    { runtimeContract with internalFunctions := internalDefs } hcompiled
+  exact InternalTableNamesReserved_of_internalPrefixed
+    { runtimeContract with internalFunctions := internalDefs }
+    (Function.InternalTableNamesInternalPrefixed_of_all_compiledInternal
+      { runtimeContract with internalFunctions := internalDefs } hcompiled)
 
 /-- Pipeline connector for the current `SupportedSpec` world: a contract produced
 by `compileValidatedCore` discharges the structural `hcompiledTable` premise

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -2971,24 +2971,38 @@ private theorem genParamLoads_callsDisjoint_of_builtins
     · subst h2; simp only [yulExprCallsDisjointFromInternalTable]
 
 /-- Package `genParamLoads` disjointness directly from the runtime contract's
-internal-table naming invariant. Because every helper name begins with
-`internalFunctionPrefix` (`"internal_"`), none of the six builtins emitted by the
-param-load prologue — whose names are not `internal_`-prefixed — can resolve to a
-helper. This is the forward-compatible replacement for the
-`internalFunctions = []` disjointness route: it does not require the internal
-table to be empty. -/
+reserved-name invariant. Every helper name is reserved (`internal_`-, `__verity_`-,
+`checked_`-, or `panic_error_`-prefixed), while the six builtins emitted by the
+param-load prologue (`calldataload`, `calldatasize`, `lt`, `revert`, `and`,
+`iszero`) are provably *not* reserved, so none of them can resolve to a helper.
+This is the true seam that replaces the false "every helper is `internal_`-prefixed"
+premise: real compiler helpers are not `internal_`-prefixed, but they *are*
+reserved, so the invariant is dischargeable from actual compilation output. -/
+theorem genParamLoads_callsDisjoint_of_reserved
+    (runtimeContract : IRContract) (params : List Param)
+    (hsupported : ∀ param ∈ params, SupportedExternalParamType param.ty)
+    (hinv : InternalTableNamesReserved runtimeContract) :
+    YulStmtListCallsDisjointFromInternalTable runtimeContract (genParamLoads params) :=
+  genParamLoads_callsDisjoint_of_builtins runtimeContract params hsupported
+    (findInternalFunction?_eq_none_of_not_reserved runtimeContract "calldataload" hinv (by decide))
+    (findInternalFunction?_eq_none_of_not_reserved runtimeContract "calldatasize" hinv (by decide))
+    (findInternalFunction?_eq_none_of_not_reserved runtimeContract "lt" hinv (by decide))
+    (findInternalFunction?_eq_none_of_not_reserved runtimeContract "revert" hinv (by decide))
+    (findInternalFunction?_eq_none_of_not_reserved runtimeContract "and" hinv (by decide))
+    (findInternalFunction?_eq_none_of_not_reserved runtimeContract "iszero" hinv (by decide))
+
+/-- Package `genParamLoads` disjointness from the `internal_`-prefix naming
+invariant, routed through the reserved-name seam
+(`genParamLoads_callsDisjoint_of_reserved` +
+`InternalTableNamesReserved_of_internalPrefixed`). Retained as the compiled-only
+entry point; the populated-table path uses the reserved variant directly. -/
 theorem genParamLoads_callsDisjoint_of_internalNamesPrefixed
     (runtimeContract : IRContract) (params : List Param)
     (hsupported : ∀ param ∈ params, SupportedExternalParamType param.ty)
     (hinv : InternalTableNamesInternalPrefixed runtimeContract) :
     YulStmtListCallsDisjointFromInternalTable runtimeContract (genParamLoads params) :=
-  genParamLoads_callsDisjoint_of_builtins runtimeContract params hsupported
-    (findInternalFunction?_eq_none_of_not_internalPrefixed runtimeContract "calldataload" hinv (by decide))
-    (findInternalFunction?_eq_none_of_not_internalPrefixed runtimeContract "calldatasize" hinv (by decide))
-    (findInternalFunction?_eq_none_of_not_internalPrefixed runtimeContract "lt" hinv (by decide))
-    (findInternalFunction?_eq_none_of_not_internalPrefixed runtimeContract "revert" hinv (by decide))
-    (findInternalFunction?_eq_none_of_not_internalPrefixed runtimeContract "and" hinv (by decide))
-    (findInternalFunction?_eq_none_of_not_internalPrefixed runtimeContract "iszero" hinv (by decide))
+  genParamLoads_callsDisjoint_of_reserved runtimeContract params hsupported
+    (InternalTableNamesReserved_of_internalPrefixed runtimeContract hinv)
 
 /-- The Yul name emitted for a compiled internal helper begins with
 `internalFunctionPrefix` (`"internal_"`). This is the structural fact that lets

--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -2202,6 +2202,75 @@ theorem findInternalFunction?_eq_none_of_not_internalPrefixed
   rw [hdname] at hdtake
   exact hname hdtake
 
+/-- Reserved name prefixes for compiler-emitted internal-table helpers. Every
+statement the compiler places in `IRContract.internalFunctions` is a helper whose
+Yul name begins with one of these:
+* `internal_` — source-level internal functions, emitted via
+  `internalFunctionYulName` (see `internalFunctionYulName_take_prefix`);
+* `__verity_` — built-in dynamic-data / full-precision-arithmetic helpers and
+  template intrinsics (`YulLowering.templateHelperName` names every template
+  helper `__verity_intrinsic_template_…`);
+* `checked_` — checked-arithmetic helpers (`checked_add_t_uint256`, …);
+* `panic_error_` — Solidity-compatible panic reverts (`panic_error_0x11`, …).
+None of the EVM/Yul builtins emitted by the ABI param-load prologue
+(`calldataload`, `calldatasize`, `lt`, `revert`, `and`, `iszero`) begins with any
+of these, so they are provably *not* reserved. -/
+def reservedInternalHelperPrefixes : List String :=
+  [CompilationModel.internalFunctionPrefix, "__verity_", "checked_", "panic_error_"]
+
+/-- A helper name is *reserved* when it carries one of the compiler's reserved
+helper prefixes. Phrased via `String.data.take` (rather than `String.startsWith`)
+so the `internal_` case reuses `internalFunctionYulName_take_prefix`, and so the
+predicate reduces under `decide` on concrete names. -/
+def IsReservedInternalHelperName (name : String) : Prop :=
+  ∃ p ∈ reservedInternalHelperPrefixes,
+    name.data.take p.data.length = p.data
+
+instance (name : String) : Decidable (IsReservedInternalHelperName name) := by
+  unfold IsReservedInternalHelperName
+  infer_instance
+
+/-- Reserved-name invariant for a runtime contract's internal-function table:
+every decoded helper name is reserved. This is the *true* generalization of
+`InternalTableNamesInternalPrefixed`: the compiled `internal_`-prefixed helpers
+satisfy it (`InternalTableNamesReserved_of_internalPrefixed`), and so do the
+non-`internal_` compiler helpers (`__verity_*`, `checked_*`, `panic_error_*`,
+template intrinsics) that a real *populated* internal table also contains. The
+consumer needs only that the param-load builtins are *not* reserved, so this
+invariant is dischargeable from the real compilation output rather than the
+false "every helper is `internal_`-prefixed" premise. -/
+def InternalTableNamesReserved (contract : IRContract) : Prop :=
+  ∀ d ∈ contract.internalFunctions.filterMap irInternalFunctionDefOfStmt?,
+    IsReservedInternalHelperName d.name
+
+/-- A name that is not reserved cannot resolve to any helper in a contract whose
+internal table satisfies `InternalTableNamesReserved`. Reserved-set generalization
+of `findInternalFunction?_eq_none_of_not_internalPrefixed`: it discharges
+`findInternalFunction? … = none` for a concrete non-reserved name (e.g. an
+EVM/Yul builtin) without requiring every helper to be `internal_`-prefixed. -/
+theorem findInternalFunction?_eq_none_of_not_reserved
+    (contract : IRContract) (name : String)
+    (hinv : InternalTableNamesReserved contract)
+    (hname : ¬ IsReservedInternalHelperName name) :
+    findInternalFunction? contract name = none := by
+  simp only [findInternalFunction?]
+  rw [List.find?_eq_none]
+  intro d hd hpred
+  have hdname : d.name = name := by simpa using hpred
+  have hdres := hinv d hd
+  rw [hdname] at hdres
+  exact hname hdres
+
+/-- Every `internal_`-prefixed table satisfies the weaker reserved-name invariant.
+Lets the compiled-internal naming route (which yields
+`InternalTableNamesInternalPrefixed`) feed the reserved-name consumer seam. -/
+theorem InternalTableNamesReserved_of_internalPrefixed
+    (contract : IRContract)
+    (hinv : InternalTableNamesInternalPrefixed contract) :
+    InternalTableNamesReserved contract :=
+  fun d hd => ⟨CompilationModel.internalFunctionPrefix,
+    by simp [reservedInternalHelperPrefixes], hinv d hd⟩
+
 /-- The first compiled-side helper retarget theorem only needs the current
 helper-free runtime-contract shape: no internal helpers and legacy-compatible
 external bodies. Encoding that shape as a proposition keeps the remaining

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1877,13 +1877,14 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed
+  Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_reserved
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compiledInternalTable
   -- Compiler.Proofs.IRGeneration.Contract.compiled_internal_functions_forall₂_of_mapM_ok'  -- private
   -- Compiler.Proofs.IRGeneration.Contract.exists_left_of_forall₂_mem_right  -- private
   Compiler.Proofs.IRGeneration.Contract.compileInternalFunction_mapM_mem_exists
   Compiler.Proofs.IRGeneration.Contract.compiledInternalTable_of_internalFunctions_eq_mapM
-  Compiler.Proofs.IRGeneration.Contract.InternalTableNamesInternalPrefixed_of_internalFunctions_append
-  Compiler.Proofs.IRGeneration.Contract.InternalTableNamesInternalPrefixed_of_helpers_append_compiledInternalTable
+  Compiler.Proofs.IRGeneration.Contract.InternalTableNamesReserved_of_internalFunctions_append
+  Compiler.Proofs.IRGeneration.Contract.InternalTableNamesReserved_of_helpers_append_compiledInternalTable
   Compiler.Proofs.IRGeneration.Contract.compiledInternalTable_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_bodyCallsDisjoint
@@ -2116,6 +2117,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Function.genScalarLoad_calldataload_callsDisjoint  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoadBodyFrom_calldataload_callsDisjoint  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoads_callsDisjoint_of_builtins  -- private
+  Compiler.Proofs.IRGeneration.Function.genParamLoads_callsDisjoint_of_reserved
   Compiler.Proofs.IRGeneration.Function.genParamLoads_callsDisjoint_of_internalNamesPrefixed
   Compiler.Proofs.IRGeneration.Function.internalFunctionYulName_take_prefix
   Compiler.Proofs.IRGeneration.Function.compileInternalFunction_isFuncDef_internalNamed
@@ -3200,6 +3202,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.execIRFunction_continue_extract_eq
   Compiler.Proofs.IRGeneration.findInternalFunction?_eq_none_of_internalFunctions_nil
   Compiler.Proofs.IRGeneration.findInternalFunction?_eq_none_of_not_internalPrefixed
+  Compiler.Proofs.IRGeneration.findInternalFunction?_eq_none_of_not_reserved
+  Compiler.Proofs.IRGeneration.InternalTableNamesReserved_of_internalPrefixed
   Compiler.Proofs.IRGeneration.legacyCompatibleExternalBodies_of_legacyCompatibleRuntimeContract
   Compiler.Proofs.IRGeneration.evalIRExprWithInternals_eq_evalIRExpr_of_no_internal
   Compiler.Proofs.IRGeneration.evalIRExprsWithInternals_eq_evalIRExprs_of_no_internal
@@ -5933,4 +5937,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5563 theorems/lemmas (3853 public, 1710 private, 0 sorry'd)
+-- Total: 5567 theorems/lemmas (3857 public, 1710 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -153,6 +153,13 @@ ALLOWLIST: set[str] = {
     # invariant instead of taking it as an opaque hypothesis. Body is a single
     # term application; the >50 lines are entirely the mirrored premise list.
     "compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed",
+    # #2080 phase 27 reserved-name dispatch seam: same signature-dominated wrapper
+    # as its `_of_internalNamesPrefixed` sibling, but discharges the generated
+    # param-load disjointness premise from the runtime contract's *reserved-name*
+    # invariant (`InternalTableNamesReserved`) — the true generalization that
+    # populated tables containing non-`internal_` compiler helpers satisfy. Body is
+    # a single term application; the >50 lines are entirely the mirrored premise list.
+    "compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_reserved",
     # #2080 whole-contract dispatch seam: same signature-dominated wrapper as the
     # `_of_internalNamesPrefixed` sibling, but derives the internal-table naming
     # invariant from the structural compilation fact (every internal-table stmt is


### PR DESCRIPTION
## Summary

Phase 27 of the #2080 L2 proof tier. The previous slice assumed every helper in a runtime contract's internal-function table is `internal_`-prefixed. That premise is **false** for a real populated table: compiler helpers are named `__verity_*`, `checked_*`, `panic_error_*`, and template intrinsics — none `internal_`-prefixed. This PR replaces that false seam with the *true* reserved-name invariant.

- **`InternalTableNamesReserved`** generalizes `InternalTableNamesInternalPrefixed`: every decoded helper name is either `internal_`-prefixed **or** carries a known compiler-helper prefix (`reservedInternalHelperPrefixes = [internal_, __verity_, checked_, panic_error_]`). `IsReservedInternalHelperName` is `Decidable`.
- Consumers need only that the six ABI param-load builtins (`calldataload`, `calldatasize`, `lt`, `revert`, `and`, `iszero`) are **not** reserved (`by decide`) to obtain `findInternalFunction? = none` and hence `genParamLoads` calls-disjointness — so the invariant is dischargeable from actual compilation output.
- `InternalTableNamesReserved_of_internalPrefixed` lets the compiled-internal naming route still feed the new consumer seam; the `_of_internalNamesPrefixed` param-load lemma is rerouted through `_of_reserved`.
- Contract-level: reserved per-function seam `compileFunctionSpec_correct_..._of_reserved`, plus populated-table `InternalTableNamesReserved_of_internalFunctions_append` / `_of_helpers_append_compiledInternalTable` connectors.

Touched: `IRInterpreter.lean`, `Function.lean`, `Contract.lean` (+ regenerated `PrintAxioms.lean`, one signature-dominated allowlist entry in `check_proof_length.py`).

## Base / dependency

Stacked on **#2120** (`paloma/issue-2080-populated-table-phase25c`), which is stacked on #2119. **Do not merge until the predecessor stack (#2119 → #2120) is merged/green.** Rebase onto `main` once they land.

## Validation

- `lean-slot lake build Compiler.Proofs.IRGeneration.{IRInterpreter,Function,Contract}` — **success** (`BUILD_EXIT=0`, 1151/1151).
- `python3 scripts/generate_print_axioms.py --check` — **OK** (up to date).
- `python3 scripts/check_proof_length.py` — **passed** (reserved seam allowlisted, signature-dominated single-term body).
- `git diff --check` — **clean**.
- No new `sorry` / `admit` / `axiom` in touched proof files.

Refs #2080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only Lean changes with no runtime or auth logic; risk is limited to theorem wiring and axiom inventory consistency.
> 
> **Overview**
> Replaces the **false** premise that every runtime internal helper is `internal_`-prefixed with a **reserved-name** invariant (`InternalTableNamesReserved` / `IsReservedInternalHelperName` over `internal_`, `__verity_`, `checked_`, `panic_error_`), so populated tables with real compiler helpers can still discharge `findInternalFunction? = none` for ABI param-load builtins.
> 
> **`IRInterpreter.lean`** adds the reserved naming definitions, `findInternalFunction?_eq_none_of_not_reserved`, and `InternalTableNamesReserved_of_internalPrefixed`. **`Function.lean`** introduces `genParamLoads_callsDisjoint_of_reserved` and routes the old `internal_`-prefixed lemma through it. **`Contract.lean`** adds the per-function seam `compileFunctionSpec_correct_..._of_reserved` and renames/populates-table connectors to `InternalTableNamesReserved_of_internalFunctions_append` / `_of_helpers_append_compiledInternalTable`. **`PrintAxioms.lean`** and **`check_proof_length.py`** are updated for the new public theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a005a2a50eef659262343d561f9b1a6f8cb2c1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->