### PR TITLE
ci: tighten OCR rules for Verity proofs

### DIFF
--- a/.github/ocr/rules.json
+++ b/.github/ocr/rules.json
@@ -1,13 +1,33 @@
 {
   "rules": [
     {
+      "path": "{AUDIT.md,TRUST_ASSUMPTIONS.md,AXIOMS.md}",
+      "rule": "Treat trust-boundary documentation changes as high-risk. Check whether a code/proof change weakens, broadens, or silently depends on assumptions, axioms, admitted facts, trusted external semantics, compiler equivalence, or audit exclusions. Flag any mismatch between these docs and changed Lean/Solidity/Yul/Cairo code. Prefer concrete line-linked findings; do not comment on wording unless it changes the trust model.",
+      "merge_system_rule": true
+    },
+    {
+      "path": "Compiler/Proofs/IRGeneration/**",
+      "rule": "Review IRGeneration proof changes as semantic preservation work. Look for theorem statements made weaker, missing cases in induction, new hypotheses that external callers cannot prove, accidental broadening of supported fragments, unsafe simp/simp_all rewrites, use of axioms/admitted facts, and changes that should be reflected in AUDIT.md/TRUST_ASSUMPTIONS.md/AXIOMS.md. Require high-confidence, proof-relevant comments only.",
+      "merge_system_rule": true
+    },
+    {
+      "path": "Compiler/Proofs/YulGeneration/**",
+      "rule": "Review YulGeneration proof changes for Solidity/Yul observable equivalence: memory/storage layout, revert data and panic payloads, calls/returns, events/logs, aliasing, source-expression closures, and backend assumptions. Flag changed semantics, missing preconditions, theorem weakening, or doc trust drift. Avoid style feedback unless it reduces proof fragility.",
+      "merge_system_rule": true
+    },
+    {
+      "path": "**/*.{sol,yul,cairo}",
+      "rule": "Review smart-contract and low-level code for semantic drift against Verity proofs, observable behavior differences, storage/memory layout, revert/panic payload compatibility, event topics/data, authorization boundaries, and test/parity coverage. Prefer concrete correctness/security findings over style.",
+      "merge_system_rule": true
+    },
+    {
       "path": "**/*.lean",
-      "rule": "Review Lean proof changes for semantic correctness, unsound shortcuts, changed trust boundaries, brittle simp usage, missing theorem coverage, accidental weakening of statements, and interactions with AUDIT.md/TRUST_ASSUMPTIONS.md/AXIOMS.md. Do not request stylistic rewrites unless they reduce proof fragility. Prefer high-confidence findings only.",
+      "rule": "Review Lean proof changes for semantic correctness, unsound shortcuts, changed trust boundaries, brittle simp usage, missing theorem coverage, accidental weakening of statements, and interactions with AUDIT.md/TRUST_ASSUMPTIONS.md/AXIOMS.md. Treat additions of axioms, admitted facts, `sorry`, `by aesop`/large automation replacing structured proof, or weakened theorem conclusions as high-risk unless clearly justified. Do not request stylistic rewrites unless they reduce proof fragility. Prefer high-confidence findings only.",
       "merge_system_rule": true
     },
     {
       "path": "**/*.{py,sh,bash,js,ts,json,yml,yaml,toml}",
-      "rule": "Review automation and CI changes for command injection, unsafe path handling, credential exposure, nondeterminism, missing failure handling, and divergence from documented project commands. Prefer high-confidence findings only.",
+      "rule": "Review automation and CI changes for command injection, unsafe path handling, credential exposure, nondeterminism, missing failure handling, brittle GitHub Actions permissions, untrusted pull_request_target checkout mistakes, and divergence from documented project commands. Prefer high-confidence findings only.",
       "merge_system_rule": true
     },
     {

--- a/.github/ocr/rules.json
+++ b/.github/ocr/rules.json
@@ -7,12 +7,12 @@
     },
     {
       "path": "Compiler/Proofs/IRGeneration/**",
-      "rule": "Review IRGeneration proof changes as semantic preservation work. Look for theorem statements made weaker, missing cases in induction, new hypotheses that external callers cannot prove, accidental broadening of supported fragments, unsafe simp/simp_all rewrites, use of axioms/admitted facts, and changes that should be reflected in AUDIT.md/TRUST_ASSUMPTIONS.md/AXIOMS.md. Require high-confidence, proof-relevant comments only.",
+      "rule": "Review IRGeneration Lean proof changes as semantic preservation work. Apply the generic Lean checks too: look for unsound shortcuts, `sorry`, new axioms/admitted facts, large automation replacing structured proof (`by aesop`, broad `simp`/`simp_all`), theorem statements made weaker, missing induction cases, new hypotheses that external callers cannot prove, accidental broadening of supported fragments, and changes that should be reflected in AUDIT.md/TRUST_ASSUMPTIONS.md/AXIOMS.md. Require high-confidence, proof-relevant comments only.",
       "merge_system_rule": true
     },
     {
       "path": "Compiler/Proofs/YulGeneration/**",
-      "rule": "Review YulGeneration proof changes for Solidity/Yul observable equivalence: memory/storage layout, revert data and panic payloads, calls/returns, events/logs, aliasing, source-expression closures, and backend assumptions. Flag changed semantics, missing preconditions, theorem weakening, or doc trust drift. Avoid style feedback unless it reduces proof fragility.",
+      "rule": "Review YulGeneration Lean proof changes for Solidity/Yul observable equivalence: memory/storage layout, revert data and panic payloads, calls/returns, events/logs, aliasing, source-expression closures, and backend assumptions. Apply the generic Lean checks too: flag `sorry`, new axioms/admitted facts, weakened theorem conclusions, missing preconditions, broad automation replacing structured proof, brittle simp usage, or trust-doc drift. Avoid style feedback unless it reduces proof fragility.",
       "merge_system_rule": true
     },
     {

--- a/.github/scripts/post-ocr-review.js
+++ b/.github/scripts/post-ocr-review.js
@@ -10,8 +10,9 @@ module.exports = async function postOcrReview({ github, context, core }) {
   const resultPath = process.env.OCR_RESULT_PATH;
   const stderrPath = process.env.OCR_STDERR_PATH;
   const maxInline = Number(process.env.OCR_MAX_INLINE_COMMENTS || 20);
-  const successTag = `<!-- paloma-ocr-review:${commit_id}:success -->`;
-  const retryableTag = `<!-- paloma-ocr-review:${commit_id}:retryable-failure -->`;
+  const rulesHash = (process.env.OCR_RULES_HASH || 'rules-v0').slice(0, 12);
+  const successTag = `<!-- paloma-ocr-review:${commit_id}:${rulesHash}:success -->`;
+  const retryableTag = `<!-- paloma-ocr-review:${commit_id}:${rulesHash}:retryable-failure -->`;
 
   if (!pull_number || !commit_id) {
     throw new Error('OCR_PR_NUMBER and OCR_HEAD_SHA are required');

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -101,6 +101,8 @@ jobs:
           mkdir -p "$RUNNER_TEMP/ocr-bin" "$RUNNER_TEMP/ocr-tools"
           cp "$TRUSTED_DIR/.github/scripts/ocr-git-wrapper.sh" "$RUNNER_TEMP/ocr-bin/git"
           cp "$TRUSTED_DIR/.github/ocr/rules.json" "$RUNNER_TEMP/ocr-tools/rules.json"
+          sha256sum "$RUNNER_TEMP/ocr-tools/rules.json" | cut -d' ' -f1 > "$RUNNER_TEMP/ocr-tools/rules.sha"
+          printf 'OCR_RULES_HASH=%s\n' "$(cut -c1-12 "$RUNNER_TEMP/ocr-tools/rules.sha")" >> "$GITHUB_ENV"
           chmod +x "$RUNNER_TEMP/ocr-bin/git"
           echo "$RUNNER_TEMP/ocr-bin" >> "$GITHUB_PATH"
 


### PR DESCRIPTION
## Summary
- Add Verity-specific OCR rules for trust-boundary docs, IRGeneration, YulGeneration, and Solidity/Yul/Cairo changes.
- Tighten generic Lean/CI guidance around theorem weakening, axioms/admitted facts, pull_request_target safety, and proof fragility.

## Test Plan
- `python3 -m json.tool .github/ocr/rules.json`
- `npx -y @alibaba-group/open-code-review@1.7.5 review --preview --from origin/paloma/issue-2080-whole-contract-retarget-phase30 --to origin/paloma/parallel-claude-fragment-2081 --rule .github/ocr/rules.json` shows Lean files will be reviewed
- `node --check .github/scripts/post-ocr-review.js`
- `bash -n .github/scripts/ocr-git-wrapper.sh`
- YAML parse + actionlint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only OCR review configuration and CI deduplication tags; no runtime compiler, proof, or contract code is modified.
> 
> **Overview**
> Tightens the OpenCodeReview pilot so automated first-pass reviews match Verity’s proof and trust model, and so duplicate posts respect rule-set changes.
> 
> **`.github/ocr/rules.json`** adds path-specific guidance for `AUDIT.md` / `TRUST_ASSUMPTIONS.md` / `AXIOMS.md`, `Compiler/Proofs/IRGeneration/**`, `Compiler/Proofs/YulGeneration/**`, and `**/*.{sol,yul,cairo}`. Generic `**/*.lean` and automation/CI globs are expanded to flag axioms/`sorry`/theorem weakening, proof automation risk, and `pull_request_target` / Actions permission pitfalls.
> 
> **`.github/workflows/ocr-review.yml`** hashes the trusted `rules.json` and exports a 12-char `OCR_RULES_HASH`. **`post-ocr-review.js`** folds that hash into success/retry HTML comment tags so the same commit can be re-reviewed after rules change without being skipped as a duplicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2974678dc8142c1f6916ab33d60509c446c263e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->