### PR TITLE
proof: reserve compileValidatedCore helper segment

### DIFF
--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -322,7 +322,7 @@ def attachNonReentrantGuard (fields : List Field) (spec : FunctionSpec)
       let release := YulStmt.exprStmt (YulExpr.call "tstore" [YulExpr.lit releaseSlot, YulExpr.lit 0])
       pure { irFn with body := prefixLoads ++ guardStmts ++ applyLockReleaseOnExits release suffix }
 
-private def compileSpecialEntrypoint (fields : List Field) (events : List EventDef)
+def compileSpecialEntrypoint (fields : List Field) (events : List EventDef)
     (errors : List ErrorDef) (adtTypes : List AdtTypeDef := [])
     (targetFork : HardFork := .cancun)
     (internalFunctions : List FunctionSpec := []) (spec : FunctionSpec) :

--- a/Compiler/CompilationModel/DynamicData.lean
+++ b/Compiler/CompilationModel/DynamicData.lean
@@ -4,6 +4,10 @@ namespace Compiler.CompilationModel
 
 open Compiler.Yul
 
+def yulFuncDefName? : YulStmt → Option String
+  | YulStmt.funcDef name _ _ _ => some name
+  | _ => none
+
 inductive DynamicDataSource where
   | calldata
   | memory
@@ -933,6 +937,133 @@ def dynamicBytesEqCalldataHelper : YulStmt :=
 
 def dynamicBytesEqMemoryHelper : YulStmt :=
   dynamicBytesEqHelper dynamicBytesEqMemoryHelperName "mload"
+
+@[simp] theorem yulFuncDefName?_panicErrorHelper (helperName : String) (code : Nat) :
+    yulFuncDefName? (panicErrorHelper helperName code) = some helperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedArrayElementCalldataHelper :
+    yulFuncDefName? checkedArrayElementCalldataHelper =
+      some checkedArrayElementCalldataHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedArrayElementMemoryHelper :
+    yulFuncDefName? checkedArrayElementMemoryHelper =
+      some checkedArrayElementMemoryHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedArrayElementWordCalldataHelper :
+    yulFuncDefName? checkedArrayElementWordCalldataHelper =
+      some checkedArrayElementWordCalldataHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedArrayElementWordMemoryHelper :
+    yulFuncDefName? checkedArrayElementWordMemoryHelper =
+      some checkedArrayElementWordMemoryHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedArrayElementDynamicWordCalldataHelper :
+    yulFuncDefName? checkedArrayElementDynamicWordCalldataHelper =
+      some checkedArrayElementDynamicWordCalldataHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedArrayElementDynamicWordMemoryHelper :
+    yulFuncDefName? checkedArrayElementDynamicWordMemoryHelper =
+      some checkedArrayElementDynamicWordMemoryHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedArrayElementDynamicDataOffsetCalldataHelper :
+    yulFuncDefName? checkedArrayElementDynamicDataOffsetCalldataHelper =
+      some checkedArrayElementDynamicDataOffsetCalldataHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedArrayElementDynamicDataOffsetMemoryHelper :
+    yulFuncDefName? checkedArrayElementDynamicDataOffsetMemoryHelper =
+      some checkedArrayElementDynamicDataOffsetMemoryHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedParamDynamicHeadWordCalldataHelper :
+    yulFuncDefName? checkedParamDynamicHeadWordCalldataHelper =
+      some checkedParamDynamicHeadWordCalldataHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedParamDynamicHeadWordMemoryHelper :
+    yulFuncDefName? checkedParamDynamicHeadWordMemoryHelper =
+      some checkedParamDynamicHeadWordMemoryHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedParamDynamicMemberLengthCalldataHelper :
+    yulFuncDefName? checkedParamDynamicMemberLengthCalldataHelper =
+      some checkedParamDynamicMemberLengthCalldataHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedParamDynamicMemberLengthMemoryHelper :
+    yulFuncDefName? checkedParamDynamicMemberLengthMemoryHelper =
+      some checkedParamDynamicMemberLengthMemoryHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedParamDynamicMemberDataOffsetCalldataHelper :
+    yulFuncDefName? checkedParamDynamicMemberDataOffsetCalldataHelper =
+      some checkedParamDynamicMemberDataOffsetCalldataHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedParamDynamicMemberDataOffsetMemoryHelper :
+    yulFuncDefName? checkedParamDynamicMemberDataOffsetMemoryHelper =
+      some checkedParamDynamicMemberDataOffsetMemoryHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedParamDynamicMemberElementCalldataHelper :
+    yulFuncDefName? checkedParamDynamicMemberElementCalldataHelper =
+      some checkedParamDynamicMemberElementCalldataHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedParamDynamicMemberElementMemoryHelper :
+    yulFuncDefName? checkedParamDynamicMemberElementMemoryHelper =
+      some checkedParamDynamicMemberElementMemoryHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedArrayElementDynamicMemberLengthCalldataHelper :
+    yulFuncDefName? checkedArrayElementDynamicMemberLengthCalldataHelper =
+      some checkedArrayElementDynamicMemberLengthCalldataHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedArrayElementDynamicMemberLengthMemoryHelper :
+    yulFuncDefName? checkedArrayElementDynamicMemberLengthMemoryHelper =
+      some checkedArrayElementDynamicMemberLengthMemoryHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedArrayElementDynamicMemberDataOffsetCalldataHelper :
+    yulFuncDefName? checkedArrayElementDynamicMemberDataOffsetCalldataHelper =
+      some checkedArrayElementDynamicMemberDataOffsetCalldataHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedArrayElementDynamicMemberDataOffsetMemoryHelper :
+    yulFuncDefName? checkedArrayElementDynamicMemberDataOffsetMemoryHelper =
+      some checkedArrayElementDynamicMemberDataOffsetMemoryHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedArrayElementDynamicMemberElementCalldataHelper :
+    yulFuncDefName? checkedArrayElementDynamicMemberElementCalldataHelper =
+      some checkedArrayElementDynamicMemberElementCalldataHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedArrayElementDynamicMemberElementMemoryHelper :
+    yulFuncDefName? checkedArrayElementDynamicMemberElementMemoryHelper =
+      some checkedArrayElementDynamicMemberElementMemoryHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_fullMulDivHelper :
+    yulFuncDefName? fullMulDivHelper = some fullMulDivHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_fullMulDivUpHelper :
+    yulFuncDefName? fullMulDivUpHelper = some fullMulDivUpHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedStorageArrayElementHelper :
+    yulFuncDefName? checkedStorageArrayElementHelper =
+      some checkedStorageArrayElementHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_dynamicBytesEqCalldataHelper :
+    yulFuncDefName? dynamicBytesEqCalldataHelper =
+      some dynamicBytesEqCalldataHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_dynamicBytesEqMemoryHelper :
+    yulFuncDefName? dynamicBytesEqMemoryHelper =
+      some dynamicBytesEqMemoryHelperName := rfl
+
+@[simp] theorem yulFuncDefName?_panicError0x11Helper :
+    yulFuncDefName? panicError0x11Helper = some panicError0x11HelperName := rfl
+
+@[simp] theorem yulFuncDefName?_panicError0x12Helper :
+    yulFuncDefName? panicError0x12Helper = some panicError0x12HelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedAddUint256Helper :
+    yulFuncDefName? checkedAddUint256Helper = some checkedAddUint256HelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedSubUint256Helper :
+    yulFuncDefName? checkedSubUint256Helper = some checkedSubUint256HelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedMulUint256Helper :
+    yulFuncDefName? checkedMulUint256Helper = some checkedMulUint256HelperName := rfl
+
+@[simp] theorem yulFuncDefName?_checkedDivUint256Helper :
+    yulFuncDefName? checkedDivUint256Helper = some checkedDivUint256HelperName := rfl
 
 def dynamicCopyData (source : DynamicDataSource)
     (destOffset sourceOffset len : YulExpr) : List YulStmt :=

--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -1915,6 +1915,170 @@ theorem InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compil
           checkedArithmeticHelpersRequired templateIntrinsicHelpers htemplate)
     exact hhelpers d hd
 
+/-- Full table-shape connector for the concrete `compileValidatedCore` output.
+
+The previous connector packaged the exact helper segment but still required
+callers to thread the template-helper reservation proof, the compiled-internal
+`mapM` equation, and the final `internalFunctions` append equation separately.
+This theorem extracts all three facts from
+`compileValidatedCore model selectors = Except.ok runtimeContract` and packages
+the real populated table:
+
+`compileValidatedCoreHelperSegment ... templateIntrinsicHelpers ++ internalFuncDefs`.
+
+It is intentionally independent of `SupportedSpec`: the supported fragment may
+make the compiled internal segment empty today, but this connector follows the
+pipeline shape directly and remains non-vacuous for source-internal functions. -/
+theorem InternalTableNamesReserved_of_compileValidatedCore
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (runtimeContract : IRContract)
+    (hcore : compileValidatedCore model selectors = Except.ok runtimeContract) :
+    InternalTableNamesReserved runtimeContract := by
+  unfold compileValidatedCore at hcore
+  simp only [bind, Except.bind, pure, Except.pure] at hcore
+  rcases hfallback :
+      pickUniqueFunctionByName "fallback" model.functions with _ | fallbackSpec
+  · simp [hfallback] at hcore
+  · rcases hreceive :
+        pickUniqueFunctionByName "receive" model.functions with _ | receiveSpec
+    · simp [hfallback, hreceive] at hcore
+    · rcases hfunctions :
+          (((model.functions.filter fun fn => !fn.isInternal && !isInteropEntrypointName fn.name).zip
+              selectors).mapM fun entry =>
+            compileGuardedFunctionSpec (applySlotAliasRanges model.fields model.slotAliasRanges)
+              model.events model.errors model.adtTypes (model.functions.filter (·.isInternal))
+              entry.2 entry.1) with _ | functions
+      · simp [hfallback, hreceive, hfunctions] at hcore
+      · rcases hinternalDefs :
+            ((model.functions.filter (·.isInternal)).mapM fun fn =>
+              compileInternalFunction (applySlotAliasRanges model.fields model.slotAliasRanges)
+                model.events model.errors model.adtTypes fn (targetFork := .cancun)
+                (model.functions.filter (·.isInternal))) with _ | internalDefs
+        · simp [hfallback, hreceive, hfunctions, hinternalDefs] at hcore
+        · rcases htemplate :
+              (if (templateIntrinsicItems model).isEmpty then
+                pure []
+              else
+                compileTemplateIntrinsicHelpers model) with _ | templateIntrinsicHelpers
+          · by_cases hitems : (templateIntrinsicItems model).isEmpty
+            · simp [hitems] at htemplate
+              cases htemplate
+            · simp [hitems] at htemplate
+              simp [hfallback, hreceive, hfunctions, hinternalDefs, hitems, htemplate] at hcore
+          · simp [hfallback, hreceive, hfunctions, hinternalDefs] at hcore
+            by_cases hitems : (templateIntrinsicItems model).isEmpty
+            · simp [hitems] at htemplate
+              cases htemplate
+              simp [hitems] at hcore
+              rcases hfallbackEntrypoint :
+                  fallbackSpec.mapM
+                    (compileSpecialEntrypoint
+                      (applySlotAliasRanges model.fields model.slotAliasRanges)
+                      model.events model.errors model.adtTypes (targetFork := .cancun)
+                      (model.functions.filter (·.isInternal))) with _ | fallbackEntrypoint
+              · simp [hfallbackEntrypoint] at hcore
+              · rcases hreceiveEntrypoint :
+                    receiveSpec.mapM
+                      (compileSpecialEntrypoint
+                        (applySlotAliasRanges model.fields model.slotAliasRanges)
+                        model.events model.errors model.adtTypes (targetFork := .cancun)
+                        (model.functions.filter (·.isInternal))) with _ | receiveEntrypoint
+                · simp [hfallbackEntrypoint, hreceiveEntrypoint] at hcore
+                · rcases hdeploy :
+                      compileConstructor
+                        (applySlotAliasRanges model.fields model.slotAliasRanges)
+                        model.events model.errors model.adtTypes model.constructor
+                        (targetFork := .cancun) (model.functions.filter (·.isInternal)) with
+                    _ | deploy
+                  · simp [hfallbackEntrypoint, hreceiveEntrypoint, hdeploy] at hcore
+                  · simp [hfallbackEntrypoint, hreceiveEntrypoint, hdeploy] at hcore
+                    have hcontract :
+                        runtimeContract.internalFunctions =
+                          compileValidatedCoreHelperSegment
+                            (contractUsesPlainArrayElement model)
+                            (contractUsesArrayElementWord model)
+                            (contractUsesParamDynamicHeadWord model)
+                            (contractUsesMulDiv512 model)
+                            (contractUsesStorageArrayElement model)
+                            (contractUsesDynamicBytesEq model)
+                            (contractUsesCheckedArithmetic model)
+                            [] ++ internalDefs := by
+                      rw [← hcore]
+                      simp [compileValidatedCoreHelperSegment, List.append_assoc]
+                    exact
+                      InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable
+                        runtimeContract
+                        (contractUsesPlainArrayElement model)
+                        (contractUsesArrayElementWord model)
+                        (contractUsesParamDynamicHeadWord model)
+                        (contractUsesMulDiv512 model)
+                        (contractUsesStorageArrayElement model)
+                        (contractUsesDynamicBytesEq model)
+                        (contractUsesCheckedArithmetic model)
+                        [] DecodedInternalHelperNamesReserved.nil
+                        (applySlotAliasRanges model.fields model.slotAliasRanges)
+                        model.events model.errors model.adtTypes
+                        Verity.Core.Intrinsics.HardFork.cancun
+                        (model.functions.filter (·.isInternal))
+                        internalDefs hinternalDefs hcontract
+            · simp [hitems] at htemplate
+              simp [hitems, htemplate] at hcore
+              rcases hfallbackEntrypoint :
+                  fallbackSpec.mapM
+                    (compileSpecialEntrypoint
+                      (applySlotAliasRanges model.fields model.slotAliasRanges)
+                      model.events model.errors model.adtTypes (targetFork := .cancun)
+                      (model.functions.filter (·.isInternal))) with _ | fallbackEntrypoint
+              · simp [hfallbackEntrypoint] at hcore
+              · rcases hreceiveEntrypoint :
+                    receiveSpec.mapM
+                      (compileSpecialEntrypoint
+                        (applySlotAliasRanges model.fields model.slotAliasRanges)
+                        model.events model.errors model.adtTypes (targetFork := .cancun)
+                        (model.functions.filter (·.isInternal))) with _ | receiveEntrypoint
+                · simp [hfallbackEntrypoint, hreceiveEntrypoint] at hcore
+                · rcases hdeploy :
+                      compileConstructor
+                        (applySlotAliasRanges model.fields model.slotAliasRanges)
+                        model.events model.errors model.adtTypes model.constructor
+                        (targetFork := .cancun) (model.functions.filter (·.isInternal)) with
+                    _ | deploy
+                  · simp [hfallbackEntrypoint, hreceiveEntrypoint, hdeploy] at hcore
+                  · simp [hfallbackEntrypoint, hreceiveEntrypoint, hdeploy] at hcore
+                    have htemplateReserved :
+                        DecodedInternalHelperNamesReserved templateIntrinsicHelpers :=
+                      compileTemplateIntrinsicHelpers_reserved model templateIntrinsicHelpers htemplate
+                    have hcontract :
+                        runtimeContract.internalFunctions =
+                          compileValidatedCoreHelperSegment
+                            (contractUsesPlainArrayElement model)
+                            (contractUsesArrayElementWord model)
+                            (contractUsesParamDynamicHeadWord model)
+                            (contractUsesMulDiv512 model)
+                            (contractUsesStorageArrayElement model)
+                            (contractUsesDynamicBytesEq model)
+                            (contractUsesCheckedArithmetic model)
+                            templateIntrinsicHelpers ++ internalDefs := by
+                      rw [← hcore]
+                      simp [compileValidatedCoreHelperSegment, List.append_assoc]
+                    exact
+                      InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable
+                        runtimeContract
+                        (contractUsesPlainArrayElement model)
+                        (contractUsesArrayElementWord model)
+                        (contractUsesParamDynamicHeadWord model)
+                        (contractUsesMulDiv512 model)
+                        (contractUsesStorageArrayElement model)
+                        (contractUsesDynamicBytesEq model)
+                        (contractUsesCheckedArithmetic model)
+                        templateIntrinsicHelpers htemplateReserved
+                        (applySlotAliasRanges model.fields model.slotAliasRanges)
+                        model.events model.errors model.adtTypes
+                        Verity.Core.Intrinsics.HardFork.cancun
+                        (model.functions.filter (·.isInternal))
+                        internalDefs hinternalDefs hcontract
+
 /-- Pipeline connector for the current `SupportedSpec` world: a contract produced
 by `compileValidatedCore` discharges the structural `hcompiledTable` premise
 outright. Under `SupportedSpec` the runtime internal table is empty
@@ -1995,11 +2159,11 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
       (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
       (execIRFunctionWithInternals runtimeContract 0 irFn tx.args
         (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
-  compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compiledInternalTable
+  compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_reserved
     model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
     bodyStmts irFn tx initialWorld htxNormalized bindings extraFuel hcalldataSizeFits hfn
     hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
-    (compiledInternalTable_of_compileValidatedCore model selectors hSupported runtimeContract hcore)
+    (InternalTableNamesReserved_of_compileValidatedCore model selectors runtimeContract hcore)
 
 /-- Structured helper-aware compiled-side wrapper for the generic function
 theorem. This replaces the raw function-level conservative-extension equality

--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -1481,6 +1481,440 @@ theorem InternalTableNamesReserved_of_helpers_append_compiledInternalTable
     (Function.InternalTableNamesInternalPrefixed_of_all_compiledInternal
       { runtimeContract with internalFunctions := internalDefs } hcompiled)
 
+/-- Segment-local reserved-name invariant for a list of internal helper
+statements. This is the helper-list analogue of `InternalTableNamesReserved`,
+used to compose the concrete helper segments emitted by `compileValidatedCore`
+before they are appended to the compiled source-internal definitions. -/
+def DecodedInternalHelperNamesReserved (stmts : List YulStmt) : Prop :=
+  ∀ d ∈ stmts.filterMap irInternalFunctionDefOfStmt?,
+    IsReservedInternalHelperName d.name
+
+private theorem DecodedInternalHelperNamesReserved.nil :
+    DecodedInternalHelperNamesReserved [] := by
+  intro d hd
+  cases hd
+
+private theorem DecodedInternalHelperNamesReserved.append
+    {xs ys : List YulStmt}
+    (hxs : DecodedInternalHelperNamesReserved xs)
+    (hys : DecodedInternalHelperNamesReserved ys) :
+    DecodedInternalHelperNamesReserved (xs ++ ys) := by
+  intro d hd
+  rw [List.filterMap_append, List.mem_append] at hd
+  rcases hd with hd | hd
+  · exact hxs d hd
+  · exact hys d hd
+
+private theorem DecodedInternalHelperNamesReserved.ifList
+    (b : Bool) {xs : List YulStmt}
+    (hxs : DecodedInternalHelperNamesReserved xs) :
+    DecodedInternalHelperNamesReserved (if b then xs else []) := by
+  cases b
+  · exact DecodedInternalHelperNamesReserved.nil
+  · exact hxs
+
+private theorem DecodedInternalHelperNamesReserved.of_funcDefNames
+    {stmts : List YulStmt}
+    (hnames : ∀ name ∈ stmts.filterMap yulFuncDefName?,
+      IsReservedInternalHelperName name) :
+    DecodedInternalHelperNamesReserved stmts := by
+  intro d hd
+  rw [List.mem_filterMap] at hd
+  obtain ⟨stmt, hstmt, hdecode⟩ := hd
+  exact hnames d.name (List.mem_filterMap.mpr ⟨stmt, hstmt, by
+    cases stmt <;> simp [irInternalFunctionDefOfStmt?, yulFuncDefName?] at hdecode ⊢
+    cases hdecode
+    rfl⟩)
+
+private theorem IsReservedInternalHelperName.templateHelperName (name : String) :
+    IsReservedInternalHelperName
+      (Verity.Core.Intrinsics.YulLowering.templateHelperName name) := by
+  refine ⟨"__verity_", by simp [reservedInternalHelperPrefixes], ?_⟩
+  unfold Verity.Core.Intrinsics.YulLowering.templateHelperName
+  simp only [String.data_append]
+  rw [List.append_assoc]
+  rw [List.take_append_of_le_length
+    (l₁ := (toString "__verity_intrinsic_template_").data)
+    (l₂ := ((toString name).data ++ (toString "").data))
+    (i := "__verity_".data.length)
+    (by decide)]
+  decide
+
+private theorem DecodedInternalHelperNamesReserved.templateFuncDef
+    (name : String) (lowering : Verity.Core.Intrinsics.YulLowering)
+    (stmt : YulStmt)
+    (hstmt :
+      Verity.Core.Intrinsics.YulLowering.templateFuncDef? name lowering =
+        some stmt) :
+    DecodedInternalHelperNamesReserved [stmt] := by
+  intro d hd
+  cases lowering <;> simp [Verity.Core.Intrinsics.YulLowering.templateFuncDef?] at hstmt
+  subst stmt
+  simp [irInternalFunctionDefOfStmt?] at hd
+  rcases hd with rfl
+  exact IsReservedInternalHelperName.templateHelperName name
+
+private theorem templateIntrinsicHelper_mapM_reserved :
+    ∀ (items : List (String × Verity.Core.Intrinsics.YulLowering)) helpers,
+      items.mapM (fun (name, lowering) =>
+        match Verity.Core.Intrinsics.YulLowering.templateFuncDef? name lowering with
+        | some funcDef => pure funcDef
+        | none =>
+            Except.error s!"Compilation error: intrinsic {name} is not a template lowering") =
+          Except.ok helpers →
+      DecodedInternalHelperNamesReserved helpers
+  | [], helpers, hmap => by
+      cases hmap
+      exact DecodedInternalHelperNamesReserved.nil
+  | (name, lowering) :: items, helpers, hmap => by
+      rcases hfunc :
+          Verity.Core.Intrinsics.YulLowering.templateFuncDef? name lowering with _ | stmt
+      · simp [List.mapM_cons, hfunc] at hmap
+        cases hmap
+      · rcases htail :
+          items.mapM (fun (name, lowering) =>
+            match Verity.Core.Intrinsics.YulLowering.templateFuncDef? name lowering with
+            | some funcDef => pure funcDef
+            | none =>
+                Except.error s!"Compilation error: intrinsic {name} is not a template lowering")
+            with _ | tail
+        · simp [List.mapM_cons, hfunc, htail] at hmap
+        · simp [List.mapM_cons, hfunc, htail] at hmap
+          cases hmap
+          exact DecodedInternalHelperNamesReserved.append
+            (DecodedInternalHelperNamesReserved.templateFuncDef name lowering stmt hfunc)
+            (templateIntrinsicHelper_mapM_reserved items tail htail)
+
+private theorem compileTemplateIntrinsicHelpers_reserved
+    (spec : CompilationModel)
+    (helpers : List YulStmt)
+    (hcompile : compileTemplateIntrinsicHelpers spec = Except.ok helpers) :
+    DecodedInternalHelperNamesReserved helpers := by
+  unfold compileTemplateIntrinsicHelpers at hcompile
+  rcases hitems : dedupTemplateIntrinsics (templateIntrinsicItems spec) with _ | items
+  · simp [hitems] at hcompile
+    cases hcompile
+  · simp [hitems] at hcompile
+    exact templateIntrinsicHelper_mapM_reserved items helpers hcompile
+
+private theorem DecodedInternalHelperNamesReserved.arrayElementBase :
+    DecodedInternalHelperNamesReserved
+      [ checkedArrayElementCalldataHelper
+      , checkedArrayElementMemoryHelper
+      ] :=
+  DecodedInternalHelperNamesReserved.of_funcDefNames (by
+  intro name hname
+  simp [checkedArrayElementCalldataHelperName, checkedArrayElementMemoryHelperName] at hname
+  rcases hname with rfl | rfl <;> decide)
+
+private theorem DecodedInternalHelperNamesReserved.arrayElementWord :
+    DecodedInternalHelperNamesReserved
+      [ checkedArrayElementWordCalldataHelper
+      , checkedArrayElementWordMemoryHelper
+      , checkedArrayElementDynamicWordCalldataHelper
+      , checkedArrayElementDynamicWordMemoryHelper
+      , checkedArrayElementDynamicDataOffsetCalldataHelper
+      , checkedArrayElementDynamicDataOffsetMemoryHelper
+      , checkedArrayElementDynamicMemberLengthCalldataHelper
+      , checkedArrayElementDynamicMemberLengthMemoryHelper
+      , checkedArrayElementDynamicMemberDataOffsetCalldataHelper
+      , checkedArrayElementDynamicMemberDataOffsetMemoryHelper
+      , checkedArrayElementDynamicMemberElementCalldataHelper
+      , checkedArrayElementDynamicMemberElementMemoryHelper
+      ] :=
+  DecodedInternalHelperNamesReserved.of_funcDefNames (by
+  intro name hname
+  simp [checkedArrayElementWordCalldataHelperName, checkedArrayElementWordMemoryHelperName,
+    checkedArrayElementDynamicWordCalldataHelperName,
+    checkedArrayElementDynamicWordMemoryHelperName,
+    checkedArrayElementDynamicDataOffsetCalldataHelperName,
+    checkedArrayElementDynamicDataOffsetMemoryHelperName,
+    checkedArrayElementDynamicMemberLengthCalldataHelperName,
+    checkedArrayElementDynamicMemberLengthMemoryHelperName,
+    checkedArrayElementDynamicMemberDataOffsetCalldataHelperName,
+    checkedArrayElementDynamicMemberDataOffsetMemoryHelperName,
+    checkedArrayElementDynamicMemberElementCalldataHelperName,
+    checkedArrayElementDynamicMemberElementMemoryHelperName] at hname
+  rcases hname with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+    decide)
+
+private theorem DecodedInternalHelperNamesReserved.paramDynamicHeadWord :
+    DecodedInternalHelperNamesReserved
+      [ checkedParamDynamicHeadWordCalldataHelper
+      , checkedParamDynamicHeadWordMemoryHelper
+      , checkedParamDynamicMemberLengthCalldataHelper
+      , checkedParamDynamicMemberLengthMemoryHelper
+      , checkedParamDynamicMemberDataOffsetCalldataHelper
+      , checkedParamDynamicMemberDataOffsetMemoryHelper
+      , checkedParamDynamicMemberElementCalldataHelper
+      , checkedParamDynamicMemberElementMemoryHelper
+      ] :=
+  DecodedInternalHelperNamesReserved.of_funcDefNames (by
+  intro name hname
+  simp [checkedParamDynamicHeadWordCalldataHelperName, checkedParamDynamicHeadWordMemoryHelperName,
+    checkedParamDynamicMemberLengthCalldataHelperName,
+    checkedParamDynamicMemberLengthMemoryHelperName,
+    checkedParamDynamicMemberDataOffsetCalldataHelperName,
+    checkedParamDynamicMemberDataOffsetMemoryHelperName,
+    checkedParamDynamicMemberElementCalldataHelperName,
+    checkedParamDynamicMemberElementMemoryHelperName] at hname
+  rcases hname with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;> decide)
+
+private theorem DecodedInternalHelperNamesReserved.mulDiv512 :
+    DecodedInternalHelperNamesReserved
+      [ fullMulDivHelper
+      , fullMulDivUpHelper
+      ] :=
+  DecodedInternalHelperNamesReserved.of_funcDefNames (by
+  intro name hname
+  simp [fullMulDivHelperName, fullMulDivUpHelperName] at hname
+  rcases hname with rfl | rfl <;> decide)
+
+private theorem DecodedInternalHelperNamesReserved.storageArray :
+    DecodedInternalHelperNamesReserved [checkedStorageArrayElementHelper] :=
+  DecodedInternalHelperNamesReserved.of_funcDefNames (by
+  intro name hname
+  simp [checkedStorageArrayElementHelperName] at hname
+  rcases hname with rfl
+  decide)
+
+private theorem DecodedInternalHelperNamesReserved.dynamicBytesEq :
+    DecodedInternalHelperNamesReserved
+      [dynamicBytesEqCalldataHelper, dynamicBytesEqMemoryHelper] :=
+  DecodedInternalHelperNamesReserved.of_funcDefNames (by
+  intro name hname
+  simp [dynamicBytesEqCalldataHelperName, dynamicBytesEqMemoryHelperName] at hname
+  rcases hname with rfl | rfl <;> decide)
+
+private theorem DecodedInternalHelperNamesReserved.checkedArithmetic :
+    DecodedInternalHelperNamesReserved
+      [ panicError0x11Helper
+      , panicError0x12Helper
+      , checkedAddUint256Helper
+      , checkedSubUint256Helper
+      , checkedMulUint256Helper
+      , checkedDivUint256Helper
+      ] :=
+  DecodedInternalHelperNamesReserved.of_funcDefNames (by
+  intro name hname
+  simp [panicError0x11HelperName, panicError0x12HelperName,
+    checkedAddUint256HelperName, checkedSubUint256HelperName,
+    checkedMulUint256HelperName, checkedDivUint256HelperName] at hname
+  rcases hname with rfl | rfl | rfl | rfl | rfl | rfl <;> decide)
+
+private theorem DecodedInternalHelperNamesReserved.compileValidatedCore_helpers
+    (arrayHelpersRequired arrayElementWordHelpersRequired
+      paramDynamicHeadWordHelpersRequired mulDiv512HelpersRequired
+      storageArrayHelpersRequired dynamicBytesEqHelpersRequired
+      checkedArithmeticHelpersRequired : Bool)
+    (templateIntrinsicHelpers : List YulStmt)
+    (htemplate : DecodedInternalHelperNamesReserved templateIntrinsicHelpers) :
+    DecodedInternalHelperNamesReserved
+      (((if arrayHelpersRequired then
+          [ checkedArrayElementCalldataHelper
+          , checkedArrayElementMemoryHelper
+          ]
+        else
+          []) ++
+        (if arrayElementWordHelpersRequired then
+          [ checkedArrayElementWordCalldataHelper
+          , checkedArrayElementWordMemoryHelper
+          , checkedArrayElementDynamicWordCalldataHelper
+          , checkedArrayElementDynamicWordMemoryHelper
+          , checkedArrayElementDynamicDataOffsetCalldataHelper
+          , checkedArrayElementDynamicDataOffsetMemoryHelper
+          , checkedArrayElementDynamicMemberLengthCalldataHelper
+          , checkedArrayElementDynamicMemberLengthMemoryHelper
+          , checkedArrayElementDynamicMemberDataOffsetCalldataHelper
+          , checkedArrayElementDynamicMemberDataOffsetMemoryHelper
+          , checkedArrayElementDynamicMemberElementCalldataHelper
+          , checkedArrayElementDynamicMemberElementMemoryHelper
+          ]
+        else
+          []) ++
+        (if paramDynamicHeadWordHelpersRequired then
+          [ checkedParamDynamicHeadWordCalldataHelper
+          , checkedParamDynamicHeadWordMemoryHelper
+          , checkedParamDynamicMemberLengthCalldataHelper
+          , checkedParamDynamicMemberLengthMemoryHelper
+          , checkedParamDynamicMemberDataOffsetCalldataHelper
+          , checkedParamDynamicMemberDataOffsetMemoryHelper
+          , checkedParamDynamicMemberElementCalldataHelper
+          , checkedParamDynamicMemberElementMemoryHelper
+          ]
+        else
+          []) ++
+        (if mulDiv512HelpersRequired then
+          [ fullMulDivHelper
+          , fullMulDivUpHelper
+          ]
+        else
+          [])) ++
+      (if storageArrayHelpersRequired then
+        [checkedStorageArrayElementHelper]
+      else
+        []) ++
+      (if dynamicBytesEqHelpersRequired then
+        [dynamicBytesEqCalldataHelper, dynamicBytesEqMemoryHelper]
+      else
+        []) ++
+      (if checkedArithmeticHelpersRequired then
+        [ panicError0x11Helper
+        , panicError0x12Helper
+        , checkedAddUint256Helper
+        , checkedSubUint256Helper
+        , checkedMulUint256Helper
+        , checkedDivUint256Helper
+        ]
+      else
+        []) ++
+      templateIntrinsicHelpers) :=
+  by
+  simpa [List.append_assoc] using
+  DecodedInternalHelperNamesReserved.append
+    (DecodedInternalHelperNamesReserved.append
+      (DecodedInternalHelperNamesReserved.append
+        (DecodedInternalHelperNamesReserved.append
+          (DecodedInternalHelperNamesReserved.append
+            (DecodedInternalHelperNamesReserved.ifList arrayHelpersRequired
+              DecodedInternalHelperNamesReserved.arrayElementBase)
+            (DecodedInternalHelperNamesReserved.ifList arrayElementWordHelpersRequired
+              DecodedInternalHelperNamesReserved.arrayElementWord))
+          (DecodedInternalHelperNamesReserved.ifList paramDynamicHeadWordHelpersRequired
+            DecodedInternalHelperNamesReserved.paramDynamicHeadWord))
+        (DecodedInternalHelperNamesReserved.ifList mulDiv512HelpersRequired
+          DecodedInternalHelperNamesReserved.mulDiv512))
+      (DecodedInternalHelperNamesReserved.ifList storageArrayHelpersRequired
+        DecodedInternalHelperNamesReserved.storageArray))
+    (DecodedInternalHelperNamesReserved.append
+      (DecodedInternalHelperNamesReserved.ifList dynamicBytesEqHelpersRequired
+        DecodedInternalHelperNamesReserved.dynamicBytesEq)
+      (DecodedInternalHelperNamesReserved.append
+        (DecodedInternalHelperNamesReserved.ifList checkedArithmeticHelpersRequired
+          DecodedInternalHelperNamesReserved.checkedArithmetic)
+        htemplate))
+
+def compileValidatedCoreHelperSegment
+    (arrayHelpersRequired arrayElementWordHelpersRequired
+      paramDynamicHeadWordHelpersRequired mulDiv512HelpersRequired
+      storageArrayHelpersRequired dynamicBytesEqHelpersRequired
+      checkedArithmeticHelpersRequired : Bool)
+    (templateIntrinsicHelpers : List YulStmt) : List YulStmt :=
+  (((if arrayHelpersRequired then
+      [ checkedArrayElementCalldataHelper
+      , checkedArrayElementMemoryHelper
+      ]
+    else
+      []) ++
+    (if arrayElementWordHelpersRequired then
+      [ checkedArrayElementWordCalldataHelper
+      , checkedArrayElementWordMemoryHelper
+      , checkedArrayElementDynamicWordCalldataHelper
+      , checkedArrayElementDynamicWordMemoryHelper
+      , checkedArrayElementDynamicDataOffsetCalldataHelper
+      , checkedArrayElementDynamicDataOffsetMemoryHelper
+      , checkedArrayElementDynamicMemberLengthCalldataHelper
+      , checkedArrayElementDynamicMemberLengthMemoryHelper
+      , checkedArrayElementDynamicMemberDataOffsetCalldataHelper
+      , checkedArrayElementDynamicMemberDataOffsetMemoryHelper
+      , checkedArrayElementDynamicMemberElementCalldataHelper
+      , checkedArrayElementDynamicMemberElementMemoryHelper
+      ]
+    else
+      []) ++
+    (if paramDynamicHeadWordHelpersRequired then
+      [ checkedParamDynamicHeadWordCalldataHelper
+      , checkedParamDynamicHeadWordMemoryHelper
+      , checkedParamDynamicMemberLengthCalldataHelper
+      , checkedParamDynamicMemberLengthMemoryHelper
+      , checkedParamDynamicMemberDataOffsetCalldataHelper
+      , checkedParamDynamicMemberDataOffsetMemoryHelper
+      , checkedParamDynamicMemberElementCalldataHelper
+      , checkedParamDynamicMemberElementMemoryHelper
+      ]
+    else
+      []) ++
+    (if mulDiv512HelpersRequired then
+      [ fullMulDivHelper
+      , fullMulDivUpHelper
+      ]
+    else
+      [])) ++
+  (if storageArrayHelpersRequired then
+    [checkedStorageArrayElementHelper]
+  else
+    []) ++
+  (if dynamicBytesEqHelpersRequired then
+    [dynamicBytesEqCalldataHelper, dynamicBytesEqMemoryHelper]
+  else
+    []) ++
+  (if checkedArithmeticHelpersRequired then
+    [ panicError0x11Helper
+    , panicError0x12Helper
+    , checkedAddUint256Helper
+    , checkedSubUint256Helper
+    , checkedMulUint256Helper
+    , checkedDivUint256Helper
+    ]
+  else
+    []) ++
+  templateIntrinsicHelpers)
+
+/-- Populated-table connector for the exact prebuilt helper segment shape emitted
+by `compileValidatedCore`. It removes the caller-supplied helper-segment
+reserved-name premise from
+`InternalTableNamesReserved_of_helpers_append_compiledInternalTable`; callers now
+only provide the template-helper compilation equation and the already-existing
+compiled source-internal `mapM` equation. -/
+theorem InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable
+    (runtimeContract : IRContract)
+    (arrayHelpersRequired arrayElementWordHelpersRequired
+      paramDynamicHeadWordHelpersRequired mulDiv512HelpersRequired
+      storageArrayHelpersRequired dynamicBytesEqHelpersRequired
+      checkedArithmeticHelpersRequired : Bool)
+    (templateIntrinsicHelpers : List YulStmt)
+    (htemplate : DecodedInternalHelperNamesReserved templateIntrinsicHelpers)
+    (fields : List Field)
+    (events : List EventDef)
+    (errors : List ErrorDef)
+    (adtTypes : List AdtTypeDef)
+    (targetFork : Verity.Core.Intrinsics.HardFork)
+    (internalFns : List FunctionSpec)
+    (internalDefs : List YulStmt)
+    (hmap : internalFns.mapM (fun fn =>
+        compileInternalFunction fields events errors adtTypes fn targetFork internalFns) =
+        Except.ok internalDefs)
+    (hcontract : runtimeContract.internalFunctions =
+      compileValidatedCoreHelperSegment
+        arrayHelpersRequired arrayElementWordHelpersRequired
+        paramDynamicHeadWordHelpersRequired mulDiv512HelpersRequired
+        storageArrayHelpersRequired dynamicBytesEqHelpersRequired
+        checkedArithmeticHelpersRequired templateIntrinsicHelpers ++ internalDefs) :
+    InternalTableNamesReserved runtimeContract := by
+  refine InternalTableNamesReserved_of_helpers_append_compiledInternalTable
+    runtimeContract
+    (compileValidatedCoreHelperSegment
+      arrayHelpersRequired arrayElementWordHelpersRequired
+      paramDynamicHeadWordHelpersRequired mulDiv512HelpersRequired
+      storageArrayHelpersRequired dynamicBytesEqHelpersRequired
+      checkedArithmeticHelpersRequired templateIntrinsicHelpers)
+    fields events errors adtTypes targetFork internalFns internalDefs hmap ?_ ?_
+  · simpa [List.append_assoc] using hcontract
+  · intro d hd
+    have hhelpers : DecodedInternalHelperNamesReserved
+        (compileValidatedCoreHelperSegment
+          arrayHelpersRequired arrayElementWordHelpersRequired
+          paramDynamicHeadWordHelpersRequired mulDiv512HelpersRequired
+          storageArrayHelpersRequired dynamicBytesEqHelpersRequired
+          checkedArithmeticHelpersRequired templateIntrinsicHelpers) := by
+      simpa [compileValidatedCoreHelperSegment, List.append_assoc] using
+        (DecodedInternalHelperNamesReserved.compileValidatedCore_helpers
+          arrayHelpersRequired arrayElementWordHelpersRequired
+          paramDynamicHeadWordHelpersRequired mulDiv512HelpersRequired
+          storageArrayHelpersRequired dynamicBytesEqHelpersRequired
+          checkedArithmeticHelpersRequired templateIntrinsicHelpers htemplate)
+    exact hhelpers d hd
+
 /-- Pipeline connector for the current `SupportedSpec` world: a contract produced
 by `compileValidatedCore` discharges the structural `hcompiledTable` premise
 outright. Under `SupportedSpec` the runtime internal table is empty

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1885,6 +1885,23 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Contract.compiledInternalTable_of_internalFunctions_eq_mapM
   Compiler.Proofs.IRGeneration.Contract.InternalTableNamesReserved_of_internalFunctions_append
   Compiler.Proofs.IRGeneration.Contract.InternalTableNamesReserved_of_helpers_append_compiledInternalTable
+  -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.nil  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.append  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.ifList  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.of_funcDefNames  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.IsReservedInternalHelperName.templateHelperName  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.templateFuncDef  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.templateIntrinsicHelper_mapM_reserved  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.compileTemplateIntrinsicHelpers_reserved  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.arrayElementBase  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.arrayElementWord  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.paramDynamicHeadWord  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.mulDiv512  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.storageArray  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.dynamicBytesEq  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.checkedArithmetic  -- private
+  -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.compileValidatedCore_helpers  -- private
+  Compiler.Proofs.IRGeneration.Contract.InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable
   Compiler.Proofs.IRGeneration.Contract.compiledInternalTable_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_bodyCallsDisjoint
@@ -5937,4 +5954,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5567 theorems/lemmas (3857 public, 1710 private, 0 sorry'd)
+-- Total: 5584 theorems/lemmas (3858 public, 1726 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1902,6 +1902,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.checkedArithmetic  -- private
   -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.compileValidatedCore_helpers  -- private
   Compiler.Proofs.IRGeneration.Contract.InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable
+  Compiler.Proofs.IRGeneration.Contract.InternalTableNamesReserved_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compiledInternalTable_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_bodyCallsDisjoint
@@ -5954,4 +5955,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5584 theorems/lemmas (3858 public, 1726 private, 0 sorry'd)
+-- Total: 5585 theorems/lemmas (3859 public, 1726 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -173,6 +173,12 @@ ALLOWLIST: set[str] = {
     # taking it as a hypothesis. Body is a single term application; the >50 lines are
     # entirely the mirrored premise list.
     "compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compileValidatedCore",
+    # #2080 helper-segment reserved-name seam: these mechanically enumerate the
+    # exact conditional helper segment emitted by `compileValidatedCore` and
+    # package it with the existing compiled-internal-table connector. The length
+    # is dominated by the concrete helper list shape, not proof search.
+    "DecodedInternalHelperNamesReserved.compileValidatedCore_helpers",
+    "InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable",
     # First concrete letVar statement-head adapter (#2080 phase 10): threads a
     # single compositional-expression existential through source execution, IR
     # fuel alignment, and four scope/runtime invariant re-establishment steps

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -179,6 +179,12 @@ ALLOWLIST: set[str] = {
     # is dominated by the concrete helper list shape, not proof search.
     "DecodedInternalHelperNamesReserved.compileValidatedCore_helpers",
     "InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable",
+    # #2080 compileValidatedCore table-shape connector: extracts the concrete
+    # helper segment, template-helper equation, compiled-internal mapM equation,
+    # fallback/receive entrypoints, and constructor from the pipeline's monadic
+    # output. The length is dominated by case-splitting the do-block shape so the
+    # downstream dispatch seam can consume a premise-free reserved-table theorem.
+    "InternalTableNamesReserved_of_compileValidatedCore",
     # First concrete letVar statement-head adapter (#2080 phase 10): threads a
     # single compositional-expression existential through source execution, IR
     # fuel alignment, and four scope/runtime invariant re-establishment steps


### PR DESCRIPTION
## Summary

- Add a `yulFuncDefName?` view plus simp facts for compiler-emitted dynamic-data, checked-arithmetic, panic, and related helper definitions.
- Prove the exact `compileValidatedCore` prebuilt helper segment satisfies the reserved-helper-name invariant, including template intrinsic helpers.
- Add `InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable`, which removes the caller-supplied helper-segment reserved-name premise from the populated internal-table seam while retaining the existing compiled-internal `mapM` premise.

Refs #2080

## Base / dependency

Stacked on `paloma/issue-2080-populated-table-phase25c` because #2122 is still open and currently clean/green when inspected. This PR targets that branch.

Do not merge until predecessor stack is merged/green.

## Validation

- `git diff --check` PASS
- `lean-slot lake build Compiler.CompilationModel.DynamicData` PASS
- `lean-slot lake build Compiler.Proofs.IRGeneration.Contract` PASS
- `python3 scripts/generate_print_axioms.py --check` PASS
- `python3 scripts/check_proof_length.py` PASS
- no new `sorry`, `admit`, or `axiom` declarations in touched Lean files

## Remaining #2080 gate

This closes the prebuilt helper-segment reserved-name proof for the current populated-table seam. The remaining gate is to thread the new helper-segment connector directly through the whole-contract dispatch retarget path from the concrete `compileValidatedCore` output, eliminating the remaining manual table-shape plumbing at the final consumer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to Lean proofs and metadata scripts; emitted Yul and compilation logic are unchanged aside from making `compileSpecialEntrypoint` public for the proof layer.
> 
> **Overview**
> Adds **`yulFuncDefName?`** and **`@[simp]`** lemmas tying each compiler-emitted dynamic-data / checked-arithmetic / panic helper `YulStmt` to its reserved `__verity_*` (or related) name, so proofs can reason about helper lists without decoding IR by hand.
> 
> Introduces **`DecodedInternalHelperNamesReserved`** and a mirrored **`compileValidatedCoreHelperSegment`** definition, then proves that segment (including **template intrinsic** helpers from `compileTemplateIntrinsicHelpers`) satisfies the reserved-helper-name invariant. New connectors **`InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable`** and **`InternalTableNamesReserved_of_compileValidatedCore`** discharge **`InternalTableNamesReserved`** from a successful **`compileValidatedCore`** run instead of manual helper-segment plumbing.
> 
> **`compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compileValidatedCore`** now feeds **`InternalTableNamesReserved_of_compileValidatedCore`** into the reserved-table seam (replacing the **`compiledInternalTable`** path). **`compileSpecialEntrypoint`** is exported (no longer `private`). **`PrintAxioms.lean`** and **`check_proof_length.py`** whitelist the new long proof theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84dfaa85dc29f27de9ec7ab6918f593f03c63d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->