### PR TITLE
proof: bridge zero-offset storage word writes

### DIFF
--- a/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
@@ -1371,6 +1371,53 @@ private theorem runtimeStateMatchesIR_writeUintSlot
         (encodeStorageAt_writeUintSlots_singleton_other
           (IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat hEq)).symm
 
+private theorem runtimeStateMatchesIR_writeStorageWordSlot_zeroOffset
+    {fields : List Field}
+    {runtime : SourceSemantics.RuntimeState}
+    {state : IRState}
+    {slot value : Nat}
+    (hruntime : FunctionBody.runtimeStateMatchesIR fields runtime state)
+    {f : Field}
+    (hresolved : findResolvedFieldAtSlotCopy fields slot = some f)
+    (hnotAddr : SourceSemantics.fieldUsesAddressStorage f = false)
+    (hnotDyn : SourceSemantics.fieldUsesDynamicArrayStorage f = false)
+    (hvalue : value < Verity.Core.Uint256.modulus) :
+    FunctionBody.runtimeStateMatchesIR fields
+      { runtime with world := SourceSemantics.writeStorageWordSlots runtime.world [slot] 0 value }
+      { state with
+          storage := Compiler.Proofs.abstractStoreStorageOrMapping state.storage slot value } := by
+  rcases hruntime with
+    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+  funext query
+  ·
+    by_cases hEq : query = IRStorageSlot.ofNat slot
+    · subst hEq
+      rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
+      have hresolved' :
+          findResolvedFieldAtSlotCopy fields (IRStorageSlot.ofNat slot).toNat = some f := by
+        simpa [IRStorageSlot.toNat_ofNat_wordNormalize] using
+          (show findResolvedFieldAtSlotCopy fields (SourceSemantics.wordNormalize slot) = some f from
+            by rw [findResolvedFieldAtSlotCopy_wordNormalize]; exact hresolved)
+      rw [encodeStorageAt_eq_storage_of_resolvedSlot hresolved' hnotAddr hnotDyn]
+      simp [SourceSemantics.writeStorageWordSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
+        SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
+        Verity.Core.UINT256_MODULUS, Verity.Core.Uint256.val_ofNat]
+      exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+        (Nat.mod_eq_of_lt hvalue).symm
+    · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
+      simp only [hEq, ↓reduceIte]
+      rw [hstorage]
+      symm
+      refine congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat ?_
+      have hneqNat := IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat hEq
+      have hneqNat' : query.toNat ≠ slot % Compiler.Constants.evmModulus := by
+        simpa [SourceSemantics.wordNormalize] using hneqNat
+      apply SourceSemantics.encodeStorageAt_congr
+      · simp [SourceSemantics.writeStorageWordSlots, SourceSemantics.wordNormalize, hneqNat']
+      · simp [SourceSemantics.writeStorageWordSlots, SourceSemantics.wordNormalize, hneqNat']
+      · simp [SourceSemantics.writeStorageWordSlots]
+
 private theorem runtimeStateMatchesIR_writeAddressSlot
     {fields : List Field}
     {runtime : SourceSemantics.RuntimeState}
@@ -2525,6 +2572,93 @@ theorem compiledStmtStep_setStorage_singleSlot
       refine ⟨.continue runtime', .continue state', hSrcExec, hIRExec, ?_⟩
       simp [stmtStepMatchesIRExec]
       exact ⟨runtimeStateMatchesIR_writeUintSlot hruntime hresolvedSlot hnotAddr hnotDyn hvalueLt,
+        hexact', hbounded, hscope'⟩
+
+theorem compiledStmtStep_setStorageWord_singleSlot_zeroOffset
+    {fields : List Field}
+    {scope : List String}
+    {fieldName : String}
+    {value : Expr}
+    {valueIR : YulExpr}
+    {f : Field}
+    {slot : Nat}
+    (hcore : FunctionBody.ExprCompileCore value)
+    (hinScope : FunctionBody.exprBoundNamesInScope value scope)
+    (hfind : findFieldWithResolvedSlot fields fieldName = some (f, slot))
+    (hwriteSlots : findFieldWriteSlots fields fieldName = some [slot])
+    (halias : f.aliasSlots = [])
+    (hunpacked : f.packedBits = none)
+    (hnoConflict : firstFieldWriteSlotConflict fields = none)
+    (hnotAddr : SourceSemantics.fieldUsesAddressStorage f = false)
+    (hnotDyn : SourceSemantics.fieldUsesDynamicArrayStorage f = false)
+    (hnotTransient : f.isTransient = false)
+    (hvalueIR : CompilationModel.compileExpr fields .calldata value = Except.ok valueIR) :
+    CompiledStmtStep fields scope (.setStorageWord fieldName 0 value)
+      [YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit slot, valueIR])] where
+  compileOk := by
+    simp [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+      hfind, halias, hnotTransient, hvalueIR]
+  preserves runtime state extraFuel hexact hscope hbounded hruntime hslack := by
+    let compiledIR := [YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit slot, valueIR])]
+    have hresolvedSlot :
+        findResolvedFieldAtSlotCopy fields slot = some f :=
+      findResolvedFieldAtSlotCopy_of_findFieldWithResolvedSlot_singleton
+        hnoConflict hfind hwriteSlots hunpacked
+    have hvalueSourceEval :=
+      FunctionBody.eval_compileExpr_core_of_scope
+        hcore hexact hinScope hbounded
+        (FunctionBody.exprBoundNamesPresent_of_scope hscope hinScope)
+        hruntime
+    rw [hvalueIR] at hvalueSourceEval
+    simp [Except.toOption] at hvalueSourceEval
+    rcases hIRValue : evalIRExpr state valueIR with _ | valueNat
+    · simp [hIRValue, Option.bind] at hvalueSourceEval
+    · simp [hIRValue, Option.bind] at hvalueSourceEval
+      have hValueSrc : SourceSemantics.evalExpr fields runtime value = some valueNat :=
+        hvalueSourceEval.symm
+      have hvalueLt := FunctionBody.evalExpr_lt_evmModulus_core_of_scope
+          hcore hexact hinScope hbounded
+          (FunctionBody.exprBoundNamesPresent_of_scope hscope hinScope)
+          hruntime
+      rw [hValueSrc] at hvalueLt
+      simp at hvalueLt
+      set state' := { state with
+          storage :=
+            Compiler.Proofs.abstractStoreStorageOrMapping state.storage slot valueNat }
+      set runtime' := { runtime with
+          world := SourceSemantics.writeStorageWordSlots runtime.world [slot] 0 valueNat }
+      have hfieldTransient :
+          SourceSemantics.fieldIsTransient fields fieldName = false := by
+        simp [SourceSemantics.fieldIsTransient, hfind, hnotTransient]
+      have hSrcExec : SourceSemantics.execStmt fields runtime
+          (.setStorageWord fieldName 0 value) = .continue runtime' := by
+        simp [SourceSemantics.execStmt, SourceSemantics.writeStorageWordFieldSlots,
+          hwriteSlots, hValueSrc, hfieldTransient, runtime']
+      have hExecStmt :
+          execIRStmt (extraFuel + 1) state
+            (YulStmt.exprStmt (YulExpr.call "sstore" [YulExpr.lit slot, valueIR])) =
+              .continue state' :=
+        execIRStmt_sstore_lit_expr_succ_of_eval
+          extraFuel state slot valueIR valueNat hIRValue
+      have hfuelEq : 1 + extraFuel = extraFuel + 1 := by omega
+      have hIRExec : execIRStmts (compiledIR.length + extraFuel + 1) state compiledIR =
+          .continue state' := by
+        simp [compiledIR, execIRStmts, hfuelEq, hExecStmt]
+      have hincl : FunctionBody.scopeNamesIncluded
+          (stmtNextScope scope (.setStorageWord fieldName 0 value)) scope := by
+        intro n hn
+        simp [stmtNextScope, collectStmtNames] at hn
+        rcases hn with hv | hs
+        · exact hinScope n (collectExprNames_mem_exprBoundNames_of_core hcore n hv)
+        · exact hs
+      have hexact' := FunctionBody.bindingsExactlyMatchIRVarsOnScope_of_included
+        (bindingsExactlyMatchIRVarsOnScope_writeUintSlot (slot := slot) (value := valueNat) hexact)
+        hincl
+      have hscope' := FunctionBody.scopeNamesPresent_of_included hscope hincl
+      refine ⟨.continue runtime', .continue state', hSrcExec, hIRExec, ?_⟩
+      simp [stmtStepMatchesIRExec]
+      exact ⟨runtimeStateMatchesIR_writeStorageWordSlot_zeroOffset
+          hruntime hresolvedSlot hnotAddr hnotDyn hvalueLt,
         hexact', hbounded, hscope'⟩
 
 private theorem compiledStmtStep_setStorageAddr_singleSlot_preserves
@@ -7429,6 +7563,35 @@ theorem stmtListGenericCore_singleton_setStorage_singleSlot
       (hNotAdt := by
         intro name maxFields hty
         cases hty)
+      (hvalueIR := hvalueIR))
+    StmtListGenericCore.nil
+
+private theorem stmtListGenericCore_singleton_setStorageWord_zeroOffset_singleSlot
+    {fields : List Field}
+    {scope : List String}
+    {fieldName : String}
+    {slot : Nat}
+    {value : Expr}
+    (hnoConflict : firstFieldWriteSlotConflict fields = none)
+    (hfind : findFieldWithResolvedSlot fields fieldName =
+      some ({ name := fieldName, ty := FieldType.uint256 }, slot))
+    (hcore : FunctionBody.ExprCompileCore value)
+    (hinScope : FunctionBody.exprBoundNamesInScope value scope) :
+    StmtListGenericCore fields scope [Stmt.setStorageWord fieldName 0 value] := by
+  rcases FunctionBody.compileExpr_core_ok (fields := fields) hcore with
+    ⟨valueIR, hvalueIR⟩
+  exact StmtListGenericCore.cons
+    (compiledStmtStep_setStorageWord_singleSlot_zeroOffset
+      (hcore := hcore)
+      (hinScope := hinScope)
+      (hfind := hfind)
+      (hwriteSlots := by simpa using findFieldWriteSlots_of_findFieldWithResolvedSlot hfind)
+      (halias := by rfl)
+      (hunpacked := by rfl)
+      (hnoConflict := hnoConflict)
+      (hnotAddr := by rfl)
+      (hnotDyn := by rfl)
+      (hnotTransient := by rfl)
       (hvalueIR := hvalueIR))
     StmtListGenericCore.nil
 

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3064,6 +3064,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_eq_written  -- private
   -- Compiler.Proofs.IRGeneration.abstractStoreStorageOrMappingMany_eq  -- private
   -- Compiler.Proofs.IRGeneration.runtimeStateMatchesIR_writeUintSlot  -- private
+  -- Compiler.Proofs.IRGeneration.runtimeStateMatchesIR_writeStorageWordSlot_zeroOffset  -- private
   -- Compiler.Proofs.IRGeneration.runtimeStateMatchesIR_writeAddressSlot  -- private
   -- Compiler.Proofs.IRGeneration.runtimeStateMatchesIR_writeUintSlots  -- private
   -- Compiler.Proofs.IRGeneration.runtimeStateMatchesIR_writeUintKeyedMappingSlot  -- private
@@ -3089,6 +3090,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.findFieldWriteSlots_of_findFieldWithResolvedSlot  -- private
   -- Compiler.Proofs.IRGeneration.findFieldWithResolvedSlot_of_findFieldWriteSlots_singleton  -- private
   Compiler.Proofs.IRGeneration.compiledStmtStep_setStorage_singleSlot
+  Compiler.Proofs.IRGeneration.compiledStmtStep_setStorageWord_singleSlot_zeroOffset
   -- Compiler.Proofs.IRGeneration.compiledStmtStep_setStorageAddr_singleSlot_preserves  -- private
   Compiler.Proofs.IRGeneration.compiledStmtStep_setStorageAddr_singleSlot
   -- Compiler.Proofs.IRGeneration.compiledStmtStep_mstore_single_preserves  -- private
@@ -3151,6 +3153,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.stmtListGenericCore_singleton_assignStorageAddrField
   Compiler.Proofs.IRGeneration.stmtListGenericCore_singleton_iteTerminal
   Compiler.Proofs.IRGeneration.stmtListGenericCore_singleton_setStorage_singleSlot
+  -- Compiler.Proofs.IRGeneration.stmtListGenericCore_singleton_setStorageWord_zeroOffset_singleSlot  -- private
   -- Compiler.Proofs.IRGeneration.stmtListGenericCore_singleton_setStorageAddr_singleSlot  -- private
   -- Compiler.Proofs.IRGeneration.stmtListGenericCore_singleton_mstore_single  -- private
   -- Compiler.Proofs.IRGeneration.stmtListGenericCore_singleton_tstore_single  -- private
@@ -6008,4 +6011,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5635 theorems/lemmas (3888 public, 1747 private, 0 sorry'd)
+-- Total: 5638 theorems/lemmas (3889 public, 1749 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -113,6 +113,11 @@ ALLOWLIST: set[str] = {
     "stmtStepMatches_forEach_literal_empty_final",
     # --- Storage write compiled step proofs ---
     "compiledStmtStep_setStorage_singleSlot",
+    # Zero-offset storage-word writes lower to the same single `sstore` shape
+    # as scalar writes.  The preservation proof must keep source and IR states,
+    # fuel, and scope bindings aligned in one witness; factoring it would only
+    # move that coupled witness into a private wrapper.
+    "compiledStmtStep_setStorageWord_singleSlot_zeroOffset",
     "compiledStmtStep_setStorage_aliasSlots",
     "compiledStmtStep_setStorage_of_validateIdentifierShapes",
     "compiledStmtStep_setStorage_of_validateIdentifierShapes_of_scopeDiscipline",


### PR DESCRIPTION
## Summary

- Adds private `runtimeStateMatchesIR_writeStorageWordSlot_zeroOffset` for zero-offset single-slot `writeStorageWordSlots` preservation.
- Adds public `compiledStmtStep_setStorageWord_singleSlot_zeroOffset` proving `.setStorageWord fieldName 0 value` lowers to the expected singleton `sstore` when the resolved field is a non-address, non-dynamic, non-transient, unaliased uint slot.
- Adds private `stmtListGenericCore_singleton_setStorageWord_zeroOffset_singleSlot` consumer/regression coverage.
- Regenerates `PrintAxioms.lean`.

## Validation

- `lake build Compiler.Proofs.IRGeneration.GenericInduction.Storage`
- `lake build Compiler.Proofs.IRGeneration.GenericInduction`
- `lake build PrintAxioms`
- `python3 scripts/lean_lint.py --only lean_hygiene`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/lean_lint.py --only axioms`
- `git diff --check`

## Notes

- No new `sorry`, `admit`, `axiom`, or `native_decide`; no theorem weakening; no fake Yul shim.
- Based on `origin/main` at `b8b9896d`.
- Independent from the #2080 stack and from #2127/#2132 mapping read/write slot work.
- Remaining gates: nonzero `wordOffset` target-slot arithmetic and alias-slot multiwrite variants, plus transient storage-word writes, before broader generic gates can be flipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only changes in the formal verification layer; no compiler or runtime behavior is modified.
> 
> **Overview**
> Extends the **generic storage induction** proofs so **zero-offset storage-word writes** are covered the same way scalar `setStorage` already is.
> 
> A private lemma **`runtimeStateMatchesIR_writeStorageWordSlot_zeroOffset`** shows that updating the source world via `writeStorageWordSlots` with offset `0` stays in sync with `abstractStoreStorageOrMapping` on the IR side (including the non-written-slot case via `encodeStorageAt_congr`).
> 
> The public theorem **`compiledStmtStep_setStorageWord_singleSlot_zeroOffset`** proves that **`.setStorageWord fieldName 0 value`** lowers to a single **`sstore`** with a literal slot when the field is a resolved, unaliased, unpacked, non-address, non-dynamic, non-transient uint slot with no write-slot conflicts, and that execution preserves runtime state, fuel, bindings, and scope discipline.
> 
> A private **`stmtListGenericCore_singleton_setStorageWord_zeroOffset_singleSlot`** hooks this into the stmt-list generic core for regression-style coverage. **`PrintAxioms.lean`** is regenerated to export the new compiled-step theorem, and **`check_proof_length.py`** allowlists the long coupled preservation witness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e4b958d5c5ca72c2f79de8a10b0453459b65f22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->