### PR TITLE
proof: connect internal helper IR execution to summaries

### DIFF
--- a/Compiler/Proofs/IRGeneration/HelperBodyBridge.lean
+++ b/Compiler/Proofs/IRGeneration/HelperBodyBridge.lean
@@ -1,4 +1,5 @@
 import Compiler.Proofs.IRGeneration.IRInterpreter
+import Compiler.Proofs.IRGeneration.InternalHelperBodyCorrespondence
 import Compiler.Proofs.IRGeneration.SourceSemantics
 import Compiler.CompilationModel.Compile
 import Compiler.Proofs.IRGeneration.SupportedSpec
@@ -7,6 +8,29 @@ namespace Compiler.Proofs.IRGeneration
 
 open Compiler.CompilationModel
 open Compiler.Yul
+
+private theorem bindInternalArgs_length_eq_of_some
+    {params : List Param} {args : List Nat} {bindings : List (String × Nat)}
+    (hbind : SourceSemantics.bindInternalArgs params args = some bindings) :
+    params.length = args.length := by
+  induction params generalizing args bindings with
+  | nil =>
+      cases args <;> simp [SourceSemantics.bindInternalArgs] at hbind
+      cases hbind
+      rfl
+  | cons param rest ih =>
+      cases args with
+      | nil =>
+          simp [SourceSemantics.bindInternalArgs] at hbind
+      | cons arg restArgs =>
+          cases htail : SourceSemantics.bindInternalArgs rest restArgs with
+          | none =>
+              simp [SourceSemantics.bindInternalArgs, htail] at hbind
+          | some tailBindings =>
+            simp [SourceSemantics.bindInternalArgs, htail] at hbind
+            cases hbind
+            have hlen := ih htail
+            simp [hlen]
 
 mutual
 
@@ -334,6 +358,251 @@ theorem compiledInternalHelper_summary_boundary_of_witness_returnStopFree
   exact hsound fuel initialWorld args
 
 end InternalHelperSummaryBoundary
+
+def internalHelperBodyIRExecResultAsCallResult
+    (callerState : IRState) (helper : IRInternalFunctionDef) :
+    IRExecResultWithInternals → IRValuesEvalResult
+  | .continue finalState =>
+      .values (internalReturnValues finalState helper.rets)
+        (restoreCallerVars callerState finalState)
+  | .leave finalState =>
+      .values (internalReturnValues finalState helper.rets)
+        (restoreCallerVars callerState finalState)
+  | .stop finalState =>
+      .stop (restoreCallerVars callerState finalState)
+  | .return value finalState =>
+      .return value (restoreCallerVars callerState finalState)
+  | .revert _ =>
+      .revert callerState
+
+/-- N1a helper-body bridge: executing the compiled helper through
+`execIRInternalFunctionWithInternals` unfolds to the helper-body execution that
+is matched by `internal_helper_body_exec_matches...`, and the projected source
+helper result satisfies the real internal-helper summary contract.
+
+The execution equation intentionally leaves `.stop` and `.return` propagation
+visible.  Callers that need ordinary helper return values must combine this with
+the existing stop/return-family exclusions for the helper body. -/
+theorem execIRInternalFunctionWithInternals_obeys_internal_helper_summary
+    {runtimeContract : IRContract} {spec : CompilationModel}
+    {callee : FunctionSpec} {helper : IRInternalFunctionDef}
+    {callerState : IRState} {initialWorld : Verity.ContractState}
+    {args : List Nat} {sourceBindings entryBindings : List (String × Nat)}
+    {summary : InternalHelperSummaryContract}
+    (helperFuel extraFuel : Nat) (hfuelPos : 0 < helperFuel)
+    (ctx : InternalHelperBodyExecContext runtimeContract spec callee helper
+      callerState initialWorld args sourceBindings entryBindings helperFuel)
+    (hsound : SourceSemantics.InternalHelperSummarySound spec callee summary)
+    (harity : helper.params.length = callee.params.length) :
+    (execIRInternalFunctionWithInternals runtimeContract
+        (sizeOf helper.body + extraFuel + 1 + 1) callerState helper args =
+      internalHelperBodyIRExecResultAsCallResult callerState helper
+        (internalHelperBodyIRExec runtimeContract helper callerState args extraFuel))
+    ∧
+      summary.post helperFuel initialWorld args
+        (internalHelperResultOfStmtResult initialWorld
+          (internalHelperBodySourceResult spec callee initialWorld entryBindings helperFuel)).success
+        (internalHelperResultOfStmtResult initialWorld
+          (internalHelperBodySourceResult spec callee initialWorld entryBindings helperFuel)).returnValue
+        (internalHelperResultOfStmtResult initialWorld
+          (internalHelperBodySourceResult spec callee initialWorld entryBindings helperFuel)).world := by
+  rcases internal_helper_body_exec_matches_entryBindings_and_projected_result_of_bindInternalArgs_and_generic
+      (runtimeContract := runtimeContract) (spec := spec) (callee := callee)
+      (helper := helper) (callerState := callerState)
+      (initialWorld := initialWorld) (args := args)
+      (sourceBindings := sourceBindings) (entryBindings := entryBindings)
+      helperFuel extraFuel hfuelPos ctx with
+    ⟨_hmatch, hinterp⟩
+  constructor
+  · have hsourceLen : callee.params.length = args.length :=
+      bindInternalArgs_length_eq_of_some ctx.bindArgs
+    have hlen : helper.params.length = args.length := harity.trans hsourceLen
+    rw [execIRInternalFunctionWithInternals_succ_of_params_match
+      runtimeContract (sizeOf helper.body + extraFuel + 1)
+      callerState helper args hlen]
+    rfl
+  · have hpost := hsound helperFuel initialWorld args
+    simpa [hinterp] using hpost
+
+private theorem internalFunctionYulName_head (calleeName : String) :
+    (CompilationModel.internalFunctionYulName calleeName).toList.head? = some 'i' := by
+  simp [CompilationModel.internalFunctionYulName, CompilationModel.internalFunctionPrefix]
+  decide
+
+private theorem internalFunctionYulName_ne_of_head
+    (calleeName builtinName : String)
+    (hhead : builtinName.toList.head? ≠ some 'i') :
+    CompilationModel.internalFunctionYulName calleeName ≠ builtinName := by
+  intro hEq
+  have hHead := congrArg (fun s : String => s.toList.head?) hEq
+  change (CompilationModel.internalFunctionYulName calleeName).toList.head? =
+    builtinName.toList.head? at hHead
+  rw [internalFunctionYulName_head calleeName] at hHead
+  exact hhead hHead.symm
+
+private theorem internalFunctionYulName_isYulLogName_false (calleeName : String) :
+    isYulLogName (CompilationModel.internalFunctionYulName calleeName) = false := by
+  simp [isYulLogName,
+    internalFunctionYulName_ne_of_head calleeName "log0" (by decide),
+    internalFunctionYulName_ne_of_head calleeName "log1" (by decide),
+    internalFunctionYulName_ne_of_head calleeName "log2" (by decide),
+    internalFunctionYulName_ne_of_head calleeName "log3" (by decide),
+    internalFunctionYulName_ne_of_head calleeName "log4" (by decide)]
+
+noncomputable abbrev internalHelperCallFuel
+    (helper : IRInternalFunctionDef) (extraFuel : Nat) : Nat :=
+  sizeOf helper.body + extraFuel + 1 + 1
+
+abbrev internalHelperSummaryPostAt
+    (spec : CompilationModel) (callee : FunctionSpec)
+    (initialWorld : Verity.ContractState)
+    (entryBindings : List (String × Nat))
+    (helperFuel : Nat) (args : List Nat)
+    (summary : InternalHelperSummaryContract) : Prop :=
+  summary.post helperFuel initialWorld args
+    (internalHelperResultOfStmtResult initialWorld
+      (internalHelperBodySourceResult spec callee initialWorld entryBindings helperFuel)).success
+    (internalHelperResultOfStmtResult initialWorld
+      (internalHelperBodySourceResult spec callee initialWorld entryBindings helperFuel)).returnValue
+    (internalHelperResultOfStmtResult initialWorld
+      (internalHelperBodySourceResult spec callee initialWorld entryBindings helperFuel)).world
+
+abbrev internalHelperAssignCallResult
+    (names : List String) (callerState : IRState) (helper : IRInternalFunctionDef)
+    (bodyResult : IRExecResultWithInternals) : IRExecResultWithInternals :=
+  match internalHelperBodyIRExecResultAsCallResult callerState helper bodyResult with
+  | .values values state' =>
+      if names.length = values.length then
+        .continue (state'.setVars (names.zip values))
+      else .revert state'
+  | .stop state' => .stop state'
+  | .return value state' => .return value state'
+  | .revert state' => .revert state'
+
+private theorem execIRStmtsWithInternals_singleton_expr_internalFunctionYulName_call_internal
+    (runtimeContract : IRContract) (fuel : Nat) (state : IRState)
+    (calleeName : String) (argExprs : List YulExpr)
+    (helper : IRInternalFunctionDef) (args : List Nat) (callerState : IRState)
+    (hargs : evalIRExprsWithInternals runtimeContract (fuel + 1) state argExprs =
+      .values args callerState)
+    (hfind : findInternalFunction? runtimeContract
+      (CompilationModel.internalFunctionYulName calleeName) = some helper) :
+    execIRStmtsWithInternals runtimeContract (fuel + 3) state
+      [YulStmt.exprStmt
+        (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs)] =
+      match execIRInternalFunctionWithInternals runtimeContract fuel
+          callerState helper args with
+      | .values _ state' => .continue state'
+      | .stop state' => .stop state'
+      | .return value state' => .return value state'
+      | .revert state' => .revert state' := by
+  exact execIRStmtsWithInternals_singleton_expr_call_internal
+    runtimeContract fuel state
+    (CompilationModel.internalFunctionYulName calleeName) argExprs helper args callerState
+    hargs hfind
+    (internalFunctionYulName_ne_of_head calleeName "stop" (by decide))
+    (internalFunctionYulName_ne_of_head calleeName "sstore" (by decide))
+    (internalFunctionYulName_ne_of_head calleeName "mstore" (by decide))
+    (internalFunctionYulName_ne_of_head calleeName "tstore" (by decide))
+    (internalFunctionYulName_ne_of_head calleeName "revert" (by decide))
+    (internalFunctionYulName_ne_of_head calleeName "return" (by decide))
+    (internalFunctionYulName_isYulLogName_false calleeName)
+
+/-- N2/N3 assignment-call instantiation of the N1a helper-summary bridge.
+This is the singleton `letMany (.call internal_helper ...)` wrapper around
+`execIRInternalFunctionWithInternals_obeys_internal_helper_summary`. -/
+theorem execIRStmtsWithInternals_internalCallAssign_obeys_internal_helper_summary
+    {runtimeContract : IRContract} {spec : CompilationModel}
+    {callee : FunctionSpec} {helper : IRInternalFunctionDef}
+    {state callerState : IRState} {initialWorld : Verity.ContractState}
+    {names : List String} {calleeName : String}
+    {argExprs : List YulExpr} {args : List Nat}
+    {sourceBindings entryBindings : List (String × Nat)}
+    {summary : InternalHelperSummaryContract}
+    (helperFuel extraFuel : Nat) (hfuelPos : 0 < helperFuel)
+    (ctx : InternalHelperBodyExecContext runtimeContract spec callee helper
+      callerState initialWorld args sourceBindings entryBindings helperFuel)
+    (hsound : SourceSemantics.InternalHelperSummarySound spec callee summary)
+    (harity : helper.params.length = callee.params.length)
+    (hfind : findInternalFunction? runtimeContract
+      (CompilationModel.internalFunctionYulName calleeName) = some helper)
+    (hargs : evalIRExprsWithInternals runtimeContract
+      (internalHelperCallFuel helper extraFuel + 1) state argExprs =
+        .values args callerState) :
+    (execIRStmtsWithInternals runtimeContract
+        (internalHelperCallFuel helper extraFuel + 3) state
+        [YulStmt.letMany names
+          (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs)] =
+      internalHelperAssignCallResult names callerState helper
+        (internalHelperBodyIRExec runtimeContract helper callerState args extraFuel))
+    ∧
+      internalHelperSummaryPostAt spec callee initialWorld entryBindings
+        helperFuel args summary := by
+  have hsummary := execIRInternalFunctionWithInternals_obeys_internal_helper_summary
+    (runtimeContract := runtimeContract) (spec := spec) (callee := callee) (helper := helper)
+    (callerState := callerState) (initialWorld := initialWorld) (args := args)
+    (sourceBindings := sourceBindings) (entryBindings := entryBindings) (summary := summary)
+    helperFuel extraFuel hfuelPos ctx hsound harity
+  constructor
+  · rw [execIRStmtsWithInternals_singleton_letMany_call_internal
+      runtimeContract (internalHelperCallFuel helper extraFuel) state names
+      (CompilationModel.internalFunctionYulName calleeName) argExprs helper args
+      callerState hargs hfind]
+    rw [show internalHelperCallFuel helper extraFuel =
+      sizeOf helper.body + extraFuel + 1 + 1 from rfl, hsummary.1]
+    simp [internalHelperAssignCallResult]
+    cases internalHelperBodyIRExecResultAsCallResult callerState helper
+      (internalHelperBodyIRExec runtimeContract helper callerState args extraFuel) <;> rfl
+  · exact hsummary.2
+
+/-- N2/N3 void-call instantiation of the N1a helper-summary bridge.  The normal
+helper values are discarded by `exprStmt`, while stop/return/revert propagation
+remains explicit. -/
+theorem execIRStmtsWithInternals_internalCall_obeys_internal_helper_summary
+    {runtimeContract : IRContract} {spec : CompilationModel}
+    {callee : FunctionSpec} {helper : IRInternalFunctionDef}
+    {state callerState : IRState} {initialWorld : Verity.ContractState}
+    {calleeName : String} {argExprs : List YulExpr} {args : List Nat}
+    {sourceBindings entryBindings : List (String × Nat)}
+    {summary : InternalHelperSummaryContract}
+    (helperFuel extraFuel : Nat) (hfuelPos : 0 < helperFuel)
+    (ctx : InternalHelperBodyExecContext runtimeContract spec callee helper
+      callerState initialWorld args sourceBindings entryBindings helperFuel)
+    (hsound : SourceSemantics.InternalHelperSummarySound spec callee summary)
+    (harity : helper.params.length = callee.params.length)
+    (hfind : findInternalFunction? runtimeContract
+      (CompilationModel.internalFunctionYulName calleeName) = some helper)
+    (hargs : evalIRExprsWithInternals runtimeContract
+      (internalHelperCallFuel helper extraFuel + 1) state argExprs =
+        .values args callerState) :
+    (execIRStmtsWithInternals runtimeContract
+        (internalHelperCallFuel helper extraFuel + 3) state
+        [YulStmt.exprStmt
+          (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs)] =
+      match internalHelperBodyIRExecResultAsCallResult callerState helper
+          (internalHelperBodyIRExec runtimeContract helper callerState args extraFuel) with
+      | .values _ state' => IRExecResultWithInternals.continue state'
+      | .stop state' => IRExecResultWithInternals.stop state'
+      | .return value state' => IRExecResultWithInternals.return value state'
+      | .revert state' => IRExecResultWithInternals.revert state')
+    ∧
+      internalHelperSummaryPostAt spec callee initialWorld entryBindings
+        helperFuel args summary := by
+  have hsummary :=
+    execIRInternalFunctionWithInternals_obeys_internal_helper_summary
+      (runtimeContract := runtimeContract) (spec := spec) (callee := callee)
+      (helper := helper) (callerState := callerState)
+      (initialWorld := initialWorld) (args := args)
+      (sourceBindings := sourceBindings) (entryBindings := entryBindings)
+      (summary := summary) helperFuel extraFuel hfuelPos ctx hsound harity
+  constructor
+  · rw [execIRStmtsWithInternals_singleton_expr_internalFunctionYulName_call_internal
+      runtimeContract (internalHelperCallFuel helper extraFuel) state
+      calleeName argExprs helper args callerState hargs hfind]
+    rw [show internalHelperCallFuel helper extraFuel =
+      sizeOf helper.body + extraFuel + 1 + 1 from rfl]
+    rw [hsummary.1]
+  · exact hsummary.2
 
 /-- Concrete regression for the rank-0 void-helper body-shape seam: an empty
 helper body is unaffected by internal return targets. -/

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3161,12 +3161,20 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.stmtListGenericCore_of_supportedStmtList_tstoreSingle_of_surface
 
   -- Compiler/Proofs/IRGeneration/HelperBodyBridge.lean
+  -- Compiler.Proofs.IRGeneration.bindInternalArgs_length_eq_of_some  -- private
   Compiler.Proofs.IRGeneration.compileStmtWithFork_internal_shape_irrelevant_of_returnFree
   Compiler.Proofs.IRGeneration.compileStmtListWithFork_internal_shape_irrelevant_of_returnFree
   Compiler.Proofs.IRGeneration.compileInternalFunction_body_eq_external_of_returnFree
   Compiler.Proofs.IRGeneration.findInternalFunction?_some_eq_compiledHelper_of_witness
   Compiler.Proofs.IRGeneration.findInternalFunction?_external_body_of_witness_returnFree
   Compiler.Proofs.IRGeneration.compiledInternalHelper_summary_boundary_of_witness_returnStopFree
+  Compiler.Proofs.IRGeneration.execIRInternalFunctionWithInternals_obeys_internal_helper_summary
+  -- Compiler.Proofs.IRGeneration.internalFunctionYulName_head  -- private
+  -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_of_head  -- private
+  -- Compiler.Proofs.IRGeneration.internalFunctionYulName_isYulLogName_false  -- private
+  -- Compiler.Proofs.IRGeneration.execIRStmtsWithInternals_singleton_expr_internalFunctionYulName_call_internal  -- private
+  Compiler.Proofs.IRGeneration.execIRStmtsWithInternals_internalCallAssign_obeys_internal_helper_summary
+  Compiler.Proofs.IRGeneration.execIRStmtsWithInternals_internalCall_obeys_internal_helper_summary
   Compiler.Proofs.IRGeneration.empty_void_helper_body_compile_shape_irrelevant_regression
 
   -- Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -6032,4 +6040,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5656 theorems/lemmas (3903 public, 1753 private, 0 sorry'd)
+-- Total: 5664 theorems/lemmas (3906 public, 1758 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- Adds `execIRInternalFunctionWithInternals_obeys_internal_helper_summary`, connecting the compiled internal-helper call wrapper to the existing helper-body execution bridge and real source summary postcondition.
- Adds N2/N3 singleton call-wrapper instantiations for `Stmt.internalCallAssign` and `Stmt.internalCall` IR execution shapes.
- Adds a small `bindInternalArgs` arity lemma plus result/fuel adapters used by downstream helper-call bridge code.
- Keeps stop/return propagation explicit; ordinary helper-return callers still need the existing stop/return-free exclusions.

## Validation
- `lean-slot lake build Compiler.Proofs.IRGeneration.HelperBodyBridge`
- `python3 scripts/generate_print_axioms.py`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_proof_length.py`
- `git diff --check`
- `rg -n "\bsorry\b|\badmit\b|axiom " Compiler/Proofs/IRGeneration/HelperBodyBridge.lean PrintAxioms.lean` (only generated PrintAxioms comments matched)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in IR generation with no runtime or compiler behavior changes; complexity is localized to formal verification plumbing.
> 
> **Overview**
> Adds a **HelperBodyBridge** layer that wires compiled internal-helper IR execution to the existing helper-body correspondence and **InternalHelperSummarySound** postconditions.
> 
> The central theorem shows `execIRInternalFunctionWithInternals` equals projecting `internalHelperBodyIRExec` through a new adapter (`internalHelperBodyIRExecResultAsCallResult`) while the summary contract holds on the projected source result. **Stop/return/revert** behavior stays explicit rather than folded into normal return values.
> 
> **N2/N3** instantiations lift that bridge to singleton Yul call shapes: `letMany` assignment calls (`internalHelperAssignCallResult`) and void `exprStmt` calls. Supporting pieces include a `bindInternalArgs` arity lemma, fuel/summary abbreviations, and lemmas that internal Yul names cannot collide with builtins (`stop`, `sstore`, `log*`, etc.).
> 
> `HelperBodyBridge.lean` now imports **InternalHelperBodyCorrespondence**; **PrintAxioms** registers the new public theorems (+8 lemmas total).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f2d113ff5fcf97073e4d836643bd3ddb651bba3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->