### PR TITLE
fix: normalize reused checkout before checks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -284,6 +284,12 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Normalize reused checkout state
+        run: |
+          if [ -d .git ]; then
+            git sparse-checkout disable || true
+          fi
+
       - name: Clear sticky remote refs before PR checkout
         if: github.event_name == 'pull_request'
         run: |

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -251,6 +251,10 @@
     ],
     "checks": [
       {
+        "name": "Normalize reused checkout state",
+        "run": "if [ -d .git ]; then\n  git sparse-checkout disable || true\nfi"
+      },
+      {
         "name": "Clear sticky remote refs before PR checkout",
         "if": "github.event_name == 'pull_request'",
         "run": "if [ -d .git ]; then\n  git for-each-ref --format='delete %(refname)' refs/remotes/origin | git update-ref --stdin || true\n  rm -rf .git/refs/remotes/origin\nfi"

--- a/scripts/verify_sync_spec_source.py
+++ b/scripts/verify_sync_spec_source.py
@@ -215,7 +215,11 @@ SPEC = {'check_only_paths': ['.github/workflows/**',
                                                   'CODE_CHANGED': '${{ steps.filter.outputs.code }}',
                                                   'BUILD_CHANGED': '${{ steps.filter.outputs.build }}',
                                                   'COMPILER_CHANGED': '${{ steps.filter.outputs.compiler }}'}}],
-                             'checks': [{'name': 'Clear sticky remote refs before PR checkout',
+                             'checks': [{'name': 'Normalize reused checkout state',
+                                         'run': 'if [ -d .git ]; then\n'
+                                                '  git sparse-checkout disable || true\n'
+                                                'fi'},
+                                        {'name': 'Clear sticky remote refs before PR checkout',
                                          'if': "github.event_name == 'pull_request'",
                                          'run': 'if [ -d .git ]; then\n'
                                                 "  git for-each-ref --format='delete "


### PR DESCRIPTION
## Summary

- disable stale sparse-checkout state before `actions/checkout` in the self-hosted checks job
- keep the generated verify workflow contract in sync
- repair run 29717074034's reused-worktree failure without weakening checks

## Local validation (exact head 1a66d6f5320873019dbe56ddec6acea5ef24fd5d)

- all derived-artifact generators and check modes: exit 0, byte-clean
- workflow contract tests: 67 tests, exit 0
- `make check`: 634 tests plus repository/trust/forbidden-token checks, exit 0
- Lean 4.24.0 `lake build PrintAxioms`: 2425 jobs, exit 0
- `lake env lean PrintAxioms.lean` and `scripts/check_axioms.py`: 4002 theorems, 0 project axioms, PASS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only precondition on self-hosted runners; no application, auth, or proof logic changes.
> 
> **Overview**
> Fixes self-hosted **checks** job failures when the workspace reuses a git tree left in **sparse-checkout** mode (e.g. after `closed-pr-cleanup`’s minimal checkout).
> 
> Adds a first step **Normalize reused checkout state** that runs `git sparse-checkout disable` when `.git` exists, **before** the existing PR sticky-ref cleanup and `actions/checkout`. The verify workflow sync contract is updated in `scripts/verify_sync_spec_source.py` and regenerated `scripts/verify_sync_spec.json` so contract tests still match the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a66d6f5320873019dbe56ddec6acea5ef24fd5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->