### PR TITLE
ci: bound OCR routing for Lean PRs

### DIFF
--- a/.github/ocr/README.md
+++ b/.github/ocr/README.md
@@ -19,4 +19,17 @@ Manual trigger on a PR:
 
 The workflow uses `.github/ocr/rules.json` for Verity-specific review focus and `.github/scripts/ocr-git-wrapper.sh` as a temporary compatibility shim for OpenCodeReview 1.7.5 on Git versions whose `git grep` does not support `--end-of-options`.
 
+## Routing modes
+
+Before installing or invoking OpenCodeReview, `.github/scripts/ocr-router.js` compares the PR head against the base branch and writes safe metrics to `$RUNNER_TEMP/ocr-metrics.json`.
+
+- `normal`: OCR runs with the current pilot bounds (`--concurrency 3`, `--timeout 20`, PR background capped at 1200 characters). This is used for non-Lean supported changes and small Lean diffs of at most 1 Lean file and 300 supported changed lines.
+- `bounded-lean`: OCR runs with stricter bounds (`--concurrency 1`, `--timeout 12`, PR background capped at 800 characters). This is used for medium Lean diffs that are above the small threshold but below the large guard.
+- `guarded-large-lean`: OCR does not run. The workflow posts a deterministic advisory comment with changed-file counts, largest files, and thresholds. This triggers for at least 3 changed Lean files or more than 800 supported changed lines.
+- `skipped`: OCR does not run because no changed files match the OCR include rules.
+
+The guarded mode is intentional: during the pilot, a 3-file Lean PR consumed about 1.25M tokens, made 121 tool calls, and still ended as `completed_with_errors`. Large Lean changes need Codex Review and human proof review rather than an unbounded OCR attempt.
+
+Deduplication includes the commit, rules hash, reviewer version, router version, and routing mode. Retryable OCR statuses such as `completed_with_errors` do not write the success dedup tag, while deterministic guarded/skipped routing posts use a stable success tag to avoid repeated `/ocr review` spam for the same commit and router policy.
+
 Promote beyond pilot only after comparing OCR vs Codex on real PRs for true positives, false positives, latency, and cost.

--- a/.github/ocr/README.md
+++ b/.github/ocr/README.md
@@ -23,17 +23,16 @@ The workflow uses `.github/ocr/rules.json` for Verity-specific review focus and 
 
 Before installing or invoking OpenCodeReview, `.github/scripts/ocr-router.js` compares the PR head against the base branch and writes safe metrics to `$RUNNER_TEMP/ocr-metrics.json`.
 
-- `normal`: OCR runs with the current pilot bounds (`--concurrency 3`, `--timeout 20`, PR background capped at 1200 characters). This is used for non-Lean supported changes and small Lean diffs of at most 1 Lean file and 300 supported changed lines.
-- `bounded-lean`: OCR runs with stricter bounds (`--concurrency 1`, `--timeout 12`, PR background capped at 800 characters). This is used for medium Lean diffs that are above the small threshold but below the large guard.
-- `packetized-lean`: full-file OCR does not run. The trusted router parses diff hunks, ranks deterministic Lean review packets, and posts bounded hotspot coverage. This triggers for at least 3 changed Lean files or more than 800 supported changed lines, as long as the diff is still within the packet budget.
-- `guarded-oversized-lean`: neither full-file OCR nor packetized review runs because the diff exceeds the bounded packet budget: more than 12 Lean files or more than 2500 supported changed lines.
-- `guarded-unpacketized-lean`: full-file OCR is avoided and packetized review could not safely produce any diff packets. The posted result is an actionable checklist based on changed-file metrics rather than a review.
-- `skipped`: OCR does not run because no changed files match the OCR include rules.
+- `no-supported`: OCR does not run because no changed files match the OCR include rules.
+- `small-lean`: OCR runs with the current pilot bounds (`--concurrency 3`, `--timeout 20`, PR background capped at 1200 characters). This is used for Lean diffs of at most 1 Lean file and 300 supported changed lines.
+- `medium-lean`: OCR runs with stricter bounds (`--concurrency 1`, `--timeout 12`, PR background capped at 800 characters). This is used for medium Lean diffs that are above the small threshold but below the large threshold.
+- `large-lean-hotspots`: full-file OCR does not run. The trusted router parses diff hunks, ranks deterministic Lean review packets, and posts bounded hotspot coverage. This triggers for at least 3 changed Lean files or more than 800 supported changed lines. If the diff exceeds the bounded packet budget, more than 12 Lean files or more than 2500 supported changed lines, or no safe packets can be produced, the same mode posts a concrete coverage report and checklist instead of a generic skip.
+- `config-docs`: OCR runs with the current pilot bounds for supported non-Lean changes, including workflows, scripts, docs, trust/security surfaces, Solidity, Yul, Cairo, and config files.
 
 Packetized Lean mode is intentionally partial. It checks deterministic signals first, including introduced `sorry`/`admit`/`axiom`/`unsafe`, changed imports, public declaration or theorem signature changes, trust-boundary documentation drift, and large deleted proof obligations. It then ranks hotspots such as `Compiler/Proofs/YulGeneration/**`, `Compiler/Proofs/**`, `Compiler/**`, `IRGeneration/**`, `Semantics/**`, trust docs, and public theorem statements. The posted comment lists the covered packets, packet budget, metrics, and residual risk. It must not be read as full review coverage.
 
 The hard guarded modes are fallback behavior only. During the pilot, a 3-file Lean PR consumed about 1.25M tokens, made 121 tool calls, and still ended as `completed_with_errors`; packetized review is meant to keep OCR useful without pretending it reviewed whole files.
 
-Deduplication includes the commit, rules hash, reviewer version, router version, and routing mode. Retryable OCR statuses such as `completed_with_errors` do not write the success dedup tag, while deterministic guarded/skipped routing posts use a stable success tag to avoid repeated `/ocr review` spam for the same commit and router policy.
+Deduplication includes the commit, rules hash, reviewer version, router version, and routing mode. Retryable OCR statuses such as `completed_with_errors` do not write the success dedup tag, while deterministic `no-supported` and `large-lean-hotspots` routing posts use a stable success tag to avoid repeated `/ocr review` spam for the same commit and router policy.
 
 Promote beyond pilot only after comparing OCR vs Codex on real PRs for true positives, false positives, latency, and cost.

--- a/.github/ocr/README.md
+++ b/.github/ocr/README.md
@@ -25,10 +25,14 @@ Before installing or invoking OpenCodeReview, `.github/scripts/ocr-router.js` co
 
 - `normal`: OCR runs with the current pilot bounds (`--concurrency 3`, `--timeout 20`, PR background capped at 1200 characters). This is used for non-Lean supported changes and small Lean diffs of at most 1 Lean file and 300 supported changed lines.
 - `bounded-lean`: OCR runs with stricter bounds (`--concurrency 1`, `--timeout 12`, PR background capped at 800 characters). This is used for medium Lean diffs that are above the small threshold but below the large guard.
-- `guarded-large-lean`: OCR does not run. The workflow posts a deterministic advisory comment with changed-file counts, largest files, and thresholds. This triggers for at least 3 changed Lean files or more than 800 supported changed lines.
+- `packetized-lean`: full-file OCR does not run. The trusted router parses diff hunks, ranks deterministic Lean review packets, and posts bounded hotspot coverage. This triggers for at least 3 changed Lean files or more than 800 supported changed lines, as long as the diff is still within the packet budget.
+- `guarded-oversized-lean`: neither full-file OCR nor packetized review runs because the diff exceeds the bounded packet budget: more than 12 Lean files or more than 2500 supported changed lines.
+- `guarded-unpacketized-lean`: full-file OCR is avoided and packetized review could not safely produce any diff packets. The posted result is an actionable checklist based on changed-file metrics rather than a review.
 - `skipped`: OCR does not run because no changed files match the OCR include rules.
 
-The guarded mode is intentional: during the pilot, a 3-file Lean PR consumed about 1.25M tokens, made 121 tool calls, and still ended as `completed_with_errors`. Large Lean changes need Codex Review and human proof review rather than an unbounded OCR attempt.
+Packetized Lean mode is intentionally partial. It checks deterministic signals first, including introduced `sorry`/`admit`/`axiom`/`unsafe`, changed imports, public declaration or theorem signature changes, trust-boundary documentation drift, and large deleted proof obligations. It then ranks hotspots such as `Compiler/Proofs/YulGeneration/**`, `Compiler/Proofs/**`, `Compiler/**`, `IRGeneration/**`, `Semantics/**`, trust docs, and public theorem statements. The posted comment lists the covered packets, packet budget, metrics, and residual risk. It must not be read as full review coverage.
+
+The hard guarded modes are fallback behavior only. During the pilot, a 3-file Lean PR consumed about 1.25M tokens, made 121 tool calls, and still ended as `completed_with_errors`; packetized review is meant to keep OCR useful without pretending it reviewed whole files.
 
 Deduplication includes the commit, rules hash, reviewer version, router version, and routing mode. Retryable OCR statuses such as `completed_with_errors` do not write the success dedup tag, while deterministic guarded/skipped routing posts use a stable success tag to avoid repeated `/ocr review` spam for the same commit and router policy.
 

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
-const ROUTER_VERSION = 'router-v2';
+const ROUTER_VERSION = 'router-v3';
 const THRESHOLDS = Object.freeze({
   smallLeanFiles: 1,
   smallChangedLines: 300,
@@ -172,7 +172,7 @@ function decideRoute(files) {
 
   if (supportedFiles.length === 0) {
     return route({
-      mode: 'skipped',
+      mode: 'no-supported',
       shouldRunOcr: false,
       reason: 'No changed files matched OCR include rules.',
       counts,
@@ -184,13 +184,13 @@ function decideRoute(files) {
 
   if (leanFiles.length > 0 && (leanFiles.length > THRESHOLDS.packetMaxFiles || changedLines > THRESHOLDS.packetMaxChangedLines)) {
     return route({
-      mode: 'guarded-oversized-lean',
+      mode: 'large-lean-hotspots',
       shouldRunOcr: false,
       reason: `Lean packet budget exceeded: ${leanFiles.length} Lean file(s), ${changedLines} changed supported line(s).`,
       counts,
       changedLines,
       largestFiles,
-      packets,
+      packets: [],
       ocr: { concurrency: 0, timeout: 0, backgroundChars: 0 },
     });
   }
@@ -198,7 +198,7 @@ function decideRoute(files) {
   if (leanFiles.length > 0 && (leanFiles.length >= THRESHOLDS.largeLeanFiles || changedLines > THRESHOLDS.largeChangedLines)) {
     if (packets.length === 0) {
       return route({
-        mode: 'guarded-unpacketized-lean',
+        mode: 'large-lean-hotspots',
         shouldRunOcr: false,
         reason: `Lean diff exceeded full OCR thresholds, but no safe review packets could be produced: ${leanFiles.length} Lean file(s), ${changedLines} changed supported line(s).`,
         counts,
@@ -209,7 +209,7 @@ function decideRoute(files) {
       });
     }
     return route({
-      mode: 'packetized-lean',
+      mode: 'large-lean-hotspots',
       shouldRunOcr: false,
       reason: `Large Lean diff routed to bounded packet review: ${leanFiles.length} Lean file(s), ${changedLines} changed supported line(s).`,
       counts,
@@ -222,7 +222,7 @@ function decideRoute(files) {
 
   if (leanFiles.length > 0 && (leanFiles.length > THRESHOLDS.smallLeanFiles || changedLines > THRESHOLDS.smallChangedLines)) {
     return route({
-      mode: 'bounded-lean',
+      mode: 'medium-lean',
       shouldRunOcr: true,
       reason: `Medium Lean diff routed with reduced OCR bounds: ${leanFiles.length} Lean file(s), ${changedLines} changed supported line(s).`,
       counts,
@@ -234,7 +234,7 @@ function decideRoute(files) {
   }
 
   return route({
-    mode: 'normal',
+    mode: leanFiles.length > 0 ? 'small-lean' : 'config-docs',
     shouldRunOcr: true,
     reason: leanFiles.length > 0
       ? `Small Lean diff: ${leanFiles.length} Lean file(s), ${changedLines} changed supported line(s).`
@@ -447,7 +447,7 @@ function buildMetrics({ prNumber, headSha, baseRef, startedAt, decision, diff })
       })),
     },
     packet_review: shouldReportPacketReview(decision) ? {
-      enabled: decision.mode === 'packetized-lean',
+      enabled: decision.mode === 'large-lean-hotspots' && (decision.packets?.length || 0) > 0,
       packets_selected: decision.packets?.length || 0,
       packet_budget: THRESHOLDS.packetMaxCount,
       packets: (decision.packets || []).map(p => ({
@@ -478,7 +478,7 @@ function buildMetrics({ prNumber, headSha, baseRef, startedAt, decision, diff })
 }
 
 function buildSyntheticResult(decision, metrics) {
-  if (decision.mode === 'packetized-lean') {
+  if (decision.mode === 'large-lean-hotspots' && (decision.packets?.length || 0) > 0) {
     return buildPacketizedResult(decision, metrics);
   }
 
@@ -486,7 +486,7 @@ function buildSyntheticResult(decision, metrics) {
     status: decision.mode,
     message: decision.reason,
     comments: [],
-    warnings: ['guarded-oversized-lean', 'guarded-unpacketized-lean'].includes(decision.mode)
+    warnings: decision.mode === 'large-lean-hotspots'
       ? [{ type: 'routing', message: 'Diff exceeded bounded packet review capability; full OCR not attempted.' }]
       : [],
     summary: {
@@ -511,7 +511,7 @@ function buildPacketizedResult(decision, metrics) {
       path: packet.path,
       start_line: packet.start_line,
       end_line: packet.end_line,
-      category: 'packetized-lean',
+      category: 'large-lean-hotspots',
       severity: packet.score >= 90 ? 'high' : packet.score >= 60 ? 'medium' : 'low',
       content: renderPacketFinding(packet),
     })),
@@ -548,20 +548,20 @@ function renderPacketFinding(packet) {
 }
 
 function packetResidualRisk(decision) {
-  if (decision.mode === 'packetized-lean') {
+  if (decision.mode === 'large-lean-hotspots' && (decision.packets?.length || 0) > 0) {
     return `Reviewed top ${decision.packets?.length || 0} packet(s) by deterministic risk score; remaining changed hunks/files require Codex or human proof review.`;
   }
-  if (decision.mode === 'guarded-oversized-lean') {
+  if (decision.mode === 'large-lean-hotspots' && ((decision.counts?.lean || 0) > THRESHOLDS.packetMaxFiles || (decision.changedLines || 0) > THRESHOLDS.packetMaxChangedLines)) {
     return 'Diff exceeded packet budget; use top changed files and deterministic signals as required Codex/human review checklist.';
   }
-  if (decision.mode === 'guarded-unpacketized-lean') {
+  if (decision.mode === 'large-lean-hotspots') {
     return 'Router could not produce safe diff packets; use top changed files as required Codex/human review checklist.';
   }
   return null;
 }
 
 function shouldReportPacketReview(decision) {
-  return ['packetized-lean', 'guarded-oversized-lean', 'guarded-unpacketized-lean'].includes(decision.mode);
+  return decision.mode === 'large-lean-hotspots';
 }
 
 function uniqueCount(values) {

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
-const ROUTER_VERSION = 'router-v1';
+const ROUTER_VERSION = 'router-v2';
 const THRESHOLDS = Object.freeze({
   smallLeanFiles: 1,
   smallChangedLines: 300,
@@ -12,6 +12,10 @@ const THRESHOLDS = Object.freeze({
   mediumChangedLines: 800,
   largeLeanFiles: 3,
   largeChangedLines: 800,
+  packetMaxFiles: 12,
+  packetMaxChangedLines: 2500,
+  packetMaxCount: 8,
+  packetContextLines: 12,
 });
 
 function main() {
@@ -59,7 +63,17 @@ function main() {
 function loadDiff(base, head) {
   const output = git(['diff', '--numstat', '--find-renames', base, head, '--']);
   const files = output.split(/\r?\n/).filter(Boolean).map(parseNumstatLine).filter(Boolean);
+  const hunksByPath = loadDiffHunks(base, head);
+  for (const file of files) {
+    file.hunks = hunksByPath.get(file.path) || [];
+    file.risk = scoreFileRisk(file);
+  }
   return { base, head, files };
+}
+
+function loadDiffHunks(base, head) {
+  const output = git(['diff', '--find-renames', `--unified=${THRESHOLDS.packetContextLines}`, base, head, '--']);
+  return parseUnifiedDiff(output);
 }
 
 function parseNumstatLine(line) {
@@ -89,6 +103,64 @@ function normalizeDiffPath(rawPath) {
   return rawPath.trim();
 }
 
+function parseUnifiedDiff(diffText) {
+  const byPath = new Map();
+  let currentPath = null;
+  let currentHunk = null;
+  let oldLine = 0;
+  let newLine = 0;
+
+  for (const line of diffText.split(/\r?\n/)) {
+    if (line.startsWith('diff --git ')) {
+      currentPath = null;
+      currentHunk = null;
+      continue;
+    }
+    if (line.startsWith('+++ ')) {
+      const raw = line.slice(4).trim();
+      if (raw === '/dev/null') {
+        currentPath = null;
+        continue;
+      }
+      currentPath = raw.replace(/^b\//, '');
+      if (!byPath.has(currentPath)) byPath.set(currentPath, []);
+      continue;
+    }
+    const hunkHeader = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,(\d+))? @@(.*)$/);
+    if (hunkHeader && currentPath) {
+      oldLine = Number(hunkHeader[1]);
+      newLine = Number(hunkHeader[2]);
+      currentHunk = {
+        path: currentPath,
+        oldStart: oldLine,
+        newStart: newLine,
+        newSpan: Number(hunkHeader[3] || 1),
+        header: hunkHeader[4].trim(),
+        lines: [],
+      };
+      byPath.get(currentPath).push(currentHunk);
+      continue;
+    }
+    if (!currentHunk || line.startsWith('\\ No newline')) continue;
+
+    const prefix = line[0] || ' ';
+    const text = line.slice(1);
+    if (prefix === '+') {
+      currentHunk.lines.push({ type: 'add', newLine, oldLine: null, text });
+      newLine += 1;
+    } else if (prefix === '-') {
+      currentHunk.lines.push({ type: 'del', newLine: null, oldLine, text });
+      oldLine += 1;
+    } else {
+      currentHunk.lines.push({ type: 'ctx', newLine, oldLine, text });
+      oldLine += 1;
+      newLine += 1;
+    }
+  }
+
+  return byPath;
+}
+
 function decideRoute(files) {
   const included = files.filter(f => !isExcluded(f.path));
   const supportedFiles = included.filter(f => f.supported);
@@ -96,6 +168,7 @@ function decideRoute(files) {
   const changedLines = supportedFiles.reduce((sum, f) => sum + f.changed, 0);
   const counts = countCategories(included, supportedFiles);
   const largestFiles = [...supportedFiles].sort((a, b) => b.changed - a.changed).slice(0, 8);
+  const packets = buildReviewPackets(supportedFiles);
 
   if (supportedFiles.length === 0) {
     return route({
@@ -109,14 +182,40 @@ function decideRoute(files) {
     });
   }
 
-  if (leanFiles.length > 0 && (leanFiles.length >= THRESHOLDS.largeLeanFiles || changedLines > THRESHOLDS.largeChangedLines)) {
+  if (leanFiles.length > 0 && (leanFiles.length > THRESHOLDS.packetMaxFiles || changedLines > THRESHOLDS.packetMaxChangedLines)) {
     return route({
-      mode: 'guarded-large-lean',
+      mode: 'guarded-oversized-lean',
       shouldRunOcr: false,
-      reason: `Lean OCR guard: ${leanFiles.length} Lean file(s), ${changedLines} changed supported line(s).`,
+      reason: `Lean packet budget exceeded: ${leanFiles.length} Lean file(s), ${changedLines} changed supported line(s).`,
       counts,
       changedLines,
       largestFiles,
+      packets,
+      ocr: { concurrency: 0, timeout: 0, backgroundChars: 0 },
+    });
+  }
+
+  if (leanFiles.length > 0 && (leanFiles.length >= THRESHOLDS.largeLeanFiles || changedLines > THRESHOLDS.largeChangedLines)) {
+    if (packets.length === 0) {
+      return route({
+        mode: 'guarded-unpacketized-lean',
+        shouldRunOcr: false,
+        reason: `Lean diff exceeded full OCR thresholds, but no safe review packets could be produced: ${leanFiles.length} Lean file(s), ${changedLines} changed supported line(s).`,
+        counts,
+        changedLines,
+        largestFiles,
+        packets,
+        ocr: { concurrency: 0, timeout: 0, backgroundChars: 0 },
+      });
+    }
+    return route({
+      mode: 'packetized-lean',
+      shouldRunOcr: false,
+      reason: `Large Lean diff routed to bounded packet review: ${leanFiles.length} Lean file(s), ${changedLines} changed supported line(s).`,
+      counts,
+      changedLines,
+      largestFiles,
+      packets,
       ocr: { concurrency: 0, timeout: 0, backgroundChars: 0 },
     });
   }
@@ -129,6 +228,7 @@ function decideRoute(files) {
       counts,
       changedLines,
       largestFiles,
+      packets,
       ocr: { concurrency: 1, timeout: 12, backgroundChars: 800 },
     });
   }
@@ -142,12 +242,125 @@ function decideRoute(files) {
     counts,
     changedLines,
     largestFiles,
+    packets,
     ocr: { concurrency: 3, timeout: 20, backgroundChars: 1200 },
   });
 }
 
 function route(decision) {
   return { ...decision, thresholds: THRESHOLDS, routerVersion: ROUTER_VERSION };
+}
+
+function buildReviewPackets(files) {
+  const packets = [];
+  for (const file of files) {
+    if (!file.supported || !Array.isArray(file.hunks)) continue;
+    for (const hunk of file.hunks) {
+      const signals = detectSignals(file, hunk);
+      const pathRisk = scorePathRisk(file.path);
+      const churnRisk = Math.min(10, Math.floor((hunk.lines.filter(l => l.type !== 'ctx').length) / 20));
+      const score = pathRisk + churnRisk + signals.reduce((sum, s) => sum + s.weight, 0);
+      if (score <= 0 && file.category !== 'lean') continue;
+
+      const addedLines = hunk.lines.filter(l => l.type === 'add');
+      const changedLines = hunk.lines.filter(l => l.type !== 'ctx');
+      const anchor = firstChangedNewLine(hunk) || hunk.newStart || 1;
+      packets.push({
+        path: file.path,
+        start_line: anchor,
+        end_line: lastChangedNewLine(hunk) || anchor,
+        score,
+        category: file.category,
+        signals: signals.map(s => s.name),
+        summary: summarizePacket(file, hunk, signals, changedLines.length),
+        added_sample: addedLines.slice(0, 8).map(l => ({ line: l.newLine, text: l.text.slice(0, 220) })),
+        changed_lines: changedLines.length,
+      });
+    }
+  }
+
+  return packets
+    .sort((a, b) => b.score - a.score || b.changed_lines - a.changed_lines || a.path.localeCompare(b.path))
+    .slice(0, THRESHOLDS.packetMaxCount);
+}
+
+function scoreFileRisk(file) {
+  return scorePathRisk(file.path) + Math.min(20, Math.floor((file.changed || 0) / 100));
+}
+
+function scorePathRisk(filePath) {
+  if (/^Compiler\/Proofs\/YulGeneration\//.test(filePath)) return 35;
+  if (/^Compiler\/Proofs\//.test(filePath)) return 30;
+  if (/^Compiler\//.test(filePath)) return 25;
+  if (/^IRGeneration\//.test(filePath) || /\/IRGeneration\//.test(filePath)) return 25;
+  if (/^Semantics\//.test(filePath) || /\/Semantics\//.test(filePath)) return 25;
+  if (/TRUST|AXIOM|AUDIT/.test(path.posix.basename(filePath))) return 24;
+  if (/^docs\/.*(trust|axiom|audit|spec)/i.test(filePath)) return 18;
+  if (filePath.endsWith('.lean')) return 12;
+  if (filePath.startsWith('.github/')) return 10;
+  return 0;
+}
+
+function detectSignals(file, hunk) {
+  const signals = new Map();
+  const add = (name, weight) => signals.set(name, { name, weight: Math.max(weight, signals.get(name)?.weight || 0) });
+  const added = hunk.lines.filter(l => l.type === 'add').map(l => l.text);
+  const deleted = hunk.lines.filter(l => l.type === 'del').map(l => l.text);
+  const allChanged = [...added, ...deleted];
+
+  if (added.some(line => /\b(sorry|admit)\b/.test(line))) add('introduced sorry/admit', 80);
+  if (added.some(line => /^\s*axiom\b/.test(line) || /\baxiom\b/.test(line))) add('introduced/changed axiom', 75);
+  if (added.some(line => /\bunsafe\b/.test(line))) add('introduced unsafe', 55);
+  if (allChanged.some(line => /^\s*import\s+/.test(line))) add('changed imports', 30);
+  if (allChanged.some(line => publicDeclPattern().test(line))) add('public declaration/signature changed', 34);
+  if (file.category === 'trust-doc') add('trust-boundary docs drift', 38);
+  if (file.category === 'doc' && /(trust|axiom|audit|sound|semantic|proof)/i.test(file.path)) add('trust/proof docs drift', 25);
+  if (deleted.length >= 80 || deleted.join('\n').length > 6000) add('large deleted proof obligation', 35);
+  if (deleted.some(line => publicDeclPattern().test(line)) && added.some(line => publicDeclPattern().test(line))) {
+    add('theorem/public statement changed', 45);
+  }
+  if (changedTheoremStatements(deleted, added).length > 0) add('theorem statement changed/possibly weakened', 65);
+
+  return [...signals.values()].sort((a, b) => b.weight - a.weight || a.name.localeCompare(b.name));
+}
+
+function publicDeclPattern() {
+  return /^\s*(?:theorem|lemma|def|abbrev|axiom|opaque|instance|class|structure|inductive)\s+[A-Za-z0-9_'.]+/;
+}
+
+function changedTheoremStatements(deleted, added) {
+  const removed = new Map();
+  for (const line of deleted) {
+    const match = line.match(/^\s*(theorem|lemma)\s+([A-Za-z0-9_'.]+)\b(.*)$/);
+    if (match) removed.set(match[2], line.trim());
+  }
+  const changed = [];
+  for (const line of added) {
+    const match = line.match(/^\s*(theorem|lemma)\s+([A-Za-z0-9_'.]+)\b(.*)$/);
+    if (match && removed.has(match[2]) && removed.get(match[2]) !== line.trim()) {
+      changed.push(match[2]);
+    }
+  }
+  return changed;
+}
+
+function summarizePacket(file, hunk, signals, changedCount) {
+  const signalText = signals.length ? signals.map(s => s.name).join(', ') : 'hotspot path/churn';
+  return `${signalText}; ${changedCount} changed line(s) near ${file.path}:${firstChangedNewLine(hunk) || hunk.newStart || 1}`;
+}
+
+function firstChangedNewLine(hunk) {
+  const changed = hunk.lines.find(l => l.type === 'add' && Number.isFinite(l.newLine)) ||
+    hunk.lines.find(l => l.type === 'ctx' && Number.isFinite(l.newLine));
+  return changed?.newLine || null;
+}
+
+function lastChangedNewLine(hunk) {
+  for (let i = hunk.lines.length - 1; i >= 0; i -= 1) {
+    const line = hunk.lines[i];
+    if ((line.type === 'add' || line.type === 'ctx') && Number.isFinite(line.newLine)) return line.newLine;
+  }
+  return null;
 }
 
 function countCategories(included, supportedFiles) {
@@ -229,8 +442,25 @@ function buildMetrics({ prNumber, headSha, baseRef, startedAt, decision, diff })
         deleted: f.deleted,
         changed: f.changed,
         category: f.category,
+        risk: f.risk || scorePathRisk(f.path),
       })),
     },
+    packet_review: shouldReportPacketReview(decision) ? {
+      enabled: decision.mode === 'packetized-lean',
+      packets_selected: decision.packets?.length || 0,
+      packet_budget: THRESHOLDS.packetMaxCount,
+      packets: (decision.packets || []).map(p => ({
+        path: p.path,
+        start_line: p.start_line,
+        end_line: p.end_line,
+        score: p.score,
+        category: p.category,
+        signals: p.signals,
+        summary: p.summary,
+        changed_lines: p.changed_lines,
+      })),
+      residual_risk: packetResidualRisk(decision),
+    } : null,
     ocr: {
       attempted: decision.shouldRunOcr,
       status: decision.shouldRunOcr ? 'pending' : decision.mode,
@@ -247,12 +477,16 @@ function buildMetrics({ prNumber, headSha, baseRef, startedAt, decision, diff })
 }
 
 function buildSyntheticResult(decision, metrics) {
+  if (decision.mode === 'packetized-lean') {
+    return buildPacketizedResult(decision, metrics);
+  }
+
   return {
     status: decision.mode,
     message: decision.reason,
     comments: [],
-    warnings: decision.mode === 'guarded-large-lean'
-      ? [{ type: 'routing', message: 'Full OCR skipped by Lean scaling guard.' }]
+    warnings: ['guarded-oversized-lean', 'guarded-unpacketized-lean'].includes(decision.mode)
+      ? [{ type: 'routing', message: 'Diff exceeded bounded packet review capability; full OCR not attempted.' }]
       : [],
     summary: {
       files_reviewed: 0,
@@ -260,10 +494,77 @@ function buildSyntheticResult(decision, metrics) {
       mode: decision.mode,
       router_version: ROUTER_VERSION,
       changed_files: metrics.changed_files,
+      packet_review: metrics.packet_review,
       thresholds: decision.thresholds,
     },
     tool_calls: { total: 0 },
   };
+}
+
+function buildPacketizedResult(decision, metrics) {
+  const packets = decision.packets || [];
+  return {
+    status: 'packetized_review',
+    message: `${decision.reason} Full-file OCR was not attempted; this is deterministic hotspot coverage, not complete review coverage.`,
+    comments: packets.map(packet => ({
+      path: packet.path,
+      start_line: packet.start_line,
+      end_line: packet.end_line,
+      category: 'packetized-lean',
+      severity: packet.score >= 90 ? 'high' : packet.score >= 60 ? 'medium' : 'low',
+      content: renderPacketFinding(packet),
+    })),
+    warnings: [{
+      type: 'coverage',
+      message: 'Packetized Lean review covers ranked hotspots only. Codex/human review must cover skipped hunks and proof obligations.',
+    }],
+    summary: {
+      files_reviewed: uniqueCount(packets.map(p => p.path)),
+      total_tokens: 0,
+      mode: decision.mode,
+      router_version: ROUTER_VERSION,
+      changed_files: metrics.changed_files,
+      packet_review: metrics.packet_review,
+      thresholds: decision.thresholds,
+    },
+    tool_calls: { total: 0 },
+  };
+}
+
+function renderPacketFinding(packet) {
+  const lines = [
+    `Bounded Lean packet selected for review: ${packet.summary}.`,
+    `Risk signals: ${packet.signals.length ? packet.signals.join(', ') : 'hotspot path/churn'}.`,
+  ];
+  if (packet.added_sample.length > 0) {
+    lines.push('Added-line sample:');
+    for (const sample of packet.added_sample.slice(0, 5)) {
+      lines.push(`- L${sample.line}: ${sample.text}`);
+    }
+  }
+  lines.push('This packet is a coverage marker and deterministic checklist item; it is not a full OCR semantic review.');
+  return lines.join('\n');
+}
+
+function packetResidualRisk(decision) {
+  if (decision.mode === 'packetized-lean') {
+    return `Reviewed top ${decision.packets?.length || 0} packet(s) by deterministic risk score; remaining changed hunks/files require Codex or human proof review.`;
+  }
+  if (decision.mode === 'guarded-oversized-lean') {
+    return 'Diff exceeded packet budget; use top changed files and deterministic signals as required Codex/human review checklist.';
+  }
+  if (decision.mode === 'guarded-unpacketized-lean') {
+    return 'Router could not produce safe diff packets; use top changed files as required Codex/human review checklist.';
+  }
+  return null;
+}
+
+function shouldReportPacketReview(decision) {
+  return ['packetized-lean', 'guarded-oversized-lean', 'guarded-unpacketized-lean'].includes(decision.mode);
+}
+
+function uniqueCount(values) {
+  return new Set(values.filter(Boolean)).size;
 }
 
 function writeOutputs(outputPath, values) {
@@ -294,4 +595,7 @@ module.exports = {
   parseNumstatLine,
   buildSyntheticResult,
   buildMetrics,
+  buildReviewPackets,
+  parseUnifiedDiff,
+  scorePathRisk,
 };

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -403,7 +403,8 @@ function isSupported(filePath) {
     /\.(sol|yul|cairo)$/.test(filePath) ||
     ['AUDIT.md', 'TRUST_ASSUMPTIONS.md', 'AXIOMS.md', 'README.md'].includes(base) ||
     (filePath.startsWith('docs/') && filePath.endsWith('.md')) ||
-    filePath.startsWith('.github/');
+    filePath.startsWith('.github/') ||
+    /\.(py|sh|bash|js|ts|json|ya?ml|toml)$/.test(filePath);
 }
 
 function isExcluded(filePath) {

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -1,0 +1,297 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROUTER_VERSION = 'router-v1';
+const THRESHOLDS = Object.freeze({
+  smallLeanFiles: 1,
+  smallChangedLines: 300,
+  mediumLeanFiles: 2,
+  mediumChangedLines: 800,
+  largeLeanFiles: 3,
+  largeChangedLines: 800,
+});
+
+function main() {
+  const baseRef = requiredEnv('BASE_REF');
+  const headSha = requiredEnv('HEAD_SHA');
+  const prNumber = process.env.OCR_PR_NUMBER || '';
+  const metricsPath = process.env.OCR_METRICS_PATH || path.join(process.env.RUNNER_TEMP || '.', 'ocr-metrics.json');
+  const resultPath = process.env.OCR_RESULT_PATH || path.join(process.env.RUNNER_TEMP || '.', 'ocr-result.json');
+  const outputPath = process.env.GITHUB_OUTPUT || '';
+
+  const startedAt = new Date().toISOString();
+  const diff = loadDiff(`origin/${baseRef}`, headSha);
+  const decision = decideRoute(diff.files);
+  const metrics = buildMetrics({
+    prNumber,
+    headSha,
+    baseRef,
+    startedAt,
+    decision,
+    diff,
+  });
+
+  fs.writeFileSync(metricsPath, `${JSON.stringify(metrics, null, 2)}\n`);
+
+  if (!decision.shouldRunOcr) {
+    fs.writeFileSync(resultPath, `${JSON.stringify(buildSyntheticResult(decision, metrics), null, 2)}\n`);
+  }
+
+  writeOutputs(outputPath, {
+    mode: decision.mode,
+    should_run_ocr: String(decision.shouldRunOcr),
+    reason: decision.reason,
+    concurrency: String(decision.ocr.concurrency),
+    timeout: String(decision.ocr.timeout),
+    background_chars: String(decision.ocr.backgroundChars),
+    metrics_path: metricsPath,
+    result_path: resultPath,
+    router_version: ROUTER_VERSION,
+  });
+
+  console.log(`OCR route: ${decision.mode} (${decision.reason})`);
+  console.log(`Changed files: ${diff.files.length}; supported: ${decision.counts.supported}; Lean: ${decision.counts.lean}; changed lines: ${decision.changedLines}`);
+}
+
+function loadDiff(base, head) {
+  const output = git(['diff', '--numstat', '--find-renames', base, head, '--']);
+  const files = output.split(/\r?\n/).filter(Boolean).map(parseNumstatLine).filter(Boolean);
+  return { base, head, files };
+}
+
+function parseNumstatLine(line) {
+  const parts = line.split('\t');
+  if (parts.length < 3) return null;
+  const added = parts[0] === '-' ? 0 : Number(parts[0]);
+  const deleted = parts[1] === '-' ? 0 : Number(parts[1]);
+  const rawPath = parts.slice(2).join('\t');
+  const filePath = normalizeDiffPath(rawPath);
+  return {
+    path: filePath,
+    added: Number.isFinite(added) ? added : 0,
+    deleted: Number.isFinite(deleted) ? deleted : 0,
+    changed: (Number.isFinite(added) ? added : 0) + (Number.isFinite(deleted) ? deleted : 0),
+    category: categorize(filePath),
+    supported: isSupported(filePath),
+  };
+}
+
+function normalizeDiffPath(rawPath) {
+  const arrow = rawPath.match(/\{(.+) => (.+)\}/);
+  if (arrow) {
+    return rawPath.replace(/\{(.+) => (.+)\}/, arrow[2]).replace(/^\s+|\s+$/g, '');
+  }
+  const rename = rawPath.match(/^(.+) => (.+)$/);
+  if (rename) return rename[2].trim();
+  return rawPath.trim();
+}
+
+function decideRoute(files) {
+  const included = files.filter(f => !isExcluded(f.path));
+  const supportedFiles = included.filter(f => f.supported);
+  const leanFiles = supportedFiles.filter(f => f.category === 'lean');
+  const changedLines = supportedFiles.reduce((sum, f) => sum + f.changed, 0);
+  const counts = countCategories(included, supportedFiles);
+  const largestFiles = [...supportedFiles].sort((a, b) => b.changed - a.changed).slice(0, 8);
+
+  if (supportedFiles.length === 0) {
+    return route({
+      mode: 'skipped',
+      shouldRunOcr: false,
+      reason: 'No changed files matched OCR include rules.',
+      counts,
+      changedLines,
+      largestFiles,
+      ocr: { concurrency: 0, timeout: 0, backgroundChars: 0 },
+    });
+  }
+
+  if (leanFiles.length > 0 && (leanFiles.length >= THRESHOLDS.largeLeanFiles || changedLines > THRESHOLDS.largeChangedLines)) {
+    return route({
+      mode: 'guarded-large-lean',
+      shouldRunOcr: false,
+      reason: `Lean OCR guard: ${leanFiles.length} Lean file(s), ${changedLines} changed supported line(s).`,
+      counts,
+      changedLines,
+      largestFiles,
+      ocr: { concurrency: 0, timeout: 0, backgroundChars: 0 },
+    });
+  }
+
+  if (leanFiles.length > 0 && (leanFiles.length > THRESHOLDS.smallLeanFiles || changedLines > THRESHOLDS.smallChangedLines)) {
+    return route({
+      mode: 'bounded-lean',
+      shouldRunOcr: true,
+      reason: `Medium Lean diff routed with reduced OCR bounds: ${leanFiles.length} Lean file(s), ${changedLines} changed supported line(s).`,
+      counts,
+      changedLines,
+      largestFiles,
+      ocr: { concurrency: 1, timeout: 12, backgroundChars: 800 },
+    });
+  }
+
+  return route({
+    mode: 'normal',
+    shouldRunOcr: true,
+    reason: leanFiles.length > 0
+      ? `Small Lean diff: ${leanFiles.length} Lean file(s), ${changedLines} changed supported line(s).`
+      : 'Supported non-Lean diff; OCR enabled.',
+    counts,
+    changedLines,
+    largestFiles,
+    ocr: { concurrency: 3, timeout: 20, backgroundChars: 1200 },
+  });
+}
+
+function route(decision) {
+  return { ...decision, thresholds: THRESHOLDS, routerVersion: ROUTER_VERSION };
+}
+
+function countCategories(included, supportedFiles) {
+  const counts = {
+    total: included.length,
+    supported: supportedFiles.length,
+    lean: 0,
+    trustDocs: 0,
+    workflowScripts: 0,
+    contracts: 0,
+    docs: 0,
+    other: 0,
+  };
+  for (const file of supportedFiles) {
+    if (file.category === 'lean') counts.lean += 1;
+    else if (file.category === 'trust-doc') counts.trustDocs += 1;
+    else if (file.category === 'workflow-script') counts.workflowScripts += 1;
+    else if (file.category === 'contract') counts.contracts += 1;
+    else if (file.category === 'doc') counts.docs += 1;
+    else counts.other += 1;
+  }
+  return counts;
+}
+
+function categorize(filePath) {
+  const base = path.posix.basename(filePath);
+  if (filePath.endsWith('.lean')) return 'lean';
+  if (['AUDIT.md', 'TRUST_ASSUMPTIONS.md', 'AXIOMS.md'].includes(base)) return 'trust-doc';
+  if (filePath.startsWith('.github/')) return 'workflow-script';
+  if (/\.(sol|yul|cairo)$/.test(filePath)) return 'contract';
+  if (filePath === 'README.md' || (filePath.startsWith('docs/') && filePath.endsWith('.md'))) return 'doc';
+  if (/\.(py|sh|bash|js|ts|json|ya?ml|toml)$/.test(filePath)) return 'workflow-script';
+  return 'other';
+}
+
+function isSupported(filePath) {
+  if (isExcluded(filePath)) return false;
+  const base = path.posix.basename(filePath);
+  return filePath.endsWith('.lean') ||
+    /\.(sol|yul|cairo)$/.test(filePath) ||
+    ['AUDIT.md', 'TRUST_ASSUMPTIONS.md', 'AXIOMS.md', 'README.md'].includes(base) ||
+    (filePath.startsWith('docs/') && filePath.endsWith('.md')) ||
+    filePath.startsWith('.github/');
+}
+
+function isExcluded(filePath) {
+  return filePath.includes('/.lake/') ||
+    filePath.includes('/lake-packages/') ||
+    filePath.includes('/node_modules/') ||
+    filePath.includes('/dist/') ||
+    filePath.includes('/build/') ||
+    filePath.includes('/generated/') ||
+    filePath.startsWith('.lake/') ||
+    filePath.startsWith('lake-packages/') ||
+    filePath.startsWith('node_modules/') ||
+    filePath.startsWith('dist/') ||
+    filePath.startsWith('build/') ||
+    filePath.startsWith('generated/') ||
+    filePath.endsWith('.lock');
+}
+
+function buildMetrics({ prNumber, headSha, baseRef, startedAt, decision, diff }) {
+  return {
+    schema_version: 1,
+    router_version: ROUTER_VERSION,
+    pr_number: prNumber ? Number(prNumber) : null,
+    head_sha: headSha,
+    base_ref: baseRef,
+    started_at: startedAt,
+    mode: decision.mode,
+    reason: decision.reason,
+    thresholds: decision.thresholds,
+    changed_files: {
+      counts: decision.counts,
+      total_changed_lines: decision.changedLines,
+      largest: decision.largestFiles.map(f => ({
+        path: f.path,
+        added: f.added,
+        deleted: f.deleted,
+        changed: f.changed,
+        category: f.category,
+      })),
+    },
+    ocr: {
+      attempted: decision.shouldRunOcr,
+      status: decision.shouldRunOcr ? 'pending' : decision.mode,
+      comments_count: 0,
+      files_reviewed: null,
+      total_tokens: null,
+      tool_calls_total: null,
+      warnings_count: 0,
+      duration_ms: null,
+    },
+    diff_base: diff.base,
+    diff_head: diff.head,
+  };
+}
+
+function buildSyntheticResult(decision, metrics) {
+  return {
+    status: decision.mode,
+    message: decision.reason,
+    comments: [],
+    warnings: decision.mode === 'guarded-large-lean'
+      ? [{ type: 'routing', message: 'Full OCR skipped by Lean scaling guard.' }]
+      : [],
+    summary: {
+      files_reviewed: 0,
+      total_tokens: 0,
+      mode: decision.mode,
+      router_version: ROUTER_VERSION,
+      changed_files: metrics.changed_files,
+      thresholds: decision.thresholds,
+    },
+    tool_calls: { total: 0 },
+  };
+}
+
+function writeOutputs(outputPath, values) {
+  const lines = Object.entries(values).map(([key, value]) => `${key}=${String(value).replace(/\n/g, ' ')}`);
+  if (outputPath) fs.appendFileSync(outputPath, `${lines.join('\n')}\n`);
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  ROUTER_VERSION,
+  THRESHOLDS,
+  categorize,
+  decideRoute,
+  isSupported,
+  parseNumstatLine,
+  buildSyntheticResult,
+  buildMetrics,
+};

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -358,7 +358,7 @@ function firstChangedNewLine(hunk) {
 function lastChangedNewLine(hunk) {
   for (let i = hunk.lines.length - 1; i >= 0; i -= 1) {
     const line = hunk.lines[i];
-    if ((line.type === 'add' || line.type === 'ctx') && Number.isFinite(line.newLine)) return line.newLine;
+    if (line.type === 'add' && Number.isFinite(line.newLine)) return line.newLine;
   }
   return null;
 }

--- a/.github/scripts/post-ocr-review.js
+++ b/.github/scripts/post-ocr-review.js
@@ -9,11 +9,15 @@ module.exports = async function postOcrReview({ github, context, core }) {
   const commit_id = process.env.OCR_HEAD_SHA;
   const resultPath = process.env.OCR_RESULT_PATH;
   const stderrPath = process.env.OCR_STDERR_PATH;
+  const metricsPath = process.env.OCR_METRICS_PATH;
   const maxInline = Number(process.env.OCR_MAX_INLINE_COMMENTS || 20);
   const rulesHash = (process.env.OCR_RULES_HASH || 'rules-v0').slice(0, 12);
   const reviewerVersion = (process.env.OCR_REVIEWER_VERSION || 'reviewer-v2').slice(0, 20);
-  const successTag = `<!-- paloma-ocr-review:${commit_id}:${rulesHash}:${reviewerVersion}:success -->`;
-  const retryableTag = `<!-- paloma-ocr-review:${commit_id}:${rulesHash}:${reviewerVersion}:retryable-failure -->`;
+  const routerVersion = (process.env.OCR_ROUTER_VERSION || 'router-v0').slice(0, 20);
+  const mode = (process.env.OCR_MODE || 'legacy').slice(0, 40);
+  const dedupKey = `${commit_id}:${rulesHash}:${reviewerVersion}:${routerVersion}:${mode}`;
+  const successTag = `<!-- paloma-ocr-review:${dedupKey}:success -->`;
+  const retryableTag = `<!-- paloma-ocr-review:${dedupKey}:retryable-failure -->`;
 
   if (!pull_number || !commit_id) {
     throw new Error('OCR_PR_NUMBER and OCR_HEAD_SHA are required');
@@ -31,6 +35,12 @@ module.exports = async function postOcrReview({ github, context, core }) {
   try {
     result = JSON.parse(raw);
   } catch (err) {
+    writeMetrics(metricsPath, enrichMetrics(readMetrics(metricsPath), {
+      mode,
+      result: { status: 'invalid_json', comments: [], warnings: [] },
+      stderr,
+      retryable: true,
+    }));
     await github.rest.issues.createComment({
       owner, repo, issue_number: pull_number,
       body: `${retryableTag}\n⚠️ **OpenCodeReview failed to produce valid JSON.**\n\n${stderr ? fenced(stderr) : 'No stderr captured.'}`,
@@ -43,6 +53,8 @@ module.exports = async function postOcrReview({ github, context, core }) {
   const usable = [];
   const summaryOnly = [];
   const retryableResult = isRetryableResult(result);
+  const metrics = enrichMetrics(readMetrics(metricsPath), { mode, result, stderr, retryable: retryableResult });
+  writeMetrics(metricsPath, metrics);
 
   for (const c of comments) {
     const path = String(c.path || '').trim();
@@ -67,8 +79,8 @@ module.exports = async function postOcrReview({ github, context, core }) {
   const overflow = usable.slice(maxInline);
   const tag = retryableResult ? retryableTag : successTag;
   const body = retryableResult
-    ? buildReviewBody({ tag, result, comments, selected: [], overflow: [...selected, ...overflow], summaryOnly, warnings, stderr })
-    : buildReviewBody({ tag, result, comments, selected, overflow, summaryOnly, warnings, stderr });
+    ? buildReviewBody({ tag, result, comments, selected: [], overflow: [...selected, ...overflow], summaryOnly, warnings, stderr, metrics })
+    : buildReviewBody({ tag, result, comments, selected, overflow, summaryOnly, warnings, stderr, metrics });
 
   if (retryableResult) {
     await github.rest.issues.createComment({
@@ -128,16 +140,17 @@ function toReviewComment(c) {
   };
 }
 
-function buildReviewBody({ tag, result, comments, selected, overflow, summaryOnly, warnings, stderr }) {
+function buildReviewBody({ tag, result, comments, selected, overflow, summaryOnly, warnings, stderr, metrics }) {
   const status = result.status || 'unknown';
   const message = result.message || '';
   const summary = result.summary || {};
-  const tokens = summary.total_tokens ? ` · ${summary.total_tokens} tokens` : '';
-  const files = summary.files_reviewed != null ? `${summary.files_reviewed} files` : 'files unknown';
-  const toolCalls = result.tool_calls?.total != null ? ` · ${result.tool_calls.total} tool calls` : '';
+  const extracted = extractOcrSummary(result);
+  const tokens = extracted.totalTokens != null ? ` · ${extracted.totalTokens} tokens` : '';
+  const files = extracted.filesReviewed != null ? `${extracted.filesReviewed} files` : 'files unknown';
+  const toolCalls = extracted.toolCallsTotal != null ? ` · ${extracted.toolCallsTotal} tool calls` : '';
 
   let body = `${tag}\n## OpenCodeReview first-pass review\n\n`;
-  body += `Status: **${escapeMd(status)}** · ${comments.length} finding(s) · ${files}${tokens}${toolCalls}\n\n`;
+  body += `Status: **${escapeMd(status)}** · Mode: **${escapeMd(metrics?.mode || summary.mode || 'unknown')}** · ${comments.length} finding(s) · ${files}${tokens}${toolCalls}\n\n`;
 
   if (message) body += `${escapeMd(message)}\n\n`;
   if (selected.length > 0) body += `✅ Posted ${selected.length} inline comment(s).\n`;
@@ -170,8 +183,95 @@ function buildReviewBody({ tag, result, comments, selected, overflow, summaryOnl
     }
   }
 
+  body += renderMetrics(metrics, result);
   body += `_Pilot mode: advisory only. Codex Review remains the merge gate._`;
   return body;
+}
+
+function extractOcrSummary(result) {
+  const summary = result.summary || {};
+  const usage = result.usage || result.metrics || {};
+  const toolCalls = result.tool_calls || result.toolCalls || {};
+  return {
+    status: result.status || 'unknown',
+    commentsCount: Array.isArray(result.comments) ? result.comments.length : 0,
+    filesReviewed: firstNumber(summary.files_reviewed, summary.filesReviewed, result.files_reviewed, result.filesReviewed),
+    totalTokens: firstNumber(summary.total_tokens, summary.totalTokens, usage.total_tokens, usage.totalTokens, result.total_tokens),
+    toolCallsTotal: firstNumber(toolCalls.total, toolCalls.total_calls, toolCalls.totalCalls, summary.tool_calls_total, summary.toolCallsTotal),
+    warningsCount: Array.isArray(result.warnings) ? result.warnings.length : firstNumber(summary.warnings_count, summary.warningsCount),
+  };
+}
+
+function enrichMetrics(metrics, { mode, result, stderr, retryable }) {
+  const base = metrics && typeof metrics === 'object' ? metrics : {};
+  const extracted = extractOcrSummary(result);
+  const started = Date.parse(base.started_at || '');
+  const completedAt = new Date().toISOString();
+  const duration = Number.isFinite(started) ? Date.parse(completedAt) - started : null;
+  return {
+    ...base,
+    mode: mode || base.mode || result.summary?.mode || 'unknown',
+    completed_at: completedAt,
+    ocr: {
+      ...(base.ocr || {}),
+      attempted: base.ocr?.attempted ?? !['skipped', 'guarded-large-lean'].includes(String(result.status || '')),
+      retryable: Boolean(retryable),
+      status: extracted.status,
+      comments_count: extracted.commentsCount,
+      files_reviewed: extracted.filesReviewed,
+      total_tokens: extracted.totalTokens,
+      tool_calls_total: extracted.toolCallsTotal,
+      warnings_count: extracted.warningsCount,
+      duration_ms: duration,
+      stderr_highlights_count: stderr ? stderr.split('\n').filter(line => /warning|error|failed|fatal/i.test(line)).length : 0,
+    },
+  };
+}
+
+function renderMetrics(metrics, result) {
+  const extracted = extractOcrSummary(result);
+  const counts = metrics?.changed_files?.counts || {};
+  const thresholds = metrics?.thresholds || result.summary?.thresholds || {};
+  const largest = metrics?.changed_files?.largest || result.summary?.changed_files?.largest || [];
+  const ocr = metrics?.ocr || {};
+  let body = `### OCR pilot metrics\n\n`;
+  body += `- Routing: ${escapeMd(metrics?.mode || result.summary?.mode || 'unknown')} (${escapeMd(metrics?.router_version || result.summary?.router_version || 'router unknown')})\n`;
+  body += `- Changed files: ${counts.supported ?? 'unknown'} supported / ${counts.total ?? 'unknown'} total; Lean ${counts.lean ?? 0}, trust docs ${counts.trustDocs ?? 0}, workflow/scripts ${counts.workflowScripts ?? 0}, contracts ${counts.contracts ?? 0}, docs ${counts.docs ?? 0}\n`;
+  body += `- Changed lines: ${metrics?.changed_files?.total_changed_lines ?? 'unknown'} supported; thresholds large Lean >=${thresholds.largeLeanFiles ?? '?'} files or >${thresholds.largeChangedLines ?? '?'} lines\n`;
+  body += `- OCR: status ${escapeMd(extracted.status)}; comments ${extracted.commentsCount}; files ${extracted.filesReviewed ?? 'unknown'}; tokens ${extracted.totalTokens ?? 0}; tool calls ${extracted.toolCallsTotal ?? 0}; warnings ${extracted.warningsCount ?? 0}; duration ${formatDuration(ocr.duration_ms)}\n`;
+  if (largest.length > 0) {
+    body += `- Largest changed files: ${largest.slice(0, 5).map(f => `${escapeMd(f.path)} (+${f.added}/-${f.deleted})`).join(', ')}\n`;
+  }
+  body += `\n`;
+  return body;
+}
+
+function readMetrics(metricsPath) {
+  if (!metricsPath || !fs.existsSync(metricsPath)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(metricsPath, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeMetrics(metricsPath, metrics) {
+  if (!metricsPath) return;
+  fs.writeFileSync(metricsPath, `${JSON.stringify(metrics, null, 2)}\n`);
+}
+
+function firstNumber(...values) {
+  for (const value of values) {
+    if (value == null || value === '') continue;
+    const number = Number(value);
+    if (Number.isFinite(number)) return number;
+  }
+  return null;
+}
+
+function formatDuration(ms) {
+  if (!Number.isFinite(Number(ms))) return 'unknown';
+  return `${Math.max(0, Math.round(Number(ms) / 1000))}s`;
 }
 
 function renderComment(c) {
@@ -208,3 +308,7 @@ function fenced(s) {
 function escapeMd(s) {
   return String(s).replace(/[<>]/g, ch => ({ '<': '&lt;', '>': '&gt;' }[ch]));
 }
+
+module.exports.isRetryableResult = isRetryableResult;
+module.exports.buildReviewBody = buildReviewBody;
+module.exports.extractOcrSummary = extractOcrSummary;

--- a/.github/scripts/post-ocr-review.js
+++ b/.github/scripts/post-ocr-review.js
@@ -153,6 +153,9 @@ function buildReviewBody({ tag, result, comments, selected, overflow, summaryOnl
   body += `Status: **${escapeMd(status)}** · Mode: **${escapeMd(metrics?.mode || summary.mode || 'unknown')}** · ${comments.length} finding(s) · ${files}${tokens}${toolCalls}\n\n`;
 
   if (message) body += `${escapeMd(message)}\n\n`;
+  if ((metrics?.mode || summary.mode) === 'packetized-lean') {
+    body += `⚠️ Packetized Lean mode covers ranked hotspot packets only; it is not a full-file OCR review.\n`;
+  }
   if (selected.length > 0) body += `✅ Posted ${selected.length} inline comment(s).\n`;
   if (overflow.length > 0) body += `📝 ${overflow.length} additional positioned finding(s) omitted from inline comments to avoid spam.\n`;
   if (summaryOnly.length > 0) body += `📝 ${summaryOnly.length} finding(s) had no resolvable line and are summarized below.\n`;
@@ -184,6 +187,7 @@ function buildReviewBody({ tag, result, comments, selected, overflow, summaryOnl
   }
 
   body += renderMetrics(metrics, result);
+  body += renderPacketCoverage(metrics, result);
   body += `_Pilot mode: advisory only. Codex Review remains the merge gate._`;
   return body;
 }
@@ -214,7 +218,7 @@ function enrichMetrics(metrics, { mode, result, stderr, retryable }) {
     completed_at: completedAt,
     ocr: {
       ...(base.ocr || {}),
-      attempted: base.ocr?.attempted ?? !['skipped', 'guarded-large-lean'].includes(String(result.status || '')),
+      attempted: base.ocr?.attempted ?? !['skipped', 'guarded-oversized-lean', 'guarded-unpacketized-lean', 'packetized_review'].includes(String(result.status || '')),
       retryable: Boolean(retryable),
       status: extracted.status,
       comments_count: extracted.commentsCount,
@@ -241,6 +245,27 @@ function renderMetrics(metrics, result) {
   body += `- OCR: status ${escapeMd(extracted.status)}; comments ${extracted.commentsCount}; files ${extracted.filesReviewed ?? 'unknown'}; tokens ${extracted.totalTokens ?? 0}; tool calls ${extracted.toolCallsTotal ?? 0}; warnings ${extracted.warningsCount ?? 0}; duration ${formatDuration(ocr.duration_ms)}\n`;
   if (largest.length > 0) {
     body += `- Largest changed files: ${largest.slice(0, 5).map(f => `${escapeMd(f.path)} (+${f.added}/-${f.deleted})`).join(', ')}\n`;
+  }
+  body += `\n`;
+  return body;
+}
+
+function renderPacketCoverage(metrics, result) {
+  const packetReview = metrics?.packet_review || result.summary?.packet_review;
+  if (!packetReview) return '';
+
+  const packets = Array.isArray(packetReview.packets) ? packetReview.packets : [];
+  let body = `### Packet coverage\n\n`;
+  body += `- Packet review: ${packetReview.enabled ? 'enabled' : 'not used'}; selected ${packetReview.packets_selected ?? packets.length}/${packetReview.packet_budget ?? '?'} packet(s)\n`;
+  if (packetReview.residual_risk) {
+    body += `- Residual risk: ${escapeMd(packetReview.residual_risk)}\n`;
+  }
+  if (packets.length > 0) {
+    body += `- Covered packets:\n`;
+    for (const packet of packets.slice(0, 8)) {
+      const signals = Array.isArray(packet.signals) && packet.signals.length ? packet.signals.join(', ') : 'hotspot path/churn';
+      body += `  - ${escapeMd(packet.path)}:${packet.start_line ?? '?'} score ${packet.score ?? '?'} — ${escapeMd(signals)}\n`;
+    }
   }
   body += `\n`;
   return body;

--- a/.github/scripts/post-ocr-review.js
+++ b/.github/scripts/post-ocr-review.js
@@ -153,8 +153,8 @@ function buildReviewBody({ tag, result, comments, selected, overflow, summaryOnl
   body += `Status: **${escapeMd(status)}** · Mode: **${escapeMd(metrics?.mode || summary.mode || 'unknown')}** · ${comments.length} finding(s) · ${files}${tokens}${toolCalls}\n\n`;
 
   if (message) body += `${escapeMd(message)}\n\n`;
-  if ((metrics?.mode || summary.mode) === 'packetized-lean') {
-    body += `⚠️ Packetized Lean mode covers ranked hotspot packets only; it is not a full-file OCR review.\n`;
+  if ((metrics?.mode || summary.mode) === 'large-lean-hotspots') {
+    body += `⚠️ Large Lean hotspot mode covers ranked packets/checklists only; it is not a full-file OCR review.\n`;
   }
   if (selected.length > 0) body += `✅ Posted ${selected.length} inline comment(s).\n`;
   if (overflow.length > 0) body += `📝 ${overflow.length} additional positioned finding(s) omitted from inline comments to avoid spam.\n`;
@@ -218,7 +218,7 @@ function enrichMetrics(metrics, { mode, result, stderr, retryable }) {
     completed_at: completedAt,
     ocr: {
       ...(base.ocr || {}),
-      attempted: base.ocr?.attempted ?? !['skipped', 'guarded-oversized-lean', 'guarded-unpacketized-lean', 'packetized_review'].includes(String(result.status || '')),
+      attempted: base.ocr?.attempted ?? !['no-supported', 'large-lean-hotspots', 'packetized_review'].includes(String(result.status || '')),
       retryable: Boolean(retryable),
       status: extracted.status,
       comments_count: extracted.commentsCount,

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const router = require('./ocr-router');
+const postOcrReview = require('./post-ocr-review');
+
+function file(filePath, added = 10, deleted = 0) {
+  return {
+    path: filePath,
+    added,
+    deleted,
+    changed: added + deleted,
+    category: router.categorize(filePath),
+    supported: router.isSupported(filePath),
+  };
+}
+
+function testNoSupportedFilesSkipped() {
+  const decision = router.decideRoute([
+    file('packages/cache.lock', 3, 1),
+    file('build/generated.out', 5, 0),
+  ]);
+  assert.strictEqual(decision.mode, 'skipped');
+  assert.strictEqual(decision.shouldRunOcr, false);
+}
+
+function testOneLeanFileNormal() {
+  const decision = router.decideRoute([
+    file('Compiler/Proofs/IRGeneration/Small.lean', 120, 20),
+  ]);
+  assert.strictEqual(decision.mode, 'normal');
+  assert.strictEqual(decision.shouldRunOcr, true);
+  assert.strictEqual(decision.ocr.concurrency, 3);
+}
+
+function testLargeLeanGuarded() {
+  const decision = router.decideRoute([
+    file('Compiler/Proofs/A.lean', 40, 0),
+    file('Compiler/Proofs/B.lean', 40, 0),
+    file('Compiler/Proofs/C.lean', 40, 0),
+  ]);
+  assert.strictEqual(decision.mode, 'guarded-large-lean');
+  assert.strictEqual(decision.shouldRunOcr, false);
+}
+
+function testWorkflowDocsEnabled() {
+  const decision = router.decideRoute([
+    file('.github/workflows/ocr-review.yml', 80, 10),
+    file('docs/ocr.md', 900, 4),
+  ]);
+  assert.strictEqual(decision.mode, 'normal');
+  assert.strictEqual(decision.shouldRunOcr, true);
+}
+
+async function testCompletedWithErrorsRetryablePreservesFindings() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-post-test-'));
+  const resultPath = path.join(dir, 'result.json');
+  const metricsPath = path.join(dir, 'metrics.json');
+  fs.writeFileSync(resultPath, JSON.stringify({
+    status: 'completed_with_errors',
+    comments: [{
+      path: 'Compiler/Proofs/Contract.lean',
+      start_line: 42,
+      content: 'Potential weakened theorem statement.',
+      category: 'proof',
+      severity: 'high',
+    }],
+    summary: { files_reviewed: 1, total_tokens: 12345 },
+    tool_calls: { total: 7 },
+    warnings: [{ type: 'timeout', message: 'Subtask deadline exceeded' }],
+  }));
+  fs.writeFileSync(metricsPath, JSON.stringify({
+    started_at: new Date(Date.now() - 1000).toISOString(),
+    router_version: router.ROUTER_VERSION,
+    mode: 'bounded-lean',
+    thresholds: router.THRESHOLDS,
+    changed_files: {
+      counts: { total: 1, supported: 1, lean: 1, trustDocs: 0, workflowScripts: 0, contracts: 0, docs: 0 },
+      total_changed_lines: 60,
+      largest: [{ path: 'Compiler/Proofs/Contract.lean', added: 50, deleted: 10, changed: 60, category: 'lean' }],
+    },
+    ocr: { attempted: true },
+  }));
+
+  const oldEnv = { ...process.env };
+  Object.assign(process.env, {
+    OCR_PR_NUMBER: '123',
+    OCR_HEAD_SHA: 'abc123',
+    OCR_RESULT_PATH: resultPath,
+    OCR_METRICS_PATH: metricsPath,
+    OCR_MAX_INLINE_COMMENTS: '20',
+    OCR_RULES_HASH: 'ruleshash',
+    OCR_REVIEWER_VERSION: 'reviewer-v3',
+    OCR_ROUTER_VERSION: router.ROUTER_VERSION,
+    OCR_MODE: 'bounded-lean',
+  });
+
+  let postedComment = '';
+  let createReviewCalled = false;
+  const github = {
+    paginate: async () => [],
+    rest: {
+      issues: {
+        listComments: async () => [],
+        createComment: async ({ body }) => {
+          postedComment = body;
+          return { data: {} };
+        },
+      },
+      pulls: {
+        listReviews: async () => [],
+        createReview: async () => {
+          createReviewCalled = true;
+        },
+      },
+    },
+  };
+
+  await postOcrReview({
+    github,
+    context: { repo: { owner: 'lfglabs-dev', repo: 'verity' } },
+    core: { notice() {}, warning() {} },
+  });
+
+  process.env = oldEnv;
+  assert.strictEqual(createReviewCalled, false);
+  assert.ok(postedComment.includes('retryable-failure'));
+  assert.ok(postedComment.includes('Potential weakened theorem statement.'));
+  assert.ok(postedComment.includes('completed_with_errors'));
+  const metrics = JSON.parse(fs.readFileSync(metricsPath, 'utf8'));
+  assert.strictEqual(metrics.ocr.retryable, true);
+  assert.strictEqual(metrics.ocr.comments_count, 1);
+  assert.strictEqual(metrics.ocr.total_tokens, 12345);
+}
+
+async function run() {
+  testNoSupportedFilesSkipped();
+  testOneLeanFileNormal();
+  testLargeLeanGuarded();
+  testWorkflowDocsEnabled();
+  await testCompletedWithErrorsRetryablePreservesFindings();
+  console.log('OCR routing tests passed');
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -20,6 +20,7 @@ function file(filePath, added = 10, deleted = 0) {
       ['ctx', 'namespace Verity'],
       ['add', 'theorem soundness_preserved : True := by trivial'],
       ['add', 'unsafe def riskyFastPath := 1'],
+      ['ctx', 'end Verity'],
     ])],
   };
 }
@@ -73,6 +74,7 @@ function testLargeLeanPacketized() {
   assert.strictEqual(decision.shouldRunOcr, false);
   assert.ok(decision.packets.length > 0);
   assert.ok(decision.packets[0].signals.includes('introduced unsafe'));
+  assert.strictEqual(decision.packets[0].end_line, 12);
 }
 
 function testOversizedLeanGuarded() {

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -91,6 +91,17 @@ function testWorkflowDocsEnabled() {
   assert.strictEqual(decision.shouldRunOcr, true);
 }
 
+function testGenericScriptConfigEnabled() {
+  const decision = router.decideRoute([
+    file('scripts/deploy.sh', 20, 4),
+    file('package.json', 6, 1),
+    file('config/app.yml', 5, 2),
+  ]);
+  assert.strictEqual(decision.mode, 'normal');
+  assert.strictEqual(decision.shouldRunOcr, true);
+  assert.strictEqual(decision.counts.workflowScripts, 3);
+}
+
 async function testCompletedWithErrorsRetryablePreservesFindings() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-post-test-'));
   const resultPath = path.join(dir, 'result.json');
@@ -178,6 +189,7 @@ async function run() {
   testLargeLeanPacketized();
   testOversizedLeanGuarded();
   testWorkflowDocsEnabled();
+  testGenericScriptConfigEnabled();
   await testCompletedWithErrorsRetryablePreservesFindings();
   console.log('OCR routing tests passed');
 }

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -16,6 +16,32 @@ function file(filePath, added = 10, deleted = 0) {
     changed: added + deleted,
     category: router.categorize(filePath),
     supported: router.isSupported(filePath),
+    hunks: [hunk(filePath, 10, [
+      ['ctx', 'namespace Verity'],
+      ['add', 'theorem soundness_preserved : True := by trivial'],
+      ['add', 'unsafe def riskyFastPath := 1'],
+    ])],
+  };
+}
+
+function hunk(filePath, newStart, lines) {
+  let next = newStart;
+  return {
+    path: filePath,
+    oldStart: newStart,
+    newStart,
+    newSpan: lines.length,
+    header: '',
+    lines: lines.map(([type, text]) => {
+      const entry = {
+        type,
+        text,
+        newLine: type === 'del' ? null : next,
+        oldLine: type === 'add' ? null : next,
+      };
+      if (type !== 'del') next += 1;
+      return entry;
+    }),
   };
 }
 
@@ -37,13 +63,22 @@ function testOneLeanFileNormal() {
   assert.strictEqual(decision.ocr.concurrency, 3);
 }
 
-function testLargeLeanGuarded() {
+function testLargeLeanPacketized() {
   const decision = router.decideRoute([
     file('Compiler/Proofs/A.lean', 40, 0),
     file('Compiler/Proofs/B.lean', 40, 0),
     file('Compiler/Proofs/C.lean', 40, 0),
   ]);
-  assert.strictEqual(decision.mode, 'guarded-large-lean');
+  assert.strictEqual(decision.mode, 'packetized-lean');
+  assert.strictEqual(decision.shouldRunOcr, false);
+  assert.ok(decision.packets.length > 0);
+  assert.ok(decision.packets[0].signals.includes('introduced unsafe'));
+}
+
+function testOversizedLeanGuarded() {
+  const files = Array.from({ length: 13 }, (_, i) => file(`Compiler/Proofs/Large${i}.lean`, 40, 0));
+  const decision = router.decideRoute(files);
+  assert.strictEqual(decision.mode, 'guarded-oversized-lean');
   assert.strictEqual(decision.shouldRunOcr, false);
 }
 
@@ -140,7 +175,8 @@ async function testCompletedWithErrorsRetryablePreservesFindings() {
 async function run() {
   testNoSupportedFilesSkipped();
   testOneLeanFileNormal();
-  testLargeLeanGuarded();
+  testLargeLeanPacketized();
+  testOversizedLeanGuarded();
   testWorkflowDocsEnabled();
   await testCompletedWithErrorsRetryablePreservesFindings();
   console.log('OCR routing tests passed');

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -50,7 +50,7 @@ function testNoSupportedFilesSkipped() {
     file('packages/cache.lock', 3, 1),
     file('build/generated.out', 5, 0),
   ]);
-  assert.strictEqual(decision.mode, 'skipped');
+  assert.strictEqual(decision.mode, 'no-supported');
   assert.strictEqual(decision.shouldRunOcr, false);
 }
 
@@ -58,7 +58,7 @@ function testOneLeanFileNormal() {
   const decision = router.decideRoute([
     file('Compiler/Proofs/IRGeneration/Small.lean', 120, 20),
   ]);
-  assert.strictEqual(decision.mode, 'normal');
+  assert.strictEqual(decision.mode, 'small-lean');
   assert.strictEqual(decision.shouldRunOcr, true);
   assert.strictEqual(decision.ocr.concurrency, 3);
 }
@@ -69,7 +69,7 @@ function testLargeLeanPacketized() {
     file('Compiler/Proofs/B.lean', 40, 0),
     file('Compiler/Proofs/C.lean', 40, 0),
   ]);
-  assert.strictEqual(decision.mode, 'packetized-lean');
+  assert.strictEqual(decision.mode, 'large-lean-hotspots');
   assert.strictEqual(decision.shouldRunOcr, false);
   assert.ok(decision.packets.length > 0);
   assert.ok(decision.packets[0].signals.includes('introduced unsafe'));
@@ -78,7 +78,7 @@ function testLargeLeanPacketized() {
 function testOversizedLeanGuarded() {
   const files = Array.from({ length: 13 }, (_, i) => file(`Compiler/Proofs/Large${i}.lean`, 40, 0));
   const decision = router.decideRoute(files);
-  assert.strictEqual(decision.mode, 'guarded-oversized-lean');
+  assert.strictEqual(decision.mode, 'large-lean-hotspots');
   assert.strictEqual(decision.shouldRunOcr, false);
 }
 
@@ -87,7 +87,7 @@ function testWorkflowDocsEnabled() {
     file('.github/workflows/ocr-review.yml', 80, 10),
     file('docs/ocr.md', 900, 4),
   ]);
-  assert.strictEqual(decision.mode, 'normal');
+  assert.strictEqual(decision.mode, 'config-docs');
   assert.strictEqual(decision.shouldRunOcr, true);
 }
 
@@ -97,7 +97,7 @@ function testGenericScriptConfigEnabled() {
     file('package.json', 6, 1),
     file('config/app.yml', 5, 2),
   ]);
-  assert.strictEqual(decision.mode, 'normal');
+  assert.strictEqual(decision.mode, 'config-docs');
   assert.strictEqual(decision.shouldRunOcr, true);
   assert.strictEqual(decision.counts.workflowScripts, 3);
 }
@@ -122,7 +122,7 @@ async function testCompletedWithErrorsRetryablePreservesFindings() {
   fs.writeFileSync(metricsPath, JSON.stringify({
     started_at: new Date(Date.now() - 1000).toISOString(),
     router_version: router.ROUTER_VERSION,
-    mode: 'bounded-lean',
+    mode: 'medium-lean',
     thresholds: router.THRESHOLDS,
     changed_files: {
       counts: { total: 1, supported: 1, lean: 1, trustDocs: 0, workflowScripts: 0, contracts: 0, docs: 0 },
@@ -142,7 +142,7 @@ async function testCompletedWithErrorsRetryablePreservesFindings() {
     OCR_RULES_HASH: 'ruleshash',
     OCR_REVIEWER_VERSION: 'reviewer-v3',
     OCR_ROUTER_VERSION: router.ROUTER_VERSION,
-    OCR_MODE: 'bounded-lean',
+    OCR_MODE: 'medium-lean',
   });
 
   let postedComment = '';

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -122,9 +122,11 @@ jobs:
           OCR_PR_NUMBER: ${{ steps.pr.outputs.number }}
           OCR_RESULT_PATH: ${{ runner.temp }}/ocr-result.json
           OCR_METRICS_PATH: ${{ runner.temp }}/ocr-metrics.json
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${GITHUB_TOKEN}" \
+            fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
           node "$GITHUB_WORKSPACE/ocr-trusted/.github/scripts/ocr-router.js"
 
       - name: Install OpenCodeReview

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -179,7 +179,7 @@ jobs:
           test -s "$RUNNER_TEMP/ocr-result.json" || echo '{"status":"error","comments":[],"message":"OCR produced no JSON output"}' > "$RUNNER_TEMP/ocr-result.json"
 
       - name: Post OCR review
-        if: steps.pr.outputs.skip != 'true' && always()
+        if: steps.pr.outputs.skip != 'true' && always() && !cancelled()
         uses: actions/github-script@v7
         env:
           OCR_RESULT_PATH: ${{ runner.temp }}/ocr-result.json
@@ -198,7 +198,7 @@ jobs:
             await post({ github, context, core });
 
       - name: Upload OCR metrics
-        if: steps.pr.outputs.skip != 'true' && always()
+        if: steps.pr.outputs.skip != 'true' && always() && !cancelled()
         uses: actions/upload-artifact@v4
         with:
           name: ocr-metrics-${{ steps.pr.outputs.number }}-${{ steps.pr.outputs.head_sha }}

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -112,15 +112,30 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install OpenCodeReview
+      - name: Route OCR review
         if: steps.pr.outputs.skip != 'true'
+        id: route
+        working-directory: repo
+        env:
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          OCR_PR_NUMBER: ${{ steps.pr.outputs.number }}
+          OCR_RESULT_PATH: ${{ runner.temp }}/ocr-result.json
+          OCR_METRICS_PATH: ${{ runner.temp }}/ocr-metrics.json
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          node "$GITHUB_WORKSPACE/ocr-trusted/.github/scripts/ocr-router.js"
+
+      - name: Install OpenCodeReview
+        if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true'
         run: |
           set -euo pipefail
           npm install -g @alibaba-group/open-code-review@1.7.5
           ocr version
 
       - name: Run OpenCodeReview
-        if: steps.pr.outputs.skip != 'true'
+        if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true'
         id: ocr
         working-directory: repo
         env:
@@ -134,42 +149,58 @@ jobs:
           PR_BODY: ${{ steps.pr.outputs.body }}
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          OCR_MODE: ${{ steps.route.outputs.mode }}
+          OCR_CONCURRENCY: ${{ steps.route.outputs.concurrency }}
+          OCR_TIMEOUT: ${{ steps.route.outputs.timeout }}
+          OCR_BACKGROUND_CHARS: ${{ steps.route.outputs.background_chars }}
         run: |
           set -euo pipefail
           mkdir -p "$HOME"
-          printf 'Reviewing %s against origin/%s\n' "$HEAD_SHA" "$BASE_REF"
+          printf 'Reviewing %s against origin/%s in %s mode\n' "$HEAD_SHA" "$BASE_REF" "$OCR_MODE"
           git rev-parse --verify "origin/${BASE_REF}^{commit}" >/dev/null
           # Keep the model focused: PR bodies can include long generated summaries (Bugbot/Cursor),
           # which inflated token use and caused Lean proof reviews to hit OCR subtask deadlines.
           CLEAN_BODY="${PR_BODY%%<!-- CURSOR_SUMMARY -->*}"
           CLEAN_BODY="${CLEAN_BODY%%<!-- BUGBOT_SUMMARY -->*}"
           CLEAN_BODY="${CLEAN_BODY%%<!-- BUGBOT_REVIEW -->*}"
-          BACKGROUND="${PR_TITLE}"$'\n\n'"${CLEAN_BODY}"
-          BACKGROUND="${BACKGROUND:0:1200}"
+          BACKGROUND="[OCR mode: ${OCR_MODE}]"$'\n\n'"${PR_TITLE}"$'\n\n'"${CLEAN_BODY}"
+          BACKGROUND="${BACKGROUND:0:${OCR_BACKGROUND_CHARS}}"
           ocr review \
             --from "origin/${BASE_REF}" \
             --to "${HEAD_SHA}" \
             --format json \
             --audience agent \
             --rule "$RUNNER_TEMP/ocr-tools/rules.json" \
-            --concurrency 3 \
-            --timeout 20 \
+            --concurrency "$OCR_CONCURRENCY" \
+            --timeout "$OCR_TIMEOUT" \
             --background "$BACKGROUND" \
             > "$RUNNER_TEMP/ocr-result.json" \
             2> "$RUNNER_TEMP/ocr-stderr.log" || true
           test -s "$RUNNER_TEMP/ocr-result.json" || echo '{"status":"error","comments":[],"message":"OCR produced no JSON output"}' > "$RUNNER_TEMP/ocr-result.json"
 
       - name: Post OCR review
-        if: steps.pr.outputs.skip != 'true'
+        if: steps.pr.outputs.skip != 'true' && always()
         uses: actions/github-script@v7
         env:
           OCR_RESULT_PATH: ${{ runner.temp }}/ocr-result.json
           OCR_STDERR_PATH: ${{ runner.temp }}/ocr-stderr.log
+          OCR_METRICS_PATH: ${{ runner.temp }}/ocr-metrics.json
           OCR_PR_NUMBER: ${{ steps.pr.outputs.number }}
           OCR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           OCR_MAX_INLINE_COMMENTS: "20"
+          OCR_MODE: ${{ steps.route.outputs.mode }}
+          OCR_ROUTER_VERSION: ${{ steps.route.outputs.router_version }}
+          OCR_REVIEWER_VERSION: "reviewer-v3"
           OCR_POST_SCRIPT: ${{ github.workspace }}/ocr-trusted/.github/scripts/post-ocr-review.js
         with:
           script: |
             const post = require(process.env.OCR_POST_SCRIPT);
             await post({ github, context, core });
+
+      - name: Upload OCR metrics
+        if: steps.pr.outputs.skip != 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ocr-metrics-${{ steps.pr.outputs.number }}-${{ steps.pr.outputs.head_sha }}
+          path: ${{ runner.temp }}/ocr-metrics.json
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Adds a trusted OCR routing preflight for the Verity OpenCodeReview pilot so large Lean PRs stay bounded without becoming a pure skip.

- Classifies PR diffs before installing/running OCR and chooses `normal`, `bounded-lean`, `packetized-lean`, guarded fallback, or `skipped`.
- Keeps OCR enabled for supported non-Lean docs/workflow/config changes.
- For large but packet-budgetable Lean diffs, parses diff hunks, ranks deterministic hotspot packets, and publishes packet coverage with residual risk instead of running full-file OCR.
- Hard-guards only when the Lean diff exceeds packet budget or packets cannot be produced safely.
- Enriches OCR comments with compact metrics and uploads `ocr-metrics.json` as an artifact.
- Includes routing mode/version in dedup tags and keeps partial/error OCR runs retryable.

## Routing thresholds

- `normal`: non-Lean supported changes, or at most 1 Lean file and at most 300 supported changed lines.
- `bounded-lean`: Lean diffs above normal but below large threshold; runs OCR with concurrency 1, timeout 12, background cap 800 chars.
- `packetized-lean`: at least 3 Lean files or more than 800 supported changed lines, if still within packet budget; no full-file OCR, posts top 8 deterministic hotspot packets.
- `guarded-oversized-lean`: more than 12 Lean files or more than 2500 supported changed lines; posts checklist/metrics because even packetized review is too broad.
- `guarded-unpacketized-lean`: large Lean diff where trusted tooling could not safely produce packets.
- `skipped`: no files match OCR include rules.

Packetized checks cover introduced `sorry`/`admit`/`axiom`/`unsafe`, changed imports, theorem/public declaration statement edits, trust-boundary docs drift, large deleted proof obligations, and hotspot paths such as `Compiler/Proofs/YulGeneration/**`, `Compiler/Proofs/**`, `Compiler/**`, `IRGeneration/**`, and `Semantics/**`. The posted result states covered packets and residual risk; it does not claim full review coverage.

## Validation

- `node --check .github/scripts/post-ocr-review.js`
- `node --check .github/scripts/ocr-router.js`
- `node --check .github/scripts/test-ocr-routing.js`
- `node .github/scripts/test-ocr-routing.js`
- `bash -n .github/scripts/ocr-git-wrapper.sh`
- `python3 -m json.tool .github/ocr/rules.json`
- Python/PyYAML parse of `.github/workflows/ocr-review.yml`
- `/tmp/actionlint-bin/actionlint .github/workflows/ocr-review.yml`
- Router smoke against this PR head: `normal`, OCR attempted true, packet coverage omitted.
- Simulated large-Lean packet smoke: `packetized-lean`, 3 packets, `packetized_review`, 3 comments.
- `npm exec --yes @alibaba-group/open-code-review@1.7.5 -- review --preview --rule .github/ocr/rules.json --format json --audience agent`

The OCR preview passed after the packetized update and again after the Codex blocker fixes. No real OCR LLM review was run locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI behavior for when OCR runs and what reviewers see on large Lean PRs; trusted scripts run on default branch before PR code, but mis-routing could skip needed LLM review or understate coverage on proof-critical changes.
> 
> **Overview**
> Adds a **trusted preflight router** (`ocr-router.js`) that runs before OpenCodeReview install/execution, classifies the PR diff into modes (`no-supported`, `small-lean`, `medium-lean`, `large-lean-hotspots`, `config-docs`), writes `ocr-metrics.json`, and gates whether full OCR runs.
> 
> **Workflow** now runs routing first, skips OCR install/run when `should_run_ocr` is false, and applies **mode-specific** concurrency, timeout, and PR background caps instead of fixed pilot defaults. **Large Lean** diffs skip full-file OCR: the router parses hunks, scores deterministic risk signals (`sorry`/`axiom`/`unsafe`, theorem edits, proof paths, etc.), emits up to eight **packet** findings via synthetic JSON, and posts coverage with explicit residual risk.
> 
> **`post-ocr-review.js`** extends dedup keys with router version and mode, enriches comments with routing/metrics/packet sections, persists metrics on post, and keeps `completed_with_errors` **retryable** without a success dedup tag. **`test-ocr-routing.js`** covers routing decisions and retryable partial runs. README documents modes and dedup behavior; metrics upload as a workflow artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ea4af15e683c1092a0ca88c1a0582acdbe6353b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

