### PR TITLE
ci: include Verity file types in OCR

### DIFF
--- a/.github/ocr/rules.json
+++ b/.github/ocr/rules.json
@@ -24,5 +24,17 @@
     "**/build/**",
     "**/*.lock",
     "**/generated/**"
+  ],
+  "include": [
+    "**/*.lean",
+    "**/*.sol",
+    "**/*.yul",
+    "**/*.cairo",
+    "AUDIT.md",
+    "TRUST_ASSUMPTIONS.md",
+    "AXIOMS.md",
+    "README.md",
+    "docs/**/*.md",
+    ".github/**/*"
   ]
 }

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -18,7 +18,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: ocr-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+  group: ocr-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Include Lean, Solidity/Yul, Cairo, trust docs, docs, and GitHub workflow files in OCR custom rules.
- This makes OCR review Verity proof PRs instead of skipping `.lean` changes as unsupported.

## Test Plan
- `python3 -m json.tool .github/ocr/rules.json`
- `node --check .github/scripts/post-ocr-review.js`
- `bash -n .github/scripts/ocr-git-wrapper.sh`
- YAML parse + actionlint
- `npx -y @alibaba-group/open-code-review@1.7.5 review --preview` on PR #2127 diff shows `.lean` file will be reviewed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/OCR configuration only; no runtime app, auth, or data-path changes.
> 
> **Overview**
> **OCR will now review Verity-relevant paths** instead of treating `.lean` and similar changes as out of scope. `.github/ocr/rules.json` gains an **`include`** list for `**/*.lean`, Solidity/Yul/Cairo, trust docs (`AUDIT.md`, `TRUST_ASSUMPTIONS.md`, `AXIOMS.md`), `README.md`, `docs/**/*.md`, and `.github/**/*`, while existing **`exclude`** patterns (e.g. `.lake`, lockfiles) stay in place.
> 
> The **OCR workflow concurrency key** in `ocr-review.yml` now appends **`github.event_name`**, so runs triggered by different events on the same PR (e.g. `pull_request_target` vs `issue_comment` `/ocr review`) no longer share one group and cancel each other when `cancel-in-progress` is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73c70cb692262fb3f660e80dd615bc999db55045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->