### PR TITLE
proof: package legacy compatibility for mapping2word writes

### DIFF
--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -3318,6 +3318,52 @@ private theorem compileSetMapping2_legacyCompatible
                           | none => "sstore")
                         key1Expr key2Expr valueExpr (slot :: slot' :: rest)
 
+private theorem compileSetMapping2Word_legacyCompatible
+    {fields : List Field} {fieldName : String} {dynamicSource : DynamicDataSource}
+    {key1 key2 value : Expr} {wordOffset : Nat} {compiledIR : List YulStmt}
+    (hcompile :
+      CompilationModel.compileSetMapping2Word fields dynamicSource fieldName key1 key2
+          wordOffset value [] =
+        Except.ok compiledIR) :
+    LegacyCompatibleExternalStmtList compiledIR := by
+  unfold CompilationModel.compileSetMapping2Word at hcompile
+  cases hMapping2 : isMapping2 fields fieldName <;> simp [hMapping2] at hcompile
+  cases hSlots : findFieldWriteSlots fields fieldName <;> simp [hSlots] at hcompile
+  rename_i slots
+  cases hkey1Expr : compileExprWithInternals fields dynamicSource [] key1 with
+  | error err => simp [hkey1Expr, bind, Except.bind] at hcompile
+  | ok key1Expr =>
+      cases hkey2Expr : compileExprWithInternals fields dynamicSource [] key2 with
+      | error err => simp [hkey1Expr, hkey2Expr, bind, Except.bind] at hcompile
+      | ok key2Expr =>
+          cases hvalueExpr : compileExprWithInternals fields dynamicSource [] value with
+          | error err => simp [hkey1Expr, hkey2Expr, hvalueExpr, bind, Except.bind] at hcompile
+          | ok valueExpr =>
+              cases slots with
+              | nil => simp [hkey1Expr, hkey2Expr, hvalueExpr, bind, Except.bind] at hcompile
+              | cons slot rest =>
+                  cases rest with
+                  | nil =>
+                      simp [hkey1Expr, hkey2Expr, hvalueExpr, bind, Except.bind] at hcompile
+                      cases hcompile
+                      exact .exprStmt _ _ .nil
+                  | cons slot' rest =>
+                      simp [hkey1Expr, hkey2Expr, hvalueExpr, bind, Except.bind] at hcompile
+                      cases hcompile
+                      exact legacyCompatibleExternalStmtList_block_key1_key2_value_writes
+                        (α := Nat)
+                        (f := fun slot =>
+                          let innerSlot :=
+                            YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key1"]
+                          let outerSlot :=
+                            YulExpr.call "mappingSlot" [innerSlot, YulExpr.ident "__compat_key2"]
+                          if wordOffset = 0 then outerSlot else
+                            YulExpr.call "add" [outerSlot, YulExpr.lit wordOffset])
+                        (match findFieldWithResolvedSlot fields fieldName with
+                          | some (f, _) => if f.isTransient then "tstore" else "sstore"
+                          | none => "sstore")
+                        key1Expr key2Expr valueExpr (slot :: slot' :: rest)
+
 private theorem compileSetMappingChain_legacyCompatible
     {fields : List Field}
     {fieldName : String}
@@ -3428,6 +3474,28 @@ theorem stmtList_setMapping2Single_compiledLegacyCompatible
     (fun compiledIR hcompile => by
       simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork] at hcompile
       exact compileSetMapping2_legacyCompatible hcompile)
+    .nil
+
+/-- Singleton `setMapping2Word` heads compile to ordinary legacy-compatible Yul. -/
+theorem stmtList_setMapping2WordSingle_compiledLegacyCompatible
+    (fields : List Field)
+    {scope : List String}
+    {fieldName : String}
+    {key1 key2 value : Expr}
+    {wordOffset slot : Nat}
+    (_hkey1 : FunctionBody.ExprCompileCore key1)
+    (_hscopeKey1 : FunctionBody.exprBoundNamesInScope key1 scope)
+    (_hkey2 : FunctionBody.ExprCompileCore key2)
+    (_hscopeKey2 : FunctionBody.exprBoundNamesInScope key2 scope)
+    (_hvalue : FunctionBody.ExprCompileCore value)
+    (_hscopeValue : FunctionBody.exprBoundNamesInScope value scope)
+    (_hslot : findFieldSlot fields fieldName = some slot) :
+    StmtListCompiledLegacyCompatible fields scope
+      [Stmt.setMapping2Word fieldName key1 key2 wordOffset value] :=
+  .cons
+    (fun compiledIR hcompile => by
+      simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork] at hcompile
+      exact compileSetMapping2Word_legacyCompatible hcompile)
     .nil
 
 /-- Singleton `setMappingUint` heads compile to ordinary legacy-compatible Yul. -/

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2151,10 +2151,12 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Function.stmtList_setStorageAddrSingleSlot_compiledLegacyCompatible
   -- Compiler.Proofs.IRGeneration.Function.compileMappingSlotWrite_legacyCompatible  -- private
   -- Compiler.Proofs.IRGeneration.Function.compileSetMapping2_legacyCompatible  -- private
+  -- Compiler.Proofs.IRGeneration.Function.compileSetMapping2Word_legacyCompatible  -- private
   -- Compiler.Proofs.IRGeneration.Function.compileSetMappingChain_legacyCompatible  -- private
   Compiler.Proofs.IRGeneration.Function.stmtList_setMappingSingle_compiledLegacyCompatible
   Compiler.Proofs.IRGeneration.Function.stmtList_setMappingChainSingle_compiledLegacyCompatible
   Compiler.Proofs.IRGeneration.Function.stmtList_setMapping2Single_compiledLegacyCompatible
+  Compiler.Proofs.IRGeneration.Function.stmtList_setMapping2WordSingle_compiledLegacyCompatible
   Compiler.Proofs.IRGeneration.Function.stmtList_setMappingUintSingle_compiledLegacyCompatible
   Compiler.Proofs.IRGeneration.Function.stmtList_setMappingWordSingle_compiledLegacyCompatible
   Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_body_legacyCompatible_of_interface
@@ -5983,4 +5985,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5613 theorems/lemmas (3875 public, 1738 private, 0 sorry'd)
+-- Total: 5615 theorems/lemmas (3876 public, 1739 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- Adds a structural legacy-compatible proof for `CompilationModel.compileSetMapping2Word` over singleton ordinary two-key mapping word writes.
- Packages `StmtListCompiledLegacyCompatible` for `[Stmt.setMapping2Word ...]`.
- Regenerates `PrintAxioms.lean` audit entries/counts.

## Base / dependencies
- Base/target: `paloma/issue-2080-mapping-chain-phase33` (#2143), which is open, clean, and green at inspection time.
- Depends on #2143 and inherited stack #2141, #2134, and #2128.
- Inspected unrelated #2132 for live status; this PR does not depend on it.

Do not merge until predecessor stack is merged/green.

## Validation
- `git diff --check` passed.
- `lean-slot lake build Compiler.Proofs.IRGeneration.Function Compiler.Proofs.IRGeneration.Contract PrintAxioms` passed.
- `python3 scripts/generate_print_axioms.py --check` passed: `PrintAxioms.lean is up to date`.
- `python3 scripts/check_proof_length.py` passed: `5811 proofs scanned`, no new proofs exceed the 50-line hard limit.
- Confirmed no new `sorry`, `admit`, or `axiom` declarations in touched proof files; `rg` hits were only `PrintAxioms` comment/header text.

Refs #2080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions with no changes to compilation logic or runtime behavior; risk is limited to formal verification maintenance.
> 
> **Overview**
> Extends the IR-generation legacy-compatibility story to **`setMapping2Word`** (two-key mapping writes at a word offset), mirroring the existing **`setMapping2`** packaging.
> 
> Adds **`compileSetMapping2Word_legacyCompatible`**, which case-splits on successful **`compileSetMapping2Word`** output and shows the emitted Yul is **`LegacyCompatibleExternalStmtList`**, including nested **`mappingSlot`** keys and an **`add`** when **`wordOffset ≠ 0`**, with **`sstore`/`tstore`** chosen from field transience. Adds public **`stmtList_setMapping2WordSingle_compiledLegacyCompatible`** so a singleton **`[Stmt.setMapping2Word …]`** list is **`StmtListCompiledLegacyCompatible`**.
> 
> **`PrintAxioms.lean`** is refreshed to list the new private helper (commented) and public theorem, with theorem counts **5613 → 5615**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03892e9bb00745c2c93a578c86b63ba1ea2c4dd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->