### PR TITLE
proof: retarget whole-contract helper IR from core output

### DIFF
--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -2105,6 +2105,25 @@ theorem compiledInternalTable_of_compileValidatedCore
   rw [hnil] at hstmt
   cases hstmt
 
+/-- Concrete compiled-runtime legacy-compatibility connector.
+
+For the current `SupportedSpec` core pipeline, `compileValidatedCore` still emits
+an empty internal table (`compileValidatedCore_ok_yields_internalFunctions_nil`).
+Package that concrete output fact with the external-body compatibility witness in
+the shape consumed by the closed helper-aware whole-contract theorem. -/
+theorem legacyCompatibleRuntimeContract_of_compileValidatedCore
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (ir : IRContract)
+    (hcore : compileValidatedCore model selectors = Except.ok ir)
+    (hlegacyBodies : LegacyCompatibleExternalBodies ir) :
+    LegacyCompatibleRuntimeContract ir := by
+  have hinternal :=
+    compileValidatedCore_ok_yields_internalFunctions_nil
+      model selectors hSupported ir hcore
+  exact ⟨hinternal, hlegacyBodies⟩
+
 /-- Whole-contract dispatch consumer of the compiled-internal-table seam.
 
 This feeds `..._of_body_goal_of_compiledInternalTable`'s `hcompiledTable` premise
@@ -2768,6 +2787,53 @@ theorem compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_disjoint
         hdisjointIR
         tx
         (FunctionBody.initialIRStateForTx model tx initialWorld))
+
+/-- Whole-contract helper-aware retarget connector for a concrete
+`compileValidatedCore` output.
+
+This is the validated-core variant of
+`compile_preserves_semantics_with_helper_proofs_and_helper_ir_closed`: the
+manual `hhelperIR` equality is replaced by the closed helper-aware interpreter
+path for the actual runtime contract emitted by `compileValidatedCore`, and the
+public `CompilationModel.compile` equality is rebuilt from the validated-input
+proof plus the core result. -/
+theorem compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (hHelperProofs : SourceSemantics.SupportedSpecHelperProofs model selectors hSupported)
+    (ir : IRContract)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (htxNormalized : Function.TxContextNormalized tx)
+    (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
+    (hvalidateInputs : validateCompileInputs model selectors = Except.ok ())
+    (hcore : compileValidatedCore model selectors = Except.ok ir)
+    (hlegacyBodies : LegacyCompatibleExternalBodies ir) :
+    FunctionBody.sourceResultMatchesIRResult
+      (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
+      (interpretIRWithInternals ir 0 tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  have hcompile : CompilationModel.compile model selectors = Except.ok ir := by
+    unfold CompilationModel.compile
+    rw [hvalidateInputs]
+    simp only [bind, Except.bind]
+    exact hcore
+  exact compile_preserves_semantics_with_helper_proofs_and_helper_ir_goal
+    (model := model)
+    (selectors := selectors)
+    (hSupported := hSupported)
+    (hHelperProofs := hHelperProofs)
+    (ir := ir)
+    (tx := tx)
+    (initialWorld := initialWorld)
+    (htxNormalized := htxNormalized)
+    (hcalldataSizeFits := hcalldataSizeFits)
+    (hcompile := hcompile)
+    (hlegacyIR :=
+      legacyCompatibleRuntimeContract_of_compileValidatedCore
+        model selectors hSupported ir hcore hlegacyBodies)
+    (hhelperIRGoal := interpretIRWithInternalsZeroConservativeExtensionGoal_closed ir)
 
 /-- Direct helper-aware whole-contract theorem on the current legacy-compatible
 runtime-contract boundary. The helper-aware compiled-side conservative-extension

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1904,6 +1904,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Contract.InternalTableNamesReserved_of_compileValidatedCore_helpers_append_compiledInternalTable
   Compiler.Proofs.IRGeneration.Contract.InternalTableNamesReserved_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compiledInternalTable_of_compileValidatedCore
+  Compiler.Proofs.IRGeneration.Contract.legacyCompatibleRuntimeContract_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_bodyCallsDisjoint
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics
@@ -1916,6 +1917,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_goal
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_disjointRuntimeContract
+  Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_closed
   Compiler.Proofs.IRGeneration.Contract.counter_supported_spec_compile_preserves_semantics
 
@@ -5955,4 +5957,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5585 theorems/lemmas (3859 public, 1726 private, 0 sorry'd)
+-- Total: 5587 theorems/lemmas (3861 public, 1726 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- Adds `legacyCompatibleRuntimeContract_of_compileValidatedCore`, packaging the concrete `compileValidatedCore = Except.ok ir` output into the closed helper-aware runtime compatibility shape.
- Adds `compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore`, a whole-contract retarget connector that consumes `interpretIRWithInternals` for the compiled runtime contract without a manual `hhelperIR` equality.
- Regenerates `PrintAxioms.lean` for the two new public theorem entries.

## Stack / base
- Base: `paloma/issue-2080-helper-segment-reserved-names-phase28`
- Stacked on #2124, transitively on #2122.
- #2125 is already merged into the phase-28 branch tip used here.

Do not merge until predecessor stack is merged/green.

## Validation
- `git diff --check` - passed
- `lean-slot lake build Compiler.Proofs.IRGeneration.Contract` - passed
- `lean-slot lake build PrintAxioms` - passed (pre-existing warnings only in unrelated modules)
- `python3 scripts/generate_print_axioms.py --check` - passed
- `python3 scripts/check_proof_length.py` - passed
- Strict added-placeholder scan over touched files found no new `sorry`, `admit`, or `axiom` declarations.

## Remaining #2080 gate
This slice removes the raw whole-contract `hhelperIR` equality at the validated-core connector. The remaining closure is to derive `LegacyCompatibleExternalBodies ir` (or preferably the weaker disjoint external-body runtime condition) directly from the concrete `compileValidatedCore` external-function compilation output, so the connector has no external-body compatibility premise.

Refs #2080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only changes in compiler IR generation lemmas and axiom inventory; no executable compiler, auth, or data-path behavior.
> 
> **Overview**
> Adds Lean proof plumbing so whole-contract **helper-aware** correctness can be stated from a concrete `compileValidatedCore = Except.ok ir` result instead of a hand-written `interpretIRWithInternals = interpretIR` equality.
> 
> **`legacyCompatibleRuntimeContract_of_compileValidatedCore`** combines the pipeline fact that supported specs yield an empty internal table with `LegacyCompatibleExternalBodies` into `LegacyCompatibleRuntimeContract`, matching what the closed conservative-extension theorems expect.
> 
> **`compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore`** is the validated-core entry point: it rebuilds `CompilationModel.compile = Except.ok ir` from validation + core, feeds the legacy runtime witness above, and uses the already-closed `interpretIRWithInternalsZeroConservativeExtensionGoal_closed` path—callers no longer supply `hhelperIR` manually. **`LegacyCompatibleExternalBodies ir`** remains an explicit premise (not yet derived from compilation output).
> 
> `PrintAxioms.lean` is regenerated to list the two new public theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f11865460aa310114aeca8c40af073e18042d96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->