### PR TITLE
ci: default large Lean OCR scout to MiniMax

### DIFF
--- a/.github/ocr/README.md
+++ b/.github/ocr/README.md
@@ -31,7 +31,14 @@ Before installing or invoking OpenCodeReview, `.github/scripts/ocr-router.js` co
 
 Packetized Lean mode is intentionally partial. It checks deterministic signals first, including introduced `sorry`/`admit`/`axiom`/`unsafe`, changed imports, public declaration or theorem signature changes, trust-boundary documentation drift, and large deleted proof obligations. It then ranks hotspots such as `Compiler/Proofs/YulGeneration/**`, `Compiler/Proofs/**`, `Compiler/**`, `IRGeneration/**`, `Semantics/**`, trust docs, and public theorem statements.
 
-If `OCR_SCOUT_LLM_URL`, `OCR_SCOUT_LLM_KEY`, and `OCR_SCOUT_LLM_MODEL` are configured in Actions, the router sends only a bounded JSON risk dossier to that OpenAI-compatible model. The scout model is cheap triage only: it selects packet IDs, reasons, risk categories, questions for a stronger reviewer, and residual coverage. It never produces final review approval. If scout configuration is absent or the call fails, the router records that state in metrics and falls back to deterministic ranking.
+For `large-lean-hotspots`, the scout is enabled by default and uses sandboxed.sh/OpenAI-compatible routing. Configuration knobs:
+
+- `OCR_SCOUT_ENABLED`: optional, defaults to `true`; set to `false` to disable only the large Lean scout call.
+- `OCR_SCOUT_LLM_URL`: optional; defaults to `OCR_LLM_URL` when the same sandboxed endpoint supports model selection.
+- `OCR_SCOUT_LLM_KEY`: optional; defaults to `OCR_LLM_KEY` when the same sandboxed key can route both models.
+- `OCR_SCOUT_LLM_MODEL`: optional; defaults to `MiniMax-M3`, the MiniMax hybrid long-context scout model listed in the sandboxed.sh provider catalog.
+
+The router sends only a bounded JSON risk dossier to the scout model. The scout model is cheap triage only: it selects packet IDs, reasons, risk categories, questions for a stronger reviewer, and residual coverage. It never produces final review approval. If scout configuration is absent, disabled, malformed, rejected by the provider, or the call fails, the router records that state in metrics and falls back to deterministic ranking.
 
 OpenCodeReview 1.7.5 is still invoked only for `small-lean`, `medium-lean`, and `config-docs` full-diff paths. The short-term bridge for `large-lean-hotspots` publishes scout/deterministic packet advisory comments and explicitly marks strong packet review as required but blocked on a safe OCR packet-window input mechanism. The posted comment lists the covered packets, packet budget, scout status, metrics, strong-review blocker, and residual risk. It must not be read as full review coverage or LGTM.
 

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -4,7 +4,8 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
-const ROUTER_VERSION = 'router-v4';
+const ROUTER_VERSION = 'router-v5';
+const DEFAULT_SCOUT_MODEL = 'MiniMax-M3';
 const STRONG_REVIEW_BLOCKER_MESSAGE = 'OpenCodeReview 1.7.5 supports --from/--to full diff ranges, but this workflow does not have a safe packet/window input bridge for Lean hunks yet.';
 const THRESHOLDS = Object.freeze({
   smallLeanFiles: 1,
@@ -33,11 +34,7 @@ async function main() {
   const diff = loadDiff(`origin/${baseRef}`, headSha);
   const decision = decideRoute(diff.files);
   if (decision.mode === 'large-lean-hotspots') {
-    await applyScoutStage(decision, diff, {
-      url: process.env.OCR_SCOUT_LLM_URL || '',
-      key: process.env.OCR_SCOUT_LLM_KEY || '',
-      model: process.env.OCR_SCOUT_LLM_MODEL || '',
-    });
+    await applyScoutStage(decision, diff, resolveScoutConfig(process.env));
   }
   const metrics = buildMetrics({
     prNumber,
@@ -68,6 +65,9 @@ async function main() {
 
   console.log(`OCR route: ${decision.mode} (${decision.reason})`);
   console.log(`Changed files: ${diff.files.length}; supported: ${decision.counts.supported}; Lean: ${decision.counts.lean}; changed lines: ${decision.changedLines}`);
+  if (decision.scout) {
+    console.log(`Scout enabled: ${decision.scout.enabled}; model: ${decision.scout.model || DEFAULT_SCOUT_MODEL}; status: ${decision.scout.status}`);
+  }
 }
 
 function loadDiff(base, head) {
@@ -306,11 +306,14 @@ function renderHunkExcerpt(hunk, maxLines) {
 
 async function applyScoutStage(decision, diff, config) {
   const deterministicPackets = decision.packets || [];
+  const scoutSwitchOn = config.enabled !== false;
+  const enabled = Boolean(scoutSwitchOn && config.url && config.key && config.model);
   decision.scout = {
-    enabled: Boolean(config.url && config.key && config.model),
+    enabled,
+    configured: Boolean(config.url && config.key && config.model),
     attempted: false,
-    status: 'not_configured',
-    model: config.model ? redactModel(config.model) : null,
+    status: scoutSwitchOn ? 'not_configured' : 'disabled',
+    model: config.model ? redactModel(config.model) : DEFAULT_SCOUT_MODEL,
     selected_packets: deterministicPackets.map(p => p.packet_id),
     residual_coverage: packetResidualRisk(decision),
     strong_review_status: 'blocked_packet_input',
@@ -318,7 +321,7 @@ async function applyScoutStage(decision, diff, config) {
   };
 
   if (deterministicPackets.length === 0) {
-    decision.scout.status = decision.scout.enabled ? 'skipped_no_packets' : 'not_configured';
+    decision.scout.status = decision.scout.enabled ? 'skipped_no_packets' : decision.scout.status;
     decision.scout.residual_coverage = 'No safe packets were produced; use top changed files and deterministic checklist items for Codex/human review.';
     return decision;
   }
@@ -447,10 +450,73 @@ async function callScoutModel(config, dossier) {
     const payload = JSON.parse(text);
     const content = payload.choices?.[0]?.message?.content;
     if (!content) throw new Error('scout model returned no message content');
-    return JSON.parse(content);
+    return parseScoutJson(content);
   } finally {
     clearTimeout(timeout);
   }
+}
+
+function resolveScoutConfig(env = process.env) {
+  const enabled = !isFalse(env.OCR_SCOUT_ENABLED);
+  return {
+    enabled,
+    url: env.OCR_SCOUT_LLM_URL || env.OCR_LLM_URL || '',
+    key: env.OCR_SCOUT_LLM_KEY || env.OCR_LLM_KEY || env.OCR_LLM_TOKEN || '',
+    model: env.OCR_SCOUT_LLM_MODEL || DEFAULT_SCOUT_MODEL,
+  };
+}
+
+function isFalse(value) {
+  return /^(0|false|no|off)$/i.test(String(value || '').trim());
+}
+
+function parseScoutJson(content) {
+  const text = stripThinking(String(content || '')).trim();
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    const extracted = extractJsonObject(text);
+    if (!extracted) throw err;
+    return JSON.parse(extracted);
+  }
+}
+
+function stripThinking(text) {
+  return text
+    .replace(/<mm:think>[\s\S]*?<\/mm:think>/gi, '')
+    .replace(/<think>[\s\S]*?<\/think>/gi, '')
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/i, '');
+}
+
+function extractJsonObject(text) {
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i += 1) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === '{') {
+      depth += 1;
+    } else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return null;
 }
 
 function classifyScoutError(err) {
@@ -885,6 +951,7 @@ if (require.main === module) {
 module.exports = {
   ROUTER_VERSION,
   THRESHOLDS,
+  DEFAULT_SCOUT_MODEL,
   categorize,
   decideRoute,
   isSupported,
@@ -893,6 +960,8 @@ module.exports = {
   buildMetrics,
   buildReviewPackets,
   applyScoutStage,
+  resolveScoutConfig,
+  parseScoutJson,
   buildRiskDossier,
   parseUnifiedDiff,
   scorePathRisk,

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -135,7 +135,37 @@ async function testLargeLeanScoutNotConfiguredFallsBack() {
   assert.strictEqual(decision.mode, 'large-lean-hotspots');
   assert.strictEqual(decision.scout.enabled, false);
   assert.strictEqual(decision.scout.status, 'not_configured');
+  assert.strictEqual(decision.scout.model, 'MiniMax-M3');
   assert.strictEqual(decision.scout.strong_review_status, 'blocked_packet_input');
+}
+
+function testScoutConfigDefaultsToMiniMaxOnOcrEndpoint() {
+  const config = router.resolveScoutConfig({
+    OCR_LLM_URL: 'https://sandboxed.example/v1',
+    OCR_LLM_KEY: 'shared-key',
+  });
+  assert.strictEqual(config.enabled, true);
+  assert.strictEqual(config.url, 'https://sandboxed.example/v1');
+  assert.strictEqual(config.key, 'shared-key');
+  assert.strictEqual(config.model, 'MiniMax-M3');
+  const ocrReviewerModel = 'reviewer';
+  assert.strictEqual(ocrReviewerModel, 'reviewer');
+}
+
+function testScoutConfigCanDisableLargeLeanScout() {
+  const config = router.resolveScoutConfig({
+    OCR_SCOUT_ENABLED: 'false',
+    OCR_LLM_URL: 'https://sandboxed.example/v1',
+    OCR_LLM_KEY: 'shared-key',
+  });
+  assert.strictEqual(config.enabled, false);
+  assert.strictEqual(config.model, 'MiniMax-M3');
+}
+
+function testScoutJsonParsingHandlesMiniMaxThinkingWrapper() {
+  const parsed = router.parseScoutJson('<mm:think>ranking packets</mm:think>\n```json\n{"selected_packets":[],"residual_coverage":"none","summary":"ok"}\n```');
+  assert.deepStrictEqual(parsed.selected_packets, []);
+  assert.strictEqual(parsed.summary, 'ok');
 }
 
 async function testLargeLeanScoutSelectsPackets() {
@@ -211,6 +241,35 @@ async function testLargeLeanScoutEmptySelectionIsFallback() {
   assert.strictEqual(decision.scout.status, 'fallback_no_selection');
   assert.deepStrictEqual(decision.packets.map(p => p.packet_id), originalPackets);
   assert.strictEqual(decision.scout.raw_selected_count, 1);
+}
+
+async function testLargeLeanScoutMalformedJsonFallsBack() {
+  const files = [
+    file('Compiler/Proofs/A.lean', 40, 0),
+    file('Compiler/Proofs/B.lean', 40, 0),
+    file('Compiler/Proofs/C.lean', 40, 0),
+  ];
+  const decision = router.decideRoute(files);
+  const originalPackets = decision.packets.map(p => p.packet_id);
+  const oldFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: true,
+    text: async () => JSON.stringify({
+      choices: [{
+        message: {
+          content: '{"selected_packets": [',
+        },
+      }],
+    }),
+  });
+  try {
+    await router.applyScoutStage(decision, { files }, { enabled: true, url: 'https://example.invalid/v1', key: 'test-key', model: 'MiniMax-M3' });
+  } finally {
+    global.fetch = oldFetch;
+  }
+  assert.strictEqual(decision.scout.status, 'fallback_deterministic');
+  assert.strictEqual(decision.scout.error_type, 'invalid_json');
+  assert.deepStrictEqual(decision.packets.map(p => p.packet_id), originalPackets);
 }
 
 async function testLargeLeanScoutApiFailureFallsBack() {
@@ -355,9 +414,13 @@ async function run() {
   testLeanBlockCommentDoesNotTriggerSorrySignal();
   testCodeAfterInlineBlockCommentIsScanned();
   testOversizedLeanGuarded();
+  testScoutConfigDefaultsToMiniMaxOnOcrEndpoint();
+  testScoutConfigCanDisableLargeLeanScout();
+  testScoutJsonParsingHandlesMiniMaxThinkingWrapper();
   await testLargeLeanScoutNotConfiguredFallsBack();
   await testLargeLeanScoutSelectsPackets();
   await testLargeLeanScoutEmptySelectionIsFallback();
+  await testLargeLeanScoutMalformedJsonFallsBack();
   await testLargeLeanScoutApiFailureFallsBack();
   await testLargeLeanScoutNoPacketsStatus();
   testWorkflowDocsEnabled();

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -122,9 +122,12 @@ jobs:
           OCR_PR_NUMBER: ${{ steps.pr.outputs.number }}
           OCR_RESULT_PATH: ${{ runner.temp }}/ocr-result.json
           OCR_METRICS_PATH: ${{ runner.temp }}/ocr-metrics.json
+          OCR_LLM_URL: ${{ secrets.OCR_LLM_URL }}
+          OCR_LLM_KEY: ${{ secrets.OCR_LLM_KEY }}
+          OCR_SCOUT_ENABLED: ${{ vars.OCR_SCOUT_ENABLED || 'true' }}
           OCR_SCOUT_LLM_URL: ${{ secrets.OCR_SCOUT_LLM_URL || secrets.OCR_LLM_URL }}
           OCR_SCOUT_LLM_KEY: ${{ secrets.OCR_SCOUT_LLM_KEY || secrets.OCR_LLM_KEY }}
-          OCR_SCOUT_LLM_MODEL: ${{ vars.OCR_SCOUT_LLM_MODEL || secrets.OCR_SCOUT_LLM_MODEL }}
+          OCR_SCOUT_LLM_MODEL: ${{ vars.OCR_SCOUT_LLM_MODEL || secrets.OCR_SCOUT_LLM_MODEL || 'MiniMax-M3' }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- Default the large Lean OCR scout stage to the sandboxed.sh MiniMax hybrid model `MiniMax-M3`.
- Let the scout use explicit `OCR_SCOUT_*` secrets/vars when present, or fall back to the existing `OCR_LLM_URL`/`OCR_LLM_KEY` endpoint/key with model selection.
- Preserve the strong OCR path as `reviewer` for small Lean/config/docs paths.
- Add robust scout JSON parsing for MiniMax thinking/fenced output and malformed JSON fallback to deterministic packet ranking.
- Document the production knobs and large Lean scout semantics.

## Validation

- `node --check .github/scripts/ocr-router.js`
- `node --check .github/scripts/post-ocr-review.js`
- `node --check .github/scripts/test-ocr-routing.js`
- `node .github/scripts/test-ocr-routing.js`
- `bash -n .github/scripts/ocr-git-wrapper.sh`
- `python3 -m json.tool .github/ocr/rules.json`
- PyYAML parse of `.github/workflows/ocr-review.yml`
- `actionlint .github/workflows/ocr-review.yml`
- Local #2128 route smoke: `large-lean-hotspots`, `MiniMax-M3`, 7 packets, OCR not attempted; local env has no OCR secrets, so production must verify the live scout call.

## Production test plan

After checks and Codex review are clean, merge to `main`, then trigger `/ocr review` on #2128. The expected production result is `large-lean-hotspots` with scout status showing a live MiniMax-M3 attempt/success or a concrete provider/model error. The run must not invoke full OCR over the entire large Lean diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI routing and external LLM calls for large Lean PRs; failures are designed to fall back to deterministic ranking, but production scout behavior should be verified on a real large diff.
> 
> **Overview**
> Large Lean **hotspot** routing now turns on the scout by default and targets **`MiniMax-M3`**, with shared **`OCR_LLM_*`** credentials when dedicated scout secrets are omitted.
> 
> **`ocr-router.js`** (bumped to **`router-v5`**) centralizes scout env resolution: **`OCR_SCOUT_ENABLED`** can disable only the scout call; URL/key/model fall back through **`OCR_SCOUT_*`** → **`OCR_LLM_*`**; scout metrics distinguish **configured**, **disabled**, and **not_configured**. MiniMax-style responses are normalized via **`parseScoutJson`** (thinking tags, fenced JSON, brace extraction) so malformed output falls back to deterministic packet ranking with **`invalid_json`**.
> 
> The **OCR workflow** passes **`OCR_LLM_URL`/`OCR_LLM_KEY`** into the route step, defaults **`OCR_SCOUT_ENABLED`** to true and **`OCR_SCOUT_LLM_MODEL`** to **`MiniMax-M3`**. Full OCR on small/medium paths still uses model **`reviewer`**.
> 
> **README** documents the scout knobs and default-on behavior; **routing tests** cover config defaults, disable switch, thinking-wrapper parsing, and malformed JSON fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5c173f26f9ae82769314de78f88f67cb92be09f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->