### PR TITLE
Version large Lean scout OCR dedup tags

### DIFF
--- a/.github/scripts/post-ocr-review.js
+++ b/.github/scripts/post-ocr-review.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const crypto = require('crypto');
 const fs = require('fs');
 
 module.exports = async function postOcrReview({ github, context, core }) {
@@ -15,18 +16,11 @@ module.exports = async function postOcrReview({ github, context, core }) {
   const reviewerVersion = (process.env.OCR_REVIEWER_VERSION || 'reviewer-v2').slice(0, 20);
   const routerVersion = (process.env.OCR_ROUTER_VERSION || 'router-v0').slice(0, 20);
   const mode = (process.env.OCR_MODE || 'legacy').slice(0, 40);
-  const dedupKey = `${commit_id}:${rulesHash}:${reviewerVersion}:${routerVersion}:${mode}`;
-  const successTag = `<!-- paloma-ocr-review:${dedupKey}:success -->`;
-  const retryableTag = `<!-- paloma-ocr-review:${dedupKey}:retryable-failure -->`;
+  const defaultDedupKey = buildDedupBaseKey({ commit_id, rulesHash, reviewerVersion, routerVersion, mode });
+  const defaultRetryableTag = `<!-- paloma-ocr-review:${defaultDedupKey}:retryable-failure -->`;
 
   if (!pull_number || !commit_id) {
     throw new Error('OCR_PR_NUMBER and OCR_HEAD_SHA are required');
-  }
-
-  const alreadyPosted = await hasExistingTag(github, { owner, repo, pull_number, tag: successTag });
-  if (alreadyPosted) {
-    core.notice(`Successful OCR review for ${commit_id} was already posted; skipping duplicate.`);
-    return;
   }
 
   const raw = fs.existsSync(resultPath) ? fs.readFileSync(resultPath, 'utf8') : '';
@@ -35,6 +29,16 @@ module.exports = async function postOcrReview({ github, context, core }) {
   try {
     result = JSON.parse(raw);
   } catch (err) {
+    const alreadySucceeded = await hasExistingSuccessForDedupBase(github, {
+      owner,
+      repo,
+      pull_number,
+      dedupKeyBase: defaultDedupKey,
+    });
+    if (alreadySucceeded) {
+      core.notice(`Successful OCR review for ${commit_id} was already posted; skipping invalid JSON failure duplicate.`);
+      return;
+    }
     writeMetrics(metricsPath, enrichMetrics(readMetrics(metricsPath), {
       mode,
       result: { status: 'invalid_json', comments: [], warnings: [] },
@@ -43,7 +47,8 @@ module.exports = async function postOcrReview({ github, context, core }) {
     }));
     await github.rest.issues.createComment({
       owner, repo, issue_number: pull_number,
-      body: `${retryableTag}\n⚠️ **OpenCodeReview failed to produce valid JSON.**\n\n${stderr ? fenced(stderr) : 'No stderr captured.'}`,
+      // Invalid JSON has no trustworthy result/metrics payload, so use the base retryable tag.
+      body: `${defaultRetryableTag}\n⚠️ **OpenCodeReview failed to produce valid JSON.**\n\n${stderr ? fenced(stderr) : 'No stderr captured.'}`,
     });
     return;
   }
@@ -54,6 +59,28 @@ module.exports = async function postOcrReview({ github, context, core }) {
   const summaryOnly = [];
   const retryableResult = isRetryableResult(result);
   const metrics = enrichMetrics(readMetrics(metricsPath), { mode, result, stderr, retryable: retryableResult });
+  const dedupKey = buildDedupKey({ commit_id, rulesHash, reviewerVersion, routerVersion, mode, result, metrics });
+  const successTag = `<!-- paloma-ocr-review:${dedupKey}:success -->`;
+  const retryableTag = `<!-- paloma-ocr-review:${dedupKey}:retryable-failure -->`;
+
+  const alreadyPosted = await hasExistingTag(github, { owner, repo, pull_number, tag: successTag });
+  if (alreadyPosted) {
+    core.notice(`Successful OCR review for ${commit_id} was already posted; skipping duplicate.`);
+    return;
+  }
+  const legacyLargeLeanDuplicate = await hasExistingLegacyLargeLeanScoutSuccess(github, {
+    owner,
+    repo,
+    pull_number,
+    dedupKeyBase: defaultDedupKey,
+    result,
+    metrics,
+  });
+  if (legacyLargeLeanDuplicate) {
+    core.notice(`Successful large Lean scout review for ${commit_id} with the same scout discriminator was already posted; skipping duplicate.`);
+    return;
+  }
+
   writeMetrics(metricsPath, metrics);
 
   for (const c of comments) {
@@ -126,9 +153,151 @@ async function hasExistingTag(github, { owner, repo, pull_number, tag }) {
   return reviews.some(r => String(r.body || '').includes(tag));
 }
 
+async function hasExistingSuccessForDedupBase(github, { owner, repo, pull_number, dedupKeyBase }) {
+  const hasSuccess = body => {
+    const text = String(body || '');
+    const start = `<!-- paloma-ocr-review:${dedupKeyBase}`;
+    let index = text.indexOf(start);
+    while (index !== -1) {
+      const end = text.indexOf('-->', index);
+      if (end !== -1 && text.slice(index, end + 3).endsWith(':success -->')) return true;
+      index = text.indexOf(start, index + start.length);
+    }
+    return false;
+  };
+
+  const issueComments = await github.paginate(github.rest.issues.listComments, {
+    owner, repo, issue_number: pull_number, per_page: 100,
+  });
+  if (issueComments.some(c => hasSuccess(c.body))) return true;
+
+  const reviews = await github.paginate(github.rest.pulls.listReviews, {
+    owner, repo, pull_number, per_page: 100,
+  });
+  return reviews.some(r => hasSuccess(r.body));
+}
+
+async function hasExistingLegacyLargeLeanScoutSuccess(github, { owner, repo, pull_number, dedupKeyBase, result, metrics }) {
+  const signature = largeLeanScoutVisibleSignature({ result, metrics });
+  if (!signature) return false;
+  const legacyTag = `<!-- paloma-ocr-review:${dedupKeyBase}:success -->`;
+  const hasMatchingLegacySuccess = body => {
+    const text = String(body || '');
+    return text.includes(legacyTag)
+      && hasExactLegacyPacketLine(text, signature)
+      && hasExactLegacyScoutLine(text, signature);
+  };
+
+  const issueComments = await github.paginate(github.rest.issues.listComments, {
+    owner, repo, issue_number: pull_number, per_page: 100,
+  });
+  if (issueComments.some(c => hasMatchingLegacySuccess(c.body))) return true;
+
+  const reviews = await github.paginate(github.rest.pulls.listReviews, {
+    owner, repo, pull_number, per_page: 100,
+  });
+  return reviews.some(r => hasMatchingLegacySuccess(r.body));
+}
+
 function isRetryableResult(result) {
   const status = String(result.status || '').toLowerCase();
   return status === 'error' || status === 'failed' || status === 'failure' || status === 'completed_with_errors';
+}
+
+function buildDedupKey({ commit_id, rulesHash, reviewerVersion, routerVersion, mode, result, metrics }) {
+  const base = buildDedupBaseKey({ commit_id, rulesHash, reviewerVersion, routerVersion, mode });
+  const discriminator = buildLargeLeanScoutDedupDiscriminator({ mode, result, metrics });
+  return discriminator ? `${base}:${discriminator}` : base;
+}
+
+function buildDedupBaseKey({ commit_id, rulesHash, reviewerVersion, routerVersion, mode }) {
+  return `${commit_id}:${rulesHash}:${reviewerVersion}:${routerVersion}:${mode}`;
+}
+
+function buildLargeLeanScoutDedupDiscriminator({ mode, result, metrics }) {
+  const effectiveMode = metrics?.mode || result?.summary?.mode || mode;
+  const packetReview = metrics?.packet_review || result?.summary?.packet_review;
+  if (effectiveMode !== 'large-lean-hotspots' || !packetReview) return '';
+
+  const scout = packetReview.scout || {};
+  const enabled = scout.enabled ? 'enabled' : 'disabled';
+  const model = sanitizeDedupComponent(scout.model || 'none', 80);
+  const status = sanitizeDedupComponent(scout.status || 'unknown', 48);
+  const selected = sanitizeDedupComponent(packetReview.packets_selected ?? 'unknown', 24);
+  const budget = sanitizeDedupComponent(packetReview.packet_budget ?? 'unknown', 24);
+  const packetFingerprint = fingerprintPacketIds(packetReview);
+  return `scout-v1:${enabled}:model-${model}:status-${status}:packets-${selected}-of-${budget}:ids-${packetFingerprint}`;
+}
+
+function largeLeanScoutVisibleSignature({ result, metrics }) {
+  const effectiveMode = metrics?.mode || result?.summary?.mode;
+  const packetReview = metrics?.packet_review || result?.summary?.packet_review;
+  if (effectiveMode !== 'large-lean-hotspots' || !packetReview) return null;
+
+  const scout = packetReview.scout || {};
+  const model = String(scout.model || '').trim();
+  const status = String(scout.status || '').trim();
+  const selected = packetReview.packets_selected;
+  const budget = packetReview.packet_budget;
+  if (!model || !status || selected == null || budget == null) return null;
+  return {
+    model,
+    status,
+    selected: String(selected),
+    budget: String(budget),
+  };
+}
+
+function hasExactLegacyPacketLine(text, signature) {
+  const selected = escapeRegExp(signature.selected);
+  const budget = escapeRegExp(signature.budget);
+  return new RegExp(`(?:^|\\n)- Packet review: [^\\n]*selected ${selected}/${budget}(?:\\s|$)`).test(text);
+}
+
+function hasExactLegacyScoutLine(text, signature) {
+  const status = escapeRegExp(signature.status);
+  const model = escapeRegExp(signature.model);
+  return new RegExp(`(?:^|\\n)- Scout: [^\\n]*status ${status}; model ${model}(?:\\s|$)`).test(text);
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function sanitizeDedupComponent(value, maxLength = 80) {
+  const raw = String(value ?? '');
+  if (isSensitiveDedupValue(raw)) {
+    return `redacted-${hashDedupValue(raw)}`;
+  }
+  const sanitized = raw
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, maxLength);
+  return sanitized || 'empty';
+}
+
+function isSensitiveDedupValue(value) {
+  const text = String(value || '').trim();
+  if (!text) return false;
+  if (/https?:\/\//i.test(text) || /(^|[\s,;])\/\/[^\s,;]+/.test(text)) return true;
+  if (/(^|[\s,;])(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}(?:[:/?#]|$)/.test(text)) return true;
+  if (/(api[_-]?key|token|secret|password|bearer)/i.test(text)) return true;
+  if (/^[A-Za-z0-9+/=_-]{16,}$/.test(text)) return true;
+  return false;
+}
+
+function hashDedupValue(value) {
+  return crypto.createHash('sha256').update(String(value)).digest('hex').slice(0, 12);
+}
+
+function fingerprintPacketIds(packetReview) {
+  const packets = Array.isArray(packetReview?.packets) ? packetReview.packets : [];
+  const ids = packets
+    .map(packet => packet?.packet_id || packet?.id || `${packet?.path || 'unknown'}:${packet?.start_line ?? '?'}-${packet?.end_line ?? '?'}`)
+    .filter(Boolean)
+    .map(String);
+  if (!ids.length) return 'none';
+  return hashDedupValue(ids.join('|'));
 }
 
 function toReviewComment(c) {
@@ -350,3 +519,5 @@ function escapeMd(s) {
 module.exports.isRetryableResult = isRetryableResult;
 module.exports.buildReviewBody = buildReviewBody;
 module.exports.extractOcrSummary = extractOcrSummary;
+module.exports.buildDedupKey = buildDedupKey;
+module.exports.buildLargeLeanScoutDedupDiscriminator = buildLargeLeanScoutDedupDiscriminator;

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -1388,6 +1388,241 @@ async function testCompletedWithErrorsRetryablePreservesFindings() {
   assert.strictEqual(metrics.ocr.total_tokens, 12345);
 }
 
+async function testInvalidJsonSkipsRetryableFailureAfterExistingSuccess() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-post-invalid-test-'));
+  const resultPath = path.join(dir, 'result.json');
+  const metricsPath = path.join(dir, 'metrics.json');
+  fs.writeFileSync(resultPath, '{not json');
+  fs.writeFileSync(metricsPath, JSON.stringify({ mode: 'large-lean-hotspots' }));
+
+  const oldEnv = { ...process.env };
+  Object.assign(process.env, {
+    OCR_PR_NUMBER: '123',
+    OCR_HEAD_SHA: 'abc123',
+    OCR_RESULT_PATH: resultPath,
+    OCR_METRICS_PATH: metricsPath,
+    OCR_RULES_HASH: 'ruleshash',
+    OCR_REVIEWER_VERSION: 'reviewer-v3',
+    OCR_ROUTER_VERSION: router.ROUTER_VERSION,
+    OCR_MODE: 'large-lean-hotspots',
+  });
+
+  const existingSuccessKey = postOcrReview.buildDedupKey({
+    commit_id: 'abc123',
+    rulesHash: 'ruleshash',
+    reviewerVersion: 'reviewer-v3',
+    routerVersion: router.ROUTER_VERSION.slice(0, 20),
+    mode: 'large-lean-hotspots',
+    result: { status: 'packetized_review', summary: { mode: 'large-lean-hotspots' } },
+    metrics: {
+      mode: 'large-lean-hotspots',
+      packet_review: {
+        packets_selected: 5,
+        packet_budget: 7,
+        scout: { enabled: true, status: 'success', model: 'reviewer_scout' },
+      },
+    },
+  });
+
+  let createCommentCalled = false;
+  let notice = '';
+  const github = {
+    paginate: async route => {
+      if (route === github.rest.pulls.listReviews) {
+        return [{ body: `<!-- paloma-ocr-review:${existingSuccessKey}:success -->\nexisting success` }];
+      }
+      return [];
+    },
+    rest: {
+      issues: {
+        listComments: async () => [],
+        createComment: async () => {
+          createCommentCalled = true;
+          return { data: {} };
+        },
+      },
+      pulls: {
+        listReviews: async () => [],
+        createReview: async () => {
+          throw new Error('createReview should not be called');
+        },
+      },
+    },
+  };
+
+  await postOcrReview({
+    github,
+    context: { repo: { owner: 'lfglabs-dev', repo: 'verity' } },
+    core: { notice(message) { notice = message; }, warning() {} },
+  });
+
+  process.env = oldEnv;
+  assert.strictEqual(createCommentCalled, false);
+  assert.ok(notice.includes('skipping invalid JSON failure duplicate'));
+}
+
+async function testSuccessfulDuplicateDoesNotRewriteMetrics() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-post-duplicate-test-'));
+  const resultPath = path.join(dir, 'result.json');
+  const metricsPath = path.join(dir, 'metrics.json');
+  fs.writeFileSync(resultPath, JSON.stringify({
+    status: 'packetized_review',
+    comments: [],
+    summary: { mode: 'large-lean-hotspots' },
+  }));
+
+  const originalMetrics = {
+    mode: 'large-lean-hotspots',
+    packet_review: {
+      enabled: true,
+      packets_selected: 5,
+      packet_budget: 7,
+      scout: { enabled: true, status: 'success', model: 'reviewer_scout' },
+    },
+  };
+  fs.writeFileSync(metricsPath, JSON.stringify(originalMetrics, null, 2));
+
+  const oldEnv = { ...process.env };
+  Object.assign(process.env, {
+    OCR_PR_NUMBER: '123',
+    OCR_HEAD_SHA: 'abc123',
+    OCR_RESULT_PATH: resultPath,
+    OCR_METRICS_PATH: metricsPath,
+    OCR_RULES_HASH: 'ruleshash',
+    OCR_REVIEWER_VERSION: 'reviewer-v3',
+    OCR_ROUTER_VERSION: router.ROUTER_VERSION,
+    OCR_MODE: 'large-lean-hotspots',
+  });
+
+  const existingSuccessKey = postOcrReview.buildDedupKey({
+    commit_id: 'abc123',
+    rulesHash: 'ruleshash',
+    reviewerVersion: 'reviewer-v3',
+    routerVersion: router.ROUTER_VERSION.slice(0, 20),
+    mode: 'large-lean-hotspots',
+    result: { status: 'packetized_review', summary: { mode: 'large-lean-hotspots' } },
+    metrics: originalMetrics,
+  });
+
+  let createReviewCalled = false;
+  const github = {
+    paginate: async route => {
+      if (route === github.rest.pulls.listReviews) {
+        return [{ body: `<!-- paloma-ocr-review:${existingSuccessKey}:success -->\nexisting success` }];
+      }
+      return [];
+    },
+    rest: {
+      issues: {
+        listComments: async () => [],
+        createComment: async () => {
+          throw new Error('createComment should not be called');
+        },
+      },
+      pulls: {
+        listReviews: async () => [],
+        createReview: async () => {
+          createReviewCalled = true;
+        },
+      },
+    },
+  };
+
+  await postOcrReview({
+    github,
+    context: { repo: { owner: 'lfglabs-dev', repo: 'verity' } },
+    core: { notice() {}, warning() {} },
+  });
+
+  process.env = oldEnv;
+  assert.strictEqual(createReviewCalled, false);
+  assert.deepStrictEqual(JSON.parse(fs.readFileSync(metricsPath, 'utf8')), originalMetrics);
+}
+
+async function testLegacyLargeLeanBaseTagDedupsOnlyMatchingScoutConfig() {
+  async function runCase({ currentModel, existingModel }) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-post-legacy-duplicate-test-'));
+    const resultPath = path.join(dir, 'result.json');
+    const metricsPath = path.join(dir, 'metrics.json');
+    fs.writeFileSync(resultPath, JSON.stringify({
+      status: 'packetized_review',
+      comments: [],
+      summary: { mode: 'large-lean-hotspots' },
+    }));
+    fs.writeFileSync(metricsPath, JSON.stringify({
+      mode: 'large-lean-hotspots',
+      packet_review: {
+        enabled: true,
+        packets_selected: 5,
+        packet_budget: 7,
+        scout: { enabled: true, status: 'success', model: currentModel },
+      },
+    }));
+
+    const oldEnv = { ...process.env };
+    Object.assign(process.env, {
+      OCR_PR_NUMBER: '123',
+      OCR_HEAD_SHA: 'abc123',
+      OCR_RESULT_PATH: resultPath,
+      OCR_METRICS_PATH: metricsPath,
+      OCR_RULES_HASH: 'ruleshash',
+      OCR_REVIEWER_VERSION: 'reviewer-v3',
+      OCR_ROUTER_VERSION: router.ROUTER_VERSION,
+      OCR_MODE: 'large-lean-hotspots',
+    });
+
+    const legacyBaseKey = [
+      'abc123',
+      'ruleshash',
+      'reviewer-v3',
+      router.ROUTER_VERSION.slice(0, 20),
+      'large-lean-hotspots',
+    ].join(':');
+    const legacyBody = [
+      `<!-- paloma-ocr-review:${legacyBaseKey}:success -->`,
+      '### Packet coverage',
+      '- Packet review: enabled; selected 5/7 packet(s)',
+      `- Scout: configured; status success; model ${existingModel}`,
+    ].join('\n');
+
+    let createReviewCalled = false;
+    const github = {
+      paginate: async route => {
+        if (route === github.rest.pulls.listReviews) return [{ body: legacyBody }];
+        return [];
+      },
+      rest: {
+        issues: {
+          listComments: async () => [],
+          createComment: async () => {
+            throw new Error('createComment should not be called');
+          },
+        },
+        pulls: {
+          listReviews: async () => [],
+          createReview: async () => {
+            createReviewCalled = true;
+            return { data: {} };
+          },
+        },
+      },
+    };
+
+    await postOcrReview({
+      github,
+      context: { repo: { owner: 'lfglabs-dev', repo: 'verity' } },
+      core: { notice() {}, warning() {} },
+    });
+
+    process.env = oldEnv;
+    return createReviewCalled;
+  }
+
+  assert.strictEqual(await runCase({ currentModel: 'reviewer_scout', existingModel: 'reviewer_scout' }), false);
+  assert.strictEqual(await runCase({ currentModel: 'reviewer_scout', existingModel: 'MiniMax-M3' }), true);
+  assert.strictEqual(await runCase({ currentModel: 'gpt-4', existingModel: 'gpt-4o' }), true);
+}
+
 function testScoutProviderErrorsNeutralizeMentions() {
   const body = postOcrReview.buildReviewBody({
     tag: '<!-- test -->',
@@ -1418,6 +1653,61 @@ function testScoutProviderErrorsNeutralizeMentions() {
   assert.ok(body.includes('&#64;octocat'));
   assert.ok(!body.includes('@verity-admins'));
   assert.ok(!body.includes('@octocat'));
+}
+
+function testLargeLeanScoutDedupVariesBySanitizedScoutConfig() {
+  const base = {
+    commit_id: 'abc123',
+    rulesHash: 'ruleshash',
+    reviewerVersion: 'reviewer-v3',
+    routerVersion: router.ROUTER_VERSION,
+    mode: 'large-lean-hotspots',
+    result: { status: 'packetized_review', summary: { mode: 'large-lean-hotspots' } },
+  };
+  const metricsFor = (model, packetIds = []) => ({
+    mode: 'large-lean-hotspots',
+    packet_review: {
+      enabled: true,
+      packets_selected: 5,
+      packet_budget: 7,
+      packets: packetIds.map(packet_id => ({ packet_id })),
+      scout: {
+        enabled: true,
+        status: 'success',
+        model,
+      },
+    },
+  });
+
+  const minimaxKey = postOcrReview.buildDedupKey({ ...base, metrics: metricsFor('MiniMax-M3') });
+  const reviewerScoutKey = postOcrReview.buildDedupKey({ ...base, metrics: metricsFor('reviewer_scout') });
+  assert.notStrictEqual(minimaxKey, reviewerScoutKey);
+  assert.ok(minimaxKey.includes('scout-v1:enabled:model-MiniMax-M3:status-success:packets-5-of-7:ids-none'));
+  assert.ok(reviewerScoutKey.includes('scout-v1:enabled:model-reviewer_scout:status-success:packets-5-of-7:ids-none'));
+
+  const packetSetAKey = postOcrReview.buildDedupKey({ ...base, metrics: metricsFor('reviewer_scout', ['lean-1', 'lean-2']) });
+  const packetSetBKey = postOcrReview.buildDedupKey({ ...base, metrics: metricsFor('reviewer_scout', ['lean-1', 'lean-3']) });
+  assert.notStrictEqual(packetSetAKey, packetSetBKey);
+  assert.ok(packetSetAKey.includes(':ids-'));
+  assert.ok(!packetSetAKey.includes('lean-1'));
+
+  const unsafeModel = 'https://sandboxed.example/v1?api_key=abcdefghijklmnopqrstuvwxyz123456';
+  const unsafeKey = postOcrReview.buildDedupKey({ ...base, metrics: metricsFor(unsafeModel) });
+  assert.ok(unsafeKey.includes('model-redacted-'));
+  assert.ok(!unsafeKey.includes('sandboxed.example'));
+  assert.ok(!unsafeKey.includes('abcdefghijklmnopqrstuvwxyz123456'));
+
+  const shortTokenKey = postOcrReview.buildDedupKey({ ...base, metrics: metricsFor('abcdefghijklmnop') });
+  assert.ok(shortTokenKey.includes('model-redacted-'));
+  assert.ok(!shortTokenKey.includes('abcdefghijklmnop'));
+
+  const normalKey = postOcrReview.buildDedupKey({
+    ...base,
+    mode: 'small-lean',
+    result: { status: 'success', summary: { mode: 'small-lean' } },
+    metrics: { mode: 'small-lean', packet_review: { scout: { model: 'reviewer_scout' } } },
+  });
+  assert.strictEqual(normalKey, `${base.commit_id}:${base.rulesHash}:${base.reviewerVersion}:${base.routerVersion}:small-lean`);
 }
 
 async function run() {
@@ -1504,7 +1794,11 @@ async function run() {
   testWorkflowDocsEnabled();
   testGenericScriptConfigEnabled();
   await testCompletedWithErrorsRetryablePreservesFindings();
+  await testInvalidJsonSkipsRetryableFailureAfterExistingSuccess();
+  await testSuccessfulDuplicateDoesNotRewriteMetrics();
+  await testLegacyLargeLeanBaseTagDedupsOnlyMatchingScoutConfig();
   testScoutProviderErrorsNeutralizeMentions();
+  testLargeLeanScoutDedupVariesBySanitizedScoutConfig();
   console.log('OCR routing tests passed');
 }
 


### PR DESCRIPTION
## Summary
- add a large-lean scout dedup discriminator to successful OCR review tags
- include only sanitized non-secret scout result/config fields: enabled state, model id, status, selected packet count, packet budget
- keep small/config/normal dedup tags unchanged

## Validation
- node --check .github/scripts/post-ocr-review.js
- node --check .github/scripts/test-ocr-routing.js
- node --check .github/scripts/ocr-router.js
- node .github/scripts/test-ocr-routing.js
- bash -n .github/scripts/ocr-git-wrapper.sh
- python3 -m json.tool .github/ocr/rules.json
- workflow YAML parse via PyYAML
- git diff --check

Note: actionlint is not installed in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to GitHub Actions OCR post-review scripting and tests; impact is limited to when duplicate or failure comments are posted on PRs.
> 
> **Overview**
> **Large-lean hotspot** OCR posting now builds success/retryable HTML comment tags **after** parsing JSON, appending a `scout-v1` discriminator (scout enablement, sanitized model/status, packet counts, hashed packet IDs) so different scout runs on the same commit are not treated as duplicates. Non–large-lean modes keep the previous base-only dedup key.
> 
> Duplicate handling is tightened: skip posting a retryable invalid-JSON comment when any success tag already exists for the base key; treat older reviews that only used the base tag as duplicates when packet/scout summary lines match; and return early on duplicate success **before** rewriting `metrics.json`.
> 
> Dedup components that look like URLs, domains, API keys, or long tokens are replaced with `redacted-<sha256-prefix>` so tags do not leak secrets. Tests cover invalid JSON after success, metrics preservation, legacy tag matching, and discriminator variation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d4b52aee1da4e2aaa3c1385aeb6b33c532873af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->