### PR TITLE
proof: extend helper expr projection core

### DIFF
--- a/Compiler/Proofs/IRGeneration/InternalHelperBodyCorrespondence.lean
+++ b/Compiler/Proofs/IRGeneration/InternalHelperBodyCorrespondence.lean
@@ -256,6 +256,85 @@ inductive InternalHelperExprProjectionCore : Expr → Prop where
   | literal (value : Nat) : InternalHelperExprProjectionCore (.literal value)
   | param (name : String) : InternalHelperExprProjectionCore (.param name)
   | localVar (name : String) : InternalHelperExprProjectionCore (.localVar name)
+  | add {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.add lhs rhs)
+  | sub {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.sub lhs rhs)
+  | mul {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.mul lhs rhs)
+  | div {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.div lhs rhs)
+  | mod {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.mod lhs rhs)
+  | eq {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.eq lhs rhs)
+  | ge {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.ge lhs rhs)
+  | gt {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.gt lhs rhs)
+  | lt {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.lt lhs rhs)
+  | le {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.le lhs rhs)
+  | logicalAnd {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.logicalAnd lhs rhs)
+  | logicalOr {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.logicalOr lhs rhs)
+  | bitAnd {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.bitAnd lhs rhs)
+  | bitOr {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.bitOr lhs rhs)
+  | bitXor {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.bitXor lhs rhs)
+  | min {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.min lhs rhs)
+  | max {lhs rhs : Expr} :
+      InternalHelperExprProjectionCore lhs →
+      InternalHelperExprProjectionCore rhs →
+      InternalHelperExprProjectionCore (.max lhs rhs)
+  | logicalNot {expr : Expr} :
+      InternalHelperExprProjectionCore expr →
+      InternalHelperExprProjectionCore (.logicalNot expr)
+  | bitNot {expr : Expr} :
+      InternalHelperExprProjectionCore expr →
+      InternalHelperExprProjectionCore (.bitNot expr)
+  | ite {cond thenVal elseVal : Expr} :
+      InternalHelperExprProjectionCore cond →
+      InternalHelperExprProjectionCore thenVal →
+      InternalHelperExprProjectionCore elseVal →
+      InternalHelperExprProjectionCore (.ite cond thenVal elseVal)
 
 inductive InternalHelperExprListProjectionCore : List Expr → Prop where
   | nil : InternalHelperExprListProjectionCore []
@@ -301,11 +380,41 @@ theorem evalExprWithHelpers_eq_of_internalHelperExprProjectionCore
     (hfresh : ∀ name, name ∈ FunctionBody.exprBoundNames expr → name ∉ reserved) :
     SourceSemantics.evalExprWithHelpers spec fields fuel { runtime with bindings := lhs } expr =
       SourceSemantics.evalExprWithHelpers spec fields fuel { runtime with bindings := rhs } expr := by
-  cases hcore with
+  induction hcore generalizing reserved lhs rhs with
   | literal value => simp [SourceSemantics.evalExprWithHelpers]
   | param name | localVar name =>
       have hlookup := (hagree name (hfresh name (by simp [FunctionBody.exprBoundNames]))).1
       simp [SourceSemantics.evalExprWithHelpers, hlookup]
+  | add _ _ ihleft ihright | sub _ _ ihleft ihright | mul _ _ ihleft ihright
+  | div _ _ ihleft ihright | mod _ _ ihleft ihright | eq _ _ ihleft ihright
+  | ge _ _ ihleft ihright | gt _ _ ihleft ihright | lt _ _ ihleft ihright
+  | le _ _ ihleft ihright | logicalAnd _ _ ihleft ihright
+  | logicalOr _ _ ihleft ihright | bitAnd _ _ ihleft ihright
+  | bitOr _ _ ihleft ihright | bitXor _ _ ihleft ihright
+  | min _ _ ihleft ihright | max _ _ ihleft ihright =>
+      have hleftEq := ihleft hagree (by
+        intro name hmem
+        exact hfresh name (by simp [FunctionBody.exprBoundNames, hmem]))
+      have hrightEq := ihright hagree (by
+        intro name hmem
+        exact hfresh name (by simp [FunctionBody.exprBoundNames, hmem]))
+      simp [SourceSemantics.evalExprWithHelpers, hleftEq, hrightEq]
+  | logicalNot _ ih | bitNot _ ih =>
+      have hexprEq := ih hagree (by
+        intro name hmem
+        exact hfresh name (by simp [FunctionBody.exprBoundNames, hmem]))
+      simp [SourceSemantics.evalExprWithHelpers, hexprEq]
+  | ite _ _ _ ihcond ihthen helse =>
+      have hcondEq := ihcond hagree (by
+        intro name hmem
+        exact hfresh name (by simp [FunctionBody.exprBoundNames, hmem]))
+      have hthenEq := ihthen hagree (by
+        intro name hmem
+        exact hfresh name (by simp [FunctionBody.exprBoundNames, hmem]))
+      have helseEq := helse hagree (by
+        intro name hmem
+        exact hfresh name (by simp [FunctionBody.exprBoundNames, hmem]))
+      simp [SourceSemantics.evalExprWithHelpers, hcondEq, hthenEq, helseEq]
 
 theorem evalExprListWithHelpers_eq_of_internalHelperExprListProjectionCore
     {spec : CompilationModel} {fields : List Field} {fuel : Nat}
@@ -568,9 +677,9 @@ private theorem internalHelperResultOfStmtListProjectionCore_eq
 
 /-- Source-semantics discharge for the helper-entry binding projection seam over
 the current projection-core fragment: empty bodies, `stop`, `return`, and
-sequencing through `letVar`, `assignVar`, and `require` with literal,
-parameter, or local-variable expressions.  Branches, loops, events, storage
-effects, and helper calls remain for the larger helper-aware source induction. -/
+sequencing through `letVar`, `assignVar`, and `require` with binding-read-only
+pure expressions.  Branches, loops, events, storage effects, and helper calls
+remain for the larger helper-aware source induction. -/
 theorem internalHelperBodyResultProjection_of_entryBindings_projectionCore
     {spec : CompilationModel} {callee : FunctionSpec} {helper : IRInternalFunctionDef}
     {initialWorld : Verity.ContractState} {sourceBindings : List (String × Nat)}


### PR DESCRIPTION
## Summary

Extends `InternalHelperExprProjectionCore` beyond literal/param/localVar so the helper-entry projection theorem can cover ordinary binding-read-only pure helper-body expressions.

Added projection constructors for:

- binary arithmetic/comparison/boolean ops: `add`, `sub`, `mul`, `div`, `mod`, `eq`, `ge`, `gt`, `lt`, `le`, `logicalAnd`, `logicalOr`
- straightforward pure bit/min/max ops: `bitAnd`, `bitOr`, `bitXor`, `min`, `max`
- unary ops: `logicalNot`, `bitNot`
- conditional expression: `ite`

Updated `evalExprWithHelpers_eq_of_internalHelperExprProjectionCore` to recurse structurally over the projection witness, preserving the existing `FunctionBody.exprBoundNames` freshness path and projection-level statement-result equality.

Remaining unsupported expression cases include runtime/world reads, storage/mapping/dynamic calldata and memory forms, helper/internal/external calls, and the rest of `ExprCompileCore` not added here (`shl`, `shr`, signed ops, `ceilDiv`, wad/mulDiv variants, `byte`, `signextend`, `mload`, `tload`, `calldataload`).

## Validation

- `lean-slot lake build Compiler.Proofs.IRGeneration.InternalHelperBodyCorrespondence PrintAxioms`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_proof_length.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof-only changes in IR generation correspondence; no runtime, auth, or compiler executable behavior is modified.
> 
> **Overview**
> Extends **`InternalHelperExprProjectionCore`** past literals, params, and locals so helper-entry projection can cover **binding-read-only pure expressions** used in `letVar`, `assignVar`, `require`, and `return`.
> 
> New projection constructors cover **binary** arithmetic, comparisons, booleans, and bit ops; **unary** `logicalNot` / `bitNot`; and **`ite`**. **`evalExprWithHelpers_eq_of_internalHelperExprProjectionCore`** is rewritten to **induct on the projection witness** and recurse on subexpressions, keeping the same `sourceBindingsAgreeOutside` and `exprBoundNames` freshness obligations.
> 
> The **`internalHelperBodyResultProjection_of_entryBindings_projectionCore`** doc now describes this fragment as pure binding-read expressions rather than only literal/param/local forms. Storage, calls, and other `Expr` forms remain out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93ad798132406981747a7b45769bd24ad2e1a074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->