### PR TITLE
proof: package direct helper statement context bridge

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -1,4 +1,5 @@
 import Compiler.Proofs.IRGeneration.GenericInduction
+import Compiler.Proofs.IRGeneration.HelperBodyBridge
 import Compiler.Proofs.IRGeneration.SourceSemantics
 
 /-!
@@ -607,6 +608,232 @@ theorem stmtListDirectInternalHelperAssignStepInterface_of_perCalleeAssignBridge
       (stmts := fn.body)
       (fun {calleeName} hmem =>
         hbridge.assign (by simpa [helperCallNames] using hmem))
+
+/-!
+### Direct statement helper context bridge
+
+This package is the supported-evidence handoff for direct statement-position
+helper calls. It does not prove the final head-step bridge by itself: the
+remaining statement proof must still align source and IR argument evaluation and
+discharge the helper-body execution context consumed by
+`execIRInternalFunctionWithInternals_obeys_internal_helper_summary`.
+-/
+
+/-- Direct-statement helper context bridge assembled from the currently exposed
+supported-helper APIs. It packages the source summary evidence and the compiled
+helper dispatch facts for both direct void calls and return-binding calls. -/
+structure DirectInternalHelperStatementContextBridge
+    (runtimeContract : IRContract)
+    (spec : CompilationModel)
+    (calleeName : String) where
+  sourceWitness :
+    SupportedInternalHelperWitness spec calleeName
+  summarySound :
+    SourceSemantics.InternalHelperSummarySound
+      spec sourceWitness.callee sourceWitness.summary.contract
+  compiledHelper :
+    SupportedCompiledInternalHelperWitness spec runtimeContract calleeName
+  irCallDispatch :
+    ∀ {fields : List Field} {scope : List String} {args : List Expr}
+      {compiledIR : List YulStmt} {argExprs : List YulExpr}
+      (state : IRState) (irFuel : Nat)
+      {argVals : List Nat} {state' : IRState},
+      CompilationModel.compileStmt fields [] [] .calldata [] false scope []
+        (Stmt.internalCall calleeName args) = Except.ok compiledIR →
+      CompilationModel.compileExprList fields .calldata args = Except.ok argExprs →
+      evalIRExprsWithInternals runtimeContract (irFuel + 1) state argExprs =
+        .values argVals state' →
+      ∃ helper,
+        compiledIR = [YulStmt.exprStmt
+          (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs)] ∧
+        findInternalFunction? runtimeContract
+          (CompilationModel.internalFunctionYulName calleeName) = some helper ∧
+        execIRStmtsWithInternals runtimeContract (irFuel + 3) state compiledIR =
+          match execIRInternalFunctionWithInternals runtimeContract irFuel state' helper argVals with
+          | .values _ state'' => .continue state''
+          | .stop state'' => .stop state''
+          | .return value' state'' => .return value' state''
+          | .revert state'' => .revert state''
+  irAssignDispatch :
+    ∀ {fields : List Field} {scope : List String} {names : List String}
+      {args : List Expr} {compiledIR : List YulStmt} {argExprs : List YulExpr}
+      (state : IRState) (irFuel : Nat)
+      {argVals : List Nat} {state' : IRState},
+      CompilationModel.compileStmt fields [] [] .calldata [] false scope []
+        (Stmt.internalCallAssign names calleeName args) = Except.ok compiledIR →
+      CompilationModel.compileExprList fields .calldata args = Except.ok argExprs →
+      evalIRExprsWithInternals runtimeContract (irFuel + 1) state argExprs =
+        .values argVals state' →
+      ∃ helper,
+        compiledIR = [YulStmt.letMany names
+          (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs)] ∧
+        findInternalFunction? runtimeContract
+          (CompilationModel.internalFunctionYulName calleeName) = some helper ∧
+        execIRStmtsWithInternals runtimeContract (irFuel + 3) state compiledIR =
+          match execIRInternalFunctionWithInternals runtimeContract irFuel state' helper argVals with
+          | .values values state'' =>
+              if names.length = values.length then
+                .continue (state''.setVars (names.zip values))
+              else .revert state''
+          | .stop state'' => .stop state''
+          | .return value' state'' => .return value' state''
+          | .revert state'' => .revert state''
+
+/-- Instantiate the direct-statement helper context bridge from the supported
+helper inventory for a callee that appears in `helperCallNames fn`. -/
+def directInternalHelperStatementContextBridge_of_supportedEvidence
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fn : FunctionSpec}
+    (hHelpers : SupportedBodyHelperInterface spec fn)
+    (hSummaries : SourceSemantics.SupportedBodyHelperSummariesSound spec fn hHelpers)
+    (hRuntime : SupportedRuntimeHelperTableInterface spec runtimeContract)
+    {calleeName : String}
+    (hmem : calleeName ∈ helperCallNames fn) :
+    DirectInternalHelperStatementContextBridge runtimeContract spec calleeName := by
+  let witness := hHelpers.summaryOfCall hmem
+  let compiledHelper := hRuntime.compiledOfCall hHelpers hmem
+  refine
+    { sourceWitness := witness
+      summarySound :=
+        SourceSemantics.SupportedBodyHelperInterface.summarySoundOfCall
+          hHelpers hSummaries hmem
+      compiledHelper := compiledHelper
+      irCallDispatch := ?_
+      irAssignDispatch := ?_ }
+  · intro fields scope args compiledIR argExprs state irFuel argVals state'
+      hcompile hargCompile hargs
+    exact
+      execIRStmtsWithInternals_of_internalCall_compiledHelperWitness
+        (runtimeContract := runtimeContract)
+        (spec := spec)
+        (fields := fields)
+        (scope := scope)
+        (calleeName := calleeName)
+        (args := args)
+        (compiledIR := compiledIR)
+        compiledHelper
+        state
+        irFuel
+        hcompile
+        argExprs
+        hargCompile
+        hargs
+  · intro fields scope names args compiledIR argExprs state irFuel argVals state'
+      hcompile hargCompile hargs
+    exact
+      execIRStmtsWithInternals_of_internalCallAssign_compiledHelperWitness
+        (runtimeContract := runtimeContract)
+        (spec := spec)
+        (fields := fields)
+        (scope := scope)
+        (names := names)
+        (calleeName := calleeName)
+        (args := args)
+        (compiledIR := compiledIR)
+        compiledHelper
+        state
+        irFuel
+        hcompile
+        argExprs
+        hargCompile
+        hargs
+
+/-- Source-side evidence for a direct void helper call from the packaged
+statement context bridge: the source statement reduces through the supported
+callee witness and the callee summary post holds for the same helper result. -/
+theorem directInternalHelperStatementContextBridge_sourceCallEvidence
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {calleeName : String}
+    {args : List Expr}
+    (hctx :
+      DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
+    (hnodup : (spec.functions.map (·.name)).Nodup)
+    {fuel : Nat}
+    {state : SourceSemantics.RuntimeState}
+    {argVals : List Nat}
+    (hargs :
+      SourceSemantics.evalExprListWithHelpers spec fields (fuel + 1) state args =
+        some argVals) :
+    let result :=
+      SourceSemantics.interpretInternalFunctionFuel
+        spec fuel hctx.sourceWitness.callee state.world argVals
+    SourceSemantics.execStmtWithHelpers spec fields (fuel + 1) state
+        (Stmt.internalCall calleeName args) =
+          (if result.success then
+            .continue { state with world := result.world }
+          else .revert) ∧
+      hctx.sourceWitness.summary.contract.post fuel state.world argVals
+        result.success result.returnValue result.world := by
+  intro result
+  refine ⟨?_, ?_⟩
+  · simpa [result, hargs] using
+      SourceSemantics.execStmtWithHelpers_internalCall_of_witness
+        (spec := spec)
+        (fields := fields)
+        (fuel := fuel)
+        (state := state)
+        (calleeName := calleeName)
+        (args := args)
+        hctx.sourceWitness
+        hnodup
+  · simpa [result] using hctx.summarySound fuel state.world argVals
+
+abbrev directInternalHelperAssignSourceResult
+    (state : SourceSemantics.RuntimeState)
+    (names : List String)
+    (result : SourceSemantics.InternalFunctionResult) :
+    SourceSemantics.StmtResult :=
+  if result.success then
+    match names, result.returnValue with
+    | [name], some value =>
+        .continue
+          { world := result.world
+            bindings := SourceSemantics.bindValue state.bindings name value }
+    | _, _ => .revert
+  else .revert
+
+abbrev DirectInternalHelperAssignSourceEvidence
+    {runtimeContract : IRContract} {spec : CompilationModel}
+    (fields : List Field) {calleeName : String} (names : List String) (args : List Expr)
+    (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
+    (fuel : Nat) (state : SourceSemantics.RuntimeState) (argVals : List Nat) : Prop :=
+  let result := SourceSemantics.interpretInternalFunctionFuel
+    spec fuel hctx.sourceWitness.callee state.world argVals
+  SourceSemantics.execStmtWithHelpers spec fields (fuel + 1) state
+      (Stmt.internalCallAssign names calleeName args) =
+        directInternalHelperAssignSourceResult state names result ∧
+    hctx.sourceWitness.summary.contract.post fuel state.world argVals
+      result.success result.returnValue result.world
+
+/-- Source-side evidence for a direct helper return-binding call from the
+packaged statement context bridge. -/
+theorem directInternalHelperStatementContextBridge_sourceAssignEvidence
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {calleeName : String} {names : List String} {args : List Expr}
+    (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
+    (hnodup : (spec.functions.map (·.name)).Nodup)
+    {fuel : Nat} {state : SourceSemantics.RuntimeState} {argVals : List Nat}
+    (hargs :
+      SourceSemantics.evalExprListWithHelpers spec fields (fuel + 1) state args =
+        some argVals) :
+    DirectInternalHelperAssignSourceEvidence fields names args hctx fuel state argVals := by
+  dsimp [DirectInternalHelperAssignSourceEvidence]
+  refine ⟨?_, ?_⟩
+  · simpa [hargs, directInternalHelperAssignSourceResult] using
+      SourceSemantics.execStmtWithHelpers_internalCallAssign_of_witness
+        (spec := spec)
+        (fields := fields)
+        (fuel := fuel)
+        (state := state)
+        (names := names)
+        (calleeName := calleeName)
+        (args := args)
+        hctx.sourceWitness
+        hnodup
+  · simpa using hctx.summarySound fuel state.world argVals
 
 /-!
 ## Expression-position internal-helper calls

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1792,6 +1792,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterface_of_assignHeadStepBridges
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterfaceWithInternals_of_assignHeadStepBridgesWithInternals
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterface_of_perCalleeAssignBridgeCatalog
+  Compiler.Proofs.HelperStepProofs.directInternalHelperStatementContextBridge_sourceCallEvidence
+  Compiler.Proofs.HelperStepProofs.directInternalHelperStatementContextBridge_sourceAssignEvidence
   Compiler.Proofs.HelperStepProofs.evalIRCallWithInternals_of_compiledHelperWitness
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCallContextBridge_sourceEvidence
   Compiler.Proofs.HelperStepProofs.compileExprWithInternals_internalCall_shape
@@ -6040,4 +6042,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5664 theorems/lemmas (3906 public, 1758 private, 0 sorry'd)
+-- Total: 5666 theorems/lemmas (3908 public, 1758 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- add `DirectInternalHelperStatementContextBridge`, packaging supported source helper summary evidence with compiled helper dispatch for direct `Stmt.internalCall` and `Stmt.internalCallAssign`
- instantiate the bridge from `SupportedBodyHelperInterface`, `SupportedBodyHelperSummariesSound`, and `SupportedRuntimeHelperTableInterface`
- expose source-side direct helper call and assign evidence theorems, plus a compact assign-result/evidence wrapper for downstream head-step bridge proofs
- refresh `PrintAxioms.lean` for the two new public proof declarations

## Validation
- `lean-slot lake build Compiler.Proofs.HelperStepProofs`
- `python3 scripts/check_proof_length.py`
- `python3 scripts/generate_print_axioms.py`
- `python3 scripts/generate_print_axioms.py --check`
- `git diff --check`
- `rg -n "\\bsorry\\b|\\badmit\\b|axiom " Compiler/Proofs/HelperStepProofs.lean PrintAxioms.lean` (only generated audit comments report `0 sorry'd`)

## Issue #2080 Position
This does not close #2080 yet. It packages the supported-evidence handoff needed by the direct statement helper call/assign obligations, while leaving the actual with-internals head-step bridge proofs to consume this context together with the helper IR execution summary theorem from the parent PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof scaffolding only; no runtime, auth, or compiler behavior changes. Remaining obligations are explicitly deferred to later head-step bridge work.
> 
> **Overview**
> Adds **`DirectInternalHelperStatementContextBridge`**, a per-callee bundle that combines supported source helper witnesses, summary soundness, compiled-helper runtime evidence, and IR dispatch lemmas for direct **`Stmt.internalCall`** and **`Stmt.internalCallAssign`** (after args are evaluated, execution routes through **`execIRInternalFunctionWithInternals`**).
> 
> **`directInternalHelperStatementContextBridge_of_supportedEvidence`** builds that bridge from **`SupportedBodyHelperInterface`**, **`SupportedBodyHelperSummariesSound`**, and **`SupportedRuntimeHelperTableInterface`**. New source-side theorems (**`directInternalHelperStatementContextBridge_sourceCallEvidence`** / **`_sourceAssignEvidence`**) plus assign result/evidence abbreviations give downstream head-step proofs the same shape as the expression helper context bridge.
> 
> **`PrintAxioms.lean`** is updated for the two new public theorems. This is scaffolding for #2080—not the full source/IR head-step bridge, which still needs arg-alignment and helper-body summary discharge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fcb01117e51b5684725c79caf1f9a3f0cfc1937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->