### PR TITLE
Phase 1B: common summaries/transitions/observables API

### DIFF
--- a/Compiler.lean
+++ b/Compiler.lean
@@ -31,6 +31,7 @@ import Compiler.Keccak.SpongeProperties
 import Compiler.Proofs.KeccakBound
 import Compiler.Proofs.MappingSlot
 import Compiler.Proofs.AbiEncoding
+import Compiler.Proofs.ExecutionSummary
 import Compiler.Proofs.StorageLens
 import Compiler.Proofs.IRGeneration.Expr
 import Compiler.Proofs.IRGeneration.SupportedFragment
@@ -44,4 +45,5 @@ import Compiler.Proofs.IRGeneration.SourceSemantics
 import Compiler.Proofs.IRGeneration.HelperSummaryEvidence
 import Compiler.Proofs.Frames
 import Compiler.Proofs.YulGeneration.PatchRulesProofs
+import Compiler.Proofs.YulGeneration.ExecutionSummary
 import Compiler.Proofs.EndToEnd

--- a/Compiler/Proofs/ExecutionSummary.lean
+++ b/Compiler/Proofs/ExecutionSummary.lean
@@ -1,0 +1,136 @@
+import Compiler.Proofs.IRGeneration.IRRuntimeTypes
+
+namespace Compiler.Proofs
+
+open Compiler.Proofs.IRGeneration
+
+/-!
+Backend-neutral, typed execution summaries.
+
+This is deliberately a projection API rather than a new semantics.  Backends
+may expose their existing result records through `RawSummary`; consumers get a
+single typed outcome and observable-state shape.  Failed executions carrying a
+return value are rejected, so adapters cannot silently reinterpret an
+inconsistent backend result.
+-/
+
+/-- The externally visible outcome of one contract execution. -/
+inductive ExecutionOutcome (α : Type) where
+  | returned (value : Option α)
+  | reverted
+  deriving DecidableEq, Repr
+
+/-- Observable state shared by the source, IR, and backend result layers. -/
+structure ExecutionObservables (StorageSlot StorageWord Event : Type) where
+  storage : StorageSlot → StorageWord
+  events : List Event
+
+/-- A typed outcome paired with the observable post-state. -/
+structure ExecutionSummary
+    (ReturnValue StorageSlot StorageWord Event : Type) where
+  outcome : ExecutionOutcome ReturnValue
+  observables : ExecutionObservables StorageSlot StorageWord Event
+
+/-- Minimal untyped result view implemented by existing execution backends. -/
+structure RawSummary
+    (ReturnValue StorageSlot StorageWord Event : Type) where
+  success : Bool
+  returnValue : Option ReturnValue
+  storage : StorageSlot → StorageWord
+  events : List Event
+
+/-- Checked projection from an existing backend result.
+
+The projection is fail-closed: a backend failure with a return value has no
+typed summary.  Successful results preserve optional return values exactly.
+-/
+def RawSummary.toExecutionSummary? {ReturnValue StorageSlot StorageWord Event : Type}
+    (raw : RawSummary ReturnValue StorageSlot StorageWord Event) :
+    Option (ExecutionSummary ReturnValue StorageSlot StorageWord Event) :=
+  if raw.success then
+    some {
+      outcome := .returned raw.returnValue
+      observables := { storage := raw.storage, events := raw.events } }
+  else
+    match raw.returnValue with
+    | none =>
+        some {
+          outcome := .reverted
+          observables := { storage := raw.storage, events := raw.events } }
+    | some _ => none
+
+/-- A backend transition retains its typed pre-state alongside the checked
+observable summary.  The state type is intentionally backend-selected. -/
+structure ExecutionTransition
+    (State ReturnValue StorageSlot StorageWord Event : Type) where
+  initial : State
+  summary : ExecutionSummary ReturnValue StorageSlot StorageWord Event
+
+@[simp] theorem RawSummary.toExecutionSummary?_success
+    {ReturnValue StorageSlot StorageWord Event : Type}
+    (returnValue : Option ReturnValue)
+    (storage : StorageSlot → StorageWord)
+    (events : List Event) :
+    (RawSummary.mk true returnValue storage events).toExecutionSummary? =
+      some {
+        outcome := .returned returnValue
+        observables := { storage := storage, events := events } } := by
+  rfl
+
+@[simp] theorem RawSummary.toExecutionSummary?_revert
+    {ReturnValue StorageSlot StorageWord Event : Type}
+    (storage : StorageSlot → StorageWord)
+    (events : List Event) :
+    (RawSummary.mk false (none : Option ReturnValue) storage events).toExecutionSummary? =
+      some {
+        outcome := (ExecutionOutcome.reverted : ExecutionOutcome ReturnValue)
+        observables := { storage := storage, events := events } } := by
+  rfl
+
+/-- Explicit fail-closed theorem for inconsistent failed results. -/
+@[simp] theorem RawSummary.toExecutionSummary?_failed_with_return
+    {ReturnValue StorageSlot StorageWord Event : Type}
+    (value : ReturnValue)
+    (storage : StorageSlot → StorageWord)
+    (events : List Event) :
+    (RawSummary.mk false (some value) storage events).toExecutionSummary? = none := by
+  rfl
+
+/-- Adequacy of the checked projection: every admitted summary preserves the
+backend success bit, return value, storage, and events exactly. -/
+theorem RawSummary.toExecutionSummary?_adequate
+    {ReturnValue StorageSlot StorageWord Event : Type}
+    {raw : RawSummary ReturnValue StorageSlot StorageWord Event}
+    {summary : ExecutionSummary ReturnValue StorageSlot StorageWord Event}
+    (h : raw.toExecutionSummary? = some summary) :
+    summary.observables.storage = raw.storage ∧
+    summary.observables.events = raw.events ∧
+    (raw.success = true ∧ summary.outcome = .returned raw.returnValue ∨
+      raw.success = false ∧ raw.returnValue = none ∧ summary.outcome = .reverted) := by
+  unfold RawSummary.toExecutionSummary? at h
+  by_cases hs : raw.success = true
+  · rw [if_pos hs] at h
+    injection h with hsummary
+    subst summary
+    simp [hs]
+  · have hf : raw.success = false := Bool.eq_false_of_not_eq_true hs
+    rw [if_neg hs] at h
+    cases hr : raw.returnValue with
+    | none =>
+        rw [hr] at h
+        injection h with hsummary
+        subst summary
+        simp [hf]
+    | some value =>
+        rw [hr] at h
+        contradiction
+
+/-- Existing IR results expose the common raw-summary interface definitionally. -/
+def RawSummary.ofIRResult (result : IRResult) :
+    RawSummary Nat IRStorageSlot IRStorageWord (List Nat) :=
+  { success := result.success
+    returnValue := result.returnValue
+    storage := result.finalStorage
+    events := result.events }
+
+end Compiler.Proofs

--- a/Compiler/Proofs/YulGeneration/ExecutionSummary.lean
+++ b/Compiler/Proofs/YulGeneration/ExecutionSummary.lean
@@ -46,10 +46,14 @@ theorem RawSummary.ofYulResult_refines_of_eq
     (hEvents : yul.events = ir.events) :
     (RawSummary.ofYulResultOn observableSlots yul).toExecutionSummary? =
       (RawSummary.ofIRResultOn observableSlots ir).toExecutionSummary? := by
-  cases yul
-  cases ir
-  simp_all [RawSummary.ofYulResultOn, RawSummary.ofIRResultOn]
-  funext slot
-  exact hStorage slot.1 slot.2
+  have hStorageOn :
+      (fun slot : ObservableStorageSlot observableSlots =>
+        yul.finalStorage (IRStorageSlot.ofNat slot.1)) =
+      (fun slot : ObservableStorageSlot observableSlots =>
+        ir.finalStorage (IRStorageSlot.ofNat slot.1)) := by
+    funext slot
+    exact hStorage slot.1 slot.2
+  simp [RawSummary.ofYulResultOn, RawSummary.ofIRResultOn,
+    hSuccess, hReturn, hEvents, hStorageOn]
 
 end Compiler.Proofs.YulGeneration

--- a/Compiler/Proofs/YulGeneration/ExecutionSummary.lean
+++ b/Compiler/Proofs/YulGeneration/ExecutionSummary.lean
@@ -1,0 +1,32 @@
+import Compiler.Proofs.ExecutionSummary
+import Compiler.Proofs.YulGeneration.RuntimeTypes
+
+namespace Compiler.Proofs.YulGeneration
+
+open Compiler.Proofs
+open Compiler.Proofs.IRGeneration
+
+/-- Existing Yul and EVMYulLean-projected results expose the common
+raw-summary interface without changing either executable semantics. -/
+def RawSummary.ofYulResult (result : YulResult) :
+    RawSummary Nat IRStorageSlot IRStorageWord (List Nat) :=
+  { success := result.success
+    returnValue := result.returnValue
+    storage := result.finalStorage
+    events := result.events }
+
+/-- Refinement seam used by backend proofs: equality of existing result
+records implies equality of their checked, typed summaries. -/
+theorem RawSummary.ofYulResult_refines_of_eq
+    (ir : IRResult) (yul : YulResult)
+    (hSuccess : yul.success = ir.success)
+    (hReturn : yul.returnValue = ir.returnValue)
+    (hStorage : yul.finalStorage = ir.finalStorage)
+    (hEvents : yul.events = ir.events) :
+    (RawSummary.ofYulResult yul).toExecutionSummary? =
+      (RawSummary.ofIRResult ir).toExecutionSummary? := by
+  cases yul
+  cases ir
+  simp_all [RawSummary.ofYulResult, RawSummary.ofIRResult]
+
+end Compiler.Proofs.YulGeneration

--- a/Compiler/Proofs/YulGeneration/ExecutionSummary.lean
+++ b/Compiler/Proofs/YulGeneration/ExecutionSummary.lean
@@ -6,27 +6,50 @@ namespace Compiler.Proofs.YulGeneration
 open Compiler.Proofs
 open Compiler.Proofs.IRGeneration
 
-/-- Existing Yul and EVMYulLean-projected results expose the common
-raw-summary interface without changing either executable semantics. -/
-def RawSummary.ofYulResult (result : YulResult) :
-    RawSummary Nat IRStorageSlot IRStorageWord (List Nat) :=
+/-- A storage slot accompanied by evidence that it belongs to the caller's
+explicit observation boundary.  Native EVMYulLean results only materialize a
+finite set of slots, so their summary adapter must not expose a total storage
+function. -/
+def ObservableStorageSlot (observableSlots : List Nat) :=
+  { slot : Nat // slot ∈ observableSlots }
+
+/-- Restrict an IR result to the same finite storage observation boundary used
+by the native EVMYulLean harness. -/
+def RawSummary.ofIRResultOn (observableSlots : List Nat) (result : IRResult) :
+    RawSummary Nat (ObservableStorageSlot observableSlots) IRStorageWord (List Nat) :=
   { success := result.success
     returnValue := result.returnValue
-    storage := result.finalStorage
+    storage := fun slot => result.finalStorage (IRStorageSlot.ofNat slot.1)
+    events := result.events }
+
+/-- Expose a Yul result only on the caller-attested finite storage boundary.
+
+In particular, an EVMYulLean-projected `YulResult` cannot be mistaken for an
+authoritative total post-state: accessing storage requires a membership proof
+for `observableSlots`, precisely the boundary used by `nativeResultsMatchOn`. -/
+def RawSummary.ofYulResultOn (observableSlots : List Nat) (result : YulResult) :
+    RawSummary Nat (ObservableStorageSlot observableSlots) IRStorageWord (List Nat) :=
+  { success := result.success
+    returnValue := result.returnValue
+    storage := fun slot => result.finalStorage (IRStorageSlot.ofNat slot.1)
     events := result.events }
 
 /-- Refinement seam used by backend proofs: equality of existing result
 records implies equality of their checked, typed summaries. -/
 theorem RawSummary.ofYulResult_refines_of_eq
-    (ir : IRResult) (yul : YulResult)
+    (observableSlots : List Nat) (ir : IRResult) (yul : YulResult)
     (hSuccess : yul.success = ir.success)
     (hReturn : yul.returnValue = ir.returnValue)
-    (hStorage : yul.finalStorage = ir.finalStorage)
+    (hStorage : ∀ slot, slot ∈ observableSlots →
+      yul.finalStorage (IRStorageSlot.ofNat slot) =
+        ir.finalStorage (IRStorageSlot.ofNat slot))
     (hEvents : yul.events = ir.events) :
-    (RawSummary.ofYulResult yul).toExecutionSummary? =
-      (RawSummary.ofIRResult ir).toExecutionSummary? := by
+    (RawSummary.ofYulResultOn observableSlots yul).toExecutionSummary? =
+      (RawSummary.ofIRResultOn observableSlots ir).toExecutionSummary? := by
   cases yul
   cases ir
-  simp_all [RawSummary.ofYulResult, RawSummary.ofIRResult]
+  simp_all [RawSummary.ofYulResultOn, RawSummary.ofIRResultOn]
+  funext slot
+  exact hStorage slot.1 slot.2
 
 end Compiler.Proofs.YulGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -41,6 +41,7 @@ import Compiler.Proofs.ArithmeticProfile
 import Compiler.Proofs.EndToEnd.Base
 import Compiler.Proofs.EndToEnd.SimpleStorage
 import Compiler.Proofs.EventSemantics
+import Compiler.Proofs.ExecutionSummary
 import Compiler.Proofs.Frames
 import Compiler.Proofs.HelperStepProofs
 import Compiler.Proofs.IRGeneration.CEISafety
@@ -103,6 +104,7 @@ import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanPureBuiltinLemmas
 import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanSignedArithSpec
 import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanSourceExprClosure
 import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanStateBridge
+import Compiler.Proofs.YulGeneration.ExecutionSummary
 import Compiler.Proofs.YulGeneration.IRFuel
 import Compiler.Proofs.YulGeneration.RuntimeTypes
 
@@ -1776,6 +1778,12 @@ end Verity.AxiomAudit
   Compiler.Proofs.EventSemantics.emit_step_spec
   Compiler.Proofs.EventSemantics.events_update_preserves_transientStorage
   Compiler.Proofs.EventSemantics.events_update_preserves_sender
+
+  -- Compiler/Proofs/ExecutionSummary.lean
+  Compiler.Proofs.RawSummary.toExecutionSummary?_success
+  Compiler.Proofs.RawSummary.toExecutionSummary?_revert
+  Compiler.Proofs.RawSummary.toExecutionSummary?_failed_with_return
+  Compiler.Proofs.RawSummary.toExecutionSummary?_adequate
 
   -- Compiler/Proofs/Frames.lean
   Compiler.Proofs.Frames.Resource.disjoint_comm
@@ -6419,6 +6427,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.StateBridge.storageLookup_projectStorage_projected
   Compiler.Proofs.YulGeneration.Backends.StateBridge.uint256_roundtrip
 
+  -- Compiler/Proofs/YulGeneration/ExecutionSummary.lean
+  Compiler.Proofs.YulGeneration.RawSummary.ofYulResult_refines_of_eq
+
   -- Compiler/Proofs/YulGeneration/IRFuel.lean
   Compiler.Proofs.YulGeneration.execIRStmtsFuel_nil
   Compiler.Proofs.YulGeneration.execIRStmtsFuel_cons
@@ -6429,4 +6440,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6026 theorems/lemmas (4173 public, 1853 private, 0 sorry'd)
+-- Total: 6031 theorems/lemmas (4178 public, 1853 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

Adds the common typed summaries, transitions, and observables API on `EVMYulLean`, providing shared interfaces for Phase 1B execution and proof integration.

## Validation

- Receipt ID: `34b4f353-4419-4263-ac7a-168758bee34e`
- Exit status: `0`
- Exact commit: `c30c9146663fbc7592c5ac1d2a3916b7eed729fc`
- Command: `lake build Compiler.Proofs.EndToEnd`
- Toolchain: `leanprover/lean4:v4.31.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-layer API and projection lemmas only; no runtime compiler behavior or auth/data paths change.
> 
> **Overview**
> Adds a **backend-neutral typed execution summary layer** so IR and Yul can expose the same outcome/observable shape without defining new semantics. Existing backend records map through `RawSummary`, and `toExecutionSummary?` **fail-closes** when `success = false` but a return value is still present.
> 
> The core API includes `ExecutionOutcome`, `ExecutionObservables`, `ExecutionSummary`, `ExecutionTransition`, plus simp/adequacy lemmas for success, revert, and inconsistent failures. `RawSummary.ofIRResult` adapts current `IRResult` records.
> 
> **Yul-specific wiring** (`Compiler.Proofs.YulGeneration.ExecutionSummary`) restricts storage to caller-listed `observableSlots` via `ObservableStorageSlot`, matching the native harness boundary (`nativeResultsMatchOn`). `ofIRResultOn` / `ofYulResultOn` build bounded raw summaries, and `ofYulResult_refines_of_eq` lifts pointwise IR/Yul equality on that boundary to equal typed summaries.
> 
> Imports are added in `Compiler.lean`; new theorems are registered in `PrintAxioms.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c5722945057f8349fe1448d998f2b032c6b124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->