### PR TITLE
proofs: assign helper bridge catalog

### DIFF
--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -913,6 +913,18 @@ structure DirectInternalHelperPerCalleeAssignBridgeCatalog
       calleeName ∈ helperCallNames fn →
       DirectInternalHelperAssignHeadStepBridge runtimeContract spec fields calleeName
 
+/-- Project the helper-return-binding half of a complete per-callee bridge
+inventory. This lets assign-only consumers use an already established full
+bridge catalog without exposing an unrelated void-call obligation. -/
+theorem directInternalHelperPerCalleeAssignBridgeCatalog_of_bridgeCatalog
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {fn : FunctionSpec}
+    (hbridge : DirectInternalHelperPerCalleeBridgeCatalog runtimeContract spec fields fn) :
+    DirectInternalHelperPerCalleeAssignBridgeCatalog runtimeContract spec fields fn := by
+  exact ⟨hbridge.assign⟩
+
 /-- Reassemble the full callee-local bridge catalog from the current supported
 body witness plus the assign-only bridge half. The call half is vacuous because
 `SupportedStmtList` still excludes direct helper calls from the fragment. -/

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2858,6 +2858,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperAssignStepInterface_cons_internalCallAssign
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperAssignStepInterfaceWithInternals_cons_internalCallAssign
   Compiler.Proofs.IRGeneration.directInternalHelperPerCalleeCallBridgeCatalog_of_bridgeCatalog
+  Compiler.Proofs.IRGeneration.directInternalHelperPerCalleeAssignBridgeCatalog_of_bridgeCatalog
   Compiler.Proofs.IRGeneration.directInternalHelperPerCalleeBridgeCatalog_of_supportedBody_and_assignBridgeCatalog
   Compiler.Proofs.IRGeneration.directInternalHelperPerCalleeCallCompileCatalog_of_supportedBody
   Compiler.Proofs.IRGeneration.directInternalHelperHeadStepBridgeCatalog_of_perCalleeBridgeCatalog
@@ -6428,4 +6429,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6025 theorems/lemmas (4172 public, 1853 private, 0 sorry'd)
+-- Total: 6026 theorems/lemmas (4173 public, 1853 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

- project the helper-return-binding half of the complete per-callee helper bridge catalog
- let the existing assign-only list-interface assembler consume a full established catalog without exposing the unrelated void-call obligation
- refresh the generated axiom audit

This is the narrow second-interface catalog increment toward #2080.

## Verification

- `python3 scripts/generate_print_axioms.py --check`
- `git diff --check`
- touched proof targets: `LEAN_NUM_THREADS=2 lake build Compiler.Proofs.IRGeneration.GenericInduction.Calls Compiler.Proofs.HelperStepProofs`
  - node: `old-agent`
  - job: `adcc5d43-6373-4e52-a72b-41d463cc4162`
  - exit: `0`
  - head: `97ea15713c23a8ed4aef3d65f6fe20852cd1cdc5`
  - receipt: `exact_head`
- full build: `LEAN_NUM_THREADS=2 lake build`
  - node: `ashur`
  - job: `62513330-efc7-4327-a125-e9f4c19a3ae3`
  - exit: `0`
  - head: `97ea15713c23a8ed4aef3d65f6fe20852cd1cdc5`
  - receipt: `exact_head`
- axiom audit: `LEAN_NUM_THREADS=2 lake build PrintAxioms`
  - node: `old-agent`
  - job: `1cdd0437-23ce-4383-9e5d-316754965f87`
  - exit: `0`
  - head: `97ea15713c23a8ed4aef3d65f6fe20852cd1cdc5`
  - receipt: `exact_head`

The known `compiler-regressions` OOM on current `main` is tracked in #2214 and is not a gate for this proof-only slice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only catalog plumbing with no runtime, auth, or compiler behavior changes.
> 
> **Overview**
> Adds **`directInternalHelperPerCalleeAssignBridgeCatalog_of_bridgeCatalog`**, mirroring the existing call-only projection: from a full `DirectInternalHelperPerCalleeBridgeCatalog`, it yields the assign-only catalog by taking `hbridge.assign`, so assign-only list-interface assembly can reuse a full catalog without a void-call bridge obligation at the API boundary.
> 
> Registers the new lemma in **`PrintAxioms.lean`** (6026 public theorems).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ea15713c23a8ed4aef3d65f6fe20852cd1cdc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->