### PR TITLE
proof: expose direct helper summary step match interface

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -835,6 +835,192 @@ theorem directInternalHelperStatementContextBridge_sourceAssignEvidence
         hnodup
   · simpa using hctx.summarySound fuel state.world argVals
 
+abbrev directInternalHelperCallSourceResult
+    (state : SourceSemantics.RuntimeState)
+    (result : SourceSemantics.InternalFunctionResult) :
+    SourceSemantics.StmtResult :=
+  if result.success then
+    .continue { state with world := result.world }
+  else .revert
+
+abbrev directInternalHelperCallIRResult
+    (callerState : IRState) (helper : IRInternalFunctionDef)
+    (bodyResult : IRExecResultWithInternals) :
+    IRExecResultWithInternals :=
+  match internalHelperBodyIRExecResultAsCallResult callerState helper bodyResult with
+  | .values _ state' => .continue state'
+  | .stop state' => .stop state'
+  | .return value state' => .return value state'
+  | .revert state' => .revert state'
+
+/-- The remaining direct void-call summary obligation after source reduction and
+the N1a/N2/N3 IR helper-summary bridge have been applied.  Downstream proofs must
+turn the helper summary post into the concrete statement-step source/IR state
+relation required by `stmtStepMatchesIRExecWithInternals`. -/
+abbrev DirectInternalHelperCallSummaryStepPostcondition
+    {runtimeContract : IRContract} {spec : CompilationModel}
+    (fields : List Field) (nextScope : List String)
+    {calleeName : String}
+    (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
+    (helperFuel : Nat)
+    (runtime : SourceSemantics.RuntimeState)
+    (argVals : List Nat)
+    (callerState : IRState)
+    (helper : IRInternalFunctionDef)
+    (bodyResult : IRExecResultWithInternals) : Prop :=
+  let sourceResult :=
+    SourceSemantics.interpretInternalFunctionFuel
+      spec helperFuel hctx.sourceWitness.callee runtime.world argVals
+  hctx.sourceWitness.summary.contract.post helperFuel runtime.world argVals
+      sourceResult.success sourceResult.returnValue sourceResult.world →
+    stmtStepMatchesIRExecWithInternals fields nextScope
+      (directInternalHelperCallSourceResult runtime sourceResult)
+      (directInternalHelperCallIRResult callerState helper bodyResult)
+
+/-- The remaining direct return-binding helper-call summary obligation after the
+source statement reduction and singleton helper-call IR summary bridge have been
+applied. -/
+abbrev DirectInternalHelperAssignSummaryStepPostcondition
+    {runtimeContract : IRContract} {spec : CompilationModel}
+    (fields : List Field) (nextScope : List String)
+    {calleeName : String}
+    (names : List String)
+    (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
+    (helperFuel : Nat)
+    (runtime : SourceSemantics.RuntimeState)
+    (argVals : List Nat)
+    (callerState : IRState)
+    (helper : IRInternalFunctionDef)
+    (bodyResult : IRExecResultWithInternals) : Prop :=
+  let sourceResult :=
+    SourceSemantics.interpretInternalFunctionFuel
+      spec helperFuel hctx.sourceWitness.callee runtime.world argVals
+  hctx.sourceWitness.summary.contract.post helperFuel runtime.world argVals
+      sourceResult.success sourceResult.returnValue sourceResult.world →
+    stmtStepMatchesIRExecWithInternals fields nextScope
+      (directInternalHelperAssignSourceResult runtime names sourceResult)
+      (internalHelperAssignCallResult names callerState helper bodyResult)
+
+section DirectInternalHelperStatementSummaryStepMatch
+
+variable {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+variable {scope : List String} {calleeName : String}
+variable {args : List Expr} {helper : IRInternalFunctionDef}
+variable {runtime : SourceSemantics.RuntimeState}
+variable {state callerState : IRState}
+variable {argVals : List Nat} {argExprs : List YulExpr}
+variable {sourceBindings entryBindings : List (String × Nat)}
+
+/-- Direct void helper-call step match at the exact helper-call fuel required by
+`execIRStmtsWithInternals_internalCall_obeys_internal_helper_summary`.
+
+This theorem is the public handoff from the source statement context bridge and
+the N1a/N2/N3 IR helper-summary bridge to the final direct-call head-step proof.
+The remaining `hpostMatch` argument is intentionally explicit: it is the exact
+place where downstream rank-summary evidence must turn the helper summary post
+into the concrete source/IR statement-step state relation. -/
+theorem directInternalHelperStatementContextBridge_callStepMatch_at_internalHelperCallFuel
+    (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
+    (hnodup : (spec.functions.map (·.name)).Nodup)
+    (helperFuel extraFuel : Nat)
+    (hfuelPos : 0 < helperFuel)
+    (bodyCtx : InternalHelperBodyExecContext runtimeContract spec
+      hctx.sourceWitness.callee helper callerState runtime.world argVals
+      sourceBindings entryBindings helperFuel)
+    (harity : helper.params.length = hctx.sourceWitness.callee.params.length)
+    (hfind : findInternalFunction? runtimeContract
+      (CompilationModel.internalFunctionYulName calleeName) = some helper)
+    (hsourceArgs :
+      SourceSemantics.evalExprListWithHelpers spec fields (helperFuel + 1)
+        runtime args = some argVals)
+    (hirArgs :
+      evalIRExprsWithInternals runtimeContract
+          (internalHelperCallFuel helper extraFuel + 1) state argExprs =
+        .values argVals callerState)
+    (hpostMatch :
+      DirectInternalHelperCallSummaryStepPostcondition fields
+        (stmtNextScope scope (Stmt.internalCall calleeName args))
+        hctx helperFuel runtime argVals callerState helper
+        (internalHelperBodyIRExec runtimeContract helper callerState argVals extraFuel)) :
+    stmtStepMatchesIRExecWithInternals fields
+      (stmtNextScope scope (Stmt.internalCall calleeName args))
+      (SourceSemantics.execStmtWithHelpers spec fields (helperFuel + 1) runtime (Stmt.internalCall calleeName args))
+      (execIRStmtsWithInternals runtimeContract
+        (internalHelperCallFuel helper extraFuel + 3) state
+        [YulStmt.exprStmt (YulExpr.call
+          (CompilationModel.internalFunctionYulName calleeName) argExprs)]) := by
+  have hsource :=
+    directInternalHelperStatementContextBridge_sourceCallEvidence
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (calleeName := calleeName) (args := args) hctx hnodup
+      (fuel := helperFuel) (state := runtime) hsourceArgs
+  have hir :=
+    execIRStmtsWithInternals_internalCall_obeys_internal_helper_summary
+      (runtimeContract := runtimeContract) (spec := spec)
+      (callee := hctx.sourceWitness.callee) (helper := helper)
+      (state := state) (callerState := callerState)
+      (initialWorld := runtime.world) (args := argVals)
+      (sourceBindings := sourceBindings) (entryBindings := entryBindings)
+      (summary := hctx.sourceWitness.summary.contract)
+      helperFuel extraFuel hfuelPos bodyCtx hctx.summarySound harity hfind hirArgs
+  rw [hsource.1, hir.1]
+  exact hpostMatch hsource.2
+
+/-- Direct return-binding helper-call step match at the exact helper-call fuel
+required by
+`execIRStmtsWithInternals_internalCallAssign_obeys_internal_helper_summary`. -/
+theorem directInternalHelperStatementContextBridge_assignStepMatch_at_internalHelperCallFuel
+    {names : List String}
+    (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
+    (hnodup : (spec.functions.map (·.name)).Nodup)
+    (helperFuel extraFuel : Nat)
+    (hfuelPos : 0 < helperFuel)
+    (bodyCtx : InternalHelperBodyExecContext runtimeContract spec
+      hctx.sourceWitness.callee helper callerState runtime.world argVals
+      sourceBindings entryBindings helperFuel)
+    (harity : helper.params.length = hctx.sourceWitness.callee.params.length)
+    (hfind : findInternalFunction? runtimeContract
+      (CompilationModel.internalFunctionYulName calleeName) = some helper)
+    (hsourceArgs :
+      SourceSemantics.evalExprListWithHelpers spec fields (helperFuel + 1)
+        runtime args = some argVals)
+    (hirArgs :
+      evalIRExprsWithInternals runtimeContract
+          (internalHelperCallFuel helper extraFuel + 1) state argExprs =
+        .values argVals callerState)
+    (hpostMatch :
+      DirectInternalHelperAssignSummaryStepPostcondition fields
+        (stmtNextScope scope (Stmt.internalCallAssign names calleeName args))
+        names hctx helperFuel runtime argVals callerState helper
+        (internalHelperBodyIRExec runtimeContract helper callerState argVals extraFuel)) :
+    stmtStepMatchesIRExecWithInternals fields
+      (stmtNextScope scope (Stmt.internalCallAssign names calleeName args))
+      (SourceSemantics.execStmtWithHelpers spec fields (helperFuel + 1) runtime
+        (Stmt.internalCallAssign names calleeName args))
+      (execIRStmtsWithInternals runtimeContract
+        (internalHelperCallFuel helper extraFuel + 3) state
+        [YulStmt.letMany names (YulExpr.call
+          (CompilationModel.internalFunctionYulName calleeName) argExprs)]) := by
+  have hsource :=
+    directInternalHelperStatementContextBridge_sourceAssignEvidence
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (calleeName := calleeName) (names := names) (args := args)
+      hctx hnodup (fuel := helperFuel) (state := runtime) hsourceArgs
+  have hir :=
+    execIRStmtsWithInternals_internalCallAssign_obeys_internal_helper_summary
+      (runtimeContract := runtimeContract) (spec := spec)
+      (callee := hctx.sourceWitness.callee) (helper := helper)
+      (state := state) (callerState := callerState)
+      (initialWorld := runtime.world) (names := names) (calleeName := calleeName)
+      (argExprs := argExprs) (args := argVals)
+      (sourceBindings := sourceBindings) (entryBindings := entryBindings)
+      (summary := hctx.sourceWitness.summary.contract)
+      helperFuel extraFuel hfuelPos bodyCtx hctx.summarySound harity hfind hirArgs
+  rw [hsource.1, hir.1]
+  exact hpostMatch hsource.2
+
+end DirectInternalHelperStatementSummaryStepMatch
+
 /-!
 ## Expression-position internal-helper calls
 

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1794,6 +1794,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterface_of_perCalleeAssignBridgeCatalog
   Compiler.Proofs.HelperStepProofs.directInternalHelperStatementContextBridge_sourceCallEvidence
   Compiler.Proofs.HelperStepProofs.directInternalHelperStatementContextBridge_sourceAssignEvidence
+  Compiler.Proofs.HelperStepProofs.directInternalHelperStatementContextBridge_callStepMatch_at_internalHelperCallFuel
+  Compiler.Proofs.HelperStepProofs.directInternalHelperStatementContextBridge_assignStepMatch_at_internalHelperCallFuel
   Compiler.Proofs.HelperStepProofs.evalIRCallWithInternals_of_compiledHelperWitness
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCallContextBridge_sourceEvidence
   Compiler.Proofs.HelperStepProofs.compileExprWithInternals_internalCall_shape
@@ -6042,4 +6044,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5666 theorems/lemmas (3908 public, 1758 private, 0 sorry'd)
+-- Total: 5668 theorems/lemmas (3910 public, 1758 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- add direct helper call/assign source and IR result wrappers for the statement-position helper bridge
- expose `DirectInternalHelperCallSummaryStepPostcondition` and `DirectInternalHelperAssignSummaryStepPostcondition` as the exact remaining summary-post-to-`stmtStepMatchesIRExecWithInternals` obligation
- add exact-fuel composition theorems consuming the #2166 singleton IR helper summary wrappers and the #2167 source statement context bridge:
  - `directInternalHelperStatementContextBridge_callStepMatch_at_internalHelperCallFuel`
  - `directInternalHelperStatementContextBridge_assignStepMatch_at_internalHelperCallFuel`
- refresh `PrintAxioms.lean` for the two new public theorem declarations

## Validation
- `lean-slot lake build Compiler.Proofs.HelperStepProofs`
- `python3 scripts/check_proof_length.py`
- `python3 scripts/generate_print_axioms.py`
- `python3 scripts/generate_print_axioms.py --check`
- `git diff --check`
- `rg -n "\\bsorry\\b|\\badmit\\b|axiom |True :=" Compiler/Proofs/HelperStepProofs.lean PrintAxioms.lean` (only generated audit comments report `0 sorry'd`)

## Issue #2080 Position
This still does not close #2080. It makes the next direct statement-helper proof boundary explicit: downstream work must prove the postcondition-to-step-match obligations and reconcile the exact `internalHelperCallFuel` used by the helper-body bridge with the current direct head-step bridge fuel interface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof scaffolding only; no runtime or compiler behavior changes, and the new theorems delegate the hard semantic work to explicit `hpostMatch` obligations.
> 
> **Overview**
> This PR **narrows the proof boundary** for statement-position direct internal helper calls (`Stmt.internalCall` and `Stmt.internalCallAssign`) without closing the full head-step bridge.
> 
> It introduces **source/IR result wrappers** (`directInternalHelperCallSourceResult`, `directInternalHelperCallIRResult`) and two **postcondition abbreviations**—`DirectInternalHelperCallSummaryStepPostcondition` and `DirectInternalHelperAssignSummaryStepPostcondition`—that state exactly what remains after source reduction and the IR helper-summary bridge: turning the helper summary **post** into `stmtStepMatchesIRExecWithInternals`.
> 
> Two **composition theorems** at `internalHelperCallFuel` wire `directInternalHelperStatementContextBridge_source*Evidence` with `execIRStmtsWithInternals_internalCall*_obeys_internal_helper_summary`, with an explicit **`hpostMatch`** argument for rank-summary evidence. **`PrintAxioms.lean`** is updated to list the new public theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a216622b51826ae0430b23dacd076420bc1c2fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->