### PR TITLE
proof: legacy compatibility for storage mapping singletons

### DIFF
--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -2894,6 +2894,38 @@ private theorem legacyCompatibleExternalStmtList_map_exprStmt
   | [] => .nil
   | _ :: rest => .exprStmt _ _ (legacyCompatibleExternalStmtList_map_exprStmt f rest)
 
+private theorem legacyCompatibleExternalStmtList_map_exprStmt_call
+    {α : Type} (f : α → YulExpr) (name : String) :
+    ∀ xs : List α,
+      LegacyCompatibleExternalStmtList
+        (xs.map (fun x => YulStmt.exprStmt (YulExpr.call name [f x, YulExpr.ident "__compat_value"])))
+  | [] => .nil
+  | _ :: rest => .exprStmt _ _
+      (legacyCompatibleExternalStmtList_map_exprStmt_call f name rest)
+
+private theorem legacyCompatibleExternalStmtList_block_value_writes
+    {α : Type} (f : α → YulExpr) (name : String) (value : YulExpr) (xs : List α) :
+    LegacyCompatibleExternalStmtList
+      [YulStmt.block
+        (YulStmt.let_ "__compat_value" value ::
+          xs.map (fun x =>
+            YulStmt.exprStmt
+              (YulExpr.call name [f x, YulExpr.ident "__compat_value"])))] := by
+  exact .block _ _ (.let_ _ _ _
+    (legacyCompatibleExternalStmtList_map_exprStmt_call f name xs)) .nil
+
+private theorem legacyCompatibleExternalStmtList_block_key_value_writes
+    {α : Type} (f : α → YulExpr) (name : String)
+    (key value : YulExpr) (xs : List α) :
+    LegacyCompatibleExternalStmtList
+      [YulStmt.block
+        ([YulStmt.let_ "__compat_key" key, YulStmt.let_ "__compat_value" value] ++
+          xs.map (fun x =>
+            YulStmt.exprStmt
+              (YulExpr.call name [f x, YulExpr.ident "__compat_value"])))] := by
+  exact .block _ _ (.let_ _ _ _ (.let_ _ _ _
+    (legacyCompatibleExternalStmtList_map_exprStmt_call f name xs))) .nil
+
 private theorem revertWithMessage_legacyCompatible
     (message : String) :
     LegacyCompatibleExternalStmtList (CompilationModel.revertWithMessage message) := by
@@ -3130,6 +3162,150 @@ theorem stmtListTerminalCore_compiledLegacyCompatible
               .nil)
         (stmtListCompileCore_compiledLegacyCompatible fields
           (compilerScope := stmtNextScope compilerScope (.ite cond thenBranch elseBranch)) hrest)
+
+/-- Singleton `setStorage` heads compile to ordinary legacy-compatible Yul when
+the supported-fragment witness resolves the field to one concrete uint256
+storage slot. -/
+theorem stmtList_setStorageSingleSlot_compiledLegacyCompatible
+    (fields : List Field)
+    {scope : List String}
+    {fieldName : String}
+    {value : Expr}
+    {slot : Nat}
+    (_hvalue : FunctionBody.ExprCompileCore value)
+    (_hscope : FunctionBody.exprBoundNamesInScope value scope)
+    (hfield :
+      findFieldWithResolvedSlot fields fieldName =
+        some ({ name := fieldName, ty := FieldType.uint256 }, slot)) :
+    StmtListCompiledLegacyCompatible fields scope [Stmt.setStorage fieldName value] :=
+  .cons
+    (fun compiledIR hcompile => by
+      simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork] at hcompile
+      simp [CompilationModel.compileSetStorage, hfield] at hcompile
+      split at hcompile <;> try contradiction
+      cases hvalueExpr : compileExprWithInternals fields .calldata [] value <;>
+        simp [hvalueExpr] at hcompile
+      cases hcompile
+      exact .exprStmt _ _ .nil)
+    .nil
+
+/-- Singleton `setStorageAddr` heads compile to ordinary legacy-compatible Yul
+when the supported-fragment witness resolves the field to one concrete address
+storage slot. -/
+theorem stmtList_setStorageAddrSingleSlot_compiledLegacyCompatible
+    (fields : List Field)
+    {scope : List String}
+    {fieldName : String}
+    {value : Expr}
+    {slot : Nat}
+    (_hvalue : FunctionBody.ExprCompileCore value)
+    (_hscope : FunctionBody.exprBoundNamesInScope value scope)
+    (hfield :
+      findFieldWithResolvedSlot fields fieldName =
+        some ({ name := fieldName, ty := FieldType.address }, slot)) :
+    StmtListCompiledLegacyCompatible fields scope [Stmt.setStorageAddr fieldName value] :=
+  .cons
+    (fun compiledIR hcompile => by
+      simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork] at hcompile
+      simp [CompilationModel.compileSetStorage, hfield] at hcompile
+      split at hcompile <;> try contradiction
+      cases hvalueExpr : compileExprWithInternals fields .calldata [] value <;>
+        simp [hvalueExpr] at hcompile
+      cases hcompile
+      exact .exprStmt _ _ .nil)
+    .nil
+
+private theorem compileMappingSlotWrite_legacyCompatible
+    {fields : List Field}
+    {fieldName label : String}
+    {keyExpr valueExpr : YulExpr}
+    {wordOffset : Nat}
+    {compiledIR : List YulStmt}
+    (hcompile :
+      CompilationModel.compileMappingSlotWrite fields fieldName keyExpr valueExpr
+          label wordOffset true =
+        Except.ok compiledIR) :
+    LegacyCompatibleExternalStmtList compiledIR := by
+  unfold CompilationModel.compileMappingSlotWrite at hcompile
+  repeat' split at hcompile <;> try contradiction
+  all_goals
+    first
+    | cases hcompile
+      exact .exprStmt _ _ .nil
+    | cases hcompile
+      exact legacyCompatibleExternalStmtList_block_key_value_writes (α := Nat) (f := _) _ _ _ _
+
+/-- Singleton `setMapping` heads compile to ordinary legacy-compatible Yul. -/
+theorem stmtList_setMappingSingle_compiledLegacyCompatible
+    (fields : List Field)
+    {scope : List String}
+    {fieldName : String}
+    {key value : Expr}
+    {slot : Nat}
+    (_hkey : FunctionBody.ExprCompileCore key)
+    (_hscopeKey : FunctionBody.exprBoundNamesInScope key scope)
+    (_hvalue : FunctionBody.ExprCompileCore value)
+    (_hscopeValue : FunctionBody.exprBoundNamesInScope value scope)
+    (_hslot : findFieldSlot fields fieldName = some slot) :
+    StmtListCompiledLegacyCompatible fields scope [Stmt.setMapping fieldName key value] :=
+  .cons
+    (fun compiledIR hcompile => by
+      simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+        bind, Except.bind] at hcompile
+      split at hcompile <;> try contradiction
+      rename_i keyExpr hkeyExpr
+      split at hcompile <;> try contradiction
+      rename_i valueExpr hvalueExpr
+      exact compileMappingSlotWrite_legacyCompatible hcompile)
+    .nil
+
+/-- Singleton `setMappingUint` heads compile to ordinary legacy-compatible Yul. -/
+theorem stmtList_setMappingUintSingle_compiledLegacyCompatible
+    (fields : List Field)
+    {scope : List String}
+    {fieldName : String}
+    {key value : Expr}
+    {slot : Nat}
+    (_hkey : FunctionBody.ExprCompileCore key)
+    (_hscopeKey : FunctionBody.exprBoundNamesInScope key scope)
+    (_hvalue : FunctionBody.ExprCompileCore value)
+    (_hscopeValue : FunctionBody.exprBoundNamesInScope value scope)
+    (_hslot : findFieldSlot fields fieldName = some slot) :
+    StmtListCompiledLegacyCompatible fields scope [Stmt.setMappingUint fieldName key value] :=
+  .cons
+    (fun compiledIR hcompile => by
+      simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+        bind, Except.bind] at hcompile
+      split at hcompile <;> try contradiction
+      rename_i keyExpr hkeyExpr
+      split at hcompile <;> try contradiction
+      rename_i valueExpr hvalueExpr
+      exact compileMappingSlotWrite_legacyCompatible hcompile)
+    .nil
+
+/-- Singleton `setMappingWord` heads compile to ordinary legacy-compatible Yul. -/
+theorem stmtList_setMappingWordSingle_compiledLegacyCompatible
+    (fields : List Field)
+    {scope : List String}
+    {fieldName : String}
+    {key value : Expr}
+    {wordOffset slot : Nat}
+    (_hkey : FunctionBody.ExprCompileCore key)
+    (_hscopeKey : FunctionBody.exprBoundNamesInScope key scope)
+    (_hvalue : FunctionBody.ExprCompileCore value)
+    (_hscopeValue : FunctionBody.exprBoundNamesInScope value scope)
+    (_hslot : findFieldSlot fields fieldName = some slot) :
+    StmtListCompiledLegacyCompatible fields scope [Stmt.setMappingWord fieldName key wordOffset value] :=
+  .cons
+    (fun compiledIR hcompile => by
+      simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+        bind, Except.bind] at hcompile
+      split at hcompile <;> try contradiction
+      rename_i keyExpr hkeyExpr
+      split at hcompile <;> try contradiction
+      rename_i valueExpr hvalueExpr
+      exact compileMappingSlotWrite_legacyCompatible hcompile)
+    .nil
 
 /-- Per-function legacy-compatibility bridge. A supported external function whose
 scalar params are supported and whose compiled body satisfies the per-statement

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2138,9 +2138,18 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Function.genParamLoads_scalar_legacy  -- private
   -- Compiler.Proofs.IRGeneration.Function.compileStmtList_legacyCompatible_of_interface  -- private
   -- Compiler.Proofs.IRGeneration.Function.legacyCompatibleExternalStmtList_map_exprStmt  -- private
+  -- Compiler.Proofs.IRGeneration.Function.legacyCompatibleExternalStmtList_map_exprStmt_call  -- private
+  -- Compiler.Proofs.IRGeneration.Function.legacyCompatibleExternalStmtList_block_value_writes  -- private
+  -- Compiler.Proofs.IRGeneration.Function.legacyCompatibleExternalStmtList_block_key_value_writes  -- private
   -- Compiler.Proofs.IRGeneration.Function.revertWithMessage_legacyCompatible  -- private
   Compiler.Proofs.IRGeneration.Function.stmtListCompileCore_compiledLegacyCompatible
   Compiler.Proofs.IRGeneration.Function.stmtListTerminalCore_compiledLegacyCompatible
+  Compiler.Proofs.IRGeneration.Function.stmtList_setStorageSingleSlot_compiledLegacyCompatible
+  Compiler.Proofs.IRGeneration.Function.stmtList_setStorageAddrSingleSlot_compiledLegacyCompatible
+  -- Compiler.Proofs.IRGeneration.Function.compileMappingSlotWrite_legacyCompatible  -- private
+  Compiler.Proofs.IRGeneration.Function.stmtList_setMappingSingle_compiledLegacyCompatible
+  Compiler.Proofs.IRGeneration.Function.stmtList_setMappingUintSingle_compiledLegacyCompatible
+  Compiler.Proofs.IRGeneration.Function.stmtList_setMappingWordSingle_compiledLegacyCompatible
   Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_body_legacyCompatible_of_interface
   Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_body_legacyCompatible_of_compileCore
   Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_body_legacyCompatible_of_terminalCore
@@ -5967,4 +5976,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5597 theorems/lemmas (3868 public, 1729 private, 0 sorry'd)
+-- Total: 5606 theorems/lemmas (3873 public, 1733 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- Proves `StmtListCompiledLegacyCompatible` packages for singleton storage write heads:
  - `Stmt.setStorage`
  - `Stmt.setStorageAddr`
- Proves `StmtListCompiledLegacyCompatible` packages for ordinary single-key mapping write heads:
  - `Stmt.setMapping`
  - `Stmt.setMappingUint`
  - `Stmt.setMappingWord`
- Adds small structural legacy-compatible Yul-list helpers for value/key binding blocks used by mapping-slot writes.
- Regenerates `PrintAxioms.lean` for the new theorem/audit entries.

## Stack / base
- Base: `paloma/issue-2080-legacy-compatible-stmt-phase31`
- Depends on #2134.
- Inherits #2128 through #2134.

Do not merge until predecessor stack is merged/green.

## Validation
- `git diff --check` passed.
- `lean-slot lake build Compiler.Proofs.IRGeneration.Function` passed locally after `lean-slot` offload returned HTTP 403 for this mission path.
- `lean-slot lake build Compiler.Proofs.IRGeneration.Contract` passed.
- `lean-slot lake build PrintAxioms` passed.
- `python3 scripts/generate_print_axioms.py --check` passed.
- `python3 scripts/check_proof_length.py` passed.
- `rg -n "\\b(sorry|admit|axiom)\\b" Compiler/Proofs/IRGeneration/Function.lean` produced no matches.

## Remaining #2080 gate
The full `SupportedStmtList` singleton/structured surface is still not completely discharged. Remaining useful slices include mapping-chain/two-key and packed/struct-member mapping writes, event heads, ECM-specific heads, and additional structured supported-fragment cases beyond the compile-core/terminal-core and storage/mapping singleton packages now present.

Refs #2080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only changes in `Compiler/Proofs/IRGeneration/Function.lean` with no runtime compiler or contract emission changes.
> 
> **Overview**
> Extends the **#2080** legacy-Yul discharge by proving that single-statement lists for **scalar storage** (`setStorage`, `setStorageAddr` with one resolved slot) and **single-key mapping** writes (`setMapping`, `setMappingUint`, `setMappingWord`) satisfy `StmtListCompiledLegacyCompatible`—so their compiled IR stays in `LegacyCompatibleExternalStmtList`.
> 
> Adds private structural lemmas for legacy-compatible Yul built from `__compat_value` / `__compat_key` binding blocks and call-shaped `exprStmt` lists (used when `compileMappingSlotWrite` emits multi-statement blocks). **`PrintAxioms.lean`** is regenerated to register the new public theorems and commented private helpers in the audit list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3ad54df194a3c3242ef6a9ebc193005f6de8223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->