### PR TITLE
proof: repair helper body seam main merge

### DIFF
--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -3396,7 +3396,7 @@ private theorem compileSetStructMember2_legacyCompatible
                       simp [hkey1Expr, hkey2Expr, hvalueExpr, bind, Except.bind] at hcompile
                       cases hcompile
                       exact .exprStmt _ _ .nil
-                    | cons slot' rest =>
+                  | cons slot' rest =>
                       simp [hkey1Expr, hkey2Expr, hvalueExpr, bind, Except.bind] at hcompile
                       cases hcompile
                       let finalSlot := fun slot =>


### PR DESCRIPTION
## Summary

- Merges current `origin/main` into `paloma/issue-2080-helper-body-seam` without modifying the helper-body proof slice.
- Resolves the generated `PrintAxioms.lean` conflict by preserving both:
  - main's `setStructMember2` legacy-compatible theorem entries from #2146
  - #2153's `HelperBodyBridge` lookup/body-shape theorem entries
- Restores the `Function.lean` `setStructMember2` legacy-compatible theorem pair through the main merge, addressing the OCR proof-interface concern that #2153 appeared to drop those public/private names.

## Validation

- `git diff --cached --check` passed before commit
- `python3 scripts/check_proof_length.py` passed
- `python3 scripts/generate_print_axioms.py --check` passed
- `lean-slot lake build Compiler.Proofs.IRGeneration.HelperBodyBridge PrintAxioms` passed via Spark (`remote build finished (exit=0)`, `Build completed successfully.`)
- Scan of touched proof files found no proof `sorry`, `admit`, or `axiom`; only generated `PrintAxioms` comment text contains `sorry'd`.

## Notes

This is only a conflict/proof-interface repair for #2153. It does not claim #2080 closure and does not prove `execIRInternalFunctionWithInternals_obeys_internal_helper_summary`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof-structure/indentation repair in an existing theorem; no runtime or compiler behavior changes.
> 
> **Overview**
> Repairs the **`compileSetStructMember2` legacy-compatible** proof in `Function.lean` after merging `main` into the helper-body seam branch.
> 
> The **`cons slot' rest`** arm of the `cases rest with` on write slots was incorrectly indented under the **`nil`** branch, so Lean treated it as nested inside the single-slot case instead of as the separate multi-slot path. **Re-indenting** restores the intended structure: single-slot still ends with `exact .exprStmt _ _ .nil`, and two-or-more slots still use `legacyCompatibleExternalStmtList_block_key1_key2_value_writes` with the nested `mappingSlot` / `wordOffset` slot function. **No change to proof content**—only case-tree layout so the `setStructMember2` theorem pair from main stays buildable alongside the helper-body work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abce908218694b2489c967c1ad4ce91f8b544e3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->