### PR TITLE
ci: address MiniMax scout review findings

### DIFF
--- a/.github/ocr/README.md
+++ b/.github/ocr/README.md
@@ -35,7 +35,7 @@ For `large-lean-hotspots`, the scout is enabled by default and uses sandboxed.sh
 
 - `OCR_SCOUT_ENABLED`: optional, defaults to `true`; set to `false` to disable only the large Lean scout call.
 - `OCR_SCOUT_LLM_URL`: optional; defaults to `OCR_LLM_URL` when the same sandboxed endpoint supports model selection.
-- `OCR_SCOUT_LLM_KEY`: optional; defaults to `OCR_LLM_KEY` when the same sandboxed key can route both models.
+- `OCR_SCOUT_LLM_KEY`: optional; defaults to `OCR_LLM_KEY`, then `OCR_LLM_TOKEN`, when the same sandboxed key can route both models.
 - `OCR_SCOUT_LLM_MODEL`: optional; defaults to `MiniMax-M3`, the MiniMax hybrid long-context scout model listed in the sandboxed.sh provider catalog.
 
 The router sends only a bounded JSON risk dossier to the scout model. The scout model is cheap triage only: it selects packet IDs, reasons, risk categories, questions for a stronger reviewer, and residual coverage. It never produces final review approval. If scout configuration is absent, disabled, malformed, rejected by the provider, or the call fails, the router records that state in metrics and falls back to deterministic ranking.

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -485,6 +485,7 @@ function stripThinking(text) {
   return text
     .replace(/<mm:think>[\s\S]*?<\/mm:think>/gi, '')
     .replace(/<think>[\s\S]*?<\/think>/gi, '')
+    .trim()
     .replace(/^```(?:json)?\s*/i, '')
     .replace(/\s*```$/i, '');
 }

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -148,8 +148,8 @@ function testScoutConfigDefaultsToMiniMaxOnOcrEndpoint() {
   assert.strictEqual(config.url, 'https://sandboxed.example/v1');
   assert.strictEqual(config.key, 'shared-key');
   assert.strictEqual(config.model, 'MiniMax-M3');
-  const ocrReviewerModel = 'reviewer';
-  assert.strictEqual(ocrReviewerModel, 'reviewer');
+  const workflow = fs.readFileSync(path.join(__dirname, '..', 'workflows', 'ocr-review.yml'), 'utf8');
+  assert.ok(workflow.includes('OCR_LLM_MODEL: reviewer'));
 }
 
 function testScoutConfigCanDisableLargeLeanScout() {


### PR DESCRIPTION
## Summary

- Address advisory OCR findings from #2138.
- Document the `OCR_LLM_TOKEN` scout-key fallback.
- Replace a dead reviewer-model test assertion with a real workflow assertion that OCR still uses `reviewer`.
- Trim MiniMax thinking output before fenced JSON stripping.

## Validation

- `node --check .github/scripts/ocr-router.js`
- `node --check .github/scripts/post-ocr-review.js`
- `node --check .github/scripts/test-ocr-routing.js`
- `node .github/scripts/test-ocr-routing.js`
- `bash -n .github/scripts/ocr-git-wrapper.sh`
- `python3 -m json.tool .github/ocr/rules.json`
- PyYAML parse `.github/workflows/ocr-review.yml`
- `actionlint .github/workflows/ocr-review.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/docs and small parsing/test tweaks only; no auth or review-gate behavior changes beyond clearer scout credential docs and safer JSON parsing.
> 
> **Overview**
> Follow-up to advisory OCR feedback: **scout key docs**, **MiniMax JSON parsing**, and a **stronger routing test**.
> 
> The OCR README now states that `OCR_SCOUT_LLM_KEY` falls back to `OCR_LLM_KEY`, then `OCR_LLM_TOKEN`, matching how the router resolves scout credentials when a dedicated scout secret is not set.
> 
> In `stripThinking`, content is **trimmed after** stripping MiniMax `<mm:think>` / `<think>` blocks and **before** removing fenced ```json``` wrappers, so scout responses with trailing whitespace or newlines still parse reliably.
> 
> `testScoutConfigDefaultsToMiniMaxOnOcrEndpoint` no longer uses a no-op reviewer-model assertion; it reads `ocr-review.yml` and checks that full OCR still sets `OCR_LLM_MODEL: reviewer` while scout config defaults to MiniMax on the shared endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7e797726f930b17849144ea320ef9628265874d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->