### PR TITLE
feat(ocr): multi-lens scout review + accumulating rubric

### DIFF
--- a/.github/ocr/README.md
+++ b/.github/ocr/README.md
@@ -37,8 +37,24 @@ For `large-lean-hotspots`, the scout is enabled by default and uses sandboxed.sh
 - `OCR_SCOUT_LLM_URL`: optional; defaults to `OCR_LLM_URL` when the same sandboxed endpoint supports model selection.
 - `OCR_SCOUT_LLM_KEY`: optional; defaults to `OCR_LLM_KEY`, then `OCR_LLM_TOKEN`, when the same sandboxed key can route both models.
 - `OCR_SCOUT_LLM_MODEL`: optional; defaults to `MiniMax-M3`, the MiniMax hybrid long-context scout model listed in the sandboxed.sh provider catalog.
+- `OCR_SCOUT_LENSES`: optional; comma-separated list of lens ids to run instead of the full set (unknown/empty values fall back to all lenses).
 
 The router sends only a bounded JSON risk dossier to the scout model. The scout model is cheap triage only: it selects packet IDs, reasons, risk categories, questions for a stronger reviewer, and residual coverage. It never produces final review approval. If scout configuration is absent, disabled, malformed, rejected by the provider, or the call fails, the router records that state in metrics and falls back to deterministic ranking.
+
+### Multi-lens scout
+
+A single scout pass converges serially: on a real PR each pass surfaced exactly one new class of defect, so review took three cycles (checksum-manifest scoping → verification-replay independence → shallow-clone verification contract). Instead of one call, the router now runs one scout call **per lens in parallel** and **unions + de-duplicates** their packet selections, so a single review surfaces every defect class at once. Each lens reframes the same bounded dossier toward a distinct failure family; the lens set is data-driven (`LENSES` in `ocr-router.js`, subsettable via `OCR_SCOUT_LENSES`). The starting lenses are:
+
+- `provenance` — data/artifact provenance and manifest scoping.
+- `verification-independence` — whether a claimed-independent check actually reuses producer code or a shallow clone.
+- `environment-determinism` — env/override/toolchain assumptions (e.g. NVCC/RUN_CPU flags, unpinned toolchains).
+- `proof-soundness` — Lean vacuous/over-strong hypotheses, `sorry`/`admit`/`axiom`, unsound tactic shortcuts.
+
+All lens calls reuse the same per-call `scoutTimeoutMs` (240s) and run concurrently, so wall-clock time stays bounded to a single scout timeout rather than N of them. A packet flagged by several lenses appears once, carrying every lens's finding (`scout_lenses`); the legacy single-value fields (`scout_reason`/`scout_risk_category`/`scout_question`) and the `<!-- paloma-ocr-review:… -->` dedup tag / verdict line / findings shape are preserved. If **some** lenses fail the union of the survivors is used (`partial_lens_failures` is recorded); only if **every** lens fails does the router fall back to deterministic ranking.
+
+### Accumulating rubric
+
+`.github/ocr/rubric.json` is a permanent, growing checklist of defect **classes** confirmed on past PRs (seeded with the three above). Every scout dossier embeds the rubric (`dossier.rubric`), and each lens also gets a lens-scoped `lens_rubric_focus` pointing it at the past defect classes it owns — so a class caught once is re-checked on every future review instead of being rediscovered serially. When a review confirms a **new** defect class, append it with the `appendRubricItem({ id, lens, title, check, origin })` helper in `ocr-router.js` (it de-dupes by `id`); that helper is also the wiring point for future automation. A missing/invalid rubric file is a soft failure — the scout still runs.
 
 OpenCodeReview 1.7.5 is still invoked only for `small-lean`, `medium-lean`, and `config-docs` full-diff paths. The short-term bridge for `large-lean-hotspots` publishes scout/deterministic packet advisory comments and explicitly marks strong packet review as required but blocked on a safe OCR packet-window input mechanism. The posted comment lists the covered packets, packet budget, scout status, metrics, strong-review blocker, and residual risk. It must not be read as full review coverage or LGTM.
 

--- a/.github/ocr/rubric.json
+++ b/.github/ocr/rubric.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "description": "Accumulating OCR review rubric. Each item is a defect CLASS that a real Verity PR needed a dedicated review cycle to catch. Every scout review injects this list into its dossier so past defect classes are re-checked on every future PR instead of being rediscovered serially. Append a new item with appendRubricItem() in ocr-router.js after a defect class is confirmed in review (see that helper's doc comment).",
+  "items": [
+    {
+      "id": "checksum-manifest-scoping",
+      "lens": "provenance",
+      "title": "Checksum / manifest scoping",
+      "check": "A checksum or manifest must cover EVERY artifact whose integrity the proof or verifier depends on. Flag manifests that pin only a subset of artifacts, hash a directory listing but not file contents, or let a producer add/swap an unlisted artifact without invalidating the checksum. Verify the manifest's scope matches the trust claim it backs.",
+      "origin": "Verity OCR review cycle 1",
+      "added_at": "2026-07-17"
+    },
+    {
+      "id": "verification-replay-independence",
+      "lens": "verification-independence",
+      "title": "Verification / replay independence",
+      "check": "A check advertised as an INDEPENDENT verification must not reuse the producer's own code, cached outputs, or state to reach its verdict. Flag replays that import the generator, trust a producer-emitted result file, or share a build step with the thing being verified — such a check can only confirm self-consistency, not correctness.",
+      "origin": "Verity OCR review cycle 2",
+      "added_at": "2026-07-17"
+    },
+    {
+      "id": "shallow-clone-verification-contract",
+      "lens": "verification-independence",
+      "title": "Shallow-clone verification contract",
+      "check": "Verification that runs against a shallow clone, a single ref, or a partial checkout must state and honor exactly which history/objects it needs. Flag shallow/sparse fetches that silently drop the merge-base, sibling refs, or blobs a sound verification requires, causing the check to pass on an incomplete view of the change.",
+      "origin": "Verity OCR review cycle 3",
+      "added_at": "2026-07-17"
+    }
+  ]
+}

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -4,8 +4,40 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
-const ROUTER_VERSION = 'router-v9';
+const ROUTER_VERSION = 'router-v10';
 const DEFAULT_SCOUT_MODEL = 'MiniMax-M3';
+const RUBRIC_PATH = path.join(__dirname, '..', 'ocr', 'rubric.json');
+
+// Multi-lens scout configuration. A single scout pass converges serially: on a
+// real PR each pass surfaced exactly one new defect class, so review needed
+// three cycles (checksum-manifest scoping -> verification-replay independence ->
+// shallow-clone verification contract). Instead we run one scout call PER LENS
+// in parallel and union their findings, so a single review surfaces every
+// defect class at once. Each lens reframes the same bounded dossier toward a
+// distinct failure family. Extend by appending to this list (and, if the lens
+// maps to a recurring defect, adding a matching rubric item — see rubric.json).
+const LENSES = Object.freeze([
+  Object.freeze({
+    id: 'provenance',
+    title: 'Data & artifact provenance',
+    focus: 'Scrutinize data/artifact provenance and manifest scoping: does a checksum or manifest cover ALL relevant artifacts or only a subset; are inputs traceable to a trusted source; can a producer silently add or swap an artifact the manifest does not pin?',
+  }),
+  Object.freeze({
+    id: 'verification-independence',
+    title: 'Verification independence',
+    focus: 'Scrutinize whether a claimed-independent check is actually independent: does the verifier reuse producer code, trust a producer-emitted output, run against a shallow/partial clone that drops required history, or otherwise replay non-independently rather than re-deriving the result?',
+  }),
+  Object.freeze({
+    id: 'environment-determinism',
+    title: 'Environment determinism',
+    focus: 'Scrutinize environment, override, and toolchain assumptions: NVCC / RUN_CPU / feature flags, environment-variable overrides, unpinned toolchains, and nondeterministic build or runtime configuration that can change what is actually proven or verified between environments.',
+  }),
+  Object.freeze({
+    id: 'proof-soundness',
+    title: 'Lean proof soundness',
+    focus: 'Scrutinize Lean proof soundness: vacuous or over-strong hypotheses, introduced sorry/admit/axiom, unsound tactic shortcuts, weakened theorem conclusions, and broad automation replacing structured proof.',
+  }),
+]);
 const STRONG_REVIEW_BLOCKER_MESSAGE = 'OpenCodeReview 1.7.9 supports --from/--to full diff ranges, but this workflow does not have a safe packet/window input bridge for Lean hunks yet.';
 const THRESHOLDS = Object.freeze({
   smallLeanFiles: 1,
@@ -315,12 +347,17 @@ async function applyScoutStage(decision, diff, config) {
   const deterministicPackets = decision.packets || [];
   const scoutSwitchOn = config.enabled !== false;
   const enabled = Boolean(scoutSwitchOn && config.url && config.key && config.model);
+  const lenses = resolveLenses(config);
+  const rubric = loadRubric();
   decision.scout = {
     enabled,
     configured: Boolean(config.url && config.key && config.model),
     attempted: false,
     status: scoutSwitchOn ? 'not_configured' : 'disabled',
     model: config.model ? redactModel(config.model) : DEFAULT_SCOUT_MODEL,
+    lenses: lenses.map(lens => lens.id),
+    lens_count: lenses.length,
+    rubric_items: rubric.length,
     selected_packets: deterministicPackets.map(p => p.packet_id),
     residual_coverage: packetResidualRisk(decision),
     strong_review_status: 'blocked_packet_input',
@@ -337,34 +374,144 @@ async function applyScoutStage(decision, diff, config) {
 
   decision.scout.attempted = true;
   decision.scout.status = 'pending';
-  try {
-    const dossier = buildRiskDossier(decision, diff);
-    const scout = await callScoutModel(config, dossier);
-    const selected = selectScoutPackets(deterministicPackets, scout);
-    decision.scout.raw_selected_count = Array.isArray(scout.selected_packets) ? scout.selected_packets.length : null;
-    if (selected.length > 0) {
-      decision.packets = selected;
-      decision.reason = `${decision.reason} Scout model ranked ${selected.length}/${deterministicPackets.length} packet(s) for stronger review.`;
-      decision.scout.selected_packets = selected.map(p => p.packet_id);
-      decision.scout.status = 'success';
-      decision.scout.summary = scout.summary || '';
-      decision.scout.residual_coverage = scout.residual_coverage || decision.scout.residual_coverage;
-    } else {
-      decision.scout.status = 'fallback_no_selection';
-      decision.scout.summary = scout.summary || 'Scout returned no valid packet IDs; deterministic ranking retained.';
-      decision.scout.residual_coverage = 'Scout returned no valid packet IDs, so deterministic packet ranking was retained and all selected packets still need strong reviewer analysis.';
-    }
-  } catch (err) {
+
+  // Fan out one scout call per lens IN PARALLEL. Each call reuses the same
+  // per-call scoutTimeoutMs, so wall-clock time stays bounded to a single
+  // scout timeout rather than N of them. Promise.all never rejects here because
+  // runScoutLens catches per-lens failures into a result object, so one broken
+  // lens cannot lose the findings of the others.
+  const results = await Promise.all(
+    lenses.map(lens => runScoutLens(config, decision, diff, lens, rubric)),
+  );
+  const successful = results.filter(r => r.ok);
+  const failed = results.filter(r => !r.ok);
+
+  decision.scout.lens_results = results.map(r => ({
+    lens: r.lens.id,
+    status: r.ok ? 'success' : 'error',
+    raw_selected: r.ok ? r.rawCount : null,
+    error_type: r.ok ? null : classifyScoutError(r.error),
+  }));
+  decision.scout.raw_selected_count = successful.reduce((sum, r) => sum + (r.rawCount || 0), 0);
+
+  if (successful.length === 0) {
+    // Every lens failed: identical outcome to the old single-call failure, so
+    // preserve the same failure surface (error/error_type/http_status/detail).
+    const err = failed[0]?.error;
     decision.scout.status = 'fallback_deterministic';
     decision.scout.error = 'Scout model call failed; deterministic packet ranking retained.';
     decision.scout.error_type = classifyScoutError(err);
     decision.scout.error_detail = sanitizeScoutErrorDetail(err);
     if (err?.status) decision.scout.http_status = err.status;
+    return decision;
+  }
+
+  const selected = unionScoutPackets(deterministicPackets, successful);
+  if (selected.length > 0) {
+    decision.packets = selected;
+    const lensList = successful.map(r => r.lens.id).join(', ');
+    decision.reason = `${decision.reason} Multi-lens scout (${successful.length}/${lenses.length} lens(es): ${lensList}) surfaced ${selected.length}/${deterministicPackets.length} packet(s) for stronger review.`;
+    decision.scout.selected_packets = selected.map(p => p.packet_id);
+    decision.scout.status = 'success';
+    decision.scout.summary = mergeLensSummaries(successful);
+    decision.scout.residual_coverage = mergeLensResidual(successful) || decision.scout.residual_coverage;
+    if (failed.length) {
+      decision.scout.partial_lens_failures = failed.length;
+    }
+  } else {
+    decision.scout.status = 'fallback_no_selection';
+    decision.scout.summary = mergeLensSummaries(successful) || 'Scout returned no valid packet IDs; deterministic ranking retained.';
+    decision.scout.residual_coverage = 'Scout returned no valid packet IDs, so deterministic packet ranking was retained and all selected packets still need strong reviewer analysis.';
   }
   return decision;
 }
 
-function buildRiskDossier(decision, diff) {
+// Run one lens's scout call. Builds a lens-framed, rubric-injected dossier and
+// resolves to a tagged result instead of throwing, so the caller can union
+// across lenses even when some fail.
+async function runScoutLens(config, decision, diff, lens, rubric) {
+  try {
+    const dossier = buildRiskDossier(decision, diff, { lens, rubric });
+    const scout = await callScoutModel(config, dossier, lens);
+    const rawCount = Array.isArray(scout.selected_packets) ? scout.selected_packets.length : 0;
+    return { lens, ok: true, scout, rawCount };
+  } catch (err) {
+    return { lens, ok: false, error: err };
+  }
+}
+
+// Union + de-duplicate packet selections across lenses. A packet flagged by
+// several lenses appears ONCE, carrying every lens's finding in scout_lenses.
+// Deterministic packet order is preserved. The legacy single-value scout fields
+// (scout_reason/scout_risk_category/scout_question) are kept, populated from the
+// first lens that flagged the packet, so the existing finding shape/contract is
+// unchanged for any consumer that does not read scout_lenses.
+function unionScoutPackets(deterministicPackets, lensResults) {
+  const byId = new Map(deterministicPackets.map(p => [p.packet_id, p]));
+  const order = deterministicPackets.map(p => p.packet_id);
+  const merged = new Map();
+  for (const result of lensResults) {
+    const items = Array.isArray(result.scout?.selected_packets) ? result.scout.selected_packets : [];
+    for (const item of items) {
+      const id = String(item.id || item.packet_id || '').trim();
+      const packet = byId.get(id);
+      if (!packet) continue;
+      if (!merged.has(id)) merged.set(id, { packet, findings: [] });
+      const entry = merged.get(id);
+      if (entry.findings.some(f => f.lens === result.lens.id)) continue;
+      entry.findings.push({
+        lens: result.lens.id,
+        lens_title: result.lens.title,
+        reason: String(item.reason || '').slice(0, 500),
+        risk_category: String(item.risk_category || '').slice(0, 120),
+        question: String(item.question_for_stronger_reviewer || '').slice(0, 500),
+      });
+    }
+  }
+  const selected = [];
+  for (const id of order) {
+    if (!merged.has(id)) continue;
+    const { packet, findings } = merged.get(id);
+    const primary = findings[0];
+    selected.push({
+      ...packet,
+      scout_reason: primary.reason,
+      scout_risk_category: primary.risk_category,
+      scout_question: primary.question,
+      scout_lenses: findings,
+      scout_lens_ids: findings.map(f => f.lens),
+    });
+  }
+  return selected.slice(0, THRESHOLDS.packetMaxCount);
+}
+
+function mergeLensSummaries(lensResults) {
+  const seen = new Set();
+  const parts = [];
+  for (const result of lensResults) {
+    const summary = String(result.scout?.summary || '').trim();
+    if (!summary || seen.has(summary)) continue;
+    seen.add(summary);
+    parts.push(`${result.lens.id}: ${summary}`);
+  }
+  return parts.join(' ').slice(0, 800);
+}
+
+function mergeLensResidual(lensResults) {
+  const seen = new Set();
+  const parts = [];
+  for (const result of lensResults) {
+    const residual = String(result.scout?.residual_coverage || '').trim();
+    if (!residual || seen.has(residual)) continue;
+    seen.add(residual);
+    parts.push(residual);
+  }
+  return parts.join(' ').slice(0, 800) || null;
+}
+
+function buildRiskDossier(decision, diff, options = {}) {
+  const lens = options.lens || null;
+  const rubric = Array.isArray(options.rubric) ? options.rubric : [];
   const packets = (decision.packets || []).map(packet => ({
     id: packet.packet_id,
     file: packet.path,
@@ -379,7 +526,10 @@ function buildRiskDossier(decision, diff) {
   const supported = diff.files.filter(f => f.supported);
   const dossier = {
     schema_version: 1,
-    task: 'Rank dangerous Lean review packets for a stronger reviewer. Do not approve the PR.',
+    task: lens
+      ? `Rank dangerous Lean/code review packets for a stronger reviewer THROUGH THE "${lens.title}" LENS. ${lens.focus} Only flag packets relevant to this lens. Do not approve the PR.`
+      : 'Rank dangerous Lean review packets for a stronger reviewer. Do not approve the PR.',
+    lens: lens ? { id: lens.id, title: lens.title, focus: lens.focus } : undefined,
     mode: decision.mode,
     thresholds: decision.thresholds,
     counts: decision.counts,
@@ -400,6 +550,18 @@ function buildRiskDossier(decision, diff) {
       hunk_count: Array.isArray(f.hunks) ? f.hunks.length : 0,
     })).slice(0, 30),
     candidate_packets: packets,
+    // Accumulating rubric: permanent checklist of defect classes confirmed on
+    // past Verity PRs. Every review re-checks these so a defect class is caught
+    // once and never has to be rediscovered serially.
+    rubric: rubric.length ? rubric.map(item => ({
+      id: item.id,
+      lens: item.lens,
+      title: item.title,
+      check: item.check,
+    })) : undefined,
+    lens_rubric_focus: lens && rubric.length
+      ? rubric.filter(item => item.lens === lens.id).map(item => item.id)
+      : undefined,
     required_json_schema: {
       selected_packets: [{
         id: 'pkt-1',
@@ -425,9 +587,12 @@ function summarizeSignals(packets) {
     .sort((a, b) => b.count - a.count || a.signal.localeCompare(b.signal));
 }
 
-async function callScoutModel(config, dossier) {
+async function callScoutModel(config, dossier, lens = null) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), THRESHOLDS.scoutTimeoutMs);
+  const systemContent = lens
+    ? `You are a cautious Lean/code review triage scout applying the "${lens.title}" lens. ${lens.focus} Only select packets relevant to this lens. Return only JSON matching the requested schema. Never claim final review coverage or approval.`
+    : 'You are a cautious Lean proof-change triage scout. Return only JSON matching the requested schema. Never claim final review coverage or approval.';
   try {
     const response = await fetch(openAiChatUrl(config.url), {
       method: 'POST',
@@ -443,7 +608,7 @@ async function callScoutModel(config, dossier) {
         messages: [
           {
             role: 'system',
-            content: 'You are a cautious Lean proof-change triage scout. Return only JSON matching the requested schema. Never claim final review coverage or approval.',
+            content: systemContent,
           },
           {
             role: 'user',
@@ -479,6 +644,60 @@ function resolveScoutConfig(env = process.env) {
 
 function isFalse(value) {
   return /^(0|false|no|off)$/i.test(String(value || '').trim());
+}
+
+// Which lenses fan out for this review. Defaults to the full LENSES set; an
+// operator can pin a subset via config.lenses or OCR_SCOUT_LENSES (a
+// comma-separated list of lens ids) without a code change. Unknown ids are
+// ignored, and an empty/all-unknown selection falls back to the full set so a
+// mis-set env var never silently disables scouting.
+function resolveLenses(config = {}, env = process.env) {
+  const requested = String(config.lenses || env.OCR_SCOUT_LENSES || '').trim();
+  if (!requested) return LENSES;
+  const ids = new Set(requested.split(',').map(s => s.trim().toLowerCase()).filter(Boolean));
+  const selected = LENSES.filter(lens => ids.has(lens.id));
+  return selected.length ? selected : LENSES;
+}
+
+// Load the accumulating review rubric. Every scout dossier embeds this so past
+// defect classes are re-checked on every future PR. Missing/invalid file is a
+// soft failure (empty rubric) — the scout still runs on its lenses.
+function loadRubric(rubricPath = RUBRIC_PATH) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(rubricPath, 'utf8'));
+    return Array.isArray(parsed.items) ? parsed.items : [];
+  } catch {
+    return [];
+  }
+}
+
+// Mechanism for growing the rubric: when a review confirms a NEW defect class,
+// call appendRubricItem({ id, lens, title, check, origin }) to persist it as a
+// permanent checklist item so every later review explicitly checks for it.
+// De-dupes by id (returns false if the id already exists). This is the wiring
+// point for future automation (e.g. a bot that appends when a reviewer labels a
+// finding as a new class); today it is invoked deliberately by an operator.
+function appendRubricItem(item, rubricPath = RUBRIC_PATH) {
+  const id = String(item && item.id || '').trim();
+  if (!id) throw new Error('appendRubricItem requires an item.id');
+  let doc;
+  try {
+    doc = JSON.parse(fs.readFileSync(rubricPath, 'utf8'));
+  } catch {
+    doc = { schema_version: 1, items: [] };
+  }
+  if (!Array.isArray(doc.items)) doc.items = [];
+  if (doc.items.some(existing => String(existing.id).trim() === id)) return false;
+  doc.items.push({
+    id,
+    lens: String(item.lens || '').trim(),
+    title: String(item.title || '').trim(),
+    check: String(item.check || '').trim(),
+    origin: String(item.origin || '').trim(),
+    added_at: String(item.added_at || new Date().toISOString().slice(0, 10)),
+  });
+  fs.writeFileSync(rubricPath, `${JSON.stringify(doc, null, 2)}\n`);
+  return true;
 }
 
 function parseScoutJson(content) {
@@ -696,22 +915,6 @@ function openAiChatUrl(baseUrl) {
   if (trimmed.endsWith('/chat/completions')) return trimmed;
   if (trimmed.endsWith('/v1')) return `${trimmed}/chat/completions`;
   return `${trimmed}/v1/chat/completions`;
-}
-
-function selectScoutPackets(deterministicPackets, scout) {
-  const byId = new Map(deterministicPackets.map(p => [p.packet_id, p]));
-  const selected = [];
-  for (const item of Array.isArray(scout?.selected_packets) ? scout.selected_packets : []) {
-    const packet = byId.get(String(item.id || item.packet_id || '').trim());
-    if (!packet || selected.some(p => p.packet_id === packet.packet_id)) continue;
-    selected.push({
-      ...packet,
-      scout_reason: String(item.reason || '').slice(0, 500),
-      scout_risk_category: String(item.risk_category || '').slice(0, 120),
-      scout_question: String(item.question_for_stronger_reviewer || '').slice(0, 500),
-    });
-  }
-  return selected.slice(0, THRESHOLDS.packetMaxCount);
 }
 
 function truncateJson(value, maxChars) {
@@ -1139,6 +1342,7 @@ function buildMetrics({ prNumber, headSha, baseRef, startedAt, decision, diff })
         scout_reason: p.scout_reason || null,
         scout_risk_category: p.scout_risk_category || null,
         scout_question: p.scout_question || null,
+        scout_lens_ids: Array.isArray(p.scout_lens_ids) ? p.scout_lens_ids : null,
         changed_lines: p.changed_lines,
       })),
       residual_risk: packetResidualRisk(decision),
@@ -1225,11 +1429,27 @@ function renderPacketFinding(packet) {
   // Reader-first ordering: the substantive finding leads, the router's
   // selection rationale follows, and the triage caveat closes.
   const lines = [];
-  if (packet.scout_reason) {
-    lines.push(`**Finding:** ${sanitizeCommentText(packet.scout_reason)}`);
-  }
-  if (packet.scout_question) {
-    lines.push(`**Ask the reviewer:** ${sanitizeCommentText(packet.scout_question)}`);
+  const lensFindings = Array.isArray(packet.scout_lenses) ? packet.scout_lenses : [];
+  if (lensFindings.length > 1) {
+    // Multi-lens: this packet tripped more than one lens, so list every lens's
+    // finding — that is the whole point of the fan-out (surface all defect
+    // classes at once instead of one per review cycle).
+    lines.push(`**Findings (${lensFindings.length} lenses):**`);
+    for (const finding of lensFindings) {
+      const label = sanitizeCommentText(finding.lens_title || finding.lens || 'lens');
+      const detail = sanitizeCommentText(finding.reason || '(no detail)');
+      lines.push(`- _${label}:_ ${detail}`);
+      if (finding.question) {
+        lines.push(`  - Ask the reviewer: ${sanitizeCommentText(finding.question)}`);
+      }
+    }
+  } else {
+    if (packet.scout_reason) {
+      lines.push(`**Finding:** ${sanitizeCommentText(packet.scout_reason)}`);
+    }
+    if (packet.scout_question) {
+      lines.push(`**Ask the reviewer:** ${sanitizeCommentText(packet.scout_question)}`);
+    }
   }
   lines.push(
     `**Why flagged:** ${packet.summary}. Signals: ${
@@ -1332,6 +1552,7 @@ module.exports = {
   ROUTER_VERSION,
   THRESHOLDS,
   DEFAULT_SCOUT_MODEL,
+  LENSES,
   categorize,
   decideRoute,
   isSupported,
@@ -1341,6 +1562,11 @@ module.exports = {
   buildReviewPackets,
   applyScoutStage,
   resolveScoutConfig,
+  resolveLenses,
+  loadRubric,
+  appendRubricItem,
+  unionScoutPackets,
+  renderPacketFinding,
   parseScoutJson,
   sanitizeScoutErrorDetail,
   buildRiskDossier,

--- a/.github/scripts/post-ocr-review.js
+++ b/.github/scripts/post-ocr-review.js
@@ -471,6 +471,12 @@ function renderPacketCoverage(metrics, result) {
   const scout = packetReview.scout || {};
   body += `- Packet review: ${packetReview.enabled ? 'enabled' : 'not used'}; selected ${packetReview.packets_selected ?? packets.length}/${packetReview.packet_budget ?? '?'} packet(s)\n`;
   body += `- Scout: ${scout.enabled ? 'configured' : 'not configured'}; status ${escapeMd(scout.status || 'unknown')}; model ${escapeMd(scout.model || 'none')}\n`;
+  if (Array.isArray(scout.lenses) && scout.lenses.length) {
+    body += `- Scout lenses: ${escapeMd(scout.lenses.join(', '))}`;
+    if (scout.partial_lens_failures) body += ` (${scout.partial_lens_failures} lens(es) failed; union of the rest used)`;
+    if (scout.rubric_items != null) body += `; rubric items checked ${scout.rubric_items}`;
+    body += `\n`;
+  }
   if (scout.error_detail) {
     if (typeof scout.http_status === 'number') body += `- Scout provider HTTP status: ${scout.http_status}\n`;
     body += `- Scout provider error: ${escapeMd(scout.error_detail)}\n`;
@@ -488,8 +494,9 @@ function renderPacketCoverage(metrics, result) {
     body += `- Covered packets:\n`;
     for (const packet of packets.slice(0, 8)) {
       const signals = Array.isArray(packet.signals) && packet.signals.length ? packet.signals.join(', ') : 'hotspot path/churn';
+      const lensTag = Array.isArray(packet.scout_lens_ids) && packet.scout_lens_ids.length ? ` [lenses: ${packet.scout_lens_ids.join(', ')}]` : '';
       const question = packet.scout_question ? `; ask: ${packet.scout_question}` : '';
-      body += `  - ${escapeMd(packet.path)}:${packet.start_line ?? '?'} score ${packet.score ?? '?'} — ${escapeMd(signals + question)}\n`;
+      body += `  - ${escapeMd(packet.path)}:${packet.start_line ?? '?'} score ${packet.score ?? '?'}${escapeMd(lensTag)} — ${escapeMd(signals + question)}\n`;
     }
   }
   body += `\n`;

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -902,7 +902,9 @@ async function testLargeLeanScoutEmptySelectionIsFallback() {
   }
   assert.strictEqual(decision.scout.status, 'fallback_no_selection');
   assert.deepStrictEqual(decision.packets.map(p => p.packet_id), originalPackets);
-  assert.strictEqual(decision.scout.raw_selected_count, 1);
+  // Multi-lens: every lens returned one (invalid) selection, so the raw count is
+  // summed across the full lens fan-out.
+  assert.strictEqual(decision.scout.raw_selected_count, router.LENSES.length);
 }
 
 async function testLargeLeanScoutMalformedJsonFallsBack() {
@@ -1766,6 +1768,244 @@ function testLargeLeanScoutDedupVariesBySanitizedScoutConfig() {
   assert.strictEqual(normalKey, `${base.commit_id}:${base.rulesHash}:${base.reviewerVersion}:${base.routerVersion}:small-lean`);
 }
 
+// Build a fetch stub that answers each scout call according to which LENS it is
+// running. It reads the lens id back out of the dossier the router sent, so the
+// tests exercise the real per-lens dossier construction, not a bypass.
+function lensAwareFetch(perLens, captured) {
+  return async (url, init) => {
+    const body = JSON.parse(init.body);
+    const dossier = JSON.parse(body.messages[1].content);
+    const lensId = dossier.lens && dossier.lens.id;
+    if (captured) captured.push({ lensId, dossier, system: body.messages[0].content });
+    const spec = perLens(lensId, dossier) || {};
+    if (spec.fail) {
+      return { ok: false, status: spec.status || 500, text: async () => spec.text || 'lens failed' };
+    }
+    return {
+      ok: true,
+      text: async () => JSON.stringify({
+        choices: [{ message: { content: JSON.stringify(spec.content || { selected_packets: [], residual_coverage: 'none', summary: 'none' }) } }],
+      }),
+    };
+  };
+}
+
+function largeLeanDecision() {
+  const files = [
+    file('Compiler/Proofs/A.lean', 40, 0),
+    file('Compiler/Proofs/B.lean', 40, 0),
+    file('Compiler/Proofs/C.lean', 40, 0),
+  ];
+  const decision = router.decideRoute(files);
+  return { files, decision };
+}
+
+async function testMultiLensScoutUnionsFindingsAcrossLenses() {
+  const { files, decision } = largeLeanDecision();
+  const ids = decision.packets.map(p => p.packet_id);
+  assert.ok(ids.length >= 3, 'fixture should yield at least three packets');
+  // Each lens flags a distinct packet; provenance and proof-soundness overlap on
+  // the first packet so we also exercise cross-lens de-duplication.
+  const lensToPacket = {
+    provenance: ids[0],
+    'verification-independence': ids[1],
+    'environment-determinism': ids[2],
+    'proof-soundness': ids[0],
+  };
+  const oldFetch = global.fetch;
+  global.fetch = lensAwareFetch(lensId => ({
+    content: {
+      selected_packets: [{
+        id: lensToPacket[lensId],
+        reason: `${lensId} sees a risk here`,
+        risk_category: lensId,
+        question_for_stronger_reviewer: `Check the ${lensId} concern.`,
+      }],
+      residual_coverage: `${lensId} residual`,
+      summary: `${lensId} summary`,
+    },
+  }));
+  try {
+    await router.applyScoutStage(decision, { files }, { url: 'https://example.invalid/v1', key: 'k', model: 'cheap-scout' });
+  } finally {
+    global.fetch = oldFetch;
+  }
+  assert.strictEqual(decision.scout.status, 'success');
+  assert.deepStrictEqual(decision.scout.lenses, router.LENSES.map(l => l.id));
+  assert.strictEqual(decision.scout.lens_count, router.LENSES.length);
+  // Union of {ids[0], ids[1], ids[2]} (proof-soundness dedups onto ids[0]).
+  assert.strictEqual(decision.packets.length, 3);
+  const first = decision.packets.find(p => p.packet_id === ids[0]);
+  assert.deepStrictEqual(first.scout_lens_ids, ['provenance', 'proof-soundness']);
+  assert.strictEqual(first.scout_lenses.length, 2);
+  // Legacy single-value contract preserved from the first flagging lens.
+  assert.strictEqual(first.scout_reason, 'provenance sees a risk here');
+  assert.ok(first.scout_question.includes('provenance'));
+  const second = decision.packets.find(p => p.packet_id === ids[1]);
+  assert.deepStrictEqual(second.scout_lens_ids, ['verification-independence']);
+  assert.ok(decision.scout.lens_results.every(r => r.status === 'success'));
+  assert.strictEqual(decision.scout.raw_selected_count, router.LENSES.length);
+}
+
+async function testMultiLensScoutRendersEveryLensFinding() {
+  const { files, decision } = largeLeanDecision();
+  const ids = decision.packets.map(p => p.packet_id);
+  const oldFetch = global.fetch;
+  // provenance and verification-independence both flag ids[0].
+  global.fetch = lensAwareFetch(lensId => {
+    if (lensId === 'provenance' || lensId === 'verification-independence') {
+      return {
+        content: {
+          selected_packets: [{
+            // provenance smuggles an @mention + HTML to prove per-lens prose is
+            // still neutralized after the union.
+            id: ids[0],
+            reason: lensId === 'provenance' ? 'ping @verity-admins <script> detail' : `${lensId} detail`,
+            risk_category: lensId,
+            question_for_stronger_reviewer: `${lensId} question`,
+          }],
+          summary: `${lensId} summary`,
+        },
+      };
+    }
+    return { content: { selected_packets: [], summary: `${lensId} summary` } };
+  });
+  try {
+    await router.applyScoutStage(decision, { files }, { url: 'https://example.invalid/v1', key: 'k', model: 'cheap-scout' });
+  } finally {
+    global.fetch = oldFetch;
+  }
+  const packet = decision.packets.find(p => p.packet_id === ids[0]);
+  const rendered = router.renderPacketFinding(packet);
+  assert.ok(rendered.includes('Findings (2 lenses)'));
+  assert.ok(rendered.includes('verification-independence detail'));
+  // Injection neutralization still applies to model-authored lens prose.
+  assert.ok(!rendered.includes('@verity-admins'));
+  assert.ok(!rendered.includes('<script>'));
+}
+
+async function testMultiLensScoutSurvivesPartialLensFailure() {
+  const { files, decision } = largeLeanDecision();
+  const ids = decision.packets.map(p => p.packet_id);
+  const oldFetch = global.fetch;
+  global.fetch = lensAwareFetch(lensId => {
+    if (lensId === 'provenance') return { fail: true, status: 503, text: 'provenance lens upstream error' };
+    return {
+      content: {
+        selected_packets: [{ id: ids[1], reason: `${lensId} risk`, risk_category: lensId, question_for_stronger_reviewer: 'q' }],
+        summary: `${lensId} summary`,
+      },
+    };
+  });
+  try {
+    await router.applyScoutStage(decision, { files }, { url: 'https://example.invalid/v1', key: 'k', model: 'cheap-scout' });
+  } finally {
+    global.fetch = oldFetch;
+  }
+  // A single broken lens must NOT lose the findings of the others.
+  assert.strictEqual(decision.scout.status, 'success');
+  assert.strictEqual(decision.scout.partial_lens_failures, 1);
+  assert.deepStrictEqual(decision.packets.map(p => p.packet_id), [ids[1]]);
+  const provenanceResult = decision.scout.lens_results.find(r => r.lens === 'provenance');
+  assert.strictEqual(provenanceResult.status, 'error');
+}
+
+async function testMultiLensScoutAllLensesFailFallsBack() {
+  const { files, decision } = largeLeanDecision();
+  const originalPackets = decision.packets.map(p => p.packet_id);
+  const oldFetch = global.fetch;
+  global.fetch = lensAwareFetch(() => ({ fail: true, status: 429, text: 'model MiniMax-M3 rate limited' }));
+  try {
+    await router.applyScoutStage(decision, { files }, { url: 'https://example.invalid/v1', key: 'k', model: 'MiniMax-M3' });
+  } finally {
+    global.fetch = oldFetch;
+  }
+  assert.strictEqual(decision.scout.status, 'fallback_deterministic');
+  assert.strictEqual(decision.scout.error_type, 'http_error');
+  assert.strictEqual(decision.scout.http_status, 429);
+  assert.deepStrictEqual(decision.packets.map(p => p.packet_id), originalPackets);
+}
+
+async function testScoutDossierInjectsRubricAndLensFraming() {
+  const { files, decision } = largeLeanDecision();
+  const captured = [];
+  const oldFetch = global.fetch;
+  global.fetch = lensAwareFetch(() => ({ content: { selected_packets: [], summary: 'none' } }), captured);
+  try {
+    await router.applyScoutStage(decision, { files }, { url: 'https://example.invalid/v1', key: 'k', model: 'cheap-scout' });
+  } finally {
+    global.fetch = oldFetch;
+  }
+  assert.strictEqual(captured.length, router.LENSES.length);
+  const seededIds = router.loadRubric().map(item => item.id);
+  assert.ok(seededIds.includes('checksum-manifest-scoping'));
+  for (const call of captured) {
+    // Every scout dossier carries the full rubric and a lens framing.
+    assert.ok(Array.isArray(call.dossier.rubric) && call.dossier.rubric.length >= 3);
+    for (const id of seededIds) {
+      assert.ok(call.dossier.rubric.some(r => r.id === id), `rubric ${id} present for ${call.lensId}`);
+    }
+    assert.ok(call.dossier.lens && call.dossier.lens.id === call.lensId);
+    const lensDef = router.LENSES.find(l => l.id === call.lensId);
+    assert.ok(call.dossier.task.includes(lensDef.title));
+    assert.ok(call.system.includes(lensDef.title));
+  }
+  // Lens-scoped rubric focus points each lens at its own past defect classes.
+  const provCall = captured.find(c => c.lensId === 'provenance');
+  assert.ok(provCall.dossier.lens_rubric_focus.includes('checksum-manifest-scoping'));
+  const viCall = captured.find(c => c.lensId === 'verification-independence');
+  assert.ok(viCall.dossier.lens_rubric_focus.includes('verification-replay-independence'));
+  assert.ok(viCall.dossier.lens_rubric_focus.includes('shallow-clone-verification-contract'));
+}
+
+function testRubricSeedContainsKnownDefectClasses() {
+  const items = router.loadRubric();
+  const ids = items.map(i => i.id);
+  assert.ok(ids.includes('checksum-manifest-scoping'));
+  assert.ok(ids.includes('verification-replay-independence'));
+  assert.ok(ids.includes('shallow-clone-verification-contract'));
+  // Each seeded class names a lens and a concrete check.
+  for (const item of items) {
+    assert.ok(item.lens && router.LENSES.some(l => l.id === item.lens), `rubric item ${item.id} maps to a real lens`);
+    assert.ok(String(item.check || '').length > 20);
+  }
+}
+
+function testAppendRubricItemAddsAndDedups() {
+  const tmp = path.join(os.tmpdir(), `ocr-rubric-${process.pid}-${Date.now()}.json`);
+  fs.writeFileSync(tmp, `${JSON.stringify({ schema_version: 1, items: [] }, null, 2)}\n`);
+  try {
+    const added = router.appendRubricItem({
+      id: 'new-defect-class',
+      lens: 'environment-determinism',
+      title: 'New defect class',
+      check: 'A confirmed new defect class discovered in review.',
+      origin: 'unit test',
+    }, tmp);
+    assert.strictEqual(added, true);
+    const again = router.appendRubricItem({ id: 'new-defect-class', lens: 'environment-determinism', title: 'dup', check: 'dup' }, tmp);
+    assert.strictEqual(again, false);
+    const doc = JSON.parse(fs.readFileSync(tmp, 'utf8'));
+    assert.strictEqual(doc.items.length, 1);
+    assert.strictEqual(doc.items[0].id, 'new-defect-class');
+    assert.ok(doc.items[0].added_at);
+    assert.throws(() => router.appendRubricItem({ lens: 'x' }, tmp), /requires an item.id/);
+  } finally {
+    fs.rmSync(tmp, { force: true });
+  }
+}
+
+function testResolveLensesSubsetAndFallback() {
+  assert.deepStrictEqual(router.resolveLenses({}, {}).map(l => l.id), router.LENSES.map(l => l.id));
+  const subset = router.resolveLenses({}, { OCR_SCOUT_LENSES: 'provenance, proof-soundness' });
+  assert.deepStrictEqual(subset.map(l => l.id), ['provenance', 'proof-soundness']);
+  // Config override wins over env, and unknown ids fall back to the full set.
+  const viaConfig = router.resolveLenses({ lenses: 'verification-independence' }, { OCR_SCOUT_LENSES: 'provenance' });
+  assert.deepStrictEqual(viaConfig.map(l => l.id), ['verification-independence']);
+  const unknown = router.resolveLenses({}, { OCR_SCOUT_LENSES: 'does-not-exist' });
+  assert.deepStrictEqual(unknown.map(l => l.id), router.LENSES.map(l => l.id));
+}
+
 async function run() {
   testNoSupportedFilesSkipped();
   testOneLeanFileNormal();
@@ -1848,6 +2088,14 @@ async function run() {
   testScoutErrorBoundsLargeProviderBodies();
   testScoutErrorRedactsLargeStructuredBodiesBeforeBounding();
   await testLargeLeanScoutNoPacketsStatus();
+  await testMultiLensScoutUnionsFindingsAcrossLenses();
+  await testMultiLensScoutRendersEveryLensFinding();
+  await testMultiLensScoutSurvivesPartialLensFailure();
+  await testMultiLensScoutAllLensesFailFallsBack();
+  await testScoutDossierInjectsRubricAndLensFraming();
+  testRubricSeedContainsKnownDefectClasses();
+  testAppendRubricItemAddsAndDedups();
+  testResolveLensesSubsetAndFallback();
   testWorkflowDocsEnabled();
   testGenericScriptConfigEnabled();
   await testCompletedWithErrorsRetryablePreservesFindings();

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -128,6 +128,7 @@ jobs:
           OCR_SCOUT_LLM_URL: ${{ secrets.OCR_SCOUT_LLM_URL || secrets.OCR_LLM_URL }}
           OCR_SCOUT_LLM_KEY: ${{ secrets.OCR_SCOUT_LLM_KEY || secrets.OCR_LLM_KEY }}
           OCR_SCOUT_LLM_MODEL: ${{ vars.OCR_SCOUT_LLM_MODEL || secrets.OCR_SCOUT_LLM_MODEL || 'MiniMax-M3' }}
+          OCR_SCOUT_LENSES: ${{ vars.OCR_SCOUT_LENSES || '' }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Follow-up to #2199. Single-scout review converges serially — Beal PR #4 needed **3 review cycles**, each surfacing one new defect class (checksum-manifest scoping → verification-replay independence → shallow-clone verification contract). This front-loads discovery.

**Multi-lens:** fan out one scout call per lens (provenance, verification-independence, environment-determinism, proof-soundness) in parallel, union + de-dup findings so one repair cycle addresses every class. Per-lens failures caught; all-fail keeps the existing fallback_deterministic surface; wall-clock stays one scoutTimeoutMs (concurrent). ROUTER_VERSION v9→v10 so the richer review is not suppressed by a prior single-lens dedup tag. Subsettable via OCR_SCOUT_LENSES.

**Accumulating rubric** (.github/ocr/rubric.json) seeded with the three known defect classes, injected into every scout dossier; appendRubricItem() is the documented growth hook.

node test-ocr-routing.js passes (8 new tests). Sanitization intact; thresholds/dedup-key unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes large-Lean CI review routing and multiplies scout LLM calls (cost/latency), but fallbacks and comment sanitization are preserved and behavior is heavily tested.
> 
> **Overview**
> Large-Lean **scout triage** no longer uses one LLM call: `applyScoutStage` fans out **one scout request per lens in parallel** (provenance, verification-independence, environment-determinism, proof-soundness), **unions and de-duplicates** packet picks, and keeps legacy single-field scout metadata while adding `scout_lenses` / `scout_lens_ids` when multiple lenses hit the same packet. Partial lens failures still succeed from the rest; only total failure keeps **deterministic fallback**. Operators can subset lenses via **`OCR_SCOUT_LENSES`** (workflow + `resolveLenses`).
> 
> Adds **`.github/ocr/rubric.json`** (three seeded defect classes) injected into every dossier with per-lens **`lens_rubric_focus`**, plus **`loadRubric`** / **`appendRubricItem`** for growth. **`ROUTER_VERSION`** bumps **v9 → v10** so prior single-lens dedup tags don’t suppress the richer run.
> 
> **`post-ocr-review.js`** packet coverage now reports lenses, partial failures, rubric count, and per-packet lens tags; **`renderPacketFinding`** lists multi-lens findings. Docs updated; **8 new routing tests** cover union, partial failure, rubric injection, and lens resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9e5f93203de0f26c200270a02a14367739abb59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->