### PR TITLE
docs: queue Lean 4.30 migration last

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -492,6 +492,7 @@ The older Phase 1 / Phase 2 / Phase 3 calendar framing is no longer accurate. Th
 - Add larger verified example contracts such as governance and AMM systems.
 - Improve contributor UX with tutorials, proof-pattern guides, and better IDE/documentation integration.
 - Expand optimization, parity-pack, and artifact-generation workflows once the current verification/documentation baselines stay stable.
+- As the final roadmap priority, upgrade Verity and its maintained EVMYulLean fork to Lean 4.30 after the existing PR drain and active proof lanes are complete; see the [migration and refactor plan in #2196](https://github.com/lfglabs-dev/verity/issues/2196).
 
 ---
 
@@ -501,5 +502,5 @@ See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for contribution guidelines and [`VE
 
 ---
 
-**Last Updated**: 2026-05-11
+**Last Updated**: 2026-07-15
 **Status**: Layer 1 is complete for the current contract set; Layer 2 now has a generic whole-contract theorem for the current supported fragment, with remaining [#1510](https://github.com/lfglabs-dev/verity/issues/1510) work focused on fragment widening and legacy bridge migration; Layer 3 is complete. Trust reduction 1/3 done. Sum properties complete (7/7 proven). CompilationModel now supports real-world contracts (loops, branching, events, multi-mappings, internal call mechanics, verified externs).


### PR DESCRIPTION
## Summary
- add the Lean 4.30 / EVMYulLean migration as the final long-term roadmap item
- link the detailed migration and refactor plan in #2196
- keep the existing PR drain and active proof lanes explicitly ahead of this work

## Validation
- `make check` (612 tests; all checks passed)

Closes #2196 only when the migration is complete; this docs PR does not close or start the implementation issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only roadmap ordering; no runtime, proof, or toolchain changes in this PR.
> 
> **Overview**
> **Longer-term roadmap** now lists upgrading Verity and the maintained **EVMYulLean** fork to **Lean 4.30** as the **final** expansion priority, explicitly **after** the current PR drain and active proof lanes finish, with a link to the migration/refactor plan in **#2196**.
> 
> The doc **Last Updated** stamp moves from 2026-05-11 to **2026-07-15**; no code or build behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f62d084aebaa39d161f8505fb0eec6d84b352f79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->