### PR TITLE
ci: bound OCR context and tool rounds

### DIFF
--- a/.github/scripts/post-ocr-review.js
+++ b/.github/scripts/post-ocr-review.js
@@ -11,8 +11,9 @@ module.exports = async function postOcrReview({ github, context, core }) {
   const stderrPath = process.env.OCR_STDERR_PATH;
   const maxInline = Number(process.env.OCR_MAX_INLINE_COMMENTS || 20);
   const rulesHash = (process.env.OCR_RULES_HASH || 'rules-v0').slice(0, 12);
-  const successTag = `<!-- paloma-ocr-review:${commit_id}:${rulesHash}:success -->`;
-  const retryableTag = `<!-- paloma-ocr-review:${commit_id}:${rulesHash}:retryable-failure -->`;
+  const reviewerVersion = (process.env.OCR_REVIEWER_VERSION || 'reviewer-v2').slice(0, 20);
+  const successTag = `<!-- paloma-ocr-review:${commit_id}:${rulesHash}:${reviewerVersion}:success -->`;
+  const retryableTag = `<!-- paloma-ocr-review:${commit_id}:${rulesHash}:${reviewerVersion}:retryable-failure -->`;
 
   if (!pull_number || !commit_id) {
     throw new Error('OCR_PR_NUMBER and OCR_HEAD_SHA are required');
@@ -113,7 +114,7 @@ async function hasExistingTag(github, { owner, repo, pull_number, tag }) {
 
 function isRetryableResult(result) {
   const status = String(result.status || '').toLowerCase();
-  return status === 'error' || status === 'failed' || status === 'failure';
+  return status === 'error' || status === 'failed' || status === 'failure' || status === 'completed_with_errors';
 }
 
 function toReviewComment(c) {

--- a/.github/scripts/post-ocr-review.js
+++ b/.github/scripts/post-ocr-review.js
@@ -66,7 +66,9 @@ module.exports = async function postOcrReview({ github, context, core }) {
   const selected = usable.slice(0, maxInline);
   const overflow = usable.slice(maxInline);
   const tag = retryableResult ? retryableTag : successTag;
-  const body = buildReviewBody({ tag, result, comments, selected, overflow, summaryOnly, warnings, stderr });
+  const body = retryableResult
+    ? buildReviewBody({ tag, result, comments, selected: [], overflow: [...selected, ...overflow], summaryOnly, warnings, stderr })
+    : buildReviewBody({ tag, result, comments, selected, overflow, summaryOnly, warnings, stderr });
 
   if (retryableResult) {
     await github.rest.issues.createComment({

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -152,7 +152,6 @@ jobs:
             --rule "$RUNNER_TEMP/ocr-tools/rules.json" \
             --concurrency 3 \
             --timeout 20 \
-            --max-tools 20 \
             --background "$BACKGROUND" \
             > "$RUNNER_TEMP/ocr-result.json" \
             2> "$RUNNER_TEMP/ocr-stderr.log" || true

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -25,7 +25,7 @@ jobs:
   review:
     name: OCR first-pass review
     runs-on: [self-hosted, linux, x64, paloma-ocr]
-    timeout-minutes: 30
+    timeout-minutes: 45
     if: |
       github.event_name == 'pull_request_target' ||
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -139,15 +139,20 @@ jobs:
           mkdir -p "$HOME"
           printf 'Reviewing %s against origin/%s\n' "$HEAD_SHA" "$BASE_REF"
           git rev-parse --verify "origin/${BASE_REF}^{commit}" >/dev/null
-          BACKGROUND="${PR_TITLE}"$'\n\n'"${PR_BODY}"
-          BACKGROUND="${BACKGROUND:0:4000}"
+          # Keep the model focused: PR bodies can include long generated summaries (Bugbot/Cursor),
+          # which inflated token use and caused Lean proof reviews to hit OCR subtask deadlines.
+          CLEAN_BODY="${PR_BODY%%<!-- CURSOR_SUMMARY -->*}"
+          BACKGROUND="${PR_TITLE}"$'\n\n'"${CLEAN_BODY}"
+          BACKGROUND="${BACKGROUND:0:1200}"
           ocr review \
             --from "origin/${BASE_REF}" \
             --to "${HEAD_SHA}" \
             --format json \
             --audience agent \
             --rule "$RUNNER_TEMP/ocr-tools/rules.json" \
-            --concurrency 4 \
+            --concurrency 3 \
+            --timeout 20 \
+            --max-tools 20 \
             --background "$BACKGROUND" \
             > "$RUNNER_TEMP/ocr-result.json" \
             2> "$RUNNER_TEMP/ocr-stderr.log" || true

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -142,6 +142,8 @@ jobs:
           # Keep the model focused: PR bodies can include long generated summaries (Bugbot/Cursor),
           # which inflated token use and caused Lean proof reviews to hit OCR subtask deadlines.
           CLEAN_BODY="${PR_BODY%%<!-- CURSOR_SUMMARY -->*}"
+          CLEAN_BODY="${CLEAN_BODY%%<!-- BUGBOT_SUMMARY -->*}"
+          CLEAN_BODY="${CLEAN_BODY%%<!-- BUGBOT_REVIEW -->*}"
           BACKGROUND="${PR_TITLE}"$'\n\n'"${CLEAN_BODY}"
           BACKGROUND="${BACKGROUND:0:1200}"
           ocr review \


### PR DESCRIPTION
## Summary
- Strip generated Cursor/Bugbot PR body tail before passing background to OCR.
- Reduce background context cap from 4000 to 1200 chars.
- Use lower concurrency plus a longer OCR subtask timeout to reduce Lean proof deadline errors.

Note: `--max-tools` is intentionally not used with OCR v1.7.5 because values below its embedded default do not reduce the effective budget.

## Test Plan
- `node --check .github/scripts/post-ocr-review.js`
- `bash -n .github/scripts/ocr-git-wrapper.sh`
- `python3 -m json.tool .github/ocr/rules.json`
- YAML parse + actionlint
- shell smoke: generated Cursor summary is stripped and background remains <1200 chars

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to OCR background trimming, limits, and posting behavior; no application runtime or security-sensitive paths.
> 
> **Overview**
> Tightens the OpenCodeReview GitHub Action so Lean-heavy PRs are less likely to blow subtask deadlines from oversized PR background text.
> 
> The workflow now **strips** everything after `<!-- CURSOR_SUMMARY -->` in the PR body, caps **background** at **1200** characters (down from 4000), runs OCR with **concurrency 3** (was 4), and adds **`--timeout 20`** on `ocr review`.
> 
> `post-ocr-review.js` extends dedupe tags with an **`OCR_REVIEWER_VERSION`** segment (default `reviewer-v2`) and treats **`completed_with_errors`** as a **retryable** OCR status so those runs post a retryable comment instead of a success review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d68bf96acb6c4d22d5df56e4ee2e4c0cdfe6a5ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->