### PR TITLE
proof: expose direct helper fuel split interface

### DIFF
--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -261,6 +261,97 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign
   rw [hshape'] at hslack ⊢; rw [hlenOne] at hslack; rw [hFuelEq]
   exact ⟨_, _, rfl, rfl, hMatch⟩
 
+private theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_delimiter :
+    (0 : Nat) = 0 := by
+  rfl
+
+abbrev InternalCallAssignWithInternalsBridgeAt
+    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
+    (scope : List String) (names : List String) (calleeName : String) (args : List Expr)
+    (argExprs : List YulExpr)
+    (runtime : SourceSemantics.RuntimeState) (state : IRState)
+    (helperFuel irFuel : Nat) : Prop :=
+    0 < helperFuel →
+    FunctionBody.bindingsExactlyMatchIRVarsOnScope scope runtime.bindings state →
+    FunctionBody.scopeNamesPresent scope runtime.bindings →
+    FunctionBody.bindingsBounded runtime.bindings →
+    FunctionBody.runtimeStateMatchesIR fields runtime state →
+    stmtStepMatchesIRExecWithInternals fields
+      (stmtNextScope scope (Stmt.internalCallAssign names calleeName args))
+      (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
+        (Stmt.internalCallAssign names calleeName args))
+      (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
+        [YulStmt.letMany names
+          (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs)])
+
+abbrev InternalCallAssignWithInternalsBridge
+    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
+    (scope : List String) (names : List String) (calleeName : String) (args : List Expr)
+    (argExprs : List YulExpr) : Prop :=
+  ∀ runtime state helperFuel irFuel,
+    InternalCallAssignWithInternalsBridgeAt runtimeContract spec fields scope names calleeName
+      args argExprs runtime state helperFuel irFuel
+
+abbrev InternalCallAssignWithInternalsSufficientBridge
+    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
+    (scope : List String) (names : List String) (calleeName : String) (args : List Expr)
+    (argExprs : List YulExpr) (helperBodySize : Nat) : Prop :=
+  ∀ (runtime : SourceSemantics.RuntimeState) (state : IRState) (helperFuel irFuel : Nat),
+    1 < helperFuel →
+    helperBodySize + 2 ≤ irFuel →
+    InternalCallAssignWithInternalsBridgeAt runtimeContract spec fields scope names calleeName
+      args argExprs runtime state helperFuel irFuel
+
+abbrev InternalCallAssignWithInternalsResidualBridge
+    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
+    (scope : List String) (names : List String) (calleeName : String) (args : List Expr)
+    (argExprs : List YulExpr) (helperBodySize : Nat) : Prop :=
+  ∀ (runtime : SourceSemantics.RuntimeState) (state : IRState) (helperFuel irFuel : Nat),
+    (¬ 1 < helperFuel ∨ ¬ helperBodySize + 2 ≤ irFuel) →
+    InternalCallAssignWithInternalsBridgeAt runtimeContract spec fields scope names calleeName
+      args argExprs runtime state helperFuel irFuel
+
+/-- Fuel-split variant of the direct assignment-call singleton constructor.
+
+This preserves the existing all-positive-fuel public target while exposing the
+two proof obligations that arise in the direct helper-summary path: the normal
+sufficient-fuel region and the residual source-low-fuel or IR-insufficient-fuel
+region. -/
+theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_of_fuelSplitBridge
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {scope : List String} {names : List String} {calleeName : String} {args : List Expr}
+    {compiledIR : List YulStmt} {argExprs : List YulExpr}
+    (helperBodySize : Nat)
+    (hcompile :
+      CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
+        (Stmt.internalCallAssign names calleeName args) spec.functions = Except.ok compiledIR)
+    (hargCompile :
+      CompilationModel.compileInternalCallArgs fields .calldata spec.functions
+        calleeName args = Except.ok argExprs)
+    (bridgeSufficient :
+      InternalCallAssignWithInternalsSufficientBridge runtimeContract spec fields scope names
+        calleeName args argExprs helperBodySize)
+    (bridgeResidual :
+      InternalCallAssignWithInternalsResidualBridge runtimeContract spec fields scope names
+        calleeName args argExprs helperBodySize) :
+    CompiledStmtStepWithHelpersAndHelperIRWithInternals
+      runtimeContract spec fields scope
+      (Stmt.internalCallAssign names calleeName args) compiledIR := by
+  refine
+    compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (scope := scope) (names := names) (calleeName := calleeName) (args := args)
+      (compiledIR := compiledIR) (argExprs := argExprs) hcompile hargCompile ?_
+  intro runtime state helperFuel irFuel hfuel hexact hscope hbounded hruntime
+  by_cases hsource : 1 < helperFuel
+  · by_cases hir : helperBodySize + 2 ≤ irFuel
+    · exact bridgeSufficient runtime state helperFuel irFuel hsource hir
+        hfuel hexact hscope hbounded hruntime
+    · exact bridgeResidual runtime state helperFuel irFuel (.inr hir)
+        hfuel hexact hscope hbounded hruntime
+  · exact bridgeResidual runtime state helperFuel irFuel (.inl hsource)
+      hfuel hexact hscope hbounded hruntime
+
 /-- Spec-functions-aware constructor for the helper-aware single-step interface
 when the head statement is `Stmt.internalCall`. -/
 theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall
@@ -308,6 +399,97 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall
     rw [hlenOne, hirFuel]; omega
   rw [hshape'] at hslack ⊢; rw [hlenOne] at hslack; rw [hFuelEq]
   exact ⟨_, _, rfl, rfl, hMatch⟩
+
+private theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_delimiter :
+    (0 : Nat) = 0 := by
+  rfl
+
+abbrev InternalCallWithInternalsBridgeAt
+    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
+    (scope : List String) (calleeName : String) (args : List Expr)
+    (argExprs : List YulExpr)
+    (runtime : SourceSemantics.RuntimeState) (state : IRState)
+    (helperFuel irFuel : Nat) : Prop :=
+    0 < helperFuel →
+    FunctionBody.bindingsExactlyMatchIRVarsOnScope scope runtime.bindings state →
+    FunctionBody.scopeNamesPresent scope runtime.bindings →
+    FunctionBody.bindingsBounded runtime.bindings →
+    FunctionBody.runtimeStateMatchesIR fields runtime state →
+    stmtStepMatchesIRExecWithInternals fields
+      (stmtNextScope scope (Stmt.internalCall calleeName args))
+      (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
+        (Stmt.internalCall calleeName args))
+      (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
+        [YulStmt.exprStmt
+          (YulExpr.call (CompilationModel.internalFunctionYulName calleeName) argExprs)])
+
+abbrev InternalCallWithInternalsBridge
+    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
+    (scope : List String) (calleeName : String) (args : List Expr)
+    (argExprs : List YulExpr) : Prop :=
+  ∀ runtime state helperFuel irFuel,
+    InternalCallWithInternalsBridgeAt runtimeContract spec fields scope calleeName args argExprs
+      runtime state helperFuel irFuel
+
+abbrev InternalCallWithInternalsSufficientBridge
+    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
+    (scope : List String) (calleeName : String) (args : List Expr)
+    (argExprs : List YulExpr) (helperBodySize : Nat) : Prop :=
+  ∀ (runtime : SourceSemantics.RuntimeState) (state : IRState) (helperFuel irFuel : Nat),
+    1 < helperFuel →
+    helperBodySize + 2 ≤ irFuel →
+    InternalCallWithInternalsBridgeAt runtimeContract spec fields scope calleeName args argExprs
+      runtime state helperFuel irFuel
+
+abbrev InternalCallWithInternalsResidualBridge
+    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
+    (scope : List String) (calleeName : String) (args : List Expr)
+    (argExprs : List YulExpr) (helperBodySize : Nat) : Prop :=
+  ∀ (runtime : SourceSemantics.RuntimeState) (state : IRState) (helperFuel irFuel : Nat),
+    (¬ 1 < helperFuel ∨ ¬ helperBodySize + 2 ≤ irFuel) →
+    InternalCallWithInternalsBridgeAt runtimeContract spec fields scope calleeName args argExprs
+      runtime state helperFuel irFuel
+
+/-- Fuel-split variant of the direct void-call singleton constructor.
+
+The existing public single-step interface still asks for every positive source
+helper fuel and every compiled-side wrapper fuel.  This constructor makes the
+proof-interface review explicit: callers may discharge the normal
+sufficient-fuel region separately from the residual low/insufficient-fuel
+region, while preserving the same final `CompiledStmtStep...` target. -/
+theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_fuelSplitBridge
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {scope : List String} {calleeName : String} {args : List Expr}
+    {compiledIR : List YulStmt} {argExprs : List YulExpr}
+    (helperBodySize : Nat)
+    (hcompile :
+      CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
+        (Stmt.internalCall calleeName args) spec.functions = Except.ok compiledIR)
+    (hargCompile :
+      CompilationModel.compileInternalCallArgs fields .calldata spec.functions
+        calleeName args = Except.ok argExprs)
+    (bridgeSufficient :
+      InternalCallWithInternalsSufficientBridge runtimeContract spec fields scope calleeName args
+        argExprs helperBodySize)
+    (bridgeResidual :
+      InternalCallWithInternalsResidualBridge runtimeContract spec fields scope calleeName args
+        argExprs helperBodySize) :
+    CompiledStmtStepWithHelpersAndHelperIRWithInternals
+      runtimeContract spec fields scope (Stmt.internalCall calleeName args) compiledIR := by
+  refine
+    compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall
+      (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+      (scope := scope) (calleeName := calleeName) (args := args)
+      (compiledIR := compiledIR) (argExprs := argExprs) hcompile hargCompile ?_
+  intro runtime state helperFuel irFuel hfuel hexact hscope hbounded hruntime
+  by_cases hsource : 1 < helperFuel
+  · by_cases hir : helperBodySize + 2 ≤ irFuel
+    · exact bridgeSufficient runtime state helperFuel irFuel hsource hir
+        hfuel hexact hscope hbounded hruntime
+    · exact bridgeResidual runtime state helperFuel irFuel (.inr hir)
+        hfuel hexact hscope hbounded hruntime
+  · exact bridgeResidual runtime state helperFuel irFuel (.inl hsource)
+      hfuel hexact hscope hbounded hruntime
 
 /-- Non-vacuous list-level constructor for a direct helper-return-binding head.
 This packages `compiledStmtStepWithHelpersAndHelperIR_internalCallAssign` into

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2628,7 +2628,11 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.compileStmt_internalCallAssign_shape_with_internals
   Compiler.Proofs.IRGeneration.compileStmt_internalCall_shape_with_internals
   Compiler.Proofs.IRGeneration.compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign
+  -- Compiler.Proofs.IRGeneration.compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_delimiter  -- private
+  Compiler.Proofs.IRGeneration.compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_of_fuelSplitBridge
   Compiler.Proofs.IRGeneration.compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall
+  -- Compiler.Proofs.IRGeneration.compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_delimiter  -- private
+  Compiler.Proofs.IRGeneration.compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_fuelSplitBridge
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperAssignStepInterface_cons_internalCallAssign
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperAssignStepInterfaceWithInternals_cons_internalCallAssign
   Compiler.Proofs.IRGeneration.directInternalHelperPerCalleeBridgeCatalog_of_supportedBody_and_assignBridgeCatalog
@@ -6046,4 +6050,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5670 theorems/lemmas (3912 public, 1758 private, 0 sorry'd)
+-- Total: 5674 theorems/lemmas (3914 public, 1760 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

Adds the reviewed direct-helper fuel split at the central singleton constructor layer:

- introduces pointwise bridge abbrevs for direct void and return-binding helper calls
- adds `compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_fuelSplitBridge`
- adds `compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_of_fuelSplitBridge`

These keep the existing all-positive-fuel `CompiledStmtStepWithHelpersAndHelperIRWithInternals` target intact while exposing the two real proof obligations now visible after #2170:

- sufficient region: `1 < helperFuel` and `helperBodySize + 2 <= irFuel`
- residual region: source-low-fuel or IR-insufficient-fuel

This is an explicit proof-interface review slice. It does not close the residual low/insufficient-fuel case and does not weaken the public single-step target.

## Validation

- `lean-slot lake build Compiler.Proofs.IRGeneration.GenericInduction.Calls`
- `python3 scripts/check_proof_length.py`
- `python3 scripts/generate_print_axioms.py`
- `python3 scripts/generate_print_axioms.py --check`
- `git diff --check`
- `rg -n "\\bsorry\\b|\\badmit\\b|axiom |True :=|\\t" Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean PrintAxioms.lean`

The final `rg` output only matches the standard `PrintAxioms.lean` audit comments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-layer API only in IR generation generic induction; no executable compiler or semantics changes, and residual obligations are still assumed, not discharged.
> 
> **Overview**
> Adds **fuel-split proof interfaces** for direct internal helper singleton steps in `GenericInduction/Calls.lean`, for both **void** `internalCall` and **return-binding** `internalCallAssign`.
> 
> For each statement kind, the PR introduces named bridge props (`…BridgeAt`, full bridge, **sufficient** when `1 < helperFuel` and `helperBodySize + 2 ≤ irFuel`, and **residual** otherwise) and new theorems `compiledStmtStepWithHelpersAndHelperIRWithInternals_*_of_fuelSplitBridge` that case-split and delegate to the existing `…_internalCall` / `…_internalCallAssign` constructors. The public `CompiledStmtStepWithHelpersAndHelperIRWithInternals` target is unchanged; callers can prove the two fuel regions separately. Private delimiter lemmas and `PrintAxioms.lean` entries register the new public theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15daa6bdec5347077fb53d500c68b4e66102eefb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->