### PR TITLE
proofs: project call bridge catalog

### DIFF
--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -888,6 +888,18 @@ structure DirectInternalHelperPerCalleeCallBridgeCatalog
       calleeName ∈ helperCallNames fn →
       DirectInternalHelperCallHeadStepBridge runtimeContract spec fields calleeName
 
+/-- Project the void-call half of a complete per-callee bridge inventory. This
+lets call-only consumers use an already established full bridge catalog without
+introducing an assign-bridge obligation at their API boundary. -/
+theorem directInternalHelperPerCalleeCallBridgeCatalog_of_bridgeCatalog
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {fn : FunctionSpec}
+    (hbridge : DirectInternalHelperPerCalleeBridgeCatalog runtimeContract spec fields fn) :
+    DirectInternalHelperPerCalleeCallBridgeCatalog runtimeContract spec fields fn := by
+  exact ⟨hbridge.call⟩
+
 /-- Assign-only half of the callee-local Tier 4 bridge inventory. This isolates
 the roadmap's current blocker, namely helper-return-binding steps, while the
 void-call half remains mechanically vacuous under the current fragment. -/

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2857,6 +2857,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_fuelSplitBridge
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperAssignStepInterface_cons_internalCallAssign
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperAssignStepInterfaceWithInternals_cons_internalCallAssign
+  Compiler.Proofs.IRGeneration.directInternalHelperPerCalleeCallBridgeCatalog_of_bridgeCatalog
   Compiler.Proofs.IRGeneration.directInternalHelperPerCalleeBridgeCatalog_of_supportedBody_and_assignBridgeCatalog
   Compiler.Proofs.IRGeneration.directInternalHelperPerCalleeCallCompileCatalog_of_supportedBody
   Compiler.Proofs.IRGeneration.directInternalHelperHeadStepBridgeCatalog_of_perCalleeBridgeCatalog
@@ -6427,4 +6428,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6024 theorems/lemmas (4171 public, 1853 private, 0 sorry'd)
+-- Total: 6025 theorems/lemmas (4172 public, 1853 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

- project the call half of an established full per-callee helper bridge catalog
- let the call-only proof API consume complete catalogs without exposing an assign obligation
- refresh the generated axiom audit

## Verification

- `LEAN_NUM_THREADS=2 lake build Compiler.Proofs.IRGeneration.GenericInduction.Calls` (remote non-GPU job submitted)
- `LEAN_NUM_THREADS=2 lake build PrintAxioms` (remote non-GPU job submitted)
- `LEAN_NUM_THREADS=2 lake build` (exact-head remote non-GPU job submitted)
- `python3 scripts/generate_print_axioms.py --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a trivial structure projection in compiler proofs only; no runtime, auth, or semantic behavior changes.
> 
> **Overview**
> Adds **`directInternalHelperPerCalleeCallBridgeCatalog_of_bridgeCatalog`**, a one-line projection from `DirectInternalHelperPerCalleeBridgeCatalog` to the call-only `DirectInternalHelperPerCalleeCallBridgeCatalog` by reusing the existing `call` field.
> 
> Call-only proof APIs (e.g. void `internalCall` list interfaces) can therefore take a full per-callee bridge catalog without surfacing assign-bridge obligations at the boundary.
> 
> The generated axiom audit in **`PrintAxioms.lean`** is updated to list the new public theorem (6025 total lemmas).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a39d022949b298d0ab8f32dfade564a2432aa066. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->