### PR TITLE
proof: reduce whole-contract legacy-bodies premise to per-statement interface

### DIFF
--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -2873,6 +2873,51 @@ theorem compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileV
         model selectors hSupported ir hcore hlegacyBodies)
     (hhelperIRGoal := interpretIRWithInternalsZeroConservativeExtensionGoal_closed ir)
 
+/-- Helper-aware whole-contract retarget theorem stated directly on the
+per-statement compiled legacy-compatibility interface.  This is the same
+statement as
+`compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore`,
+but the `LegacyCompatibleExternalBodies ir` premise is replaced by the
+per-statement `StmtListCompiledLegacyCompatible` obligations that #2080 already
+tracks for the disjoint interface.  The whole-body-shape premise is discharged
+internally via `legacyCompatibleExternalBodies_of_compileValidatedCore_of_interface`,
+so downstream users only ever have to supply the per-statement interface. -/
+theorem compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore_of_interface
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (hHelperProofs : SourceSemantics.SupportedSpecHelperProofs model selectors hSupported)
+    (ir : IRContract)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (htxNormalized : Function.TxContextNormalized tx)
+    (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
+    (hvalidateInputs : validateCompileInputs model selectors = Except.ok ())
+    (hcore : compileValidatedCore model selectors = Except.ok ir)
+    (hbodies :
+      ∀ entry ∈ SourceSemantics.selectorFunctionPairs model selectors,
+        StmtListCompiledLegacyCompatible model.fields
+          (entry.1.params.map (·.name)) entry.1.body) :
+    FunctionBody.sourceResultMatchesIRResult
+      (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
+      (interpretIRWithInternals ir 0 tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  exact compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore
+    (model := model)
+    (selectors := selectors)
+    (hSupported := hSupported)
+    (hHelperProofs := hHelperProofs)
+    (ir := ir)
+    (tx := tx)
+    (initialWorld := initialWorld)
+    (htxNormalized := htxNormalized)
+    (hcalldataSizeFits := hcalldataSizeFits)
+    (hvalidateInputs := hvalidateInputs)
+    (hcore := hcore)
+    (hlegacyBodies :=
+      legacyCompatibleExternalBodies_of_compileValidatedCore_of_interface
+        model selectors hSupported ir hcore hbodies)
+
 /-- Direct helper-aware whole-contract theorem on the current legacy-compatible
 runtime-contract boundary. The helper-aware compiled-side conservative-extension
 goal is now closed in `IRInterpreter.lean`, so theorem users no longer need to

--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -1346,6 +1346,44 @@ private theorem exists_left_of_forall₂_mem_right
       · rcases ih hmemTail with ⟨x, hx, hRx⟩
         exact ⟨x, by simp [hx], hRx⟩
 
+/-- Whole-contract legacy-compatibility bridge for a concrete `compileValidatedCore`
+output.  Given the per-statement compiled legacy-compatibility interface
+(`StmtListCompiledLegacyCompatible`) for every selector-dispatched function body,
+the emitted runtime contract's external bodies all stay inside the
+legacy-compatible external Yul subset (`LegacyCompatibleExternalBodies`).
+
+This reduces the `LegacyCompatibleExternalBodies` premise still carried by the
+helper-aware whole-contract retarget theorem
+(`compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore`)
+to the same per-statement legacy obligations that #2080 already tracks for the
+disjoint interface, closing the whole-contract plumbing for the body-shape half. -/
+theorem legacyCompatibleExternalBodies_of_compileValidatedCore_of_interface
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (ir : IRContract)
+    (hcore : compileValidatedCore model selectors = Except.ok ir)
+    (hbodies :
+      ∀ entry ∈ SourceSemantics.selectorFunctionPairs model selectors,
+        StmtListCompiledLegacyCompatible model.fields
+          (entry.1.params.map (·.name)) entry.1.body) :
+    LegacyCompatibleExternalBodies ir := by
+  have hforall₂ :=
+    compileValidatedCore_ok_yields_compiled_functions model selectors hSupported ir hcore
+  intro fn hfn
+  obtain ⟨⟨spec, sel⟩, hentry, hcompileEntry⟩ :=
+    exists_left_of_forall₂_mem_right hforall₂ hfn
+  have hfnDispatched : spec ∈ selectorDispatchedFunctions model := by
+    simpa [SourceSemantics.selectorFunctionPairs] using (List.of_mem_zip hentry).1
+  have hparams : ∀ param ∈ spec.params, SupportedExternalParamType param.ty :=
+    supported_params_of_supportedSpec model selectors hSupported spec hfnDispatched
+  have hcompileEntry' :
+      compileFunctionSpec model.fields [] [] [] sel spec = Except.ok fn := by
+    rw [← hSupported.noEvents, ← hSupported.noErrors]
+    exact hcompileEntry
+  exact Function.compileFunctionSpec_body_legacyCompatible_of_interface
+    model.fields sel spec fn hparams (hbodies (spec, sel) hentry) hcompileEntry'
+
 /-- Structural compiled-internal-table premise, derived from the compilation
 pipeline's `mapM` step. Every statement produced by
 `internalFns.mapM compileInternalFunction` is a `compileInternalFunction` output

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -2858,6 +2858,55 @@ private theorem genParamLoads_scalar_legacy
   simp [genParamLoads, genParamLoadsFrom]
   exact .if_ _ _ _ (.exprStmt _ _ .nil) hbody
 
+/-- Legacy-compatibility analog of `compileStmtList_scalar_events_callsDisjoint`:
+turn a per-statement compiled legacy-compatibility interface
+(`StmtListCompiledLegacyCompatible`) into a whole-list legacy-compatibility
+witness for the emitted Yul body. This is the missing list-composition bridge
+that lifts the per-statement legacy obligations (the remaining #2080 discharge
+target) to a `LegacyCompatibleExternalStmtList` for the compiled body, mirroring
+the already-proven disjoint composition. -/
+private theorem compileStmtList_legacyCompatible_of_interface
+    {fields : List Field} :
+    ∀ {scope : List String} {stmts : List Stmt} {compiledIR : List YulStmt},
+      StmtListCompiledLegacyCompatible fields scope stmts →
+      CompilationModel.compileStmtList fields [] [] .calldata [] false scope [] stmts =
+          Except.ok compiledIR →
+      LegacyCompatibleExternalStmtList compiledIR
+  | _, [], _, _, hcompile => by
+      try unfold CompilationModel.compileStmtList at hcompile
+      unfold CompilationModel.compileStmtListWithFork at hcompile
+      cases hcompile
+      exact .nil
+  | _, _ :: _, _, hInterface, hcompile => by
+      obtain ⟨headIR, tailIR, hheadCompile, htailCompile, hbody⟩ :=
+        FunctionBody.compileStmtList_cons_ok_inv hcompile
+      cases hInterface with
+      | cons hhead htail =>
+          rw [hbody]
+          exact legacyCompatibleExternalStmtList_append
+            (hhead headIR hheadCompile)
+            (compileStmtList_legacyCompatible_of_interface htail htailCompile)
+
+/-- Per-function legacy-compatibility bridge. A supported external function whose
+scalar params are supported and whose compiled body satisfies the per-statement
+legacy interface compiles to a function whose IR body stays inside the
+legacy-compatible external Yul subset (`LegacyCompatibleExternalStmtList`).
+Composes `genParamLoads_scalar_legacy` with the body composition lemma. -/
+theorem compileFunctionSpec_body_legacyCompatible_of_interface
+    (fields : List Field) (selector : Nat) (spec : FunctionSpec) (irFn : IRFunction)
+    (hparams : ∀ param ∈ spec.params, SupportedExternalParamType param.ty)
+    (hbodyInterface :
+      StmtListCompiledLegacyCompatible fields (spec.params.map (·.name)) spec.body)
+    (hcompile : compileFunctionSpec fields [] [] [] selector spec = Except.ok irFn) :
+    LegacyCompatibleExternalStmtList irFn.body := by
+  obtain ⟨returns, bodyStmts, _hvalidate, _hreturns, hbodyCompile, hirFn⟩ :=
+    compileFunctionSpec_ok_components fields [] [] selector spec irFn hcompile
+  subst hirFn
+  simp only [compiledFunctionIR]
+  exact legacyCompatibleExternalStmtList_append
+    (genParamLoads_scalar_legacy spec.params hparams)
+    (compileStmtList_legacyCompatible_of_interface hbodyInterface hbodyCompile)
+
 /-- Disjointness of a single scalar param-load (with the `calldataload` word
 loader used by `genParamLoads`) from a runtime contract's internal-function
 table. Every EVM/Yul builtin emitted by `genScalarLoad`

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1881,6 +1881,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compiledInternalTable
   -- Compiler.Proofs.IRGeneration.Contract.compiled_internal_functions_forall₂_of_mapM_ok'  -- private
   -- Compiler.Proofs.IRGeneration.Contract.exists_left_of_forall₂_mem_right  -- private
+  Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalBodies_of_compileValidatedCore_of_interface
   Compiler.Proofs.IRGeneration.Contract.compileInternalFunction_mapM_mem_exists
   Compiler.Proofs.IRGeneration.Contract.compiledInternalTable_of_internalFunctions_eq_mapM
   Compiler.Proofs.IRGeneration.Contract.InternalTableNamesReserved_of_internalFunctions_append
@@ -1918,6 +1919,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_goal
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_disjointRuntimeContract
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore
+  Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore_of_interface
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_closed
   Compiler.Proofs.IRGeneration.Contract.counter_supported_spec_compile_preserves_semantics
 
@@ -2134,6 +2136,8 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Function.genScalarLoad_legacy  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoadBodyFrom_scalar_legacy  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoads_scalar_legacy  -- private
+  -- Compiler.Proofs.IRGeneration.Function.compileStmtList_legacyCompatible_of_interface  -- private
+  Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_body_legacyCompatible_of_interface
   -- Compiler.Proofs.IRGeneration.Function.genScalarLoad_calldataload_callsDisjoint  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoadBodyFrom_calldataload_callsDisjoint  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoads_callsDisjoint_of_builtins  -- private
@@ -5957,4 +5961,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5587 theorems/lemmas (3861 public, 1726 private, 0 sorry'd)
+-- Total: 5591 theorems/lemmas (3864 public, 1727 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

Complementary #2080 fragment slice built on top of the phase30 whole-contract
retarget (**depends on #2126**; base = `paloma/issue-2080-whole-contract-retarget-phase30`).

It closes the body-shape half of the whole-contract plumbing by reducing the
`LegacyCompatibleExternalBodies ir` premise still carried by
`compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore`
down to the same **per-statement** `StmtListCompiledLegacyCompatible` interface
that #2080 already tracks for the proven-disjoint infrastructure.

New results (purely additive, no existing declaration touched):

- `Function.lean`
  - `compileStmtList_legacyCompatible_of_interface` (private) — reusable legacy
    composition: a per-statement legacy interface + a successful `compileStmtList`
    yields a `LegacyCompatibleExternalStmtList` compiled body, by structural
    induction mirroring the existing disjoint-composition chain.
  - `compileFunctionSpec_body_legacyCompatible_of_interface` — lifts that to a
    whole function body (param loads ++ compiled statements).
- `Contract.lean`
  - `legacyCompatibleExternalBodies_of_compileValidatedCore_of_interface` — bridges
    the per-function interface across every selector-dispatched function to
    `LegacyCompatibleExternalBodies ir` for a concrete `compileValidatedCore` output.
  - `compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore_of_interface`
    — whole-contract retarget theorem restated directly on the per-statement
    interface; discharges the `hlegacyBodies` premise internally.

This does **not** duplicate the active storage/mapping bridge work; it reuses the
existing legacy-subset predicates and mirrors the already-landed disjoint chain.

## Validation

- `lean-slot lake build Compiler.Proofs.IRGeneration.Function` — green
- `lean-slot lake build Compiler.Proofs.IRGeneration.Contract` — green
- Diff is purely additive (132 insertions, 0 deletions); no existing theorem
  weakened, no signature changed, so no downstream module can regress.
- Zero new `sorry` / `admit` / `axiom` / `native_decide` in any added line.
- Full-project `lake build` was launched as the authoritative confirmation and
  GitHub CI runs it independently on this PR.

## Test plan

- [ ] CI full `lake build` green
- [ ] No new axioms (AXIOMS.md remains "0 active")

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive Lean proofs with no signature changes to existing theorems; risk is limited to proof maintenance in the IR generation proof layer, not runtime or auth behavior.
> 
> **Overview**
> Adds **legacy-compatibility composition lemmas** so the helper-aware whole-contract retarget theorem can take **per-statement** `StmtListCompiledLegacyCompatible` obligations (aligned with #2080) instead of a whole-contract `LegacyCompatibleExternalBodies ir` premise.
> 
> In `Function.lean`, `compileStmtList_legacyCompatible_of_interface` inductively lifts the per-statement interface to a `LegacyCompatibleExternalStmtList` for a successful `compileStmtList`, and `compileFunctionSpec_body_legacyCompatible_of_interface` extends that to full external function bodies (param loads plus compiled statements).
> 
> In `Contract.lean`, `legacyCompatibleExternalBodies_of_compileValidatedCore_of_interface` walks every selector-dispatched function from a `compileValidatedCore` output and assembles `LegacyCompatibleExternalBodies`. **`compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore_of_interface`** is the same semantic conclusion as the existing `..._of_compileValidatedCore` theorem but discharges `hlegacyBodies` internally from `hbodies`. `PrintAxioms.lean` registers the new public theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64a61deaacb49336d48959992635509959823670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->