### PR TITLE
ci: add repository-pinned Lean LSP evidence to OCR

### DIFF
--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -6,7 +6,7 @@ const { execFileSync } = require('child_process');
 
 const ROUTER_VERSION = 'router-v8';
 const DEFAULT_SCOUT_MODEL = 'MiniMax-M3';
-const STRONG_REVIEW_BLOCKER_MESSAGE = 'OpenCodeReview 1.7.5 supports --from/--to full diff ranges, but this workflow does not have a safe packet/window input bridge for Lean hunks yet.';
+const STRONG_REVIEW_BLOCKER_MESSAGE = 'OpenCodeReview 1.7.9 supports --from/--to full diff ranges, but this workflow does not have a safe packet/window input bridge for Lean hunks yet.';
 const THRESHOLDS = Object.freeze({
   smallLeanFiles: 1,
   smallChangedLines: 300,

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
-const ROUTER_VERSION = 'router-v8';
+const ROUTER_VERSION = 'router-v9';
 const DEFAULT_SCOUT_MODEL = 'MiniMax-M3';
 const STRONG_REVIEW_BLOCKER_MESSAGE = 'OpenCodeReview 1.7.9 supports --from/--to full diff ranges, but this workflow does not have a safe packet/window input bridge for Lean hunks yet.';
 const THRESHOLDS = Object.freeze({
@@ -61,6 +61,7 @@ async function main() {
     background_chars: String(decision.ocr.backgroundChars),
     metrics_path: metricsPath,
     result_path: resultPath,
+    diff_base: diff.base,
     router_version: ROUTER_VERSION,
   });
 
@@ -72,14 +73,15 @@ async function main() {
 }
 
 function loadDiff(base, head) {
-  const output = git(['diff', '--numstat', '--find-renames', base, head, '--']);
+  const mergeBase = git(['merge-base', base, head]).trim();
+  const output = git(['diff', '--numstat', '--find-renames', mergeBase, head, '--']);
   const files = output.split(/\r?\n/).filter(Boolean).map(parseNumstatLine).filter(Boolean);
-  const hunksByPath = loadDiffHunks(base, head);
+  const hunksByPath = loadDiffHunks(mergeBase, head);
   for (const file of files) {
     file.hunks = hunksByPath.get(file.path) || [];
     file.risk = scoreFileRisk(file);
   }
-  return { base, head, files };
+  return { base: mergeBase, head, files };
 }
 
 function loadDiffHunks(base, head) {
@@ -1305,4 +1307,5 @@ module.exports = {
   buildRiskDossier,
   parseUnifiedDiff,
   scorePathRisk,
+  loadDiff,
 };

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -54,6 +54,7 @@ async function main() {
   writeOutputs(outputPath, {
     mode: decision.mode,
     should_run_ocr: String(decision.shouldRunOcr),
+    has_lean: String(decision.counts.lean > 0),
     reason: decision.reason,
     concurrency: String(decision.ocr.concurrency),
     timeout: String(decision.ocr.timeout),

--- a/.github/scripts/prepare-lean-lsp.sh
+++ b/.github/scripts/prepare-lean-lsp.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Prepare only the Lean toolchain named by the checked-out repository.  This is
+# intentionally a trusted workflow helper: it validates untrusted PR metadata
+# before it reaches elan and keeps the installed toolchain in the run temp dir.
+set -euo pipefail
+
+repo=${1:?usage: prepare-lean-lsp.sh REPOSITORY_ROOT}
+toolchain_file="$repo/lean-toolchain"
+
+if [ ! -f "$toolchain_file" ]; then
+  echo "::error::Lean LSP evidence requires a repository-root lean-toolchain file"
+  exit 1
+fi
+
+toolchain="$(tr -d '\r\n' < "$toolchain_file")"
+if ! [[ "$toolchain" =~ ^leanprover/lean4:v4\.[0-9]+\.[0-9]+$ ]]; then
+  echo "::error::Refusing non-pinned or unsupported Lean toolchain value"
+  exit 1
+fi
+
+if ! command -v elan >/dev/null 2>&1; then
+  echo "::error::elan is required on the OCR runner to collect Lean LSP evidence"
+  exit 1
+fi
+
+# ELAN_HOME is supplied by the workflow and must be per-run, never a shared
+# runner installation.  This prevents a PR-selected toolchain from persisting
+# on the self-hosted host.
+: "${ELAN_HOME:?ELAN_HOME must point to a per-run directory}"
+mkdir -p "$ELAN_HOME"
+elan toolchain install "$toolchain"
+elan run "$toolchain" lean --version
+
+printf 'LEAN_TOOLCHAIN=%s\n' "$toolchain" >> "$GITHUB_ENV"

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -1306,6 +1306,7 @@ function testWorkflowDocsEnabled() {
   assert.ok(workflow.includes('lean-lsp-mcp==${LEAN_LSP_MCP_VERSION}'));
   assert.ok(workflow.includes('"lean_diagnostic_messages","lean_file_outline","lean_hover_info"'));
   assert.ok(workflow.includes('LEAN_MCP_DISABLED_TOOLS=lean_run_code,lean_build'));
+  assert.ok(workflow.includes('OCR_LLM_TOKEN='));
 }
 
 function testGenericScriptConfigEnabled() {

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -1300,6 +1300,7 @@ function testWorkflowDocsEnabled() {
   assert.ok(workflow.includes('npm install --prefix "$RUNNER_TEMP/ocr-cli"'));
   assert.ok(!workflow.includes('npm install -g @alibaba-group/open-code-review'));
   assert.ok(workflow.includes('prepare-lean-lsp.sh'));
+  assert.ok(workflow.includes("steps.route.outputs.has_lean == 'true'"));
   assert.ok(workflow.includes('Number(context.payload.inputs.pr_number)'));
   assert.ok(workflow.includes('ELAN_HOME: ${{ runner.temp }}/ocr-elan'));
   assert.ok(workflow.includes('lean-lsp-mcp==${LEAN_LSP_MCP_VERSION}'));

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -1300,6 +1300,7 @@ function testWorkflowDocsEnabled() {
   assert.ok(workflow.includes('npm install --prefix "$RUNNER_TEMP/ocr-cli"'));
   assert.ok(!workflow.includes('npm install -g @alibaba-group/open-code-review'));
   assert.ok(workflow.includes('prepare-lean-lsp.sh'));
+  assert.ok(workflow.includes('Number(context.payload.inputs.pr_number)'));
   assert.ok(workflow.includes('ELAN_HOME: ${{ runner.temp }}/ocr-elan'));
   assert.ok(workflow.includes('lean-lsp-mcp==${LEAN_LSP_MCP_VERSION}'));
   assert.ok(workflow.includes('"lean_diagnostic_messages","lean_file_outline","lean_hover_info"'));

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -1294,6 +1294,16 @@ function testWorkflowDocsEnabled() {
   ]);
   assert.strictEqual(decision.mode, 'config-docs');
   assert.strictEqual(decision.shouldRunOcr, true);
+
+  const workflow = fs.readFileSync(path.join(__dirname, '..', 'workflows', 'ocr-review.yml'), 'utf8');
+  assert.ok(workflow.includes('@alibaba-group/open-code-review@1.7.9'));
+  assert.ok(workflow.includes('npm install --prefix "$RUNNER_TEMP/ocr-cli"'));
+  assert.ok(!workflow.includes('npm install -g @alibaba-group/open-code-review'));
+  assert.ok(workflow.includes('prepare-lean-lsp.sh'));
+  assert.ok(workflow.includes('ELAN_HOME: ${{ runner.temp }}/ocr-elan'));
+  assert.ok(workflow.includes('lean-lsp-mcp==${LEAN_LSP_MCP_VERSION}'));
+  assert.ok(workflow.includes('"lean_diagnostic_messages","lean_file_outline","lean_hover_info"'));
+  assert.ok(workflow.includes('LEAN_MCP_DISABLED_TOOLS=lean_run_code,lean_build'));
 }
 
 function testGenericScriptConfigEnabled() {

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
 const router = require('./ocr-router');
 const postOcrReview = require('./post-ocr-review');
@@ -62,6 +63,45 @@ function testOneLeanFileNormal() {
   assert.strictEqual(decision.mode, 'small-lean');
   assert.strictEqual(decision.shouldRunOcr, true);
   assert.strictEqual(decision.ocr.concurrency, 3);
+}
+
+function testBaseOnlyLeanChangesDoNotRouteThroughLeanPath() {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-merge-base-routing-'));
+  const runGit = args => execFileSync('git', args, { cwd: repo, encoding: 'utf8' });
+  const write = (filePath, content) => {
+    const fullPath = path.join(repo, filePath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content);
+  };
+  const commit = message => {
+    runGit(['add', '.']);
+    runGit(['-c', 'user.name=OCR test', '-c', 'user.email=ocr-test@example.invalid', 'commit', '-m', message]);
+  };
+
+  runGit(['init', '--initial-branch=main']);
+  write('README.md', 'ancestor\n');
+  commit('ancestor');
+  runGit(['checkout', '-b', 'pr']);
+  write('.github/workflows/ocr-review.yml', 'name: OCR config only\n');
+  commit('PR workflow change');
+  const prHead = runGit(['rev-parse', 'HEAD']).trim();
+  runGit(['checkout', 'main']);
+  write('Compiler/BaseOnly.lean', 'theorem baseOnly : True := by trivial\n');
+  commit('base-only Lean change');
+  runGit(['update-ref', 'refs/remotes/origin/main', runGit(['rev-parse', 'HEAD']).trim()]);
+  runGit(['checkout', 'pr']);
+
+  const previousCwd = process.cwd();
+  try {
+    process.chdir(repo);
+    const diff = router.loadDiff('origin/main', prHead);
+    const decision = router.decideRoute(diff.files);
+    assert.strictEqual(diff.files.some(entry => entry.path.endsWith('.lean')), false);
+    assert.strictEqual(decision.counts.lean, 0);
+    assert.strictEqual(decision.mode, 'config-docs');
+  } finally {
+    process.chdir(previousCwd);
+  }
 }
 
 function testLargeLeanPacketized() {
@@ -1301,6 +1341,8 @@ function testWorkflowDocsEnabled() {
   assert.ok(!workflow.includes('npm install -g @alibaba-group/open-code-review'));
   assert.ok(workflow.includes('prepare-lean-lsp.sh'));
   assert.ok(workflow.includes("steps.route.outputs.has_lean == 'true'"));
+  assert.ok(workflow.includes('DIFF_BASE: ${{ steps.route.outputs.diff_base }}'));
+  assert.ok(workflow.includes('--from "${DIFF_BASE}"'));
   assert.ok(workflow.includes('Number(context.payload.inputs.pr_number)'));
   assert.ok(workflow.includes('ELAN_HOME: ${{ runner.temp }}/ocr-elan'));
   assert.ok(workflow.includes('lean-lsp-mcp==${LEAN_LSP_MCP_VERSION}'));
@@ -1726,6 +1768,7 @@ function testLargeLeanScoutDedupVariesBySanitizedScoutConfig() {
 async function run() {
   testNoSupportedFilesSkipped();
   testOneLeanFileNormal();
+  testBaseOnlyLeanChangesDoNotRouteThroughLeanPath();
   testLargeLeanPacketized();
   testLeanCommentDoesNotTriggerSorrySignal();
   testLeanBlockCommentDoesNotTriggerSorrySignal();

--- a/.github/scripts/test-prepare-lean-lsp.js
+++ b/.github/scripts/test-prepare-lean-lsp.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const script = path.join(__dirname, 'prepare-lean-lsp.sh');
+
+function run(toolchain) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-lean-lsp-'));
+  const repo = path.join(root, 'repo');
+  const bin = path.join(root, 'bin');
+  const elanLog = path.join(root, 'elan.log');
+  const envFile = path.join(root, 'github-env');
+  fs.mkdirSync(repo);
+  fs.mkdirSync(bin);
+  fs.writeFileSync(path.join(repo, 'lean-toolchain'), toolchain);
+  fs.writeFileSync(path.join(bin, 'elan'), `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> '${elanLog}'\n`);
+  fs.chmodSync(path.join(bin, 'elan'), 0o755);
+  const result = spawnSync('bash', [script, repo], {
+    encoding: 'utf8',
+    env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, ELAN_HOME: path.join(root, 'elan'), GITHUB_ENV: envFile },
+  });
+  return { root, envFile, elanLog, result };
+}
+
+{
+  const { envFile, elanLog, result } = run('leanprover/lean4:v4.24.0\n');
+  assert.strictEqual(result.status, 0, result.stderr);
+  assert.strictEqual(fs.readFileSync(envFile, 'utf8'), 'LEAN_TOOLCHAIN=leanprover/lean4:v4.24.0\n');
+  assert.strictEqual(fs.readFileSync(elanLog, 'utf8'), 'toolchain install leanprover/lean4:v4.24.0\nrun leanprover/lean4:v4.24.0 lean --version\n');
+}
+
+{
+  const { result } = run('leanprover/lean4:nightly\n');
+  assert.notStrictEqual(result.status, 0);
+  assert.match(result.stdout, /Refusing non-pinned/);
+}
+
+console.log('Lean LSP setup tests passed');

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -112,15 +112,6 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Prepare repository-pinned Lean toolchain for LSP evidence
-        if: steps.pr.outputs.skip != 'true'
-        env:
-          # Never reuse the runner's elan store for a PR-selected toolchain.
-          ELAN_HOME: ${{ runner.temp }}/ocr-elan
-        run: |
-          set -euo pipefail
-          "$GITHUB_WORKSPACE/ocr-trusted/.github/scripts/prepare-lean-lsp.sh" "$GITHUB_WORKSPACE/repo"
-
       - name: Route OCR review
         if: steps.pr.outputs.skip != 'true'
         id: route
@@ -148,6 +139,15 @@ jobs:
           trap - EXIT
           node "$GITHUB_WORKSPACE/ocr-trusted/.github/scripts/ocr-router.js"
 
+      - name: Prepare repository-pinned Lean toolchain for LSP evidence
+        if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true' && steps.route.outputs.has_lean == 'true'
+        env:
+          # Never reuse the runner's elan store for a PR-selected toolchain.
+          ELAN_HOME: ${{ runner.temp }}/ocr-elan
+        run: |
+          set -euo pipefail
+          "$GITHUB_WORKSPACE/ocr-trusted/.github/scripts/prepare-lean-lsp.sh" "$GITHUB_WORKSPACE/repo"
+
       - name: Install OpenCodeReview
         if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true'
         run: |
@@ -160,7 +160,7 @@ jobs:
           ocr version
 
       - name: Configure bounded Lean LSP evidence
-        if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true'
+        if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true' && steps.route.outputs.has_lean == 'true'
         env:
           HOME: ${{ runner.temp }}/ocr-home
           ELAN_HOME: ${{ runner.temp }}/ocr-elan

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -112,6 +112,15 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Prepare repository-pinned Lean toolchain for LSP evidence
+        if: steps.pr.outputs.skip != 'true'
+        env:
+          # Never reuse the runner's elan store for a PR-selected toolchain.
+          ELAN_HOME: ${{ runner.temp }}/ocr-elan
+        run: |
+          set -euo pipefail
+          "$GITHUB_WORKSPACE/ocr-trusted/.github/scripts/prepare-lean-lsp.sh" "$GITHUB_WORKSPACE/repo"
+
       - name: Route OCR review
         if: steps.pr.outputs.skip != 'true'
         id: route
@@ -143,8 +152,31 @@ jobs:
         if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true'
         run: |
           set -euo pipefail
-          npm install -g @alibaba-group/open-code-review@1.7.5
+          # Keep the OCR client out of the self-hosted runner's global npm
+          # prefix.  It is run-scoped just like the elan toolchain above.
+          npm install --prefix "$RUNNER_TEMP/ocr-cli" @alibaba-group/open-code-review@1.7.9
+          echo "$RUNNER_TEMP/ocr-cli/node_modules/.bin" >> "$GITHUB_PATH"
+          export PATH="$RUNNER_TEMP/ocr-cli/node_modules/.bin:$PATH"
           ocr version
+
+      - name: Configure bounded Lean LSP evidence
+        if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true'
+        env:
+          HOME: ${{ runner.temp }}/ocr-home
+          ELAN_HOME: ${{ runner.temp }}/ocr-elan
+          LEAN_LSP_MCP_VERSION: "0.28.0"
+        run: |
+          set -euo pipefail
+          command -v uvx >/dev/null
+          mkdir -p "$HOME"
+          # OCR 1.7.9 is the MCP client.  Expose only read-only local evidence
+          # tools: diagnostics, declaration outlines, and hover information.
+          # In particular, no build, code-execution, proof-attempt, or remote
+          # search tool is available to the model.
+          ocr config set mcp_servers.lean_lsp.command uvx
+          ocr config set mcp_servers.lean_lsp.args "[\"--from\",\"lean-lsp-mcp==${LEAN_LSP_MCP_VERSION}\",\"lean-lsp-mcp\",\"--transport\",\"stdio\"]"
+          ocr config set mcp_servers.lean_lsp.tools '["lean_diagnostic_messages","lean_file_outline","lean_hover_info"]'
+          ocr config set mcp_servers.lean_lsp.env "[\"LEAN_PROJECT_PATH=${GITHUB_WORKSPACE}/repo\",\"ELAN_HOME=${ELAN_HOME}\",\"ELAN_TOOLCHAIN=${LEAN_TOOLCHAIN}\",\"LEAN_MCP_DISABLED_TOOLS=lean_run_code,lean_build,lean_multi_attempt,lean_code_actions,lean_verify,lean_minimal_hypotheses,lean_local_search\",\"LEAN_LOG_LEVEL=WARNING\"]"
 
       - name: Run OpenCodeReview
         if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true'

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -47,7 +47,7 @@ jobs:
               pr = context.payload.pull_request;
             } else {
               const prNumber = context.eventName === 'workflow_dispatch'
-                ? Number(core.getInput('pr_number'))
+                ? Number(context.payload.inputs.pr_number)
                 : context.issue.number;
               const res = await github.rest.pulls.get({
                 owner: context.repo.owner,

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -194,14 +194,15 @@ jobs:
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           OCR_MODE: ${{ steps.route.outputs.mode }}
+          DIFF_BASE: ${{ steps.route.outputs.diff_base }}
           OCR_CONCURRENCY: ${{ steps.route.outputs.concurrency }}
           OCR_TIMEOUT: ${{ steps.route.outputs.timeout }}
           OCR_BACKGROUND_CHARS: ${{ steps.route.outputs.background_chars }}
         run: |
           set -euo pipefail
           mkdir -p "$HOME"
-          printf 'Reviewing %s against origin/%s in %s mode\n' "$HEAD_SHA" "$BASE_REF" "$OCR_MODE"
-          git rev-parse --verify "origin/${BASE_REF}^{commit}" >/dev/null
+          printf 'Reviewing %s from merge-base %s in %s mode\n' "$HEAD_SHA" "$DIFF_BASE" "$OCR_MODE"
+          git rev-parse --verify "${DIFF_BASE}^{commit}" >/dev/null
           # Keep the model focused: PR bodies can include long generated summaries (Bugbot/Cursor),
           # which inflated token use and caused Lean proof reviews to hit OCR subtask deadlines.
           CLEAN_BODY="${PR_BODY%%<!-- CURSOR_SUMMARY -->*}"
@@ -210,7 +211,7 @@ jobs:
           BACKGROUND="[OCR mode: ${OCR_MODE}]"$'\n\n'"${PR_TITLE}"$'\n\n'"${CLEAN_BODY}"
           BACKGROUND="${BACKGROUND:0:${OCR_BACKGROUND_CHARS}}"
           ocr review \
-            --from "origin/${BASE_REF}" \
+            --from "${DIFF_BASE}" \
             --to "${HEAD_SHA}" \
             --format json \
             --audience agent \

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -176,7 +176,7 @@ jobs:
           ocr config set mcp_servers.lean_lsp.command uvx
           ocr config set mcp_servers.lean_lsp.args "[\"--from\",\"lean-lsp-mcp==${LEAN_LSP_MCP_VERSION}\",\"lean-lsp-mcp\",\"--transport\",\"stdio\"]"
           ocr config set mcp_servers.lean_lsp.tools '["lean_diagnostic_messages","lean_file_outline","lean_hover_info"]'
-          ocr config set mcp_servers.lean_lsp.env "[\"LEAN_PROJECT_PATH=${GITHUB_WORKSPACE}/repo\",\"ELAN_HOME=${ELAN_HOME}\",\"ELAN_TOOLCHAIN=${LEAN_TOOLCHAIN}\",\"LEAN_MCP_DISABLED_TOOLS=lean_run_code,lean_build,lean_multi_attempt,lean_code_actions,lean_verify,lean_minimal_hypotheses,lean_local_search\",\"LEAN_LOG_LEVEL=WARNING\"]"
+          ocr config set mcp_servers.lean_lsp.env "[\"LEAN_PROJECT_PATH=${GITHUB_WORKSPACE}/repo\",\"ELAN_HOME=${ELAN_HOME}\",\"ELAN_TOOLCHAIN=${LEAN_TOOLCHAIN}\",\"LEAN_MCP_DISABLED_TOOLS=lean_run_code,lean_build,lean_multi_attempt,lean_code_actions,lean_verify,lean_minimal_hypotheses,lean_local_search\",\"LEAN_LOG_LEVEL=WARNING\",\"OCR_LLM_URL=\",\"OCR_LLM_TOKEN=\"]"
 
       - name: Run OpenCodeReview
         if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true'


### PR DESCRIPTION
## Summary
- update the self-hosted OpenCodeReview client from 1.7.5 to 1.7.9, which provides the MCP client support needed here
- validate and install only the checked-out repository's pinned stable Lean toolchain into a per-run `ELAN_HOME` (including Lean 4.24)
- configure `lean-lsp-mcp` as a bounded, read-only evidence source: diagnostics, outline, and hover only
- scope OCR's npm installation and its config to the workflow run, leaving no new global runner state

## Boundaries
- the trusted default-branch checkout supplies the helper and OCR rules; PR metadata is only parsed as a strict official stable Lean version
- fork PRs remain skipped; normal OCR diff review, CI, and existing thread de-duplication/posting are unchanged
- no deployment, credential, or secret changes

## Verification
- `node .github/scripts/test-ocr-routing.js`
- `node .github/scripts/test-prepare-lean-lsp.js`
- local OCR 1.7.9 MCP config smoke
- `uvx --from lean-lsp-mcp==0.28.0 lean-lsp-mcp --help`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes self-hosted CI routing, diff scope, and Lean toolchain/MCP setup on PR metadata; mitigations include pinned-toolchain validation and per-run elan/npm isolation, but workflow behavior shifts could affect review coverage or runner state if misconfigured.
> 
> **Overview**
> Upgrades the self-hosted **OpenCodeReview** workflow to **1.7.9** and scopes the CLI install to **`$RUNNER_TEMP/ocr-cli`** instead of a global npm prefix.
> 
> **OCR routing** now diffs from the **merge base** to the PR head (not `origin/base..head`), exposes **`diff_base`** and **`has_lean`** to the workflow, and bumps the router to **v9**. Lean-only changes on the base branch no longer count as PR Lean churn when routing.
> 
> For PRs with Lean changes, the workflow runs **`prepare-lean-lsp.sh`** to install only a **pinned `leanprover/lean4:v4.x.y`** toolchain into a per-run **`ELAN_HOME`**, then configures **`lean-lsp-mcp`** with **read-only** tools (diagnostics, outline, hover) and disabled build/run/search tools. **`ocr review --from`** uses the routed merge-base SHA.
> 
> Also fixes **`workflow_dispatch`** PR resolution to use **`context.payload.inputs.pr_number`**, and adds tests for merge-base routing and Lean toolchain validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6f087598e1405649da6ba1f324654f0adf3de35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->