### PR TITLE
proofs: integrate incremental helper-rich proven fragments

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -274,8 +274,7 @@ theorem stmtListDirectInternalHelperCallStepInterfaceWithInternals_cons_internal
       (calleeName := calleeName)
       (args := args)
       (compiledIR := compiledIR)
-      (rest := rest)
-      (irFuelSlack := 0)
+      (rest := rest) (irFuelSlack := 0)
       hstep
       hrest
 

--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -275,6 +275,7 @@ theorem stmtListDirectInternalHelperCallStepInterfaceWithInternals_cons_internal
       (args := args)
       (compiledIR := compiledIR)
       (rest := rest)
+      (irFuelSlack := 0)
       hstep
       hrest
 
@@ -519,6 +520,7 @@ theorem stmtListDirectInternalHelperAssignStepInterfaceWithInternals_cons_intern
     ⟨compiledIR, hstep⟩
   exact
     stmtListDirectInternalHelperAssignStepInterfaceWithInternals_cons_internalCallAssign
+      (irFuelSlack := 0)
       hstep
       hrest
 
@@ -1516,12 +1518,14 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_dire
     compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_fuelSplitBridge
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
       (scope := scope) (calleeName := calleeName) (args := args)
-      (compiledIR := compiledIR) (argExprs := argExprs) helperBodySize
+      (compiledIR := compiledIR) (argExprs := argExprs)
+      (irFuelSlack := irFuelSlack) helperBodySize
       hcompile hargCompile
       (internalCallWithInternalsSufficientBridge_of_directContextEvidence
         (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
         (scope := scope) (calleeName := calleeName) (args := args)
-        (argExprs := argExprs) hctx hnodup helperBodySize hevidence)
+        (argExprs := argExprs) hctx hnodup helperBodySize
+        (irFuelSlack := irFuelSlack) hevidence)
       hresidual
 
 abbrev DirectInternalHelperAssignSufficientFuelEvidence
@@ -1622,12 +1626,14 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_o
     compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_of_fuelSplitBridge
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
       (scope := scope) (names := names) (calleeName := calleeName) (args := args)
-      (compiledIR := compiledIR) (argExprs := argExprs) helperBodySize
+      (compiledIR := compiledIR) (argExprs := argExprs)
+      (irFuelSlack := irFuelSlack) helperBodySize
       hcompile hargCompile
       (internalCallAssignWithInternalsSufficientBridge_of_directContextEvidence
         (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
         (scope := scope) (calleeName := calleeName) (args := args)
-        (argExprs := argExprs) (names := names) hctx hnodup helperBodySize hevidence)
+        (argExprs := argExprs) (names := names) hctx hnodup helperBodySize
+        (irFuelSlack := irFuelSlack) hevidence)
       hresidual
 
 end DirectInternalHelperFuelSplitConsumer

--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -1449,10 +1449,11 @@ theorem internalCallWithInternalsSufficientBridge_of_directContextEvidence
     (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
     (hnodup : (spec.functions.map (·.name)).Nodup)
     (helperBodySize : Nat)
+    {irFuelSlack : Nat := 0}
     (hevidence :
       ∀ runtime state stmtHelperFuel irFuel,
         1 < stmtHelperFuel →
-        helperBodySize + 2 ≤ irFuel →
+        helperBodySize + 2 + irFuelSlack ≤ irFuel →
         FunctionBody.bindingsExactlyMatchIRVarsOnScope scope runtime.bindings state →
         FunctionBody.scopeNamesPresent scope runtime.bindings →
         FunctionBody.bindingsBounded runtime.bindings →
@@ -1461,8 +1462,8 @@ theorem internalCallWithInternalsSufficientBridge_of_directContextEvidence
           (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
           (scope := scope) (calleeName := calleeName) (args := args)
           (argExprs := argExprs) hctx helperBodySize stmtHelperFuel irFuel runtime state) :
-    InternalCallWithInternalsSufficientBridge runtimeContract spec fields scope
-      calleeName args argExprs helperBodySize := by
+    InternalCallWithInternalsAdditiveBridge runtimeContract spec fields scope
+      calleeName args argExprs helperBodySize irFuelSlack := by
   intro runtime state stmtHelperFuel irFuel hstmtFuel hirFuel hfuel hexact hscope hbounded hruntime
   rcases hevidence runtime state stmtHelperFuel irFuel hstmtFuel hirFuel
       hexact hscope hbounded hruntime with
@@ -1486,6 +1487,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_dire
     (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
     (hnodup : (spec.functions.map (·.name)).Nodup)
     (helperBodySize : Nat)
+    {irFuelSlack : Nat := 0}
     {compiledIR : List YulStmt}
     (hcompile :
       CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
@@ -1496,7 +1498,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_dire
     (hevidence :
       ∀ runtime state stmtHelperFuel irFuel,
         1 < stmtHelperFuel →
-        helperBodySize + 2 ≤ irFuel →
+        helperBodySize + 2 + irFuelSlack ≤ irFuel →
         FunctionBody.bindingsExactlyMatchIRVarsOnScope scope runtime.bindings state →
         FunctionBody.scopeNamesPresent scope runtime.bindings →
         FunctionBody.bindingsBounded runtime.bindings →
@@ -1506,10 +1508,10 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_dire
           (scope := scope) (calleeName := calleeName) (args := args)
           (argExprs := argExprs) hctx helperBodySize stmtHelperFuel irFuel runtime state)
     (hresidual :
-      InternalCallWithInternalsResidualBridge runtimeContract spec fields scope
-        calleeName args argExprs helperBodySize) :
+      InternalCallWithInternalsAdditiveResidualBridge runtimeContract spec fields scope
+        calleeName args argExprs helperBodySize irFuelSlack) :
     CompiledStmtStepWithHelpersAndHelperIRWithInternals runtimeContract spec fields scope
-      (Stmt.internalCall calleeName args) compiledIR := by
+      (Stmt.internalCall calleeName args) compiledIR irFuelSlack := by
   exact
     compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_fuelSplitBridge
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -1553,10 +1555,11 @@ theorem internalCallAssignWithInternalsSufficientBridge_of_directContextEvidence
     (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
     (hnodup : (spec.functions.map (·.name)).Nodup)
     (helperBodySize : Nat)
+    {irFuelSlack : Nat := 0}
     (hevidence :
       ∀ runtime state stmtHelperFuel irFuel,
         1 < stmtHelperFuel →
-        helperBodySize + 2 ≤ irFuel →
+        helperBodySize + 2 + irFuelSlack ≤ irFuel →
         FunctionBody.bindingsExactlyMatchIRVarsOnScope scope runtime.bindings state →
         FunctionBody.scopeNamesPresent scope runtime.bindings →
         FunctionBody.bindingsBounded runtime.bindings →
@@ -1565,8 +1568,8 @@ theorem internalCallAssignWithInternalsSufficientBridge_of_directContextEvidence
           (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
           (scope := scope) (calleeName := calleeName) (args := args)
           (argExprs := argExprs) names hctx helperBodySize stmtHelperFuel irFuel runtime state) :
-    InternalCallAssignWithInternalsSufficientBridge runtimeContract spec fields scope
-      names calleeName args argExprs helperBodySize := by
+    InternalCallAssignWithInternalsAdditiveBridge runtimeContract spec fields scope
+      names calleeName args argExprs helperBodySize irFuelSlack := by
   intro runtime state stmtHelperFuel irFuel hstmtFuel hirFuel hfuel hexact hscope hbounded hruntime
   rcases hevidence runtime state stmtHelperFuel irFuel hstmtFuel hirFuel
       hexact hscope hbounded hruntime with
@@ -1590,6 +1593,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_o
     (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
     (hnodup : (spec.functions.map (·.name)).Nodup)
     (helperBodySize : Nat)
+    {irFuelSlack : Nat := 0}
     {compiledIR : List YulStmt}
     (hcompile :
       CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
@@ -1600,7 +1604,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_o
     (hevidence :
       ∀ runtime state stmtHelperFuel irFuel,
         1 < stmtHelperFuel →
-        helperBodySize + 2 ≤ irFuel →
+        helperBodySize + 2 + irFuelSlack ≤ irFuel →
         FunctionBody.bindingsExactlyMatchIRVarsOnScope scope runtime.bindings state →
         FunctionBody.scopeNamesPresent scope runtime.bindings →
         FunctionBody.bindingsBounded runtime.bindings →
@@ -1610,10 +1614,10 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_o
           (scope := scope) (calleeName := calleeName) (args := args)
           (argExprs := argExprs) names hctx helperBodySize stmtHelperFuel irFuel runtime state)
     (hresidual :
-      InternalCallAssignWithInternalsResidualBridge runtimeContract spec fields scope names
-        calleeName args argExprs helperBodySize) :
+      InternalCallAssignWithInternalsAdditiveResidualBridge runtimeContract spec fields scope names
+        calleeName args argExprs helperBodySize irFuelSlack) :
     CompiledStmtStepWithHelpersAndHelperIRWithInternals runtimeContract spec fields scope
-      (Stmt.internalCallAssign names calleeName args) compiledIR := by
+      (Stmt.internalCallAssign names calleeName args) compiledIR irFuelSlack := by
   exact
     compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_of_fuelSplitBridge
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -6994,26 +6998,27 @@ theorem fullHelperAwareListWitnessWithInternals_of_allInterfaces
     {fields : List Field}
     {scope : List String}
     {stmts : List Stmt}
+    {irFuelSlack : Nat}
     (hhelperFree :
       StmtListHelperFreeStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hcall :
       StmtListDirectInternalHelperCallStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hassign :
       StmtListDirectInternalHelperAssignStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hexpr :
       StmtListExprInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hstruct :
       StmtListStructuralInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hresidual :
       StmtListResidualHelperSurfaceStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts) :
+        runtimeContract spec fields scope stmts irFuelSlack) :
     StmtListGenericWithHelpersAndHelperIRWithInternals
-      runtimeContract spec fields scope stmts :=
+      runtimeContract spec fields scope stmts irFuelSlack :=
   stmtListGenericWithHelpersAndHelperIRWithInternals_of_helperFreeStepInterfaceWithInternals_and_directInternalHelperStepInterfaceWithInternals_and_exprInternalHelperStepInterfaceWithInternals_and_structuralInternalHelperStepInterfaceWithInternals_and_residualHelperSurfaceStepInterfaceWithInternals
     hhelperFree
     (stmtListDirectInternalHelperStepInterfaceWithInternals_of_callStepInterfaceWithInternals_and_assignStepInterfaceWithInternals

--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -868,8 +868,8 @@ theorem directInternalHelperStatementContextBridge_sourceAssignEvidence
           (if result.success then
             match names, result.returnValue with
             | [name], some value =>
-                .continue
-                  { world := result.world
+                .continue { state with
+                    world := result.world
                     bindings := SourceSemantics.bindValue state.bindings name value }
             | _, _ => .revert
           else .revert) ∧
@@ -1077,8 +1077,8 @@ abbrev directInternalHelperAssignSourceResult
   if result.success then
     match names, result.returnValue with
     | [name], some value =>
-        .continue
-          { world := result.world
+        .continue { state with
+            world := result.world
             bindings := SourceSemantics.bindValue state.bindings name value }
     | _, _ => .revert
   else .revert

--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -2137,33 +2137,123 @@ theorem exprListInternalHelperCompositionalContextResult_cons_head
   · simp [evalIRExprsWithInternals, hir, hirRest]
   exact ⟨hcompile, hsource, hir, hruntime, hpayload⟩
 
-/-- Lift a helper-bearing list of children through an arbitrary enclosing
-expression constructor once that constructor's compile/source/IR equations are
-known.  This is the generic n-ary recursion theorem; unary, binary, ternary,
-internal-call argument, intrinsic argument, ADT-constructor argument, and
-mapping-chain contexts are all instances. -/
-theorem exprInternalHelperCompositionalContextResult_of_exprList
+/-- Lift a helper-bearing list through a source/IR expression context.
+
+Unlike an unconstrained outer-expression lift, the result is indexed by
+`sourceContext children` and `irContext childrenIR`.  Thus the exact source
+children carrying the helper and their exact threaded IR compilation are
+definitionally the children used by the enclosing expressions.  Constructor-
+specific proofs only need to discharge the three ordinary outer equations. -/
+theorem exprInternalHelperCompositionalContextResult_of_exprListContext
     {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
     {children : List Expr} {childrenIR : List YulExpr} {childValues : List Nat}
-    {expr : Expr} {exprIR : YulExpr} {helperFuel irFuel : Nat}
+    (sourceContext : List Expr → Expr) (irContext : List YulExpr → YulExpr)
+    {helperFuel irFuel : Nat}
     {runtime headRuntime : SourceSemantics.RuntimeState}
     {state headState childrenFinalState finalState : IRState} {value : Nat}
     (hchildren : ExprListInternalHelperCompositionalContextResult runtimeContract spec fields
       children childrenIR helperFuel irFuel runtime headRuntime state headState
       childrenFinalState childValues)
-    (hcompile : CompilationModel.compileExprWithInternals fields .calldata spec.functions expr =
-      Except.ok exprIR)
-    (hsource : SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime expr =
-      some value)
-    (hir : evalIRExprWithInternals runtimeContract (irFuel + 1) state exprIR =
-      .value value finalState) :
+    (hcompile : CompilationModel.compileExprWithInternals fields .calldata spec.functions
+      (sourceContext children) = Except.ok (irContext childrenIR))
+    (hsource : SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime
+      (sourceContext children) = some value)
+    (hir : evalIRExprWithInternals runtimeContract (irFuel + 1) state
+      (irContext childrenIR) = .value value finalState) :
     ExprInternalHelperCompositionalContextResult runtimeContract spec fields
-      expr exprIR helperFuel irFuel runtime headRuntime state headState finalState value := by
+      (sourceContext children) (irContext childrenIR) helperFuel irFuel runtime
+      headRuntime state headState finalState value := by
   rcases hchildren with ⟨_, _, _, hruntime, pre, suffix, preIR, suffixIR,
     preValues, suffixValues, headExpr, headExprIR, headValue, headEntryState,
     headFinalState, _, _, _, hhead⟩
   rcases hhead with ⟨_, _, _, _, hpayload⟩
   exact ⟨hcompile, hsource, hir, hruntime, hpayload⟩
+
+/-- Focused non-head-sibling witness: a helper-bearing middle expression can
+be threaded between an evaluated left sibling and an evaluated right sibling.
+The source runtime is unchanged for all three expressions, while IR states are
+`state → middleEntry → middleFinal → finalState`. -/
+theorem exprListInternalHelperCompositionalContextResult_three_middle
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {left middle right : Expr} {leftIR middleIR rightIR : YulExpr}
+    {helperFuel irFuel : Nat} {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state middleEntry headState middleFinal finalState : IRState}
+    {leftValue middleValue rightValue : Nat}
+    (hcompileLeft : CompilationModel.compileExprWithInternals fields .calldata spec.functions
+      left = Except.ok leftIR)
+    (hsourceLeft : SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1)
+      runtime left = some leftValue)
+    (hirLeft : evalIRExprWithInternals runtimeContract (irFuel + 1) state leftIR =
+      .value leftValue middleEntry)
+    (hmiddle : ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      middle middleIR helperFuel irFuel runtime headRuntime middleEntry headState
+      middleFinal middleValue)
+    (hcompileRight : CompilationModel.compileExprWithInternals fields .calldata spec.functions
+      right = Except.ok rightIR)
+    (hsourceRight : SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1)
+      runtime right = some rightValue)
+    (hirRight : evalIRExprWithInternals runtimeContract (irFuel + 1) middleFinal rightIR =
+      .value rightValue finalState) :
+    ExprListInternalHelperCompositionalContextResult runtimeContract spec fields
+      [left, middle, right] [leftIR, middleIR, rightIR] helperFuel irFuel runtime
+      headRuntime state headState finalState [leftValue, middleValue, rightValue] := by
+  apply exprListInternalHelperCompositionalContextResult_cons_tail
+      hcompileLeft hsourceLeft hirLeft
+  apply exprListInternalHelperCompositionalContextResult_cons_head hmiddle
+  · simp [CompilationModel.compileExprListWithInternals, hcompileRight]
+  · simp [SourceSemantics.evalExprListWithHelpers, hsourceRight]
+  · simp [evalIRExprsWithInternals, hirRight]
+
+/-- N-ary ADT-constructor instantiation of the structurally tied context lift. -/
+theorem exprInternalHelperCompositionalContextResult_adtConstruct_args
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {typeName ctorName : String} {args : List Expr} {argsIR : List YulExpr}
+    {argValues : List Nat} (assembleIR : List YulExpr → YulExpr)
+    {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state headState argsFinalState finalState : IRState} {value : Nat}
+    (hargs : ExprListInternalHelperCompositionalContextResult runtimeContract spec fields
+      args argsIR helperFuel irFuel runtime headRuntime state headState argsFinalState argValues)
+    (hcompile : CompilationModel.compileExprWithInternals fields .calldata spec.functions
+      (.adtConstruct typeName ctorName args) = Except.ok (assembleIR argsIR))
+    (hsource : SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime
+      (.adtConstruct typeName ctorName args) = some value)
+    (hir : evalIRExprWithInternals runtimeContract (irFuel + 1) state (assembleIR argsIR) =
+      .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      (.adtConstruct typeName ctorName args) (assembleIR argsIR) helperFuel irFuel runtime
+      headRuntime state headState finalState value := by
+  exact exprInternalHelperCompositionalContextResult_of_exprListContext
+    (fun xs => .adtConstruct typeName ctorName xs) assembleIR
+    hargs hcompile hsource hir
+
+/-- Internal-call argument-context instantiation.  The exact helper-bearing
+`args` and their left-to-right compiled `argsIR` are tied to the enclosing call
+and its Yul call node. -/
+theorem exprInternalHelperCompositionalContextResult_internalCall_args
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {calleeName : String} {args : List Expr} {argsIR : List YulExpr}
+    {argValues : List Nat} {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state headState argsFinalState finalState : IRState} {value : Nat}
+    (hargs : ExprListInternalHelperCompositionalContextResult runtimeContract spec fields
+      args argsIR helperFuel irFuel runtime headRuntime state headState argsFinalState argValues)
+    (hcompile : CompilationModel.compileExprWithInternals fields .calldata spec.functions
+      (.internalCall calleeName args) =
+        Except.ok (.call (CompilationModel.internalFunctionYulName calleeName) argsIR))
+    (hsource : SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime
+      (.internalCall calleeName args) = some value)
+    (hir : evalIRExprWithInternals runtimeContract (irFuel + 1) state
+      (.call (CompilationModel.internalFunctionYulName calleeName) argsIR) =
+        .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      (.internalCall calleeName args)
+      (.call (CompilationModel.internalFunctionYulName calleeName) argsIR)
+      helperFuel irFuel runtime headRuntime state headState finalState value := by
+  exact exprInternalHelperCompositionalContextResult_of_exprListContext
+    (fun xs => .internalCall calleeName xs)
+    (fun xs => .call (CompilationModel.internalFunctionYulName calleeName) xs)
+    hargs hcompile hsource hir
 
 /-- Direct-head base case for the compositional expression-context payload. -/
 theorem exprInternalHelperCompositionalContextResult_internalCall_head

--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -2048,6 +2048,12 @@ def ExprListInternalHelperCompositionalContextResult
       exprs = pre ++ headExpr :: suffix ∧
       exprIRs = preIR ++ headExprIR :: suffixIR ∧
       values = preValues ++ headValue :: suffixValues ∧
+      CompilationModel.compileExprListWithInternals fields .calldata spec.functions pre =
+        Except.ok preIR ∧
+      SourceSemantics.evalExprListWithHelpers spec fields (helperFuel + 1) runtime pre =
+        some preValues ∧
+      evalIRExprsWithInternals runtimeContract (irFuel + 1) state preIR =
+        .values preValues headEntryState ∧
       ExprInternalHelperCompositionalContextResult runtimeContract spec fields
         headExpr headExprIR helperFuel irFuel runtime headRuntime headEntryState
         headState headFinalState headValue
@@ -2067,7 +2073,10 @@ theorem exprListInternalHelperCompositionalContextResult_singleton
       finalState [value] := by
   rcases hexpr with ⟨hcompile, hsource, hir, hruntime, hpayload⟩
   refine ⟨?_, ?_, ?_, hruntime, [], [], [], [], [], [], expr, exprIR, value,
-    state, finalState, by simp, by simp, by simp, ?_⟩
+    state, finalState, by simp, by simp, by simp,
+    by simp [CompilationModel.compileExprListWithInternals, pure, Except.pure],
+    by simp [SourceSemantics.evalExprListWithHelpers],
+    by simp [evalIRExprsWithInternals], ?_⟩
   · simp [CompilationModel.compileExprListWithInternals, hcompile]
   · simp [SourceSemantics.evalExprListWithHelpers, hsource]
   · simp [evalIRExprsWithInternals, hir]
@@ -2096,10 +2105,10 @@ theorem exprListInternalHelperCompositionalContextResult_cons_tail
   rcases hrest with ⟨hcompileRest, hsourceRest, hirRest, hruntime,
     pre, suffix, preIR, suffixIR, preValues, suffixValues,
     headExpr, headExprIR, headValue, headEntryState, headFinalState,
-    hexprs, hexprIRs, hvalues, hhead⟩
+    hexprs, hexprIRs, hvalues, hcompilePre, hsourcePre, hirPre, hhead⟩
   refine ⟨?_, ?_, ?_, hruntime, expr :: pre, suffix, exprIR :: preIR,
     suffixIR, value :: preValues, suffixValues, headExpr, headExprIR, headValue,
-    headEntryState, headFinalState, ?_, ?_, ?_, hhead⟩
+    headEntryState, headFinalState, ?_, ?_, ?_, ?_, ?_, ?_, hhead⟩
   · simp [CompilationModel.compileExprListWithInternals, hcompile, hcompileRest,
       bind, Except.bind, pure, Except.pure]
   · simp [SourceSemantics.evalExprListWithHelpers, hsource, hsourceRest]
@@ -2107,6 +2116,10 @@ theorem exprListInternalHelperCompositionalContextResult_cons_tail
   · simp [hexprs]
   · simp [hexprIRs]
   · simp [hvalues]
+  · simp [CompilationModel.compileExprListWithInternals, hcompile, hcompilePre,
+      bind, Except.bind, pure, Except.pure]
+  · simp [SourceSemantics.evalExprListWithHelpers, hsource, hsourcePre]
+  · simp [evalIRExprsWithInternals, hir, hirPre]
 
 /-- Add a helper-bearing head in front of an already-evaluated sibling tail.
 The tail starts in the helper head's final IR state, providing the dual of
@@ -2130,7 +2143,10 @@ theorem exprListInternalHelperCompositionalContextResult_cons_head
       headState finalState (value :: values) := by
   rcases hexpr with ⟨hcompile, hsource, hir, hruntime, hpayload⟩
   refine ⟨?_, ?_, ?_, hruntime, [], rest, [], restIR, [], values, expr, exprIR,
-    value, state, exprFinalState, by simp, by simp, by simp, ?_⟩
+    value, state, exprFinalState, by simp, by simp, by simp,
+    by simp [CompilationModel.compileExprListWithInternals, pure, Except.pure],
+    by simp [SourceSemantics.evalExprListWithHelpers],
+    by simp [evalIRExprsWithInternals], ?_⟩
   · simp [CompilationModel.compileExprListWithInternals, hcompile, hcompileRest,
       bind, Except.bind, pure, Except.pure]
   · simp [SourceSemantics.evalExprListWithHelpers, hsource, hsourceRest]
@@ -2165,7 +2181,7 @@ theorem exprInternalHelperCompositionalContextResult_of_exprListContext
       headRuntime state headState finalState value := by
   rcases hchildren with ⟨_, _, _, hruntime, pre, suffix, preIR, suffixIR,
     preValues, suffixValues, headExpr, headExprIR, headValue, headEntryState,
-    headFinalState, _, _, _, hhead⟩
+    headFinalState, _, _, _, _, _, _, hhead⟩
   rcases hhead with ⟨_, _, _, _, hpayload⟩
   exact ⟨hcompile, hsource, hir, hruntime, hpayload⟩
 

--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -1449,7 +1449,7 @@ theorem internalCallWithInternalsSufficientBridge_of_directContextEvidence
     (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
     (hnodup : (spec.functions.map (·.name)).Nodup)
     (helperBodySize : Nat)
-    {irFuelSlack : Nat := 0}
+    (irFuelSlack : Nat := 0)
     (hevidence :
       ∀ runtime state stmtHelperFuel irFuel,
         1 < stmtHelperFuel →
@@ -1487,7 +1487,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_dire
     (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
     (hnodup : (spec.functions.map (·.name)).Nodup)
     (helperBodySize : Nat)
-    {irFuelSlack : Nat := 0}
+    (irFuelSlack : Nat := 0)
     {compiledIR : List YulStmt}
     (hcompile :
       CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
@@ -1555,7 +1555,7 @@ theorem internalCallAssignWithInternalsSufficientBridge_of_directContextEvidence
     (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
     (hnodup : (spec.functions.map (·.name)).Nodup)
     (helperBodySize : Nat)
-    {irFuelSlack : Nat := 0}
+    (irFuelSlack : Nat := 0)
     (hevidence :
       ∀ runtime state stmtHelperFuel irFuel,
         1 < stmtHelperFuel →
@@ -1593,7 +1593,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_o
     (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)
     (hnodup : (spec.functions.map (·.name)).Nodup)
     (helperBodySize : Nat)
-    {irFuelSlack : Nat := 0}
+    (irFuelSlack : Nat := 0)
     {compiledIR : List YulStmt}
     (hcompile :
       CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []

--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -2014,6 +2014,157 @@ def ExprInternalHelperCompositionalPostStateResult
     FunctionBody.bindingsExactlyMatchIRVarsOnScope scope runtime.bindings finalState ∧
     value < Compiler.Constants.evmModulus
 
+/-- Expression-list counterpart of
+`ExprInternalHelperCompositionalContextResult`.
+
+Source expressions are all evaluated in the same (read-only) source runtime,
+whereas the compiled expressions thread their state from left to right.  The
+last conjunct retains a concrete helper-bearing member of the list, including
+the IR state at which that member starts and finishes.  Consequently this
+carrier can be nested through any expression constructor whose children are
+compiled and evaluated as an expression list; it does not require the other
+siblings, or the enclosing expression, to be helper-surface closed. -/
+def ExprListInternalHelperCompositionalContextResult
+    (runtimeContract : IRContract)
+    (spec : CompilationModel)
+    (fields : List Field)
+    (exprs : List Expr)
+    (exprIRs : List YulExpr)
+    (helperFuel irFuel : Nat)
+    (runtime headRuntime : SourceSemantics.RuntimeState)
+    (state headState finalState : IRState)
+    (values : List Nat) : Prop :=
+  CompilationModel.compileExprListWithInternals fields .calldata spec.functions exprs =
+      Except.ok exprIRs ∧
+    SourceSemantics.evalExprListWithHelpers spec fields (helperFuel + 1) runtime exprs =
+      some values ∧
+    evalIRExprsWithInternals runtimeContract (irFuel + 1) state exprIRs =
+      .values values finalState ∧
+    FunctionBody.runtimeStateMatchesIR fields headRuntime headState ∧
+    ∃ (pre suffix : List Expr) (preIR suffixIR : List YulExpr)
+        (preValues suffixValues : List Nat)
+        (headExpr : Expr) (headExprIR : YulExpr)
+        (headValue : Nat) (headEntryState headFinalState : IRState),
+      exprs = pre ++ headExpr :: suffix ∧
+      exprIRs = preIR ++ headExprIR :: suffixIR ∧
+      values = preValues ++ headValue :: suffixValues ∧
+      ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+        headExpr headExprIR helperFuel irFuel runtime headRuntime headEntryState
+        headState headFinalState headValue
+
+/-- A helper-bearing expression is a helper-bearing singleton expression list.
+The equal entry/final list states expose the precise one-element threading
+boundary for later `cons` composition. -/
+theorem exprListInternalHelperCompositionalContextResult_singleton
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {expr : Expr} {exprIR : YulExpr} {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state headState finalState : IRState} {value : Nat}
+    (hexpr : ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      expr exprIR helperFuel irFuel runtime headRuntime state headState finalState value) :
+    ExprListInternalHelperCompositionalContextResult runtimeContract spec fields
+      [expr] [exprIR] helperFuel irFuel runtime headRuntime state headState
+      finalState [value] := by
+  rcases hexpr with ⟨hcompile, hsource, hir, hruntime, hpayload⟩
+  refine ⟨?_, ?_, ?_, hruntime, [], [], [], [], [], [], expr, exprIR, value,
+    state, finalState, by simp, by simp, by simp, ?_⟩
+  · simp [CompilationModel.compileExprListWithInternals, hcompile]
+  · simp [SourceSemantics.evalExprListWithHelpers, hsource]
+  · simp [evalIRExprsWithInternals, hir]
+  exact ⟨hcompile, hsource, hir, hruntime, hpayload⟩
+
+/-- Add an already-evaluated left sibling in front of a helper-bearing tail.
+The source sibling uses the original source runtime, while its compiled result
+state is exactly the entry state used by the tail. -/
+theorem exprListInternalHelperCompositionalContextResult_cons_tail
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {expr : Expr} {rest : List Expr} {exprIR : YulExpr} {restIR : List YulExpr}
+    {helperFuel irFuel : Nat} {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state restState headState finalState : IRState}
+    {value : Nat} {values : List Nat}
+    (hcompile : CompilationModel.compileExprWithInternals fields .calldata spec.functions expr =
+      Except.ok exprIR)
+    (hsource : SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime expr =
+      some value)
+    (hir : evalIRExprWithInternals runtimeContract (irFuel + 1) state exprIR =
+      .value value restState)
+    (hrest : ExprListInternalHelperCompositionalContextResult runtimeContract spec fields
+      rest restIR helperFuel irFuel runtime headRuntime restState headState finalState values) :
+    ExprListInternalHelperCompositionalContextResult runtimeContract spec fields
+      (expr :: rest) (exprIR :: restIR) helperFuel irFuel runtime headRuntime state
+      headState finalState (value :: values) := by
+  rcases hrest with ⟨hcompileRest, hsourceRest, hirRest, hruntime,
+    pre, suffix, preIR, suffixIR, preValues, suffixValues,
+    headExpr, headExprIR, headValue, headEntryState, headFinalState,
+    hexprs, hexprIRs, hvalues, hhead⟩
+  refine ⟨?_, ?_, ?_, hruntime, expr :: pre, suffix, exprIR :: preIR,
+    suffixIR, value :: preValues, suffixValues, headExpr, headExprIR, headValue,
+    headEntryState, headFinalState, ?_, ?_, ?_, hhead⟩
+  · simp [CompilationModel.compileExprListWithInternals, hcompile, hcompileRest,
+      bind, Except.bind, pure, Except.pure]
+  · simp [SourceSemantics.evalExprListWithHelpers, hsource, hsourceRest]
+  · simp [evalIRExprsWithInternals, hir, hirRest]
+  · simp [hexprs]
+  · simp [hexprIRs]
+  · simp [hvalues]
+
+/-- Add a helper-bearing head in front of an already-evaluated sibling tail.
+The tail starts in the helper head's final IR state, providing the dual of
+`exprListInternalHelperCompositionalContextResult_cons_tail`. -/
+theorem exprListInternalHelperCompositionalContextResult_cons_head
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {expr : Expr} {rest : List Expr} {exprIR : YulExpr} {restIR : List YulExpr}
+    {helperFuel irFuel : Nat} {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state headState exprFinalState finalState : IRState}
+    {value : Nat} {values : List Nat}
+    (hexpr : ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      expr exprIR helperFuel irFuel runtime headRuntime state headState exprFinalState value)
+    (hcompileRest : CompilationModel.compileExprListWithInternals fields .calldata
+      spec.functions rest = Except.ok restIR)
+    (hsourceRest : SourceSemantics.evalExprListWithHelpers spec fields (helperFuel + 1)
+      runtime rest = some values)
+    (hirRest : evalIRExprsWithInternals runtimeContract (irFuel + 1) exprFinalState restIR =
+      .values values finalState) :
+    ExprListInternalHelperCompositionalContextResult runtimeContract spec fields
+      (expr :: rest) (exprIR :: restIR) helperFuel irFuel runtime headRuntime state
+      headState finalState (value :: values) := by
+  rcases hexpr with ⟨hcompile, hsource, hir, hruntime, hpayload⟩
+  refine ⟨?_, ?_, ?_, hruntime, [], rest, [], restIR, [], values, expr, exprIR,
+    value, state, exprFinalState, by simp, by simp, by simp, ?_⟩
+  · simp [CompilationModel.compileExprListWithInternals, hcompile, hcompileRest,
+      bind, Except.bind, pure, Except.pure]
+  · simp [SourceSemantics.evalExprListWithHelpers, hsource, hsourceRest]
+  · simp [evalIRExprsWithInternals, hir, hirRest]
+  exact ⟨hcompile, hsource, hir, hruntime, hpayload⟩
+
+/-- Lift a helper-bearing list of children through an arbitrary enclosing
+expression constructor once that constructor's compile/source/IR equations are
+known.  This is the generic n-ary recursion theorem; unary, binary, ternary,
+internal-call argument, intrinsic argument, ADT-constructor argument, and
+mapping-chain contexts are all instances. -/
+theorem exprInternalHelperCompositionalContextResult_of_exprList
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {children : List Expr} {childrenIR : List YulExpr} {childValues : List Nat}
+    {expr : Expr} {exprIR : YulExpr} {helperFuel irFuel : Nat}
+    {runtime headRuntime : SourceSemantics.RuntimeState}
+    {state headState childrenFinalState finalState : IRState} {value : Nat}
+    (hchildren : ExprListInternalHelperCompositionalContextResult runtimeContract spec fields
+      children childrenIR helperFuel irFuel runtime headRuntime state headState
+      childrenFinalState childValues)
+    (hcompile : CompilationModel.compileExprWithInternals fields .calldata spec.functions expr =
+      Except.ok exprIR)
+    (hsource : SourceSemantics.evalExprWithHelpers spec fields (helperFuel + 1) runtime expr =
+      some value)
+    (hir : evalIRExprWithInternals runtimeContract (irFuel + 1) state exprIR =
+      .value value finalState) :
+    ExprInternalHelperCompositionalContextResult runtimeContract spec fields
+      expr exprIR helperFuel irFuel runtime headRuntime state headState finalState value := by
+  rcases hchildren with ⟨_, _, _, hruntime, pre, suffix, preIR, suffixIR,
+    preValues, suffixValues, headExpr, headExprIR, headValue, headEntryState,
+    headFinalState, _, _, _, hhead⟩
+  rcases hhead with ⟨_, _, _, _, hpayload⟩
+  exact ⟨hcompile, hsource, hir, hruntime, hpayload⟩
+
 /-- Direct-head base case for the compositional expression-context payload. -/
 theorem exprInternalHelperCompositionalContextResult_internalCall_head
     {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}

--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -1062,6 +1062,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (initialWorld : Verity.ContractState)
     (htxNormalized : Function.TxContextNormalized tx)
     (bindings : List (String × Nat))
+    (irFuelSlack : Nat)
     (extraFuel : Nat)
     (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
     (hfn : fn ∈ selectorDispatchedFunctions model)
@@ -1075,7 +1076,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
     (hcompiledBodyFuel :
       (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
-        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body)
+        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body + irFuelSlack)
     (hbodyCorrect :
       SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
         runtimeContract model fn bodyStmts hSupported.helperFuel tx initialWorld
@@ -1089,12 +1090,12 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
         (genParamLoads fn.params)) :
     FunctionBody.sourceResultMatchesIRResult
       (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
-      (execIRFunctionWithInternals runtimeContract 0 irFn tx.args
+      (execIRFunctionWithInternals runtimeContract irFuelSlack irFn tx.args
         (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
   exact Function.supported_function_correct_with_helper_proofs_body_goal_with_internals
     model selectors hSupported hHelperProofs hvalidateInputs runtimeContract
     fn sel returns bodyStmts irFn tx initialWorld bindings hfn hvalidate hreturns
-    hbodyCompile hcompileFn hbind htxNormalized extraFuel hcompiledBodyFuel
+    hbodyCompile hcompileFn hbind htxNormalized irFuelSlack extraFuel hcompiledBodyFuel
     hbodyCorrect hparamDisjoint hcalldataSizeFits
 
 /-- Packaged helper-aware compiled-side wrapper that discharges the ABI
@@ -1150,7 +1151,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
         (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
   compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal
     model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
-    bodyStmts irFn tx initialWorld htxNormalized bindings extraFuel hcalldataSizeFits hfn
+    bodyStmts irFn tx initialWorld htxNormalized bindings 0 extraFuel hcalldataSizeFits hfn
     hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
     (Function.genParamLoads_callsDisjoint_of_internalNamesPrefixed runtimeContract fn.params
       (supported_params_of_supportedSpec model selectors hSupported fn hfn) hinv)
@@ -1209,7 +1210,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
         (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
   compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal
     model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
-    bodyStmts irFn tx initialWorld htxNormalized bindings extraFuel hcalldataSizeFits hfn
+    bodyStmts irFn tx initialWorld htxNormalized bindings 0 extraFuel hcalldataSizeFits hfn
     hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
     (Function.genParamLoads_callsDisjoint_of_reserved runtimeContract fn.params
       (supported_params_of_supportedSpec model selectors hSupported fn hfn) hinv)
@@ -2763,14 +2764,15 @@ theorem compile_preserves_semantics_with_helper_proofs_and_helper_ir
     (htxNormalized : Function.TxContextNormalized tx)
     (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
     (hcompile : CompilationModel.compile model selectors = Except.ok ir)
+    (irFuelSlack : Nat := 0)
     (hhelperIR :
-      interpretIRWithInternals ir 0 tx
+      interpretIRWithInternals ir irFuelSlack tx
         (FunctionBody.initialIRStateForTx model tx initialWorld) =
       interpretIR ir tx
         (FunctionBody.initialIRStateForTx model tx initialWorld)) :
     FunctionBody.sourceResultMatchesIRResult
       (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
-      (interpretIRWithInternals ir 0 tx
+      (interpretIRWithInternals ir irFuelSlack tx
         (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
   have hlegacy :=
     compile_preserves_semantics_with_helper_proofs

--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -1062,6 +1062,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (initialWorld : Verity.ContractState)
     (htxNormalized : Function.TxContextNormalized tx)
     (bindings : List (String × Nat))
+    (internalFunctions : List FunctionSpec)
     (irFuelSlack : Nat)
     (extraFuel : Nat)
     (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
@@ -1070,9 +1071,10 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (hreturns : functionReturns fn = Except.ok returns)
     (hbodyCompile :
       compileStmtList model.fields model.events model.errors .calldata [] false
-        (fn.params.map (·.name)) [] fn.body = Except.ok bodyStmts)
+        (fn.params.map (·.name)) [] fn.body internalFunctions = Except.ok bodyStmts)
     (hcompileFn :
-      compileFunctionSpec model.fields model.events model.errors [] sel fn = Except.ok irFn)
+      compileFunctionSpec model.fields model.events model.errors [] sel fn
+        (internalFunctions := internalFunctions) = Except.ok irFn)
     (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
     (hcompiledBodyFuel :
       (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
@@ -1094,7 +1096,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
         (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
   exact Function.supported_function_correct_with_helper_proofs_body_goal_with_internals
     model selectors hSupported hHelperProofs hvalidateInputs runtimeContract
-    fn sel returns bodyStmts irFn tx initialWorld bindings hfn hvalidate hreturns
+    fn sel returns bodyStmts irFn tx initialWorld bindings internalFunctions hfn hvalidate hreturns
     hbodyCompile hcompileFn hbind htxNormalized irFuelSlack extraFuel hcompiledBodyFuel
     hbodyCorrect hparamDisjoint hcalldataSizeFits
 
@@ -1122,6 +1124,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (initialWorld : Verity.ContractState)
     (htxNormalized : Function.TxContextNormalized tx)
     (bindings : List (String × Nat))
+    (internalFunctions : List FunctionSpec)
     (irFuelSlack : Nat)
     (extraFuel : Nat)
     (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
@@ -1130,9 +1133,10 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (hreturns : functionReturns fn = Except.ok returns)
     (hbodyCompile :
       compileStmtList model.fields model.events model.errors .calldata [] false
-        (fn.params.map (·.name)) [] fn.body = Except.ok bodyStmts)
+        (fn.params.map (·.name)) [] fn.body internalFunctions = Except.ok bodyStmts)
     (hcompileFn :
-      compileFunctionSpec model.fields model.events model.errors [] sel fn = Except.ok irFn)
+      compileFunctionSpec model.fields model.events model.errors [] sel fn
+        (internalFunctions := internalFunctions) = Except.ok irFn)
     (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
     (hcompiledBodyFuel :
       (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
@@ -1152,7 +1156,8 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
         (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
   compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal
     model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
-    bodyStmts irFn tx initialWorld htxNormalized bindings irFuelSlack extraFuel hcalldataSizeFits hfn
+    bodyStmts irFn tx initialWorld htxNormalized bindings internalFunctions irFuelSlack extraFuel
+    hcalldataSizeFits hfn
     hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
     (Function.genParamLoads_callsDisjoint_of_internalNamesPrefixed runtimeContract fn.params
       (supported_params_of_supportedSpec model selectors hSupported fn hfn) hinv)
@@ -1182,6 +1187,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (initialWorld : Verity.ContractState)
     (htxNormalized : Function.TxContextNormalized tx)
     (bindings : List (String × Nat))
+    (internalFunctions : List FunctionSpec)
     (irFuelSlack : Nat)
     (extraFuel : Nat)
     (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
@@ -1190,9 +1196,10 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (hreturns : functionReturns fn = Except.ok returns)
     (hbodyCompile :
       compileStmtList model.fields model.events model.errors .calldata [] false
-        (fn.params.map (·.name)) [] fn.body = Except.ok bodyStmts)
+        (fn.params.map (·.name)) [] fn.body internalFunctions = Except.ok bodyStmts)
     (hcompileFn :
-      compileFunctionSpec model.fields model.events model.errors [] sel fn = Except.ok irFn)
+      compileFunctionSpec model.fields model.events model.errors [] sel fn
+        (internalFunctions := internalFunctions) = Except.ok irFn)
     (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
     (hcompiledBodyFuel :
       (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
@@ -1212,7 +1219,8 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
         (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
   compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal
     model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
-    bodyStmts irFn tx initialWorld htxNormalized bindings irFuelSlack extraFuel hcalldataSizeFits hfn
+    bodyStmts irFn tx initialWorld htxNormalized bindings internalFunctions irFuelSlack extraFuel
+    hcalldataSizeFits hfn
     hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
     (Function.genParamLoads_callsDisjoint_of_reserved runtimeContract fn.params
       (supported_params_of_supportedSpec model selectors hSupported fn hfn) hinv)
@@ -1278,7 +1286,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
         (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
   compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed
     model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
-    bodyStmts irFn tx initialWorld htxNormalized bindings irFuelSlack extraFuel hcalldataSizeFits hfn
+    bodyStmts irFn tx initialWorld htxNormalized bindings [] irFuelSlack extraFuel hcalldataSizeFits hfn
     hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
     (Function.InternalTableNamesInternalPrefixed_of_all_compiledInternal runtimeContract
       hcompiledTable)
@@ -2222,7 +2230,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
         (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
   compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_reserved
     model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
-    bodyStmts irFn tx initialWorld htxNormalized bindings irFuelSlack extraFuel hcalldataSizeFits hfn
+    bodyStmts irFn tx initialWorld htxNormalized bindings [] irFuelSlack extraFuel hcalldataSizeFits hfn
     hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
     (InternalTableNamesReserved_of_compileValidatedCore model selectors runtimeContract hcore)
 

--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -3001,6 +3001,61 @@ theorem compile_preserves_semantics_with_helper_proofs_and_helper_ir_closed
     (hlegacyIR := hlegacyIR)
     (hhelperIRGoal := interpretIRWithInternalsZeroConservativeExtensionGoal_closed ir)
 
+/-- Contract-facing wrapper for the helper-rich Function support boundary.
+The caller supplies the exact helper-aware body/IR preservation goal, while
+parameter support and helper fuel come from `SupportedSpecWithHelpers`. -/
+theorem compileFunctionSpec_correct_with_helper_rich_support_of_body_goal
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpecWithHelpers model selectors)
+    (hvalidateInputs : validateCompileInputs model selectors = Except.ok ())
+    (runtimeContract : IRContract)
+    (fn : FunctionSpec)
+    (sel : Nat)
+    (returns : List ParamType)
+    (bodyStmts : List YulStmt)
+    (irFn : IRFunction)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (htxNormalized : Function.TxContextNormalized tx)
+    (bindings : List (String × Nat))
+    (internalFunctions : List FunctionSpec)
+    (irFuelSlack extraFuel : Nat)
+    (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
+    (hfn : fn ∈ selectorDispatchedFunctions model)
+    (hvalidate : validateFunctionSpec fn = Except.ok ())
+    (hreturns : functionReturns fn = Except.ok returns)
+    (hbodyCompile :
+      compileStmtList model.fields model.events model.errors .calldata [] false
+        (fn.params.map (·.name)) [] fn.body internalFunctions = Except.ok bodyStmts)
+    (hcompileFn :
+      compileFunctionSpec model.fields model.events model.errors [] sel fn
+        (internalFunctions := internalFunctions) = Except.ok irFn)
+    (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
+    (hcompiledBodyFuel :
+      (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
+        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body + irFuelSlack)
+    (hbodyCorrect :
+      SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
+        runtimeContract model fn bodyStmts hSupported.helperFuel tx initialWorld
+        (ParamLoading.applyBindingsToIRState
+          (Function.prebindRawArgs
+            (FunctionBody.initialIRStateForTx model tx initialWorld) fn.params)
+          bindings)
+        bindings extraFuel)
+    (hparamDisjoint :
+      YulStmtListCallsDisjointFromInternalTable runtimeContract (genParamLoads fn.params)) :
+    FunctionBody.sourceResultMatchesIRResult
+      (supportedSourceFunctionSemanticsWithHelpers
+        model selectors hSupported fn tx initialWorld)
+      (execIRFunctionWithInternals runtimeContract irFuelSlack irFn tx.args
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  exact Function.supported_function_correct_with_helper_rich_support_body_goal_with_internals
+    model selectors hSupported hvalidateInputs runtimeContract fn sel returns bodyStmts irFn
+    tx initialWorld bindings internalFunctions hfn hvalidate hreturns hbodyCompile hcompileFn
+    hbind htxNormalized irFuelSlack extraFuel hcompiledBodyFuel hbodyCorrect hparamDisjoint
+    hcalldataSizeFits
+
 /-- First direct consumer of the generic Layer 2 theorem surface: the existing
 supported single-function demo model can now obtain whole-contract correctness
 by instantiating `compile_preserves_semantics`, with no contract-specific body

--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -1122,6 +1122,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (initialWorld : Verity.ContractState)
     (htxNormalized : Function.TxContextNormalized tx)
     (bindings : List (String × Nat))
+    (irFuelSlack : Nat)
     (extraFuel : Nat)
     (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
     (hfn : fn ∈ selectorDispatchedFunctions model)
@@ -1135,7 +1136,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
     (hcompiledBodyFuel :
       (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
-        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body)
+        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body + irFuelSlack)
     (hbodyCorrect :
       SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
         runtimeContract model fn bodyStmts hSupported.helperFuel tx initialWorld
@@ -1147,11 +1148,11 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (hinv : InternalTableNamesInternalPrefixed runtimeContract) :
     FunctionBody.sourceResultMatchesIRResult
       (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
-      (execIRFunctionWithInternals runtimeContract 0 irFn tx.args
+      (execIRFunctionWithInternals runtimeContract irFuelSlack irFn tx.args
         (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
   compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal
     model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
-    bodyStmts irFn tx initialWorld htxNormalized bindings 0 extraFuel hcalldataSizeFits hfn
+    bodyStmts irFn tx initialWorld htxNormalized bindings irFuelSlack extraFuel hcalldataSizeFits hfn
     hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
     (Function.genParamLoads_callsDisjoint_of_internalNamesPrefixed runtimeContract fn.params
       (supported_params_of_supportedSpec model selectors hSupported fn hfn) hinv)
@@ -1181,6 +1182,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (initialWorld : Verity.ContractState)
     (htxNormalized : Function.TxContextNormalized tx)
     (bindings : List (String × Nat))
+    (irFuelSlack : Nat)
     (extraFuel : Nat)
     (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
     (hfn : fn ∈ selectorDispatchedFunctions model)
@@ -1194,7 +1196,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
     (hcompiledBodyFuel :
       (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
-        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body)
+        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body + irFuelSlack)
     (hbodyCorrect :
       SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
         runtimeContract model fn bodyStmts hSupported.helperFuel tx initialWorld
@@ -1206,11 +1208,11 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (hinv : InternalTableNamesReserved runtimeContract) :
     FunctionBody.sourceResultMatchesIRResult
       (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
-      (execIRFunctionWithInternals runtimeContract 0 irFn tx.args
+      (execIRFunctionWithInternals runtimeContract irFuelSlack irFn tx.args
         (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
   compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal
     model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
-    bodyStmts irFn tx initialWorld htxNormalized bindings 0 extraFuel hcalldataSizeFits hfn
+    bodyStmts irFn tx initialWorld htxNormalized bindings irFuelSlack extraFuel hcalldataSizeFits hfn
     hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
     (Function.genParamLoads_callsDisjoint_of_reserved runtimeContract fn.params
       (supported_params_of_supportedSpec model selectors hSupported fn hfn) hinv)
@@ -1240,6 +1242,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (initialWorld : Verity.ContractState)
     (htxNormalized : Function.TxContextNormalized tx)
     (bindings : List (String × Nat))
+    (irFuelSlack : Nat)
     (extraFuel : Nat)
     (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
     (hfn : fn ∈ selectorDispatchedFunctions model)
@@ -1253,7 +1256,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
     (hcompiledBodyFuel :
       (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
-        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body)
+        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body + irFuelSlack)
     (hbodyCorrect :
       SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
         runtimeContract model fn bodyStmts hSupported.helperFuel tx initialWorld
@@ -1271,11 +1274,11 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
             = Except.ok stmt) :
     FunctionBody.sourceResultMatchesIRResult
       (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
-      (execIRFunctionWithInternals runtimeContract 0 irFn tx.args
+      (execIRFunctionWithInternals runtimeContract irFuelSlack irFn tx.args
         (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
   compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_internalNamesPrefixed
     model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
-    bodyStmts irFn tx initialWorld htxNormalized bindings extraFuel hcalldataSizeFits hfn
+    bodyStmts irFn tx initialWorld htxNormalized bindings irFuelSlack extraFuel hcalldataSizeFits hfn
     hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
     (Function.InternalTableNamesInternalPrefixed_of_all_compiledInternal runtimeContract
       hcompiledTable)
@@ -2190,6 +2193,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (initialWorld : Verity.ContractState)
     (htxNormalized : Function.TxContextNormalized tx)
     (bindings : List (String × Nat))
+    (irFuelSlack : Nat)
     (extraFuel : Nat)
     (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
     (hfn : fn ∈ selectorDispatchedFunctions model)
@@ -2203,7 +2207,7 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
     (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
     (hcompiledBodyFuel :
       (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
-        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body)
+        sizeOf (Function.compiledFunctionIR sel fn returns bodyStmts).body + irFuelSlack)
     (hbodyCorrect :
       SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
         runtimeContract model fn bodyStmts hSupported.helperFuel tx initialWorld
@@ -2214,11 +2218,11 @@ theorem compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_
         bindings extraFuel) :
     FunctionBody.sourceResultMatchesIRResult
       (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
-      (execIRFunctionWithInternals runtimeContract 0 irFn tx.args
+      (execIRFunctionWithInternals runtimeContract irFuelSlack irFn tx.args
         (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
   compileFunctionSpec_correct_generic_with_helper_proofs_and_helper_ir_of_body_goal_of_reserved
     model selectors hSupported hHelperProofs hvalidateInputs runtimeContract fn sel returns
-    bodyStmts irFn tx initialWorld htxNormalized bindings extraFuel hcalldataSizeFits hfn
+    bodyStmts irFn tx initialWorld htxNormalized bindings irFuelSlack extraFuel hcalldataSizeFits hfn
     hvalidate hreturns hbodyCompile hcompileFn hbind hcompiledBodyFuel hbodyCorrect
     (InternalTableNamesReserved_of_compileValidatedCore model selectors runtimeContract hcore)
 

--- a/Compiler/Proofs/IRGeneration/ContractFeatureTest.lean
+++ b/Compiler/Proofs/IRGeneration/ContractFeatureTest.lean
@@ -579,7 +579,7 @@ private theorem constructorOnly_compileBody_empty_surfaces_withFork :
   rcases hhead with ⟨headIR, hhead⟩
   rcases htail with ⟨tailIR, htail⟩
   exact ⟨headIR ++ tailIR,
-    FunctionBody.compileStmtListWithFork_cons_eq_ok _ _ _ _ _ _ _ _ _ _ _ _ hhead htail⟩
+    FunctionBody.compileStmtListWithFork_cons_eq_ok _ _ _ _ _ _ _ _ _ _ _ _ _ hhead htail⟩
 
 private theorem constructorOnly_compileBody :
     ∃ bodyStmts,

--- a/Compiler/Proofs/IRGeneration/Dispatch.lean
+++ b/Compiler/Proofs/IRGeneration/Dispatch.lean
@@ -75,18 +75,19 @@ private theorem bindSupportedParams_some_of_supported
 private theorem find_compiledFunction_some_of_forall₂
     (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
     (selector : Nat)
+    (internalFunctions : List FunctionSpec := [])
     {pairs : List (FunctionSpec × Nat)} {irFns : List IRFunction}
     (hcompiled :
       List.Forall₂
         (fun entry irFn =>
-          compileFunctionSpec fields events errors [] entry.2 entry.1 = Except.ok irFn)
+          compileFunctionSpec fields events errors [] entry.2 entry.1 internalFunctions = Except.ok irFn)
         pairs irFns)
     {fn : FunctionSpec} {sel : Nat}
     (hfind :
       pairs.find? (fun entry => entry.2 == selector) = some (fn, sel)) :
     ∃ irFn,
       irFns.find? (fun irFn => irFn.selector == selector) = some irFn ∧
-      compileFunctionSpec fields events errors [] sel fn = Except.ok irFn := by
+      compileFunctionSpec fields events errors [] sel fn internalFunctions = Except.ok irFn := by
   induction hcompiled generalizing fn sel with
   | nil =>
       simp at hfind
@@ -95,14 +96,14 @@ private theorem find_compiledFunction_some_of_forall₂
       by_cases hselEq : headSel = selector
       · simp [hselEq] at hfind
         rcases hfind with ⟨rfl, rfl⟩
-        have hhead' : compileFunctionSpec fields events errors [] selector headFn = Except.ok irFn := by
+        have hhead' : compileFunctionSpec fields events errors [] selector headFn internalFunctions = Except.ok irFn := by
           simpa [hselEq] using hhead
         refine ⟨irFn, ?_, hhead'⟩
         have hselector : irFn.selector = selector := by
           calc
             irFn.selector = headSel :=
-              Function.compileFunctionSpec_ok_selector
-                fields events errors headSel headFn irFn hhead
+              (Function.compileFunctionSpec_ok_metadata_with_internals
+                fields events errors headSel headFn irFn internalFunctions hhead).2.1
             _ = selector := hselEq
         simp [hselector]
       · have hfindRest :
@@ -111,18 +112,19 @@ private theorem find_compiledFunction_some_of_forall₂
         rcases ih hfindRest with ⟨irFn', hfindIr, hcompile⟩
         refine ⟨irFn', ?_, hcompile⟩
         have hheadSelector : irFn.selector = headSel := by
-          exact Function.compileFunctionSpec_ok_selector
-            fields events errors headSel headFn irFn hhead
+          exact (Function.compileFunctionSpec_ok_metadata_with_internals
+            fields events errors headSel headFn irFn internalFunctions hhead).2.1
         simp [hselEq, hheadSelector, hfindIr]
 
 private theorem find_compiledFunction_none_of_forall₂
     (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
     (selector : Nat)
+    (internalFunctions : List FunctionSpec := [])
     {pairs : List (FunctionSpec × Nat)} {irFns : List IRFunction}
     (hcompiled :
       List.Forall₂
         (fun entry irFn =>
-          compileFunctionSpec fields events errors [] entry.2 entry.1 = Except.ok irFn)
+          compileFunctionSpec fields events errors [] entry.2 entry.1 internalFunctions = Except.ok irFn)
         pairs irFns)
     (hfind :
       pairs.find? (fun entry => entry.2 == selector) = none) :
@@ -137,8 +139,8 @@ private theorem find_compiledFunction_none_of_forall₂
       · have hfindRest : pairs.find? (fun entry => entry.2 == selector) = none := by
           simpa [hselEq] using hfind
         have hheadSelector : irFn.selector = headSel := by
-          exact Function.compileFunctionSpec_ok_selector
-            fields events errors headSel headFn irFn hhead
+          exact (Function.compileFunctionSpec_ok_metadata_with_internals
+            fields events errors headSel headFn irFn internalFunctions hhead).2.1
         simp [hselEq, hheadSelector, ih hfindRest]
 
 theorem interpretContract_correct_of_compiled_functions
@@ -204,7 +206,7 @@ theorem interpretContract_correct_of_compiled_functions
       have hfindIr :
           irFns.find? (fun irFn => irFn.selector == tx.functionSelector) = none :=
         find_compiledFunction_none_of_forall₂
-          model.fields model.events model.errors tx.functionSelector hcompiled hfindPairs
+          model.fields model.events model.errors tx.functionSelector [] hcompiled hfindPairs
       rw [hinterp, hfindIr]
       simp [hfindPairs, FunctionBody.sourceResultMatchesIRResult,
         SourceSemantics.revertedResult, FunctionBody.initialIRStateForTx,
@@ -213,7 +215,7 @@ theorem interpretContract_correct_of_compiled_functions
   | some pair =>
       rcases pair with ⟨fn, sel⟩
       rcases find_compiledFunction_some_of_forall₂
-          model.fields model.events model.errors tx.functionSelector hcompiled hfindPairs with
+          model.fields model.events model.errors tx.functionSelector [] hcompiled hfindPairs with
         ⟨irFn, hfindIr, hcompileFn⟩
       have hpairMem : (fn, sel) ∈ pairs := List.mem_of_find?_eq_some hfindPairs
       have hfnMem : fn ∈ selectorDispatchedFunctions model := by
@@ -344,7 +346,7 @@ theorem interpretContractWithInternals_correct_of_compiled_functions
       have hfindIr :
           irFns.find? (fun irFn => irFn.selector == tx.functionSelector) = none :=
         find_compiledFunction_none_of_forall₂
-          model.fields model.events model.errors tx.functionSelector hcompiled hfindPairs
+          model.fields model.events model.errors tx.functionSelector [] hcompiled hfindPairs
       rw [hinterp, hfindIr]
       simp [hfindPairs, FunctionBody.sourceResultMatchesIRResult,
         SourceSemantics.revertedResult, FunctionBody.initialIRStateForTx,
@@ -353,7 +355,7 @@ theorem interpretContractWithInternals_correct_of_compiled_functions
   | some pair =>
       rcases pair with ⟨fn, sel⟩
       rcases find_compiledFunction_some_of_forall₂
-          model.fields model.events model.errors tx.functionSelector hcompiled hfindPairs with
+          model.fields model.events model.errors tx.functionSelector [] hcompiled hfindPairs with
         ⟨irFn, hfindIr, hcompileFn⟩
       have hpairMem : (fn, sel) ∈ pairs := List.mem_of_find?_eq_some hfindPairs
       have hfnMem : fn ∈ selectorDispatchedFunctions model := by
@@ -427,7 +429,8 @@ theorem interpretContractWithHelpersWithInternals_correct_of_compiled_functions
     (hfunctions : runtimeContract.functions = irFns)
     (hcompiled :
       List.Forall₂
-        (fun entry irFn => compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1 = Except.ok irFn)
+        (fun entry irFn => compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1
+          (model.functions.filter (·.isInternal)) = Except.ok irFn)
         (SourceSemantics.selectorFunctionPairs model selectors)
         irFns)
     (hparamsSupported :
@@ -436,7 +439,8 @@ theorem interpretContractWithHelpersWithInternals_correct_of_compiled_functions
     (hfunction :
       ∀ fn sel irFn bindings,
         fn ∈ selectorDispatchedFunctions model →
-        compileFunctionSpec model.fields model.events model.errors [] sel fn = Except.ok irFn →
+        compileFunctionSpec model.fields model.events model.errors [] sel fn
+          (model.functions.filter (·.isInternal)) = Except.ok irFn →
         SourceSemantics.bindSupportedParams fn.params tx.args = some bindings →
         FunctionBody.sourceResultMatchesIRResult
           (SourceSemantics.interpretFunctionWithHelpers model helperFuel fn tx initialWorld)
@@ -490,7 +494,8 @@ theorem interpretContractWithHelpersWithInternals_correct_of_compiled_functions
       have hfindIr :
           irFns.find? (fun irFn => irFn.selector == tx.functionSelector) = none :=
         find_compiledFunction_none_of_forall₂
-          model.fields model.events model.errors tx.functionSelector hcompiled hfindPairs
+          model.fields model.events model.errors tx.functionSelector
+          (model.functions.filter (·.isInternal)) hcompiled hfindPairs
       rw [hinterp, hfindIr]
       simp [hfindPairs, FunctionBody.sourceResultMatchesIRResult,
         SourceSemantics.revertedResult, FunctionBody.initialIRStateForTx,
@@ -499,19 +504,19 @@ theorem interpretContractWithHelpersWithInternals_correct_of_compiled_functions
   | some pair =>
       rcases pair with ⟨fn, sel⟩
       rcases find_compiledFunction_some_of_forall₂
-          model.fields model.events model.errors tx.functionSelector hcompiled hfindPairs with
+          model.fields model.events model.errors tx.functionSelector
+          (model.functions.filter (·.isInternal)) hcompiled hfindPairs with
         ⟨irFn, hfindIr, hcompileFn⟩
       have hpairMem : (fn, sel) ∈ pairs := List.mem_of_find?_eq_some hfindPairs
       have hfnMem : fn ∈ selectorDispatchedFunctions model := by
         simpa [pairs, SourceSemantics.selectorFunctionPairs] using (List.of_mem_zip hpairMem).1
-      have hparamsEq : irFn.params = fn.params.map Param.toIRParam :=
-        Function.compileFunctionSpec_ok_params
-          model.fields model.events model.errors sel fn irFn hcompileFn
+      have hmetadata := Function.compileFunctionSpec_ok_metadata_with_internals
+        model.fields model.events model.errors sel fn irFn
+        (model.functions.filter (·.isInternal)) hcompileFn
+      have hparamsEq : irFn.params = fn.params.map Param.toIRParam := hmetadata.1
       have hlenEq : irFn.params.length = fn.params.length := by
         simpa [hparamsEq]
-      have hpayableEq : irFn.payable = fn.isPayable :=
-        Function.compileFunctionSpec_ok_payable
-          model.fields model.events model.errors sel fn irFn hcompileFn
+      have hpayableEq : irFn.payable = fn.isPayable := hmetadata.2.2
       by_cases hguard :
           (!fn.isPayable && tx.msgValue % Compiler.Constants.evmModulus != 0) = true
       · have hguardIr :
@@ -568,12 +573,14 @@ theorem interpretContractWithInternals_correct_of_compiled_functions_with_helper
     (hfunctions : runtimeContract.functions = irFns)
     (hcompiled :
       List.Forall₂
-        (fun entry irFn => compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1 = Except.ok irFn)
+        (fun entry irFn => compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1
+          (model.functions.filter (·.isInternal)) = Except.ok irFn)
         (SourceSemantics.selectorFunctionPairs model selectors) irFns)
     (hfunction :
       ∀ fn sel irFn bindings,
         fn ∈ selectorDispatchedFunctions model →
-        compileFunctionSpec model.fields model.events model.errors [] sel fn = Except.ok irFn →
+        compileFunctionSpec model.fields model.events model.errors [] sel fn
+          (model.functions.filter (·.isInternal)) = Except.ok irFn →
         SourceSemantics.bindSupportedParams fn.params tx.args = some bindings →
         FunctionBody.sourceResultMatchesIRResult
           (supportedSourceFunctionSemanticsWithHelpers

--- a/Compiler/Proofs/IRGeneration/Dispatch.lean
+++ b/Compiler/Proofs/IRGeneration/Dispatch.lean
@@ -80,14 +80,16 @@ private theorem find_compiledFunction_some_of_forall₂
     (hcompiled :
       List.Forall₂
         (fun entry irFn =>
-          compileFunctionSpec fields events errors [] entry.2 entry.1 internalFunctions = Except.ok irFn)
+          compileFunctionSpec fields events errors [] entry.2 entry.1
+            (internalFunctions := internalFunctions) = Except.ok irFn)
         pairs irFns)
     {fn : FunctionSpec} {sel : Nat}
     (hfind :
       pairs.find? (fun entry => entry.2 == selector) = some (fn, sel)) :
     ∃ irFn,
       irFns.find? (fun irFn => irFn.selector == selector) = some irFn ∧
-      compileFunctionSpec fields events errors [] sel fn internalFunctions = Except.ok irFn := by
+      compileFunctionSpec fields events errors [] sel fn
+        (internalFunctions := internalFunctions) = Except.ok irFn := by
   induction hcompiled generalizing fn sel with
   | nil =>
       simp at hfind
@@ -96,7 +98,8 @@ private theorem find_compiledFunction_some_of_forall₂
       by_cases hselEq : headSel = selector
       · simp [hselEq] at hfind
         rcases hfind with ⟨rfl, rfl⟩
-        have hhead' : compileFunctionSpec fields events errors [] selector headFn internalFunctions = Except.ok irFn := by
+        have hhead' : compileFunctionSpec fields events errors [] selector headFn
+            (internalFunctions := internalFunctions) = Except.ok irFn := by
           simpa [hselEq] using hhead
         refine ⟨irFn, ?_, hhead'⟩
         have hselector : irFn.selector = selector := by
@@ -124,7 +127,8 @@ private theorem find_compiledFunction_none_of_forall₂
     (hcompiled :
       List.Forall₂
         (fun entry irFn =>
-          compileFunctionSpec fields events errors [] entry.2 entry.1 internalFunctions = Except.ok irFn)
+          compileFunctionSpec fields events errors [] entry.2 entry.1
+            (internalFunctions := internalFunctions) = Except.ok irFn)
         pairs irFns)
     (hfind :
       pairs.find? (fun entry => entry.2 == selector) = none) :
@@ -430,7 +434,7 @@ theorem interpretContractWithHelpersWithInternals_correct_of_compiled_functions
     (hcompiled :
       List.Forall₂
         (fun entry irFn => compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1
-          (model.functions.filter (·.isInternal)) = Except.ok irFn)
+          (internalFunctions := model.functions.filter (·.isInternal)) = Except.ok irFn)
         (SourceSemantics.selectorFunctionPairs model selectors)
         irFns)
     (hparamsSupported :
@@ -440,7 +444,7 @@ theorem interpretContractWithHelpersWithInternals_correct_of_compiled_functions
       ∀ fn sel irFn bindings,
         fn ∈ selectorDispatchedFunctions model →
         compileFunctionSpec model.fields model.events model.errors [] sel fn
-          (model.functions.filter (·.isInternal)) = Except.ok irFn →
+          (internalFunctions := model.functions.filter (·.isInternal)) = Except.ok irFn →
         SourceSemantics.bindSupportedParams fn.params tx.args = some bindings →
         FunctionBody.sourceResultMatchesIRResult
           (SourceSemantics.interpretFunctionWithHelpers model helperFuel fn tx initialWorld)
@@ -574,13 +578,13 @@ theorem interpretContractWithInternals_correct_of_compiled_functions_with_helper
     (hcompiled :
       List.Forall₂
         (fun entry irFn => compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1
-          (model.functions.filter (·.isInternal)) = Except.ok irFn)
+          (internalFunctions := model.functions.filter (·.isInternal)) = Except.ok irFn)
         (SourceSemantics.selectorFunctionPairs model selectors) irFns)
     (hfunction :
       ∀ fn sel irFn bindings,
         fn ∈ selectorDispatchedFunctions model →
         compileFunctionSpec model.fields model.events model.errors [] sel fn
-          (model.functions.filter (·.isInternal)) = Except.ok irFn →
+          (internalFunctions := model.functions.filter (·.isInternal)) = Except.ok irFn →
         SourceSemantics.bindSupportedParams fn.params tx.args = some bindings →
         FunctionBody.sourceResultMatchesIRResult
           (supportedSourceFunctionSemanticsWithHelpers

--- a/Compiler/Proofs/IRGeneration/Dispatch.lean
+++ b/Compiler/Proofs/IRGeneration/Dispatch.lean
@@ -271,6 +271,146 @@ theorem interpretContract_correct_of_compiled_functions
             FunctionBody.encodeStorage_withTransactionContext,
             FunctionBody.encodeEvents_withTransactionContext]
 
+theorem interpretContractWithInternals_correct_of_compiled_functions
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (runtimeContract : IRContract)
+    (irFuelSlack : Nat)
+    (irFns : List IRFunction)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (hfunctions : runtimeContract.functions = irFns)
+    (hcompiled :
+      List.Forall₂
+        (fun entry irFn => compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1 = Except.ok irFn)
+        (SourceSemantics.selectorFunctionPairs model selectors)
+        irFns)
+    (hparamsSupported :
+      ∀ fn ∈ selectorDispatchedFunctions model,
+        ∀ param ∈ fn.params, SupportedExternalParamType param.ty)
+    (hfunction :
+      ∀ fn sel irFn bindings,
+        fn ∈ selectorDispatchedFunctions model →
+        compileFunctionSpec model.fields model.events model.errors [] sel fn = Except.ok irFn →
+        SourceSemantics.bindSupportedParams fn.params tx.args = some bindings →
+        FunctionBody.sourceResultMatchesIRResult
+          (SourceSemantics.interpretFunction model fn tx initialWorld)
+          (execIRFunctionWithInternals runtimeContract irFuelSlack irFn tx.args
+            (FunctionBody.initialIRStateForTx model tx initialWorld))) :
+    FunctionBody.sourceResultMatchesIRResult
+      (SourceSemantics.interpretContract model selectors tx initialWorld)
+      (interpretIRWithInternals runtimeContract irFuelSlack tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  let pairs := SourceSemantics.selectorFunctionPairs model selectors
+  have hstate :
+      applyIRTransactionContext tx (FunctionBody.initialIRStateForTx model tx initialWorld) =
+        FunctionBody.initialIRStateForTx model tx initialWorld := by
+    rfl
+  have hinterp :
+      interpretIRWithInternals runtimeContract irFuelSlack tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld) =
+      match irFns.find? (fun irFn => irFn.selector == tx.functionSelector) with
+      | some irFn =>
+          if !irFn.payable && tx.msgValue % Compiler.Constants.evmModulus != 0 then
+            { success := false
+              returnValue := none
+              finalStorage := (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              finalMappings := Compiler.Proofs.storageAsMappings
+                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              events := (FunctionBody.initialIRStateForTx model tx initialWorld).events }
+          else if irFn.params.length ≤ tx.args.length then
+            execIRFunctionWithInternals runtimeContract irFuelSlack irFn tx.args
+              (FunctionBody.initialIRStateForTx model tx initialWorld)
+          else
+            { success := false
+              returnValue := none
+              finalStorage := (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              finalMappings := Compiler.Proofs.storageAsMappings
+                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              events := (FunctionBody.initialIRStateForTx model tx initialWorld).events }
+      | none =>
+          { success := false
+            returnValue := none
+            finalStorage := (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+            finalMappings := Compiler.Proofs.storageAsMappings
+              (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+            events := (FunctionBody.initialIRStateForTx model tx initialWorld).events } := by
+        simp [interpretIRWithInternals, hfunctions, FunctionBody.initialIRStateForTx]
+        congr
+  unfold SourceSemantics.interpretContract SourceSemantics.findFunctionBySelector
+  cases hfindPairs :
+      pairs.find? (fun entry => entry.2 == tx.functionSelector) with
+  | none =>
+      have hfindIr :
+          irFns.find? (fun irFn => irFn.selector == tx.functionSelector) = none :=
+        find_compiledFunction_none_of_forall₂
+          model.fields model.events model.errors tx.functionSelector hcompiled hfindPairs
+      rw [hinterp, hfindIr]
+      simp [hfindPairs, FunctionBody.sourceResultMatchesIRResult,
+        SourceSemantics.revertedResult, FunctionBody.initialIRStateForTx,
+        FunctionBody.encodeStorage_withTransactionContext,
+        FunctionBody.encodeEvents_withTransactionContext]
+  | some pair =>
+      rcases pair with ⟨fn, sel⟩
+      rcases find_compiledFunction_some_of_forall₂
+          model.fields model.events model.errors tx.functionSelector hcompiled hfindPairs with
+        ⟨irFn, hfindIr, hcompileFn⟩
+      have hpairMem : (fn, sel) ∈ pairs := List.mem_of_find?_eq_some hfindPairs
+      have hfnMem : fn ∈ selectorDispatchedFunctions model := by
+        simpa [pairs, SourceSemantics.selectorFunctionPairs] using (List.of_mem_zip hpairMem).1
+      have hparamsEq :
+          irFn.params = fn.params.map Param.toIRParam :=
+        Function.compileFunctionSpec_ok_params
+          model.fields model.events model.errors sel fn irFn hcompileFn
+      have hlenEq : irFn.params.length = fn.params.length := by
+        simpa [hparamsEq]
+      have hpayableEq :
+          irFn.payable = fn.isPayable :=
+        Function.compileFunctionSpec_ok_payable
+          model.fields model.events model.errors sel fn irFn hcompileFn
+      by_cases hguard : (!fn.isPayable && tx.msgValue % Compiler.Constants.evmModulus != 0) = true
+      · have hguardIr :
+            (!irFn.payable && tx.msgValue % Compiler.Constants.evmModulus != 0) = true := by
+          simpa [hpayableEq] using hguard
+        rw [hinterp, hfindIr]
+        simp [hfindPairs, hguard, hguardIr, FunctionBody.sourceResultMatchesIRResult,
+          SourceSemantics.revertedResult, FunctionBody.initialIRStateForTx,
+          FunctionBody.encodeStorage_withTransactionContext,
+          FunctionBody.encodeEvents_withTransactionContext]
+      ·
+        have hguardFalse :
+            (!fn.isPayable && tx.msgValue % Compiler.Constants.evmModulus != 0) = false :=
+          Bool.eq_false_iff.2 hguard
+        have hguardIrFalse :
+            (!irFn.payable && tx.msgValue % Compiler.Constants.evmModulus != 0) = false := by
+          simpa [hpayableEq] using hguardFalse
+        by_cases hlen : fn.params.length ≤ tx.args.length
+        · rcases bindSupportedParams_some_of_supported fn.params tx.args
+              (hparamsSupported fn hfnMem) hlen with ⟨bindings, hbindings⟩
+          have hmatch := hfunction fn sel irFn bindings hfnMem hcompileFn hbindings
+          have hlenIr : irFn.params.length ≤ tx.args.length := by
+            simpa [hlenEq] using hlen
+          rw [hinterp, hfindIr]
+          simpa [hfindPairs, hguardFalse, hguardIrFalse, hlenIr] using hmatch
+        · have hbindNone : SourceSemantics.bindSupportedParams fn.params tx.args = none := by
+            cases hbind : SourceSemantics.bindSupportedParams fn.params tx.args with
+            | none =>
+                rfl
+            | some bindings =>
+                exfalso
+                exact hlen (ParamLoading.bindSupportedParams_some_length hbind)
+          have hlenIr : ¬ irFn.params.length ≤ tx.args.length := by
+            simpa [hlenEq] using hlen
+          have hbindExternalNone :
+              SourceSemantics.bindExternalParams tx.functionSelector fn.params tx.args = none :=
+            SourceSemantics.bindExternalParams_eq_none_of_not_length_le tx.functionSelector hlen
+          rw [hinterp, hfindIr]
+          simp [SourceSemantics.interpretFunction, hbindNone, hbindExternalNone, hfindPairs, hguardFalse,
+            hguardIrFalse, hlenIr, FunctionBody.sourceResultMatchesIRResult,
+            SourceSemantics.revertedResult, FunctionBody.initialIRStateForTx,
+            FunctionBody.encodeStorage_withTransactionContext,
+            FunctionBody.encodeEvents_withTransactionContext]
+
 /-- Helper-proof-carrying wrapper for the dispatch theorem.
 The current proof still reduces helper-aware source semantics to the legacy
 helper-free semantics via the helper-excluding `SupportedStmtList` body
@@ -327,6 +467,51 @@ theorem interpretContract_correct_of_compiled_functions_with_helper_proofs
       (hcompiled := hcompiled)
       (hparamsSupported := hparamsSupported)
       (hfunction := hlegacyFunction)
+  simpa [supportedSourceContractSemantics_eq_sourceContractSemantics
+    (hSupported := hSupported) tx initialWorld] using hlegacy
+
+/-- Populated-runtime, slack-indexed dispatch consumer for helper-aware
+per-function correctness results. -/
+theorem interpretContractWithInternals_correct_of_compiled_functions_with_helper_proofs
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpec model selectors)
+    (_hHelperProofs : SourceSemantics.SupportedSpecHelperProofs model selectors hSupported)
+    (runtimeContract : IRContract)
+    (irFuelSlack : Nat)
+    (irFns : List IRFunction)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (hfunctions : runtimeContract.functions = irFns)
+    (hcompiled :
+      List.Forall₂
+        (fun entry irFn =>
+          compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1 = Except.ok irFn)
+        (SourceSemantics.selectorFunctionPairs model selectors)
+        irFns)
+    (hparamsSupported :
+      ∀ fn ∈ selectorDispatchedFunctions model,
+        ∀ param ∈ fn.params, SupportedExternalParamType param.ty)
+    (hfunction :
+      ∀ fn sel irFn bindings,
+        fn ∈ selectorDispatchedFunctions model →
+        compileFunctionSpec model.fields model.events model.errors [] sel fn = Except.ok irFn →
+        SourceSemantics.bindSupportedParams fn.params tx.args = some bindings →
+        FunctionBody.sourceResultMatchesIRResult
+          (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
+          (execIRFunctionWithInternals runtimeContract irFuelSlack irFn tx.args
+            (FunctionBody.initialIRStateForTx model tx initialWorld))) :
+    FunctionBody.sourceResultMatchesIRResult
+      (supportedSourceContractSemantics model selectors hSupported tx initialWorld)
+      (interpretIRWithInternals runtimeContract irFuelSlack tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  have hlegacy := interpretContractWithInternals_correct_of_compiled_functions
+    model selectors runtimeContract irFuelSlack irFns tx initialWorld hfunctions
+    hcompiled hparamsSupported (by
+      intro fn sel irFn bindings hfn hcompileFn hbind
+      simpa [supportedSourceFunctionSemantics_eq_interpretFunction_of_selectorDispatched
+        (hSupported := hSupported) hfn tx initialWorld] using
+        hfunction fn sel irFn bindings hfn hcompileFn hbind)
   simpa [supportedSourceContractSemantics_eq_sourceContractSemantics
     (hSupported := hSupported) tx initialWorld] using hlegacy
 

--- a/Compiler/Proofs/IRGeneration/Dispatch.lean
+++ b/Compiler/Proofs/IRGeneration/Dispatch.lean
@@ -411,6 +411,187 @@ theorem interpretContractWithInternals_correct_of_compiled_functions
             FunctionBody.encodeStorage_withTransactionContext,
             FunctionBody.encodeEvents_withTransactionContext]
 
+/-- Helper-aware dispatch skeleton.  This is the populated-runtime analogue of
+`interpretContractWithInternals_correct_of_compiled_functions`, but it keeps
+`interpretContractWithHelpers`/`interpretFunctionWithHelpers` all the way
+through and therefore does not reduce helper callers to legacy semantics. -/
+theorem interpretContractWithHelpersWithInternals_correct_of_compiled_functions
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (helperFuel : Nat)
+    (runtimeContract : IRContract)
+    (irFuelSlack : Nat)
+    (irFns : List IRFunction)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (hfunctions : runtimeContract.functions = irFns)
+    (hcompiled :
+      List.Forall₂
+        (fun entry irFn => compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1 = Except.ok irFn)
+        (SourceSemantics.selectorFunctionPairs model selectors)
+        irFns)
+    (hparamsSupported :
+      ∀ fn ∈ selectorDispatchedFunctions model,
+        ∀ param ∈ fn.params, SupportedExternalParamType param.ty)
+    (hfunction :
+      ∀ fn sel irFn bindings,
+        fn ∈ selectorDispatchedFunctions model →
+        compileFunctionSpec model.fields model.events model.errors [] sel fn = Except.ok irFn →
+        SourceSemantics.bindSupportedParams fn.params tx.args = some bindings →
+        FunctionBody.sourceResultMatchesIRResult
+          (SourceSemantics.interpretFunctionWithHelpers model helperFuel fn tx initialWorld)
+          (execIRFunctionWithInternals runtimeContract irFuelSlack irFn tx.args
+            (FunctionBody.initialIRStateForTx model tx initialWorld))) :
+    FunctionBody.sourceResultMatchesIRResult
+      (SourceSemantics.interpretContractWithHelpers
+        model selectors helperFuel tx initialWorld)
+      (interpretIRWithInternals runtimeContract irFuelSlack tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  let pairs := SourceSemantics.selectorFunctionPairs model selectors
+  have hstate :
+      applyIRTransactionContext tx (FunctionBody.initialIRStateForTx model tx initialWorld) =
+        FunctionBody.initialIRStateForTx model tx initialWorld := by
+    rfl
+  have hinterp :
+      interpretIRWithInternals runtimeContract irFuelSlack tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld) =
+      match irFns.find? (fun irFn => irFn.selector == tx.functionSelector) with
+      | some irFn =>
+          if !irFn.payable && tx.msgValue % Compiler.Constants.evmModulus != 0 then
+            { success := false
+              returnValue := none
+              finalStorage := (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              finalMappings := Compiler.Proofs.storageAsMappings
+                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              events := (FunctionBody.initialIRStateForTx model tx initialWorld).events }
+          else if irFn.params.length ≤ tx.args.length then
+            execIRFunctionWithInternals runtimeContract irFuelSlack irFn tx.args
+              (FunctionBody.initialIRStateForTx model tx initialWorld)
+          else
+            { success := false
+              returnValue := none
+              finalStorage := (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              finalMappings := Compiler.Proofs.storageAsMappings
+                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              events := (FunctionBody.initialIRStateForTx model tx initialWorld).events }
+      | none =>
+          { success := false
+            returnValue := none
+            finalStorage := (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+            finalMappings := Compiler.Proofs.storageAsMappings
+              (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+            events := (FunctionBody.initialIRStateForTx model tx initialWorld).events } := by
+        simp [interpretIRWithInternals, hfunctions, FunctionBody.initialIRStateForTx]
+        congr
+  unfold SourceSemantics.interpretContractWithHelpers SourceSemantics.findFunctionBySelector
+  cases hfindPairs :
+      pairs.find? (fun entry => entry.2 == tx.functionSelector) with
+  | none =>
+      have hfindIr :
+          irFns.find? (fun irFn => irFn.selector == tx.functionSelector) = none :=
+        find_compiledFunction_none_of_forall₂
+          model.fields model.events model.errors tx.functionSelector hcompiled hfindPairs
+      rw [hinterp, hfindIr]
+      simp [hfindPairs, FunctionBody.sourceResultMatchesIRResult,
+        SourceSemantics.revertedResult, FunctionBody.initialIRStateForTx,
+        FunctionBody.encodeStorage_withTransactionContext,
+        FunctionBody.encodeEvents_withTransactionContext]
+  | some pair =>
+      rcases pair with ⟨fn, sel⟩
+      rcases find_compiledFunction_some_of_forall₂
+          model.fields model.events model.errors tx.functionSelector hcompiled hfindPairs with
+        ⟨irFn, hfindIr, hcompileFn⟩
+      have hpairMem : (fn, sel) ∈ pairs := List.mem_of_find?_eq_some hfindPairs
+      have hfnMem : fn ∈ selectorDispatchedFunctions model := by
+        simpa [pairs, SourceSemantics.selectorFunctionPairs] using (List.of_mem_zip hpairMem).1
+      have hparamsEq : irFn.params = fn.params.map Param.toIRParam :=
+        Function.compileFunctionSpec_ok_params
+          model.fields model.events model.errors sel fn irFn hcompileFn
+      have hlenEq : irFn.params.length = fn.params.length := by
+        simpa [hparamsEq]
+      have hpayableEq : irFn.payable = fn.isPayable :=
+        Function.compileFunctionSpec_ok_payable
+          model.fields model.events model.errors sel fn irFn hcompileFn
+      by_cases hguard :
+          (!fn.isPayable && tx.msgValue % Compiler.Constants.evmModulus != 0) = true
+      · have hguardIr :
+            (!irFn.payable && tx.msgValue % Compiler.Constants.evmModulus != 0) = true := by
+          simpa [hpayableEq] using hguard
+        rw [hinterp, hfindIr]
+        simp [hfindPairs, hguard, hguardIr, FunctionBody.sourceResultMatchesIRResult,
+          SourceSemantics.revertedResult, FunctionBody.initialIRStateForTx,
+          FunctionBody.encodeStorage_withTransactionContext,
+          FunctionBody.encodeEvents_withTransactionContext]
+      · have hguardFalse :
+            (!fn.isPayable && tx.msgValue % Compiler.Constants.evmModulus != 0) = false :=
+          Bool.eq_false_iff.2 hguard
+        have hguardIrFalse :
+            (!irFn.payable && tx.msgValue % Compiler.Constants.evmModulus != 0) = false := by
+          simpa [hpayableEq] using hguardFalse
+        by_cases hlen : fn.params.length ≤ tx.args.length
+        · rcases bindSupportedParams_some_of_supported fn.params tx.args
+              (hparamsSupported fn hfnMem) hlen with ⟨bindings, hbindings⟩
+          have hmatch := hfunction fn sel irFn bindings hfnMem hcompileFn hbindings
+          have hlenIr : irFn.params.length ≤ tx.args.length := by
+            simpa [hlenEq] using hlen
+          rw [hinterp, hfindIr]
+          simpa [hfindPairs, hguardFalse, hguardIrFalse, hlenIr] using hmatch
+        · have hbindNone : SourceSemantics.bindSupportedParams fn.params tx.args = none := by
+            cases hbind : SourceSemantics.bindSupportedParams fn.params tx.args with
+            | none => rfl
+            | some bindings =>
+                exfalso
+                exact hlen (ParamLoading.bindSupportedParams_some_length hbind)
+          have hlenIr : ¬ irFn.params.length ≤ tx.args.length := by
+            simpa [hlenEq] using hlen
+          have hbindExternalNone :
+              SourceSemantics.bindExternalParams tx.functionSelector fn.params tx.args = none :=
+            SourceSemantics.bindExternalParams_eq_none_of_not_length_le tx.functionSelector hlen
+          rw [hinterp, hfindIr]
+          simp [SourceSemantics.interpretFunctionWithHelpers, hbindNone, hbindExternalNone, hfindPairs,
+            hguardFalse, hguardIrFalse, hlenIr,
+            FunctionBody.sourceResultMatchesIRResult, SourceSemantics.revertedResult,
+            FunctionBody.initialIRStateForTx,
+            FunctionBody.encodeStorage_withTransactionContext,
+            FunctionBody.encodeEvents_withTransactionContext]
+
+/-- Dispatch consumer specialized to the new helper-rich support inventory. -/
+theorem interpretContractWithInternals_correct_of_compiled_functions_with_helper_rich_support
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpecWithHelpers model selectors)
+    (runtimeContract : IRContract)
+    (irFuelSlack : Nat)
+    (irFns : List IRFunction)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (hfunctions : runtimeContract.functions = irFns)
+    (hcompiled :
+      List.Forall₂
+        (fun entry irFn => compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1 = Except.ok irFn)
+        (SourceSemantics.selectorFunctionPairs model selectors) irFns)
+    (hfunction :
+      ∀ fn sel irFn bindings,
+        fn ∈ selectorDispatchedFunctions model →
+        compileFunctionSpec model.fields model.events model.errors [] sel fn = Except.ok irFn →
+        SourceSemantics.bindSupportedParams fn.params tx.args = some bindings →
+        FunctionBody.sourceResultMatchesIRResult
+          (supportedSourceFunctionSemanticsWithHelpers
+            model selectors hSupported fn tx initialWorld)
+          (execIRFunctionWithInternals runtimeContract irFuelSlack irFn tx.args
+            (FunctionBody.initialIRStateForTx model tx initialWorld))) :
+    FunctionBody.sourceResultMatchesIRResult
+      (supportedSourceContractSemanticsWithHelpers
+        model selectors hSupported tx initialWorld)
+      (interpretIRWithInternals runtimeContract irFuelSlack tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  exact interpretContractWithHelpersWithInternals_correct_of_compiled_functions
+    model selectors hSupported.helperFuel runtimeContract irFuelSlack irFns tx initialWorld
+    hfunctions hcompiled (fun fn hfn => hSupported.selectorFunctionParamsSupported hfn) (by
+      intro fn sel irFn bindings hfn hcompile hbind
+      simpa [supportedSourceFunctionSemanticsWithHelpers] using
+        hfunction fn sel irFn bindings hfn hcompile hbind)
+
 /-- Helper-proof-carrying wrapper for the dispatch theorem.
 The current proof still reduces helper-aware source semantics to the legacy
 helper-free semantics via the helper-excluding `SupportedStmtList` body

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -317,11 +317,13 @@ theorem compileFunctionSpec_ok_metadata_with_internals
           compileStmtList fields events errors .calldata [] false
             (spec.params.map (·.name)) [] spec.body internalFunctions
       · rw [hvalidate, hreturns,
-          FunctionBody.compileStmtListWithFork_cancun_eq_compileStmtList, hbody] at hcompile
+          FunctionBody.compileStmtListWithFork_cancun_eq_compileStmtList
+            (internalFunctions := internalFunctions), hbody] at hcompile
         cases hcompile
       case ok bodyStmts =>
         rw [hvalidate, hreturns,
-          FunctionBody.compileStmtListWithFork_cancun_eq_compileStmtList, hbody] at hcompile
+          FunctionBody.compileStmtListWithFork_cancun_eq_compileStmtList
+            (internalFunctions := internalFunctions), hbody] at hcompile
         injection hcompile with hEq
         exact ⟨by simpa using congrArg IRFunction.params hEq.symm,
           by simpa using congrArg IRFunction.selector hEq.symm,

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -2313,10 +2313,11 @@ theorem supported_function_correct_with_helper_proofs_body_goal_with_internals
       compileFunctionSpec model.fields model.events model.errors [] selector fn = Except.ok irFn)
     (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
     (_htxNormalized : TxContextNormalized tx)
+    (irFuelSlack : Nat)
     (extraFuel : Nat)
     (hcompiledBodyFuel :
       (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
-        sizeOf (compiledFunctionIR selector fn returns bodyStmts).body)
+        sizeOf (compiledFunctionIR selector fn returns bodyStmts).body + irFuelSlack)
     (hbodyCorrect :
       SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
         runtimeContract
@@ -2331,7 +2332,7 @@ theorem supported_function_correct_with_helper_proofs_body_goal_with_internals
     (hcalldataSizeFits : TxCalldataSizeFitsEvm tx) :
     FunctionBody.sourceResultMatchesIRResult
       (supportedSourceFunctionSemantics model selectors hSupported fn tx initialWorld)
-      (execIRFunctionWithInternals runtimeContract 0 irFn tx.args
+      (execIRFunctionWithInternals runtimeContract irFuelSlack irFn tx.args
         (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
   rcases hbodyCorrect with ⟨sourceResult, irExec, hsource, hbodyExec, hmatch⟩
@@ -2373,11 +2374,11 @@ theorem supported_function_correct_with_helper_proofs_body_goal_with_internals
   subst hirFn
   have hcompiledBodyFuel' :
       (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
-        sizeOf (genParamLoads fn.params ++ bodyStmts) := by
+        sizeOf (genParamLoads fn.params ++ bodyStmts) + irFuelSlack := by
     simpa [compiledFunctionIR] using hcompiledBodyFuel
   have hcompiledExec :
       execIRStmtsWithInternals runtimeContract
-          (sizeOf (genParamLoads fn.params ++ bodyStmts) + 1)
+          (sizeOf (genParamLoads fn.params ++ bodyStmts) + irFuelSlack + 1)
           (prebindRawArgs initialState fn.params)
           (genParamLoads fn.params ++ bodyStmts) =
         irExec := by
@@ -2396,12 +2397,12 @@ theorem supported_function_correct_with_helper_proofs_body_goal_with_internals
         hcalldataSizeFits hbind hparamDisjoint hbodyExec
     have hfuel :
         (genParamLoads fn.params ++ bodyStmts).length + extraFuel + 1 =
-          sizeOf (genParamLoads fn.params ++ bodyStmts) + 1 := by
+          sizeOf (genParamLoads fn.params ++ bodyStmts) + irFuelSlack + 1 := by
       omega
     rw [← hfuel]
     simpa [compiledFunctionIR] using hprefix
   have hfunctionExec :
-      execIRFunctionWithInternals runtimeContract 0
+      execIRFunctionWithInternals runtimeContract irFuelSlack
           (compiledFunctionIR selector fn returns bodyStmts) tx.args initialState =
         FunctionBody.irResultOfExecResultWithInternals initialState irExec := by
     have hstateWithParams :

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -292,6 +292,40 @@ theorem compileFunctionSpec_ok_payable
         injection hcompile with hEq
         simpa using congrArg IRFunction.payable hEq.symm
 
+/-- Structural fields of a compiled function do not depend on whether its body
+is compiled against an empty or populated internal-function table. -/
+theorem compileFunctionSpec_ok_metadata_with_internals
+    (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
+    (selector : Nat) (spec : FunctionSpec) (irFn : IRFunction)
+    (internalFunctions : List FunctionSpec)
+    (hcompile :
+      compileFunctionSpec fields events errors [] selector spec internalFunctions =
+        Except.ok irFn) :
+    irFn.params = spec.params.map Param.toIRParam ∧
+      irFn.selector = selector ∧ irFn.payable = spec.isPayable := by
+  unfold CompilationModel.compileFunctionSpec at hcompile
+  cases hvalidate : validateFunctionSpec spec
+  · rw [hvalidate] at hcompile
+    cases hcompile
+  case ok _ =>
+    cases hreturns : functionReturns spec
+    · rw [hvalidate, hreturns] at hcompile
+      cases hcompile
+    case ok returns =>
+      cases hbody :
+          compileStmtList fields events errors .calldata [] false
+            (spec.params.map (·.name)) [] spec.body internalFunctions
+      · rw [hvalidate, hreturns,
+          FunctionBody.compileStmtListWithFork_cancun_eq_compileStmtList, hbody] at hcompile
+        cases hcompile
+      case ok bodyStmts =>
+        rw [hvalidate, hreturns,
+          FunctionBody.compileStmtListWithFork_cancun_eq_compileStmtList, hbody] at hcompile
+        injection hcompile with hEq
+        exact ⟨by simpa using congrArg IRFunction.params hEq.symm,
+          by simpa using congrArg IRFunction.selector hEq.symm,
+          by simpa using congrArg IRFunction.payable hEq.symm⟩
+
 theorem compileFunctionSpec_ok_components
     (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
     (selector : Nat) (spec : FunctionSpec) (irFn : IRFunction)

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -299,7 +299,8 @@ theorem compileFunctionSpec_ok_metadata_with_internals
     (selector : Nat) (spec : FunctionSpec) (irFn : IRFunction)
     (internalFunctions : List FunctionSpec)
     (hcompile :
-      compileFunctionSpec fields events errors [] selector spec internalFunctions =
+      compileFunctionSpec fields events errors [] selector spec
+        (internalFunctions := internalFunctions) =
         Except.ok irFn) :
     irFn.params = spec.params.map Param.toIRParam ∧
       irFn.selector = selector ∧ irFn.payable = spec.isPayable := by

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -2446,6 +2446,127 @@ theorem supported_function_correct_with_helper_proofs_body_goal_with_internals
     rfl
   simpa [initialState, hfunctionExec] using hsourceMatch
 
+/-- Helper-rich Function consumer.  Unlike the legacy wrapper above, this
+theorem is gated by `SupportedSpecWithHelpers`, whose function inventory may
+carry a `SupportedHelperRichBodyFragment`; no `SupportedStmtList` or
+helper-free body witness is required. -/
+theorem supported_function_correct_with_helper_rich_support_body_goal_with_internals
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpecWithHelpers model selectors)
+    (_hvalidateInputs : validateCompileInputs model selectors = Except.ok ())
+    (runtimeContract : IRContract)
+    (fn : FunctionSpec)
+    (selector : Nat)
+    (returns : List ParamType)
+    (bodyStmts : List YulStmt)
+    (irFn : IRFunction)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (bindings : List (String × Nat))
+    (internalFunctions : List FunctionSpec)
+    (hfn : fn ∈ selectorDispatchedFunctions model)
+    (hvalidate : validateFunctionSpec fn = Except.ok ())
+    (hreturns : functionReturns fn = Except.ok returns)
+    (hbodyCompile :
+      compileStmtList model.fields model.events model.errors .calldata [] false
+        (fn.params.map (·.name)) [] fn.body internalFunctions = Except.ok bodyStmts)
+    (hcompile :
+      compileFunctionSpec model.fields model.events model.errors [] selector fn
+        (internalFunctions := internalFunctions) = Except.ok irFn)
+    (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
+    (_htxNormalized : TxContextNormalized tx)
+    (irFuelSlack extraFuel : Nat)
+    (hcompiledBodyFuel :
+      (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
+        sizeOf (compiledFunctionIR selector fn returns bodyStmts).body + irFuelSlack)
+    (hbodyCorrect :
+      SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal
+        runtimeContract model fn bodyStmts hSupported.helperFuel tx initialWorld
+        (ParamLoading.applyBindingsToIRState
+          (prebindRawArgs
+            (FunctionBody.initialIRStateForTx model tx initialWorld) fn.params)
+          bindings)
+        bindings extraFuel)
+    (hparamDisjoint :
+      YulStmtListCallsDisjointFromInternalTable runtimeContract (genParamLoads fn.params))
+    (hcalldataSizeFits : TxCalldataSizeFitsEvm tx) :
+    FunctionBody.sourceResultMatchesIRResult
+      (supportedSourceFunctionSemanticsWithHelpers
+        model selectors hSupported fn tx initialWorld)
+      (execIRFunctionWithInternals runtimeContract irFuelSlack irFn tx.args
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
+  rcases hbodyCorrect with ⟨sourceResult, irExec, hsource, hbodyExec, hmatch⟩
+  have hcompiled := compileFunctionSpec_ok_of_components_with_internals
+      model.fields model.events model.errors internalFunctions selector fn returns bodyStmts
+      hvalidate hreturns hbodyCompile
+  have hirFn : irFn = compiledFunctionIR selector fn returns bodyStmts := by
+    rw [hcompile] at hcompiled
+    injection hcompiled
+  have hrollbackStorage :
+        initialState.storage = fun s =>
+          Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+            (SourceSemantics.encodeStorage model
+              (SourceSemantics.withTransactionContext initialWorld tx) s.toNat) := by
+    funext s
+    simp [initialState, FunctionBody.initialIRStateForTx,
+      FunctionBody.encodeStorage_withTransactionContext]
+  have hrollbackEvents :
+      initialState.events =
+        SourceSemantics.encodeEvents
+          (SourceSemantics.withTransactionContext initialWorld tx).events := by
+    simp [initialState, FunctionBody.initialIRStateForTx]
+  have hsourceMatch :
+      FunctionBody.sourceResultMatchesIRResult
+        (supportedSourceFunctionSemanticsWithHelpers
+          model selectors hSupported fn tx initialWorld)
+        (FunctionBody.irResultOfExecResultWithInternals initialState irExec) := by
+    simpa [supportedSourceFunctionSemanticsWithHelpers] using
+      (interpretFunctionWithHelpers_eq_execResultToIRResultWithInternals_of_body
+      (model := model) (fn := fn) (helperFuel := hSupported.helperFuel)
+      (tx := tx) (initialWorld := initialWorld) (sourceResult := sourceResult)
+      (rollback := initialState) (irResult := irExec) (bindings := bindings)
+      hbind hsource hrollbackStorage hrollbackEvents hmatch)
+  subst hirFn
+  have hcompiledBodyFuel' :
+      (genParamLoads fn.params ++ bodyStmts).length + extraFuel =
+        sizeOf (genParamLoads fn.params ++ bodyStmts) + irFuelSlack := by
+    simpa [compiledFunctionIR] using hcompiledBodyFuel
+  have hcompiledExec :
+      execIRStmtsWithInternals runtimeContract
+          (sizeOf (genParamLoads fn.params ++ bodyStmts) + irFuelSlack + 1)
+          (prebindRawArgs initialState fn.params)
+          (genParamLoads fn.params ++ bodyStmts) = irExec := by
+    have hprefix :=
+      exec_compiledFunctionIR_withInternals_of_body_extraFuel
+        (runtimeContract := runtimeContract) (state := initialState)
+        (selector := selector) (spec := fn) (returns := returns)
+        (bodyStmts := bodyStmts) (bindings := bindings) (tailResult := irExec)
+        (extraFuel := extraFuel)
+        (hSupported.selectorFunctionParamsSupported hfn)
+        hcalldataSizeFits hbind hparamDisjoint hbodyExec
+    have hfuel :
+        (genParamLoads fn.params ++ bodyStmts).length + extraFuel + 1 =
+          sizeOf (genParamLoads fn.params ++ bodyStmts) + irFuelSlack + 1 := by
+      omega
+    rw [← hfuel]
+    simpa [compiledFunctionIR] using hprefix
+  have hfunctionExec :
+      execIRFunctionWithInternals runtimeContract irFuelSlack
+          (compiledFunctionIR selector fn returns bodyStmts) tx.args initialState =
+        FunctionBody.irResultOfExecResultWithInternals initialState irExec := by
+    have hstateWithParams :
+        List.foldl (fun s x => s.setVar x.1.name x.2) initialState
+            ((List.map Param.toIRParam fn.params).zip tx.args) =
+          prebindRawArgs initialState fn.params := by
+      simp [prebindRawArgs, initialState, FunctionBody.initialIRStateForTx]
+    rw [execIRFunctionWithInternals]
+    simp [compiledFunctionIR, hstateWithParams]
+    rw [hcompiledExec]
+    rfl
+  simpa [initialState, hfunctionExec] using hsourceMatch
+
 /-- Structured exact helper-aware function/IR wrapper under compiled-body
 disjointness. The exact helper-aware body theorem can now be reused all the way
 up to function-level results without requiring callers to restate the

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -193,6 +193,33 @@ theorem compileFunctionSpec_ok_of_components
   rw [hvalidate, hreturns, FunctionBody.compileStmtListWithFork_cancun_eq_compileStmtList, hbody]
   rfl
 
+/-- Populated-internal-table variant of `compileFunctionSpec_ok_of_components`.
+The body equation and the enclosing function compilation must use the same
+caller-supplied internal function table. -/
+theorem compileFunctionSpec_ok_of_components_with_internals
+    (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
+    (internalFunctions : List FunctionSpec)
+    (selector : Nat) (spec : FunctionSpec)
+    (returns : List ParamType) (bodyStmts : List YulStmt)
+    (hvalidate : validateFunctionSpec spec = Except.ok ())
+    (hreturns : functionReturns spec = Except.ok returns)
+    (hbody :
+      compileStmtList fields events errors .calldata [] false
+        (spec.params.map (·.name)) [] spec.body internalFunctions = Except.ok bodyStmts) :
+    compileFunctionSpec fields events errors [] selector spec
+        (internalFunctions := internalFunctions) =
+      Except.ok (compiledFunctionIR selector spec returns bodyStmts) := by
+  unfold CompilationModel.compileFunctionSpec
+  rw [hvalidate, hreturns]
+  change
+    (do
+      let compiledBody ←
+        compileStmtList fields events errors .calldata [] false
+          (spec.params.map (fun p : Param => p.name)) [] spec.body internalFunctions
+      pure (compiledFunctionIR selector spec returns compiledBody)) = _
+  rw [hbody]
+  rfl
+
 theorem compileFunctionSpec_ok_params
     (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
     (selector : Nat) (spec : FunctionSpec) (irFn : IRFunction)
@@ -2303,14 +2330,16 @@ theorem supported_function_correct_with_helper_proofs_body_goal_with_internals
     (tx : IRTransaction)
     (initialWorld : Verity.ContractState)
     (bindings : List (String × Nat))
+    (internalFunctions : List FunctionSpec)
     (hfn : fn ∈ selectorDispatchedFunctions model)
     (hvalidate : validateFunctionSpec fn = Except.ok ())
     (hreturns : functionReturns fn = Except.ok returns)
     (hbodyCompile :
       compileStmtList model.fields model.events model.errors .calldata [] false
-        (fn.params.map (·.name)) [] fn.body = Except.ok bodyStmts)
+        (fn.params.map (·.name)) [] fn.body internalFunctions = Except.ok bodyStmts)
     (hcompile :
-      compileFunctionSpec model.fields model.events model.errors [] selector fn = Except.ok irFn)
+      compileFunctionSpec model.fields model.events model.errors [] selector fn
+        (internalFunctions := internalFunctions) = Except.ok irFn)
     (hbind : SourceSemantics.bindSupportedParams fn.params tx.args = some bindings)
     (_htxNormalized : TxContextNormalized tx)
     (irFuelSlack : Nat)
@@ -2336,8 +2365,9 @@ theorem supported_function_correct_with_helper_proofs_body_goal_with_internals
         (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
   let initialState := FunctionBody.initialIRStateForTx model tx initialWorld
   rcases hbodyCorrect with ⟨sourceResult, irExec, hsource, hbodyExec, hmatch⟩
-  have hcompiled := compileFunctionSpec_ok_of_components model.fields model.events model.errors
-      selector fn returns bodyStmts hvalidate hreturns hbodyCompile
+  have hcompiled := compileFunctionSpec_ok_of_components_with_internals
+      model.fields model.events model.errors internalFunctions selector fn returns bodyStmts
+      hvalidate hreturns hbodyCompile
   have hirFn : irFn = compiledFunctionIR selector fn returns bodyStmts := by
     rw [hcompile] at hcompiled
     injection hcompiled

--- a/Compiler/Proofs/IRGeneration/FunctionBody/Stmt.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody/Stmt.lean
@@ -173,9 +173,10 @@ theorem compileStmtList_nil_eq_ok
     (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
     (dynamicSource : DynamicDataSource) (internalRetNames : List String)
     (isInternal : Bool) (inScopeNames : List String)
-    (adtTypes : List AdtTypeDef) :
+    (adtTypes : List AdtTypeDef)
+    (internalFunctions : List FunctionSpec := []) :
     CompilationModel.compileStmtList fields events errors dynamicSource
-      internalRetNames isInternal inScopeNames adtTypes [] = Except.ok [] := by
+      internalRetNames isInternal inScopeNames adtTypes [] internalFunctions = Except.ok [] := by
   unfold CompilationModel.compileStmtList
   unfold CompilationModel.compileStmtListWithFork
   rfl
@@ -244,31 +245,38 @@ theorem compileStmtListWithFork_nil_eq_ok
     (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
     (dynamicSource : DynamicDataSource) (internalRetNames : List String)
     (isInternal : Bool) (inScopeNames : List String)
-    (adtTypes : List AdtTypeDef) :
+    (adtTypes : List AdtTypeDef)
+    (internalFunctions : List FunctionSpec := []) :
     CompilationModel.compileStmtListWithFork fields events errors dynamicSource
       internalRetNames isInternal inScopeNames adtTypes Verity.Core.Intrinsics.HardFork.cancun
-      [] = Except.ok [] := by
-  rw [compileStmtListWithFork_cancun_eq_compileStmtList]
-  exact compileStmtList_nil_eq_ok _ _ _ _ _ _ _ _
+      [] internalFunctions = Except.ok [] := by
+  rw [compileStmtListWithFork_cancun_eq_compileStmtList
+    fields events errors dynamicSource internalRetNames isInternal inScopeNames adtTypes []
+    internalFunctions]
+  exact compileStmtList_nil_eq_ok _ _ _ _ _ _ _ _ internalFunctions
 
 theorem compileStmtListWithFork_cons_eq_ok
     (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
     (dynamicSource : DynamicDataSource) (internalRetNames : List String)
     (isInternal : Bool) (inScopeNames : List String)
     (adtTypes : List AdtTypeDef) (stmt : Stmt) (rest : List Stmt)
+    (internalFunctions : List FunctionSpec := [])
     (headIR tailIR : List YulStmt)
     (hhead :
       CompilationModel.compileStmt fields events errors dynamicSource
-        internalRetNames isInternal inScopeNames adtTypes stmt = Except.ok headIR)
+        internalRetNames isInternal inScopeNames adtTypes stmt internalFunctions = Except.ok headIR)
     (htail :
       CompilationModel.compileStmtList fields events errors dynamicSource
-        internalRetNames isInternal (collectStmtBindNames stmt ++ inScopeNames) adtTypes rest =
-          Except.ok tailIR) :
+        internalRetNames isInternal (collectStmtBindNames stmt ++ inScopeNames) adtTypes rest
+          internalFunctions = Except.ok tailIR) :
     CompilationModel.compileStmtListWithFork fields events errors dynamicSource
       internalRetNames isInternal inScopeNames adtTypes Verity.Core.Intrinsics.HardFork.cancun
-      (stmt :: rest) = Except.ok (headIR ++ tailIR) := by
-  rw [compileStmtListWithFork_cancun_eq_compileStmtList]
-  exact compileStmtList_cons_eq_ok _ _ _ _ _ _ _ _ _ _ _ _ hhead htail
+      (stmt :: rest) internalFunctions = Except.ok (headIR ++ tailIR) := by
+  rw [compileStmtListWithFork_cancun_eq_compileStmtList
+    fields events errors dynamicSource internalRetNames isInternal inScopeNames adtTypes
+    (stmt :: rest) internalFunctions]
+  exact compileStmtList_cons_eq_ok_with_internals
+    _ _ _ _ _ _ _ _ _ _ internalFunctions _ _ hhead htail
 
 theorem compileStmtList_cons_ok_inv
     {fields : List Field}

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -450,48 +450,6 @@ abbrev InternalCallWithInternalsResidualBridge
     InternalCallWithInternalsBridgeAt runtimeContract spec fields scope calleeName args argExprs
       runtime state helperFuel irFuel
 
-/-- Sound caller-supplied-fuel package for a compiled direct helper call.
-
-Unlike `CompiledStmtStepWithHelpersAndHelperIRWithInternals`, this interface
-does not quantify over IR fuel below the amount needed to enter and execute the
-compiled helper body.  It is the appropriate input for a future fuel-indexed
-statement-list induction: the caller must supply `helperBodySize + 2` units of
-call fuel, in addition to positive source helper fuel. -/
-structure CompiledInternalCallWithInternalsFuelBounded
-    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
-    (scope : List String) (calleeName : String) (args : List Expr)
-    (compiledIR : List YulStmt) (argExprs : List YulExpr) (helperBodySize : Nat) : Prop where
-  compileOk :
-    CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
-      (Stmt.internalCall calleeName args) spec.functions = Except.ok compiledIR
-  argsCompileOk :
-    CompilationModel.compileInternalCallArgs fields .calldata spec.functions
-      calleeName args = Except.ok argExprs
-  preserves :
-    InternalCallWithInternalsSufficientBridge runtimeContract spec fields scope calleeName args
-      argExprs helperBodySize
-
-/-- Constructor for the fuel-bounded direct-call package.  Keeping this
-separate from the legacy all-fuels step prevents an insufficient-fuel residual
-obligation from being smuggled into a genuine successful helper call. -/
-theorem compiledInternalCallWithInternalsFuelBounded_of_sufficientBridge
-    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
-    {scope : List String} {calleeName : String} {args : List Expr}
-    {compiledIR : List YulStmt} {argExprs : List YulExpr}
-    (helperBodySize : Nat)
-    (hcompile :
-      CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
-        (Stmt.internalCall calleeName args) spec.functions = Except.ok compiledIR)
-    (hargCompile :
-      CompilationModel.compileInternalCallArgs fields .calldata spec.functions
-        calleeName args = Except.ok argExprs)
-    (bridge :
-      InternalCallWithInternalsSufficientBridge runtimeContract spec fields scope calleeName args
-        argExprs helperBodySize) :
-    CompiledInternalCallWithInternalsFuelBounded runtimeContract spec fields scope calleeName args
-      compiledIR argExprs helperBodySize :=
-  ⟨hcompile, hargCompile, bridge⟩
-
 /-- Fuel-split variant of the direct void-call singleton constructor.
 
 The existing public single-step interface still asks for every positive source

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -219,6 +219,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign
     {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
     {scope : List String} {names : List String} {calleeName : String} {args : List Expr}
     {compiledIR : List YulStmt} {argExprs : List YulExpr}
+    {irFuelSlack : Nat := 0}
     (hcompile :
       CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
         (Stmt.internalCallAssign names calleeName args) spec.functions = Except.ok compiledIR)
@@ -241,7 +242,8 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign
             [YulStmt.letMany names (YulExpr.call
               (CompilationModel.internalFunctionYulName calleeName) argExprs)])) :
     CompiledStmtStepWithHelpersAndHelperIRWithInternals
-      runtimeContract spec fields scope (Stmt.internalCallAssign names calleeName args) compiledIR := by
+      runtimeContract spec fields scope
+        (Stmt.internalCallAssign names calleeName args) compiledIR irFuelSlack := by
   refine { compileOk := hcompile, preserves := ?_ }
   intro runtime state helperFuel extraFuel hfuelPos hexact hscope hbounded hruntime hslack
   obtain ⟨argExprs', hargOk, hshape⟩ := compileStmt_internalCallAssign_shape_with_internals hcompile
@@ -325,6 +327,15 @@ abbrev InternalCallAssignWithInternalsResidualBridge
     InternalCallAssignWithInternalsBridgeAt runtimeContract spec fields scope names calleeName
       args argExprs runtime state helperFuel irFuel
 
+abbrev InternalCallAssignWithInternalsAdditiveResidualBridge
+    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
+    (scope : List String) (names : List String) (calleeName : String) (args : List Expr)
+    (argExprs : List YulExpr) (helperBodySize irFuelSlack : Nat) : Prop :=
+  ∀ (runtime : SourceSemantics.RuntimeState) (state : IRState) (helperFuel irFuel : Nat),
+    (¬ 1 < helperFuel ∨ ¬ helperBodySize + 2 + irFuelSlack ≤ irFuel) →
+    InternalCallAssignWithInternalsBridgeAt runtimeContract spec fields scope names calleeName
+      args argExprs runtime state helperFuel irFuel
+
 /-- Fuel-split variant of the direct assignment-call singleton constructor.
 
 This preserves the existing all-positive-fuel public target while exposing the
@@ -335,6 +346,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_o
     {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
     {scope : List String} {names : List String} {calleeName : String} {args : List Expr}
     {compiledIR : List YulStmt} {argExprs : List YulExpr}
+    {irFuelSlack : Nat := 0}
     (helperBodySize : Nat)
     (hcompile :
       CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
@@ -343,14 +355,14 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_o
       CompilationModel.compileInternalCallArgs fields .calldata spec.functions
         calleeName args = Except.ok argExprs)
     (bridgeSufficient :
-      InternalCallAssignWithInternalsSufficientBridge runtimeContract spec fields scope names
-        calleeName args argExprs helperBodySize)
+      InternalCallAssignWithInternalsAdditiveBridge runtimeContract spec fields scope names
+        calleeName args argExprs helperBodySize irFuelSlack)
     (bridgeResidual :
-      InternalCallAssignWithInternalsResidualBridge runtimeContract spec fields scope names
-        calleeName args argExprs helperBodySize) :
+      InternalCallAssignWithInternalsAdditiveResidualBridge runtimeContract spec fields scope names
+        calleeName args argExprs helperBodySize irFuelSlack) :
     CompiledStmtStepWithHelpersAndHelperIRWithInternals
       runtimeContract spec fields scope
-      (Stmt.internalCallAssign names calleeName args) compiledIR := by
+      (Stmt.internalCallAssign names calleeName args) compiledIR irFuelSlack := by
   refine
     compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -358,7 +370,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_o
       (compiledIR := compiledIR) (argExprs := argExprs) hcompile hargCompile ?_
   intro runtime state helperFuel irFuel hfuel hexact hscope hbounded hruntime
   by_cases hsource : 1 < helperFuel
-  · by_cases hir : helperBodySize + 2 ≤ irFuel
+  · by_cases hir : helperBodySize + 2 + irFuelSlack ≤ irFuel
     · exact bridgeSufficient runtime state helperFuel irFuel hsource hir
         hfuel hexact hscope hbounded hruntime
     · exact bridgeResidual runtime state helperFuel irFuel (.inr hir)
@@ -372,6 +384,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall
     {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
     {scope : List String} {calleeName : String} {args : List Expr}
     {compiledIR : List YulStmt} {argExprs : List YulExpr}
+    {irFuelSlack : Nat := 0}
     (hcompile :
       CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
         (Stmt.internalCall calleeName args) spec.functions = Except.ok compiledIR)
@@ -394,7 +407,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall
             [YulStmt.exprStmt (YulExpr.call
               (CompilationModel.internalFunctionYulName calleeName) argExprs)])) :
     CompiledStmtStepWithHelpersAndHelperIRWithInternals
-      runtimeContract spec fields scope (Stmt.internalCall calleeName args) compiledIR := by
+      runtimeContract spec fields scope (Stmt.internalCall calleeName args) compiledIR irFuelSlack := by
   refine { compileOk := hcompile, preserves := ?_ }
   intro runtime state helperFuel extraFuel hfuelPos hexact hscope hbounded hruntime hslack
   obtain ⟨argExprs', hargOk, hshape⟩ := compileStmt_internalCall_shape_with_internals hcompile
@@ -487,6 +500,15 @@ abbrev InternalCallWithInternalsResidualBridge
     InternalCallWithInternalsBridgeAt runtimeContract spec fields scope calleeName args argExprs
       runtime state helperFuel irFuel
 
+abbrev InternalCallWithInternalsAdditiveResidualBridge
+    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
+    (scope : List String) (calleeName : String) (args : List Expr)
+    (argExprs : List YulExpr) (helperBodySize irFuelSlack : Nat) : Prop :=
+  ∀ (runtime : SourceSemantics.RuntimeState) (state : IRState) (helperFuel irFuel : Nat),
+    (¬ 1 < helperFuel ∨ ¬ helperBodySize + 2 + irFuelSlack ≤ irFuel) →
+    InternalCallWithInternalsBridgeAt runtimeContract spec fields scope calleeName args argExprs
+      runtime state helperFuel irFuel
+
 /-- Fuel-split variant of the direct void-call singleton constructor.
 
 The existing public single-step interface still asks for every positive source
@@ -498,6 +520,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_fuel
     {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
     {scope : List String} {calleeName : String} {args : List Expr}
     {compiledIR : List YulStmt} {argExprs : List YulExpr}
+    {irFuelSlack : Nat := 0}
     (helperBodySize : Nat)
     (hcompile :
       CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
@@ -506,13 +529,13 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_fuel
       CompilationModel.compileInternalCallArgs fields .calldata spec.functions
         calleeName args = Except.ok argExprs)
     (bridgeSufficient :
-      InternalCallWithInternalsSufficientBridge runtimeContract spec fields scope calleeName args
-        argExprs helperBodySize)
+      InternalCallWithInternalsAdditiveBridge runtimeContract spec fields scope calleeName args
+        argExprs helperBodySize irFuelSlack)
     (bridgeResidual :
-      InternalCallWithInternalsResidualBridge runtimeContract spec fields scope calleeName args
-        argExprs helperBodySize) :
+      InternalCallWithInternalsAdditiveResidualBridge runtimeContract spec fields scope calleeName args
+        argExprs helperBodySize irFuelSlack) :
     CompiledStmtStepWithHelpersAndHelperIRWithInternals
-      runtimeContract spec fields scope (Stmt.internalCall calleeName args) compiledIR := by
+      runtimeContract spec fields scope (Stmt.internalCall calleeName args) compiledIR irFuelSlack := by
   refine
     compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -520,7 +543,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_fuel
       (compiledIR := compiledIR) (argExprs := argExprs) hcompile hargCompile ?_
   intro runtime state helperFuel irFuel hfuel hexact hscope hbounded hruntime
   by_cases hsource : 1 < helperFuel
-  · by_cases hir : helperBodySize + 2 ≤ irFuel
+  · by_cases hir : helperBodySize + 2 + irFuelSlack ≤ irFuel
     · exact bridgeSufficient runtime state helperFuel irFuel hsource hir
         hfuel hexact hscope hbounded hruntime
     · exact bridgeResidual runtime state helperFuel irFuel (.inr hir)
@@ -572,24 +595,25 @@ theorem stmtListDirectInternalHelperAssignStepInterfaceWithInternals_cons_intern
     {names : List String} {calleeName : String} {args : List Expr}
     {compiledIR : List YulStmt}
     {rest : List Stmt}
+    {irFuelSlack : Nat := 0}
     (hstep :
       CompiledStmtStepWithHelpersAndHelperIRWithInternals
         runtimeContract spec fields scope
         (Stmt.internalCallAssign names calleeName args)
-        compiledIR)
+        compiledIR irFuelSlack)
     (hrest :
       StmtListDirectInternalHelperAssignStepInterfaceWithInternals
         runtimeContract
         spec
         fields
         (stmtNextScope scope (Stmt.internalCallAssign names calleeName args))
-        rest) :
+        rest irFuelSlack) :
     StmtListDirectInternalHelperAssignStepInterfaceWithInternals
       runtimeContract
       spec
       fields
       scope
-      (Stmt.internalCallAssign names calleeName args :: rest) := by
+      (Stmt.internalCallAssign names calleeName args :: rest) irFuelSlack := by
   refine .cons ?_ hrest
   intro _
   exact ⟨compiledIR, hstep⟩
@@ -1411,24 +1435,25 @@ theorem stmtListDirectInternalHelperCallStepInterfaceWithInternals_cons_internal
     {calleeName : String} {args : List Expr}
     {compiledIR : List YulStmt}
     {rest : List Stmt}
+    {irFuelSlack : Nat := 0}
     (hstep :
       CompiledStmtStepWithHelpersAndHelperIRWithInternals
         runtimeContract spec fields scope
         (Stmt.internalCall calleeName args)
-        compiledIR)
+        compiledIR irFuelSlack)
     (hrest :
       StmtListDirectInternalHelperCallStepInterfaceWithInternals
         runtimeContract
         spec
         fields
         (stmtNextScope scope (Stmt.internalCall calleeName args))
-        rest) :
+        rest irFuelSlack) :
     StmtListDirectInternalHelperCallStepInterfaceWithInternals
       runtimeContract
       spec
       fields
       scope
-      (Stmt.internalCall calleeName args :: rest) := by
+      (Stmt.internalCall calleeName args :: rest) irFuelSlack := by
   refine .cons ?_ hrest
   intro _
   exact ⟨compiledIR, hstep⟩

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -450,6 +450,48 @@ abbrev InternalCallWithInternalsResidualBridge
     InternalCallWithInternalsBridgeAt runtimeContract spec fields scope calleeName args argExprs
       runtime state helperFuel irFuel
 
+/-- Sound caller-supplied-fuel package for a compiled direct helper call.
+
+Unlike `CompiledStmtStepWithHelpersAndHelperIRWithInternals`, this interface
+does not quantify over IR fuel below the amount needed to enter and execute the
+compiled helper body.  It is the appropriate input for a future fuel-indexed
+statement-list induction: the caller must supply `helperBodySize + 2` units of
+call fuel, in addition to positive source helper fuel. -/
+structure CompiledInternalCallWithInternalsFuelBounded
+    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
+    (scope : List String) (calleeName : String) (args : List Expr)
+    (compiledIR : List YulStmt) (argExprs : List YulExpr) (helperBodySize : Nat) : Prop where
+  compileOk :
+    CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
+      (Stmt.internalCall calleeName args) spec.functions = Except.ok compiledIR
+  argsCompileOk :
+    CompilationModel.compileInternalCallArgs fields .calldata spec.functions
+      calleeName args = Except.ok argExprs
+  preserves :
+    InternalCallWithInternalsSufficientBridge runtimeContract spec fields scope calleeName args
+      argExprs helperBodySize
+
+/-- Constructor for the fuel-bounded direct-call package.  Keeping this
+separate from the legacy all-fuels step prevents an insufficient-fuel residual
+obligation from being smuggled into a genuine successful helper call. -/
+theorem compiledInternalCallWithInternalsFuelBounded_of_sufficientBridge
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {scope : List String} {calleeName : String} {args : List Expr}
+    {compiledIR : List YulStmt} {argExprs : List YulExpr}
+    (helperBodySize : Nat)
+    (hcompile :
+      CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
+        (Stmt.internalCall calleeName args) spec.functions = Except.ok compiledIR)
+    (hargCompile :
+      CompilationModel.compileInternalCallArgs fields .calldata spec.functions
+        calleeName args = Except.ok argExprs)
+    (bridge :
+      InternalCallWithInternalsSufficientBridge runtimeContract spec fields scope calleeName args
+        argExprs helperBodySize) :
+    CompiledInternalCallWithInternalsFuelBounded runtimeContract spec fields scope calleeName args
+      compiledIR argExprs helperBodySize :=
+  ⟨hcompile, hargCompile, bridge⟩
+
 /-- Fuel-split variant of the direct void-call singleton constructor.
 
 The existing public single-step interface still asks for every positive source

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -219,7 +219,6 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign
     {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
     {scope : List String} {names : List String} {calleeName : String} {args : List Expr}
     {compiledIR : List YulStmt} {argExprs : List YulExpr}
-    (irFuelSlack : Nat := 0)
     (hcompile :
       CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
         (Stmt.internalCallAssign names calleeName args) spec.functions = Except.ok compiledIR)
@@ -240,7 +239,8 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign
             (Stmt.internalCallAssign names calleeName args))
           (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
             [YulStmt.letMany names (YulExpr.call
-              (CompilationModel.internalFunctionYulName calleeName) argExprs)])) :
+              (CompilationModel.internalFunctionYulName calleeName) argExprs)]))
+    (irFuelSlack : Nat := 0) :
     CompiledStmtStepWithHelpersAndHelperIRWithInternals
       runtimeContract spec fields scope
         (Stmt.internalCallAssign names calleeName args) compiledIR irFuelSlack := by
@@ -367,7 +367,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_o
     compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
       (scope := scope) (names := names) (calleeName := calleeName) (args := args)
-      (compiledIR := compiledIR) (argExprs := argExprs) hcompile hargCompile ?_
+      (compiledIR := compiledIR) (argExprs := argExprs) hcompile hargCompile ?_ irFuelSlack
   intro runtime state helperFuel irFuel hfuel hexact hscope hbounded hruntime
   by_cases hsource : 1 < helperFuel
   · by_cases hir : helperBodySize + 2 + irFuelSlack ≤ irFuel
@@ -384,7 +384,6 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall
     {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
     {scope : List String} {calleeName : String} {args : List Expr}
     {compiledIR : List YulStmt} {argExprs : List YulExpr}
-    (irFuelSlack : Nat := 0)
     (hcompile :
       CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
         (Stmt.internalCall calleeName args) spec.functions = Except.ok compiledIR)
@@ -405,7 +404,8 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall
             (Stmt.internalCall calleeName args))
           (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
             [YulStmt.exprStmt (YulExpr.call
-              (CompilationModel.internalFunctionYulName calleeName) argExprs)])) :
+              (CompilationModel.internalFunctionYulName calleeName) argExprs)]))
+    (irFuelSlack : Nat := 0) :
     CompiledStmtStepWithHelpersAndHelperIRWithInternals
       runtimeContract spec fields scope (Stmt.internalCall calleeName args) compiledIR irFuelSlack := by
   refine { compileOk := hcompile, preserves := ?_ }
@@ -540,7 +540,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_fuel
     compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
       (scope := scope) (calleeName := calleeName) (args := args)
-      (compiledIR := compiledIR) (argExprs := argExprs) hcompile hargCompile ?_
+      (compiledIR := compiledIR) (argExprs := argExprs) hcompile hargCompile ?_ irFuelSlack
   intro runtime state helperFuel irFuel hfuel hexact hscope hbounded hruntime
   by_cases hsource : 1 < helperFuel
   · by_cases hir : helperBodySize + 2 + irFuelSlack ≤ irFuel

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -219,7 +219,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign
     {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
     {scope : List String} {names : List String} {calleeName : String} {args : List Expr}
     {compiledIR : List YulStmt} {argExprs : List YulExpr}
-    {irFuelSlack : Nat := 0}
+    (irFuelSlack : Nat := 0)
     (hcompile :
       CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
         (Stmt.internalCallAssign names calleeName args) spec.functions = Except.ok compiledIR)
@@ -346,7 +346,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_o
     {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
     {scope : List String} {names : List String} {calleeName : String} {args : List Expr}
     {compiledIR : List YulStmt} {argExprs : List YulExpr}
-    {irFuelSlack : Nat := 0}
+    (irFuelSlack : Nat := 0)
     (helperBodySize : Nat)
     (hcompile :
       CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
@@ -384,7 +384,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall
     {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
     {scope : List String} {calleeName : String} {args : List Expr}
     {compiledIR : List YulStmt} {argExprs : List YulExpr}
-    {irFuelSlack : Nat := 0}
+    (irFuelSlack : Nat := 0)
     (hcompile :
       CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
         (Stmt.internalCall calleeName args) spec.functions = Except.ok compiledIR)
@@ -520,7 +520,7 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_fuel
     {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
     {scope : List String} {calleeName : String} {args : List Expr}
     {compiledIR : List YulStmt} {argExprs : List YulExpr}
-    {irFuelSlack : Nat := 0}
+    (irFuelSlack : Nat := 0)
     (helperBodySize : Nat)
     (hcompile :
       CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
@@ -595,7 +595,7 @@ theorem stmtListDirectInternalHelperAssignStepInterfaceWithInternals_cons_intern
     {names : List String} {calleeName : String} {args : List Expr}
     {compiledIR : List YulStmt}
     {rest : List Stmt}
-    {irFuelSlack : Nat := 0}
+    (irFuelSlack : Nat := 0)
     (hstep :
       CompiledStmtStepWithHelpersAndHelperIRWithInternals
         runtimeContract spec fields scope
@@ -1435,7 +1435,7 @@ theorem stmtListDirectInternalHelperCallStepInterfaceWithInternals_cons_internal
     {calleeName : String} {args : List Expr}
     {compiledIR : List YulStmt}
     {rest : List Stmt}
-    {irFuelSlack : Nat := 0}
+    (irFuelSlack : Nat := 0)
     (hstep :
       CompiledStmtStepWithHelpersAndHelperIRWithInternals
         runtimeContract spec fields scope

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -302,6 +302,20 @@ abbrev InternalCallAssignWithInternalsSufficientBridge
     InternalCallAssignWithInternalsBridgeAt runtimeContract spec fields scope names calleeName
       args argExprs runtime state helperFuel irFuel
 
+/-- Compositional sufficient-fuel obligation for a direct assignment helper
+call.  The helper consumes `helperBodySize + 2` units before recursive
+preservation is invoked, so the caller must reserve the downstream slack
+additively rather than proving two unrelated upper bounds. -/
+abbrev InternalCallAssignWithInternalsAdditiveBridge
+    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
+    (scope : List String) (names : List String) (calleeName : String) (args : List Expr)
+    (argExprs : List YulExpr) (helperBodySize irFuelSlack : Nat) : Prop :=
+  ∀ (runtime : SourceSemantics.RuntimeState) (state : IRState) (helperFuel irFuel : Nat),
+    1 < helperFuel →
+    helperBodySize + 2 + irFuelSlack ≤ irFuel →
+    InternalCallAssignWithInternalsBridgeAt runtimeContract spec fields scope names calleeName
+      args argExprs runtime state helperFuel irFuel
+
 abbrev InternalCallAssignWithInternalsResidualBridge
     (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
     (scope : List String) (names : List String) (calleeName : String) (args : List Expr)
@@ -440,6 +454,29 @@ abbrev InternalCallWithInternalsSufficientBridge
     helperBodySize + 2 ≤ irFuel →
     InternalCallWithInternalsBridgeAt runtimeContract spec fields scope calleeName args argExprs
       runtime state helperFuel irFuel
+
+/-- Compositional sufficient-fuel obligation for a direct void helper call.
+After entering and executing the helper body, `irFuelSlack` remains available
+to the recursive preservation proof.  In particular, equal independent bounds
+on the body cost, slack, and caller fuel are intentionally not accepted. -/
+abbrev InternalCallWithInternalsAdditiveBridge
+    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
+    (scope : List String) (calleeName : String) (args : List Expr)
+    (argExprs : List YulExpr) (helperBodySize irFuelSlack : Nat) : Prop :=
+  ∀ (runtime : SourceSemantics.RuntimeState) (state : IRState) (helperFuel irFuel : Nat),
+    1 < helperFuel →
+    helperBodySize + 2 + irFuelSlack ≤ irFuel →
+    InternalCallWithInternalsBridgeAt runtimeContract spec fields scope calleeName args argExprs
+      runtime state helperFuel irFuel
+
+/-- The arithmetic fact needed at the recursive helper boundary: the additive
+caller obligation leaves the complete promised slack after subtracting the
+helper-entry/body cost. -/
+theorem internalCall_irFuelSlack_le_residual
+    (helperBodySize irFuelSlack irFuel : Nat)
+    (h : helperBodySize + 2 + irFuelSlack ≤ irFuel) :
+    irFuelSlack ≤ irFuel - (helperBodySize + 2) := by
+  omega
 
 abbrev InternalCallWithInternalsResidualBridge
     (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Helpers.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Helpers.lean
@@ -3340,12 +3340,14 @@ theorem exec_compileStmtList_generic_with_helpers_and_helper_ir_with_internals_s
     {state : IRState}
     {scope : List String}
     {stmts : List Stmt}
+    {irFuelSlack : Nat}
     (helperFuel : Nat)
     (extraFuel : Nat)
     (hfuelPos : 0 < helperFuel)
+    (hreserve : irFuelSlack ≤ extraFuel)
     (hgeneric :
       StmtListGenericWithHelpersAndHelperIRWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hscope : FunctionBody.scopeNamesPresent scope runtime.bindings)
     (hexact : FunctionBody.bindingsExactlyMatchIRVarsOnScope scope runtime.bindings state)
     (hbounded : FunctionBody.bindingsBounded runtime.bindings)
@@ -3370,7 +3372,7 @@ theorem exec_compileStmtList_generic_with_helpers_and_helper_ir_with_internals_s
       · simp [SourceSemantics.execStmtListWithHelpers, execIRStmtsWithInternals,
               stmtStepMatchesIRExecWithInternals]
         exact And.intro hruntime <| And.intro hexact <| And.intro hbounded hscope
-  | @cons scope stmt compiledIR rest hstep hrest ih =>
+  | @cons irFuelSlack scope stmt compiledIR rest hstep hrest ih =>
       rcases compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIRWithInternals_exact
           hrest with ⟨tailIR, htailCompile⟩
       let bodyIR := compiledIR ++ tailIR
@@ -3384,7 +3386,7 @@ theorem exec_compileStmtList_generic_with_helpers_and_helper_ir_with_internals_s
           spec.functions compiledIR tailIR hstep.compileOk htailCompile
       let headExtraFuel := sizeOf bodyIR - compiledIR.length + extraFuel
       have hheadSlack :
-          sizeOf compiledIR - compiledIR.length ≤ headExtraFuel := by
+          sizeOf compiledIR - compiledIR.length + irFuelSlack ≤ headExtraFuel := by
         have hsize : sizeOf compiledIR ≤ sizeOf bodyIR := by
           simpa [bodyIR] using yulStmtList_sizeOf_append_left_le compiledIR tailIR
         dsimp [headExtraFuel]
@@ -3407,11 +3409,15 @@ theorem exec_compileStmtList_generic_with_helpers_and_helper_ir_with_internals_s
         rcases hheadMatch with ⟨hruntime', hexact', hbounded', hscope'⟩
         let tailExtraFuel' :=
           sizeOf bodyIR - compiledIR.length - sizeOf tailIR + extraFuel
+        have htailReserve : irFuelSlack ≤ tailExtraFuel' := by
+          dsimp [tailExtraFuel']
+          omega
         have htailSem' :=
           ih
             (runtime := _)
             (state := _)
             (extraFuel := tailExtraFuel')
+            htailReserve
             hscope' hexact' hbounded' hruntime'
         rcases htailSem' with ⟨tailIR', htailCompile', htailSem''⟩
         rw [htailCompile] at htailCompile'
@@ -3556,6 +3562,7 @@ theorem exec_compileStmtList_generic_with_helpers_and_helper_ir_with_internals_s
       (helperFuel := helperFuel)
       (extraFuel := extraFuel)
       hfuelPos
+      (Nat.zero_le extraFuel)
       hgeneric
       hscope
       hexact

--- a/Compiler/Proofs/IRGeneration/GenericInduction/InterfaceAssembly.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/InterfaceAssembly.lean
@@ -372,7 +372,7 @@ theorem stmtListDirectInternalHelperStepInterfaceWithInternals_of_callStepInterf
   induction hcall with
   | nil =>
       exact .nil
-  | @cons scope stmt rest hheadCall htailCall ih =>
+  | @cons _ scope stmt rest hheadCall htailCall ih =>
       cases hassign with
       | cons hheadAssign htailAssign =>
           refine .cons ?_ (ih htailAssign)
@@ -409,7 +409,7 @@ theorem stmtListInternalHelperSurfaceStepInterfaceWithInternals_of_directInterna
   induction hdirect with
   | nil =>
       exact .nil
-  | @cons scope stmt rest hheadDirect htailDirect ih =>
+  | @cons _ scope stmt rest hheadDirect htailDirect ih =>
       cases hexpr with
       | cons hheadExpr htailExpr =>
           cases hstruct with
@@ -693,7 +693,7 @@ theorem stmtListHelperSurfaceStepInterfaceWithInternals_of_internalHelperSurface
   induction hinternal with
   | nil =>
       exact .nil
-  | @cons scope stmt rest hheadInternal htailInternal ih =>
+  | @cons _ scope stmt rest hheadInternal htailInternal ih =>
       cases hresidual with
       | cons hheadResidual htailResidual =>
           refine .cons ?_ (ih htailResidual)
@@ -1020,7 +1020,7 @@ theorem
   induction hexpr with
   | nil =>
       exact .nil
-  | @cons scope stmt rest hhead htail ih =>
+  | @cons _ scope stmt rest hhead htail ih =>
       rcases hhead (hallExpr stmt List.mem_cons_self) with ⟨compiledIR, hcompiled⟩
       exact .cons hcompiled
         (ih (fun stmt' hmem =>
@@ -1048,7 +1048,7 @@ theorem
   induction hdirect with
   | nil =>
       exact .nil
-  | @cons scope stmt rest hhead htail ih =>
+  | @cons _ scope stmt rest hhead htail ih =>
       rcases hhead (hallDirect stmt List.mem_cons_self) with ⟨compiledIR, hcompiled⟩
       exact .cons hcompiled
         (ih (fun stmt' hmem =>
@@ -1076,7 +1076,7 @@ theorem
   induction hstruct with
   | nil =>
       exact .nil
-  | @cons scope stmt rest hhead htail ih =>
+  | @cons _ scope stmt rest hhead htail ih =>
       rcases hhead (hallStructural stmt List.mem_cons_self) with
         ⟨compiledIR, hcompiled⟩
       exact .cons hcompiled
@@ -1107,7 +1107,7 @@ theorem
   induction hsteps with
   | nil =>
       exact .nil
-  | @cons scope stmt rest hheadStep htailSteps ih =>
+  | @cons _ scope stmt rest hheadStep htailSteps ih =>
       cases hhelperFree with
       | cons hheadFree htailFree =>
           by_cases hsurface : stmtTouchesUnsupportedHelperSurface stmt = false

--- a/Compiler/Proofs/IRGeneration/GenericInduction/InterfaceAssembly.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/InterfaceAssembly.lean
@@ -362,12 +362,13 @@ theorem stmtListDirectInternalHelperStepInterfaceWithInternals_of_callStepInterf
     {fields : List Field}
     {scope : List String}
     {stmts : List Stmt}
+    {irFuelSlack : Nat}
     (hcall :
-      StmtListDirectInternalHelperCallStepInterfaceWithInternals runtimeContract spec fields scope stmts)
+      StmtListDirectInternalHelperCallStepInterfaceWithInternals runtimeContract spec fields scope stmts irFuelSlack)
     (hassign :
-      StmtListDirectInternalHelperAssignStepInterfaceWithInternals runtimeContract spec fields scope stmts) :
+      StmtListDirectInternalHelperAssignStepInterfaceWithInternals runtimeContract spec fields scope stmts irFuelSlack) :
     StmtListDirectInternalHelperStepInterfaceWithInternals
-      runtimeContract spec fields scope stmts := by
+      runtimeContract spec fields scope stmts irFuelSlack := by
   induction hcall with
   | nil =>
       exact .nil
@@ -393,17 +394,18 @@ theorem stmtListInternalHelperSurfaceStepInterfaceWithInternals_of_directInterna
     {fields : List Field}
     {scope : List String}
     {stmts : List Stmt}
+    {irFuelSlack : Nat}
     (hdirect :
       StmtListDirectInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hexpr :
       StmtListExprInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hstruct :
       StmtListStructuralInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts) :
+        runtimeContract spec fields scope stmts irFuelSlack) :
     StmtListInternalHelperSurfaceStepInterfaceWithInternals
-      runtimeContract spec fields scope stmts := by
+      runtimeContract spec fields scope stmts irFuelSlack := by
   induction hdirect with
   | nil =>
       exact .nil
@@ -560,9 +562,10 @@ theorem stmtListStructuralInternalHelperStepInterfaceWithInternals_of_structural
     {fields : List Field}
     {scope : List String}
     {stmts : List Stmt}
+    {irFuelSlack : Nat}
     (hsurface : stmtListTouchesStructuralInternalHelperSurface stmts = false) :
     StmtListStructuralInternalHelperStepInterfaceWithInternals
-      runtimeContract spec fields scope stmts := by
+      runtimeContract spec fields scope stmts irFuelSlack := by
   induction stmts generalizing scope with
   | nil =>
       exact .nil
@@ -678,14 +681,15 @@ theorem stmtListHelperSurfaceStepInterfaceWithInternals_of_internalHelperSurface
     {fields : List Field}
     {scope : List String}
     {stmts : List Stmt}
+    {irFuelSlack : Nat}
     (hinternal :
       StmtListInternalHelperSurfaceStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hresidual :
       StmtListResidualHelperSurfaceStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts) :
+        runtimeContract spec fields scope stmts irFuelSlack) :
     StmtListHelperSurfaceStepInterfaceWithInternals
-      runtimeContract spec fields scope stmts := by
+      runtimeContract spec fields scope stmts irFuelSlack := by
   induction hinternal with
   | nil =>
       exact .nil
@@ -1005,13 +1009,14 @@ theorem
     {fields : List Field}
     {scope : List String}
     {stmts : List Stmt}
+    {irFuelSlack : Nat}
     (hexpr :
       StmtListExprInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hallExpr :
       ∀ stmt ∈ stmts, stmtTouchesExprInternalHelperSurface stmt = true) :
     StmtListGenericWithHelpersAndHelperIRWithInternals
-      runtimeContract spec fields scope stmts := by
+      runtimeContract spec fields scope stmts irFuelSlack := by
   induction hexpr with
   | nil =>
       exact .nil
@@ -1032,13 +1037,14 @@ theorem
     {fields : List Field}
     {scope : List String}
     {stmts : List Stmt}
+    {irFuelSlack : Nat}
     (hdirect :
       StmtListDirectInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hallDirect :
       ∀ stmt ∈ stmts, stmtTouchesDirectInternalHelperSurface stmt = true) :
     StmtListGenericWithHelpersAndHelperIRWithInternals
-      runtimeContract spec fields scope stmts := by
+      runtimeContract spec fields scope stmts irFuelSlack := by
   induction hdirect with
   | nil =>
       exact .nil
@@ -1059,13 +1065,14 @@ theorem
     {fields : List Field}
     {scope : List String}
     {stmts : List Stmt}
+    {irFuelSlack : Nat}
     (hstruct :
       StmtListStructuralInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hallStructural :
       ∀ stmt ∈ stmts, stmtTouchesStructuralInternalHelperSurface stmt = true) :
     StmtListGenericWithHelpersAndHelperIRWithInternals
-      runtimeContract spec fields scope stmts := by
+      runtimeContract spec fields scope stmts irFuelSlack := by
   induction hstruct with
   | nil =>
       exact .nil
@@ -1088,14 +1095,15 @@ theorem
     {fields : List Field}
     {scope : List String}
     {stmts : List Stmt}
+    {irFuelSlack : Nat}
     (hhelperFree :
       StmtListHelperFreeStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hsteps :
       StmtListHelperSurfaceStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts) :
+        runtimeContract spec fields scope stmts irFuelSlack) :
     StmtListGenericWithHelpersAndHelperIRWithInternals
-      runtimeContract spec fields scope stmts := by
+      runtimeContract spec fields scope stmts irFuelSlack := by
   induction hsteps with
   | nil =>
       exact .nil
@@ -1122,23 +1130,24 @@ theorem
     {fields : List Field}
     {scope : List String}
     {stmts : List Stmt}
+    {irFuelSlack : Nat}
     (hhelperFree :
       StmtListHelperFreeStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hdirect :
       StmtListDirectInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hexpr :
       StmtListExprInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hstruct :
       StmtListStructuralInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hresidual :
       StmtListResidualHelperSurfaceStepInterfaceWithInternals
-        runtimeContract spec fields scope stmts) :
+        runtimeContract spec fields scope stmts irFuelSlack) :
     StmtListGenericWithHelpersAndHelperIRWithInternals
-      runtimeContract spec fields scope stmts := by
+      runtimeContract spec fields scope stmts irFuelSlack := by
   exact
     stmtListGenericWithHelpersAndHelperIRWithInternals_of_helperFreeStepInterfaceWithInternals_and_helperSurfaceStepInterfaceWithInternals
       (runtimeContract := runtimeContract)

--- a/Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean
@@ -208,7 +208,8 @@ structure CompiledStmtStepWithHelpersAndHelperIRWithInternals
     (fields : List Field)
     (scope : List String)
     (stmt : Stmt)
-    (compiledIR : List YulStmt) : Prop where
+    (compiledIR : List YulStmt)
+    (irFuelSlack : Nat := 0) : Prop where
   compileOk :
     CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
         stmt spec.functions =
@@ -223,7 +224,7 @@ structure CompiledStmtStepWithHelpersAndHelperIRWithInternals
       FunctionBody.scopeNamesPresent scope runtime.bindings →
       FunctionBody.bindingsBounded runtime.bindings →
       FunctionBody.runtimeStateMatchesIR fields runtime state →
-      sizeOf compiledIR - compiledIR.length ≤ extraFuel →
+      sizeOf compiledIR - compiledIR.length + irFuelSlack ≤ extraFuel →
       ∃ sourceResult irExec,
         SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime stmt = sourceResult ∧
         execIRStmtsWithInternals runtimeContract
@@ -468,17 +469,17 @@ enough for callers that thread the compiler scope structurally. -/
 inductive StmtListGenericWithHelpersAndHelperIRWithInternals
     (runtimeContract : IRContract)
     (spec : CompilationModel)
-    (fields : List Field) : List String → List Stmt → Prop where
+    (fields : List Field) : List String → List Stmt → (irFuelSlack : Nat := 0) → Prop where
   | nil {scope : List String} :
       StmtListGenericWithHelpersAndHelperIRWithInternals
-        runtimeContract spec fields scope []
+        runtimeContract spec fields scope [] irFuelSlack
   | cons {scope : List String} {stmt : Stmt} {compiledIR : List YulStmt} {rest : List Stmt} :
       CompiledStmtStepWithHelpersAndHelperIRWithInternals
-        runtimeContract spec fields scope stmt compiledIR →
+        runtimeContract spec fields scope stmt compiledIR irFuelSlack →
       StmtListGenericWithHelpersAndHelperIRWithInternals
-        runtimeContract spec fields (stmtNextScope scope stmt) rest →
+        runtimeContract spec fields (stmtNextScope scope stmt) rest irFuelSlack →
       StmtListGenericWithHelpersAndHelperIRWithInternals
-        runtimeContract spec fields scope (stmt :: rest)
+        runtimeContract spec fields scope (stmt :: rest) irFuelSlack
 
 /-- Exact-scope compile reconstruction for the spec-functions-aware helper IR
 list seam. -/
@@ -488,9 +489,10 @@ theorem compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIRWithInternals
     {fields : List Field}
     {scope : List String}
     {stmts : List Stmt}
+    {irFuelSlack : Nat}
     (hgeneric :
       StmtListGenericWithHelpersAndHelperIRWithInternals
-        runtimeContract spec fields scope stmts) :
+        runtimeContract spec fields scope stmts irFuelSlack) :
     ∃ bodyIR,
       CompilationModel.compileStmtList
         fields spec.events spec.errors .calldata [] false scope [] stmts spec.functions =
@@ -500,7 +502,7 @@ theorem compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIRWithInternals
       exact ⟨[], by
         simp [CompilationModel.compileStmtList, CompilationModel.compileStmtListWithFork,
           Pure.pure, Except.pure]⟩
-  | @cons scope stmt compiledIR rest hstep _hrest ih =>
+  | @cons irFuelSlack scope stmt compiledIR rest hstep _hrest ih =>
       rcases ih with ⟨tailIR, htail⟩
       rcases FunctionBody.compileStmtList_ok_any_scope_with_surface_with_internals
           (scope2 := collectStmtBindNames stmt ++ scope) ⟨tailIR, htail⟩ with
@@ -524,9 +526,10 @@ theorem compileStmtList_ok_of_stmtListGenericWithHelpersAndHelperIRWithInternals
     {fields : List Field}
     {scope inScopeNames : List String}
     {stmts : List Stmt}
+    {irFuelSlack : Nat}
     (hgeneric :
       StmtListGenericWithHelpersAndHelperIRWithInternals
-        runtimeContract spec fields scope stmts)
+        runtimeContract spec fields scope stmts irFuelSlack)
     (hincluded : FunctionBody.scopeNamesIncluded scope inScopeNames) :
     ∃ bodyIR,
       CompilationModel.compileStmtList

--- a/Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/ResultRelation.lean
@@ -383,18 +383,18 @@ visible while allowing mixed `WithInternals` list assembly to stop depending on
 inductive StmtListHelperFreeStepInterfaceWithInternals
     (runtimeContract : IRContract)
     (spec : CompilationModel)
-    (fields : List Field) : List String → List Stmt → Prop where
+    (fields : List Field) : List String → List Stmt → (irFuelSlack : Nat := 0) → Prop where
   | nil {scope : List String} :
-      StmtListHelperFreeStepInterfaceWithInternals runtimeContract spec fields scope []
+      StmtListHelperFreeStepInterfaceWithInternals runtimeContract spec fields scope [] irFuelSlack
   | cons {scope : List String} {stmt : Stmt} {rest : List Stmt} :
       (stmtTouchesUnsupportedHelperSurface stmt = false →
         ∃ compiledIR,
           CompiledStmtStepWithHelpersAndHelperIRWithInternals
-            runtimeContract spec fields scope stmt compiledIR) →
+            runtimeContract spec fields scope stmt compiledIR irFuelSlack) →
       StmtListHelperFreeStepInterfaceWithInternals
-        runtimeContract spec fields (stmtNextScope scope stmt) rest →
+        runtimeContract spec fields (stmtNextScope scope stmt) rest irFuelSlack →
       StmtListHelperFreeStepInterfaceWithInternals
-        runtimeContract spec fields scope (stmt :: rest)
+        runtimeContract spec fields scope (stmt :: rest) irFuelSlack
 
 /-- Scalar-event variant of the helper-free source-step interface. Event heads
 are discharged by `StmtListEventSurfaceStepInterface`, so helper-free compiled
@@ -689,18 +689,18 @@ internal-helper heads. This mirrors
 inductive StmtListDirectInternalHelperCallStepInterfaceWithInternals
     (runtimeContract : IRContract)
     (spec : CompilationModel)
-    (fields : List Field) : List String → List Stmt → Prop where
+    (fields : List Field) : List String → List Stmt → (irFuelSlack : Nat := 0) → Prop where
   | nil {scope : List String} :
-      StmtListDirectInternalHelperCallStepInterfaceWithInternals runtimeContract spec fields scope []
+      StmtListDirectInternalHelperCallStepInterfaceWithInternals runtimeContract spec fields scope [] irFuelSlack
   | cons {scope : List String} {stmt : Stmt} {rest : List Stmt} :
       (stmtTouchesDirectInternalHelperCallSurface stmt = true →
         ∃ compiledIR,
           CompiledStmtStepWithHelpersAndHelperIRWithInternals
-            runtimeContract spec fields scope stmt compiledIR) →
+            runtimeContract spec fields scope stmt compiledIR irFuelSlack) →
       StmtListDirectInternalHelperCallStepInterfaceWithInternals
-        runtimeContract spec fields (stmtNextScope scope stmt) rest →
+        runtimeContract spec fields (stmtNextScope scope stmt) rest irFuelSlack →
       StmtListDirectInternalHelperCallStepInterfaceWithInternals
-        runtimeContract spec fields scope (stmt :: rest)
+        runtimeContract spec fields scope (stmt :: rest) irFuelSlack
 
 /-- Spec-functions-aware exact step interface for direct statement-position
 helper-return binding heads. This mirrors
@@ -709,18 +709,18 @@ helper-return binding heads. This mirrors
 inductive StmtListDirectInternalHelperAssignStepInterfaceWithInternals
     (runtimeContract : IRContract)
     (spec : CompilationModel)
-    (fields : List Field) : List String → List Stmt → Prop where
+    (fields : List Field) : List String → List Stmt → (irFuelSlack : Nat := 0) → Prop where
   | nil {scope : List String} :
-      StmtListDirectInternalHelperAssignStepInterfaceWithInternals runtimeContract spec fields scope []
+      StmtListDirectInternalHelperAssignStepInterfaceWithInternals runtimeContract spec fields scope [] irFuelSlack
   | cons {scope : List String} {stmt : Stmt} {rest : List Stmt} :
       (stmtTouchesDirectInternalHelperAssignSurface stmt = true →
         ∃ compiledIR,
           CompiledStmtStepWithHelpersAndHelperIRWithInternals
-            runtimeContract spec fields scope stmt compiledIR) →
+            runtimeContract spec fields scope stmt compiledIR irFuelSlack) →
       StmtListDirectInternalHelperAssignStepInterfaceWithInternals
-        runtimeContract spec fields (stmtNextScope scope stmt) rest →
+        runtimeContract spec fields (stmtNextScope scope stmt) rest irFuelSlack →
       StmtListDirectInternalHelperAssignStepInterfaceWithInternals
-        runtimeContract spec fields scope (stmt :: rest)
+        runtimeContract spec fields scope (stmt :: rest) irFuelSlack
 
 /-- Coarser direct statement-position helper interface retained as the assembly
 point for the two direct helper proof shapes above. -/
@@ -745,18 +745,18 @@ shapes. -/
 inductive StmtListDirectInternalHelperStepInterfaceWithInternals
     (runtimeContract : IRContract)
     (spec : CompilationModel)
-    (fields : List Field) : List String → List Stmt → Prop where
+    (fields : List Field) : List String → List Stmt → (irFuelSlack : Nat := 0) → Prop where
   | nil {scope : List String} :
-      StmtListDirectInternalHelperStepInterfaceWithInternals runtimeContract spec fields scope []
+      StmtListDirectInternalHelperStepInterfaceWithInternals runtimeContract spec fields scope [] irFuelSlack
   | cons {scope : List String} {stmt : Stmt} {rest : List Stmt} :
       (stmtTouchesDirectInternalHelperSurface stmt = true →
         ∃ compiledIR,
           CompiledStmtStepWithHelpersAndHelperIRWithInternals
-            runtimeContract spec fields scope stmt compiledIR) →
+            runtimeContract spec fields scope stmt compiledIR irFuelSlack) →
       StmtListDirectInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields (stmtNextScope scope stmt) rest →
+        runtimeContract spec fields (stmtNextScope scope stmt) rest irFuelSlack →
       StmtListDirectInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope (stmt :: rest)
+        runtimeContract spec fields scope (stmt :: rest) irFuelSlack
 
 /-- Exact step interface for heads whose internal-helper work appears only in
 expression position at the current statement head. These are the cases that
@@ -785,18 +785,18 @@ compile shape. -/
 inductive StmtListExprInternalHelperStepInterfaceWithInternals
     (runtimeContract : IRContract)
     (spec : CompilationModel)
-    (fields : List Field) : List String → List Stmt → Prop where
+    (fields : List Field) : List String → List Stmt → (irFuelSlack : Nat := 0) → Prop where
   | nil {scope : List String} :
-      StmtListExprInternalHelperStepInterfaceWithInternals runtimeContract spec fields scope []
+      StmtListExprInternalHelperStepInterfaceWithInternals runtimeContract spec fields scope [] irFuelSlack
   | cons {scope : List String} {stmt : Stmt} {rest : List Stmt} :
       (stmtTouchesExprInternalHelperSurface stmt = true →
         ∃ compiledIR,
           CompiledStmtStepWithHelpersAndHelperIRWithInternals
-            runtimeContract spec fields scope stmt compiledIR) →
+            runtimeContract spec fields scope stmt compiledIR irFuelSlack) →
       StmtListExprInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields (stmtNextScope scope stmt) rest →
+        runtimeContract spec fields (stmtNextScope scope stmt) rest irFuelSlack →
       StmtListExprInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope (stmt :: rest)
+        runtimeContract spec fields scope (stmt :: rest) irFuelSlack
 
 /-- Exact step interface for structural heads whose helper burden is recursive
 transport through nested bodies (`ite` / `forEach`) rather than direct helper
@@ -821,19 +821,19 @@ internal-helper work is recursive transport through nested statement lists. -/
 inductive StmtListStructuralInternalHelperStepInterfaceWithInternals
     (runtimeContract : IRContract)
     (spec : CompilationModel)
-    (fields : List Field) : List String → List Stmt → Prop where
+    (fields : List Field) : List String → List Stmt → (irFuelSlack : Nat := 0) → Prop where
   | nil {scope : List String} :
       StmtListStructuralInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope []
+        runtimeContract spec fields scope [] irFuelSlack
   | cons {scope : List String} {stmt : Stmt} {rest : List Stmt} :
       (stmtTouchesStructuralInternalHelperSurface stmt = true →
         ∃ compiledIR,
           CompiledStmtStepWithHelpersAndHelperIRWithInternals
-            runtimeContract spec fields scope stmt compiledIR) →
+            runtimeContract spec fields scope stmt compiledIR irFuelSlack) →
       StmtListStructuralInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields (stmtNextScope scope stmt) rest →
+        runtimeContract spec fields (stmtNextScope scope stmt) rest irFuelSlack →
       StmtListStructuralInternalHelperStepInterfaceWithInternals
-        runtimeContract spec fields scope (stmt :: rest)
+        runtimeContract spec fields scope (stmt :: rest) irFuelSlack
 
 /-- Residual exact-step interface for heads that still fall on the coarse old
 helper surface but do not actually execute internal helpers. Splitting these
@@ -860,20 +860,20 @@ sit on the coarse helper surface but are not genuine internal-helper heads. -/
 inductive StmtListResidualHelperSurfaceStepInterfaceWithInternals
     (runtimeContract : IRContract)
     (spec : CompilationModel)
-    (fields : List Field) : List String → List Stmt → Prop where
+    (fields : List Field) : List String → List Stmt → (irFuelSlack : Nat := 0) → Prop where
   | nil {scope : List String} :
       StmtListResidualHelperSurfaceStepInterfaceWithInternals
-        runtimeContract spec fields scope []
+        runtimeContract spec fields scope [] irFuelSlack
   | cons {scope : List String} {stmt : Stmt} {rest : List Stmt} :
       (stmtTouchesUnsupportedHelperSurface stmt = true →
         stmtTouchesInternalHelperSurface stmt = false →
         ∃ compiledIR,
           CompiledStmtStepWithHelpersAndHelperIRWithInternals
-            runtimeContract spec fields scope stmt compiledIR) →
+            runtimeContract spec fields scope stmt compiledIR irFuelSlack) →
       StmtListResidualHelperSurfaceStepInterfaceWithInternals
-        runtimeContract spec fields (stmtNextScope scope stmt) rest →
+        runtimeContract spec fields (stmtNextScope scope stmt) rest irFuelSlack →
       StmtListResidualHelperSurfaceStepInterfaceWithInternals
-        runtimeContract spec fields scope (stmt :: rest)
+        runtimeContract spec fields scope (stmt :: rest) irFuelSlack
 
 /-- Spec-functions-aware exact step interface for genuine internal-helper
 heads, assembled from direct, expression-position, and structural helper
@@ -881,38 +881,38 @@ interfaces. -/
 inductive StmtListInternalHelperSurfaceStepInterfaceWithInternals
     (runtimeContract : IRContract)
     (spec : CompilationModel)
-    (fields : List Field) : List String → List Stmt → Prop where
+    (fields : List Field) : List String → List Stmt → (irFuelSlack : Nat := 0) → Prop where
   | nil {scope : List String} :
       StmtListInternalHelperSurfaceStepInterfaceWithInternals
-        runtimeContract spec fields scope []
+        runtimeContract spec fields scope [] irFuelSlack
   | cons {scope : List String} {stmt : Stmt} {rest : List Stmt} :
       (stmtTouchesInternalHelperSurface stmt = true →
         ∃ compiledIR,
           CompiledStmtStepWithHelpersAndHelperIRWithInternals
-            runtimeContract spec fields scope stmt compiledIR) →
+            runtimeContract spec fields scope stmt compiledIR irFuelSlack) →
       StmtListInternalHelperSurfaceStepInterfaceWithInternals
-        runtimeContract spec fields (stmtNextScope scope stmt) rest →
+        runtimeContract spec fields (stmtNextScope scope stmt) rest irFuelSlack →
       StmtListInternalHelperSurfaceStepInterfaceWithInternals
-        runtimeContract spec fields scope (stmt :: rest)
+        runtimeContract spec fields scope (stmt :: rest) irFuelSlack
 
 /-- Spec-functions-aware helper-surface interface, including genuine internal
 helper heads and residual coarse helper-surface heads. -/
 inductive StmtListHelperSurfaceStepInterfaceWithInternals
     (runtimeContract : IRContract)
     (spec : CompilationModel)
-    (fields : List Field) : List String → List Stmt → Prop where
+    (fields : List Field) : List String → List Stmt → (irFuelSlack : Nat := 0) → Prop where
   | nil {scope : List String} :
       StmtListHelperSurfaceStepInterfaceWithInternals
-        runtimeContract spec fields scope []
+        runtimeContract spec fields scope [] irFuelSlack
   | cons {scope : List String} {stmt : Stmt} {rest : List Stmt} :
       (stmtTouchesUnsupportedHelperSurface stmt = true →
         ∃ compiledIR,
           CompiledStmtStepWithHelpersAndHelperIRWithInternals
-            runtimeContract spec fields scope stmt compiledIR) →
+            runtimeContract spec fields scope stmt compiledIR irFuelSlack) →
       StmtListHelperSurfaceStepInterfaceWithInternals
-        runtimeContract spec fields (stmtNextScope scope stmt) rest →
+        runtimeContract spec fields (stmtNextScope scope stmt) rest irFuelSlack →
       StmtListHelperSurfaceStepInterfaceWithInternals
-        runtimeContract spec fields scope (stmt :: rest)
+        runtimeContract spec fields scope (stmt :: rest) irFuelSlack
 
 
 end Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/IRGeneration/HelperBodyBridge.lean
+++ b/Compiler/Proofs/IRGeneration/HelperBodyBridge.lean
@@ -63,7 +63,7 @@ theorem execIRInternalFunctionWithInternals_obeys_internal_helper_summary
       (helper := helper) (callerState := callerState)
       (initialWorld := initialWorld) (logicalArgs := logicalArgs) (irArgs := irArgs)
       (sourceBindings := sourceBindings) (entryBindings := entryBindings)
-      helperFuel extraFuel hfuelPos ctx with
+      helperFuel extraFuel hfuelPos (Nat.zero_le extraFuel) ctx with
     ⟨_hmatch, hinterp⟩
   constructor
   · -- Public source-arity fact retained for consumers (`harity` + bind).

--- a/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
+++ b/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
@@ -558,8 +558,8 @@ def helperA_supportedHelperRichBodyFragment :
   refine {
     hasInternalHelperCall := ?_
     coreSupported := rfl
-    helperArgsInScope := by
-      simp [helperA, stmtListHelperCallArgsInScope, stmtHelperCallArgsInScope,
+    expressionsInScope := by
+      simp [helperA, stmtListHelperRichExprsInScope, stmtHelperRichExprsInScope,
         stmtNextScope]
     state := ⟨rfl⟩
     calls :=

--- a/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
+++ b/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
@@ -563,7 +563,11 @@ def helperA_supportedHelperRichBodyFragment :
       -- bound-name fold closes the direct-metadata subexpression obligation.
       simp [helperA, stmtListHelperRichExprsInScope, stmtHelperRichExprsInScope,
         Stmt.directMetadata, FunctionBody.exprBoundNamesInScope,
-        FunctionBody.exprBoundNames, FunctionBody.exprListBoundNames, stmtNextScope]
+        FunctionBody.exprBoundNames, FunctionBody.exprListBoundNames,
+        stmtHelperRichNextScope, stmtNextScope]
+    assignTargetsSupported := by
+      simp [helperA, stmtListHelperRichAssignTargetsSupported,
+        stmtHelperRichAssignTargetsSupported]
     stateSupported := rfl
     calls :=
       { helpers := helperA_supportedBodyHelperInterface

--- a/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
+++ b/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
@@ -561,7 +561,7 @@ def helperA_supportedHelperRichBodyFragment :
     expressionsInScope := by
       simp [helperA, stmtListHelperRichExprsInScope, stmtHelperRichExprsInScope,
         stmtNextScope]
-    state := ⟨rfl⟩
+    stateSupported := rfl
     calls :=
       { helpers := helperA_supportedBodyHelperInterface
         foreign := rfl

--- a/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
+++ b/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
@@ -560,7 +560,8 @@ def helperA_supportedHelperRichBodyFragment :
     coreSupported := rfl
     expressionsInScope := by
       simp [helperA, stmtListHelperRichExprsInScope, stmtHelperRichExprsInScope,
-        stmtNextScope]
+        Stmt.directMetadata, FunctionBody.exprBoundNamesInScope,
+        FunctionBody.exprBoundNames, stmtNextScope]
     stateSupported := rfl
     calls :=
       { helpers := helperA_supportedBodyHelperInterface

--- a/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
+++ b/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
@@ -574,7 +574,73 @@ def helperA_supportedHelperRichBodyFragment :
     apply List.mem_eraseDups_of_mem_local
     simp [helperA, stmtListInternalHelperCallNames,
       stmtInternalHelperCallNames, exprInternalHelperCallNames,
-      exprListInternalHelperCallNames]⟩
+    exprListInternalHelperCallNames]⟩
+
+/-- Function-boundary witness for the genuine helper caller.  This is the
+non-vacuous inhabitant that the legacy `SupportedFunction` gate could not
+express. -/
+def helperA_supportedFunctionWithHelpers :
+    SupportedFunctionWithHelpers twoHelperSpec helperA := by
+  refine {
+    nonSpecialEntrypoint := by simp [helperA, isInteropEntrypointName]
+    noNonReentrant := rfl
+    params := ?_
+    returns := ?_
+    body := .helperRich helperA_supportedHelperRichBodyFragment
+  }
+  · refine ⟨by simp [helperA], ?_, ?_⟩
+    · simp [helperA]
+    · simp [helperA, Compiler.Constants.evmModulus]
+  · exact { resolved := ⟨[], rfl, trivial⟩ }
+
+private def helperB_supportedFunctionWithHelpers :
+    SupportedFunctionWithHelpers twoHelperSpec helperB := by
+  refine {
+    nonSpecialEntrypoint := by simp [helperB, isInteropEntrypointName]
+    noNonReentrant := rfl
+    params := ?_
+    returns := ?_
+    body := .internalHelper helperB_support.toWitness.summary
+  }
+  · refine ⟨by simp [helperB], ?_, ?_⟩
+    · simp [helperB]
+    · simp [helperB, Compiler.Constants.evmModulus]
+  · exact { resolved := ⟨[], rfl, trivial⟩ }
+
+/-- Whole-spec regression: a model containing an internal helper caller and
+its callee now inhabits the helper-aware support inventory without any
+helper-free premise. -/
+noncomputable def twoHelper_supportedSpecWithHelpers :
+    SupportedSpecWithHelpers twoHelperSpec [] := by
+  refine {
+    invariants := ?_
+    surface := ?_
+    constructor := ?_
+    functions := ?_
+  }
+  · refine ⟨rfl, ?_, rfl, rfl, ?_⟩
+    · simp [twoHelperSpec]
+    · simp [twoHelperSpec, helperA, helperB]
+  · refine ⟨rfl, rfl, rfl, rfl, ?_, ?_, ?_, ?_⟩
+    · native_decide
+    · rw [templateIntrinsicItems, twoHelperSpec, helperA, helperB]
+      unfold collectTemplateIntrinsicsFromStmts
+      simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+      repeat rw [collectTemplateIntrinsicsFromStmt.eq_def]
+      simp [Stmt.directMetadata, Stmt.childLists,
+        collectTemplateIntrinsicsFromExpr, Expr.children]
+    · simp [twoHelperSpec, helperA, helperB]
+    · simp [twoHelperSpec, helperA, helperB]
+  · intro ctor hctor
+    simp [twoHelperSpec] at hctor
+  · intro fn hfn
+    simp [twoHelperSpec] at hfn
+    by_cases hA : fn = helperA
+    · subst fn
+      exact helperA_supportedFunctionWithHelpers
+    · have hB : fn = helperB := Or.resolve_left hfn hA
+      subst fn
+      exact helperB_supportedFunctionWithHelpers
 
 /-- Explicit source-syntax evidence that the positive witness is genuinely
 helper-rich, rather than inhabited through an empty call inventory. -/

--- a/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
+++ b/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
@@ -622,7 +622,10 @@ noncomputable def twoHelper_supportedSpecWithHelpers :
     · simp [twoHelperSpec]
     · simp [twoHelperSpec, helperA, helperB]
   · refine ⟨rfl, rfl, rfl, rfl, ?_, ?_, ?_, ?_⟩
-    · native_decide
+    · simp [contractUsesCheckedArithmetic, twoHelperSpec]
+      constructor
+      · simp [helperA, stmtListMayUseCheckedArithmetic, stmtMayUseCheckedArithmetic]
+      · simp [helperB, stmtListMayUseCheckedArithmetic, stmtMayUseCheckedArithmetic]
     · rw [templateIntrinsicItems, twoHelperSpec, helperA, helperB]
       unfold collectTemplateIntrinsicsFromStmts
       simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]

--- a/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
+++ b/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
@@ -561,7 +561,7 @@ def helperA_supportedHelperRichBodyFragment :
     expressionsInScope := by
       simp [helperA, stmtListHelperRichExprsInScope, stmtHelperRichExprsInScope,
         Stmt.directMetadata, FunctionBody.exprBoundNamesInScope,
-        FunctionBody.exprBoundNames, stmtNextScope]
+        FunctionBody.exprBoundNames, FunctionBody.exprListBoundNames, stmtNextScope]
     stateSupported := rfl
     calls :=
       { helpers := helperA_supportedBodyHelperInterface

--- a/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
+++ b/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
@@ -559,6 +559,8 @@ def helperA_supportedHelperRichBodyFragment :
     hasInternalHelperCall := ?_
     coreSupported := rfl
     expressionsInScope := by
+      -- The concrete helper call has no arguments, so exposing the expression-list
+      -- bound-name fold closes the direct-metadata subexpression obligation.
       simp [helperA, stmtListHelperRichExprsInScope, stmtHelperRichExprsInScope,
         Stmt.directMetadata, FunctionBody.exprBoundNamesInScope,
         FunctionBody.exprBoundNames, FunctionBody.exprListBoundNames, stmtNextScope]

--- a/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
+++ b/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
@@ -57,6 +57,10 @@ private theorem List.mem_of_mem_eraseDups_local [BEq α] [LawfulBEq α]
     {a : α} {l : List α} (h : a ∈ l.eraseDups) : a ∈ l :=
   ((eraseDups_nodup_and_mem_aux_local l.length l (Nat.le_refl _)).2 a).mp h
 
+private theorem List.mem_eraseDups_of_mem_local [BEq α] [LawfulBEq α]
+    {a : α} {l : List α} (h : a ∈ l) : a ∈ l.eraseDups :=
+  ((eraseDups_nodup_and_mem_aux_local l.length l (Nat.le_refl _)).2 a).mpr h
+
 /-- Canonical selector-aware helper summary. -/
 def exactInternalHelperSummary
     (spec : CompilationModel)
@@ -544,6 +548,43 @@ def helperA_supportedBodyHelperInterface :
     change helperStmtListReadOnly helperB.body = true
     simp [helperB, helperStmtListReadOnly, helperStmtReadOnly,
       helperExprReadOnly, exprTouchesUnsupportedCallSurface]
+
+/-- Non-vacuous witness for the positive helper-rich supported fragment.
+`helperA` contains the expression-position call `helperB()`, whose exact
+summary, decreasing rank, and successful world preservation are supplied by
+`helperA_supportedBodyHelperInterface`. -/
+def helperA_supportedHelperRichBodyFragment :
+    SupportedHelperRichBodyFragment twoHelperSpec helperA := by
+  refine {
+    hasInternalHelperCall := ?_
+    coreSupported := rfl
+    state := ⟨rfl⟩
+    calls :=
+      { helpers := helperA_supportedBodyHelperInterface
+        foreign := rfl
+        lowLevel := rfl }
+    effects := ⟨rfl⟩
+    constructorRawCalldataSurfaceClosed := rfl
+    noLocalObligations := rfl
+  }
+  exact ⟨"helperB", by
+    apply List.mem_eraseDups_of_mem_local
+    simp [helperA, stmtListInternalHelperCallNames,
+      stmtInternalHelperCallNames, exprInternalHelperCallNames,
+      exprListInternalHelperCallNames]⟩
+
+/-- Explicit source-syntax evidence that the positive witness is genuinely
+helper-rich, rather than inhabited through an empty call inventory. -/
+theorem helperA_contains_internal_helper_call :
+    Stmt.letVar "x" (Expr.internalCall "helperB" []) ∈ helperA.body := by
+  simp [helperA]
+
+theorem helperA_helperB_occurs_in_call_inventory :
+    "helperB" ∈ helperCallNames helperA := by
+  apply List.mem_eraseDups_of_mem_local
+  simp [helperA, stmtListInternalHelperCallNames,
+    stmtInternalHelperCallNames, exprInternalHelperCallNames,
+    exprListInternalHelperCallNames]
 
 theorem helperA_supportedBodyHelperInterface_summary_sound :
     SupportedBodyHelperSummariesSound twoHelperSpec helperA

--- a/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
+++ b/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
@@ -558,6 +558,9 @@ def helperA_supportedHelperRichBodyFragment :
   refine {
     hasInternalHelperCall := ?_
     coreSupported := rfl
+    helperArgsInScope := by
+      simp [helperA, stmtListHelperCallArgsInScope, stmtHelperCallArgsInScope,
+        stmtNextScope]
     state := ⟨rfl⟩
     calls :=
       { helpers := helperA_supportedBodyHelperInterface

--- a/Compiler/Proofs/IRGeneration/InternalHelperBodyCorrespondence.lean
+++ b/Compiler/Proofs/IRGeneration/InternalHelperBodyCorrespondence.lean
@@ -797,13 +797,14 @@ structure InternalHelperBodyExecContext
     (callee : FunctionSpec) (helper : IRInternalFunctionDef)
     (callerState : IRState) (initialWorld : Verity.ContractState)
     (logicalArgs irArgs : List Nat) (sourceBindings entryBindings : List (String × Nat))
-    (helperFuel : Nat) : Prop where
+    (helperFuel : Nat) (irFuelSlack : Nat := 0) : Prop where
   /-- Source arguments have one value per source parameter, whereas `irArgs`
   has one value per lowered Yul parameter. -/
   bindArgs : SourceSemantics.bindInternalArgs callee.params logicalArgs = some sourceBindings
   helperParams : helper.params = CompilationModel.internalFunctionYulParamNames callee.params
   generic : StmtListGenericWithHelpersAndHelperIRWithInternals runtimeContract spec
     (SourceSemantics.effectiveFields spec) (internalHelperBodyScope callee helper) callee.body
+    irFuelSlack
   bodyCompile : CompilationModel.compileStmtList (SourceSemantics.effectiveFields spec)
     spec.events spec.errors .calldata helper.rets true (internalHelperBodyScope callee helper)
     [] callee.body spec.functions = Except.ok helper.body
@@ -833,9 +834,11 @@ theorem internal_helper_body_exec_matches_entryBindings_and_projected_result_of_
     {callee : FunctionSpec} {helper : IRInternalFunctionDef}
     {callerState : IRState} {initialWorld : Verity.ContractState}
     {logicalArgs irArgs : List Nat} {sourceBindings entryBindings : List (String × Nat)}
+    {irFuelSlack : Nat}
     (helperFuel extraFuel : Nat) (hfuelPos : 0 < helperFuel)
+    (hreserve : irFuelSlack ≤ extraFuel)
     (ctx : InternalHelperBodyExecContext runtimeContract spec callee helper
-      callerState initialWorld logicalArgs irArgs sourceBindings entryBindings helperFuel) :
+      callerState initialWorld logicalArgs irArgs sourceBindings entryBindings helperFuel irFuelSlack) :
     stmtResultMatchesIRExecWithInternals (SourceSemantics.effectiveFields spec)
         (internalHelperBodySourceResult spec callee initialWorld callerState.selector entryBindings helperFuel)
         (internalHelperBodyIRExec runtimeContract helper callerState irArgs extraFuel) ∧
@@ -849,7 +852,7 @@ theorem internal_helper_body_exec_matches_entryBindings_and_projected_result_of_
         (runtime := internalHelperBodyRuntime initialWorld callerState.selector entryBindings)
         (state := prepareInternalCalleeState callerState helper irArgs)
         (scope := internalHelperBodyScope callee helper) (stmts := callee.body)
-        helperFuel extraFuel hfuelPos ctx.generic ctx.scope ctx.exact ctx.bounded
+        helperFuel extraFuel hfuelPos hreserve ctx.generic ctx.scope ctx.exact ctx.bounded
         ctx.runtime with ⟨bodyIR, hcompile, hstep⟩
     have hmatch :=
       stmtStepMatchesIRExecWithInternals_implies_stmtResultMatchesIRExecWithInternals hstep

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -6050,6 +6050,17 @@ noncomputable def supportedSourceFunctionSemantics
   SourceSemantics.interpretFunctionWithHelpers
     spec hSupported.helperFuel fn tx initialWorld
 
+noncomputable def supportedSourceFunctionSemanticsWithHelpers
+    (spec : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpecWithHelpers spec selectors)
+    (fn : FunctionSpec)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState) :
+    SourceSemantics.SourceContractResult :=
+  SourceSemantics.interpretFunctionWithHelpers
+    spec hSupported.helperFuel fn tx initialWorld
+
 noncomputable def supportedSourceFunctionSemanticsExceptMappingWrites
     (spec : CompilationModel)
     (selectors : List Nat)
@@ -6079,6 +6090,15 @@ noncomputable def supportedSourceContractSemantics
     (tx : IRTransaction)
     (initialWorld : Verity.ContractState) :
   SourceSemantics.SourceContractResult :=
+  sourceContractSemanticsWithHelpers spec selectors hSupported.helperFuel tx initialWorld
+
+noncomputable def supportedSourceContractSemanticsWithHelpers
+    (spec : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpecWithHelpers spec selectors)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState) :
+    SourceSemantics.SourceContractResult :=
   sourceContractSemanticsWithHelpers spec selectors hSupported.helperFuel tx initialWorld
 
 noncomputable def supportedSourceContractSemanticsWithScalarEvents

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -5046,7 +5046,9 @@ theorem SupportedSpecHelperProofs.execInternalCallAssignObeysSummary
         = (if result.success then
             match names, result.returnValue with
             | [name], some value =>
-                .continue { world := result.world, bindings := bindValue state.bindings name value }
+                .continue { state with
+                  world := result.world
+                  bindings := bindValue state.bindings name value }
             | _, _ => .revert
           else .revert)
       ∧ witness.summary.contract.post fuel 0 state.world argVals

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -4690,7 +4690,7 @@ theorem execStmtWithHelpers_internalCallAssign_of_witness
         if hresult.success then
           match names, hresult.returnValue with
           | [name], some value =>
-              .continue {
+              .continue { state with
                 world := hresult.world
                 bindings := bindValue state.bindings name value
               }

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -4153,7 +4153,7 @@ mutual
                 if hresult.success then
                   match names, hresult.returnValue with
                   | [name], some value =>
-                      .continue {
+                      .continue { state with
                         world := hresult.world
                         bindings := bindValue state.bindings name value
                       }

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -2715,10 +2715,10 @@ structure SupportedBodyCallInterface (spec : CompilationModel) (fn : FunctionSpe
   foreign : stmtListTouchesUnsupportedForeignSurface fn.body = false
   lowLevel : stmtListTouchesUnsupportedLowLevelSurface fn.body = false
 
-/-- Core-safe helper-positive statement heads. Helper arguments must remain in
-the existing core expression fragment; every non-helper head still passes the
-existing fail-closed core classifier. -/
 mutual
+  /-- Core-safe helper-positive statement heads. Helper arguments must remain in
+  the existing core expression fragment; every non-helper head still passes the
+  existing fail-closed core classifier. -/
   def stmtHelperRichCoreSupported : Stmt → Bool
     | .internalCall _ args | .internalCallAssign _ _ args =>
         args.all (fun arg => !exprTouchesUnsupportedCoreSurface arg)
@@ -2736,10 +2736,10 @@ mutual
         stmtHelperRichCoreSupported stmt && stmtListHelperRichCoreSupported rest
 end
 
-/-- Scope check retained specifically for helper-call arguments.  The scope is
-threaded across the surrounding statement list, so a helper may consume an
-earlier local but cannot refer to a name that has not yet been bound. -/
 mutual
+  /-- Scope check retained specifically for helper-call arguments.  The scope is
+  threaded across the surrounding statement list, so a helper may consume an
+  earlier local but cannot refer to a name that has not yet been bound. -/
   def stmtHelperCallArgsInScope (scope : List String) : Stmt → Prop
     | .internalCall _ args | .internalCallAssign _ _ args =>
         ∀ arg ∈ args, FunctionBody.exprBoundNamesInScope arg scope
@@ -2769,7 +2769,7 @@ example :
     ¬ stmtListHelperCallArgsInScope []
       [.ite (.literal 1) [.internalCall "helper" [.param "missing"]] []] := by
   simp [stmtListHelperCallArgsInScope, stmtHelperCallArgsInScope,
-    FunctionBody.exprBoundNamesInScope, exprBoundNames]
+    FunctionBody.exprBoundNamesInScope, FunctionBody.exprBoundNames]
 
 /-- Positive supported fragment for a helper-rich function body. Unlike the
 initial `SupportedBodyInterface`, this interface does not pass through

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -2718,31 +2718,58 @@ structure SupportedBodyCallInterface (spec : CompilationModel) (fn : FunctionSpe
 /-- Core-safe helper-positive statement heads. Helper arguments must remain in
 the existing core expression fragment; every non-helper head still passes the
 existing fail-closed core classifier. -/
-def stmtHelperRichCoreSupported : Stmt → Bool
-  | .internalCall _ args | .internalCallAssign _ _ args =>
-      args.all (fun arg => !exprTouchesUnsupportedCoreSurface arg)
-  | .letVar _ (.internalCall _ args) | .assignVar _ (.internalCall _ args) =>
-      args.all (fun arg => !exprTouchesUnsupportedCoreSurface arg)
-  | stmt => !stmtTouchesUnsupportedCoreSurface stmt
+mutual
+  def stmtHelperRichCoreSupported : Stmt → Bool
+    | .internalCall _ args | .internalCallAssign _ _ args =>
+        args.all (fun arg => !exprTouchesUnsupportedCoreSurface arg)
+    | .letVar _ (.internalCall _ args) | .assignVar _ (.internalCall _ args) =>
+        args.all (fun arg => !exprTouchesUnsupportedCoreSurface arg)
+    | .ite cond thenBranch elseBranch =>
+        !exprTouchesUnsupportedCoreSurface cond &&
+          stmtListHelperRichCoreSupported thenBranch &&
+          stmtListHelperRichCoreSupported elseBranch
+    | stmt => !stmtTouchesUnsupportedCoreSurface stmt
 
-def stmtListHelperRichCoreSupported (stmts : List Stmt) : Bool :=
-  stmts.all stmtHelperRichCoreSupported
+  def stmtListHelperRichCoreSupported : List Stmt → Bool
+    | [] => true
+    | stmt :: rest =>
+        stmtHelperRichCoreSupported stmt && stmtListHelperRichCoreSupported rest
+end
 
 /-- Scope check retained specifically for helper-call arguments.  The scope is
 threaded across the surrounding statement list, so a helper may consume an
 earlier local but cannot refer to a name that has not yet been bound. -/
-def stmtHelperCallArgsInScope (scope : List String) : Stmt → Prop
-  | .internalCall _ args | .internalCallAssign _ _ args =>
-      ∀ arg ∈ args, FunctionBody.exprBoundNamesInScope arg scope
-  | .letVar _ (.internalCall _ args) | .assignVar _ (.internalCall _ args) =>
-      ∀ arg ∈ args, FunctionBody.exprBoundNamesInScope arg scope
-  | _ => True
+mutual
+  def stmtHelperCallArgsInScope (scope : List String) : Stmt → Prop
+    | .internalCall _ args | .internalCallAssign _ _ args =>
+        ∀ arg ∈ args, FunctionBody.exprBoundNamesInScope arg scope
+    | .letVar _ (.internalCall _ args) | .assignVar _ (.internalCall _ args) =>
+        ∀ arg ∈ args, FunctionBody.exprBoundNamesInScope arg scope
+    | .ite _ thenBranch elseBranch =>
+        stmtListHelperCallArgsInScope scope thenBranch ∧
+          stmtListHelperCallArgsInScope scope elseBranch
+    | _ => True
 
-def stmtListHelperCallArgsInScope : List String → List Stmt → Prop
-  | _, [] => True
-  | scope, stmt :: rest =>
-      stmtHelperCallArgsInScope scope stmt ∧
-        stmtListHelperCallArgsInScope (stmtNextScope scope stmt) rest
+  def stmtListHelperCallArgsInScope : List String → List Stmt → Prop
+    | _, [] => True
+    | scope, stmt :: rest =>
+        stmtHelperCallArgsInScope scope stmt ∧
+          stmtListHelperCallArgsInScope (stmtNextScope scope stmt) rest
+end
+
+/-- Regression: helper arguments nested below a branch remain subject to the
+core-expression gate. -/
+example :
+    stmtListHelperRichCoreSupported
+      [.ite (.literal 1) [.internalCall "helper" [.internalCall "nested" []]] []] = false := by
+  rfl
+
+/-- Regression: branch-local helper calls cannot consume an unbound name. -/
+example :
+    ¬ stmtListHelperCallArgsInScope []
+      [.ite (.literal 1) [.internalCall "helper" [.param "missing"]] []] := by
+  simp [stmtListHelperCallArgsInScope, stmtHelperCallArgsInScope,
+    FunctionBody.exprBoundNamesInScope, exprBoundNames]
 
 /-- Positive supported fragment for a helper-rich function body. Unlike the
 initial `SupportedBodyInterface`, this interface does not pass through

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -2680,10 +2680,10 @@ structure SupportedRuntimeHelperTableInterface
     ∀ calleeName (witness : SupportedInternalHelperWitness spec calleeName),
       (compiledOfWitness calleeName witness).sourceWitness = witness
 
-/-- Helper-call boundary for the current generic theorem.
-It already inventories helper callees via positive summary witnesses, but it
-still carries the helper-excluding body fragment witness, so the generic theorem
-shape and trusted boundary remain unchanged until helper semantics are modeled. -/
+/-- Positive helper-summary boundary used by both helper-free and helper-rich
+bodies. Every syntactically mentioned callee must resolve to a supported
+internal function with a decreasing rank, and expression-position helpers must
+preserve the world on success. -/
 structure SupportedBodyHelperInterface (spec : CompilationModel) (fn : FunctionSpec) where
   helperRank : Nat
   callNamesNodup : (helperCallNames fn).Nodup
@@ -2704,6 +2704,38 @@ structure SupportedBodyCallInterface (spec : CompilationModel) (fn : FunctionSpe
   helpers : SupportedBodyHelperInterface spec fn
   foreign : stmtListTouchesUnsupportedForeignSurface fn.body = false
   lowLevel : stmtListTouchesUnsupportedLowLevelSurface fn.body = false
+
+/-- Core-safe helper-positive statement heads. Helper arguments must remain in
+the existing core expression fragment; every non-helper head still passes the
+existing fail-closed core classifier. -/
+def stmtHelperRichCoreSupported : Stmt → Bool
+  | .internalCall _ args | .internalCallAssign _ _ args =>
+      args.all (fun arg => !exprTouchesUnsupportedCoreSurface arg)
+  | .letVar _ (.internalCall _ args) | .assignVar _ (.internalCall _ args) =>
+      args.all (fun arg => !exprTouchesUnsupportedCoreSurface arg)
+  | stmt => !stmtTouchesUnsupportedCoreSurface stmt
+
+def stmtListHelperRichCoreSupported (stmts : List Stmt) : Bool :=
+  stmts.all stmtHelperRichCoreSupported
+
+/-- Positive supported fragment for a helper-rich function body. Unlike the
+initial `SupportedBodyInterface`, this interface does not pass through
+`SupportedStmtList` (whose current constructors imply helper-surface closure).
+Instead it explicitly requires a genuine internal-helper call while retaining
+the independent syntactic gates and the semantic helper-summary obligations.
+
+This is only a supported-fragment definition; it does not claim the final
+whole-contract correctness theorem for helper-rich bodies. -/
+structure SupportedHelperRichBodyFragment
+    (spec : CompilationModel) (fn : FunctionSpec) where
+  hasInternalHelperCall : ∃ calleeName, calleeName ∈ helperCallNames fn
+  coreSupported : stmtListHelperRichCoreSupported fn.body = true
+  state : SupportedBodyStateInterface fn
+  calls : SupportedBodyCallInterface spec fn
+  effects : SupportedBodyEffectInterface fn
+  constructorRawCalldataSurfaceClosed :
+    stmtListTouchesUnsupportedConstructorRawCalldataSurface fn.body = false
+  noLocalObligations : fn.localObligations = []
 
 /-- Body-level interface for the initial theorem boundary. This keeps the current
 syntactic support inventory local to the body witness instead of baking it

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -2737,24 +2737,24 @@ mutual
 end
 
 mutual
-  /-- Scope check retained specifically for helper-call arguments.  The scope is
-  threaded across the surrounding statement list, so a helper may consume an
-  earlier local but cannot refer to a name that has not yet been bound. -/
-  def stmtHelperCallArgsInScope (scope : List String) : Stmt → Prop
-    | .internalCall _ args | .internalCallAssign _ _ args =>
-        ∀ arg ∈ args, FunctionBody.exprBoundNamesInScope arg scope
-    | .letVar _ (.internalCall _ args) | .assignVar _ (.internalCall _ args) =>
-        ∀ arg ∈ args, FunctionBody.exprBoundNamesInScope arg scope
+  /-- Every expression evaluated by an admitted helper-rich statement must use
+  only names already in scope. `directMetadata.subexpressions` is the common
+  inventory for all statement heads, including ordinary expressions and helper
+  arguments; admitted `ite` children are checked recursively. -/
+  def stmtHelperRichExprsInScope (scope : List String) (stmt : Stmt) : Prop :=
+    (∀ expr ∈ stmt.directMetadata.subexpressions,
+      FunctionBody.exprBoundNamesInScope expr scope) ∧
+    match stmt with
     | .ite _ thenBranch elseBranch =>
-        stmtListHelperCallArgsInScope scope thenBranch ∧
-          stmtListHelperCallArgsInScope scope elseBranch
+        stmtListHelperRichExprsInScope scope thenBranch ∧
+          stmtListHelperRichExprsInScope scope elseBranch
     | _ => True
 
-  def stmtListHelperCallArgsInScope : List String → List Stmt → Prop
+  def stmtListHelperRichExprsInScope : List String → List Stmt → Prop
     | _, [] => True
     | scope, stmt :: rest =>
-        stmtHelperCallArgsInScope scope stmt ∧
-          stmtListHelperCallArgsInScope (stmtNextScope scope stmt) rest
+        stmtHelperRichExprsInScope scope stmt ∧
+          stmtListHelperRichExprsInScope (stmtNextScope scope stmt) rest
 end
 
 /-- Regression: helper arguments nested below a branch remain subject to the
@@ -2766,10 +2766,19 @@ example :
 
 /-- Regression: branch-local helper calls cannot consume an unbound name. -/
 example :
-    ¬ stmtListHelperCallArgsInScope []
+    ¬ stmtListHelperRichExprsInScope []
       [.ite (.literal 1) [.internalCall "helper" [.param "missing"]] []] := by
-  simp [stmtListHelperCallArgsInScope, stmtHelperCallArgsInScope,
+  simp [stmtListHelperRichExprsInScope, stmtHelperRichExprsInScope,
     FunctionBody.exprBoundNamesInScope, FunctionBody.exprBoundNames]
+
+/-- Regression: a valid helper call elsewhere in the body does not allow an
+ordinary expression to read an unbound local. -/
+example :
+    ¬ stmtListHelperRichExprsInScope []
+      [.letVar "x" (.localVar "missing"), .internalCall "helper" []] := by
+  simp [stmtListHelperRichExprsInScope, stmtHelperRichExprsInScope,
+    FunctionBody.exprBoundNamesInScope, FunctionBody.exprBoundNames,
+    stmtNextScope, collectStmtBindNames]
 
 /-- Positive supported fragment for a helper-rich function body. Unlike the
 initial `SupportedBodyInterface`, this interface does not pass through
@@ -2783,8 +2792,8 @@ structure SupportedHelperRichBodyFragment
     (spec : CompilationModel) (fn : FunctionSpec) where
   hasInternalHelperCall : ∃ calleeName, calleeName ∈ helperCallNames fn
   coreSupported : stmtListHelperRichCoreSupported fn.body = true
-  helperArgsInScope :
-    stmtListHelperCallArgsInScope (fn.params.map (·.name)) fn.body
+  expressionsInScope :
+    stmtListHelperRichExprsInScope (fn.params.map (·.name)) fn.body
   state : SupportedBodyStateInterface fn
   calls : SupportedBodyCallInterface spec fn
   effects : SupportedBodyEffectInterface fn

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -2832,6 +2832,28 @@ structure SupportedFunction (spec : CompilationModel) (fn : FunctionSpec) where
   returns : SupportedReturnProfile fn
   body : SupportedBodyInterface spec fn
 
+/-- Body support at the helper-aware function boundary.  The legacy arm keeps
+all existing helper-free consumers available, while the helper-rich arm admits
+the positive fragment directly without manufacturing a `SupportedStmtList`
+witness (which would imply that the helper-call inventory is empty). -/
+inductive SupportedFunctionBodyWithHelpers
+    (spec : CompilationModel) (fn : FunctionSpec) : Type where
+  | legacy (body : SupportedBodyInterface spec fn)
+  | helperRich (body : SupportedHelperRichBodyFragment spec fn)
+  | internalHelper (summary : SupportedInternalHelperSummary spec fn)
+
+/-- Function support interface for helper-aware consumers.  Internal helpers
+and selector-dispatched callers share this interface; whether a function is an
+external dispatch target remains a property of `selectorDispatchedFunctions`,
+not a body-fragment restriction. -/
+structure SupportedFunctionWithHelpers
+    (spec : CompilationModel) (fn : FunctionSpec) where
+  nonSpecialEntrypoint : isInteropEntrypointName fn.name = false
+  noNonReentrant : fn.nonReentrantLock = none
+  params : SupportedParamProfile fn.params
+  returns : SupportedReturnProfile fn
+  body : SupportedFunctionBodyWithHelpers spec fn
+
 /-- Supported external function for the scalar-event Layer 2 slice. -/
 structure SupportedFunctionWithScalarEvents
     (spec : CompilationModel) (fn : FunctionSpec) where
@@ -2949,6 +2971,19 @@ structure SupportedSpec (spec : CompilationModel) (selectors : List Nat) where
     ∀ ctor, spec.constructor = some ctor → SupportedConstructor spec ctor
   functions :
     ∀ fn, fn ∈ spec.functions → SupportedFunction spec fn
+
+/-- Whole-contract support inventory for the helper-aware Function/Contract/
+Dispatch chain.  It shares the established global invariants and surface gates,
+but its function inventory accepts `SupportedHelperRichBodyFragment` through
+`SupportedFunctionWithHelpers`. -/
+structure SupportedSpecWithHelpers
+    (spec : CompilationModel) (selectors : List Nat) where
+  invariants : SupportedSpecInvariants spec selectors
+  surface : SupportedSpecSurface spec
+  constructor :
+    ∀ ctor, spec.constructor = some ctor → SupportedConstructor spec ctor
+  functions :
+    ∀ fn, fn ∈ spec.functions → SupportedFunctionWithHelpers spec fn
 
 /-- Whole-contract support witness for the top-level scalar-event theorem. -/
 structure SupportedSpecWithScalarEvents
@@ -3125,6 +3160,31 @@ def SupportedFunctionExceptMappingWrites.helperFuel
     {spec : CompilationModel} {fn : FunctionSpec}
     (hSupported : SupportedFunctionExceptMappingWrites spec fn) : Nat :=
   hSupported.body.calls.helpers.helperRank
+
+def SupportedFunctionWithHelpers.helperFuel
+    {spec : CompilationModel} {fn : FunctionSpec}
+    (hSupported : SupportedFunctionWithHelpers spec fn) : Nat :=
+  match hSupported.body with
+  | .legacy body => body.calls.helpers.helperRank
+  | .helperRich body => body.calls.helpers.helperRank
+  | .internalHelper summary => summary.helperRank
+
+def SupportedFunction.withHelpers
+    {spec : CompilationModel} {fn : FunctionSpec}
+    (hSupported : SupportedFunction spec fn) : SupportedFunctionWithHelpers spec fn :=
+  { nonSpecialEntrypoint := hSupported.nonSpecialEntrypoint
+    noNonReentrant := hSupported.noNonReentrant
+    params := hSupported.params
+    returns := hSupported.returns
+    body := .legacy hSupported.body }
+
+def SupportedSpec.withHelpers
+    {spec : CompilationModel} {selectors : List Nat}
+    (hSupported : SupportedSpec spec selectors) : SupportedSpecWithHelpers spec selectors :=
+  { invariants := hSupported.invariants
+    surface := hSupported.surface
+    constructor := hSupported.constructor
+    functions := fun fn hmem => (hSupported.functions fn hmem).withHelpers }
 
 private theorem exprCompileCore_helperSurfaceClosed
     {expr : Expr}
@@ -7164,6 +7224,14 @@ def SupportedSpec.supportedFunctionOfSelectorDispatched
     SupportedFunction spec fn :=
   hSupported.functions fn ((List.mem_filter.mp hfn).1)
 
+def SupportedSpecWithHelpers.supportedFunctionOfSelectorDispatched
+    {spec : CompilationModel} {selectors : List Nat}
+    (hSupported : SupportedSpecWithHelpers spec selectors)
+    {fn : FunctionSpec}
+    (hfn : fn ∈ selectorDispatchedFunctions spec) :
+    SupportedFunctionWithHelpers spec fn :=
+  hSupported.functions fn ((List.mem_filter.mp hfn).1)
+
 def SupportedSpecExceptMappingWrites.supportedFunctionOfSelectorDispatched
     {spec : CompilationModel} {selectors : List Nat}
     (hSupported : SupportedSpecExceptMappingWrites spec selectors)
@@ -7183,6 +7251,16 @@ def SupportedSpecWithScalarEvents.supportedFunctionOfSelectorDispatched
 noncomputable def SupportedSpec.helperFuelOfFunction
     {spec : CompilationModel} {selectors : List Nat}
     (hSupported : SupportedSpec spec selectors)
+    (fn : FunctionSpec) : Nat :=
+  open Classical in
+  if hfn : fn ∈ selectorDispatchedFunctions spec then
+    (hSupported.supportedFunctionOfSelectorDispatched hfn).helperFuel
+  else
+    0
+
+noncomputable def SupportedSpecWithHelpers.helperFuelOfFunction
+    {spec : CompilationModel} {selectors : List Nat}
+    (hSupported : SupportedSpecWithHelpers spec selectors)
     (fn : FunctionSpec) : Nat :=
   open Classical in
   if hfn : fn ∈ selectorDispatchedFunctions spec then
@@ -7218,6 +7296,13 @@ noncomputable def SupportedSpec.helperFuel
     (fun fuel fn => max fuel (hSupported.helperFuelOfFunction fn))
     0
 
+noncomputable def SupportedSpecWithHelpers.helperFuel
+    {spec : CompilationModel} {selectors : List Nat}
+    (hSupported : SupportedSpecWithHelpers spec selectors) : Nat :=
+  (selectorDispatchedFunctions spec).foldl
+    (fun fuel fn => max fuel (hSupported.helperFuelOfFunction fn))
+    0
+
 noncomputable def SupportedSpecExceptMappingWrites.helperFuel
     {spec : CompilationModel} {selectors : List Nat}
     (hSupported : SupportedSpecExceptMappingWrites spec selectors) : Nat :=
@@ -7235,6 +7320,14 @@ noncomputable def SupportedSpecWithScalarEvents.helperFuel
 theorem SupportedSpec.selectorFunctionParamsSupported
     {spec : CompilationModel} {selectors : List Nat}
     (hSupported : SupportedSpec spec selectors)
+    {fn : FunctionSpec}
+    (hfn : fn ∈ selectorDispatchedFunctions spec) :
+    ∀ param ∈ fn.params, SupportedExternalParamType param.ty :=
+  (hSupported.supportedFunctionOfSelectorDispatched hfn).params.supported
+
+theorem SupportedSpecWithHelpers.selectorFunctionParamsSupported
+    {spec : CompilationModel} {selectors : List Nat}
+    (hSupported : SupportedSpecWithHelpers spec selectors)
     {fn : FunctionSpec}
     (hfn : fn ∈ selectorDispatchedFunctions spec) :
     ∀ param ∈ fn.params, SupportedExternalParamType param.ty :=

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -868,6 +868,14 @@ def stmtListTouchesUnsupportedConstructorRawCalldataSurface : List Stmt → Bool
         stmtListTouchesUnsupportedConstructorRawCalldataSurface rest
 end
 
+/-- Scope exposed to the continuation of a helper-rich statement.  Branch
+bindings of an `ite` are local to the branch in both source validation and Yul,
+so unlike the compiler's conservative name inventory they must not be added to
+the tail scope. -/
+def stmtHelperRichNextScope (scope : List String) : Stmt → List String
+  | .ite _ _ _ => scope
+  | stmt => stmtNextScope scope stmt
+
 /-- Selector-dispatched entrypoints in the same order used by `CompilationModel.compile`. -/
 def selectorDispatchedFunctions (spec : CompilationModel) : List FunctionSpec :=
   spec.functions.filter (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)
@@ -2773,7 +2781,32 @@ mutual
     | _, [] => True
     | scope, stmt :: rest =>
         stmtHelperRichExprsInScope scope stmt ∧
-          stmtListHelperRichExprsInScope (stmtNextScope scope stmt) rest
+          stmtListHelperRichExprsInScope (stmtHelperRichNextScope scope stmt) rest
+end
+
+mutual
+  /-- Direct assigning helper calls are supported only when the source helper
+  has exactly one resolved return and the call binds exactly one target.  This
+  matches the successful arm of `execStmtWithHelpers`; in particular, an empty
+  or multi-target `letMany` can no longer expose names to a continuation that
+  source execution would never reach. -/
+  def stmtHelperRichAssignTargetsSupported
+      (spec : CompilationModel) : Stmt → Prop
+    | .internalCallAssign names calleeName _ =>
+        (∃ name, names = [name]) ∧
+          ∃ callee ∈ spec.functions, callee.name = calleeName ∧
+            ∃ returnTy, functionReturns callee = Except.ok [returnTy]
+    | .ite _ thenBranch elseBranch =>
+        stmtListHelperRichAssignTargetsSupported spec thenBranch ∧
+          stmtListHelperRichAssignTargetsSupported spec elseBranch
+    | _ => True
+
+  def stmtListHelperRichAssignTargetsSupported
+      (spec : CompilationModel) : List Stmt → Prop
+    | [] => True
+    | stmt :: rest =>
+        stmtHelperRichAssignTargetsSupported spec stmt ∧
+          stmtListHelperRichAssignTargetsSupported spec rest
 end
 
 /-- Regression: helper arguments nested below a branch remain subject to the
@@ -2800,6 +2833,24 @@ example :
     Stmt.directMetadata, FunctionBody.exprBoundNamesInScope,
     FunctionBody.exprBoundNames, stmtNextScope, collectStmtBindNames]
 
+/-- Regression: a binding introduced inside either `ite` branch is not visible
+to the statement following the conditional. -/
+example :
+    ¬ stmtListHelperRichExprsInScope []
+      [.ite (.literal 1) [.letVar "x" (.literal 1)] [],
+        .letVar "y" (.localVar "x")] := by
+  simp [stmtListHelperRichExprsInScope, stmtHelperRichExprsInScope,
+    stmtHelperRichNextScope, Stmt.directMetadata,
+    FunctionBody.exprBoundNamesInScope, FunctionBody.exprBoundNames]
+
+/-- Regression: direct helper assignment cannot advertise no targets (and the
+same singleton requirement excludes multiple targets). -/
+example (spec : CompilationModel) :
+    ¬ stmtListHelperRichAssignTargetsSupported spec
+      [.internalCallAssign [] "helper" []] := by
+  simp [stmtListHelperRichAssignTargetsSupported,
+    stmtHelperRichAssignTargetsSupported]
+
 /-- Regression: admitting an expression-position helper call does not hide a
 stateful argument from the helper-rich state boundary. -/
 example :
@@ -2821,6 +2872,8 @@ structure SupportedHelperRichBodyFragment
   coreSupported : stmtListHelperRichCoreSupported fn.body = true
   expressionsInScope :
     stmtListHelperRichExprsInScope (fn.params.map (·.name)) fn.body
+  assignTargetsSupported :
+    stmtListHelperRichAssignTargetsSupported spec fn.body
   stateSupported : stmtListHelperRichStateSupported fn.body = true
   calls : SupportedBodyCallInterface spec fn
   effects : SupportedBodyEffectInterface fn

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -1436,7 +1436,7 @@ def stmtTouchesUnsupportedCoreSurface : Stmt → Bool
   | .storageArrayPop _
   | .requireError _ _ _ | .revertError _ _ | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _ | .returnCodeData _ | .calldatacopy _ _ _
-  | .returndataCopy _ _ _ | .revertReturndata
+  | .returndataCopy _ _ _ | .revertReturndata => false
   | .emit _ _ | .internalCall _ _ | .internalCallAssign _ _ _
   | .rawLog _ _ _ | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _ | .ecm _ _ => false
   | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _ => true
@@ -1462,8 +1462,12 @@ def stmtTouchesUnsupportedStateSurface : Stmt → Bool
   | .stop
   | .requireError _ _ _ | .revertError _ _ | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _ | .returnCodeData _ | .calldatacopy _ _ _
-  | .returndataCopy _ _ _ | .revertReturndata
-  | .emit _ _ | .internalCall _ _ | .internalCallAssign _ _ _
+  | .returndataCopy _ _ _ | .revertReturndata => false
+  | .internalCall _ args =>
+      exprListTouchesUnsupportedStateSurface args
+  | .internalCallAssign _ _ args =>
+      exprListTouchesUnsupportedStateSurface args
+  | .emit _ _
   | .rawLog _ _ _ | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _ | .ecm _ _ => false
   | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _ => true
   | .ite cond thenBranch elseBranch =>
@@ -1472,6 +1476,12 @@ def stmtTouchesUnsupportedStateSurface : Stmt → Bool
         stmtListTouchesUnsupportedStateSurface elseBranch
   | .forEach _ (.literal _) [] => false
   | .forEach _ _ _ | .forEachSetBit _ _ _ => true
+
+def exprListTouchesUnsupportedStateSurface : List Expr → Bool
+  | [] => false
+  | expr :: rest =>
+      exprTouchesUnsupportedStateSurface expr ||
+        exprListTouchesUnsupportedStateSurface rest
 
 /-- Weaker Tier 2 state-surface gate used by the singleton storage-write bridge:
 all existing unsupported stateful forms remain excluded except for the proved
@@ -2718,6 +2728,22 @@ def stmtHelperRichCoreSupported : Stmt → Bool
 def stmtListHelperRichCoreSupported (stmts : List Stmt) : Bool :=
   stmts.all stmtHelperRichCoreSupported
 
+/-- Scope check retained specifically for helper-call arguments.  The scope is
+threaded across the surrounding statement list, so a helper may consume an
+earlier local but cannot refer to a name that has not yet been bound. -/
+def stmtHelperCallArgsInScope (scope : List String) : Stmt → Prop
+  | .internalCall _ args | .internalCallAssign _ _ args =>
+      ∀ arg ∈ args, FunctionBody.exprBoundNamesInScope arg scope
+  | .letVar _ (.internalCall _ args) | .assignVar _ (.internalCall _ args) =>
+      ∀ arg ∈ args, FunctionBody.exprBoundNamesInScope arg scope
+  | _ => True
+
+def stmtListHelperCallArgsInScope : List String → List Stmt → Prop
+  | _, [] => True
+  | scope, stmt :: rest =>
+      stmtHelperCallArgsInScope scope stmt ∧
+        stmtListHelperCallArgsInScope (stmtNextScope scope stmt) rest
+
 /-- Positive supported fragment for a helper-rich function body. Unlike the
 initial `SupportedBodyInterface`, this interface does not pass through
 `SupportedStmtList` (whose current constructors imply helper-surface closure).
@@ -2730,6 +2756,8 @@ structure SupportedHelperRichBodyFragment
     (spec : CompilationModel) (fn : FunctionSpec) where
   hasInternalHelperCall : ∃ calleeName, calleeName ∈ helperCallNames fn
   coreSupported : stmtListHelperRichCoreSupported fn.body = true
+  helperArgsInScope :
+    stmtListHelperCallArgsInScope (fn.params.map (·.name)) fn.body
   state : SupportedBodyStateInterface fn
   calls : SupportedBodyCallInterface spec fn
   effects : SupportedBodyEffectInterface fn

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -2730,10 +2730,29 @@ mutual
           stmtListHelperRichCoreSupported elseBranch
     | stmt => !stmtTouchesUnsupportedCoreSurface stmt
 
-  def stmtListHelperRichCoreSupported : List Stmt → Bool
+def stmtListHelperRichCoreSupported : List Stmt → Bool
     | [] => true
     | stmt :: rest =>
         stmtHelperRichCoreSupported stmt && stmtListHelperRichCoreSupported rest
+end
+
+mutual
+  /-- State-surface gate for helper-rich statements. Expression-position helper
+  calls are transparent here: their arguments must satisfy the ordinary state
+  classifier even though the helper call node itself is admitted. -/
+  def stmtHelperRichStateSupported : Stmt → Bool
+    | .letVar _ (.internalCall _ args) | .assignVar _ (.internalCall _ args) =>
+        args.all (fun arg => !exprTouchesUnsupportedStateSurface arg)
+    | .ite cond thenBranch elseBranch =>
+        !exprTouchesUnsupportedStateSurface cond &&
+          stmtListHelperRichStateSupported thenBranch &&
+          stmtListHelperRichStateSupported elseBranch
+    | stmt => !stmtTouchesUnsupportedStateSurface stmt
+
+  def stmtListHelperRichStateSupported : List Stmt → Bool
+    | [] => true
+    | stmt :: rest =>
+        stmtHelperRichStateSupported stmt && stmtListHelperRichStateSupported rest
 end
 
 mutual
@@ -2769,7 +2788,8 @@ example :
     ¬ stmtListHelperRichExprsInScope []
       [.ite (.literal 1) [.internalCall "helper" [.param "missing"]] []] := by
   simp [stmtListHelperRichExprsInScope, stmtHelperRichExprsInScope,
-    FunctionBody.exprBoundNamesInScope, FunctionBody.exprBoundNames]
+    Stmt.directMetadata, FunctionBody.exprBoundNamesInScope,
+    FunctionBody.exprBoundNames]
 
 /-- Regression: a valid helper call elsewhere in the body does not allow an
 ordinary expression to read an unbound local. -/
@@ -2777,8 +2797,15 @@ example :
     ¬ stmtListHelperRichExprsInScope []
       [.letVar "x" (.localVar "missing"), .internalCall "helper" []] := by
   simp [stmtListHelperRichExprsInScope, stmtHelperRichExprsInScope,
-    FunctionBody.exprBoundNamesInScope, FunctionBody.exprBoundNames,
-    stmtNextScope, collectStmtBindNames]
+    Stmt.directMetadata, FunctionBody.exprBoundNamesInScope,
+    FunctionBody.exprBoundNames, stmtNextScope, collectStmtBindNames]
+
+/-- Regression: admitting an expression-position helper call does not hide a
+stateful argument from the helper-rich state boundary. -/
+example :
+    stmtListHelperRichStateSupported
+      [.letVar "x" (.internalCall "helper" [.storage "slot"])] = false := by
+  rfl
 
 /-- Positive supported fragment for a helper-rich function body. Unlike the
 initial `SupportedBodyInterface`, this interface does not pass through
@@ -2794,7 +2821,7 @@ structure SupportedHelperRichBodyFragment
   coreSupported : stmtListHelperRichCoreSupported fn.body = true
   expressionsInScope :
     stmtListHelperRichExprsInScope (fn.params.map (·.name)) fn.body
-  state : SupportedBodyStateInterface fn
+  stateSupported : stmtListHelperRichStateSupported fn.body = true
   calls : SupportedBodyCallInterface spec fn
   effects : SupportedBodyEffectInterface fn
   constructorRawCalldataSurfaceClosed :

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2114,6 +2114,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_of_compileValidatedCore_of_interface
   Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_helper_proofs_and_helper_ir_closed
+  Compiler.Proofs.IRGeneration.Contract.compileFunctionSpec_correct_with_helper_rich_support_of_body_goal
   Compiler.Proofs.IRGeneration.Contract.counter_supported_spec_compile_preserves_semantics
 
   -- Compiler/Proofs/IRGeneration/ContractFeatureTest.lean
@@ -2248,7 +2249,11 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Dispatch.find_compiledFunction_some_of_forall₂  -- private
   -- Compiler.Proofs.IRGeneration.Dispatch.find_compiledFunction_none_of_forall₂  -- private
   Compiler.Proofs.IRGeneration.Dispatch.interpretContract_correct_of_compiled_functions
+  Compiler.Proofs.IRGeneration.Dispatch.interpretContractWithInternals_correct_of_compiled_functions
+  Compiler.Proofs.IRGeneration.Dispatch.interpretContractWithHelpersWithInternals_correct_of_compiled_functions
+  Compiler.Proofs.IRGeneration.Dispatch.interpretContractWithInternals_correct_of_compiled_functions_with_helper_rich_support
   Compiler.Proofs.IRGeneration.Dispatch.interpretContract_correct_of_compiled_functions_with_helper_proofs
+  Compiler.Proofs.IRGeneration.Dispatch.interpretContractWithInternals_correct_of_compiled_functions_with_helper_proofs
   -- Compiler.Proofs.IRGeneration.Dispatch.legacy_function_correct_of_supportedSourceFunctionSemanticsExceptMappingWrites  -- private
   Compiler.Proofs.IRGeneration.Dispatch.interpretContract_correct_of_compiled_functions_except_mapping_writes
   Compiler.Proofs.IRGeneration.Dispatch.interpretContract_correct_of_compiled_functions_except_mapping_writes_and_helper_ir
@@ -2274,6 +2279,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Function.rawArgBindings_names_of_length_le
   Compiler.Proofs.IRGeneration.Function.rawArgBindings_names_of_bindSupportedParams
   Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_ok_of_components
+  Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_ok_of_components_with_internals
   Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_ok_params
   Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_ok_selector
   Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_ok_payable
@@ -2316,6 +2322,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_scalar_events_body_goal
   Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_helper_proofs_body_goal_and_helper_ir
   Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_helper_proofs_body_goal_with_internals
+  Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_helper_rich_support_body_goal_with_internals
   Compiler.Proofs.IRGeneration.Function.supported_function_correct_with_helper_proofs_body_goal_and_helper_ir_of_bodyCallsDisjoint
   -- Compiler.Proofs.IRGeneration.Function.function_body_scopeNamesPresent_of_bindSupportedParams  -- private
   -- Compiler.Proofs.IRGeneration.Function.function_body_state_runtime_of_bindSupportedParams  -- private
@@ -2830,6 +2837,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_of_fuelSplitBridge
   Compiler.Proofs.IRGeneration.compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall
   -- Compiler.Proofs.IRGeneration.compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_delimiter  -- private
+  Compiler.Proofs.IRGeneration.internalCall_irFuelSlack_le_residual
   Compiler.Proofs.IRGeneration.compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_fuelSplitBridge
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperAssignStepInterface_cons_internalCallAssign
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperAssignStepInterfaceWithInternals_cons_internalCallAssign
@@ -4243,6 +4251,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.SupportedSpec.noReceive
   Compiler.Proofs.IRGeneration.SupportedSpecExceptMappingWrites.noReceive
   Compiler.Proofs.IRGeneration.SupportedSpec.selectorFunctionParamsSupported
+  Compiler.Proofs.IRGeneration.SupportedSpecWithHelpers.selectorFunctionParamsSupported
   Compiler.Proofs.IRGeneration.SupportedSpec.selectorFunctionParamCalldataThreshold
   Compiler.Proofs.IRGeneration.SupportedSpecExceptMappingWrites.selectorFunctionParamsSupported
   Compiler.Proofs.IRGeneration.SupportedSpecExceptMappingWrites.selectorFunctionParamCalldataThreshold
@@ -6390,4 +6399,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5993 theorems/lemmas (4168 public, 1825 private, 0 sorry'd)
+-- Total: 6002 theorems/lemmas (4177 public, 1825 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1868,6 +1868,13 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.compileExprWithInternals_internalCall_shape
   Compiler.Proofs.HelperStepProofs.evalIRExprWithInternals_call_of_dispatch
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCallContextBridge_compileExprWithInternals_internalCall
+  Compiler.Proofs.HelperStepProofs.exprListInternalHelperCompositionalContextResult_singleton
+  Compiler.Proofs.HelperStepProofs.exprListInternalHelperCompositionalContextResult_cons_tail
+  Compiler.Proofs.HelperStepProofs.exprListInternalHelperCompositionalContextResult_cons_head
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_of_exprListContext
+  Compiler.Proofs.HelperStepProofs.exprListInternalHelperCompositionalContextResult_three_middle
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_adtConstruct_args
+  Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_internalCall_args
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_internalCall_head
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_of_outer_facts
   Compiler.Proofs.HelperStepProofs.exprInternalHelperCompositionalContextResult_of_outer_facts_threaded_head
@@ -3430,6 +3437,7 @@ end Verity.AxiomAudit
   -- Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
   -- Compiler.Proofs.IRGeneration.eraseDups_nodup_and_mem_aux_local  -- private
   -- Compiler.Proofs.IRGeneration.List.mem_of_mem_eraseDups_local  -- private
+  -- Compiler.Proofs.IRGeneration.List.mem_eraseDups_of_mem_local  -- private
   Compiler.Proofs.IRGeneration.exactInternalHelperSummary_soundAtSelector
   Compiler.Proofs.IRGeneration.exactInternalHelperSummary_sound
   -- Compiler.Proofs.IRGeneration.stmtResultWorldEq_of_eq  -- private
@@ -3447,6 +3455,8 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Regression.twoHelperRanksDecrease  -- private
   Compiler.Proofs.IRGeneration.Regression.helperB_exactSummary_sound
   Compiler.Proofs.IRGeneration.Regression.helperB_exactSummary_preservesWorld
+  Compiler.Proofs.IRGeneration.Regression.helperA_contains_internal_helper_call
+  Compiler.Proofs.IRGeneration.Regression.helperA_helperB_occurs_in_call_inventory
   Compiler.Proofs.IRGeneration.Regression.helperA_supportedBodyHelperInterface_summary_sound
   Compiler.Proofs.IRGeneration.Regression.helperA_calls_helperB_rank_decreases
 
@@ -6380,4 +6390,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 5983 theorems/lemmas (4159 public, 1824 private, 0 sorry'd)
+-- Total: 5993 theorems/lemmas (4168 public, 1825 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2283,6 +2283,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_ok_params
   Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_ok_selector
   Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_ok_payable
+  Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_ok_metadata_with_internals
   Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_ok_components
   Compiler.Proofs.IRGeneration.Function.compileConstructor_some_ok_of_body
   Compiler.Proofs.IRGeneration.Function.compileConstructor_ok_components
@@ -6399,4 +6400,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6002 theorems/lemmas (4177 public, 1825 private, 0 sorry'd)
+-- Total: 6003 theorems/lemmas (4178 public, 1825 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -160,6 +160,19 @@ ALLOWLIST: set[str] = {
     # param-load execution into the helper-aware compiled body while preserving
     # the exact fuel equality needed by `execIRFunctionWithInternals`.
     "exec_compiledFunctionIR_withInternals_of_body_extraFuel",
+    # #2205 selector dispatch with populated internal tables: these two proofs
+    # mirror the same payable/argument-length case split as the legacy dispatch
+    # theorem while threading the helper-aware interpreter. Splitting either
+    # would duplicate the Forall₂ lookup and rollback-result plumbing.
+    "interpretContractWithInternals_correct_of_compiled_functions",
+    "interpretContractWithHelpersWithInternals_correct_of_compiled_functions",
+    # #2205 helper-rich function seam: source/IR rollback states, parameter
+    # prefix execution, and the exact helper/body fuel equality form one coupled
+    # witness. Factoring the cases would only move that witness into wrappers.
+    "supported_function_correct_with_helper_rich_support_body_goal_with_internals",
+    # #2205 contract-facing adapter: the body is one application; its length is
+    # dominated by the mirrored helper-rich function premises and named types.
+    "compileFunctionSpec_correct_with_helper_rich_support_of_body_goal",
     # #2080 phase 21 direct helper-aware function theorem: packages source
     # helper semantics, the exact helper-IR body goal, function compilation
     # shape, rollback state, and param-prefix execution into the final


### PR DESCRIPTION
## Summary

This integrates the independently proven helper-rich fragments that are ready now, while deliberately deferring the remaining concrete end-to-end helper witness.

### Proven definitions and theorems included

- Expression/list helper recursion and structurally tied contexts:
  - `ExprListInternalHelperCompositionalContextResult`
  - `exprListInternalHelperCompositionalContextResult_singleton`
  - `exprListInternalHelperCompositionalContextResult_cons_tail`
  - `exprListInternalHelperCompositionalContextResult_cons_head`
  - `exprInternalHelperCompositionalContextResult_of_exprListContext`
  - `exprListInternalHelperCompositionalContextResult_three_middle`
  - `exprInternalHelperCompositionalContextResult_adtConstruct_args`
  - `exprInternalHelperCompositionalContextResult_internalCall_args`
- Positive helper-rich supported fragment and concrete occurrence evidence:
  - `stmtHelperRichCoreSupported`
  - `stmtListHelperRichCoreSupported`
  - `SupportedHelperRichBodyFragment`
  - `helperA_supportedHelperRichBodyFragment`
  - `helperA_contains_internal_helper_call`
  - `helperA_helperB_occurs_in_call_inventory`
- Internal-functions-parametric statement-list compilation:
  - strengthened `compileStmtList_nil_eq_ok`
  - strengthened `compileStmtListWithFork_nil_eq_ok`
  - strengthened `compileStmtListWithFork_cons_eq_ok`

The statement-list results preserve arbitrary `internalFunctions` through nil/cons recursion and fork-to-default compilation.

## Verification

Toolchain:

- Lean 4.24.0
- Lake 5.0.0
- elan 4.2.3

Foreground verification:

```text
lake build
Build completed successfully (2125 jobs).
BUILD_EXIT_CODE=0
```

## Deferred follow-up

`compileFunctionSpec_correct_with_helpers_with_internals` and its concrete `hbodyBridge` witness are intentionally not part of this incremental PR. The remaining hard proof gap is the fuel-sensitive construction of `StmtListGenericWithHelpersAndHelperIRWithInternals` for a genuine helper-calling body; it will be tracked and resolved separately rather than blocking these proven fragments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are confined to Lean proof layers and one source-semantics preservation fix for internal-call assignment; risk is moderate complexity in fuel accounting and new proof APIs rather than runtime compiler behavior.
> 
> **Overview**
> Extends the helper-aware correctness stack with **additive IR fuel slack** (`irFuelSlack`): statement-step and list-level `WithInternals` interfaces, internal-call fuel-split bridges (additive sufficient/residual obligations), list induction, helper-body execution, and `execIRFunctionWithInternals` / `interpretIRWithInternals` now index slack explicitly (default `0`). Function and contract theorems take optional **`internalFunctions`** on body compilation and align compiled-body fuel with `sizeOf body + irFuelSlack`.
> 
> Adds **expression-list compositional context** (`ExprListInternalHelperCompositionalContextResult` and cons/singleton/lift lemmas for ADT args and internal-call args) so helper-bearing subexpressions in lists thread compile/eval/IR state without requiring helper-surface-closed siblings.
> 
> Introduces **`SupportedSpecWithHelpers`** wiring: concrete `twoHelper` / `helperA` helper-rich witnesses, `supportedSource*WithHelpers` semantics, per-function and contract wrappers (`compileFunctionSpec_correct_with_helper_rich_support_of_body_goal`), and dispatch theorems that keep `interpretFunctionWithHelpers` through to `interpretIRWithInternals` (including compilation against `model.functions.filter (·.isInternal)`).
> 
> **Semantics fix:** successful `internalCallAssign` continues with `{ state with world := …, bindings := … }` instead of rebuilding state from only world/bindings (source exec, helper proofs, and abbreviations).
> 
> Statement-list **compile nil/cons** lemmas gain optional `internalFunctions` threading for fork/default paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b5a333994810385794b57d9d470f27913e642d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->