### PR TITLE
Bridge dynamic ABI array member offsets to core model

### DIFF
--- a/Compiler/Proofs/IRGeneration/DynamicAbiRefinement.lean
+++ b/Compiler/Proofs/IRGeneration/DynamicAbiRefinement.lean
@@ -164,23 +164,25 @@ def arrayElementDynamicMemberElement? (selector : Nat) (calldata : List Nat)
 theorem arrayElementDynamicMemberDataOffset_eq_length_pos_add_word
     {selector : Nat} {calldata : List Nat} {dataOffset length index wordOffset data : Nat}
     (h :
-      arrayElementDynamicMemberDataOffset? selector calldata dataOffset length index wordOffset =
-        some data) :
+      DynamicAbi.arrayElementDynamicMemberDataOffset?
+          selector calldata dataOffset length index wordOffset = some data) :
     ∃ elementHead memberRelOffset,
-      arrayElementDynamicHeadOffset? selector calldata dataOffset length index = some elementHead ∧
-      externalWordAt? selector calldata (elementHead + wordOffset * 32) = some memberRelOffset ∧
+      DynamicAbi.arrayElementDynamicHeadOffset?
+          selector calldata dataOffset length index = some elementHead ∧
+      DynamicAbi.externalWordAt? selector calldata
+          (elementHead + wordOffset * 32) = some memberRelOffset ∧
       data = elementHead + memberRelOffset + 32 := by
-  unfold arrayElementDynamicMemberDataOffset? at h
+  unfold DynamicAbi.arrayElementDynamicMemberDataOffset? at h
   cases hhead :
-      arrayElementDynamicHeadOffset? selector calldata dataOffset length index with
+      DynamicAbi.arrayElementDynamicHeadOffset? selector calldata dataOffset length index with
   | none => simp [hhead] at h
   | some elementHead =>
       cases hmember :
-          externalWordAt? selector calldata (elementHead + wordOffset * 32) with
+          DynamicAbi.externalWordAt? selector calldata (elementHead + wordOffset * 32) with
       | none => simp [hhead, hmember] at h
       | some memberRelOffset =>
           by_cases hbounds :
-              elementHead + memberRelOffset + 32 ≤ externalCalldataSize calldata
+              elementHead + memberRelOffset + 32 ≤ DynamicAbi.externalCalldataSize calldata
           · simp [hhead, hmember, hbounds] at h
             refine ⟨elementHead, memberRelOffset, ?_, ?_, ?_⟩
             · rfl


### PR DESCRIPTION
## Summary
- Retarget `Compiler.Proofs.IRGeneration.DynamicAbiRefinement.arrayElementDynamicMemberDataOffset_eq_length_pos_add_word` to prove the decomposition for core `DynamicAbi.*` functions directly.
- Keep the proof-side duplicate helpers untouched for existing local consumers.

## Context
This is #2083 reusable ABI-array groundwork. It bridges the offset decomposition lemma to the core model and does not remove or alter any SupportedSpec blockers.

## Validation
- `lean-slot lake build Compiler.Proofs.IRGeneration.DynamicAbiRefinement` passed.
- `python3 scripts/lean_lint.py --only proof_length` passed.
- `rg -n "sorry|admit|axiom |unsafe|allowlist" Compiler/Proofs/IRGeneration/DynamicAbiRefinement.lean` returned no matches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only namespace qualification in a single theorem; no runtime or spec behavior changes.
> 
> **Overview**
> **`arrayElementDynamicMemberDataOffset_eq_length_pos_add_word`** in `DynamicAbiRefinement.lean` now states and proves its decomposition against **`Verity.Core.Model.DynamicAbi`** (`DynamicAbi.arrayElementDynamicMemberDataOffset?`, `arrayElementDynamicHeadOffset?`, `externalWordAt?`, `externalCalldataSize`) instead of the unqualified refinement-local copies.
> 
> The proof script is the same case split on head offset, member word, and bounds; only names in the hypothesis, `unfold`, and `cases` targets are qualified. Local dynamic-ABI helpers in this file are unchanged for existing consumers (e.g. ERC-4337 decoding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fed4a9ab8912e1a7975eb7d7d05254af38925dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->