### PR TITLE
proof: expose helper IR mapping-write slot-safety seam

### DIFF
--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -2548,6 +2548,42 @@ theorem compile_preserves_semantics_except_mapping_writes_stmtSafety
 mapping-write whole-contract theorem. This keeps the widened Tier 2 theorem
 available on `interpretIRWithInternals` while the compiled-side retarget is
 factored behind a conservative-extension equality. -/
+theorem compile_preserves_semantics_except_mapping_writes_and_helper_ir_globalSlotSafety
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpecExceptMappingWrites model selectors)
+    (ir : IRContract)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (hnoConflict : firstFieldWriteSlotConflict model.fields = none)
+    (hsafety : SupportedStmtListMappingWriteSlotSafety model.fields)
+    (htxNormalized : Function.TxContextNormalized tx)
+    (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
+    (hcompile : CompilationModel.compile model selectors = Except.ok ir)
+    (hhelperIR :
+      interpretIRWithInternals ir 0 tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld) =
+      interpretIR ir tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) :
+    FunctionBody.sourceResultMatchesIRResult
+      (supportedSourceContractSemanticsExceptMappingWrites model selectors hSupported tx initialWorld)
+      (interpretIRWithInternals ir 0 tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  have hlegacy :=
+    compile_preserves_semantics_except_mapping_writes
+      (model := model)
+      (selectors := selectors)
+      (hSupported := hSupported)
+      (ir := ir)
+      (tx := tx)
+      (initialWorld := initialWorld)
+      (hnoConflict := hnoConflict)
+      (hsafety := hsafety)
+      (htxNormalized := htxNormalized)
+      (hcalldataSizeFits := hcalldataSizeFits)
+      (hcompile := hcompile)
+  simpa [hhelperIR] using hlegacy
+
 theorem compile_preserves_semantics_except_mapping_writes_and_helper_ir
     (model : CompilationModel)
     (selectors : List Nat)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1912,6 +1912,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_scalar_events
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_except_mapping_writes
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_except_mapping_writes_stmtSafety
+  Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_except_mapping_writes_and_helper_ir_globalSlotSafety
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_except_mapping_writes_and_helper_ir
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir
@@ -5957,4 +5958,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5587 theorems/lemmas (3861 public, 1726 private, 0 sorry'd)
+-- Total: 5588 theorems/lemmas (3862 public, 1726 private, 0 sorry'd)

--- a/artifacts/layer2_boundary_catalog.json
+++ b/artifacts/layer2_boundary_catalog.json
@@ -42,6 +42,8 @@
     "helper_ir_ready_variant": "Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir",
     "helper_proof_ready_variant": "Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs",
     "layer2_axioms": [],
+    "mapping_write_helper_ir_global_slot_safety_variant": "Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_except_mapping_writes_and_helper_ir_globalSlotSafety",
+    "mapping_write_helper_ir_stmt_safety_variant": "Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_except_mapping_writes_and_helper_ir",
     "remaining_global_hypotheses": [
       "CompilationModel.compile spec selectors = Except.ok ir",
       "Function.TxContextNormalized tx",

--- a/scripts/generate_layer2_boundary_catalog.py
+++ b/scripts/generate_layer2_boundary_catalog.py
@@ -50,6 +50,14 @@ def build_catalog() -> dict:
                 "Compiler.Proofs.IRGeneration.Contract."
                 "compile_preserves_semantics_with_helper_proofs_and_helper_ir_closed"
             ),
+            "mapping_write_helper_ir_global_slot_safety_variant": (
+                "Compiler.Proofs.IRGeneration.Contract."
+                "compile_preserves_semantics_except_mapping_writes_and_helper_ir_globalSlotSafety"
+            ),
+            "mapping_write_helper_ir_stmt_safety_variant": (
+                "Compiler.Proofs.IRGeneration.Contract."
+                "compile_preserves_semantics_except_mapping_writes_and_helper_ir"
+            ),
             "source_semantics": (
                 "Compiler.Proofs.IRGeneration.SourceSemantics.supportedSourceContractSemantics"
             ),


### PR DESCRIPTION
## Summary
- Exposes `compile_preserves_semantics_except_mapping_writes_and_helper_ir_globalSlotSafety`, a helper-IR mapping-write whole-contract seam using the existing global slot-safety hypotheses.
- Adds the theorem to `PrintAxioms.lean` and records both mapping-write helper-IR variants in the Layer 2 boundary catalog.

## Base
- Based on `origin/main` after #2126 was merged.
- No active dependency on #2126 remains.

## Validation
- `lean-slot lake env lean Compiler/Proofs/IRGeneration/Contract.lean`
  - Spark offload refused this sibling worktree path with HTTP 403, then `lean-slot` fell back to local validation and passed.
- `python3 scripts/generate_layer2_boundary_catalog.py --check`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/lean_lint.py --only axioms`
- `git diff --check`

## Notes
- Adds no `sorry`, `admit`, or project-level `axiom`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof and catalog/axiom inventory updates only; no runtime compiler behavior or trusted axioms added.
> 
> **Overview**
> Adds **`compile_preserves_semantics_except_mapping_writes_and_helper_ir_globalSlotSafety`**, a whole-contract Tier 2 wrapper that matches the existing mapping-write semantics theorem but uses **`SupportedStmtListMappingWriteSlotSafety`** (global slot safety) and concludes over **`interpretIRWithInternals`** when a conservative-extension equality to **`interpretIR`** is assumed.
> 
> The proof is a thin **`simpa`** over **`compile_preserves_semantics_except_mapping_writes`**, parallel to the per-statement **`..._and_helper_ir`** variant that still uses per-function **`StmtMappingWriteSlotSafe`** obligations.
> 
> **`PrintAxioms.lean`** lists the new theorem (public count 3888→3889). The Layer 2 boundary catalog generator and **`artifacts/layer2_boundary_catalog.json`** now name both mapping-write helper-IR theorem variants for tooling and reviewers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc860c4647bd241f15dc278de94988a891c57717. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->