### PR TITLE
proof: package legacy compatibility for struct member2 writes

### DIFF
--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -3364,6 +3364,56 @@ private theorem compileSetMapping2Word_legacyCompatible
                           | none => "sstore")
                         key1Expr key2Expr valueExpr (slot :: slot' :: rest)
 
+private theorem compileSetStructMember2_legacyCompatible
+    {fields : List Field} {fieldName memberName : String} {dynamicSource : DynamicDataSource}
+    {key1 key2 value : Expr} {wordOffset : Nat} {members : List StructMember}
+    {compiledIR : List YulStmt}
+    (hmembers : findStructMembers fields fieldName = some members)
+    (hmember : findStructMember members memberName =
+        some { name := memberName, wordOffset := wordOffset, packed := none })
+    (hcompile : CompilationModel.compileSetStructMember2 fields dynamicSource fieldName key1 key2
+          memberName value [] = Except.ok compiledIR) :
+    LegacyCompatibleExternalStmtList compiledIR := by
+  unfold CompilationModel.compileSetStructMember2 at hcompile
+  cases hMapping2 : isMapping2 fields fieldName <;> simp [hMapping2] at hcompile
+  simp [hmembers, hmember] at hcompile
+  cases hSlots : findFieldWriteSlots fields fieldName <;> simp [hSlots] at hcompile
+  rename_i slots
+  cases hkey1Expr : compileExprWithInternals fields dynamicSource [] key1 with
+  | error err => simp [hkey1Expr, bind, Except.bind] at hcompile
+  | ok key1Expr =>
+      cases hkey2Expr : compileExprWithInternals fields dynamicSource [] key2 with
+      | error err => simp [hkey1Expr, hkey2Expr, bind, Except.bind] at hcompile
+      | ok key2Expr =>
+          cases hvalueExpr : compileExprWithInternals fields dynamicSource [] value with
+          | error err => simp [hkey1Expr, hkey2Expr, hvalueExpr, bind, Except.bind] at hcompile
+          | ok valueExpr =>
+              cases slots with
+              | nil => simp [hkey1Expr, hkey2Expr, hvalueExpr, bind, Except.bind] at hcompile
+              | cons slot rest =>
+                  cases rest with
+                  | nil =>
+                      simp [hkey1Expr, hkey2Expr, hvalueExpr, bind, Except.bind] at hcompile
+                      cases hcompile
+                      exact .exprStmt _ _ .nil
+                    | cons slot' rest =>
+                      simp [hkey1Expr, hkey2Expr, hvalueExpr, bind, Except.bind] at hcompile
+                      cases hcompile
+                      let finalSlot := fun slot =>
+                        let innerSlot :=
+                          YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key1"]
+                        let outerSlot :=
+                          YulExpr.call "mappingSlot" [innerSlot, YulExpr.ident "__compat_key2"]
+                        if wordOffset = 0 then outerSlot else
+                          YulExpr.call "add" [outerSlot, YulExpr.lit wordOffset]
+                      exact legacyCompatibleExternalStmtList_block_key1_key2_value_writes
+                        (α := Nat)
+                        (f := finalSlot)
+                        (match findFieldWithResolvedSlot fields fieldName with
+                          | some (f, _) => if f.isTransient then "tstore" else "sstore"
+                          | none => "sstore")
+                        key1Expr key2Expr valueExpr (slot :: slot' :: rest)
+
 private theorem compileSetMappingChain_legacyCompatible
     {fields : List Field}
     {fieldName : String}
@@ -3496,6 +3546,34 @@ theorem stmtList_setMapping2WordSingle_compiledLegacyCompatible
     (fun compiledIR hcompile => by
       simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork] at hcompile
       exact compileSetMapping2Word_legacyCompatible hcompile)
+    .nil
+
+/-- Singleton `setStructMember2` heads for unpacked members compile to ordinary
+legacy-compatible Yul. -/
+theorem stmtList_setStructMember2Single_compiledLegacyCompatible
+    (fields : List Field)
+    {scope : List String}
+    {fieldName memberName : String}
+    {key1 key2 value : Expr}
+    {slot wordOffset : Nat}
+    {members : List StructMember}
+    (_hkey1 : FunctionBody.ExprCompileCore key1)
+    (_hscopeKey1 : FunctionBody.exprBoundNamesInScope key1 scope)
+    (_hkey2 : FunctionBody.ExprCompileCore key2)
+    (_hscopeKey2 : FunctionBody.exprBoundNamesInScope key2 scope)
+    (_hvalue : FunctionBody.ExprCompileCore value)
+    (_hscopeValue : FunctionBody.exprBoundNamesInScope value scope)
+    (_hslot : findFieldSlot fields fieldName = some slot)
+    (hmembers : findStructMembers fields fieldName = some members)
+    (hmember :
+      findStructMember members memberName =
+        some { name := memberName, wordOffset := wordOffset, packed := none }) :
+    StmtListCompiledLegacyCompatible fields scope
+      [Stmt.setStructMember2 fieldName key1 key2 memberName value] :=
+  .cons
+    (fun compiledIR hcompile => by
+      simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork] at hcompile
+      exact compileSetStructMember2_legacyCompatible hmembers hmember hcompile)
     .nil
 
 /-- Singleton `setMappingUint` heads compile to ordinary legacy-compatible Yul. -/

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2152,11 +2152,13 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Function.compileMappingSlotWrite_legacyCompatible  -- private
   -- Compiler.Proofs.IRGeneration.Function.compileSetMapping2_legacyCompatible  -- private
   -- Compiler.Proofs.IRGeneration.Function.compileSetMapping2Word_legacyCompatible  -- private
+  -- Compiler.Proofs.IRGeneration.Function.compileSetStructMember2_legacyCompatible  -- private
   -- Compiler.Proofs.IRGeneration.Function.compileSetMappingChain_legacyCompatible  -- private
   Compiler.Proofs.IRGeneration.Function.stmtList_setMappingSingle_compiledLegacyCompatible
   Compiler.Proofs.IRGeneration.Function.stmtList_setMappingChainSingle_compiledLegacyCompatible
   Compiler.Proofs.IRGeneration.Function.stmtList_setMapping2Single_compiledLegacyCompatible
   Compiler.Proofs.IRGeneration.Function.stmtList_setMapping2WordSingle_compiledLegacyCompatible
+  Compiler.Proofs.IRGeneration.Function.stmtList_setStructMember2Single_compiledLegacyCompatible
   Compiler.Proofs.IRGeneration.Function.stmtList_setMappingUintSingle_compiledLegacyCompatible
   Compiler.Proofs.IRGeneration.Function.stmtList_setMappingWordSingle_compiledLegacyCompatible
   Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_body_legacyCompatible_of_interface
@@ -5985,4 +5987,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5615 theorems/lemmas (3876 public, 1739 private, 0 sorry'd)
+-- Total: 5617 theorems/lemmas (3877 public, 1740 private, 0 sorry'd)


### PR DESCRIPTION
Refs #2080

## Base / dependency chain

Stacked on #2145 (`paloma/issue-2080-mapping2word-phase34`, head `03892e9bb00745c2c93a578c86b63ba1ea2c4dd5`). Inherited stack:

#2128 -> #2134 -> #2141 -> #2143 -> #2145 -> this PR

Live preflight before editing found #2145 open and healthy; its remaining foundry shard has since completed successfully.

## Slice

Packages the next ordinary supported singleton after `setMapping2WordSingle` in `SupportedStmtList`: unpacked `setStructMember2Single`.

Changes:
- Adds `compileSetStructMember2_legacyCompatible` for the compiler shape emitted by `compileSetStructMember2` when the supported witness resolves an unpacked struct member.
- Adds public `stmtList_setStructMember2Single_compiledLegacyCompatible` producing `StmtListCompiledLegacyCompatible fields scope [Stmt.setStructMember2 ...]`.
- Regenerates `PrintAxioms.lean` for the added theorem surface.

Event heads were inspected but not selected for this #2080 no-events slice: event support is on the scalar-events proof tier, while the current #2080 legacy body bridge remains over `SupportedSpec` with `noEvents`.

## Validation

- `git diff --check`
- `lean-slot lake build Compiler.Proofs.IRGeneration.Function`
- `lean-slot lake build Compiler.Proofs.IRGeneration.Contract`
- `lean-slot lake build Compiler.Proofs.IRGeneration.Function Compiler.Proofs.IRGeneration.Contract`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_proof_length.py`
- Verified no added `sorry`, `admit`, or `axiom` declarations in the diff

## Remaining #2080 gate

The whole-contract retarget still consumes per-body `StmtListCompiledLegacyCompatible` obligations and still ultimately depends on retiring `SupportedStmtList.helperSurfaceClosed`. This PR only closes one more singleton body-shape obligation.

## Recommended next slice

Package the next uncovered ordinary supported singleton in the same no-events storage tier, likely `setStructMemberSingle` or `setMappingPackedWordSingle` after inspecting exact constructor order and compiler shape. Keep event heads for the scalar-events roadmap unless the #2080 bridge is explicitly widened beyond `SupportedSpec.noEvents`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only changes in IR generation lemmas; no compiler runtime or code generation behavior is modified.
> 
> **Overview**
> Extends the **#2080** legacy Yul bridge with one more supported singleton: a single **`Stmt.setStructMember2`** whose struct member is **unpacked** (no packed layout).
> 
> Adds **`compileSetStructMember2_legacyCompatible`**, showing the IR from **`compileSetStructMember2`** in that shape satisfies **`LegacyCompatibleExternalStmtList`**—including nested **`mappingSlot`** keys and **`sstore`/`tstore`** choice from field transience, reusing the same block-write helper pattern as **`setMapping2Word`**.
> 
> Adds public **`stmtList_setStructMember2Single_compiledLegacyCompatible`**, yielding **`StmtListCompiledLegacyCompatible`** for that one-statement list under the usual compile-core and scope hypotheses.
> 
> **`PrintAxioms.lean`** is regenerated (private helper listed; public theorem exported). Theorem count +2; no new axioms or sorries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d95803aa24caffaa8f36aade1e401b8533d6bb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->