### PR TITLE
proofs: assemble void helper bridge catalog

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -627,6 +627,31 @@ post and the IR helper dispatch below cannot be assembled into the existing
 direct call/assign head-step bridge catalog non-vacuously.
 -/
 
+/-- Assemble the direct void-helper-call list interface for a function body
+from the per-callee bridge catalog used by the rank-decreasing helper-summary
+layer.  This is the call-only consumer of that catalog: it deliberately does
+not require an assign bridge for a body whose helper surface consists solely
+of void `Stmt.internalCall` statements. -/
+theorem stmtListDirectInternalHelperCallStepInterface_of_perCalleeBridgeCatalog
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {fn : FunctionSpec}
+    (hbridge :
+      DirectInternalHelperPerCalleeBridgeCatalog runtimeContract spec fields fn) :
+    StmtListDirectInternalHelperCallStepInterface
+      runtimeContract spec fields scope fn.body := by
+  exact
+    stmtListDirectInternalHelperCallStepInterface_of_callHeadStepBridges
+      (runtimeContract := runtimeContract)
+      (spec := spec)
+      (fields := fields)
+      (scope := scope)
+      (stmts := fn.body)
+      (fun {calleeName} hmem =>
+        hbridge.call (by simpa [helperCallNames] using hmem))
+
 /-- Assemble the direct helper-return-binding list interface for a function
 body from the per-callee assign bridge catalog used by the rank-decreasing
 helper-summary layer. -/

--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -639,7 +639,7 @@ theorem stmtListDirectInternalHelperCallStepInterface_of_perCalleeBridgeCatalog
     {scope : List String}
     {fn : FunctionSpec}
     (hbridge :
-      DirectInternalHelperPerCalleeBridgeCatalog runtimeContract spec fields fn) :
+      DirectInternalHelperPerCalleeCallBridgeCatalog runtimeContract spec fields fn) :
     StmtListDirectInternalHelperCallStepInterface
       runtimeContract spec fields scope fn.body := by
   exact

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -876,6 +876,18 @@ structure DirectInternalHelperPerCalleeBridgeCatalog
       calleeName ∈ helperCallNames fn →
       DirectInternalHelperAssignHeadStepBridge runtimeContract spec fields calleeName
 
+/-- Call-only half of the callee-local Tier 4 bridge inventory. This lets
+void-helper-call consumers avoid requiring unrelated return-binding bridges. -/
+structure DirectInternalHelperPerCalleeCallBridgeCatalog
+    (runtimeContract : IRContract)
+    (spec : CompilationModel)
+    (fields : List Field)
+    (fn : FunctionSpec) : Prop where
+  call :
+    ∀ {calleeName : String},
+      calleeName ∈ helperCallNames fn →
+      DirectInternalHelperCallHeadStepBridge runtimeContract spec fields calleeName
+
 /-- Assign-only half of the callee-local Tier 4 bridge inventory. This isolates
 the roadmap's current blocker, namely helper-return-binding steps, while the
 void-call half remains mechanically vacuous under the current fragment. -/

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1863,6 +1863,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterfaceWithInternals_cons_internalCallAssign_of_assignHeadStepBridgeWithInternals
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterface_of_assignHeadStepBridges
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterfaceWithInternals_of_assignHeadStepBridgesWithInternals
+  Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperCallStepInterface_of_perCalleeBridgeCatalog
   Compiler.Proofs.HelperStepProofs.stmtListDirectInternalHelperAssignStepInterface_of_perCalleeAssignBridgeCatalog
   Compiler.Proofs.HelperStepProofs.LegacyDirectStatementBridge.directInternalHelperStatementContextBridge_summarySound_compiledHelper
   Compiler.Proofs.HelperStepProofs.LegacyDirectStatementBridge.directInternalHelperStatementContextBridge_sourceCallEvidence
@@ -6426,4 +6427,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6023 theorems/lemmas (4170 public, 1853 private, 0 sorry'd)
+-- Total: 6024 theorems/lemmas (4171 public, 1853 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

- assemble the direct void internal-helper interface from the existing per-callee bridge catalog
- keep void helper proof consumption independent of return-binding obligations

## Verification

- `LEAN_NUM_THREADS=2 lake build Compiler.Proofs.HelperStepProofs` (pinned remote Lean 4.31 build pending)
- `lake -j 2 build ...` is not accepted by the Lean 4.31 Lake CLI; it reports `unknown short option -j`
- `lake env lean ...` is blocked by the sandbox remote-only Lake policy

Closes no issue; narrow proven-fragment increment toward #2080.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only scaffolding with no runtime or compilation behavior changes; mirrors an existing assign-only pattern.
> 
> **Overview**
> Introduces a **call-only** per-callee bridge catalog (`DirectInternalHelperPerCalleeCallBridgeCatalog`) alongside the existing full and assign-only catalogs, so void internal-helper proof paths do not need return-binding (`assign`) bridges.
> 
> Adds **`stmtListDirectInternalHelperCallStepInterface_of_perCalleeBridgeCatalog`**, which builds `StmtListDirectInternalHelperCallStepInterface` for `fn.body` by delegating to the existing `…_of_callHeadStepBridges` lemma with `hbridge.call` on each `helperCallNames` member. **`PrintAxioms.lean`** registers the new theorem (6024 total lemmas).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55d414e212d4a4114d345baa4864a5e4f62e0f3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->