### PR TITLE
ci: preserve Lean comment context in OCR routing

### DIFF
--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -848,6 +848,13 @@ function changedInterpolationLineText(text, state, options = {}) {
         outerStringEscaped = false;
       } else if (ch === '\\') {
         outerStringEscaped = true;
+      } else if (ch === '{') {
+        interpolationDepth = 1;
+        interpolationString = false;
+        interpolationChar = false;
+        interpolationEscaped = false;
+        interpolationCommentDepth = 0;
+        inOuterStringTail = false;
       } else if (ch === '"') {
         inOuterStringTail = false;
       }

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -777,8 +777,12 @@ function codeLinesForHunkSide(hunk, side, options = {}) {
   let stringEscaped = false;
   let inStringInterpolated = false;
   let stringInterpolationState = null;
+  let pendingChangedInterpolation = false;
   for (const line of hunk.lines || []) {
     if (line.type === skipType) continue;
+    if (line.type === includeType && isOpenInterpolationState({ inStringInterpolated, stringInterpolationState })) {
+      pendingChangedInterpolation = true;
+    }
     const stripped = stripLeanCommentsFromLine(line.text, {
       commentDepth,
       inString,
@@ -791,9 +795,41 @@ function codeLinesForHunkSide(hunk, side, options = {}) {
     stringEscaped = stripped.stringEscaped;
     inStringInterpolated = stripped.inStringInterpolated;
     stringInterpolationState = stripped.stringInterpolationState;
-    if (line.type === includeType && stripped.code.trim()) code.push(stripped.code);
+    if (line.type === includeType && isOpenInterpolationState(stripped)) {
+      pendingChangedInterpolation = true;
+    }
+    if ((line.type === includeType || (pendingChangedInterpolation && stripped.emittedInterpolationCode)) && stripped.code.trim()) {
+      code.push(stripped.code);
+    }
+    if (stripped.emittedInterpolationCode || !isOpenInterpolationState(stripped)) {
+      pendingChangedInterpolation = false;
+    }
   }
   return code;
+}
+
+function isOpenInterpolationState(state) {
+  return Boolean(
+    state?.inStringInterpolated &&
+    Number(state?.stringInterpolationState?.interpolationDepth || 0) > 0
+  );
+}
+
+function stripLeanCommentsFromText(text, state, depth = 0, options = {}) {
+  let nextState = state;
+  let emittedInterpolationCode = false;
+  const code = [];
+  for (const line of String(text || '').split('\n')) {
+    const stripped = stripLeanCommentsFromLine(line, nextState, depth, options);
+    nextState = stripped;
+    emittedInterpolationCode = emittedInterpolationCode || Boolean(stripped.emittedInterpolationCode);
+    if (stripped.code.trim()) code.push(stripped.code);
+  }
+  return {
+    ...nextState,
+    code: code.join('\n'),
+    emittedInterpolationCode,
+  };
 }
 
 function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
@@ -807,9 +843,11 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
       stringEscaped: Boolean(state.stringEscaped),
       inStringInterpolated: Boolean(state.inStringInterpolated),
       stringInterpolationState: state.stringInterpolationState || null,
+      emittedInterpolationCode: false,
     };
   }
   let code = '';
+  let emittedInterpolationCode = false;
   let commentDepth = Number(state.commentDepth || 0);
   let inString = Boolean(state.inString);
   let stringEscaped = Boolean(state.stringEscaped);
@@ -825,6 +863,7 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
       if (inStringInterpolated) {
         const stringResult = scanLeanString(text, -1, true, depth + 1, stringInterpolationState);
         code += options.preserveStrings ? text.slice(0, stringResult.nextIndex) : stringResult.code;
+        emittedInterpolationCode = emittedInterpolationCode || Boolean(stringResult.emittedInterpolationCode);
         i = stringResult.nextIndex;
         if (stringResult.closed) {
           inString = false;
@@ -866,6 +905,7 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
       const interpolated = /[A-Za-z]!$/.test(text.slice(0, i));
       const stringResult = scanLeanString(text, i, interpolated, depth + 1);
       code += options.preserveStrings ? text.slice(i, stringResult.nextIndex) : stringResult.code;
+      emittedInterpolationCode = emittedInterpolationCode || Boolean(stringResult.emittedInterpolationCode);
       i = stringResult.nextIndex;
       if (!stringResult.closed) {
         inString = true;
@@ -877,7 +917,7 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
     }
 
     if (ch === '-' && next === '-') {
-      return { code, inBlockComment: false, commentDepth: 0, inString, stringEscaped, inStringInterpolated, stringInterpolationState };
+      return { code, inBlockComment: false, commentDepth: 0, inString, stringEscaped, inStringInterpolated, stringInterpolationState, emittedInterpolationCode };
     }
 
     if (ch === '/' && next === '-') {
@@ -890,15 +930,16 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
     i += 1;
   }
 
-  return { code, inBlockComment: commentDepth > 0, commentDepth, inString, stringEscaped, inStringInterpolated, stringInterpolationState };
+  return { code, inBlockComment: commentDepth > 0, commentDepth, inString, stringEscaped, inStringInterpolated, stringInterpolationState, emittedInterpolationCode };
 }
 
 function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState = null) {
-  if (depth > 8) return { code: quoteIndex >= 0 ? '""' : '', nextIndex: Math.max(0, quoteIndex + 1), closed: false, escaped: false, state: null };
+  if (depth > 8) return { code: quoteIndex >= 0 ? '""' : '', nextIndex: Math.max(0, quoteIndex + 1), closed: false, escaped: false, state: null, emittedInterpolationCode: false };
   let code = quoteIndex >= 0 ? '""' : '';
   let i = quoteIndex >= 0 ? quoteIndex + 1 : 0;
   let escaped = Boolean(initialState?.escaped);
   let closed = false;
+  let emittedInterpolationCode = false;
   let interpolationDepth = Number(initialState?.interpolationDepth || 0);
   let interpolation = String(initialState?.interpolation || '');
   let interpolationString = Boolean(initialState?.interpolationString);
@@ -949,7 +990,7 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState 
         continue;
       }
       if (ch === '-' && next === '-') {
-        interpolation += text.slice(i);
+        interpolation += `${text.slice(i)}\n`;
         i = text.length;
         continue;
       }
@@ -965,7 +1006,9 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState 
         interpolationDepth -= 1;
         if (interpolationDepth === 0) {
           interpolation = interpolation.slice(0, -1);
-          code += ` ${stripLeanCommentsFromLine(interpolation, { commentDepth: 0 }, depth + 1).code} `;
+          const strippedInterpolation = stripLeanCommentsFromText(interpolation, { commentDepth: 0 }, depth + 1);
+          code += ` ${strippedInterpolation.code} `;
+          emittedInterpolationCode = true;
           interpolation = '';
         }
       }
@@ -1008,6 +1051,7 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState 
       interpolationEscaped,
       interpolationCommentDepth,
     },
+    emittedInterpolationCode,
   };
 }
 

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -745,25 +745,25 @@ function scorePathRisk(filePath) {
 function detectSignals(file, hunk) {
   const signals = new Map();
   const add = (name, weight) => signals.set(name, { name, weight: Math.max(weight, signals.get(name)?.weight || 0) });
-  const addedCode = codeLinesForHunkSide(hunk, 'new');
-  const deletedCode = codeLinesForHunkSide(hunk, 'old');
-  const addedStatements = codeLinesForHunkSide(hunk, 'new', { preserveStrings: true });
-  const deletedStatements = codeLinesForHunkSide(hunk, 'old', { preserveStrings: true });
-  const allChanged = [...addedCode, ...deletedCode];
-  const allChangedStatements = [...addedStatements, ...deletedStatements];
+  const addedRiskCode = codeLinesForHunkSide(hunk, 'new');
+  const deletedRiskCode = codeLinesForHunkSide(hunk, 'old');
+  const addedStatementText = statementLinesForHunkSide(hunk, 'new');
+  const deletedStatementText = statementLinesForHunkSide(hunk, 'old');
+  const allChangedRiskCode = [...addedRiskCode, ...deletedRiskCode];
+  const allChangedStatementText = [...addedStatementText, ...deletedStatementText];
 
-  if (addedCode.some(line => /\b(sorry|admit)\b/.test(line))) add('introduced sorry/admit', 80);
-  if (addedCode.some(line => /^\s*axiom\b/.test(line) || /\baxiom\b/.test(line))) add('introduced/changed axiom', 75);
-  if (addedCode.some(line => /\bunsafe\b/.test(line))) add('introduced unsafe', 55);
-  if (allChanged.some(line => /^\s*import\s+/.test(line))) add('changed imports', 30);
-  if (allChangedStatements.some(line => publicDeclPattern().test(line))) add('public declaration/signature changed', 34);
+  if (addedRiskCode.some(line => /\b(sorry|admit)\b/.test(line))) add('introduced sorry/admit', 80);
+  if (addedRiskCode.some(line => /^\s*axiom\b/.test(line) || /\baxiom\b/.test(line))) add('introduced/changed axiom', 75);
+  if (addedRiskCode.some(line => /\bunsafe\b/.test(line))) add('introduced unsafe', 55);
+  if (allChangedRiskCode.some(line => /^\s*import\s+/.test(line))) add('changed imports', 30);
+  if (allChangedStatementText.some(line => publicDeclPattern().test(line))) add('public declaration/signature changed', 34);
   if (file.category === 'trust-doc') add('trust-boundary docs drift', 38);
   if (file.category === 'doc' && /(trust|axiom|audit|sound|semantic|proof)/i.test(file.path)) add('trust/proof docs drift', 25);
-  if (deletedCode.length >= 80 || deletedCode.join('\n').length > 6000) add('large deleted proof obligation', 35);
-  if (deletedStatements.some(line => publicDeclPattern().test(line)) && addedStatements.some(line => publicDeclPattern().test(line))) {
+  if (deletedRiskCode.length >= 80 || deletedRiskCode.join('\n').length > 6000) add('large deleted proof obligation', 35);
+  if (deletedStatementText.some(line => publicDeclPattern().test(line)) && addedStatementText.some(line => publicDeclPattern().test(line))) {
     add('theorem/public statement changed', 45);
   }
-  if (changedTheoremStatements(deletedStatements, addedStatements).length > 0) add('theorem statement changed/possibly weakened', 65);
+  if (changedTheoremStatements(deletedStatementText, addedStatementText).length > 0) add('theorem statement changed/possibly weakened', 65);
 
   return [...signals.values()].sort((a, b) => b.weight - a.weight || a.name.localeCompare(b.name));
 }
@@ -777,6 +777,10 @@ function codeLinesForHunkSide(hunk, side, options = {}) {
     scanner.scanLine(line.text, line.type === includeType);
   }
   return scanner.finish();
+}
+
+function statementLinesForHunkSide(hunk, side) {
+  return codeLinesForHunkSide(hunk, side, { preserveStrings: true });
 }
 
 function createLeanChangedCodeScanner(options = {}) {
@@ -896,7 +900,7 @@ function createLeanChangedCodeScanner(options = {}) {
         openInterpolation();
         return 1;
       }
-      if (ch === '"') {
+      if (!string.rawTerminator && ch === '"') {
         if (options.preserveStrings) emit(ch, include);
         remember(ch);
         string = null;

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -837,12 +837,26 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0) {
   let interpolationString = false;
   let interpolationChar = false;
   let interpolationEscaped = false;
+  let interpolationCommentDepth = 0;
   while (i < text.length) {
     const ch = text[i];
     i += 1;
 
     if (interpolationDepth > 0) {
       interpolation += ch;
+      const next = text[i];
+      if (interpolationCommentDepth > 0) {
+        if (ch === '/' && next === '-') {
+          interpolation += next;
+          i += 1;
+          interpolationCommentDepth += 1;
+        } else if (ch === '-' && next === '/') {
+          interpolation += next;
+          i += 1;
+          interpolationCommentDepth -= 1;
+        }
+        continue;
+      }
       if (interpolationEscaped) {
         interpolationEscaped = false;
         continue;
@@ -865,6 +879,17 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0) {
       }
       if (ch === "'" && startsLeanCharLiteral(interpolation, interpolation.length - 1)) {
         interpolationChar = true;
+        continue;
+      }
+      if (ch === '-' && next === '-') {
+        interpolation += text.slice(i);
+        i = text.length;
+        continue;
+      }
+      if (ch === '/' && next === '-') {
+        interpolation += next;
+        i += 1;
+        interpolationCommentDepth = 1;
         continue;
       }
       if (ch === '{') {
@@ -894,6 +919,7 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0) {
       interpolationString = false;
       interpolationChar = false;
       interpolationEscaped = false;
+      interpolationCommentDepth = 0;
       continue;
     }
     if (ch === '"') break;

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -745,10 +745,8 @@ function scorePathRisk(filePath) {
 function detectSignals(file, hunk) {
   const signals = new Map();
   const add = (name, weight) => signals.set(name, { name, weight: Math.max(weight, signals.get(name)?.weight || 0) });
-  const added = hunk.lines.filter(l => l.type === 'add').map(l => l.text);
-  const deleted = hunk.lines.filter(l => l.type === 'del').map(l => l.text);
-  const addedCode = codeLines(added);
-  const deletedCode = codeLines(deleted);
+  const addedCode = codeLinesForHunkSide(hunk, 'new');
+  const deletedCode = codeLinesForHunkSide(hunk, 'old');
   const allChanged = [...addedCode, ...deletedCode];
 
   if (addedCode.some(line => /\b(sorry|admit)\b/.test(line))) add('introduced sorry/admit', 80);
@@ -767,50 +765,144 @@ function detectSignals(file, hunk) {
   return [...signals.values()].sort((a, b) => b.weight - a.weight || a.name.localeCompare(b.name));
 }
 
-function codeLines(lines) {
+function codeLinesForHunkSide(hunk, side) {
+  const includeType = side === 'old' ? 'del' : 'add';
+  const skipType = side === 'old' ? 'add' : 'del';
   const code = [];
-  let inBlockComment = false;
-  for (const line of lines) {
-    const stripped = stripLeanCommentsFromLine(line, { inBlockComment });
-    inBlockComment = stripped.inBlockComment;
-    if (stripped.code.trim()) code.push(stripped.code);
+  let commentDepth = 0;
+  for (const line of hunk.lines || []) {
+    if (line.type === skipType) continue;
+    const stripped = stripLeanCommentsFromLine(line.text, { commentDepth });
+    commentDepth = stripped.commentDepth;
+    if (line.type === includeType && stripped.code.trim()) code.push(stripped.code);
   }
   return code;
 }
 
-function stripLeanCommentsFromLine(line, state) {
-  let rest = String(line || '');
+function stripLeanCommentsFromLine(line, state, depth = 0) {
+  const text = String(line || '');
+  if (depth > 8) return { code: '', inBlockComment: Boolean(state.commentDepth), commentDepth: Number(state.commentDepth || 0) };
   let code = '';
-  let inBlockComment = Boolean(state.inBlockComment);
+  let commentDepth = Number(state.commentDepth || 0);
+  let i = 0;
 
-  while (rest) {
-    if (inBlockComment) {
-      const blockEnd = rest.indexOf('-/');
-      if (blockEnd === -1) return { code, inBlockComment: true };
-      rest = rest.slice(blockEnd + 2);
-      inBlockComment = false;
+  while (i < text.length) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (commentDepth > 0) {
+      if (ch === '/' && next === '-') {
+        commentDepth += 1;
+        i += 2;
+      } else if (ch === '-' && next === '/') {
+        commentDepth -= 1;
+        i += 2;
+      } else {
+        i += 1;
+      }
       continue;
     }
 
-    const lineComment = rest.indexOf('--');
-    const blockStart = rest.indexOf('/-');
-    if (lineComment !== -1 && (blockStart === -1 || lineComment < blockStart)) {
-      code += rest.slice(0, lineComment);
-      return { code, inBlockComment: false };
-    }
-    if (blockStart === -1) {
-      code += rest;
-      return { code, inBlockComment: false };
+    if (ch === '"') {
+      const stringResult = scanLeanString(text, i, /[A-Za-z]!$/.test(text.slice(0, i)), depth + 1);
+      code += stringResult.code;
+      i = stringResult.nextIndex;
+      continue;
     }
 
-    code += rest.slice(0, blockStart);
-    rest = rest.slice(blockStart + 2);
-    const blockEnd = rest.indexOf('-/');
-    if (blockEnd === -1) return { code, inBlockComment: true };
-    rest = rest.slice(blockEnd + 2);
+    if (ch === '-' && next === '-') {
+      return { code, inBlockComment: false, commentDepth: 0 };
+    }
+
+    if (ch === '/' && next === '-') {
+      commentDepth = 1;
+      i += 2;
+      continue;
+    }
+
+    code += ch;
+    i += 1;
   }
 
-  return { code, inBlockComment };
+  return { code, inBlockComment: commentDepth > 0, commentDepth };
+}
+
+function scanLeanString(text, quoteIndex, interpolated, depth = 0) {
+  if (depth > 8) return { code: '""', nextIndex: quoteIndex + 1 };
+  let code = '""';
+  let i = quoteIndex + 1;
+  let escaped = false;
+  let interpolationDepth = 0;
+  let interpolation = '';
+  let interpolationString = false;
+  let interpolationChar = false;
+  let interpolationEscaped = false;
+  while (i < text.length) {
+    const ch = text[i];
+    i += 1;
+
+    if (interpolationDepth > 0) {
+      interpolation += ch;
+      if (interpolationEscaped) {
+        interpolationEscaped = false;
+        continue;
+      }
+      if (ch === '\\') {
+        interpolationEscaped = interpolationString || interpolationChar;
+        continue;
+      }
+      if (interpolationString) {
+        if (ch === '"') interpolationString = false;
+        continue;
+      }
+      if (interpolationChar) {
+        if (ch === "'") interpolationChar = false;
+        continue;
+      }
+      if (ch === '"') {
+        interpolationString = true;
+        continue;
+      }
+      if (ch === "'" && !isLeanIdentContinue(interpolation[interpolation.length - 2] || '')) {
+        interpolationChar = true;
+        continue;
+      }
+      if (ch === '{') {
+        interpolationDepth += 1;
+      } else if (ch === '}') {
+        interpolationDepth -= 1;
+        if (interpolationDepth === 0) {
+          interpolation = interpolation.slice(0, -1);
+          code += ` ${stripLeanCommentsFromLine(interpolation, { commentDepth: 0 }, depth + 1).code} `;
+          interpolation = '';
+        }
+      }
+      continue;
+    }
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (interpolated && ch === '{') {
+      interpolationDepth = 1;
+      interpolation = '';
+      interpolationString = false;
+      interpolationChar = false;
+      interpolationEscaped = false;
+      continue;
+    }
+    if (ch === '"') break;
+  }
+  return { code, nextIndex: i };
+}
+
+function isLeanIdentContinue(ch) {
+  return /^[\p{L}\p{N}\p{M}_]$/u.test(ch);
 }
 
 function publicDeclPattern() {

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -775,12 +775,22 @@ function codeLinesForHunkSide(hunk, side, options = {}) {
   let commentDepth = 0;
   let inString = false;
   let stringEscaped = false;
+  let inStringInterpolated = false;
+  let stringInterpolationState = null;
   for (const line of hunk.lines || []) {
     if (line.type === skipType) continue;
-    const stripped = stripLeanCommentsFromLine(line.text, { commentDepth, inString, stringEscaped }, 0, options);
+    const stripped = stripLeanCommentsFromLine(line.text, {
+      commentDepth,
+      inString,
+      stringEscaped,
+      inStringInterpolated,
+      stringInterpolationState,
+    }, 0, options);
     commentDepth = stripped.commentDepth;
     inString = stripped.inString;
     stringEscaped = stripped.stringEscaped;
+    inStringInterpolated = stripped.inStringInterpolated;
+    stringInterpolationState = stripped.stringInterpolationState;
     if (line.type === includeType && stripped.code.trim()) code.push(stripped.code);
   }
   return code;
@@ -795,12 +805,16 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
       commentDepth: Number(state.commentDepth || 0),
       inString: Boolean(state.inString),
       stringEscaped: Boolean(state.stringEscaped),
+      inStringInterpolated: Boolean(state.inStringInterpolated),
+      stringInterpolationState: state.stringInterpolationState || null,
     };
   }
   let code = '';
   let commentDepth = Number(state.commentDepth || 0);
   let inString = Boolean(state.inString);
   let stringEscaped = Boolean(state.stringEscaped);
+  let inStringInterpolated = Boolean(state.inStringInterpolated);
+  let stringInterpolationState = state.stringInterpolationState || null;
   let i = 0;
 
   while (i < text.length) {
@@ -808,6 +822,21 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
     const next = text[i + 1];
 
     if (inString) {
+      if (inStringInterpolated) {
+        const stringResult = scanLeanString(text, -1, true, depth + 1, stringInterpolationState);
+        code += options.preserveStrings ? text.slice(0, stringResult.nextIndex) : stringResult.code;
+        i = stringResult.nextIndex;
+        if (stringResult.closed) {
+          inString = false;
+          stringEscaped = false;
+          inStringInterpolated = false;
+          stringInterpolationState = null;
+        } else {
+          stringEscaped = Boolean(stringResult.escaped);
+          stringInterpolationState = stringResult.state;
+        }
+        continue;
+      }
       if (options.preserveStrings) code += ch;
       i += 1;
       if (stringEscaped) {
@@ -834,18 +863,21 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
     }
 
     if (ch === '"') {
-      const stringResult = scanLeanString(text, i, /[A-Za-z]!$/.test(text.slice(0, i)), depth + 1);
+      const interpolated = /[A-Za-z]!$/.test(text.slice(0, i));
+      const stringResult = scanLeanString(text, i, interpolated, depth + 1);
       code += options.preserveStrings ? text.slice(i, stringResult.nextIndex) : stringResult.code;
       i = stringResult.nextIndex;
       if (!stringResult.closed) {
         inString = true;
         stringEscaped = Boolean(stringResult.escaped);
+        inStringInterpolated = interpolated;
+        stringInterpolationState = stringResult.state;
       }
       continue;
     }
 
     if (ch === '-' && next === '-') {
-      return { code, inBlockComment: false, commentDepth: 0, inString, stringEscaped };
+      return { code, inBlockComment: false, commentDepth: 0, inString, stringEscaped, inStringInterpolated, stringInterpolationState };
     }
 
     if (ch === '/' && next === '-') {
@@ -858,21 +890,21 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
     i += 1;
   }
 
-  return { code, inBlockComment: commentDepth > 0, commentDepth, inString, stringEscaped };
+  return { code, inBlockComment: commentDepth > 0, commentDepth, inString, stringEscaped, inStringInterpolated, stringInterpolationState };
 }
 
-function scanLeanString(text, quoteIndex, interpolated, depth = 0) {
-  if (depth > 8) return { code: '""', nextIndex: quoteIndex + 1, closed: false, escaped: false };
-  let code = '""';
-  let i = quoteIndex + 1;
-  let escaped = false;
+function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState = null) {
+  if (depth > 8) return { code: quoteIndex >= 0 ? '""' : '', nextIndex: Math.max(0, quoteIndex + 1), closed: false, escaped: false, state: null };
+  let code = quoteIndex >= 0 ? '""' : '';
+  let i = quoteIndex >= 0 ? quoteIndex + 1 : 0;
+  let escaped = Boolean(initialState?.escaped);
   let closed = false;
-  let interpolationDepth = 0;
-  let interpolation = '';
-  let interpolationString = false;
-  let interpolationChar = false;
-  let interpolationEscaped = false;
-  let interpolationCommentDepth = 0;
+  let interpolationDepth = Number(initialState?.interpolationDepth || 0);
+  let interpolation = String(initialState?.interpolation || '');
+  let interpolationString = Boolean(initialState?.interpolationString);
+  let interpolationChar = Boolean(initialState?.interpolationChar);
+  let interpolationEscaped = Boolean(initialState?.interpolationEscaped);
+  let interpolationCommentDepth = Number(initialState?.interpolationCommentDepth || 0);
   while (i < text.length) {
     const ch = text[i];
     i += 1;
@@ -962,7 +994,21 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0) {
       break;
     }
   }
-  return { code, nextIndex: i, closed, escaped };
+  return {
+    code,
+    nextIndex: i,
+    closed,
+    escaped,
+    state: {
+      escaped,
+      interpolationDepth,
+      interpolation,
+      interpolationString,
+      interpolationChar,
+      interpolationEscaped,
+      interpolationCommentDepth,
+    },
+  };
 }
 
 function isLeanIdentContinue(ch) {

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -863,7 +863,7 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0) {
         interpolationString = true;
         continue;
       }
-      if (ch === "'" && !isLeanIdentContinue(interpolation[interpolation.length - 2] || '')) {
+      if (ch === "'" && startsLeanCharLiteral(interpolation, interpolation.length - 1)) {
         interpolationChar = true;
         continue;
       }
@@ -903,6 +903,17 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0) {
 
 function isLeanIdentContinue(ch) {
   return /^[\p{L}\p{N}\p{M}_]$/u.test(ch);
+}
+
+function startsLeanCharLiteral(text, quoteIndex) {
+  const previous = previousCodePoint(text, quoteIndex);
+  return previous !== "'" && !isLeanIdentContinue(previous);
+}
+
+function previousCodePoint(text, index) {
+  if (index <= 0) return '';
+  const points = Array.from(text.slice(0, index));
+  return points[points.length - 1] || '';
 }
 
 function publicDeclPattern() {

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -805,6 +805,13 @@ function codeLinesForHunkSide(hunk, side, options = {}) {
       pendingChangedInterpolation = false;
     }
   }
+  if (pendingChangedInterpolation && isOpenInterpolationState({ inStringInterpolated, stringInterpolationState })) {
+    const strippedInterpolation = stripLeanCommentsFromText(
+      stringInterpolationState.interpolation,
+      { commentDepth: 0 }
+    );
+    if (strippedInterpolation.code.trim()) code.push(strippedInterpolation.code);
+  }
   return code;
 }
 

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -784,7 +784,7 @@ function codeLinesForHunkSide(hunk, side, options = {}) {
     const wasOpenInterpolation = isOpenInterpolationState({ inStringInterpolated, stringInterpolationState });
     if (line.type === includeType && wasOpenInterpolation) {
       pendingChangedInterpolation = true;
-      pendingChangedInterpolationText += `${line.text}\n`;
+      pendingChangedInterpolationText += changedInterpolationLineText(line.text, stringInterpolationState, options);
     }
     const stripped = stripLeanCommentsFromLine(line.text, {
       commentDepth,
@@ -801,7 +801,7 @@ function codeLinesForHunkSide(hunk, side, options = {}) {
     if (line.type === includeType && isOpenInterpolationState(stripped)) {
       pendingChangedInterpolation = true;
     }
-    if (line.type === includeType && stripped.code.trim()) {
+    if (line.type === includeType && stripped.code.trim() && !wasOpenInterpolation) {
       code.push(stripped.code);
     } else if (pendingChangedInterpolation && !isOpenInterpolationState(stripped) && pendingChangedInterpolationText.trim()) {
       const changedInterpolation = stripLeanCommentsFromText(
@@ -827,6 +827,20 @@ function codeLinesForHunkSide(hunk, side, options = {}) {
     if (strippedInterpolation.code.trim()) code.push(strippedInterpolation.code);
   }
   return code;
+}
+
+function changedInterpolationLineText(text, state, options = {}) {
+  if (Number(state?.interpolationCommentDepth || 0) > 0) {
+    const stripped = stripLeanCommentsFromLine(
+      text,
+      { commentDepth: Number(state.interpolationCommentDepth || 0) },
+      0,
+      options
+    );
+    return stripped.code.trim() ? `${stripped.code}\n` : '';
+  }
+  if (state?.interpolationString || state?.interpolationChar) return '';
+  return `${text}\n`;
 }
 
 function isOpenInterpolationState(state) {

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -802,8 +802,14 @@ function createLeanChangedCodeScanner(options = {}) {
     current = '';
   };
   const inInterpolationCode = () => interpolationFrames.length > 0 && !string;
-  const openString = interpolated => {
-    string = { interpolated, escaped: false };
+  const rememberText = text => {
+    for (const ch of String(text || '')) remember(ch);
+  };
+  const emitText = (text, include) => {
+    if (include) current += text;
+  };
+  const openString = (interpolated, rawTerminator = null) => {
+    string = { interpolated, escaped: false, rawTerminator };
   };
   const openInterpolation = () => {
     interpolationFrames.push({ braceDepth: 1, returnString: string ? { ...string, escaped: false } : null });
@@ -861,6 +867,18 @@ function createLeanChangedCodeScanner(options = {}) {
     }
 
     if (string) {
+      if (string.rawTerminator) {
+        if (ch === '"' && text.slice(index, index + string.rawTerminator.length) === string.rawTerminator) {
+          const length = string.rawTerminator.length;
+          if (options.preserveStrings) emitText(string.rawTerminator, include);
+          rememberText(string.rawTerminator);
+          string = null;
+          return length;
+        }
+        if (options.preserveStrings) emit(ch, include);
+        remember(ch);
+        return 1;
+      }
       if (string.escaped) {
         if (options.preserveStrings) emit(ch, include);
         remember(ch);
@@ -904,10 +922,11 @@ function createLeanChangedCodeScanner(options = {}) {
       return 1;
     }
     if (ch === '"') {
+      const rawTerminator = rawStringTerminatorBeforeQuote(prefix);
       const interpolated = /[A-Za-z]!$/.test(prefix);
       if (options.preserveStrings) emit(ch, include);
       remember(ch);
-      openString(interpolated);
+      openString(interpolated && !rawTerminator, rawTerminator);
       return 1;
     }
     if (ch === "'" && startsLeanCharLiteral(text, index)) {
@@ -950,6 +969,12 @@ function createLeanChangedCodeScanner(options = {}) {
 
 function isLeanIdentContinue(ch) {
   return /^[\p{L}\p{N}\p{M}_]$/u.test(ch);
+}
+
+function rawStringTerminatorBeforeQuote(prefix) {
+  const match = String(prefix || '').match(/r(#{0,16})$/);
+  if (!match) return null;
+  return `"${match[1]}`;
 }
 
 function startsLeanCharLiteral(text, quoteIndex) {

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -833,6 +833,8 @@ function changedInterpolationLineText(text, state, options = {}) {
   const line = String(text || '');
   let code = '';
   let interpolationString = Boolean(state?.interpolationString);
+  let interpolationStringInterpolated = Boolean(state?.interpolationStringInterpolated);
+  let interpolationStringInterpolationDepth = Number(state?.interpolationStringInterpolationDepth || 0);
   let interpolationChar = Boolean(state?.interpolationChar);
   let interpolationEscaped = Boolean(state?.interpolationEscaped);
   let interpolationCommentDepth = Number(state?.interpolationCommentDepth || 0);
@@ -884,7 +886,24 @@ function changedInterpolationLineText(text, state, options = {}) {
       continue;
     }
     if (interpolationString) {
-      if (ch === '"') interpolationString = false;
+      if (interpolationStringInterpolated && interpolationStringInterpolationDepth > 0) {
+        if (ch === '{') {
+          interpolationStringInterpolationDepth += 1;
+          code += ch;
+        } else if (ch === '}') {
+          interpolationStringInterpolationDepth -= 1;
+        } else {
+          code += ch;
+        }
+        i += 1;
+        continue;
+      }
+      if (interpolationStringInterpolated && ch === '{') {
+        interpolationStringInterpolationDepth = 1;
+      } else if (ch === '"') {
+        interpolationString = false;
+        interpolationStringInterpolated = false;
+      }
       i += 1;
       continue;
     }
@@ -901,6 +920,8 @@ function changedInterpolationLineText(text, state, options = {}) {
     }
     if (ch === '"') {
       interpolationString = true;
+      interpolationStringInterpolated = /[A-Za-z]!$/.test(line.slice(0, i));
+      interpolationStringInterpolationDepth = 0;
       i += 1;
       continue;
     }
@@ -1070,6 +1091,8 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState 
   let interpolationDepth = Number(initialState?.interpolationDepth || 0);
   let interpolation = String(initialState?.interpolation || '');
   let interpolationString = Boolean(initialState?.interpolationString);
+  let interpolationStringInterpolated = Boolean(initialState?.interpolationStringInterpolated);
+  let interpolationStringInterpolationDepth = Number(initialState?.interpolationStringInterpolationDepth || 0);
   let interpolationChar = Boolean(initialState?.interpolationChar);
   let interpolationEscaped = Boolean(initialState?.interpolationEscaped);
   let interpolationCommentDepth = Number(initialState?.interpolationCommentDepth || 0);
@@ -1101,7 +1124,20 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState 
         continue;
       }
       if (interpolationString) {
-        if (ch === '"') interpolationString = false;
+        if (interpolationStringInterpolated && interpolationStringInterpolationDepth > 0) {
+          if (ch === '{') {
+            interpolationStringInterpolationDepth += 1;
+          } else if (ch === '}') {
+            interpolationStringInterpolationDepth -= 1;
+          }
+          continue;
+        }
+        if (interpolationStringInterpolated && ch === '{') {
+          interpolationStringInterpolationDepth = 1;
+        } else if (ch === '"') {
+          interpolationString = false;
+          interpolationStringInterpolated = false;
+        }
         continue;
       }
       if (interpolationChar) {
@@ -1110,6 +1146,8 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState 
       }
       if (ch === '"') {
         interpolationString = true;
+        interpolationStringInterpolated = /[A-Za-z]!$/.test(interpolation.slice(0, -1));
+        interpolationStringInterpolationDepth = 0;
         continue;
       }
       if (ch === "'" && startsLeanCharLiteral(interpolation, interpolation.length - 1)) {
@@ -1175,6 +1213,8 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState 
       interpolationDepth,
       interpolation,
       interpolationString,
+      interpolationStringInterpolated,
+      interpolationStringInterpolationDepth,
       interpolationChar,
       interpolationEscaped,
       interpolationCommentDepth,

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -830,17 +830,68 @@ function codeLinesForHunkSide(hunk, side, options = {}) {
 }
 
 function changedInterpolationLineText(text, state, options = {}) {
-  if (Number(state?.interpolationCommentDepth || 0) > 0) {
-    const stripped = stripLeanCommentsFromLine(
-      text,
-      { commentDepth: Number(state.interpolationCommentDepth || 0) },
-      0,
-      options
-    );
-    return stripped.code.trim() ? `${stripped.code}\n` : '';
+  const line = String(text || '');
+  let code = '';
+  let interpolationString = Boolean(state?.interpolationString);
+  let interpolationChar = Boolean(state?.interpolationChar);
+  let interpolationEscaped = Boolean(state?.interpolationEscaped);
+  let interpolationCommentDepth = Number(state?.interpolationCommentDepth || 0);
+  let i = 0;
+  while (i < line.length) {
+    const ch = line[i];
+    const next = line[i + 1];
+    if (interpolationCommentDepth > 0) {
+      if (ch === '/' && next === '-') {
+        interpolationCommentDepth += 1;
+        i += 2;
+      } else if (ch === '-' && next === '/') {
+        interpolationCommentDepth -= 1;
+        i += 2;
+      } else {
+        i += 1;
+      }
+      continue;
+    }
+    if (interpolationEscaped) {
+      interpolationEscaped = false;
+      i += 1;
+      continue;
+    }
+    if (ch === '\\' && (interpolationString || interpolationChar)) {
+      interpolationEscaped = true;
+      i += 1;
+      continue;
+    }
+    if (interpolationString) {
+      if (ch === '"') interpolationString = false;
+      i += 1;
+      continue;
+    }
+    if (interpolationChar) {
+      if (ch === "'") interpolationChar = false;
+      i += 1;
+      continue;
+    }
+    if (ch === '-' && next === '-') break;
+    if (ch === '/' && next === '-') {
+      interpolationCommentDepth = 1;
+      i += 2;
+      continue;
+    }
+    if (ch === '"') {
+      interpolationString = true;
+      i += 1;
+      continue;
+    }
+    if (ch === "'" && startsLeanCharLiteral(line, i)) {
+      interpolationChar = true;
+      i += 1;
+      continue;
+    }
+    code += ch;
+    i += 1;
   }
-  if (state?.interpolationString || state?.interpolationChar) return '';
-  return `${text}\n`;
+  return code.trim() ? `${code}\n` : '';
 }
 
 function isOpenInterpolationState(state) {

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -896,6 +896,7 @@ function createLeanChangedCodeScanner(options = {}) {
         return 1;
       }
       if (string.interpolated && ch === '{') {
+        if (options.preserveStrings) emit(ch, include);
         remember(ch);
         openInterpolation();
         return 1;
@@ -947,6 +948,7 @@ function createLeanChangedCodeScanner(options = {}) {
       return 1;
     }
     if (inInterpolationCode() && ch === '}') {
+      if (options.preserveStrings) emit(ch, include);
       remember(ch);
       closeInterpolationBrace();
       return 1;

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -747,48 +747,78 @@ function detectSignals(file, hunk) {
   const add = (name, weight) => signals.set(name, { name, weight: Math.max(weight, signals.get(name)?.weight || 0) });
   const addedCode = codeLinesForHunkSide(hunk, 'new');
   const deletedCode = codeLinesForHunkSide(hunk, 'old');
+  const addedStatements = codeLinesForHunkSide(hunk, 'new', { preserveStrings: true });
+  const deletedStatements = codeLinesForHunkSide(hunk, 'old', { preserveStrings: true });
   const allChanged = [...addedCode, ...deletedCode];
+  const allChangedStatements = [...addedStatements, ...deletedStatements];
 
   if (addedCode.some(line => /\b(sorry|admit)\b/.test(line))) add('introduced sorry/admit', 80);
   if (addedCode.some(line => /^\s*axiom\b/.test(line) || /\baxiom\b/.test(line))) add('introduced/changed axiom', 75);
   if (addedCode.some(line => /\bunsafe\b/.test(line))) add('introduced unsafe', 55);
   if (allChanged.some(line => /^\s*import\s+/.test(line))) add('changed imports', 30);
-  if (allChanged.some(line => publicDeclPattern().test(line))) add('public declaration/signature changed', 34);
+  if (allChangedStatements.some(line => publicDeclPattern().test(line))) add('public declaration/signature changed', 34);
   if (file.category === 'trust-doc') add('trust-boundary docs drift', 38);
   if (file.category === 'doc' && /(trust|axiom|audit|sound|semantic|proof)/i.test(file.path)) add('trust/proof docs drift', 25);
   if (deletedCode.length >= 80 || deletedCode.join('\n').length > 6000) add('large deleted proof obligation', 35);
-  if (deletedCode.some(line => publicDeclPattern().test(line)) && addedCode.some(line => publicDeclPattern().test(line))) {
+  if (deletedStatements.some(line => publicDeclPattern().test(line)) && addedStatements.some(line => publicDeclPattern().test(line))) {
     add('theorem/public statement changed', 45);
   }
-  if (changedTheoremStatements(deletedCode, addedCode).length > 0) add('theorem statement changed/possibly weakened', 65);
+  if (changedTheoremStatements(deletedStatements, addedStatements).length > 0) add('theorem statement changed/possibly weakened', 65);
 
   return [...signals.values()].sort((a, b) => b.weight - a.weight || a.name.localeCompare(b.name));
 }
 
-function codeLinesForHunkSide(hunk, side) {
+function codeLinesForHunkSide(hunk, side, options = {}) {
   const includeType = side === 'old' ? 'del' : 'add';
   const skipType = side === 'old' ? 'add' : 'del';
   const code = [];
   let commentDepth = 0;
+  let inString = false;
+  let stringEscaped = false;
   for (const line of hunk.lines || []) {
     if (line.type === skipType) continue;
-    const stripped = stripLeanCommentsFromLine(line.text, { commentDepth });
+    const stripped = stripLeanCommentsFromLine(line.text, { commentDepth, inString, stringEscaped }, 0, options);
     commentDepth = stripped.commentDepth;
+    inString = stripped.inString;
+    stringEscaped = stripped.stringEscaped;
     if (line.type === includeType && stripped.code.trim()) code.push(stripped.code);
   }
   return code;
 }
 
-function stripLeanCommentsFromLine(line, state, depth = 0) {
+function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
   const text = String(line || '');
-  if (depth > 8) return { code: '', inBlockComment: Boolean(state.commentDepth), commentDepth: Number(state.commentDepth || 0) };
+  if (depth > 8) {
+    return {
+      code: '',
+      inBlockComment: Boolean(state.commentDepth),
+      commentDepth: Number(state.commentDepth || 0),
+      inString: Boolean(state.inString),
+      stringEscaped: Boolean(state.stringEscaped),
+    };
+  }
   let code = '';
   let commentDepth = Number(state.commentDepth || 0);
+  let inString = Boolean(state.inString);
+  let stringEscaped = Boolean(state.stringEscaped);
   let i = 0;
 
   while (i < text.length) {
     const ch = text[i];
     const next = text[i + 1];
+
+    if (inString) {
+      if (options.preserveStrings) code += ch;
+      i += 1;
+      if (stringEscaped) {
+        stringEscaped = false;
+      } else if (ch === '\\') {
+        stringEscaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
 
     if (commentDepth > 0) {
       if (ch === '/' && next === '-') {
@@ -805,13 +835,17 @@ function stripLeanCommentsFromLine(line, state, depth = 0) {
 
     if (ch === '"') {
       const stringResult = scanLeanString(text, i, /[A-Za-z]!$/.test(text.slice(0, i)), depth + 1);
-      code += stringResult.code;
+      code += options.preserveStrings ? text.slice(i, stringResult.nextIndex) : stringResult.code;
       i = stringResult.nextIndex;
+      if (!stringResult.closed) {
+        inString = true;
+        stringEscaped = Boolean(stringResult.escaped);
+      }
       continue;
     }
 
     if (ch === '-' && next === '-') {
-      return { code, inBlockComment: false, commentDepth: 0 };
+      return { code, inBlockComment: false, commentDepth: 0, inString, stringEscaped };
     }
 
     if (ch === '/' && next === '-') {
@@ -824,14 +858,15 @@ function stripLeanCommentsFromLine(line, state, depth = 0) {
     i += 1;
   }
 
-  return { code, inBlockComment: commentDepth > 0, commentDepth };
+  return { code, inBlockComment: commentDepth > 0, commentDepth, inString, stringEscaped };
 }
 
 function scanLeanString(text, quoteIndex, interpolated, depth = 0) {
-  if (depth > 8) return { code: '""', nextIndex: quoteIndex + 1 };
+  if (depth > 8) return { code: '""', nextIndex: quoteIndex + 1, closed: false, escaped: false };
   let code = '""';
   let i = quoteIndex + 1;
   let escaped = false;
+  let closed = false;
   let interpolationDepth = 0;
   let interpolation = '';
   let interpolationString = false;
@@ -922,9 +957,12 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0) {
       interpolationCommentDepth = 0;
       continue;
     }
-    if (ch === '"') break;
+    if (ch === '"') {
+      closed = true;
+      break;
+    }
   }
-  return { code, nextIndex: i };
+  return { code, nextIndex: i, closed, escaped };
 }
 
 function isLeanIdentContinue(ch) {

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -778,10 +778,13 @@ function codeLinesForHunkSide(hunk, side, options = {}) {
   let inStringInterpolated = false;
   let stringInterpolationState = null;
   let pendingChangedInterpolation = false;
+  let pendingChangedInterpolationText = '';
   for (const line of hunk.lines || []) {
     if (line.type === skipType) continue;
-    if (line.type === includeType && isOpenInterpolationState({ inStringInterpolated, stringInterpolationState })) {
+    const wasOpenInterpolation = isOpenInterpolationState({ inStringInterpolated, stringInterpolationState });
+    if (line.type === includeType && wasOpenInterpolation) {
       pendingChangedInterpolation = true;
+      pendingChangedInterpolationText += `${line.text}\n`;
     }
     const stripped = stripLeanCommentsFromLine(line.text, {
       commentDepth,
@@ -800,17 +803,26 @@ function codeLinesForHunkSide(hunk, side, options = {}) {
     }
     if (line.type === includeType && stripped.code.trim()) {
       code.push(stripped.code);
-    } else if (pendingChangedInterpolation && stripped.emittedInterpolationCodeText?.trim()) {
-      code.push(stripped.emittedInterpolationCodeText);
+    } else if (pendingChangedInterpolation && !isOpenInterpolationState(stripped) && pendingChangedInterpolationText.trim()) {
+      const changedInterpolation = stripLeanCommentsFromText(
+        pendingChangedInterpolationText,
+        { commentDepth: 0 },
+        0,
+        options
+      );
+      if (changedInterpolation.code.trim()) code.push(changedInterpolation.code);
     }
     if (stripped.emittedInterpolationCode || !isOpenInterpolationState(stripped)) {
       pendingChangedInterpolation = false;
+      pendingChangedInterpolationText = '';
     }
   }
   if (pendingChangedInterpolation && isOpenInterpolationState({ inStringInterpolated, stringInterpolationState })) {
     const strippedInterpolation = stripLeanCommentsFromText(
-      stringInterpolationState.interpolation,
-      { commentDepth: 0 }
+      pendingChangedInterpolationText || stringInterpolationState.interpolation,
+      { commentDepth: 0 },
+      0,
+      options
     );
     if (strippedInterpolation.code.trim()) code.push(strippedInterpolation.code);
   }

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -836,10 +836,24 @@ function changedInterpolationLineText(text, state, options = {}) {
   let interpolationChar = Boolean(state?.interpolationChar);
   let interpolationEscaped = Boolean(state?.interpolationEscaped);
   let interpolationCommentDepth = Number(state?.interpolationCommentDepth || 0);
+  let interpolationDepth = Number(state?.interpolationDepth || 0);
+  let inOuterStringTail = interpolationDepth <= 0;
+  let outerStringEscaped = false;
   let i = 0;
   while (i < line.length) {
     const ch = line[i];
     const next = line[i + 1];
+    if (inOuterStringTail) {
+      if (outerStringEscaped) {
+        outerStringEscaped = false;
+      } else if (ch === '\\') {
+        outerStringEscaped = true;
+      } else if (ch === '"') {
+        inOuterStringTail = false;
+      }
+      i += 1;
+      continue;
+    }
     if (interpolationCommentDepth > 0) {
       if (ch === '/' && next === '-') {
         interpolationCommentDepth += 1;
@@ -885,6 +899,18 @@ function changedInterpolationLineText(text, state, options = {}) {
     }
     if (ch === "'" && startsLeanCharLiteral(line, i)) {
       interpolationChar = true;
+      i += 1;
+      continue;
+    }
+    if (interpolationDepth > 0 && ch === '{') {
+      interpolationDepth += 1;
+      code += ch;
+      i += 1;
+      continue;
+    }
+    if (interpolationDepth > 0 && ch === '}') {
+      interpolationDepth -= 1;
+      if (interpolationDepth === 0) inOuterStringTail = true;
       i += 1;
       continue;
     }

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -798,8 +798,10 @@ function codeLinesForHunkSide(hunk, side, options = {}) {
     if (line.type === includeType && isOpenInterpolationState(stripped)) {
       pendingChangedInterpolation = true;
     }
-    if ((line.type === includeType || (pendingChangedInterpolation && stripped.emittedInterpolationCode)) && stripped.code.trim()) {
+    if (line.type === includeType && stripped.code.trim()) {
       code.push(stripped.code);
+    } else if (pendingChangedInterpolation && stripped.emittedInterpolationCodeText?.trim()) {
+      code.push(stripped.emittedInterpolationCodeText);
     }
     if (stripped.emittedInterpolationCode || !isOpenInterpolationState(stripped)) {
       pendingChangedInterpolation = false;
@@ -825,17 +827,20 @@ function isOpenInterpolationState(state) {
 function stripLeanCommentsFromText(text, state, depth = 0, options = {}) {
   let nextState = state;
   let emittedInterpolationCode = false;
+  let emittedInterpolationCodeText = '';
   const code = [];
   for (const line of String(text || '').split('\n')) {
     const stripped = stripLeanCommentsFromLine(line, nextState, depth, options);
     nextState = stripped;
     emittedInterpolationCode = emittedInterpolationCode || Boolean(stripped.emittedInterpolationCode);
+    emittedInterpolationCodeText += stripped.emittedInterpolationCodeText || '';
     if (stripped.code.trim()) code.push(stripped.code);
   }
   return {
     ...nextState,
     code: code.join('\n'),
     emittedInterpolationCode,
+    emittedInterpolationCodeText,
   };
 }
 
@@ -851,10 +856,12 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
       inStringInterpolated: Boolean(state.inStringInterpolated),
       stringInterpolationState: state.stringInterpolationState || null,
       emittedInterpolationCode: false,
+      emittedInterpolationCodeText: '',
     };
   }
   let code = '';
   let emittedInterpolationCode = false;
+  let emittedInterpolationCodeText = '';
   let commentDepth = Number(state.commentDepth || 0);
   let inString = Boolean(state.inString);
   let stringEscaped = Boolean(state.stringEscaped);
@@ -871,6 +878,7 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
         const stringResult = scanLeanString(text, -1, true, depth + 1, stringInterpolationState);
         code += options.preserveStrings ? text.slice(0, stringResult.nextIndex) : stringResult.code;
         emittedInterpolationCode = emittedInterpolationCode || Boolean(stringResult.emittedInterpolationCode);
+        emittedInterpolationCodeText += stringResult.emittedInterpolationCodeText || '';
         i = stringResult.nextIndex;
         if (stringResult.closed) {
           inString = false;
@@ -913,6 +921,7 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
       const stringResult = scanLeanString(text, i, interpolated, depth + 1);
       code += options.preserveStrings ? text.slice(i, stringResult.nextIndex) : stringResult.code;
       emittedInterpolationCode = emittedInterpolationCode || Boolean(stringResult.emittedInterpolationCode);
+      emittedInterpolationCodeText += stringResult.emittedInterpolationCodeText || '';
       i = stringResult.nextIndex;
       if (!stringResult.closed) {
         inString = true;
@@ -924,7 +933,7 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
     }
 
     if (ch === '-' && next === '-') {
-      return { code, inBlockComment: false, commentDepth: 0, inString, stringEscaped, inStringInterpolated, stringInterpolationState, emittedInterpolationCode };
+      return { code, inBlockComment: false, commentDepth: 0, inString, stringEscaped, inStringInterpolated, stringInterpolationState, emittedInterpolationCode, emittedInterpolationCodeText };
     }
 
     if (ch === '/' && next === '-') {
@@ -937,16 +946,17 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
     i += 1;
   }
 
-  return { code, inBlockComment: commentDepth > 0, commentDepth, inString, stringEscaped, inStringInterpolated, stringInterpolationState, emittedInterpolationCode };
+  return { code, inBlockComment: commentDepth > 0, commentDepth, inString, stringEscaped, inStringInterpolated, stringInterpolationState, emittedInterpolationCode, emittedInterpolationCodeText };
 }
 
 function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState = null) {
-  if (depth > 8) return { code: quoteIndex >= 0 ? '""' : '', nextIndex: Math.max(0, quoteIndex + 1), closed: false, escaped: false, state: null, emittedInterpolationCode: false };
+  if (depth > 8) return { code: quoteIndex >= 0 ? '""' : '', nextIndex: Math.max(0, quoteIndex + 1), closed: false, escaped: false, state: null, emittedInterpolationCode: false, emittedInterpolationCodeText: '' };
   let code = quoteIndex >= 0 ? '""' : '';
   let i = quoteIndex >= 0 ? quoteIndex + 1 : 0;
   let escaped = Boolean(initialState?.escaped);
   let closed = false;
   let emittedInterpolationCode = false;
+  let emittedInterpolationCodeText = '';
   let interpolationDepth = Number(initialState?.interpolationDepth || 0);
   let interpolation = String(initialState?.interpolation || '');
   let interpolationString = Boolean(initialState?.interpolationString);
@@ -1016,6 +1026,7 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState 
           const strippedInterpolation = stripLeanCommentsFromText(interpolation, { commentDepth: 0 }, depth + 1);
           code += ` ${strippedInterpolation.code} `;
           emittedInterpolationCode = true;
+          emittedInterpolationCodeText += ` ${strippedInterpolation.code} `;
           interpolation = '';
         }
       }
@@ -1059,6 +1070,7 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState 
       interpolationCommentDepth,
     },
     emittedInterpolationCode,
+    emittedInterpolationCodeText,
   };
 }
 

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -777,6 +777,7 @@ function codeLinesForHunkSide(hunk, side, options = {}) {
   let stringEscaped = false;
   let inStringInterpolated = false;
   let stringInterpolationState = null;
+  let inEscapedIdent = false;
   let pendingChangedInterpolation = false;
   let pendingChangedInterpolationText = '';
   for (const line of hunk.lines || []) {
@@ -792,12 +793,14 @@ function codeLinesForHunkSide(hunk, side, options = {}) {
       stringEscaped,
       inStringInterpolated,
       stringInterpolationState,
+      inEscapedIdent,
     }, 0, options);
     commentDepth = stripped.commentDepth;
     inString = stripped.inString;
     stringEscaped = stripped.stringEscaped;
     inStringInterpolated = stripped.inStringInterpolated;
     stringInterpolationState = stripped.stringInterpolationState;
+    inEscapedIdent = stripped.inEscapedIdent;
     if (line.type === includeType && isOpenInterpolationState(stripped)) {
       pendingChangedInterpolation = true;
     }
@@ -838,6 +841,7 @@ function changedInterpolationLineText(text, state, options = {}) {
   let interpolationChar = Boolean(state?.interpolationChar);
   let interpolationEscaped = Boolean(state?.interpolationEscaped);
   let interpolationCommentDepth = Number(state?.interpolationCommentDepth || 0);
+  let interpolationEscapedIdent = Boolean(state?.interpolationEscapedIdent);
   let interpolationDepth = Number(state?.interpolationDepth || 0);
   let inOuterStringTail = interpolationDepth <= 0;
   let outerStringEscaped = false;
@@ -873,6 +877,12 @@ function changedInterpolationLineText(text, state, options = {}) {
       } else {
         i += 1;
       }
+      continue;
+    }
+    if (interpolationEscapedIdent) {
+      if (ch === '»') interpolationEscapedIdent = false;
+      code += ch;
+      i += 1;
       continue;
     }
     if (interpolationEscaped) {
@@ -916,6 +926,12 @@ function changedInterpolationLineText(text, state, options = {}) {
     if (ch === '/' && next === '-') {
       interpolationCommentDepth = 1;
       i += 2;
+      continue;
+    }
+    if (ch === '«') {
+      interpolationEscapedIdent = true;
+      code += ch;
+      i += 1;
       continue;
     }
     if (ch === '"') {
@@ -986,6 +1002,7 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
       stringEscaped: Boolean(state.stringEscaped),
       inStringInterpolated: Boolean(state.inStringInterpolated),
       stringInterpolationState: state.stringInterpolationState || null,
+      inEscapedIdent: Boolean(state.inEscapedIdent),
       emittedInterpolationCode: false,
       emittedInterpolationCodeText: '',
     };
@@ -998,6 +1015,7 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
   let stringEscaped = Boolean(state.stringEscaped);
   let inStringInterpolated = Boolean(state.inStringInterpolated);
   let stringInterpolationState = state.stringInterpolationState || null;
+  let inEscapedIdent = Boolean(state.inEscapedIdent);
   let i = 0;
 
   while (i < text.length) {
@@ -1047,6 +1065,13 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
       continue;
     }
 
+    if (inEscapedIdent) {
+      if (options.preserveStrings) code += ch;
+      if (ch === '»') inEscapedIdent = false;
+      i += 1;
+      continue;
+    }
+
     if (ch === '"') {
       const interpolated = /[A-Za-z]!$/.test(text.slice(0, i));
       const stringResult = scanLeanString(text, i, interpolated, depth + 1);
@@ -1064,7 +1089,7 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
     }
 
     if (ch === '-' && next === '-') {
-      return { code, inBlockComment: false, commentDepth: 0, inString, stringEscaped, inStringInterpolated, stringInterpolationState, emittedInterpolationCode, emittedInterpolationCodeText };
+      return { code, inBlockComment: false, commentDepth: 0, inString, stringEscaped, inStringInterpolated, stringInterpolationState, inEscapedIdent, emittedInterpolationCode, emittedInterpolationCodeText };
     }
 
     if (ch === '/' && next === '-') {
@@ -1073,11 +1098,18 @@ function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
       continue;
     }
 
+    if (ch === '«') {
+      if (options.preserveStrings) code += ch;
+      inEscapedIdent = true;
+      i += 1;
+      continue;
+    }
+
     code += ch;
     i += 1;
   }
 
-  return { code, inBlockComment: commentDepth > 0, commentDepth, inString, stringEscaped, inStringInterpolated, stringInterpolationState, emittedInterpolationCode, emittedInterpolationCodeText };
+  return { code, inBlockComment: commentDepth > 0, commentDepth, inString, stringEscaped, inStringInterpolated, stringInterpolationState, inEscapedIdent, emittedInterpolationCode, emittedInterpolationCodeText };
 }
 
 function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState = null) {
@@ -1096,6 +1128,7 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState 
   let interpolationChar = Boolean(initialState?.interpolationChar);
   let interpolationEscaped = Boolean(initialState?.interpolationEscaped);
   let interpolationCommentDepth = Number(initialState?.interpolationCommentDepth || 0);
+  let interpolationEscapedIdent = Boolean(initialState?.interpolationEscapedIdent);
   while (i < text.length) {
     const ch = text[i];
     i += 1;
@@ -1113,6 +1146,10 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState 
           i += 1;
           interpolationCommentDepth -= 1;
         }
+        continue;
+      }
+      if (interpolationEscapedIdent) {
+        if (ch === '»') interpolationEscapedIdent = false;
         continue;
       }
       if (interpolationEscaped) {
@@ -1163,6 +1200,10 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState 
         interpolation += next;
         i += 1;
         interpolationCommentDepth = 1;
+        continue;
+      }
+      if (ch === '«') {
+        interpolationEscapedIdent = true;
         continue;
       }
       if (ch === '{') {
@@ -1218,6 +1259,7 @@ function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState 
       interpolationChar,
       interpolationEscaped,
       interpolationCommentDepth,
+      interpolationEscapedIdent,
     },
     emittedInterpolationCode,
     emittedInterpolationCodeText,

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -771,498 +771,180 @@ function detectSignals(file, hunk) {
 function codeLinesForHunkSide(hunk, side, options = {}) {
   const includeType = side === 'old' ? 'del' : 'add';
   const skipType = side === 'old' ? 'add' : 'del';
-  const code = [];
-  let commentDepth = 0;
-  let inString = false;
-  let stringEscaped = false;
-  let inStringInterpolated = false;
-  let stringInterpolationState = null;
-  let inEscapedIdent = false;
-  let pendingChangedInterpolation = false;
-  let pendingChangedInterpolationText = '';
+  const scanner = createLeanChangedCodeScanner(options);
   for (const line of hunk.lines || []) {
     if (line.type === skipType) continue;
-    const wasOpenInterpolation = isOpenInterpolationState({ inStringInterpolated, stringInterpolationState });
-    if (line.type === includeType && wasOpenInterpolation) {
-      pendingChangedInterpolation = true;
-      pendingChangedInterpolationText += changedInterpolationLineText(line.text, stringInterpolationState, options);
-    }
-    const stripped = stripLeanCommentsFromLine(line.text, {
-      commentDepth,
-      inString,
-      stringEscaped,
-      inStringInterpolated,
-      stringInterpolationState,
-      inEscapedIdent,
-    }, 0, options);
-    commentDepth = stripped.commentDepth;
-    inString = stripped.inString;
-    stringEscaped = stripped.stringEscaped;
-    inStringInterpolated = stripped.inStringInterpolated;
-    stringInterpolationState = stripped.stringInterpolationState;
-    inEscapedIdent = stripped.inEscapedIdent;
-    if (line.type === includeType && isOpenInterpolationState(stripped)) {
-      pendingChangedInterpolation = true;
-    }
-    if (line.type === includeType && stripped.code.trim() && !wasOpenInterpolation) {
-      code.push(stripped.code);
-    } else if (pendingChangedInterpolation && !isOpenInterpolationState(stripped) && pendingChangedInterpolationText.trim()) {
-      const changedInterpolation = stripLeanCommentsFromText(
-        pendingChangedInterpolationText,
-        { commentDepth: 0 },
-        0,
-        options
-      );
-      if (changedInterpolation.code.trim()) code.push(changedInterpolation.code);
-    }
-    if (stripped.emittedInterpolationCode || !isOpenInterpolationState(stripped)) {
-      pendingChangedInterpolation = false;
-      pendingChangedInterpolationText = '';
-    }
+    scanner.scanLine(line.text, line.type === includeType);
   }
-  if (pendingChangedInterpolation && isOpenInterpolationState({ inStringInterpolated, stringInterpolationState })) {
-    const strippedInterpolation = stripLeanCommentsFromText(
-      pendingChangedInterpolationText || stringInterpolationState.interpolation,
-      { commentDepth: 0 },
-      0,
-      options
-    );
-    if (strippedInterpolation.code.trim()) code.push(strippedInterpolation.code);
-  }
-  return code;
+  return scanner.finish();
 }
 
-function changedInterpolationLineText(text, state, options = {}) {
-  const line = String(text || '');
-  let code = '';
-  let interpolationString = Boolean(state?.interpolationString);
-  let interpolationStringInterpolated = Boolean(state?.interpolationStringInterpolated);
-  let interpolationStringInterpolationDepth = Number(state?.interpolationStringInterpolationDepth || 0);
-  let interpolationChar = Boolean(state?.interpolationChar);
-  let interpolationEscaped = Boolean(state?.interpolationEscaped);
-  let interpolationCommentDepth = Number(state?.interpolationCommentDepth || 0);
-  let interpolationEscapedIdent = Boolean(state?.interpolationEscapedIdent);
-  let interpolationDepth = Number(state?.interpolationDepth || 0);
-  let inOuterStringTail = interpolationDepth <= 0;
-  let outerStringEscaped = false;
-  let i = 0;
-  while (i < line.length) {
-    const ch = line[i];
-    const next = line[i + 1];
-    if (inOuterStringTail) {
-      if (outerStringEscaped) {
-        outerStringEscaped = false;
-      } else if (ch === '\\') {
-        outerStringEscaped = true;
-      } else if (ch === '{') {
-        interpolationDepth = 1;
-        interpolationString = false;
-        interpolationChar = false;
-        interpolationEscaped = false;
-        interpolationCommentDepth = 0;
-        inOuterStringTail = false;
-      } else if (ch === '"') {
-        inOuterStringTail = false;
-      }
-      i += 1;
-      continue;
-    }
-    if (interpolationCommentDepth > 0) {
-      if (ch === '/' && next === '-') {
-        interpolationCommentDepth += 1;
-        i += 2;
-      } else if (ch === '-' && next === '/') {
-        interpolationCommentDepth -= 1;
-        i += 2;
-      } else {
-        i += 1;
-      }
-      continue;
-    }
-    if (interpolationEscapedIdent) {
-      if (ch === '»') interpolationEscapedIdent = false;
-      code += ch;
-      i += 1;
-      continue;
-    }
-    if (interpolationEscaped) {
-      interpolationEscaped = false;
-      i += 1;
-      continue;
-    }
-    if (ch === '\\' && (interpolationString || interpolationChar)) {
-      interpolationEscaped = true;
-      i += 1;
-      continue;
-    }
-    if (interpolationString) {
-      if (interpolationStringInterpolated && interpolationStringInterpolationDepth > 0) {
-        if (ch === '{') {
-          interpolationStringInterpolationDepth += 1;
-          code += ch;
-        } else if (ch === '}') {
-          interpolationStringInterpolationDepth -= 1;
-        } else {
-          code += ch;
-        }
-        i += 1;
-        continue;
-      }
-      if (interpolationStringInterpolated && ch === '{') {
-        interpolationStringInterpolationDepth = 1;
-      } else if (ch === '"') {
-        interpolationString = false;
-        interpolationStringInterpolated = false;
-      }
-      i += 1;
-      continue;
-    }
-    if (interpolationChar) {
-      if (ch === "'") interpolationChar = false;
-      i += 1;
-      continue;
-    }
-    if (ch === '-' && next === '-') break;
-    if (ch === '/' && next === '-') {
-      interpolationCommentDepth = 1;
-      i += 2;
-      continue;
-    }
-    if (ch === '«') {
-      interpolationEscapedIdent = true;
-      code += ch;
-      i += 1;
-      continue;
-    }
-    if (ch === '"') {
-      interpolationString = true;
-      interpolationStringInterpolated = /[A-Za-z]!$/.test(line.slice(0, i));
-      interpolationStringInterpolationDepth = 0;
-      i += 1;
-      continue;
-    }
-    if (ch === "'" && startsLeanCharLiteral(line, i)) {
-      interpolationChar = true;
-      i += 1;
-      continue;
-    }
-    if (interpolationDepth > 0 && ch === '{') {
-      interpolationDepth += 1;
-      code += ch;
-      i += 1;
-      continue;
-    }
-    if (interpolationDepth > 0 && ch === '}') {
-      interpolationDepth -= 1;
-      if (interpolationDepth === 0) inOuterStringTail = true;
-      i += 1;
-      continue;
-    }
-    code += ch;
-    i += 1;
-  }
-  return code.trim() ? `${code}\n` : '';
-}
-
-function isOpenInterpolationState(state) {
-  return Boolean(
-    state?.inStringInterpolated &&
-    Number(state?.stringInterpolationState?.interpolationDepth || 0) > 0
-  );
-}
-
-function stripLeanCommentsFromText(text, state, depth = 0, options = {}) {
-  let nextState = state;
-  let emittedInterpolationCode = false;
-  let emittedInterpolationCodeText = '';
+function createLeanChangedCodeScanner(options = {}) {
   const code = [];
-  for (const line of String(text || '').split('\n')) {
-    const stripped = stripLeanCommentsFromLine(line, nextState, depth, options);
-    nextState = stripped;
-    emittedInterpolationCode = emittedInterpolationCode || Boolean(stripped.emittedInterpolationCode);
-    emittedInterpolationCodeText += stripped.emittedInterpolationCodeText || '';
-    if (stripped.code.trim()) code.push(stripped.code);
-  }
-  return {
-    ...nextState,
-    code: code.join('\n'),
-    emittedInterpolationCode,
-    emittedInterpolationCodeText,
+  const interpolationFrames = [];
+  let current = '';
+  let commentDepth = 0;
+  let lineComment = false;
+  let escapedIdent = false;
+  let charLiteral = false;
+  let charEscaped = false;
+  let string = null;
+  let prefix = '';
+
+  const remember = ch => {
+    prefix = ch === '\n' ? '' : `${prefix}${ch}`.slice(-32);
   };
-}
-
-function stripLeanCommentsFromLine(line, state, depth = 0, options = {}) {
-  const text = String(line || '');
-  if (depth > 8) {
-    return {
-      code: '',
-      inBlockComment: Boolean(state.commentDepth),
-      commentDepth: Number(state.commentDepth || 0),
-      inString: Boolean(state.inString),
-      stringEscaped: Boolean(state.stringEscaped),
-      inStringInterpolated: Boolean(state.inStringInterpolated),
-      stringInterpolationState: state.stringInterpolationState || null,
-      inEscapedIdent: Boolean(state.inEscapedIdent),
-      emittedInterpolationCode: false,
-      emittedInterpolationCodeText: '',
-    };
-  }
-  let code = '';
-  let emittedInterpolationCode = false;
-  let emittedInterpolationCodeText = '';
-  let commentDepth = Number(state.commentDepth || 0);
-  let inString = Boolean(state.inString);
-  let stringEscaped = Boolean(state.stringEscaped);
-  let inStringInterpolated = Boolean(state.inStringInterpolated);
-  let stringInterpolationState = state.stringInterpolationState || null;
-  let inEscapedIdent = Boolean(state.inEscapedIdent);
-  let i = 0;
-
-  while (i < text.length) {
-    const ch = text[i];
-    const next = text[i + 1];
-
-    if (inString) {
-      if (inStringInterpolated) {
-        const stringResult = scanLeanString(text, -1, true, depth + 1, stringInterpolationState);
-        code += options.preserveStrings ? text.slice(0, stringResult.nextIndex) : stringResult.code;
-        emittedInterpolationCode = emittedInterpolationCode || Boolean(stringResult.emittedInterpolationCode);
-        emittedInterpolationCodeText += stringResult.emittedInterpolationCodeText || '';
-        i = stringResult.nextIndex;
-        if (stringResult.closed) {
-          inString = false;
-          stringEscaped = false;
-          inStringInterpolated = false;
-          stringInterpolationState = null;
-        } else {
-          stringEscaped = Boolean(stringResult.escaped);
-          stringInterpolationState = stringResult.state;
-        }
-        continue;
-      }
-      if (options.preserveStrings) code += ch;
-      i += 1;
-      if (stringEscaped) {
-        stringEscaped = false;
-      } else if (ch === '\\') {
-        stringEscaped = true;
-      } else if (ch === '"') {
-        inString = false;
-      }
-      continue;
+  const emit = (ch, include) => {
+    if (include) current += ch;
+  };
+  const flush = () => {
+    if (current.trim()) code.push(current);
+    current = '';
+  };
+  const inInterpolationCode = () => interpolationFrames.length > 0 && !string;
+  const openString = interpolated => {
+    string = { interpolated, escaped: false };
+  };
+  const openInterpolation = () => {
+    interpolationFrames.push({ braceDepth: 1, returnString: string ? { ...string, escaped: false } : null });
+    string = null;
+  };
+  const closeInterpolationBrace = () => {
+    const frame = interpolationFrames[interpolationFrames.length - 1];
+    frame.braceDepth -= 1;
+    if (frame.braceDepth === 0) {
+      interpolationFrames.pop();
+      string = frame.returnString;
     }
+  };
+
+  const scanChar = (ch, next, include, text, index) => {
+    if (ch === '\n') {
+      lineComment = false;
+      flush();
+      remember(ch);
+      return 1;
+    }
+
+    if (lineComment) return 1;
 
     if (commentDepth > 0) {
       if (ch === '/' && next === '-') {
         commentDepth += 1;
-        i += 2;
-      } else if (ch === '-' && next === '/') {
+        return 2;
+      }
+      if (ch === '-' && next === '/') {
         commentDepth -= 1;
-        i += 2;
-      } else {
-        i += 1;
+        return 2;
       }
-      continue;
+      return 1;
     }
 
-    if (inEscapedIdent) {
-      if (options.preserveStrings) code += ch;
-      if (ch === '»') inEscapedIdent = false;
-      i += 1;
-      continue;
+    if (escapedIdent) {
+      emit(ch, include);
+      remember(ch);
+      if (ch === '»') escapedIdent = false;
+      return 1;
     }
 
-    if (ch === '"') {
-      const interpolated = /[A-Za-z]!$/.test(text.slice(0, i));
-      const stringResult = scanLeanString(text, i, interpolated, depth + 1);
-      code += options.preserveStrings ? text.slice(i, stringResult.nextIndex) : stringResult.code;
-      emittedInterpolationCode = emittedInterpolationCode || Boolean(stringResult.emittedInterpolationCode);
-      emittedInterpolationCodeText += stringResult.emittedInterpolationCodeText || '';
-      i = stringResult.nextIndex;
-      if (!stringResult.closed) {
-        inString = true;
-        stringEscaped = Boolean(stringResult.escaped);
-        inStringInterpolated = interpolated;
-        stringInterpolationState = stringResult.state;
+    if (charLiteral) {
+      emit(ch, include);
+      remember(ch);
+      if (charEscaped) {
+        charEscaped = false;
+      } else if (ch === '\\') {
+        charEscaped = true;
+      } else if (ch === "'") {
+        charLiteral = false;
       }
-      continue;
+      return 1;
+    }
+
+    if (string) {
+      if (string.escaped) {
+        if (options.preserveStrings) emit(ch, include);
+        remember(ch);
+        string.escaped = false;
+        return 1;
+      }
+      if (ch === '\\') {
+        if (options.preserveStrings) emit(ch, include);
+        remember(ch);
+        string.escaped = true;
+        return 1;
+      }
+      if (string.interpolated && ch === '{') {
+        remember(ch);
+        openInterpolation();
+        return 1;
+      }
+      if (ch === '"') {
+        if (options.preserveStrings) emit(ch, include);
+        remember(ch);
+        string = null;
+        return 1;
+      }
+      if (options.preserveStrings) emit(ch, include);
+      remember(ch);
+      return 1;
     }
 
     if (ch === '-' && next === '-') {
-      return { code, inBlockComment: false, commentDepth: 0, inString, stringEscaped, inStringInterpolated, stringInterpolationState, inEscapedIdent, emittedInterpolationCode, emittedInterpolationCodeText };
+      lineComment = true;
+      return 2;
     }
-
     if (ch === '/' && next === '-') {
       commentDepth = 1;
-      i += 2;
-      continue;
+      return 2;
     }
-
     if (ch === '«') {
-      if (options.preserveStrings) code += ch;
-      inEscapedIdent = true;
-      i += 1;
-      continue;
-    }
-
-    code += ch;
-    i += 1;
-  }
-
-  return { code, inBlockComment: commentDepth > 0, commentDepth, inString, stringEscaped, inStringInterpolated, stringInterpolationState, inEscapedIdent, emittedInterpolationCode, emittedInterpolationCodeText };
-}
-
-function scanLeanString(text, quoteIndex, interpolated, depth = 0, initialState = null) {
-  if (depth > 8) return { code: quoteIndex >= 0 ? '""' : '', nextIndex: Math.max(0, quoteIndex + 1), closed: false, escaped: false, state: null, emittedInterpolationCode: false, emittedInterpolationCodeText: '' };
-  let code = quoteIndex >= 0 ? '""' : '';
-  let i = quoteIndex >= 0 ? quoteIndex + 1 : 0;
-  let escaped = Boolean(initialState?.escaped);
-  let closed = false;
-  let emittedInterpolationCode = false;
-  let emittedInterpolationCodeText = '';
-  let interpolationDepth = Number(initialState?.interpolationDepth || 0);
-  let interpolation = String(initialState?.interpolation || '');
-  let interpolationString = Boolean(initialState?.interpolationString);
-  let interpolationStringInterpolated = Boolean(initialState?.interpolationStringInterpolated);
-  let interpolationStringInterpolationDepth = Number(initialState?.interpolationStringInterpolationDepth || 0);
-  let interpolationChar = Boolean(initialState?.interpolationChar);
-  let interpolationEscaped = Boolean(initialState?.interpolationEscaped);
-  let interpolationCommentDepth = Number(initialState?.interpolationCommentDepth || 0);
-  let interpolationEscapedIdent = Boolean(initialState?.interpolationEscapedIdent);
-  while (i < text.length) {
-    const ch = text[i];
-    i += 1;
-
-    if (interpolationDepth > 0) {
-      interpolation += ch;
-      const next = text[i];
-      if (interpolationCommentDepth > 0) {
-        if (ch === '/' && next === '-') {
-          interpolation += next;
-          i += 1;
-          interpolationCommentDepth += 1;
-        } else if (ch === '-' && next === '/') {
-          interpolation += next;
-          i += 1;
-          interpolationCommentDepth -= 1;
-        }
-        continue;
-      }
-      if (interpolationEscapedIdent) {
-        if (ch === '»') interpolationEscapedIdent = false;
-        continue;
-      }
-      if (interpolationEscaped) {
-        interpolationEscaped = false;
-        continue;
-      }
-      if (ch === '\\') {
-        interpolationEscaped = interpolationString || interpolationChar;
-        continue;
-      }
-      if (interpolationString) {
-        if (interpolationStringInterpolated && interpolationStringInterpolationDepth > 0) {
-          if (ch === '{') {
-            interpolationStringInterpolationDepth += 1;
-          } else if (ch === '}') {
-            interpolationStringInterpolationDepth -= 1;
-          }
-          continue;
-        }
-        if (interpolationStringInterpolated && ch === '{') {
-          interpolationStringInterpolationDepth = 1;
-        } else if (ch === '"') {
-          interpolationString = false;
-          interpolationStringInterpolated = false;
-        }
-        continue;
-      }
-      if (interpolationChar) {
-        if (ch === "'") interpolationChar = false;
-        continue;
-      }
-      if (ch === '"') {
-        interpolationString = true;
-        interpolationStringInterpolated = /[A-Za-z]!$/.test(interpolation.slice(0, -1));
-        interpolationStringInterpolationDepth = 0;
-        continue;
-      }
-      if (ch === "'" && startsLeanCharLiteral(interpolation, interpolation.length - 1)) {
-        interpolationChar = true;
-        continue;
-      }
-      if (ch === '-' && next === '-') {
-        interpolation += `${text.slice(i)}\n`;
-        i = text.length;
-        continue;
-      }
-      if (ch === '/' && next === '-') {
-        interpolation += next;
-        i += 1;
-        interpolationCommentDepth = 1;
-        continue;
-      }
-      if (ch === '«') {
-        interpolationEscapedIdent = true;
-        continue;
-      }
-      if (ch === '{') {
-        interpolationDepth += 1;
-      } else if (ch === '}') {
-        interpolationDepth -= 1;
-        if (interpolationDepth === 0) {
-          interpolation = interpolation.slice(0, -1);
-          const strippedInterpolation = stripLeanCommentsFromText(interpolation, { commentDepth: 0 }, depth + 1);
-          code += ` ${strippedInterpolation.code} `;
-          emittedInterpolationCode = true;
-          emittedInterpolationCodeText += ` ${strippedInterpolation.code} `;
-          interpolation = '';
-        }
-      }
-      continue;
-    }
-
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
-    if (ch === '\\') {
-      escaped = true;
-      continue;
-    }
-    if (interpolated && ch === '{') {
-      interpolationDepth = 1;
-      interpolation = '';
-      interpolationString = false;
-      interpolationChar = false;
-      interpolationEscaped = false;
-      interpolationCommentDepth = 0;
-      continue;
+      escapedIdent = true;
+      emit(ch, include);
+      remember(ch);
+      return 1;
     }
     if (ch === '"') {
-      closed = true;
-      break;
+      const interpolated = /[A-Za-z]!$/.test(prefix);
+      if (options.preserveStrings) emit(ch, include);
+      remember(ch);
+      openString(interpolated);
+      return 1;
     }
-  }
+    if (ch === "'" && startsLeanCharLiteral(text, index)) {
+      charLiteral = true;
+      charEscaped = false;
+      emit(ch, include);
+      remember(ch);
+      return 1;
+    }
+    if (inInterpolationCode() && ch === '{') {
+      interpolationFrames[interpolationFrames.length - 1].braceDepth += 1;
+      emit(ch, include);
+      remember(ch);
+      return 1;
+    }
+    if (inInterpolationCode() && ch === '}') {
+      remember(ch);
+      closeInterpolationBrace();
+      return 1;
+    }
+
+    emit(ch, include);
+    remember(ch);
+    return 1;
+  };
+
   return {
-    code,
-    nextIndex: i,
-    closed,
-    escaped,
-    state: {
-      escaped,
-      interpolationDepth,
-      interpolation,
-      interpolationString,
-      interpolationStringInterpolated,
-      interpolationStringInterpolationDepth,
-      interpolationChar,
-      interpolationEscaped,
-      interpolationCommentDepth,
-      interpolationEscapedIdent,
+    scanLine(text, include) {
+      const line = `${String(text || '')}\n`;
+      for (let i = 0; i < line.length;) {
+        i += scanChar(line[i], line[i + 1], include, line, i);
+      }
     },
-    emittedInterpolationCode,
-    emittedInterpolationCodeText,
+    finish() {
+      flush();
+      return code;
+    },
   };
 }
 

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -588,6 +588,25 @@ function testLeanScannerBlockerRegressionCases() {
       excludes: ['introduced sorry/admit'],
     },
     {
+      name: 'theorem statement comparisons preserve raw strings with inner quotes',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['del', 'theorem render_sound : render x = r#"old "quoted" value"# := by trivial'],
+        ['add', 'theorem render_sound : render x = r#"new "quoted" value"# := by trivial'],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['theorem statement changed/possibly weakened'],
+    },
+    {
+      name: 'code after a raw string with inner quotes is scanned',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['add', 'def marker := r#"said "hi""#; unsafe def riskyAfterRaw : Nat := 0'],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['introduced unsafe'],
+    },
+    {
       name: 'multiline interrupted interpolation keeps state from context into added line',
       lines: [
         ['ctx', 'namespace Verity'],

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -412,6 +412,20 @@ function testLeanContextOpenedInterpolationScansSecondInterpolationInTail() {
   assert.ok(packets[0].signals.includes('introduced sorry/admit'));
 }
 
+function testLeanContextOpenedNestedInterpolationAttributesAddedCode() {
+  const leanFile = file('Compiler/Proofs/ContextOpenedNestedInterpolation.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/ContextOpenedNestedInterpolation.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', 'def note : String := s!"outer { s!"inner {'],
+    ['add', '(by sorry : Nat)'],
+    ['ctx', '}"}"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
 function testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode() {
   const leanFile = file('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 20, [
@@ -1237,6 +1251,7 @@ async function run() {
   testLeanContextOpenedInterpolationNestedCharResumesOnAddedLine();
   testLeanContextOpenedInterpolationScansCodeAfterClosingString();
   testLeanContextOpenedInterpolationScansSecondInterpolationInTail();
+  testLeanContextOpenedNestedInterpolationAttributesAddedCode();
   testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode();
   testLeanMultilineInterpolationLineCommentDoesNotHideNextLine();
   testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -330,6 +330,36 @@ function testLeanContextOpenedInterpolationDoesNotAttributePriorContextCode() {
   assert.ok(!packets[0].signals.includes('introduced sorry/admit'));
 }
 
+function testLeanContextOpenedInterpolationCommentDoesNotAttributeAddedProse() {
+  const leanFile = file('Compiler/Proofs/ContextOpenedInterpolationComment.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/ContextOpenedInterpolationComment.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', 'def note := s!"value { /-'],
+    ['add', 'prose mentioning sorry and unsafe'],
+    ['ctx', '-/ 0 }"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(!packets[0].signals.includes('introduced sorry/admit'));
+  assert.ok(!packets[0].signals.includes('introduced unsafe'));
+}
+
+function testLeanContextOpenedInterpolationClosingChangeDoesNotAttributePriorCode() {
+  const leanFile = file('Compiler/Proofs/ContextOpenedInterpolationClosingChange.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/ContextOpenedInterpolationClosingChange.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', 'def note := s!"value {'],
+    ['ctx', '(by sorry : Nat)'],
+    ['del', '}"'],
+    ['add', '}!"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(!packets[0].signals.includes('introduced sorry/admit'));
+}
+
 function testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode() {
   const leanFile = file('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 20, [
@@ -1149,6 +1179,8 @@ async function run() {
   testLeanContextOpenedInterpolationAttributesAddedCode();
   testLeanContextClosedInterpolationDoesNotAttributeContextCode();
   testLeanContextOpenedInterpolationDoesNotAttributePriorContextCode();
+  testLeanContextOpenedInterpolationCommentDoesNotAttributeAddedProse();
+  testLeanContextOpenedInterpolationClosingChangeDoesNotAttributePriorCode();
   testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode();
   testLeanMultilineInterpolationLineCommentDoesNotHideNextLine();
   testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -182,7 +182,19 @@ function testLeanInterpolatedStringQuotedBracesDoNotStopScanning() {
   const leanFile = file('Compiler/Proofs/InterpolatedStringQuotedBrace.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/InterpolatedStringQuotedBrace.lean', 20, [
     ['ctx', 'namespace Verity'],
-    ['add', "def note := s!\"value { let c := '}'; (by sorry : Nat) }\""],
+    ['add', 'def exact := s!"{ let c := \'}\'; (by sorry : Nat) }"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
+function testLeanInterpolatedStringNestedQuotedBracesDoNotStopScanning() {
+  const leanFile = file('Compiler/Proofs/InterpolatedStringNestedQuotedBrace.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/InterpolatedStringNestedQuotedBrace.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', 'def nested := s!"{ let text := "}"; (by admit : Nat) }"'],
     ['ctx', 'end Verity'],
   ])];
   const packets = router.buildReviewPackets([leanFile]);
@@ -195,6 +207,18 @@ function testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning() {
   leanFile.hunks = [hunk('Compiler/Proofs/InterpolatedStringPrimedIdentifier.lean', 20, [
     ['ctx', 'namespace Verity'],
     ['add', "def note := s!\"value { let x' := (by sorry : Nat); x' }\""],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
+function testLeanInterpolatedStringMultiPrimedIdentifiersDoNotStopScanning() {
+  const leanFile = file('Compiler/Proofs/InterpolatedStringMultiPrimedIdentifier.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/InterpolatedStringMultiPrimedIdentifier.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', "def double := s!\"value { let h'' := (by admit : Nat); h'' }\""],
     ['ctx', 'end Verity'],
   ])];
   const packets = router.buildReviewPackets([leanFile]);
@@ -947,7 +971,9 @@ async function run() {
   testLeanStringLiteralsDoNotTriggerSignals();
   testLeanInterpolatedStringExpressionsAreScanned();
   testLeanInterpolatedStringQuotedBracesDoNotStopScanning();
+  testLeanInterpolatedStringNestedQuotedBracesDoNotStopScanning();
   testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning();
+  testLeanInterpolatedStringMultiPrimedIdentifiersDoNotStopScanning();
   testLeanInterpolatedStringUnicodePrimedIdentifiersDoNotStopScanning();
   testBangBeforeStringDoesNotEnableInterpolationScanning();
   testLeanNestedBlockCommentDoesNotTriggerSignals();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -399,6 +399,19 @@ function testLeanContextOpenedInterpolationScansCodeAfterClosingString() {
   assert.ok(packets[0].signals.includes('introduced sorry/admit'));
 }
 
+function testLeanContextOpenedInterpolationScansSecondInterpolationInTail() {
+  const leanFile = file('Compiler/Proofs/ContextOpenedInterpolationSecondTail.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/ContextOpenedInterpolationSecondTail.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', 'def note : String := s!"value {'],
+    ['add', '0 } and {(by sorry : Nat)}"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
 function testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode() {
   const leanFile = file('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 20, [
@@ -1223,6 +1236,7 @@ async function run() {
   testLeanContextOpenedInterpolationNestedStringResumesOnAddedLine();
   testLeanContextOpenedInterpolationNestedCharResumesOnAddedLine();
   testLeanContextOpenedInterpolationScansCodeAfterClosingString();
+  testLeanContextOpenedInterpolationScansSecondInterpolationInTail();
   testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode();
   testLeanMultilineInterpolationLineCommentDoesNotHideNextLine();
   testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -314,6 +314,22 @@ function testLeanContextClosedInterpolationDoesNotAttributeContextCode() {
   assert.ok(!packets[0].signals.includes('introduced sorry/admit'));
 }
 
+function testLeanContextOpenedInterpolationDoesNotAttributePriorContextCode() {
+  const leanFile = file('Compiler/Proofs/ContextOpenedInterpolationPriorCode.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/ContextOpenedInterpolationPriorCode.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', 'def note := s!"value {'],
+    ['ctx', '(by sorry : Nat)'],
+    ['add', 'let harmless := 0'],
+    ['ctx', 'harmless'],
+    ['ctx', '}"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(!packets[0].signals.includes('introduced sorry/admit'));
+}
+
 function testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode() {
   const leanFile = file('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 20, [
@@ -1132,6 +1148,7 @@ async function run() {
   testLeanMultilineInterpolationUnicodePrimedIdentifiersDoNotStopScanning();
   testLeanContextOpenedInterpolationAttributesAddedCode();
   testLeanContextClosedInterpolationDoesNotAttributeContextCode();
+  testLeanContextOpenedInterpolationDoesNotAttributePriorContextCode();
   testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode();
   testLeanMultilineInterpolationLineCommentDoesNotHideNextLine();
   testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -166,6 +166,19 @@ function testLeanMultilineStringCommentDelimiterInContextDoesNotHideSignals() {
   assert.ok(packets[0].signals.includes('introduced unsafe'));
 }
 
+function testLeanEscapedIdentifierCommentDelimiterInContextDoesNotHideSignals() {
+  const leanFile = file('Compiler/Proofs/EscapedIdentifierDelimiterContext.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/EscapedIdentifierDelimiterContext.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', 'def «/-» : Nat := 0'],
+    ['add', 'unsafe def riskyAfterEscapedIdentifier : Nat := 0'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced unsafe'));
+}
+
 function testLeanStringLiteralsDoNotTriggerSignals() {
   const leanFile = file('Compiler/Proofs/StringSignalProse.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/StringSignalProse.lean', 20, [
@@ -1233,6 +1246,7 @@ async function run() {
   testLeanCodeAfterContextBlockCommentIsScanned();
   testLeanStringCommentDelimiterInContextDoesNotHideSignals();
   testLeanMultilineStringCommentDelimiterInContextDoesNotHideSignals();
+  testLeanEscapedIdentifierCommentDelimiterInContextDoesNotHideSignals();
   testLeanStringLiteralsDoNotTriggerSignals();
   testLeanInterpolatedStringExpressionsAreScanned();
   testLeanInterpolatedStringQuotedBracesDoNotStopScanning();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -229,6 +229,63 @@ function testLeanInterpolatedStringBlockCommentBracesDoNotStopScanning() {
   assert.ok(packets[0].signals.includes('introduced sorry/admit'));
 }
 
+function testLeanMultilineInterpolatedStringExpressionsAreScanned() {
+  const leanFile = file('Compiler/Proofs/MultilineInterpolatedString.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/MultilineInterpolatedString.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', 'def note := s!"value'],
+    ['add', '{(by sorry : Nat)}"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
+function testLeanMultilineOpenInterpolationExpressionsAreScanned() {
+  const leanFile = file('Compiler/Proofs/MultilineOpenInterpolation.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/MultilineOpenInterpolation.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', 'def note := s!"value {'],
+    ['add', '(by admit : Nat)'],
+    ['add', '}"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
+function testLeanMultilineInterpolationQuotedBracesDoNotStopScanning() {
+  const leanFile = file('Compiler/Proofs/MultilineInterpolationQuotedBrace.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/MultilineInterpolationQuotedBrace.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', 'def exact := s!"{'],
+    ['add', 'let c := \'}\''],
+    ['add', '(by sorry : Nat)'],
+    ['add', '}"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
+function testLeanMultilineInterpolationUnicodePrimedIdentifiersDoNotStopScanning() {
+  const leanFile = file('Compiler/Proofs/MultilineInterpolationUnicodePrimedIdentifier.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/MultilineInterpolationUnicodePrimedIdentifier.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', 'def note := s!"value {'],
+    ['add', "let x₁' := 0"],
+    ['add', '(by sorry : Nat)'],
+    ['add', '}"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
 function testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning() {
   const leanFile = file('Compiler/Proofs/InterpolatedStringPrimedIdentifier.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/InterpolatedStringPrimedIdentifier.lean', 20, [
@@ -1014,6 +1071,10 @@ async function run() {
   testLeanInterpolatedStringQuotedBracesDoNotStopScanning();
   testLeanInterpolatedStringNestedQuotedBracesDoNotStopScanning();
   testLeanInterpolatedStringBlockCommentBracesDoNotStopScanning();
+  testLeanMultilineInterpolatedStringExpressionsAreScanned();
+  testLeanMultilineOpenInterpolationExpressionsAreScanned();
+  testLeanMultilineInterpolationQuotedBracesDoNotStopScanning();
+  testLeanMultilineInterpolationUnicodePrimedIdentifiersDoNotStopScanning();
   testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning();
   testLeanInterpolatedStringMultiPrimedIdentifiersDoNotStopScanning();
   testLeanInterpolatedStringUnicodePrimedIdentifiersDoNotStopScanning();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -386,6 +386,19 @@ function testLeanContextOpenedInterpolationNestedCharResumesOnAddedLine() {
   assert.ok(packets[0].signals.includes('introduced sorry/admit'));
 }
 
+function testLeanContextOpenedInterpolationScansCodeAfterClosingString() {
+  const leanFile = file('Compiler/Proofs/ContextOpenedInterpolationPostStringCode.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/ContextOpenedInterpolationPostStringCode.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', 'def note : Nat := let _ := s!"value {'],
+    ['add', '0 }"; (by sorry : Nat)'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
 function testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode() {
   const leanFile = file('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 20, [
@@ -1209,6 +1222,7 @@ async function run() {
   testLeanContextOpenedInterpolationClosingChangeDoesNotAttributePriorCode();
   testLeanContextOpenedInterpolationNestedStringResumesOnAddedLine();
   testLeanContextOpenedInterpolationNestedCharResumesOnAddedLine();
+  testLeanContextOpenedInterpolationScansCodeAfterClosingString();
   testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode();
   testLeanMultilineInterpolationLineCommentDoesNotHideNextLine();
   testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -151,6 +151,21 @@ function testLeanStringCommentDelimiterInContextDoesNotHideSignals() {
   assert.ok(packets[0].signals.includes('introduced unsafe'));
 }
 
+function testLeanMultilineStringCommentDelimiterInContextDoesNotHideSignals() {
+  const leanFile = file('Compiler/Proofs/MultilineStringDelimiterContext.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/MultilineStringDelimiterContext.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', 'def marker := "string starts'],
+    ['ctx', '/- not a block comment'],
+    ['ctx', 'string ends"'],
+    ['add', 'unsafe def riskyAfterMultilineString : Nat := 0'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced unsafe'));
+}
+
 function testLeanStringLiteralsDoNotTriggerSignals() {
   const leanFile = file('Compiler/Proofs/StringSignalProse.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/StringSignalProse.lean', 20, [
@@ -288,6 +303,19 @@ function testCodeAfterInlineBlockCommentIsScanned() {
   const packets = router.buildReviewPackets([leanFile]);
   assert.ok(packets.length > 0);
   assert.ok(packets[0].signals.includes('introduced/changed axiom'));
+}
+
+function testTheoremStatementStringLiteralChangesAreDetected() {
+  const leanFile = file('Compiler/Proofs/TheoremStringChange.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/TheoremStringChange.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['del', 'theorem render_sound : render x = "old" := by trivial'],
+    ['add', 'theorem render_sound : render x = "new" := by trivial'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('theorem statement changed/possibly weakened'));
 }
 
 function testOversizedLeanGuarded() {
@@ -980,6 +1008,7 @@ async function run() {
   testLeanBlockCommentStateFromContextDoesNotTriggerSignals();
   testLeanCodeAfterContextBlockCommentIsScanned();
   testLeanStringCommentDelimiterInContextDoesNotHideSignals();
+  testLeanMultilineStringCommentDelimiterInContextDoesNotHideSignals();
   testLeanStringLiteralsDoNotTriggerSignals();
   testLeanInterpolatedStringExpressionsAreScanned();
   testLeanInterpolatedStringQuotedBracesDoNotStopScanning();
@@ -991,6 +1020,7 @@ async function run() {
   testBangBeforeStringDoesNotEnableInterpolationScanning();
   testLeanNestedBlockCommentDoesNotTriggerSignals();
   testCodeAfterInlineBlockCommentIsScanned();
+  testTheoremStatementStringLiteralChangesAreDetected();
   testOversizedLeanGuarded();
   testScoutConfigDefaultsToMiniMaxOnOcrEndpoint();
   testScoutConfigCanDisableLargeLeanScout();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -555,6 +555,160 @@ function testTheoremStatementStringLiteralChangesAreDetected() {
   assert.ok(packets[0].signals.includes('theorem statement changed/possibly weakened'));
 }
 
+function testLeanScannerBlockerRegressionCases() {
+  const cases = [
+    {
+      name: 'quoted braces inside interpolation expressions',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['add', 'def x := s!"{ let c := \'}\'; (by sorry : Nat) }"'],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['introduced sorry/admit'],
+    },
+    {
+      name: 'Lean block comments inside interpolation are ignored and following code is scanned',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['add', 'def x := s!"{ /- prose sorry axiom unsafe } -/ (by admit : Nat) }"'],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['introduced sorry/admit'],
+      excludes: ['introduced/changed axiom', 'introduced unsafe'],
+    },
+    {
+      name: 'theorem statement comparisons preserve changed raw string literal text',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['del', 'theorem render_sound : render x = r#"old { sorry }"# := by trivial'],
+        ['add', 'theorem render_sound : render x = r#"new { sorry }"# := by trivial'],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['theorem statement changed/possibly weakened'],
+      excludes: ['introduced sorry/admit'],
+    },
+    {
+      name: 'multiline interrupted interpolation keeps state from context into added line',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['ctx', 'def x := s!"prefix {'],
+        ['ctx', 'let y := 0'],
+        ['add', '(by sorry : Nat)'],
+        ['ctx', '}"'],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['introduced sorry/admit'],
+    },
+    {
+      name: 'newline after interpolation line comment resumes scanning',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['add', 'def x := s!"{'],
+        ['add', '-- comment with } sorry'],
+        ['add', '(by admit : Nat)'],
+        ['add', '}"'],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['introduced sorry/admit'],
+    },
+    {
+      name: 'unterminated interpolation fragments are flushed at hunk end',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['ctx', 'def x := s!"{'],
+        ['add', '(by sorry : Nat)'],
+      ],
+      includes: ['introduced sorry/admit'],
+    },
+    {
+      name: 'interpolation block comment state is preserved while flushing added lines',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['ctx', 'def x := s!"{ /-'],
+        ['add', 'prose sorry axiom unsafe'],
+        ['add', '-/ (by admit : Nat)'],
+        ['ctx', '}"'],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['introduced sorry/admit'],
+      excludes: ['introduced/changed axiom', 'introduced unsafe'],
+    },
+    {
+      name: 'code after a closed interpolation is scanned',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['add', 'def x : Nat := let _ := s!"{0}"; (by sorry : Nat)'],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['introduced sorry/admit'],
+    },
+    {
+      name: 'subsequent interpolation in added tail is scanned',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['ctx', 'def x := s!"{'],
+        ['add', '0 } and {(by admit : Nat)}"'],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['introduced sorry/admit'],
+    },
+    {
+      name: 'nested interpolated string resumes outer interpolation state',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['add', 'def x := s!"outer { let inner := s!"inner {(0 : Nat)}"; (by sorry : Nat) }"'],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['introduced sorry/admit'],
+    },
+    {
+      name: 'escaped identifiers containing comment delimiters do not open comments',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['add', 'def «/-» := 0'],
+        ['add', 'unsafe def riskyAfterEscapedIdent : Nat := 0'],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['introduced unsafe'],
+    },
+    {
+      name: 'opening interpolation fragment from added line is buffered through later added line',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['add', 'def x := s!"prefix {'],
+        ['ctx', 'let old := 0'],
+        ['add', '(by sorry : Nat)'],
+        ['ctx', '}"'],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['introduced sorry/admit'],
+    },
+    {
+      name: 'apostrophe after non-ASCII Lean identifier is not a char literal',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['add', "def x := s!\"{ let x₁' := 0; (by sorry : Nat) }\""],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['introduced sorry/admit'],
+    },
+  ];
+
+  for (const regression of cases) {
+    const leanFile = file(`Compiler/Proofs/${regression.name.replace(/[^A-Za-z0-9]+/g, '')}.lean`, 10, 0);
+    leanFile.hunks = [hunk(leanFile.path, 20, regression.lines)];
+    const packets = router.buildReviewPackets([leanFile]);
+    assert.ok(packets.length > 0, regression.name);
+    const signals = packets.flatMap(packet => packet.signals);
+    for (const signal of regression.includes || []) {
+      assert.ok(signals.includes(signal), `${regression.name}: expected ${signal}; got ${signals.join(', ')}`);
+    }
+    for (const signal of regression.excludes || []) {
+      assert.ok(!signals.includes(signal), `${regression.name}: unexpected ${signal}; got ${signals.join(', ')}`);
+    }
+  }
+}
+
 function testOversizedLeanGuarded() {
   const files = Array.from({ length: 13 }, (_, i) => file(`Compiler/Proofs/Large${i}.lean`, 40, 0));
   const decision = router.decideRoute(files);
@@ -1275,6 +1429,7 @@ async function run() {
   testLeanNestedBlockCommentDoesNotTriggerSignals();
   testCodeAfterInlineBlockCommentIsScanned();
   testTheoremStatementStringLiteralChangesAreDetected();
+  testLeanScannerBlockerRegressionCases();
   testOversizedLeanGuarded();
   testScoutConfigDefaultsToMiniMaxOnOcrEndpoint();
   testScoutConfigCanDisableLargeLeanScout();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -286,6 +286,35 @@ function testLeanMultilineInterpolationUnicodePrimedIdentifiersDoNotStopScanning
   assert.ok(packets[0].signals.includes('introduced sorry/admit'));
 }
 
+function testLeanContextOpenedInterpolationAttributesAddedCode() {
+  const leanFile = file('Compiler/Proofs/ContextOpenedInterpolation.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/ContextOpenedInterpolation.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', 'def note := s!"value {'],
+    ['add', '(by sorry : Nat)'],
+    ['ctx', '}"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
+function testLeanMultilineInterpolationLineCommentDoesNotHideNextLine() {
+  const leanFile = file('Compiler/Proofs/MultilineInterpolationLineComment.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/MultilineInterpolationLineComment.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', 'def note := s!"value {'],
+    ['add', '-- a comment about a proof'],
+    ['add', '(by admit : Nat)'],
+    ['add', '}"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
 function testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning() {
   const leanFile = file('Compiler/Proofs/InterpolatedStringPrimedIdentifier.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/InterpolatedStringPrimedIdentifier.lean', 20, [
@@ -1075,6 +1104,8 @@ async function run() {
   testLeanMultilineOpenInterpolationExpressionsAreScanned();
   testLeanMultilineInterpolationQuotedBracesDoNotStopScanning();
   testLeanMultilineInterpolationUnicodePrimedIdentifiersDoNotStopScanning();
+  testLeanContextOpenedInterpolationAttributesAddedCode();
+  testLeanMultilineInterpolationLineCommentDoesNotHideNextLine();
   testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning();
   testLeanInterpolatedStringMultiPrimedIdentifiersDoNotStopScanning();
   testLeanInterpolatedStringUnicodePrimedIdentifiersDoNotStopScanning();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -202,6 +202,18 @@ function testLeanInterpolatedStringNestedQuotedBracesDoNotStopScanning() {
   assert.ok(packets[0].signals.includes('introduced sorry/admit'));
 }
 
+function testLeanInterpolatedStringBlockCommentBracesDoNotStopScanning() {
+  const leanFile = file('Compiler/Proofs/InterpolatedStringBlockCommentBrace.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/InterpolatedStringBlockCommentBrace.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', 'def commented := s!"{ /- } -/ (by sorry : Nat) }"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
 function testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning() {
   const leanFile = file('Compiler/Proofs/InterpolatedStringPrimedIdentifier.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/InterpolatedStringPrimedIdentifier.lean', 20, [
@@ -972,6 +984,7 @@ async function run() {
   testLeanInterpolatedStringExpressionsAreScanned();
   testLeanInterpolatedStringQuotedBracesDoNotStopScanning();
   testLeanInterpolatedStringNestedQuotedBracesDoNotStopScanning();
+  testLeanInterpolatedStringBlockCommentBracesDoNotStopScanning();
   testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning();
   testLeanInterpolatedStringMultiPrimedIdentifiersDoNotStopScanning();
   testLeanInterpolatedStringUnicodePrimedIdentifiersDoNotStopScanning();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -598,6 +598,17 @@ function testLeanScannerBlockerRegressionCases() {
       includes: ['theorem statement changed/possibly weakened'],
     },
     {
+      name: 'theorem statement comparisons preserve interpolation braces',
+      lines: [
+        ['ctx', 'namespace Verity'],
+        ['del', 'theorem render_sound : render x = s!"{x}" := by trivial'],
+        ['add', 'theorem render_sound : render x = s!"x" := by trivial'],
+        ['ctx', 'end Verity'],
+      ],
+      includes: ['theorem statement changed/possibly weakened'],
+      excludes: ['introduced sorry/admit'],
+    },
+    {
       name: 'code after a raw string with inner quotes is scanned',
       lines: [
         ['ctx', 'namespace Verity'],

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -300,6 +300,18 @@ function testLeanContextOpenedInterpolationAttributesAddedCode() {
   assert.ok(packets[0].signals.includes('introduced sorry/admit'));
 }
 
+function testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode() {
+  const leanFile = file('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', 'def note := s!"value {'],
+    ['add', '(by sorry : Nat)'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
 function testLeanMultilineInterpolationLineCommentDoesNotHideNextLine() {
   const leanFile = file('Compiler/Proofs/MultilineInterpolationLineComment.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/MultilineInterpolationLineComment.lean', 20, [
@@ -1105,6 +1117,7 @@ async function run() {
   testLeanMultilineInterpolationQuotedBracesDoNotStopScanning();
   testLeanMultilineInterpolationUnicodePrimedIdentifiersDoNotStopScanning();
   testLeanContextOpenedInterpolationAttributesAddedCode();
+  testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode();
   testLeanMultilineInterpolationLineCommentDoesNotHideNextLine();
   testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning();
   testLeanInterpolatedStringMultiPrimedIdentifiersDoNotStopScanning();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -360,6 +360,32 @@ function testLeanContextOpenedInterpolationClosingChangeDoesNotAttributePriorCod
   assert.ok(!packets[0].signals.includes('introduced sorry/admit'));
 }
 
+function testLeanContextOpenedInterpolationNestedStringResumesOnAddedLine() {
+  const leanFile = file('Compiler/Proofs/ContextOpenedInterpolationNestedString.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/ContextOpenedInterpolationNestedString.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', 'def note := s!"value { let s := "'],
+    ['add', '"; (by sorry : Nat) }"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
+function testLeanContextOpenedInterpolationNestedCharResumesOnAddedLine() {
+  const leanFile = file('Compiler/Proofs/ContextOpenedInterpolationNestedChar.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/ContextOpenedInterpolationNestedChar.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', 'def note := s!"value { let c := \''],
+    ['add', '\'; (by admit : Nat) }"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
 function testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode() {
   const leanFile = file('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 20, [
@@ -1181,6 +1207,8 @@ async function run() {
   testLeanContextOpenedInterpolationDoesNotAttributePriorContextCode();
   testLeanContextOpenedInterpolationCommentDoesNotAttributeAddedProse();
   testLeanContextOpenedInterpolationClosingChangeDoesNotAttributePriorCode();
+  testLeanContextOpenedInterpolationNestedStringResumesOnAddedLine();
+  testLeanContextOpenedInterpolationNestedCharResumesOnAddedLine();
   testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode();
   testLeanMultilineInterpolationLineCommentDoesNotHideNextLine();
   testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -105,6 +105,143 @@ function testLeanBlockCommentDoesNotTriggerSorrySignal() {
   assert.ok(!packets[0].signals.includes('introduced sorry/admit'));
 }
 
+function testLeanBlockCommentStateFromContextDoesNotTriggerSignals() {
+  const leanFile = file('Compiler/Proofs/ContextBlockComment.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/ContextBlockComment.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', '/-'],
+    ['add', 'This explanatory note mentions sorry, axiom, and unsafe in prose.'],
+    ['ctx', '-/'],
+    ['add', 'theorem still_ok : True := by trivial'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(!packets[0].signals.includes('introduced sorry/admit'));
+  assert.ok(!packets[0].signals.includes('introduced/changed axiom'));
+  assert.ok(!packets[0].signals.includes('introduced unsafe'));
+}
+
+function testLeanCodeAfterContextBlockCommentIsScanned() {
+  const leanFile = file('Compiler/Proofs/ContextBlockCommentCode.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/ContextBlockCommentCode.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', '/-'],
+    ['add', 'This explanatory note mentions sorry in prose.'],
+    ['ctx', '-/'],
+    ['add', 'unsafe def riskyAfterComment : Nat := 0'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(!packets[0].signals.includes('introduced sorry/admit'));
+  assert.ok(packets[0].signals.includes('introduced unsafe'));
+}
+
+function testLeanStringCommentDelimiterInContextDoesNotHideSignals() {
+  const leanFile = file('Compiler/Proofs/StringDelimiterContext.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/StringDelimiterContext.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', 'def marker := "/-"'],
+    ['add', 'unsafe def riskyAfterString : Nat := 0'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced unsafe'));
+}
+
+function testLeanStringLiteralsDoNotTriggerSignals() {
+  const leanFile = file('Compiler/Proofs/StringSignalProse.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/StringSignalProse.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', 'def note := "sorry axiom unsafe"'],
+    ['add', 'theorem still_ok : True := by trivial'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(!packets[0].signals.includes('introduced sorry/admit'));
+  assert.ok(!packets[0].signals.includes('introduced/changed axiom'));
+  assert.ok(!packets[0].signals.includes('introduced unsafe'));
+}
+
+function testLeanInterpolatedStringExpressionsAreScanned() {
+  const leanFile = file('Compiler/Proofs/InterpolatedString.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/InterpolatedString.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', 'def note := s!"value {(by sorry : Nat)}"'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
+function testLeanInterpolatedStringQuotedBracesDoNotStopScanning() {
+  const leanFile = file('Compiler/Proofs/InterpolatedStringQuotedBrace.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/InterpolatedStringQuotedBrace.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', "def note := s!\"value { let c := '}'; (by sorry : Nat) }\""],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
+function testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning() {
+  const leanFile = file('Compiler/Proofs/InterpolatedStringPrimedIdentifier.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/InterpolatedStringPrimedIdentifier.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', "def note := s!\"value { let x' := (by sorry : Nat); x' }\""],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
+function testLeanInterpolatedStringUnicodePrimedIdentifiersDoNotStopScanning() {
+  const leanFile = file('Compiler/Proofs/InterpolatedStringUnicodePrimedIdentifier.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/InterpolatedStringUnicodePrimedIdentifier.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', "def note := s!\"value { let x1' := 0; let x₁' := x1'; (by sorry : Nat) }\""],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced sorry/admit'));
+}
+
+function testBangBeforeStringDoesNotEnableInterpolationScanning() {
+  const leanFile = file('Compiler/Proofs/BangString.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/BangString.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', 'def note := !"literal { not interpolation"'],
+    ['add', 'unsafe def riskyAfterBangString : Nat := 0'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(packets[0].signals.includes('introduced unsafe'));
+}
+
+function testLeanNestedBlockCommentDoesNotTriggerSignals() {
+  const leanFile = file('Compiler/Proofs/NestedBlockComment.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/NestedBlockComment.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['add', '/- outer /- inner -/ sorry axiom unsafe -/'],
+    ['add', 'theorem still_ok : True := by trivial'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(!packets[0].signals.includes('introduced sorry/admit'));
+  assert.ok(!packets[0].signals.includes('introduced/changed axiom'));
+  assert.ok(!packets[0].signals.includes('introduced unsafe'));
+}
+
 function testCodeAfterInlineBlockCommentIsScanned() {
   const leanFile = file('Compiler/Proofs/InlineBlockComment.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/InlineBlockComment.lean', 20, [
@@ -804,6 +941,16 @@ async function run() {
   testLargeLeanPacketized();
   testLeanCommentDoesNotTriggerSorrySignal();
   testLeanBlockCommentDoesNotTriggerSorrySignal();
+  testLeanBlockCommentStateFromContextDoesNotTriggerSignals();
+  testLeanCodeAfterContextBlockCommentIsScanned();
+  testLeanStringCommentDelimiterInContextDoesNotHideSignals();
+  testLeanStringLiteralsDoNotTriggerSignals();
+  testLeanInterpolatedStringExpressionsAreScanned();
+  testLeanInterpolatedStringQuotedBracesDoNotStopScanning();
+  testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning();
+  testLeanInterpolatedStringUnicodePrimedIdentifiersDoNotStopScanning();
+  testBangBeforeStringDoesNotEnableInterpolationScanning();
+  testLeanNestedBlockCommentDoesNotTriggerSignals();
   testCodeAfterInlineBlockCommentIsScanned();
   testOversizedLeanGuarded();
   testScoutConfigDefaultsToMiniMaxOnOcrEndpoint();

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -300,6 +300,20 @@ function testLeanContextOpenedInterpolationAttributesAddedCode() {
   assert.ok(packets[0].signals.includes('introduced sorry/admit'));
 }
 
+function testLeanContextClosedInterpolationDoesNotAttributeContextCode() {
+  const leanFile = file('Compiler/Proofs/ContextClosedInterpolation.lean', 10, 0);
+  leanFile.hunks = [hunk('Compiler/Proofs/ContextClosedInterpolation.lean', 20, [
+    ['ctx', 'namespace Verity'],
+    ['ctx', 'def note := s!"value {'],
+    ['add', '0'],
+    ['ctx', '}"; (by sorry : Nat)'],
+    ['ctx', 'end Verity'],
+  ])];
+  const packets = router.buildReviewPackets([leanFile]);
+  assert.ok(packets.length > 0);
+  assert.ok(!packets[0].signals.includes('introduced sorry/admit'));
+}
+
 function testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode() {
   const leanFile = file('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 10, 0);
   leanFile.hunks = [hunk('Compiler/Proofs/UnterminatedContextOpenedInterpolation.lean', 20, [
@@ -1117,6 +1131,7 @@ async function run() {
   testLeanMultilineInterpolationQuotedBracesDoNotStopScanning();
   testLeanMultilineInterpolationUnicodePrimedIdentifiersDoNotStopScanning();
   testLeanContextOpenedInterpolationAttributesAddedCode();
+  testLeanContextClosedInterpolationDoesNotAttributeContextCode();
   testLeanUnterminatedContextOpenedInterpolationFlushesAddedCode();
   testLeanMultilineInterpolationLineCommentDoesNotHideNextLine();
   testLeanInterpolatedStringPrimedIdentifiersDoNotStopScanning();


### PR DESCRIPTION
## Summary
- preserve Lean block-comment state from unchanged hunk context before scanning added/deleted lines for OCR risk signals
- add regressions for context-delimited Lean block comments so prose mentioning `sorry`/`axiom`/`unsafe` is not treated as code
- keep scanning actual code after a context block comment closes

## Validation
- `node --check .github/scripts/ocr-router.js`
- `node --check .github/scripts/test-ocr-routing.js`
- `node --check .github/scripts/post-ocr-review.js`
- `node .github/scripts/test-ocr-routing.js`
- `bash -n .github/scripts/ocr-git-wrapper.sh`
- `python3 -m json.tool .github/ocr/rules.json`
- PyYAML parse of `.github/workflows/ocr-review.yml`
- `/tmp/actionlint-bin/actionlint .github/workflows/ocr-review.yml`

Fixes the latest-head blocker reported on #2137: https://github.com/lfglabs-dev/verity/pull/2137#discussion_r3554431578

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only CI OCR routing heuristics, but mis-parsing Lean could miss real proof risks or inflate packet scores; coverage is heavily regression-tested.
> 
> **Overview**
> **OCR Lean risk detection** now walks each diff hunk with a **stateful scanner** instead of stripping comments line-by-line. Unchanged `ctx` lines establish block comments, strings, and open `s!"…{` interpolations before added/deleted lines are classified, which fixes false positives when prose inside context-delimited `/- … -/` mentions `sorry`, `axiom`, or `unsafe`.
> 
> The scanner understands **nested block comments**, line comments, raw strings (`r#"…"#`), interpolated strings (including nested braces, quoted `'}'`, and Unicode primed identifiers), `«…»` escaped ids, and char literals. **Risk signals** (`sorry`/`admit`, `axiom`, `unsafe`, imports) run on code extracted from changed sides only; **theorem weakening** uses a separate pass with `preserveStrings` so literal and raw-string changes in theorem statements still compare correctly.
> 
> **`test-ocr-routing.js`** adds a large regression suite (context block comments, string delimiters, interpolation edge cases, and a parameterized blocker table).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ed2a37f6d3c7f5b98ff89cc870c47eab655052. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->