### PR TITLE
ci: bootstrap OCR Lean toolchain client per run

### DIFF
--- a/.github/scripts/prepare-lean-lsp.sh
+++ b/.github/scripts/prepare-lean-lsp.sh
@@ -31,9 +31,14 @@ if [ ! -x "$elan_bin" ]; then
   elan_archive='elan-x86_64-unknown-linux-gnu.tar.gz'
   elan_sha256='f81c2e48c1588d4612cd2c8851947898a45ac8d72748a07dff3a5694f1cf589b'
   elan_url="https://github.com/leanprover/elan/releases/download/${elan_version}/${elan_archive}"
+  if [ "${PREPARE_LEAN_LSP_TESTING:-}" = "1" ]; then
+    elan_archive="${PREPARE_LEAN_LSP_TEST_ELAN_ARCHIVE:-$elan_archive}"
+    elan_sha256="${PREPARE_LEAN_LSP_TEST_ELAN_SHA256:-$elan_sha256}"
+    elan_url="${PREPARE_LEAN_LSP_TEST_ELAN_URL:-$elan_url}"
+  fi
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' EXIT
-  curl -fsSL --retry 3 --retry-delay 5 "$elan_url" -o "$tmpdir/$elan_archive"
+  curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 20 --max-time 120 "$elan_url" -o "$tmpdir/$elan_archive"
   printf '%s  %s\n' "$elan_sha256" "$tmpdir/$elan_archive" | sha256sum -c -
   tar -xzf "$tmpdir/$elan_archive" -C "$tmpdir"
   ELAN_HOME="$ELAN_HOME" "$tmpdir/elan-init" -y --no-modify-path --default-toolchain none

--- a/.github/scripts/prepare-lean-lsp.sh
+++ b/.github/scripts/prepare-lean-lsp.sh
@@ -18,17 +18,34 @@ if ! [[ "$toolchain" =~ ^leanprover/lean4:v4\.[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 
-if ! command -v elan >/dev/null 2>&1; then
-  echo "::error::elan is required on the OCR runner to collect Lean LSP evidence"
-  exit 1
-fi
-
 # ELAN_HOME is supplied by the workflow and must be per-run, never a shared
 # runner installation.  This prevents a PR-selected toolchain from persisting
-# on the self-hosted host.
+# on the self-hosted host.  Bootstrap the pinned elan client there as well: the
+# OCR runner pool need not expose a host-installed elan on PATH.
 : "${ELAN_HOME:?ELAN_HOME must point to a per-run directory}"
 mkdir -p "$ELAN_HOME"
-elan toolchain install "$toolchain"
-elan run "$toolchain" lean --version
+
+elan_bin="$ELAN_HOME/bin/elan"
+if [ ! -x "$elan_bin" ]; then
+  elan_version='v4.1.2'
+  elan_archive='elan-x86_64-unknown-linux-gnu.tar.gz'
+  elan_sha256='f81c2e48c1588d4612cd2c8851947898a45ac8d72748a07dff3a5694f1cf589b'
+  elan_url="https://github.com/leanprover/elan/releases/download/${elan_version}/${elan_archive}"
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' EXIT
+  curl -fsSL --retry 3 --retry-delay 5 "$elan_url" -o "$tmpdir/$elan_archive"
+  printf '%s  %s\n' "$elan_sha256" "$tmpdir/$elan_archive" | sha256sum -c -
+  tar -xzf "$tmpdir/$elan_archive" -C "$tmpdir"
+  ELAN_HOME="$ELAN_HOME" "$tmpdir/elan-init" -y --no-modify-path --default-toolchain none
+  trap - EXIT
+  rm -rf "$tmpdir"
+fi
+
+export PATH="$ELAN_HOME/bin:$PATH"
+if [ -n "${GITHUB_PATH:-}" ]; then
+  printf '%s\n' "$ELAN_HOME/bin" >> "$GITHUB_PATH"
+fi
+"$elan_bin" toolchain install "$toolchain"
+"$elan_bin" run "$toolchain" lean --version
 
 printf 'LEAN_TOOLCHAIN=%s\n' "$toolchain" >> "$GITHUB_ENV"

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -1349,6 +1349,7 @@ function testWorkflowDocsEnabled() {
   assert.ok(workflow.includes('"lean_diagnostic_messages","lean_file_outline","lean_hover_info"'));
   assert.ok(workflow.includes('LEAN_MCP_DISABLED_TOOLS=lean_run_code,lean_build'));
   assert.ok(workflow.includes('OCR_LLM_TOKEN='));
+  assert.ok(workflow.includes("steps.ocr.outcome == 'success'"));
 }
 
 function testGenericScriptConfigEnabled() {

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -1344,7 +1344,7 @@ function testWorkflowDocsEnabled() {
   assert.ok(workflow.includes('DIFF_BASE: ${{ steps.route.outputs.diff_base }}'));
   assert.ok(workflow.includes('--from "${DIFF_BASE}"'));
   assert.ok(workflow.includes('Number(context.payload.inputs.pr_number)'));
-  assert.ok(workflow.includes('ELAN_HOME: ${{ runner.temp }}/ocr-elan'));
+  assert.ok(workflow.includes('ELAN_HOME: ${{ runner.temp }}/ocr-elan-${{ github.run_id }}-${{ github.run_attempt }}'));
   assert.ok(workflow.includes('lean-lsp-mcp==${LEAN_LSP_MCP_VERSION}'));
   assert.ok(workflow.includes('"lean_diagnostic_messages","lean_file_outline","lean_hover_info"'));
   assert.ok(workflow.includes('LEAN_MCP_DISABLED_TOOLS=lean_run_code,lean_build'));

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -1349,7 +1349,7 @@ function testWorkflowDocsEnabled() {
   assert.ok(workflow.includes('"lean_diagnostic_messages","lean_file_outline","lean_hover_info"'));
   assert.ok(workflow.includes('LEAN_MCP_DISABLED_TOOLS=lean_run_code,lean_build'));
   assert.ok(workflow.includes('OCR_LLM_TOKEN='));
-  assert.ok(workflow.includes("steps.ocr.outcome == 'success'"));
+  assert.ok(workflow.includes("steps.route.outputs.should_run_ocr != 'true' || steps.ocr.outcome == 'success'"));
 }
 
 function testGenericScriptConfigEnabled() {

--- a/.github/scripts/test-prepare-lean-lsp.js
+++ b/.github/scripts/test-prepare-lean-lsp.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -8,17 +9,43 @@ const { spawnSync } = require('child_process');
 
 const script = path.join(__dirname, 'prepare-lean-lsp.sh');
 
+function writeRepo(root, toolchain) {
+  const repo = path.join(root, 'repo');
+  fs.mkdirSync(repo);
+  fs.writeFileSync(path.join(repo, 'lean-toolchain'), toolchain);
+  return repo;
+}
+
+function createFakeElanArchive(root) {
+  const stage = path.join(root, 'archive-stage');
+  const archive = path.join(root, 'elan-test.tar.gz');
+  fs.mkdirSync(stage);
+  fs.writeFileSync(path.join(stage, 'elan-init'), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$ELAN_INIT_LOG"
+mkdir -p "$ELAN_HOME/bin"
+cat > "$ELAN_HOME/bin/elan" <<'EOS'
+#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$ELAN_FAKE_LOG"
+EOS
+chmod +x "$ELAN_HOME/bin/elan"
+`);
+  fs.chmodSync(path.join(stage, 'elan-init'), 0o755);
+  const tar = spawnSync('tar', ['-czf', archive, '-C', stage, 'elan-init'], { encoding: 'utf8' });
+  assert.strictEqual(tar.status, 0, tar.stderr);
+  const sha256 = crypto.createHash('sha256').update(fs.readFileSync(archive)).digest('hex');
+  return { archive, sha256 };
+}
+
 function run(toolchain) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-lean-lsp-'));
-  const repo = path.join(root, 'repo');
+  const repo = writeRepo(root, toolchain);
   const bin = path.join(root, 'bin');
   const elanLog = path.join(root, 'elan.log');
   const elanHome = path.join(root, 'elan');
   const envFile = path.join(root, 'github-env');
   const pathFile = path.join(root, 'github-path');
-  fs.mkdirSync(repo);
   fs.mkdirSync(bin);
-  fs.writeFileSync(path.join(repo, 'lean-toolchain'), toolchain);
   fs.mkdirSync(path.join(elanHome, 'bin'), { recursive: true });
   fs.writeFileSync(path.join(elanHome, 'bin', 'elan'), `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> '${elanLog}'\n`);
   fs.chmodSync(path.join(elanHome, 'bin', 'elan'), 0o755);
@@ -44,10 +71,41 @@ function run(toolchain) {
 }
 
 {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-lean-lsp-bootstrap-'));
+  const repo = writeRepo(root, 'leanprover/lean4:v4.24.0\n');
+  const elanHome = path.join(root, 'elan');
+  const envFile = path.join(root, 'github-env');
+  const pathFile = path.join(root, 'github-path');
+  const initLog = path.join(root, 'elan-init.log');
+  const elanLog = path.join(root, 'elan.log');
+  const { archive, sha256 } = createFakeElanArchive(root);
+  const result = spawnSync('bash', [script, repo], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ELAN_HOME: elanHome,
+      GITHUB_ENV: envFile,
+      GITHUB_PATH: pathFile,
+      ELAN_INIT_LOG: initLog,
+      ELAN_FAKE_LOG: elanLog,
+      PREPARE_LEAN_LSP_TESTING: '1',
+      PREPARE_LEAN_LSP_TEST_ELAN_ARCHIVE: path.basename(archive),
+      PREPARE_LEAN_LSP_TEST_ELAN_SHA256: sha256,
+      PREPARE_LEAN_LSP_TEST_ELAN_URL: `file://${archive}`,
+    },
+  });
+  assert.strictEqual(result.status, 0, result.stderr);
+  assert.strictEqual(fs.readFileSync(initLog, 'utf8'), '-y --no-modify-path --default-toolchain none\n');
+  assert.strictEqual(fs.readFileSync(elanLog, 'utf8'), 'toolchain install leanprover/lean4:v4.24.0\nrun leanprover/lean4:v4.24.0 lean --version\n');
+  assert.strictEqual(fs.readFileSync(envFile, 'utf8'), 'LEAN_TOOLCHAIN=leanprover/lean4:v4.24.0\n');
+}
+
+{
   const source = fs.readFileSync(script, 'utf8');
   assert.match(source, /elan_version='v4\.1\.2'/);
   assert.match(source, /elan_sha256='f81c2e48c1588d4612cd2c8851947898a45ac8d72748a07dff3a5694f1cf589b'/);
   assert.match(source, /elan_bin="\$ELAN_HOME\/bin\/elan"/);
+  assert.match(source, /--connect-timeout 20 --max-time 120/);
   assert.match(source, /ELAN_HOME="\$ELAN_HOME" "\$tmpdir\/elan-init"/);
   assert.doesNotMatch(source, /command -v elan/);
 }

--- a/.github/scripts/test-prepare-lean-lsp.js
+++ b/.github/scripts/test-prepare-lean-lsp.js
@@ -13,15 +13,17 @@ function run(toolchain) {
   const repo = path.join(root, 'repo');
   const bin = path.join(root, 'bin');
   const elanLog = path.join(root, 'elan.log');
+  const elanHome = path.join(root, 'elan');
   const envFile = path.join(root, 'github-env');
   fs.mkdirSync(repo);
   fs.mkdirSync(bin);
   fs.writeFileSync(path.join(repo, 'lean-toolchain'), toolchain);
-  fs.writeFileSync(path.join(bin, 'elan'), `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> '${elanLog}'\n`);
-  fs.chmodSync(path.join(bin, 'elan'), 0o755);
+  fs.mkdirSync(path.join(elanHome, 'bin'), { recursive: true });
+  fs.writeFileSync(path.join(elanHome, 'bin', 'elan'), `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> '${elanLog}'\n`);
+  fs.chmodSync(path.join(elanHome, 'bin', 'elan'), 0o755);
   const result = spawnSync('bash', [script, repo], {
     encoding: 'utf8',
-    env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, ELAN_HOME: path.join(root, 'elan'), GITHUB_ENV: envFile },
+    env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, ELAN_HOME: elanHome, GITHUB_ENV: envFile },
   });
   return { root, envFile, elanLog, result };
 }
@@ -37,6 +39,15 @@ function run(toolchain) {
   const { result } = run('leanprover/lean4:nightly\n');
   assert.notStrictEqual(result.status, 0);
   assert.match(result.stdout, /Refusing non-pinned/);
+}
+
+{
+  const source = fs.readFileSync(script, 'utf8');
+  assert.match(source, /elan_version='v4\.1\.2'/);
+  assert.match(source, /elan_sha256='f81c2e48c1588d4612cd2c8851947898a45ac8d72748a07dff3a5694f1cf589b'/);
+  assert.match(source, /elan_bin="\$ELAN_HOME\/bin\/elan"/);
+  assert.match(source, /ELAN_HOME="\$ELAN_HOME" "\$tmpdir\/elan-init"/);
+  assert.doesNotMatch(source, /command -v elan/);
 }
 
 console.log('Lean LSP setup tests passed');

--- a/.github/scripts/test-prepare-lean-lsp.js
+++ b/.github/scripts/test-prepare-lean-lsp.js
@@ -15,6 +15,7 @@ function run(toolchain) {
   const elanLog = path.join(root, 'elan.log');
   const elanHome = path.join(root, 'elan');
   const envFile = path.join(root, 'github-env');
+  const pathFile = path.join(root, 'github-path');
   fs.mkdirSync(repo);
   fs.mkdirSync(bin);
   fs.writeFileSync(path.join(repo, 'lean-toolchain'), toolchain);
@@ -23,15 +24,16 @@ function run(toolchain) {
   fs.chmodSync(path.join(elanHome, 'bin', 'elan'), 0o755);
   const result = spawnSync('bash', [script, repo], {
     encoding: 'utf8',
-    env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, ELAN_HOME: elanHome, GITHUB_ENV: envFile },
+    env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, ELAN_HOME: elanHome, GITHUB_ENV: envFile, GITHUB_PATH: pathFile },
   });
-  return { root, envFile, elanLog, result };
+  return { root, envFile, pathFile, elanLog, result };
 }
 
 {
-  const { envFile, elanLog, result } = run('leanprover/lean4:v4.24.0\n');
+  const { envFile, pathFile, elanLog, result } = run('leanprover/lean4:v4.24.0\n');
   assert.strictEqual(result.status, 0, result.stderr);
   assert.strictEqual(fs.readFileSync(envFile, 'utf8'), 'LEAN_TOOLCHAIN=leanprover/lean4:v4.24.0\n');
+  assert.match(fs.readFileSync(pathFile, 'utf8'), /\/elan\/bin\n$/);
   assert.strictEqual(fs.readFileSync(elanLog, 'utf8'), 'toolchain install leanprover/lean4:v4.24.0\nrun leanprover/lean4:v4.24.0 lean --version\n');
 }
 

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -224,7 +224,7 @@ jobs:
           test -s "$RUNNER_TEMP/ocr-result.json" || echo '{"status":"error","comments":[],"message":"OCR produced no JSON output"}' > "$RUNNER_TEMP/ocr-result.json"
 
       - name: Post OCR review
-        if: steps.pr.outputs.skip != 'true' && always() && !cancelled() && steps.route.outcome == 'success'
+        if: steps.pr.outputs.skip != 'true' && always() && !cancelled() && steps.route.outcome == 'success' && steps.ocr.outcome == 'success'
         uses: actions/github-script@v7
         env:
           OCR_RESULT_PATH: ${{ runner.temp }}/ocr-result.json
@@ -243,7 +243,7 @@ jobs:
             await post({ github, context, core });
 
       - name: Upload OCR metrics
-        if: steps.pr.outputs.skip != 'true' && always() && !cancelled() && steps.route.outcome == 'success'
+        if: steps.pr.outputs.skip != 'true' && always() && !cancelled() && steps.route.outcome == 'success' && steps.ocr.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: ocr-metrics-${{ steps.pr.outputs.number }}-${{ steps.pr.outputs.head_sha }}

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -143,7 +143,9 @@ jobs:
         if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true' && steps.route.outputs.has_lean == 'true'
         env:
           # Never reuse the runner's elan store for a PR-selected toolchain.
-          ELAN_HOME: ${{ runner.temp }}/ocr-elan
+          # The run/attempt suffix also prevents stale self-hosted runner state
+          # from bypassing the pinned elan bootstrap after an interrupted job.
+          ELAN_HOME: ${{ runner.temp }}/ocr-elan-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           set -euo pipefail
           "$GITHUB_WORKSPACE/ocr-trusted/.github/scripts/prepare-lean-lsp.sh" "$GITHUB_WORKSPACE/repo"
@@ -163,7 +165,7 @@ jobs:
         if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true' && steps.route.outputs.has_lean == 'true'
         env:
           HOME: ${{ runner.temp }}/ocr-home
-          ELAN_HOME: ${{ runner.temp }}/ocr-elan
+          ELAN_HOME: ${{ runner.temp }}/ocr-elan-${{ github.run_id }}-${{ github.run_attempt }}
           LEAN_LSP_MCP_VERSION: "0.28.0"
         run: |
           set -euo pipefail

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -224,7 +224,7 @@ jobs:
           test -s "$RUNNER_TEMP/ocr-result.json" || echo '{"status":"error","comments":[],"message":"OCR produced no JSON output"}' > "$RUNNER_TEMP/ocr-result.json"
 
       - name: Post OCR review
-        if: steps.pr.outputs.skip != 'true' && always() && !cancelled() && steps.route.outcome == 'success' && steps.ocr.outcome == 'success'
+        if: steps.pr.outputs.skip != 'true' && always() && !cancelled() && steps.route.outcome == 'success' && (steps.route.outputs.should_run_ocr != 'true' || steps.ocr.outcome == 'success')
         uses: actions/github-script@v7
         env:
           OCR_RESULT_PATH: ${{ runner.temp }}/ocr-result.json
@@ -243,7 +243,7 @@ jobs:
             await post({ github, context, core });
 
       - name: Upload OCR metrics
-        if: steps.pr.outputs.skip != 'true' && always() && !cancelled() && steps.route.outcome == 'success' && steps.ocr.outcome == 'success'
+        if: steps.pr.outputs.skip != 'true' && always() && !cancelled() && steps.route.outcome == 'success' && (steps.route.outputs.should_run_ocr != 'true' || steps.ocr.outcome == 'success')
         uses: actions/upload-artifact@v4
         with:
           name: ocr-metrics-${{ steps.pr.outputs.number }}-${{ steps.pr.outputs.head_sha }}


### PR DESCRIPTION
## Summary
- bootstrap pinned, checksum-verified elan in the OCR run temporary directory
- retain the repository-pinned strict Lean toolchain and bounded LSP evidence
- remove the OCR runner host-PATH elan dependency

## Verification
- `node .github/scripts/test-prepare-lean-lsp.js`
- `node .github/scripts/test-ocr-routing.js`
- isolated real bootstrap of `leanprover/lean4:v4.24.0` in a temporary ELAN_HOME

The advisory OCR smoke on #2190 is recorded separately; its pre-fix main workflow failed closed because runner `nippur-verity-ocr-1` did not expose elan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI now downloads and executes a pinned elan binary (mitigated by SHA256 checks), and OCR posting is gated on review step success, which changes failure visibility on Lean PRs.
> 
> **Overview**
> OCR Lean LSP setup no longer depends on a host-installed **elan** on self-hosted runners. **`prepare-lean-lsp.sh`** now bootstraps a **pinned, checksum-verified** elan release into the per-run **`ELAN_HOME`**, installs the repo’s strict **`lean-toolchain`**, and exposes **`ELAN_HOME/bin`** via **`GITHUB_PATH`**.
> 
> The workflow uses a **run/attempt-scoped** **`ELAN_HOME`** so interrupted jobs cannot reuse a half-bootstrapped store. **Post OCR review** and **metrics upload** run only when routing succeeded and, if OCR was scheduled, the **Run OpenCodeReview** step succeeded—avoiding misleading PR comments after a failed review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45657acdfc636e71ba2594d413e003a3396bc881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->