### PR TITLE
CI maintenance: count-cap + low-water eviction for lake-packages cache

### DIFF
--- a/scripts/ci_host_maintenance.sh
+++ b/scripts/ci_host_maintenance.sh
@@ -7,6 +7,7 @@ LAKE_BUILD_MAX_AGE_DAYS="${LAKE_BUILD_MAX_AGE_DAYS:-21}"
 LAKE_PACKAGES_MAX_AGE_DAYS="${LAKE_PACKAGES_MAX_AGE_DAYS:-14}"
 LAKE_PACKAGES_MAX_ENTRIES="${LAKE_PACKAGES_MAX_ENTRIES:-20}"
 MIN_FREE_GB="${MIN_FREE_GB:-100}"
+MIN_ENTRY_AGE_HOURS="${MIN_ENTRY_AGE_HOURS:-6}"
 COMPILER_CCACHE_MAX_AGE_DAYS="${COMPILER_CCACHE_MAX_AGE_DAYS:-21}"
 ARTIFACT_MAX_AGE_HOURS="${ARTIFACT_MAX_AGE_HOURS:-24}"
 JOURNAL_VACUUM_TIME="${JOURNAL_VACUUM_TIME:-14d}"
@@ -29,6 +30,9 @@ Environment:
   LAKE_PACKAGES_MAX_AGE_DAYS    Default: 14
   LAKE_PACKAGES_MAX_ENTRIES     Default: 20 (newest kept; one entry exists per PR/branch)
   MIN_FREE_GB                   Default: 100 (LRU-evict lake-packages below this)
+  MIN_ENTRY_AGE_HOURS           Default: 6 (never delete entries touched more recently;
+                                ci_local_persistence.sh mount touches an entry on attach,
+                                so caches of running/recent jobs are spared)
   COMPILER_CCACHE_MAX_AGE_DAYS  Default: 21
   ARTIFACT_MAX_AGE_HOURS        Default: 24
   JOURNAL_VACUUM_TIME           Default: 14d
@@ -62,6 +66,27 @@ prune_tree() {
   echo "${label}: removed ${count} entries older than ${max_age_days} days"
 }
 
+# Direct children of $1 as NUL-delimited "epoch-mtime<TAB>path" records —
+# newline-safe, unlike parsing ls output. Order controlled by the caller.
+list_entries_with_mtime() {
+  find "$1" -mindepth 1 -maxdepth 1 -printf '%T@\t%p\0' 2>/dev/null
+}
+
+# Whether an epoch mtime ($1) is younger than MIN_ENTRY_AGE_HOURS.
+# ci_local_persistence.sh touches an entry when a job attaches it, so a
+# young mtime means "a running or recent CI job may be using this" — the
+# maintenance pass must never delete it out from under the job.
+entry_is_recent() {
+  local mtime_epoch="${1%%.*}"
+  local now
+  now="$(date +%s)"
+  [ $((now - mtime_epoch)) -lt $((MIN_ENTRY_AGE_HOURS * 3600)) ]
+}
+
+avail_gb() {
+  df --output=avail -BG "$1" | tail -1 | tr -dc '0-9'
+}
+
 # Keep only the newest $2 entries of $1 (mtime order). Age-based pruning
 # alone cannot bound this cache: one ~6 GB entry exists per PR/branch, so
 # two weeks of PR churn filled 664 GB and took the runner host disk to 100%
@@ -75,16 +100,31 @@ cap_tree_entries() {
     return
   fi
 
-  local removed=0
-  while IFS= read -r entry; do
-    rm -rf "$dir/$entry"
-    removed=$((removed + 1))
-  done < <(ls -t "$dir" | tail -n +"$((max_entries + 1))")
+  local index=0 removed=0 failed=0 mtime entry
+  while IFS=$'\t' read -r -d '' mtime entry; do
+    index=$((index + 1))
+    if [ "$index" -le "$max_entries" ]; then
+      continue
+    fi
+    if entry_is_recent "$mtime"; then
+      continue
+    fi
+    if rm -rf "$entry"; then
+      removed=$((removed + 1))
+    else
+      failed=$((failed + 1))
+      echo "${label}: failed to remove ${entry}" >&2
+    fi
+  done < <(list_entries_with_mtime "$dir" | sort -z -r -n)
 
-  echo "${label}: removed ${removed} entries beyond the newest ${max_entries}"
+  if [ "$removed" -gt 0 ] || [ "$failed" -gt 0 ]; then
+    echo "${label}: removed ${removed} entries beyond the newest ${max_entries} (${failed} failures)"
+  fi
 }
 
 # LRU-evict entries of $1 until the filesystem has at least $2 GiB free.
+# Single pass over an oldest-first snapshot: an entry whose rm fails is
+# skipped, never retried, so a stuck entry cannot spin this loop forever.
 evict_until_free() {
   local dir="$1"
   local min_free_gb="$2"
@@ -93,20 +133,30 @@ evict_until_free() {
   if [ ! -d "$dir" ]; then
     return
   fi
+  if [ "$(avail_gb "$dir")" -ge "$min_free_gb" ]; then
+    return
+  fi
 
-  local removed=0
-  while [ "$(df --output=avail -BG "$dir" | tail -1 | tr -dc '0-9')" -lt "$min_free_gb" ]; do
-    local oldest
-    oldest="$(ls -t "$dir" | tail -1)"
-    if [ -z "$oldest" ]; then
+  local removed=0 mtime entry
+  while IFS=$'\t' read -r -d '' mtime entry; do
+    if [ "$(avail_gb "$dir")" -ge "$min_free_gb" ]; then
       break
     fi
-    rm -rf "$dir/$oldest"
-    removed=$((removed + 1))
-  done
+    if entry_is_recent "$mtime"; then
+      continue
+    fi
+    if rm -rf "$entry"; then
+      removed=$((removed + 1))
+    else
+      echo "${label}: failed to evict ${entry}" >&2
+    fi
+  done < <(list_entries_with_mtime "$dir" | sort -z -n)
 
   if [ "$removed" -gt 0 ]; then
     echo "${label}: evicted ${removed} LRU entries to restore ${min_free_gb} GiB free"
+  fi
+  if [ "$(avail_gb "$dir")" -lt "$min_free_gb" ]; then
+    echo "${label}: still below ${min_free_gb} GiB free after eviction (remaining entries are recent or unremovable)" >&2
   fi
 }
 

--- a/scripts/ci_host_maintenance.sh
+++ b/scripts/ci_host_maintenance.sh
@@ -5,6 +5,8 @@ CACHE_ROOT="${CACHE_ROOT:-/srv/verity-ci-cache}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LAKE_BUILD_MAX_AGE_DAYS="${LAKE_BUILD_MAX_AGE_DAYS:-21}"
 LAKE_PACKAGES_MAX_AGE_DAYS="${LAKE_PACKAGES_MAX_AGE_DAYS:-14}"
+LAKE_PACKAGES_MAX_ENTRIES="${LAKE_PACKAGES_MAX_ENTRIES:-20}"
+MIN_FREE_GB="${MIN_FREE_GB:-100}"
 COMPILER_CCACHE_MAX_AGE_DAYS="${COMPILER_CCACHE_MAX_AGE_DAYS:-21}"
 ARTIFACT_MAX_AGE_HOURS="${ARTIFACT_MAX_AGE_HOURS:-24}"
 JOURNAL_VACUUM_TIME="${JOURNAL_VACUUM_TIME:-14d}"
@@ -25,6 +27,8 @@ Environment:
   CACHE_ROOT                    Default: /srv/verity-ci-cache
   LAKE_BUILD_MAX_AGE_DAYS       Default: 21
   LAKE_PACKAGES_MAX_AGE_DAYS    Default: 14
+  LAKE_PACKAGES_MAX_ENTRIES     Default: 20 (newest kept; one entry exists per PR/branch)
+  MIN_FREE_GB                   Default: 100 (LRU-evict lake-packages below this)
   COMPILER_CCACHE_MAX_AGE_DAYS  Default: 21
   ARTIFACT_MAX_AGE_HOURS        Default: 24
   JOURNAL_VACUUM_TIME           Default: 14d
@@ -58,12 +62,62 @@ prune_tree() {
   echo "${label}: removed ${count} entries older than ${max_age_days} days"
 }
 
+# Keep only the newest $2 entries of $1 (mtime order). Age-based pruning
+# alone cannot bound this cache: one ~6 GB entry exists per PR/branch, so
+# two weeks of PR churn filled 664 GB and took the runner host disk to 100%
+# on 2026-07-12 (runner listener crash-looped, CI jobs sat queued forever).
+cap_tree_entries() {
+  local dir="$1"
+  local max_entries="$2"
+  local label="$3"
+
+  if [ ! -d "$dir" ]; then
+    return
+  fi
+
+  local removed=0
+  while IFS= read -r entry; do
+    rm -rf "$dir/$entry"
+    removed=$((removed + 1))
+  done < <(ls -t "$dir" | tail -n +"$((max_entries + 1))")
+
+  echo "${label}: removed ${removed} entries beyond the newest ${max_entries}"
+}
+
+# LRU-evict entries of $1 until the filesystem has at least $2 GiB free.
+evict_until_free() {
+  local dir="$1"
+  local min_free_gb="$2"
+  local label="$3"
+
+  if [ ! -d "$dir" ]; then
+    return
+  fi
+
+  local removed=0
+  while [ "$(df --output=avail -BG "$dir" | tail -1 | tr -dc '0-9')" -lt "$min_free_gb" ]; do
+    local oldest
+    oldest="$(ls -t "$dir" | tail -1)"
+    if [ -z "$oldest" ]; then
+      break
+    fi
+    rm -rf "$dir/$oldest"
+    removed=$((removed + 1))
+  done
+
+  if [ "$removed" -gt 0 ]; then
+    echo "${label}: evicted ${removed} LRU entries to restore ${min_free_gb} GiB free"
+  fi
+}
+
 run_maintenance() {
   require_root
 
   mkdir -p "$CACHE_ROOT"
   prune_tree "$CACHE_ROOT/lake-build" "$LAKE_BUILD_MAX_AGE_DAYS" "lake-build cache"
   prune_tree "$CACHE_ROOT/lake-packages" "$LAKE_PACKAGES_MAX_AGE_DAYS" "lake-packages cache"
+  cap_tree_entries "$CACHE_ROOT/lake-packages" "$LAKE_PACKAGES_MAX_ENTRIES" "lake-packages cache"
+  evict_until_free "$CACHE_ROOT/lake-packages" "$MIN_FREE_GB" "lake-packages cache"
   prune_tree "$CACHE_ROOT/compiler-ccache" "$COMPILER_CCACHE_MAX_AGE_DAYS" "compiler ccache"
 
   if [ -x "$SCRIPT_DIR/ci_local_persistence.sh" ]; then
@@ -99,10 +153,10 @@ EOF
 
   cat > /etc/systemd/system/verity-ci-host-maintenance.timer <<'EOF'
 [Unit]
-Description=Weekly Verity CI host maintenance
+Description=Daily Verity CI host maintenance
 
 [Timer]
-OnCalendar=Sun *-*-* 04:30:00
+OnCalendar=*-*-* 04:30:00
 Persistent=true
 RandomizedDelaySec=30m
 

--- a/scripts/ci_host_maintenance.sh
+++ b/scripts/ci_host_maintenance.sh
@@ -83,8 +83,22 @@ entry_is_recent() {
   [ $((now - mtime_epoch)) -lt $((MIN_ENTRY_AGE_HOURS * 3600)) ]
 }
 
+# Available GiB on the filesystem backing $1. Fails SAFE: if df errors (path
+# vanished, transient fs issue), report "plenty of space" so eviction stops
+# instead of looping or over-deleting on garbage input.
 avail_gb() {
-  df --output=avail -BG "$1" | tail -1 | tr -dc '0-9'
+  local out
+  out="$(df --output=avail -BG "$1" 2>/dev/null | tail -1 | tr -dc '0-9')"
+  if [ -z "$out" ]; then
+    echo 999999999
+  else
+    echo "$out"
+  fi
+}
+
+# Current epoch mtime of $1, empty if it vanished.
+current_mtime() {
+  stat -c %Y "$1" 2>/dev/null || true
 }
 
 # Keep only the newest $2 entries of $1 (mtime order). Age-based pruning
@@ -104,6 +118,12 @@ cap_tree_entries() {
   while IFS=$'\t' read -r -d '' mtime entry; do
     index=$((index + 1))
     if [ "$index" -le "$max_entries" ]; then
+      continue
+    fi
+    # Re-stat right before deleting: a job may have attached (touched) this
+    # entry after the snapshot above was taken.
+    mtime="$(current_mtime "$entry")"
+    if [ -z "$mtime" ]; then
       continue
     fi
     if entry_is_recent "$mtime"; then
@@ -141,6 +161,11 @@ evict_until_free() {
   while IFS=$'\t' read -r -d '' mtime entry; do
     if [ "$(avail_gb "$dir")" -ge "$min_free_gb" ]; then
       break
+    fi
+    # Re-stat right before deleting (same attach race as cap_tree_entries).
+    mtime="$(current_mtime "$entry")"
+    if [ -z "$mtime" ]; then
+      continue
     fi
     if entry_is_recent "$mtime"; then
       continue

--- a/scripts/ci_local_persistence.sh
+++ b/scripts/ci_local_persistence.sh
@@ -84,6 +84,10 @@ mount_persistent_dir() {
   mkdir -p "$(dirname "$path")"
   rm -rf "$path"
   ln -s "$primary_dir" "$path"
+  # Refresh the entry mtime on attach: host maintenance treats a recently
+  # touched entry as in-use (MIN_ENTRY_AGE_HOURS) and will not delete the
+  # cache out from under a running job.
+  touch "$primary_dir"
 
   if ! is_dir_empty "$primary_dir"; then
     exit 0

--- a/scripts/ci_local_persistence.sh
+++ b/scripts/ci_local_persistence.sh
@@ -98,6 +98,10 @@ mount_persistent_dir() {
   fi
 
   cp -a "$fallback_dir/." "$primary_dir/"
+  # cp -a re-applies the fallback dir's (old) mtime onto the primary,
+  # undoing the attach-time touch above — refresh it again so maintenance
+  # still sees this entry as in-use.
+  touch "$primary_dir"
 }
 
 publish_artifact() {

--- a/scripts/test_ci_infra_maintenance.py
+++ b/scripts/test_ci_infra_maintenance.py
@@ -56,7 +56,7 @@ class CiInfraMaintenanceTests(unittest.TestCase):
         self.assertIn("runs-on: [self-hosted, linux, ARM64, dgx-spark, gpu]", text)
         self.assertIn("nvidia-smi", text)
 
-    def test_weekly_host_maintenance_prunes_ci_disk_journald_and_docker(self) -> None:
+    def test_daily_host_maintenance_prunes_ci_disk_journald_and_docker(self) -> None:
         text = MAINTENANCE_SCRIPT.read_text(encoding="utf-8")
         self.assertIn('CACHE_ROOT="${CACHE_ROOT:-/srv/verity-ci-cache}"', text)
         self.assertIn('prune_tree "$CACHE_ROOT/lake-build"', text)
@@ -64,8 +64,26 @@ class CiInfraMaintenanceTests(unittest.TestCase):
         self.assertIn('journalctl --vacuum-time="$JOURNAL_VACUUM_TIME"', text)
         self.assertIn('journalctl --vacuum-size="$JOURNAL_VACUUM_SIZE"', text)
         self.assertIn('docker image prune -af --filter "$DOCKER_PRUNE_FILTER"', text)
-        self.assertIn("OnCalendar=Sun *-*-* 04:30:00", text)
+        # Daily, not weekly: the weekly run executed hours before the
+        # 2026-07-12 disk-full incident and pruned nothing.
+        self.assertIn("OnCalendar=*-*-* 04:30:00", text)
+        self.assertNotIn("OnCalendar=Sun *-*-* 04:30:00", text)
         self.assertIn("verity-ci-host-maintenance.timer", text)
+
+    def test_host_maintenance_bounds_lake_packages_cache(self) -> None:
+        text = MAINTENANCE_SCRIPT.read_text(encoding="utf-8")
+        self.assertIn('cap_tree_entries "$CACHE_ROOT/lake-packages"', text)
+        self.assertIn('evict_until_free "$CACHE_ROOT/lake-packages"', text)
+        self.assertIn('LAKE_PACKAGES_MAX_ENTRIES="${LAKE_PACKAGES_MAX_ENTRIES:-20}"', text)
+        self.assertIn('MIN_FREE_GB="${MIN_FREE_GB:-100}"', text)
+        # In-use protection: recently attached entries are never deleted,
+        # and the mount path refreshes the entry mtime on attach.
+        self.assertIn('MIN_ENTRY_AGE_HOURS="${MIN_ENTRY_AGE_HOURS:-6}"', text)
+        self.assertIn("entry_is_recent", text)
+        persistence = (MAINTENANCE_SCRIPT.parent / "ci_local_persistence.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('touch "$primary_dir"', persistence)
 
     def test_parallel_build_jobs_use_four_lean_threads(self) -> None:
         text = VERIFY_WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Incident (2026-07-12)

The runner host (`build-88-99-4-254-1`) filled its disk to 100%: `/srv/verity-ci-cache/lake-packages` had grown to **664 GB** (117 entries, one ~6 GB per PR/branch). The runner listener crash-looped on trace-log writes, GitHub showed the runner offline, and `build-compiler-binaries` jobs (e.g. PR #2153's) sat queued forever — surfacing as 'CI failure with no logs'.

The existing weekly age-based maintenance had run the same morning and pruned nothing: every entry was younger than 14 days. Age alone cannot bound a per-PR cache under churn.

## Fix

- `cap_tree_entries`: keep only the newest `LAKE_PACKAGES_MAX_ENTRIES` (default 20)
- `evict_until_free`: LRU-evict until `MIN_FREE_GB` (default 100) free, so churn spikes between runs can't reach zero
- timer: weekly → daily

Host state today: I purged to the 15 newest entries (100% → 26% used), restarted the runner (back online), and installed an interim daily cap timer (`verity-ci-cache-cap.timer`) which this PR supersedes — remove it after merge + `install-systemd`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes large cache directories on the self-hosted runner; wrong thresholds or mtime logic could evict caches mid-job, though recent-entry guards and re-stat before delete mitigate that.
> 
> **Overview**
> **Prevents runner disk exhaustion** from unbounded per-PR `lake-packages` caches (age-only pruning left 117 young entries and filled the host in the 2026-07-12 incident).
> 
> `ci_host_maintenance.sh` now caps `lake-packages` to the newest **20** entries (`cap_tree_entries`) and **LRU-evicts** until at least **100 GiB** free (`evict_until_free`), skipping entries younger than **6 hours** (`MIN_ENTRY_AGE_HOURS`). Eviction re-checks mtime before delete to avoid races with active jobs. The systemd timer moves from **weekly Sunday** to **daily** at 04:30.
> 
> `ci_local_persistence.sh` **touches** the cache directory on mount (and again after `cp -a` from a fallback) so maintenance treats attached caches as in-use.
> 
> Tests in `test_ci_infra_maintenance.py` assert the daily schedule and the new lake-packages limits plus mount `touch` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ac2667ff8ba3898ef767bd4eb983df8c03b3063. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->