### PR TITLE
ci: add self-hosted OpenCodeReview pilot

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+self-hosted-runner:
+  labels:
+    - paloma-ocr
+    - verity
+    - ocr
+    - nippur
+    - cpu-8
+    - mem-32g

--- a/.github/ocr/README.md
+++ b/.github/ocr/README.md
@@ -1,0 +1,22 @@
+# OpenCodeReview pilot
+
+This repository runs Alibaba OpenCodeReview as a **non-blocking first-pass reviewer**.
+
+Current policy:
+
+- OCR comments are advisory.
+- Codex Review remains the merge/review gate for important PRs.
+- The workflow uses `pull_request_target` and checks out trusted OCR scripts/rules from the default branch before checking out PR code.
+- Fork PRs are skipped during the pilot so LLM credentials are never exposed to untrusted code.
+- OCR runs on Thomas/Paloma-managed self-hosted runner label `paloma-ocr`.
+- LLM credentials are GitHub Actions secrets: `OCR_LLM_URL` and `OCR_LLM_KEY`; model is `reviewer`; protocol is OpenAI-compatible.
+
+Manual trigger on a PR:
+
+```text
+/ocr review
+```
+
+The workflow uses `.github/ocr/rules.json` for Verity-specific review focus and `.github/scripts/ocr-git-wrapper.sh` as a temporary compatibility shim for OpenCodeReview 1.7.5 on Git versions whose `git grep` does not support `--end-of-options`.
+
+Promote beyond pilot only after comparing OCR vs Codex on real PRs for true positives, false positives, latency, and cost.

--- a/.github/ocr/rules.json
+++ b/.github/ocr/rules.json
@@ -1,0 +1,28 @@
+{
+  "rules": [
+    {
+      "path": "**/*.lean",
+      "rule": "Review Lean proof changes for semantic correctness, unsound shortcuts, changed trust boundaries, brittle simp usage, missing theorem coverage, accidental weakening of statements, and interactions with AUDIT.md/TRUST_ASSUMPTIONS.md/AXIOMS.md. Do not request stylistic rewrites unless they reduce proof fragility. Prefer high-confidence findings only.",
+      "merge_system_rule": true
+    },
+    {
+      "path": "**/*.{py,sh,bash,js,ts,json,yml,yaml,toml}",
+      "rule": "Review automation and CI changes for command injection, unsafe path handling, credential exposure, nondeterminism, missing failure handling, and divergence from documented project commands. Prefer high-confidence findings only.",
+      "merge_system_rule": true
+    },
+    {
+      "path": "docs/**",
+      "rule": "Review documentation changes for contradictions with code, trust-boundary drift, stale commands, and missing updates to related docs. Avoid wording nitpicks.",
+      "merge_system_rule": true
+    }
+  ],
+  "exclude": [
+    "**/.lake/**",
+    "**/lake-packages/**",
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/*.lock",
+    "**/generated/**"
+  ]
+}

--- a/.github/scripts/ocr-git-wrapper.sh
+++ b/.github/scripts/ocr-git-wrapper.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Temporary compatibility shim for Alibaba OpenCodeReview 1.7.5.
+# OCR's code_search invokes: git --no-pager grep ... --end-of-options <validated-ref> -- <pathspec>
+# Some Git versions (including 2.43 on Ubuntu 24.04) do not accept --end-of-options
+# in `git grep` and treat it as the revision, causing:
+#   fatal: unable to resolve revision: --end-of-options
+# OCR validates PR refs before invoking git grep, and this workflow supplies a GitHub
+# commit SHA as --to, so dropping the unsupported flag for grep only preserves review
+# functionality without widening the workflow's trust boundary.
+
+real_git=/usr/bin/git
+
+is_grep=false
+for arg in "$@"; do
+  if [[ "$arg" == "grep" ]]; then
+    is_grep=true
+    break
+  fi
+done
+
+if $is_grep; then
+  filtered=()
+  for arg in "$@"; do
+    [[ "$arg" == "--end-of-options" ]] && continue
+    filtered+=("$arg")
+  done
+  exec "$real_git" "${filtered[@]}"
+fi
+
+exec "$real_git" "$@"

--- a/.github/scripts/post-ocr-review.js
+++ b/.github/scripts/post-ocr-review.js
@@ -10,15 +10,16 @@ module.exports = async function postOcrReview({ github, context, core }) {
   const resultPath = process.env.OCR_RESULT_PATH;
   const stderrPath = process.env.OCR_STDERR_PATH;
   const maxInline = Number(process.env.OCR_MAX_INLINE_COMMENTS || 20);
-  const tag = `<!-- paloma-ocr-review:${commit_id} -->`;
+  const successTag = `<!-- paloma-ocr-review:${commit_id}:success -->`;
+  const retryableTag = `<!-- paloma-ocr-review:${commit_id}:retryable-failure -->`;
 
   if (!pull_number || !commit_id) {
     throw new Error('OCR_PR_NUMBER and OCR_HEAD_SHA are required');
   }
 
-  const alreadyPosted = await hasExistingTag(github, { owner, repo, pull_number, tag });
+  const alreadyPosted = await hasExistingTag(github, { owner, repo, pull_number, tag: successTag });
   if (alreadyPosted) {
-    core.notice(`OCR review for ${commit_id} was already posted; skipping duplicate.`);
+    core.notice(`Successful OCR review for ${commit_id} was already posted; skipping duplicate.`);
     return;
   }
 
@@ -30,7 +31,7 @@ module.exports = async function postOcrReview({ github, context, core }) {
   } catch (err) {
     await github.rest.issues.createComment({
       owner, repo, issue_number: pull_number,
-      body: `${tag}\n⚠️ **OpenCodeReview failed to produce valid JSON.**\n\n${stderr ? fenced(stderr) : 'No stderr captured.'}`,
+      body: `${retryableTag}\n⚠️ **OpenCodeReview failed to produce valid JSON.**\n\n${stderr ? fenced(stderr) : 'No stderr captured.'}`,
     });
     return;
   }
@@ -58,7 +59,7 @@ module.exports = async function postOcrReview({ github, context, core }) {
 
   const selected = usable.slice(0, maxInline);
   const overflow = usable.slice(maxInline);
-  const body = buildReviewBody({ tag, result, comments, selected, overflow, summaryOnly, warnings, stderr });
+  const body = buildReviewBody({ tag: successTag, result, comments, selected, overflow, summaryOnly, warnings, stderr });
 
   try {
     await github.rest.pulls.createReview({
@@ -72,7 +73,7 @@ module.exports = async function postOcrReview({ github, context, core }) {
     });
   } catch (err) {
     core.warning(`Batch createReview failed: ${err.message}`);
-    const fallbackBody = `${body}\n\n⚠️ Inline publication failed, so OCR findings are summarized here instead.\n\n${renderInlineFallback(selected)}\n\n${fenced(String(err.message || err))}`;
+    const fallbackBody = `${body.replace(successTag, retryableTag)}\n\n⚠️ Inline publication failed, so OCR findings are summarized here instead.\n\n${renderInlineFallback(selected)}\n\n${fenced(String(err.message || err))}`;
     await github.rest.issues.createComment({
       owner,
       repo,

--- a/.github/scripts/post-ocr-review.js
+++ b/.github/scripts/post-ocr-review.js
@@ -40,6 +40,7 @@ module.exports = async function postOcrReview({ github, context, core }) {
   const warnings = Array.isArray(result.warnings) ? result.warnings : [];
   const usable = [];
   const summaryOnly = [];
+  const retryableResult = isRetryableResult(result);
 
   for (const c of comments) {
     const path = String(c.path || '').trim();
@@ -54,12 +55,26 @@ module.exports = async function postOcrReview({ github, context, core }) {
       line,
       side: 'RIGHT',
       body: renderComment(c),
+      content,
+      category: c.category,
+      severity: c.severity,
     });
   }
 
   const selected = usable.slice(0, maxInline);
   const overflow = usable.slice(maxInline);
-  const body = buildReviewBody({ tag: successTag, result, comments, selected, overflow, summaryOnly, warnings, stderr });
+  const tag = retryableResult ? retryableTag : successTag;
+  const body = buildReviewBody({ tag, result, comments, selected, overflow, summaryOnly, warnings, stderr });
+
+  if (retryableResult) {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: pull_number,
+      body: `${body}\n\n⚠️ OCR did not complete successfully; this run is intentionally retryable for the same commit.`,
+    });
+    return;
+  }
 
   try {
     await github.rest.pulls.createReview({
@@ -69,7 +84,7 @@ module.exports = async function postOcrReview({ github, context, core }) {
       commit_id,
       event: 'COMMENT',
       body,
-      comments: selected,
+      comments: selected.map(toReviewComment),
     });
   } catch (err) {
     core.warning(`Batch createReview failed: ${err.message}`);
@@ -93,6 +108,20 @@ async function hasExistingTag(github, { owner, repo, pull_number, tag }) {
     owner, repo, pull_number, per_page: 100,
   });
   return reviews.some(r => String(r.body || '').includes(tag));
+}
+
+function isRetryableResult(result) {
+  const status = String(result.status || '').toLowerCase();
+  return status === 'error' || status === 'failed' || status === 'failure';
+}
+
+function toReviewComment(c) {
+  return {
+    path: c.path,
+    line: c.line,
+    side: c.side,
+    body: c.body,
+  };
 }
 
 function buildReviewBody({ tag, result, comments, selected, overflow, summaryOnly, warnings, stderr }) {

--- a/.github/scripts/post-ocr-review.js
+++ b/.github/scripts/post-ocr-review.js
@@ -72,11 +72,12 @@ module.exports = async function postOcrReview({ github, context, core }) {
     });
   } catch (err) {
     core.warning(`Batch createReview failed: ${err.message}`);
+    const fallbackBody = `${body}\n\n⚠️ Inline publication failed, so OCR findings are summarized here instead.\n\n${renderInlineFallback(selected)}\n\n${fenced(String(err.message || err))}`;
     await github.rest.issues.createComment({
       owner,
       repo,
       issue_number: pull_number,
-      body: `${body}\n\n⚠️ Inline publication failed, so OCR findings are summarized here instead.\n\n${fenced(String(err.message || err))}`,
+      body: fallbackBody,
     });
   }
 };
@@ -145,6 +146,15 @@ function renderComment(c) {
     body += `\n\nSuggested change:\n${fenced(String(c.suggestion_code))}`;
   }
   return body;
+}
+
+function renderInlineFallback(selected) {
+  if (!selected.length) return 'No positioned inline findings were selected.';
+  let body = '### Inline findings that could not be posted\n\n';
+  for (const c of selected) {
+    body += `- **${escapeMd(c.path)}:${c.line}** — ${escapeMd(firstLine(c.body.replace(/\*\*OpenCodeReview[^\n]*\*\*\n\n?/, '')))}\n`;
+  }
+  return body.trim();
 }
 
 function badge(c) {

--- a/.github/scripts/post-ocr-review.js
+++ b/.github/scripts/post-ocr-review.js
@@ -1,0 +1,166 @@
+'use strict';
+
+const fs = require('fs');
+
+module.exports = async function postOcrReview({ github, context, core }) {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const pull_number = Number(process.env.OCR_PR_NUMBER);
+  const commit_id = process.env.OCR_HEAD_SHA;
+  const resultPath = process.env.OCR_RESULT_PATH;
+  const stderrPath = process.env.OCR_STDERR_PATH;
+  const maxInline = Number(process.env.OCR_MAX_INLINE_COMMENTS || 20);
+  const tag = `<!-- paloma-ocr-review:${commit_id} -->`;
+
+  if (!pull_number || !commit_id) {
+    throw new Error('OCR_PR_NUMBER and OCR_HEAD_SHA are required');
+  }
+
+  const alreadyPosted = await hasExistingTag(github, { owner, repo, pull_number, tag });
+  if (alreadyPosted) {
+    core.notice(`OCR review for ${commit_id} was already posted; skipping duplicate.`);
+    return;
+  }
+
+  const raw = fs.existsSync(resultPath) ? fs.readFileSync(resultPath, 'utf8') : '';
+  const stderr = fs.existsSync(stderrPath) ? fs.readFileSync(stderrPath, 'utf8').trim() : '';
+  let result;
+  try {
+    result = JSON.parse(raw);
+  } catch (err) {
+    await github.rest.issues.createComment({
+      owner, repo, issue_number: pull_number,
+      body: `${tag}\n⚠️ **OpenCodeReview failed to produce valid JSON.**\n\n${stderr ? fenced(stderr) : 'No stderr captured.'}`,
+    });
+    return;
+  }
+
+  const comments = Array.isArray(result.comments) ? result.comments : [];
+  const warnings = Array.isArray(result.warnings) ? result.warnings : [];
+  const usable = [];
+  const summaryOnly = [];
+
+  for (const c of comments) {
+    const path = String(c.path || '').trim();
+    const line = Number(c.end_line || c.start_line || 0);
+    const content = String(c.content || '').trim();
+    if (!path || !content || !Number.isFinite(line) || line < 1) {
+      summaryOnly.push(c);
+      continue;
+    }
+    usable.push({
+      path,
+      line,
+      side: 'RIGHT',
+      body: renderComment(c),
+    });
+  }
+
+  const selected = usable.slice(0, maxInline);
+  const overflow = usable.slice(maxInline);
+  const body = buildReviewBody({ tag, result, comments, selected, overflow, summaryOnly, warnings, stderr });
+
+  try {
+    await github.rest.pulls.createReview({
+      owner,
+      repo,
+      pull_number,
+      commit_id,
+      event: 'COMMENT',
+      body,
+      comments: selected,
+    });
+  } catch (err) {
+    core.warning(`Batch createReview failed: ${err.message}`);
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: pull_number,
+      body: `${body}\n\n⚠️ Inline publication failed, so OCR findings are summarized here instead.\n\n${fenced(String(err.message || err))}`,
+    });
+  }
+};
+
+async function hasExistingTag(github, { owner, repo, pull_number, tag }) {
+  const issueComments = await github.paginate(github.rest.issues.listComments, {
+    owner, repo, issue_number: pull_number, per_page: 100,
+  });
+  if (issueComments.some(c => String(c.body || '').includes(tag))) return true;
+
+  const reviews = await github.paginate(github.rest.pulls.listReviews, {
+    owner, repo, pull_number, per_page: 100,
+  });
+  return reviews.some(r => String(r.body || '').includes(tag));
+}
+
+function buildReviewBody({ tag, result, comments, selected, overflow, summaryOnly, warnings, stderr }) {
+  const status = result.status || 'unknown';
+  const message = result.message || '';
+  const summary = result.summary || {};
+  const tokens = summary.total_tokens ? ` · ${summary.total_tokens} tokens` : '';
+  const files = summary.files_reviewed != null ? `${summary.files_reviewed} files` : 'files unknown';
+  const toolCalls = result.tool_calls?.total != null ? ` · ${result.tool_calls.total} tool calls` : '';
+
+  let body = `${tag}\n## OpenCodeReview first-pass review\n\n`;
+  body += `Status: **${escapeMd(status)}** · ${comments.length} finding(s) · ${files}${tokens}${toolCalls}\n\n`;
+
+  if (message) body += `${escapeMd(message)}\n\n`;
+  if (selected.length > 0) body += `✅ Posted ${selected.length} inline comment(s).\n`;
+  if (overflow.length > 0) body += `📝 ${overflow.length} additional positioned finding(s) omitted from inline comments to avoid spam.\n`;
+  if (summaryOnly.length > 0) body += `📝 ${summaryOnly.length} finding(s) had no resolvable line and are summarized below.\n`;
+  if (warnings.length > 0) body += `⚠️ ${warnings.length} OCR warning(s) reported.\n`;
+  body += `\n`;
+
+  const summarized = [...summaryOnly, ...overflow].slice(0, 20);
+  if (summarized.length > 0) {
+    body += `### Summary-only findings\n\n`;
+    for (const c of summarized) {
+      body += `- **${escapeMd(c.path || 'unknown')}**${badge(c)} — ${escapeMd(firstLine(c.content || ''))}\n`;
+    }
+    body += `\n`;
+  }
+
+  if (warnings.length > 0) {
+    body += `### Warnings\n\n`;
+    for (const w of warnings.slice(0, 10)) {
+      body += `- **${escapeMd(w.type || 'warning')}** ${escapeMd(w.file || '')}: ${escapeMd(firstLine(w.message || ''))}\n`;
+    }
+    body += `\n`;
+  }
+
+  if (stderr) {
+    const interesting = stderr.split('\n').filter(line => /warning|error|failed|fatal/i.test(line)).slice(0, 20).join('\n');
+    if (interesting) {
+      body += `<details><summary>OCR stderr highlights</summary>\n\n${fenced(interesting)}\n</details>\n\n`;
+    }
+  }
+
+  body += `_Pilot mode: advisory only. Codex Review remains the merge gate._`;
+  return body;
+}
+
+function renderComment(c) {
+  let body = `**OpenCodeReview${badge(c)}**\n\n${String(c.content || '').trim()}`;
+  if (c.suggestion_code) {
+    body += `\n\nSuggested change:\n${fenced(String(c.suggestion_code))}`;
+  }
+  return body;
+}
+
+function badge(c) {
+  const bits = [c.category, c.severity].filter(Boolean).map(String);
+  return bits.length ? ` [${bits.join(' · ')}]` : '';
+}
+
+function firstLine(s) {
+  return String(s).trim().split(/\r?\n/)[0].slice(0, 240);
+}
+
+function fenced(s) {
+  const ticks = String(s).includes('```') ? '````' : '```';
+  return `${ticks}\n${String(s).slice(0, 8000)}\n${ticks}`;
+}
+
+function escapeMd(s) {
+  return String(s).replace(/[<>]/g, ch => ({ '<': '&lt;', '>': '&gt;' }[ch]));
+}

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -137,7 +137,8 @@ jobs:
           mkdir -p "$HOME"
           git fetch --no-tags origin "${BASE_REF}"
           printf 'Reviewing %s against origin/%s\n' "$HEAD_SHA" "$BASE_REF"
-          BACKGROUND=$(printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" | head -c 4000)
+          BACKGROUND="${PR_TITLE}"$'\n\n'"${PR_BODY}"
+          BACKGROUND="${BACKGROUND:0:4000}"
           ocr review \
             --from "origin/${BASE_REF}" \
             --to "${HEAD_SHA}" \

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1,0 +1,166 @@
+name: OpenCodeReview pilot
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review"
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: ocr-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: OCR first-pass review
+    runs-on: [self-hosted, linux, x64, paloma-ocr]
+    timeout-minutes: 30
+    if: |
+      github.event_name == 'pull_request_target' ||
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/ocr review') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      )
+
+    steps:
+      - name: Resolve PR context
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let pr;
+            if (context.eventName === 'pull_request_target') {
+              pr = context.payload.pull_request;
+            } else {
+              const prNumber = context.eventName === 'workflow_dispatch'
+                ? Number(core.getInput('pr_number'))
+                : context.issue.number;
+              const res = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              pr = res.data;
+            }
+
+            if (pr.draft) {
+              core.notice(`PR #${pr.number} is draft; OCR review skipped.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.notice(`PR #${pr.number} is from a fork; OCR review skipped in pilot mode to avoid exposing secrets to untrusted code.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            core.setOutput('skip', 'false');
+            core.setOutput('number', String(pr.number));
+            core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('title', pr.title || '');
+            core.setOutput('body', pr.body || '');
+
+      - name: Checkout trusted OCR tooling
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: ocr-trusted
+          persist-credentials: false
+
+      - name: Checkout PR head
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.pr.outputs.head_sha }}
+          path: repo
+          persist-credentials: false
+
+      - name: Prepare trusted OCR assets
+        if: steps.pr.outputs.skip != 'true'
+        env:
+          TRUSTED_DIR: ${{ github.workspace }}/ocr-trusted
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/ocr-bin" "$RUNNER_TEMP/ocr-tools"
+          cp "$TRUSTED_DIR/.github/scripts/ocr-git-wrapper.sh" "$RUNNER_TEMP/ocr-bin/git"
+          cp "$TRUSTED_DIR/.github/ocr/rules.json" "$RUNNER_TEMP/ocr-tools/rules.json"
+          chmod +x "$RUNNER_TEMP/ocr-bin/git"
+          echo "$RUNNER_TEMP/ocr-bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install OpenCodeReview
+        if: steps.pr.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          npm install -g @alibaba-group/open-code-review@1.7.5
+          ocr version
+
+      - name: Run OpenCodeReview
+        if: steps.pr.outputs.skip != 'true'
+        id: ocr
+        working-directory: repo
+        env:
+          HOME: ${{ runner.temp }}/ocr-home
+          OCR_LLM_URL: ${{ secrets.OCR_LLM_URL }}
+          OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_KEY }}
+          OCR_LLM_MODEL: reviewer
+          OCR_USE_ANTHROPIC: "false"
+          OCR_LLM_TIMEOUT: "300"
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+          PR_BODY: ${{ steps.pr.outputs.body }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME"
+          git fetch --no-tags origin "${BASE_REF}"
+          printf 'Reviewing %s against origin/%s\n' "$HEAD_SHA" "$BASE_REF"
+          BACKGROUND=$(printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" | head -c 4000)
+          ocr review \
+            --from "origin/${BASE_REF}" \
+            --to "${HEAD_SHA}" \
+            --format json \
+            --audience agent \
+            --rule "$RUNNER_TEMP/ocr-tools/rules.json" \
+            --concurrency 4 \
+            --background "$BACKGROUND" \
+            > "$RUNNER_TEMP/ocr-result.json" \
+            2> "$RUNNER_TEMP/ocr-stderr.log" || true
+          test -s "$RUNNER_TEMP/ocr-result.json" || echo '{"status":"error","comments":[],"message":"OCR produced no JSON output"}' > "$RUNNER_TEMP/ocr-result.json"
+
+      - name: Post OCR review
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        env:
+          OCR_RESULT_PATH: ${{ runner.temp }}/ocr-result.json
+          OCR_STDERR_PATH: ${{ runner.temp }}/ocr-stderr.log
+          OCR_PR_NUMBER: ${{ steps.pr.outputs.number }}
+          OCR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          OCR_MAX_INLINE_COMMENTS: "20"
+          OCR_POST_SCRIPT: ${{ github.workspace }}/ocr-trusted/.github/scripts/post-ocr-review.js
+        with:
+          script: |
+            const post = require(process.env.OCR_POST_SCRIPT);
+            await post({ github, context, core });

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -135,8 +135,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$HOME"
-          git fetch --no-tags origin "${BASE_REF}"
           printf 'Reviewing %s against origin/%s\n' "$HEAD_SHA" "$BASE_REF"
+          git rev-parse --verify "origin/${BASE_REF}^{commit}" >/dev/null
           BACKGROUND="${PR_TITLE}"$'\n\n'"${PR_BODY}"
           BACKGROUND="${BACKGROUND:0:4000}"
           ocr review \


### PR DESCRIPTION
## Summary

Adds a non-blocking OpenCodeReview pilot for PRs:

- self-hosted runner label: `paloma-ocr`
- LLM provider: OpenAI-compatible, model `reviewer`
- credentials: GitHub Actions secrets `OCR_LLM_URL` + `OCR_LLM_KEY`
- trusted tooling pattern: `pull_request_target` checks out OCR scripts/rules from the default branch, then checks out PR code separately
- fork PRs skipped during pilot
- Codex Review remains the merge gate; OCR is advisory first-pass only

Also adds:

- Verity-focused OCR rules
- PR review comment publisher
- temporary Git wrapper for OpenCodeReview 1.7.5 / Git `grep --end-of-options` compatibility
- `actionlint` config for the custom self-hosted label

## Validation

- `node --check .github/scripts/post-ocr-review.js`
- `bash -n .github/scripts/ocr-git-wrapper.sh`
- `python3 -m json.tool .github/ocr/rules.json`
- YAML parsed with Ruby `YAML.load_file`
- `actionlint .github/workflows/ocr-review.yml`
- Synthetic `post-ocr-review.js` mock smoke test
- Verified GitHub repo secrets exist: `OCR_LLM_URL`, `OCR_LLM_KEY` (values not printed)
- Installed and verified online runner `nippur-verity-ocr-1` with labels including `paloma-ocr`

## Pilot notes

This workflow uses `pull_request_target` for secret safety, so this newly-added workflow will become active after it lands on `main`. After merge, trigger on a test PR or comment `/ocr review`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uses `pull_request_target` with LLM secrets and PR write permissions; mitigations (trusted default-branch tooling, fork skip, advisory-only posting) are documented but the pattern still warrants careful review before broad rollout.
> 
> **Overview**
> Adds a **non-blocking OpenCodeReview pilot** on self-hosted runners (`paloma-ocr`) that posts advisory first-pass PR feedback while Codex Review stays the merge gate.
> 
> A new `ocr-review` workflow uses `pull_request_target` to load trusted scripts and rules from the default branch, then checks out the PR head separately; it skips drafts and fork PRs, runs Alibaba OpenCodeReview 1.7.5 against `origin/<base>..HEAD` with Verity-focused rules, and publishes results via `post-ocr-review.js` (inline comments capped at 20, dedupe tags, retryable-failure handling). Triggers include PR events, `/ocr review` from trusted collaborators, and `workflow_dispatch`.
> 
> Supporting pieces include `.github/ocr/rules.json` (Lean, automation/CI, docs focus plus build artifact excludes), a temporary `ocr-git-wrapper.sh` that strips unsupported `git grep --end-of-options` for older Git, pilot docs in `.github/ocr/README.md`, and `actionlint` allowlisting for the custom runner labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f98f2c4b51e1abf61ca44f59970ffc26525449a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->