### PR TITLE
ci: authenticate OCR router base fetch

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -125,8 +125,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${GITHUB_TOKEN}" \
-            fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          origin_url="$(git remote get-url origin)"
+          trap 'git remote set-url origin "$origin_url"' EXIT
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          git remote set-url origin "$origin_url"
+          trap - EXIT
           node "$GITHUB_WORKSPACE/ocr-trusted/.github/scripts/ocr-router.js"
 
       - name: Install OpenCodeReview
@@ -181,7 +185,7 @@ jobs:
           test -s "$RUNNER_TEMP/ocr-result.json" || echo '{"status":"error","comments":[],"message":"OCR produced no JSON output"}' > "$RUNNER_TEMP/ocr-result.json"
 
       - name: Post OCR review
-        if: steps.pr.outputs.skip != 'true' && always() && !cancelled()
+        if: steps.pr.outputs.skip != 'true' && always() && !cancelled() && steps.route.outcome == 'success'
         uses: actions/github-script@v7
         env:
           OCR_RESULT_PATH: ${{ runner.temp }}/ocr-result.json
@@ -200,7 +204,7 @@ jobs:
             await post({ github, context, core });
 
       - name: Upload OCR metrics
-        if: steps.pr.outputs.skip != 'true' && always() && !cancelled()
+        if: steps.pr.outputs.skip != 'true' && always() && !cancelled() && steps.route.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: ocr-metrics-${{ steps.pr.outputs.number }}-${{ steps.pr.outputs.head_sha }}


### PR DESCRIPTION
## Summary
- use a transient tokenized origin URL for the OCR router base-ref fetch on self-hosted runners
- skip OCR publishing/artifact upload when the router step fails before producing metrics/result JSON

## Validation
- node --check .github/scripts/post-ocr-review.js
- node --check .github/scripts/ocr-router.js
- node --check .github/scripts/test-ocr-routing.js
- node .github/scripts/test-ocr-routing.js
- PyYAML parse .github/workflows/ocr-review.yml
- actionlint .github/workflows/ocr-review.yml

## Production context
Production /ocr review on #2128 and #2127 after #2133 merged failed in Route OCR review because the authenticated fetch prompted for GitHub credentials on the self-hosted runner. This PR fixes that production blocker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes for git auth and step gating; no application runtime or security-sensitive product code.
> 
> **Overview**
> Fixes **Route OCR review** failing on self-hosted runners when `git fetch` for the PR base ref prompted for credentials (production blocker after #2133).
> 
> The router step no longer relies on `git -c http.extraheader=...` for auth. It briefly rewrites `origin` to a `x-access-token` URL, fetches `BASE_REF`, then restores the original remote (with an `EXIT` trap so cleanup still runs on failure).
> 
> **Post OCR review** and **Upload OCR metrics** now require `steps.route.outcome == 'success'`, so a failed router does not publish a review or upload metrics when result/metrics JSON was never produced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5041cee775970d70fc21ad6a2a52e62d788877e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->