### PR TITLE
proof: add direct helper sufficient fuel adapters

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -1019,6 +1019,121 @@ theorem directInternalHelperStatementContextBridge_assignStepMatch_at_internalHe
   rw [hsource.1, hir.1]
   exact hpostMatch hsource.2
 
+noncomputable abbrev directInternalHelperExtraFuel
+    (helper : IRInternalFunctionDef) (irFuel : Nat) : Nat :=
+  irFuel - (sizeOf helper.body + 2)
+
+section DirectInternalHelperStatementSufficientFuel
+
+variable {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+variable {scope : List String} {calleeName : String}
+variable {args : List Expr} {helper : IRInternalFunctionDef}
+variable {runtime : SourceSemantics.RuntimeState}
+variable {state callerState : IRState}
+variable {argVals : List Nat} {argExprs : List YulExpr}
+variable {sourceBindings entryBindings : List (String × Nat)}
+
+/-- Re-index the exact-fuel direct void-call bridge under explicit sufficient-fuel bounds. -/
+theorem directInternalHelperStatementContextBridge_callStepMatch_of_sufficientFuel
+    (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName) (hnodup : (spec.functions.map (·.name)).Nodup)
+    (stmtHelperFuel irFuel : Nat)
+    (hstmtFuel : 1 < stmtHelperFuel)
+    (hirFuel : sizeOf helper.body + 2 ≤ irFuel)
+    (bodyCtx : InternalHelperBodyExecContext runtimeContract spec
+      hctx.sourceWitness.callee helper callerState runtime.world argVals
+      sourceBindings entryBindings (stmtHelperFuel - 1))
+    (harity : helper.params.length = hctx.sourceWitness.callee.params.length)
+    (hfind : findInternalFunction? runtimeContract
+      (CompilationModel.internalFunctionYulName calleeName) = some helper)
+    (hsourceArgs : SourceSemantics.evalExprListWithHelpers spec fields stmtHelperFuel runtime args = some argVals)
+    (hirArgs :
+      evalIRExprsWithInternals runtimeContract (irFuel + 1) state argExprs =
+        .values argVals callerState)
+    (hpostMatch :
+      DirectInternalHelperCallSummaryStepPostcondition fields
+        (stmtNextScope scope (Stmt.internalCall calleeName args))
+        hctx (stmtHelperFuel - 1) runtime argVals callerState helper
+        (internalHelperBodyIRExec runtimeContract helper callerState argVals
+          (directInternalHelperExtraFuel helper irFuel))) :
+    stmtStepMatchesIRExecWithInternals fields
+      (stmtNextScope scope (Stmt.internalCall calleeName args))
+      (SourceSemantics.execStmtWithHelpers spec fields stmtHelperFuel runtime
+        (Stmt.internalCall calleeName args))
+      (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
+        [YulStmt.exprStmt (YulExpr.call
+          (CompilationModel.internalFunctionYulName calleeName) argExprs)]) := by
+  have hbodyFuelPos : 0 < stmtHelperFuel - 1 := by omega
+  have hstmtFuelEq : stmtHelperFuel - 1 + 1 = stmtHelperFuel := by omega
+  have hirFuelEq :
+      internalHelperCallFuel helper (directInternalHelperExtraFuel helper irFuel) = irFuel := by
+    unfold internalHelperCallFuel
+    unfold directInternalHelperExtraFuel
+    omega
+  rw [← hstmtFuelEq] at hsourceArgs
+  rw [← hirFuelEq] at hirArgs ⊢
+  have hmatch :=
+    directInternalHelperStatementContextBridge_callStepMatch_at_internalHelperCallFuel
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (scope := scope) (calleeName := calleeName) (args := args)
+      (helper := helper) (runtime := runtime) (state := state)
+      (callerState := callerState) (argVals := argVals) (argExprs := argExprs)
+      (sourceBindings := sourceBindings) (entryBindings := entryBindings)
+      hctx hnodup (stmtHelperFuel - 1) (directInternalHelperExtraFuel helper irFuel)
+      hbodyFuelPos bodyCtx harity hfind hsourceArgs hirArgs hpostMatch
+  simpa [hstmtFuelEq] using hmatch
+
+/-- Return-binding counterpart of the sufficient-fuel direct void-call adapter. -/
+theorem directInternalHelperStatementContextBridge_assignStepMatch_of_sufficientFuel
+    {names : List String}
+    (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName) (hnodup : (spec.functions.map (·.name)).Nodup)
+    (stmtHelperFuel irFuel : Nat)
+    (hstmtFuel : 1 < stmtHelperFuel)
+    (hirFuel : sizeOf helper.body + 2 ≤ irFuel)
+    (bodyCtx : InternalHelperBodyExecContext runtimeContract spec
+      hctx.sourceWitness.callee helper callerState runtime.world argVals
+      sourceBindings entryBindings (stmtHelperFuel - 1))
+    (harity : helper.params.length = hctx.sourceWitness.callee.params.length)
+    (hfind : findInternalFunction? runtimeContract
+      (CompilationModel.internalFunctionYulName calleeName) = some helper)
+    (hsourceArgs : SourceSemantics.evalExprListWithHelpers spec fields stmtHelperFuel runtime args = some argVals)
+    (hirArgs :
+      evalIRExprsWithInternals runtimeContract (irFuel + 1) state argExprs =
+        .values argVals callerState)
+    (hpostMatch :
+      DirectInternalHelperAssignSummaryStepPostcondition fields
+        (stmtNextScope scope (Stmt.internalCallAssign names calleeName args))
+        names hctx (stmtHelperFuel - 1) runtime argVals callerState helper
+        (internalHelperBodyIRExec runtimeContract helper callerState argVals
+          (directInternalHelperExtraFuel helper irFuel))) :
+    stmtStepMatchesIRExecWithInternals fields
+      (stmtNextScope scope (Stmt.internalCallAssign names calleeName args))
+      (SourceSemantics.execStmtWithHelpers spec fields stmtHelperFuel runtime
+        (Stmt.internalCallAssign names calleeName args))
+      (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
+        [YulStmt.letMany names (YulExpr.call
+          (CompilationModel.internalFunctionYulName calleeName) argExprs)]) := by
+  have hbodyFuelPos : 0 < stmtHelperFuel - 1 := by omega
+  have hstmtFuelEq : stmtHelperFuel - 1 + 1 = stmtHelperFuel := by omega
+  have hirFuelEq :
+      internalHelperCallFuel helper (directInternalHelperExtraFuel helper irFuel) = irFuel := by
+    unfold internalHelperCallFuel
+    unfold directInternalHelperExtraFuel
+    omega
+  rw [← hstmtFuelEq] at hsourceArgs
+  rw [← hirFuelEq] at hirArgs ⊢
+  have hmatch :=
+    directInternalHelperStatementContextBridge_assignStepMatch_at_internalHelperCallFuel
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (scope := scope) (calleeName := calleeName) (names := names) (args := args)
+      (helper := helper) (runtime := runtime) (state := state)
+      (callerState := callerState) (argVals := argVals) (argExprs := argExprs)
+      (sourceBindings := sourceBindings) (entryBindings := entryBindings)
+      hctx hnodup (stmtHelperFuel - 1) (directInternalHelperExtraFuel helper irFuel)
+      hbodyFuelPos bodyCtx harity hfind hsourceArgs hirArgs hpostMatch
+  simpa [hstmtFuelEq] using hmatch
+
+end DirectInternalHelperStatementSufficientFuel
+
 end DirectInternalHelperStatementSummaryStepMatch
 
 /-!

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1796,6 +1796,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.directInternalHelperStatementContextBridge_sourceAssignEvidence
   Compiler.Proofs.HelperStepProofs.directInternalHelperStatementContextBridge_callStepMatch_at_internalHelperCallFuel
   Compiler.Proofs.HelperStepProofs.directInternalHelperStatementContextBridge_assignStepMatch_at_internalHelperCallFuel
+  Compiler.Proofs.HelperStepProofs.directInternalHelperStatementContextBridge_callStepMatch_of_sufficientFuel
+  Compiler.Proofs.HelperStepProofs.directInternalHelperStatementContextBridge_assignStepMatch_of_sufficientFuel
   Compiler.Proofs.HelperStepProofs.evalIRCallWithInternals_of_compiledHelperWitness
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCallContextBridge_sourceEvidence
   Compiler.Proofs.HelperStepProofs.compileExprWithInternals_internalCall_shape
@@ -6044,4 +6046,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5668 theorems/lemmas (3910 public, 1758 private, 0 sorry'd)
+-- Total: 5670 theorems/lemmas (3912 public, 1758 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- add `directInternalHelperExtraFuel`, the explicit inverse offset for `internalHelperCallFuel`
- expose sufficient-fuel adapters for direct statement helper calls:
  - `directInternalHelperStatementContextBridge_callStepMatch_of_sufficientFuel`
  - `directInternalHelperStatementContextBridge_assignStepMatch_of_sufficientFuel`
- these re-index the exact-fuel #2169 direct step-match theorems to statement-level helper fuel and arbitrary IR fuel when:
  - `1 < stmtHelperFuel`
  - `sizeOf helper.body + 2 <= irFuel`
- refresh `PrintAxioms.lean` for the two new public proof declarations

## Validation
- `lean-slot lake build Compiler.Proofs.HelperStepProofs`
- `python3 scripts/check_proof_length.py`
- `python3 scripts/generate_print_axioms.py`
- `python3 scripts/generate_print_axioms.py --check`
- `git diff --check`
- `rg -n "\\bsorry\\b|\\badmit\\b|axiom |True :=|\\t" Compiler/Proofs/HelperStepProofs.lean PrintAxioms.lean` (only generated audit comments report `0 sorry'd`)

## Issue #2080 Position
This still does not close #2080. It makes the remaining direct head-step fuel gap explicit: the helper-body summary path covers the sufficient-fuel region, while the existing direct head-step bridge asks for all positive statement fuel and all wrapper IR fuel. The next proof/interface review must account for the low-fuel cases or strengthen the public head-step fuel contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in HelperStepProofs with no runtime or compiler behavior changes; low risk aside from downstream proof obligations still needing low-fuel cases.
> 
> **Overview**
> Adds **`directInternalHelperExtraFuel`** (`irFuel - (sizeOf helper.body + 2)`) as the explicit inverse of **`internalHelperCallFuel`**, so wrapper IR fuel can be stated in terms of statement-level fuel.
> 
> Introduces two **sufficient-fuel adapters** that delegate to the existing exact-fuel step-match theorems after rewriting fuels: **`directInternalHelperStatementContextBridge_callStepMatch_of_sufficientFuel`** (void `internalCall`) and **`..._assignStepMatch_of_sufficientFuel`** (return-binding `internalCallAssign`). They require `1 < stmtHelperFuel` and `sizeOf helper.body + 2 ≤ irFuel`, then prove `stmtStepMatchesIRExecWithInternals` at `stmtHelperFuel` and `irFuel + 3` instead of tying callers to `internalHelperCallFuel` directly.
> 
> **`PrintAxioms.lean`** is regenerated to list the two new public theorems (5670 total declarations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0a1b549ab0ae3125763b23da30621172261cd1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->