### PR TITLE
proof: discharge legacy compatibility for core statement lists

### DIFF
--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -2873,6 +2873,51 @@ theorem compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileV
         model selectors hSupported ir hcore hlegacyBodies)
     (hhelperIRGoal := interpretIRWithInternalsZeroConservativeExtensionGoal_closed ir)
 
+/-- Helper-aware whole-contract retarget theorem stated directly on the
+per-statement compiled legacy-compatibility interface.  This is the same
+statement as
+`compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore`,
+but the `LegacyCompatibleExternalBodies ir` premise is replaced by the
+per-statement `StmtListCompiledLegacyCompatible` obligations that #2080 already
+tracks for the disjoint interface.  The whole-body-shape premise is discharged
+internally via `legacyCompatibleExternalBodies_of_compileValidatedCore_of_interface`,
+so downstream users only ever have to supply the per-statement interface. -/
+theorem compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore_of_interface
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (hHelperProofs : SourceSemantics.SupportedSpecHelperProofs model selectors hSupported)
+    (ir : IRContract)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (htxNormalized : Function.TxContextNormalized tx)
+    (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
+    (hvalidateInputs : validateCompileInputs model selectors = Except.ok ())
+    (hcore : compileValidatedCore model selectors = Except.ok ir)
+    (hbodies :
+      ∀ entry ∈ SourceSemantics.selectorFunctionPairs model selectors,
+        StmtListCompiledLegacyCompatible model.fields
+          (entry.1.params.map (·.name)) entry.1.body) :
+    FunctionBody.sourceResultMatchesIRResult
+      (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
+      (interpretIRWithInternals ir 0 tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  exact compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore
+    (model := model)
+    (selectors := selectors)
+    (hSupported := hSupported)
+    (hHelperProofs := hHelperProofs)
+    (ir := ir)
+    (tx := tx)
+    (initialWorld := initialWorld)
+    (htxNormalized := htxNormalized)
+    (hcalldataSizeFits := hcalldataSizeFits)
+    (hvalidateInputs := hvalidateInputs)
+    (hcore := hcore)
+    (hlegacyBodies :=
+      legacyCompatibleExternalBodies_of_compileValidatedCore_of_interface
+        model selectors hSupported ir hcore hbodies)
+
 /-- Direct helper-aware whole-contract theorem on the current legacy-compatible
 runtime-contract boundary. The helper-aware compiled-side conservative-extension
 goal is now closed in `IRInterpreter.lean`, so theorem users no longer need to

--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -1346,6 +1346,44 @@ private theorem exists_left_of_forall₂_mem_right
       · rcases ih hmemTail with ⟨x, hx, hRx⟩
         exact ⟨x, by simp [hx], hRx⟩
 
+/-- Whole-contract legacy-compatibility bridge for a concrete `compileValidatedCore`
+output.  Given the per-statement compiled legacy-compatibility interface
+(`StmtListCompiledLegacyCompatible`) for every selector-dispatched function body,
+the emitted runtime contract's external bodies all stay inside the
+legacy-compatible external Yul subset (`LegacyCompatibleExternalBodies`).
+
+This reduces the `LegacyCompatibleExternalBodies` premise still carried by the
+helper-aware whole-contract retarget theorem
+(`compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore`)
+to the same per-statement legacy obligations that #2080 already tracks for the
+disjoint interface, closing the whole-contract plumbing for the body-shape half. -/
+theorem legacyCompatibleExternalBodies_of_compileValidatedCore_of_interface
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (ir : IRContract)
+    (hcore : compileValidatedCore model selectors = Except.ok ir)
+    (hbodies :
+      ∀ entry ∈ SourceSemantics.selectorFunctionPairs model selectors,
+        StmtListCompiledLegacyCompatible model.fields
+          (entry.1.params.map (·.name)) entry.1.body) :
+    LegacyCompatibleExternalBodies ir := by
+  have hforall₂ :=
+    compileValidatedCore_ok_yields_compiled_functions model selectors hSupported ir hcore
+  intro fn hfn
+  obtain ⟨⟨spec, sel⟩, hentry, hcompileEntry⟩ :=
+    exists_left_of_forall₂_mem_right hforall₂ hfn
+  have hfnDispatched : spec ∈ selectorDispatchedFunctions model := by
+    simpa [SourceSemantics.selectorFunctionPairs] using (List.of_mem_zip hentry).1
+  have hparams : ∀ param ∈ spec.params, SupportedExternalParamType param.ty :=
+    supported_params_of_supportedSpec model selectors hSupported spec hfnDispatched
+  have hcompileEntry' :
+      compileFunctionSpec model.fields [] [] [] sel spec = Except.ok fn := by
+    rw [← hSupported.noEvents, ← hSupported.noErrors]
+    exact hcompileEntry
+  exact Function.compileFunctionSpec_body_legacyCompatible_of_interface
+    model.fields sel spec fn hparams (hbodies (spec, sel) hentry) hcompileEntry'
+
 /-- Structural compiled-internal-table premise, derived from the compilation
 pipeline's `mapM` step. Every statement produced by
 `internalFns.mapM compileInternalFunction` is a `compileInternalFunction` output

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -2887,6 +2887,250 @@ private theorem compileStmtList_legacyCompatible_of_interface
             (hhead headIR hheadCompile)
             (compileStmtList_legacyCompatible_of_interface htail htailCompile)
 
+private theorem legacyCompatibleExternalStmtList_map_exprStmt
+    {α : Type} (f : α → YulExpr) :
+    ∀ xs : List α,
+      LegacyCompatibleExternalStmtList (xs.map (fun x => YulStmt.exprStmt (f x)))
+  | [] => .nil
+  | _ :: rest => .exprStmt _ _ (legacyCompatibleExternalStmtList_map_exprStmt f rest)
+
+private theorem revertWithMessage_legacyCompatible
+    (message : String) :
+    LegacyCompatibleExternalStmtList (CompilationModel.revertWithMessage message) := by
+  simp only [CompilationModel.revertWithMessage]
+  exact .exprStmt _ _
+    (.exprStmt _ _
+      (.exprStmt _ _
+        (legacyCompatibleExternalStmtList_append
+          (legacyCompatibleExternalStmtList_map_exprStmt
+            (fun x : List UInt8 × Nat =>
+              YulExpr.call "mstore"
+                [YulExpr.lit (68 + x.2 * 32), YulExpr.hex (wordFromBytes x.1)])
+            (chunkBytes32 (bytesFromString message)).zipIdx)
+          (.exprStmt _ _ .nil))))
+
+/-- Generic compile-core statement lists discharge the per-head legacy-compatible
+compiled-output interface consumed by the helper-aware whole-contract bridge.
+
+The compiler scope is deliberately independent of the proof scope: core
+statement heads do not use the scope to choose their emitted Yul constructors,
+and the tail is threaded through the compiler's `stmtNextScope`. -/
+theorem stmtListCompileCore_compiledLegacyCompatible
+    (fields : List Field) :
+    ∀ {proofScope compilerScope : List String} {stmts : List Stmt},
+      FunctionBody.StmtListCompileCore proofScope stmts →
+        StmtListCompiledLegacyCompatible fields compilerScope stmts
+  | _, _, [], .nil => .nil
+  | _, compilerScope, .letVar name value :: rest,
+      .letVar _hvalue _hscope hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+            bind, Except.bind] at hcompile
+          split at hcompile <;> cases hcompile
+          exact .let_ _ _ [] .nil)
+        (stmtListCompileCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope (.letVar name value)) hrest)
+  | _, compilerScope, .assignVar name value :: rest,
+      .assignVar _hvalue _hscope hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+            bind, Except.bind] at hcompile
+          split at hcompile <;> cases hcompile
+          exact .assign _ _ [] .nil)
+        (stmtListCompileCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope (.assignVar name value)) hrest)
+  | _, compilerScope, .require cond message :: rest,
+      .require_ _hcond _hscope hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+            bind, Except.bind] at hcompile
+          split at hcompile <;> cases hcompile
+          exact .if_ _ _ [] (revertWithMessage_legacyCompatible message) .nil)
+        (stmtListCompileCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope (.require cond message)) hrest)
+  | _, compilerScope, .return value :: rest,
+      .return_ _hvalue _hscope hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+            bind, Except.bind] at hcompile
+          split at hcompile <;> cases hcompile
+          exact .exprStmt _ _ (.exprStmt _ _ .nil))
+        (stmtListCompileCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope (.return value)) hrest)
+  | _, compilerScope, .stop :: rest, .stop hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork] at hcompile
+          cases hcompile
+          exact .exprStmt _ _ .nil)
+        (stmtListCompileCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope .stop) hrest)
+  | _, compilerScope, .mstore offset value :: rest,
+      .mstore _hoffset _hscopeOffset _hvalue _hscopeValue hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+            bind, Except.bind] at hcompile
+          split at hcompile <;> try contradiction
+          split at hcompile <;> cases hcompile
+          exact .exprStmt _ _ .nil)
+        (stmtListCompileCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope (.mstore offset value)) hrest)
+  | _, compilerScope, .tstore offset value :: rest,
+      .tstore _hoffset _hscopeOffset _hvalue _hscopeValue hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+            bind, Except.bind] at hcompile
+          split at hcompile <;> try contradiction
+          split at hcompile <;> cases hcompile
+          exact .exprStmt _ _ .nil)
+        (stmtListCompileCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope (.tstore offset value)) hrest)
+
+/-- Terminal-core statement lists also discharge the per-head legacy-compatible
+compiled-output interface.  The `ite` case uses the existing list bridge on the
+terminal branches and compile-core tail. -/
+theorem stmtListTerminalCore_compiledLegacyCompatible
+    (fields : List Field) :
+    ∀ {proofScope compilerScope : List String} {stmts : List Stmt},
+      FunctionBody.StmtListTerminalCore proofScope stmts →
+        StmtListCompiledLegacyCompatible fields compilerScope stmts
+  | _, compilerScope, .letVar name value :: rest,
+      .letVar _hvalue _hscope hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+            bind, Except.bind] at hcompile
+          split at hcompile <;> cases hcompile
+          exact .let_ _ _ [] .nil)
+        (stmtListTerminalCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope (.letVar name value)) hrest)
+  | _, compilerScope, .assignVar name value :: rest,
+      .assignVar _hvalue _hscope hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+            bind, Except.bind] at hcompile
+          split at hcompile <;> cases hcompile
+          exact .assign _ _ [] .nil)
+        (stmtListTerminalCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope (.assignVar name value)) hrest)
+  | _, compilerScope, .require cond message :: rest,
+      .require_ _hcond _hscope hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+            bind, Except.bind] at hcompile
+          split at hcompile <;> cases hcompile
+          exact .if_ _ _ [] (revertWithMessage_legacyCompatible message) .nil)
+        (stmtListTerminalCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope (.require cond message)) hrest)
+  | _, compilerScope, .return value :: rest,
+      .return_ _hvalue _hscope hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+            bind, Except.bind] at hcompile
+          split at hcompile <;> cases hcompile
+          exact .exprStmt _ _ (.exprStmt _ _ .nil))
+        (stmtListCompileCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope (.return value)) hrest)
+  | _, compilerScope, .stop :: rest, .stop hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork] at hcompile
+          cases hcompile
+          exact .exprStmt _ _ .nil)
+        (stmtListCompileCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope .stop) hrest)
+  | _, compilerScope, .mstore offset value :: rest,
+      .mstore _hoffset _hscopeOffset _hvalue _hscopeValue hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+            bind, Except.bind] at hcompile
+          split at hcompile <;> try contradiction
+          split at hcompile <;> cases hcompile
+          exact .exprStmt _ _ .nil)
+        (stmtListTerminalCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope (.mstore offset value)) hrest)
+  | _, compilerScope, .tstore offset value :: rest,
+      .tstore _hoffset _hscopeOffset _hvalue _hscopeValue hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+            bind, Except.bind] at hcompile
+          split at hcompile <;> try contradiction
+          split at hcompile <;> cases hcompile
+          exact .exprStmt _ _ .nil)
+        (stmtListTerminalCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope (.tstore offset value)) hrest)
+  | _, compilerScope, .ite cond thenBranch elseBranch :: rest,
+      .ite _hcond _hscope hthen helse hrest =>
+      .cons
+        (fun compiledIR hcompile => by
+          simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+            bind, Except.bind] at hcompile
+          split at hcompile <;> try contradiction
+          rename_i condIR hcondIR
+          split at hcompile <;> try contradiction
+          rename_i thenIR hthenIR
+          split at hcompile <;> try contradiction
+          rename_i elseIR helseIR
+          have hthenLegacy :
+              LegacyCompatibleExternalStmtList thenIR :=
+            compileStmtList_legacyCompatible_of_interface
+              (stmtListTerminalCore_compiledLegacyCompatible fields
+                (compilerScope := compilerScope) hthen)
+              hthenIR
+          have helseLegacy :
+              LegacyCompatibleExternalStmtList elseIR :=
+            compileStmtList_legacyCompatible_of_interface
+              (stmtListTerminalCore_compiledLegacyCompatible fields
+                (compilerScope := compilerScope) helse)
+              helseIR
+          by_cases hempty : elseBranch.isEmpty
+          · simp [hempty] at hcompile
+            cases hcompile
+            exact .if_ condIR thenIR [] hthenLegacy .nil
+          · simp [hempty] at hcompile
+            cases hcompile
+            exact .block
+              [YulStmt.let_
+                (pickFreshName "__ite_cond"
+                  (compilerScope ++
+                    (collectExprNames cond ++
+                      (collectStmtListNames thenBranch ++ collectStmtListNames elseBranch))))
+                condIR,
+               YulStmt.if_
+                (YulExpr.ident
+                  (pickFreshName "__ite_cond"
+                    (compilerScope ++
+                      (collectExprNames cond ++
+                        (collectStmtListNames thenBranch ++ collectStmtListNames elseBranch)))))
+                thenIR,
+               YulStmt.if_
+                (YulExpr.call "iszero"
+                  [YulExpr.ident
+                    (pickFreshName "__ite_cond"
+                      (compilerScope ++
+                        (collectExprNames cond ++
+                          (collectStmtListNames thenBranch ++ collectStmtListNames elseBranch))))])
+                elseIR]
+              []
+              (.let_ _ _ _
+                (.if_ _ _ _
+                  hthenLegacy
+                  (.if_ _ _ _ helseLegacy .nil)))
+              .nil)
+        (stmtListCompileCore_compiledLegacyCompatible fields
+          (compilerScope := stmtNextScope compilerScope (.ite cond thenBranch elseBranch)) hrest)
+
 /-- Per-function legacy-compatibility bridge. A supported external function whose
 scalar params are supported and whose compiled body satisfies the per-statement
 legacy interface compiles to a function whose IR body stays inside the
@@ -2906,6 +3150,37 @@ theorem compileFunctionSpec_body_legacyCompatible_of_interface
   exact legacyCompatibleExternalStmtList_append
     (genParamLoads_scalar_legacy spec.params hparams)
     (compileStmtList_legacyCompatible_of_interface hbodyInterface hbodyCompile)
+
+/-- Function-level legacy-compatibility package for the generic compile-core
+body fragment. This discharges #2080's per-statement legacy interface for
+external functions whose source body is already in `StmtListCompileCore`. -/
+theorem compileFunctionSpec_body_legacyCompatible_of_compileCore
+    (fields : List Field) (selector : Nat) (spec : FunctionSpec) (irFn : IRFunction)
+    (hparams : ∀ param ∈ spec.params, SupportedExternalParamType param.ty)
+    (hbodyCore :
+      FunctionBody.StmtListCompileCore (spec.params.map (·.name)) spec.body)
+    (hcompile : compileFunctionSpec fields [] [] [] selector spec = Except.ok irFn) :
+    LegacyCompatibleExternalStmtList irFn.body :=
+  compileFunctionSpec_body_legacyCompatible_of_interface
+    fields selector spec irFn hparams
+    (stmtListCompileCore_compiledLegacyCompatible fields
+      (compilerScope := spec.params.map (·.name)) hbodyCore)
+    hcompile
+
+/-- Function-level legacy-compatibility package for the terminal-core body
+fragment, including terminal `ite` bodies. -/
+theorem compileFunctionSpec_body_legacyCompatible_of_terminalCore
+    (fields : List Field) (selector : Nat) (spec : FunctionSpec) (irFn : IRFunction)
+    (hparams : ∀ param ∈ spec.params, SupportedExternalParamType param.ty)
+    (hbodyTerminal :
+      FunctionBody.StmtListTerminalCore (spec.params.map (·.name)) spec.body)
+    (hcompile : compileFunctionSpec fields [] [] [] selector spec = Except.ok irFn) :
+    LegacyCompatibleExternalStmtList irFn.body :=
+  compileFunctionSpec_body_legacyCompatible_of_interface
+    fields selector spec irFn hparams
+    (stmtListTerminalCore_compiledLegacyCompatible fields
+      (compilerScope := spec.params.map (·.name)) hbodyTerminal)
+    hcompile
 
 /-- Disjointness of a single scalar param-load (with the `calldataload` word
 loader used by `genParamLoads`) from a runtime contract's internal-function

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -2858,6 +2858,55 @@ private theorem genParamLoads_scalar_legacy
   simp [genParamLoads, genParamLoadsFrom]
   exact .if_ _ _ _ (.exprStmt _ _ .nil) hbody
 
+/-- Legacy-compatibility analog of `compileStmtList_scalar_events_callsDisjoint`:
+turn a per-statement compiled legacy-compatibility interface
+(`StmtListCompiledLegacyCompatible`) into a whole-list legacy-compatibility
+witness for the emitted Yul body. This is the missing list-composition bridge
+that lifts the per-statement legacy obligations (the remaining #2080 discharge
+target) to a `LegacyCompatibleExternalStmtList` for the compiled body, mirroring
+the already-proven disjoint composition. -/
+private theorem compileStmtList_legacyCompatible_of_interface
+    {fields : List Field} :
+    ∀ {scope : List String} {stmts : List Stmt} {compiledIR : List YulStmt},
+      StmtListCompiledLegacyCompatible fields scope stmts →
+      CompilationModel.compileStmtList fields [] [] .calldata [] false scope [] stmts =
+          Except.ok compiledIR →
+      LegacyCompatibleExternalStmtList compiledIR
+  | _, [], _, _, hcompile => by
+      try unfold CompilationModel.compileStmtList at hcompile
+      unfold CompilationModel.compileStmtListWithFork at hcompile
+      cases hcompile
+      exact .nil
+  | _, _ :: _, _, hInterface, hcompile => by
+      obtain ⟨headIR, tailIR, hheadCompile, htailCompile, hbody⟩ :=
+        FunctionBody.compileStmtList_cons_ok_inv hcompile
+      cases hInterface with
+      | cons hhead htail =>
+          rw [hbody]
+          exact legacyCompatibleExternalStmtList_append
+            (hhead headIR hheadCompile)
+            (compileStmtList_legacyCompatible_of_interface htail htailCompile)
+
+/-- Per-function legacy-compatibility bridge. A supported external function whose
+scalar params are supported and whose compiled body satisfies the per-statement
+legacy interface compiles to a function whose IR body stays inside the
+legacy-compatible external Yul subset (`LegacyCompatibleExternalStmtList`).
+Composes `genParamLoads_scalar_legacy` with the body composition lemma. -/
+theorem compileFunctionSpec_body_legacyCompatible_of_interface
+    (fields : List Field) (selector : Nat) (spec : FunctionSpec) (irFn : IRFunction)
+    (hparams : ∀ param ∈ spec.params, SupportedExternalParamType param.ty)
+    (hbodyInterface :
+      StmtListCompiledLegacyCompatible fields (spec.params.map (·.name)) spec.body)
+    (hcompile : compileFunctionSpec fields [] [] [] selector spec = Except.ok irFn) :
+    LegacyCompatibleExternalStmtList irFn.body := by
+  obtain ⟨returns, bodyStmts, _hvalidate, _hreturns, hbodyCompile, hirFn⟩ :=
+    compileFunctionSpec_ok_components fields [] [] selector spec irFn hcompile
+  subst hirFn
+  simp only [compiledFunctionIR]
+  exact legacyCompatibleExternalStmtList_append
+    (genParamLoads_scalar_legacy spec.params hparams)
+    (compileStmtList_legacyCompatible_of_interface hbodyInterface hbodyCompile)
+
 /-- Disjointness of a single scalar param-load (with the `calldataload` word
 loader used by `genParamLoads`) from a runtime contract's internal-function
 table. Every EVM/Yul builtin emitted by `genScalarLoad`

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2137,7 +2137,13 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Function.genParamLoadBodyFrom_scalar_legacy  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoads_scalar_legacy  -- private
   -- Compiler.Proofs.IRGeneration.Function.compileStmtList_legacyCompatible_of_interface  -- private
+  -- Compiler.Proofs.IRGeneration.Function.legacyCompatibleExternalStmtList_map_exprStmt  -- private
+  -- Compiler.Proofs.IRGeneration.Function.revertWithMessage_legacyCompatible  -- private
+  Compiler.Proofs.IRGeneration.Function.stmtListCompileCore_compiledLegacyCompatible
+  Compiler.Proofs.IRGeneration.Function.stmtListTerminalCore_compiledLegacyCompatible
   Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_body_legacyCompatible_of_interface
+  Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_body_legacyCompatible_of_compileCore
+  Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_body_legacyCompatible_of_terminalCore
   -- Compiler.Proofs.IRGeneration.Function.genScalarLoad_calldataload_callsDisjoint  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoadBodyFrom_calldataload_callsDisjoint  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoads_callsDisjoint_of_builtins  -- private
@@ -5961,4 +5967,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5591 theorems/lemmas (3864 public, 1727 private, 0 sorry'd)
+-- Total: 5597 theorems/lemmas (3868 public, 1729 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1881,6 +1881,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_compiledInternalTable
   -- Compiler.Proofs.IRGeneration.Contract.compiled_internal_functions_forall₂_of_mapM_ok'  -- private
   -- Compiler.Proofs.IRGeneration.Contract.exists_left_of_forall₂_mem_right  -- private
+  Compiler.Proofs.IRGeneration.Contract.legacyCompatibleExternalBodies_of_compileValidatedCore_of_interface
   Compiler.Proofs.IRGeneration.Contract.compileInternalFunction_mapM_mem_exists
   Compiler.Proofs.IRGeneration.Contract.compiledInternalTable_of_internalFunctions_eq_mapM
   Compiler.Proofs.IRGeneration.Contract.InternalTableNamesReserved_of_internalFunctions_append
@@ -1918,6 +1919,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_goal
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_disjointRuntimeContract
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore
+  Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore_of_interface
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_closed
   Compiler.Proofs.IRGeneration.Contract.counter_supported_spec_compile_preserves_semantics
 
@@ -2134,6 +2136,8 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Function.genScalarLoad_legacy  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoadBodyFrom_scalar_legacy  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoads_scalar_legacy  -- private
+  -- Compiler.Proofs.IRGeneration.Function.compileStmtList_legacyCompatible_of_interface  -- private
+  Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_body_legacyCompatible_of_interface
   -- Compiler.Proofs.IRGeneration.Function.genScalarLoad_calldataload_callsDisjoint  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoadBodyFrom_calldataload_callsDisjoint  -- private
   -- Compiler.Proofs.IRGeneration.Function.genParamLoads_callsDisjoint_of_builtins  -- private
@@ -5957,4 +5961,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5587 theorems/lemmas (3861 public, 1726 private, 0 sorry'd)
+-- Total: 5591 theorems/lemmas (3864 public, 1727 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -69,6 +69,12 @@ ALLOWLIST: set[str] = {
     "compileStmtList_core_ok",
     "compileStmtList_terminal_core_ok",
     "compileStmtList_terminal_core_ok_nonempty",
+    # Mechanical per-constructor legacy-compatible Yul shape witnesses for the
+    # compile-core / terminal-core statement-list grammars. Splitting further
+    # would duplicate the same compile-success destructuring and constructor
+    # plumbing without reducing proof complexity.
+    "stmtListCompileCore_compiledLegacyCompatible",
+    "stmtListTerminalCore_compiledLegacyCompatible",
     # Fork-aware list append inversion and constructor smoke witnesses are
     # mechanical normalization proofs; splitting them duplicates the same
     # head/tail compile-success plumbing.


### PR DESCRIPTION
## Summary
- Discharges `StmtListCompiledLegacyCompatible` for the generic `StmtListCompileCore` grammar.
- Adds terminal-core coverage via `stmtListTerminalCore_compiledLegacyCompatible`, including terminal `ite` bodies by reusing the #2128 list bridge on compiled branches.
- Packages function-level entrypoints for compile-core and terminal-core bodies: `compileFunctionSpec_body_legacyCompatible_of_compileCore` and `compileFunctionSpec_body_legacyCompatible_of_terminalCore`.
- Regenerates `PrintAxioms.lean` and documents the two mechanical structural witnesses in the proof-length allowlist.

## Stack / dependency
Base/target: `paloma/parallel-fallback-fragment-helper` (#2128).

Do not merge until predecessor stack is merged/green.

## Validation
- `git diff --check` PASS
- `lean-slot lake build Compiler.Proofs.IRGeneration.Function` PASS (local fallback after Spark offload 403 for this isolated worktree path)
- `lean-slot lake build Compiler.Proofs.IRGeneration.Contract` PASS (local fallback after Spark offload 403 for this isolated worktree path)
- `python3 scripts/generate_print_axioms.py --check` PASS
- `python3 scripts/check_proof_length.py` PASS
- `rg -n "\\b(sorry|admit|axiom)\\b" Compiler/Proofs/IRGeneration/Function.lean` PASS (no matches)

Refs #2080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to Lean proofs and axiom inventory; no compiler runtime or security-sensitive execution paths are modified.
> 
> **Overview**
> Advances **#2080** by proving that bodies in the `StmtListCompileCore` and `StmtListTerminalCore` grammars satisfy `StmtListCompiledLegacyCompatible`, so compiled Yul stays in the legacy-compatible external subset without hand-written per-statement witnesses.
> 
> Adds structural lemmas (`legacyCompatibleExternalStmtList_map_exprStmt`, `revertWithMessage_legacyCompatible`) and large inductive theorems `stmtListCompileCore_compiledLegacyCompatible` and `stmtListTerminalCore_compiledLegacyCompatible` (per-constructor cases aligned with compilation, including terminal `ite` via the existing list bridge). Two function-level corollaries—`compileFunctionSpec_body_legacyCompatible_of_compileCore` and `..._of_terminalCore`—compose param loads with those list proofs.
> 
> **PrintAxioms.lean** is regenerated to export the new public theorems; **check_proof_length.py** allowlists the two mechanical structural witnesses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e54ef9906bab5520c669463f7830669a23237ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->