### PR TITLE
fix(ocr): give the scout model time to think

### DIFF
--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -19,7 +19,11 @@ const THRESHOLDS = Object.freeze({
   packetMaxCount: 8,
   packetContextLines: 12,
   scoutDossierMaxChars: 18000,
-  scoutTimeoutMs: 45000,
+  // Thinking models (GLM-5.2, MiniMax-M3) reason at length before emitting
+  // the JSON verdict; 45s aborted every scout call and forced
+  // fallback_deterministic on all large-Lean reviews. The scout runs once
+  // per review inside a 45-minute job budget — give it real headroom.
+  scoutTimeoutMs: 240000,
 });
 
 async function main() {


### PR DESCRIPTION
`scoutTimeoutMs` was 45s. GLM-5.2 and MiniMax-M3 are thinking models that reason at length on the 18k-char dossier before emitting the JSON verdict, so **every scout call aborted** (`Scout provider error: This operation was aborted`) and all large-Lean reviews silently fell back to `fallback_deterministic` — the LLM scout has effectively never fired in production (verified across yesterday's MiniMax runs and today's `builtin/assistant` runs alike).

Raise to 240s: the scout runs once per review inside a 45-minute job budget, so the extra patience is free. `node test-ocr-routing.js` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single threshold change in CI routing with no auth or data-path changes; main effect is longer worst-case wait on large-Lean scout calls.
> 
> **Overview**
> Raises **`scoutTimeoutMs`** in the OCR router from **45s to 240s** so the large-Lean **scout** LLM call can finish before `AbortController` kills it.
> 
> Thinking models (e.g. GLM-5.2, MiniMax-M3) spend a long time reasoning on the ~18k-char dossier before returning JSON; the old limit caused timeouts, **`fallback_deterministic`** packet ranking, and effectively no successful scout triage in production. Comments document that tradeoff; the scout still runs once per review within the wider job budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45ece0fc1f0c229edcf614faddd59c8d6ad02429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->