### PR TITLE
proof: package compileValidatedCore table shape

### DIFF
--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -322,7 +322,7 @@ def attachNonReentrantGuard (fields : List Field) (spec : FunctionSpec)
       let release := YulStmt.exprStmt (YulExpr.call "tstore" [YulExpr.lit releaseSlot, YulExpr.lit 0])
       pure { irFn with body := prefixLoads ++ guardStmts ++ applyLockReleaseOnExits release suffix }
 
-private def compileSpecialEntrypoint (fields : List Field) (events : List EventDef)
+def compileSpecialEntrypoint (fields : List Field) (events : List EventDef)
     (errors : List ErrorDef) (adtTypes : List AdtTypeDef := [])
     (targetFork : HardFork := .cancun)
     (internalFunctions : List FunctionSpec := []) (spec : FunctionSpec) :

--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -1915,6 +1915,170 @@ theorem InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compil
           checkedArithmeticHelpersRequired templateIntrinsicHelpers htemplate)
     exact hhelpers d hd
 
+/-- Full table-shape connector for the concrete `compileValidatedCore` output.
+
+The previous connector packaged the exact helper segment but still required
+callers to thread the template-helper reservation proof, the compiled-internal
+`mapM` equation, and the final `internalFunctions` append equation separately.
+This theorem extracts all three facts from
+`compileValidatedCore model selectors = Except.ok runtimeContract` and packages
+the real populated table:
+
+`compileValidatedCoreHelperSegment ... templateIntrinsicHelpers ++ internalFuncDefs`.
+
+It is intentionally independent of `SupportedSpec`: the supported fragment may
+make the compiled internal segment empty today, but this connector follows the
+pipeline shape directly and remains non-vacuous for source-internal functions. -/
+theorem InternalTableNamesReserved_of_compileValidatedCore
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (runtimeContract : IRContract)
+    (hcore : compileValidatedCore model selectors = Except.ok runtimeContract) :
+    InternalTableNamesReserved runtimeContract := by
+  unfold compileValidatedCore at hcore
+  simp only [bind, Except.bind, pure, Except.pure] at hcore
+  rcases hfallback :
+      pickUniqueFunctionByName "fallback" model.functions with _ | fallbackSpec
+  · simp [hfallback] at hcore
+  · rcases hreceive :
+        pickUniqueFunctionByName "receive" model.functions with _ | receiveSpec
+    · simp [hfallback, hreceive] at hcore
+    · rcases hfunctions :
+          (((model.functions.filter fun fn => !fn.isInternal && !isInteropEntrypointName fn.name).zip
+              selectors).mapM fun entry =>
+            compileGuardedFunctionSpec (applySlotAliasRanges model.fields model.slotAliasRanges)
+              model.events model.errors model.adtTypes (model.functions.filter (·.isInternal))
+              entry.2 entry.1) with _ | functions
+      · simp [hfallback, hreceive, hfunctions] at hcore
+      · rcases hinternalDefs :
+            ((model.functions.filter (·.isInternal)).mapM fun fn =>
+              compileInternalFunction (applySlotAliasRanges model.fields model.slotAliasRanges)
+                model.events model.errors model.adtTypes fn (targetFork := .cancun)
+                (model.functions.filter (·.isInternal))) with _ | internalDefs
+        · simp [hfallback, hreceive, hfunctions, hinternalDefs] at hcore
+        · rcases htemplate :
+              (if (templateIntrinsicItems model).isEmpty then
+                pure []
+              else
+                compileTemplateIntrinsicHelpers model) with _ | templateIntrinsicHelpers
+          · by_cases hitems : (templateIntrinsicItems model).isEmpty
+            · simp [hitems] at htemplate
+              cases htemplate
+            · simp [hitems] at htemplate
+              simp [hfallback, hreceive, hfunctions, hinternalDefs, hitems, htemplate] at hcore
+          · simp [hfallback, hreceive, hfunctions, hinternalDefs] at hcore
+            by_cases hitems : (templateIntrinsicItems model).isEmpty
+            · simp [hitems] at htemplate
+              cases htemplate
+              simp [hitems] at hcore
+              rcases hfallbackEntrypoint :
+                  fallbackSpec.mapM
+                    (compileSpecialEntrypoint
+                      (applySlotAliasRanges model.fields model.slotAliasRanges)
+                      model.events model.errors model.adtTypes (targetFork := .cancun)
+                      (model.functions.filter (·.isInternal))) with _ | fallbackEntrypoint
+              · simp [hfallbackEntrypoint] at hcore
+              · rcases hreceiveEntrypoint :
+                    receiveSpec.mapM
+                      (compileSpecialEntrypoint
+                        (applySlotAliasRanges model.fields model.slotAliasRanges)
+                        model.events model.errors model.adtTypes (targetFork := .cancun)
+                        (model.functions.filter (·.isInternal))) with _ | receiveEntrypoint
+                · simp [hfallbackEntrypoint, hreceiveEntrypoint] at hcore
+                · rcases hdeploy :
+                      compileConstructor
+                        (applySlotAliasRanges model.fields model.slotAliasRanges)
+                        model.events model.errors model.adtTypes model.constructor
+                        (targetFork := .cancun) (model.functions.filter (·.isInternal)) with
+                    _ | deploy
+                  · simp [hfallbackEntrypoint, hreceiveEntrypoint, hdeploy] at hcore
+                  · simp [hfallbackEntrypoint, hreceiveEntrypoint, hdeploy] at hcore
+                    have hcontract :
+                        runtimeContract.internalFunctions =
+                          compileValidatedCoreHelperSegment
+                            (contractUsesPlainArrayElement model)
+                            (contractUsesArrayElementWord model)
+                            (contractUsesParamDynamicHeadWord model)
+                            (contractUsesMulDiv512 model)
+                            (contractUsesStorageArrayElement model)
+                            (contractUsesDynamicBytesEq model)
+                            (contractUsesCheckedArithmetic model)
+                            [] ++ internalDefs := by
+                      rw [← hcore]
+                      simp [compileValidatedCoreHelperSegment, List.append_assoc]
+                    exact
+                      InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable
+                        runtimeContract
+                        (contractUsesPlainArrayElement model)
+                        (contractUsesArrayElementWord model)
+                        (contractUsesParamDynamicHeadWord model)
+                        (contractUsesMulDiv512 model)
+                        (contractUsesStorageArrayElement model)
+                        (contractUsesDynamicBytesEq model)
+                        (contractUsesCheckedArithmetic model)
+                        [] DecodedInternalHelperNamesReserved.nil
+                        (applySlotAliasRanges model.fields model.slotAliasRanges)
+                        model.events model.errors model.adtTypes
+                        Verity.Core.Intrinsics.HardFork.cancun
+                        (model.functions.filter (·.isInternal))
+                        internalDefs hinternalDefs hcontract
+            · simp [hitems] at htemplate
+              simp [hitems, htemplate] at hcore
+              rcases hfallbackEntrypoint :
+                  fallbackSpec.mapM
+                    (compileSpecialEntrypoint
+                      (applySlotAliasRanges model.fields model.slotAliasRanges)
+                      model.events model.errors model.adtTypes (targetFork := .cancun)
+                      (model.functions.filter (·.isInternal))) with _ | fallbackEntrypoint
+              · simp [hfallbackEntrypoint] at hcore
+              · rcases hreceiveEntrypoint :
+                    receiveSpec.mapM
+                      (compileSpecialEntrypoint
+                        (applySlotAliasRanges model.fields model.slotAliasRanges)
+                        model.events model.errors model.adtTypes (targetFork := .cancun)
+                        (model.functions.filter (·.isInternal))) with _ | receiveEntrypoint
+                · simp [hfallbackEntrypoint, hreceiveEntrypoint] at hcore
+                · rcases hdeploy :
+                      compileConstructor
+                        (applySlotAliasRanges model.fields model.slotAliasRanges)
+                        model.events model.errors model.adtTypes model.constructor
+                        (targetFork := .cancun) (model.functions.filter (·.isInternal)) with
+                    _ | deploy
+                  · simp [hfallbackEntrypoint, hreceiveEntrypoint, hdeploy] at hcore
+                  · simp [hfallbackEntrypoint, hreceiveEntrypoint, hdeploy] at hcore
+                    have htemplateReserved :
+                        DecodedInternalHelperNamesReserved templateIntrinsicHelpers :=
+                      compileTemplateIntrinsicHelpers_reserved model templateIntrinsicHelpers htemplate
+                    have hcontract :
+                        runtimeContract.internalFunctions =
+                          compileValidatedCoreHelperSegment
+                            (contractUsesPlainArrayElement model)
+                            (contractUsesArrayElementWord model)
+                            (contractUsesParamDynamicHeadWord model)
+                            (contractUsesMulDiv512 model)
+                            (contractUsesStorageArrayElement model)
+                            (contractUsesDynamicBytesEq model)
+                            (contractUsesCheckedArithmetic model)
+                            templateIntrinsicHelpers ++ internalDefs := by
+                      rw [← hcore]
+                      simp [compileValidatedCoreHelperSegment, List.append_assoc]
+                    exact
+                      InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable
+                        runtimeContract
+                        (contractUsesPlainArrayElement model)
+                        (contractUsesArrayElementWord model)
+                        (contractUsesParamDynamicHeadWord model)
+                        (contractUsesMulDiv512 model)
+                        (contractUsesStorageArrayElement model)
+                        (contractUsesDynamicBytesEq model)
+                        (contractUsesCheckedArithmetic model)
+                        templateIntrinsicHelpers htemplateReserved
+                        (applySlotAliasRanges model.fields model.slotAliasRanges)
+                        model.events model.errors model.adtTypes
+                        Verity.Core.Intrinsics.HardFork.cancun
+                        (model.functions.filter (·.isInternal))
+                        internalDefs hinternalDefs hcontract
+
 /-- Pipeline connector for the current `SupportedSpec` world: a contract produced
 by `compileValidatedCore` discharges the structural `hcompiledTable` premise
 outright. Under `SupportedSpec` the runtime internal table is empty
@@ -1995,11 +2159,11 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
       (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
       (execIRFunctionWithInternals runtimeContract 0 irFn tx.args
         (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
-  compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compiledInternalTable
+  compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_reserved
     model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
     bodyStmts irFn tx initialWorld htxNormalized bindings extraFuel hcalldataSizeFits hfn
     hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
-    (compiledInternalTable_of_compileValidatedCore model selectors hSupported runtimeContract hcore)
+    (InternalTableNamesReserved_of_compileValidatedCore model selectors runtimeContract hcore)
 
 /-- Structured helper-aware compiled-side wrapper for the generic function
 theorem. This replaces the raw function-level conservative-extension equality

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1902,6 +1902,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.checkedArithmetic  -- private
   -- Compiler.Proofs.IRGeneration.Contract.DecodedInternalHelperNamesReserved.compileValidatedCore_helpers  -- private
   Compiler.Proofs.IRGeneration.Contract.InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable
+  Compiler.Proofs.IRGeneration.Contract.InternalTableNamesReserved_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compiledInternalTable_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_bodyCallsDisjoint
@@ -5954,4 +5955,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5584 theorems/lemmas (3858 public, 1726 private, 0 sorry'd)
+-- Total: 5585 theorems/lemmas (3859 public, 1726 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -179,6 +179,12 @@ ALLOWLIST: set[str] = {
     # is dominated by the concrete helper list shape, not proof search.
     "DecodedInternalHelperNamesReserved.compileValidatedCore_helpers",
     "InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable",
+    # #2080 compileValidatedCore table-shape connector: extracts the concrete
+    # helper segment, template-helper equation, compiled-internal mapM equation,
+    # fallback/receive entrypoints, and constructor from the pipeline's monadic
+    # output. The length is dominated by case-splitting the do-block shape so the
+    # downstream dispatch seam can consume a premise-free reserved-table theorem.
+    "InternalTableNamesReserved_of_compileValidatedCore",
     # First concrete letVar statement-head adapter (#2080 phase 10): threads a
     # single compositional-expression existential through source execution, IR
     # fuel alignment, and four scope/runtime invariant re-establishment steps


### PR DESCRIPTION
## Summary
- adds `InternalTableNamesReserved_of_compileValidatedCore`, a premise-light connector from the concrete `compileValidatedCore model selectors = Except.ok runtimeContract` output to the populated internal-table reserved-name invariant
- packages the real helper table shape `compileValidatedCoreHelperSegment ... templateIntrinsicHelpers ++ internalFuncDefs`, including the template-helper reservation proof and compiled internal `mapM` equation extracted from the pipeline
- retargets the helper-aware function dispatch consumer to consume the new compileValidatedCore reserved-table connector instead of the older compiled-table structural premise
- makes `compileSpecialEntrypoint` public so the proof can unfold the full `compileValidatedCore` pipeline shape

## Stack / dependencies
- Base: `paloma/issue-2080-helper-segment-reserved-names-phase28`
- Depends on #2124
- Transitively depends on #2122

Do not merge until predecessor stack is merged/green.

## Validation
- `git diff --check` passed
- `lean-slot lake build Compiler.CompilationModel.Dispatch` passed locally after Spark offload returned HTTP 403 for this mission path
- `lean-slot lake build Compiler.Proofs.IRGeneration.Contract` passed locally after Spark offload returned HTTP 403 for this mission path
- `python3 scripts/generate_print_axioms.py --check` passed
- `python3 scripts/check_proof_length.py` passed
- Declaration-level scan confirmed no new `sorry`, `admit`, or `axiom` declarations in touched files

Refs #2080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to Lean proof plumbing and API visibility; runtime compilation behavior is unchanged aside from exporting `compileSpecialEntrypoint`.
> 
> **Overview**
> **Packages the populated internal helper table shape** from a single `compileValidatedCore model selectors = Except.ok runtimeContract` hypothesis into `InternalTableNamesReserved`, instead of asking callers to thread template-helper proofs, internal `mapM` equations, and append facts separately.
> 
> The new theorem `InternalTableNamesReserved_of_compileValidatedCore` case-splits the compiler pipeline (externals, internal defs, conditional template helpers, fallback/receive, constructor) and reuses `InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable` with the real segment `compileValidatedCoreHelperSegment … ++ internalFuncDefs`. **`compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compileValidatedCore`** now discharges reserved-table naming via that connector (`…_of_reserved`) rather than the older compiled-internal-table structural premise.
> 
> **`compileSpecialEntrypoint`** is made **public** so the proof can match the same `mapM` calls `compileValidatedCore` uses for fallback/receive. `PrintAxioms.lean` and `check_proof_length.py` are updated for the new public theorem and its long mechanical proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c2f5c1add673799e62326df1e5573276c692cf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->