### PR TITLE
feat(ocr): packet semantic review, honest status check, grounded scout markers

### DIFF
--- a/.github/ocr/README.md
+++ b/.github/ocr/README.md
@@ -63,3 +63,31 @@ The hard guarded modes are fallback behavior only. During the pilot, a 3-file Le
 Deduplication includes the commit, rules hash, reviewer version, router version, and routing mode. Retryable OCR statuses such as `completed_with_errors` do not write the success dedup tag, while deterministic `no-supported` and `large-lean-hotspots` routing posts use a stable success tag to avoid repeated `/ocr review` spam for the same commit and router policy.
 
 Promote beyond pilot only after comparing OCR vs Codex on real PRs for true positives, false positives, latency, and cost.
+
+## Large-Lean packet semantic review (2026-07-31)
+
+Large Lean PRs (≥3 Lean files or >800 changed lines) previously stopped at
+scout triage. The route now continues:
+
+1. The multi-lens scout selects packets as before; the router writes an
+   executable plan (`ocr-packet-plan.json`) grouping selected packets by file.
+2. `ocr-packet-review.js` runs the real `ocr review` once per group, scoped by
+   excluding the exact complement (every other changed supported file — `ocr`
+   has no `--include` flag). ~10 min budget per group, at most 4 groups, one
+   at a time; a group failure never discards another group's findings.
+3. `post-ocr-review.js` publishes an **`OCR semantic review` check-run** that
+   carries the honest meaning: `success` only when a semantic review covered
+   the diff (full OCR, or all planned packet groups), `neutral` for
+   triage-only/partial coverage, `failure` on errored runs. The pipeline job
+   staying green only means the pipeline ran.
+4. Scout inline markers now lead with a "question de triage (non-review)"
+   caveat, stale markers from older heads are minimized as OUTDATED on the
+   next successful post, and the summary's first line reports
+   `covered/total` packet groups with uncovered groups listed unfolded.
+5. Scout dossiers embed a bounded node-side outline of each packet's file
+   (declarations + `sorry`/`axiom`/`native_decide` markers). Full LSP
+   diagnostics remain the packet reviewer's tools via its `lean_lsp` MCP
+   session.
+
+Kill switch: repo variable `OCR_PACKET_REVIEW_ENABLED=false`;
+per-group budget: `OCR_PACKET_TIMEOUT_MINUTES` (default 10).

--- a/.github/scripts/ocr-packet-review.js
+++ b/.github/scripts/ocr-packet-review.js
@@ -1,0 +1,128 @@
+'use strict';
+
+// P1: bounded per-packet semantic review for large-lean PRs.
+//
+// The router's large-lean route used to dead-end after scout triage
+// (`strong_review_status: blocked_packet_input`). This runner closes the loop:
+// for each scout-selected packet group it executes the real `ocr review`
+// scoped to that group's files. `ocr` has no --include flag, so scoping works
+// by excluding the exact complement — every OTHER changed supported file from
+// the same diff. The exclusion list is finite and derived from the diff, so a
+// packet run reviews precisely its files' hunks with full-file context.
+//
+// Failure isolation mirrors the scout lens fan-out: one packet's failure never
+// discards another packet's findings, and every outcome lands in the result
+// summary so the posting step can report honest covered/total numbers.
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const PER_PACKET_TIMEOUT_MINUTES = Number(process.env.OCR_PACKET_TIMEOUT_MINUTES || 10);
+// Hard node-side ceiling: the CLI timeout is advisory inside the tool; a hung
+// provider call must not consume the whole 45-minute job budget.
+const PER_PACKET_KILL_MS = (PER_PACKET_TIMEOUT_MINUTES + 3) * 60_000;
+
+function main() {
+  const planPath = requiredEnv('OCR_PACKET_PLAN_PATH');
+  const resultPath = requiredEnv('OCR_RESULT_PATH');
+  const metricsPath = process.env.OCR_METRICS_PATH || '';
+  const rulesPath = requiredEnv('OCR_RULES_PATH');
+
+  const plan = readJson(planPath);
+  const result = readJson(resultPath);
+  const groups = Array.isArray(plan.groups) ? plan.groups : [];
+
+  const perGroup = [];
+  let covered = 0;
+  for (const group of groups) {
+    const outcome = reviewGroup(plan, group, rulesPath);
+    perGroup.push(outcome);
+    if (outcome.status === 'success') {
+      covered += 1;
+      const comments = Array.isArray(outcome.comments) ? outcome.comments : [];
+      for (const comment of comments) {
+        result.comments = result.comments || [];
+        result.comments.push({ ...comment, category: 'packet-semantic' });
+      }
+    }
+    console.log(`packet group [${group.files.join(', ')}]: ${outcome.status}${outcome.findings != null ? ` (${outcome.findings} finding(s))` : ''}`);
+  }
+
+  result.summary = result.summary || {};
+  result.summary.packet_semantic = {
+    covered_groups: covered,
+    total_groups: groups.length,
+    total_groups_available: plan.total_groups_available ?? groups.length,
+    per_group: perGroup.map(g => ({
+      files: g.files,
+      packet_ids: g.packet_ids,
+      status: g.status,
+      findings: g.findings ?? 0,
+      error: g.error,
+    })),
+  };
+  if (covered > 0) {
+    result.status = 'scout_triage_with_packet_review';
+  }
+  fs.writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`);
+
+  if (metricsPath && fs.existsSync(metricsPath)) {
+    try {
+      const metrics = readJson(metricsPath);
+      metrics.packet_semantic = result.summary.packet_semantic;
+      fs.writeFileSync(metricsPath, `${JSON.stringify(metrics, null, 2)}\n`);
+    } catch (err) {
+      console.warn(`metrics update skipped: ${err.message}`);
+    }
+  }
+
+  console.log(`packet semantic review: ${covered}/${groups.length} group(s) covered`);
+}
+
+function reviewGroup(plan, group, rulesPath) {
+  const base = { files: group.files, packet_ids: group.packet_ids };
+  const outPath = path.join(process.env.RUNNER_TEMP || '.', `ocr-packet-${(group.packet_ids || ['g'])[0]}.json`);
+  const args = [
+    'review',
+    '--from', plan.diff_base,
+    '--to', plan.head,
+    '--format', 'json',
+    '--audience', 'agent',
+    '--rule', rulesPath,
+    '--concurrency', '1',
+    '--timeout', String(PER_PACKET_TIMEOUT_MINUTES),
+  ];
+  const exclude = Array.isArray(group.exclude) ? group.exclude.filter(Boolean) : [];
+  if (exclude.length > 0) {
+    args.push('--exclude', exclude.join(','));
+  }
+  try {
+    const stdout = execFileSync('ocr', args, {
+      encoding: 'utf8',
+      timeout: PER_PACKET_KILL_MS,
+      maxBuffer: 32 * 1024 * 1024,
+      env: process.env,
+    });
+    fs.writeFileSync(outPath, stdout);
+    const parsed = JSON.parse(stdout);
+    const comments = Array.isArray(parsed.comments) ? parsed.comments : [];
+    return { ...base, status: 'success', findings: comments.length, comments };
+  } catch (err) {
+    const detail = String(err && err.message ? err.message : err).slice(0, 300);
+    const status = err && err.killed ? 'timeout' : 'error';
+    return { ...base, status, error: detail };
+  }
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env: ${name}`);
+  return value;
+}
+
+main();

--- a/.github/scripts/ocr-router.js
+++ b/.github/scripts/ocr-router.js
@@ -72,6 +72,7 @@ async function main() {
   if (decision.mode === 'large-lean-hotspots') {
     await applyScoutStage(decision, diff, resolveScoutConfig(process.env));
   }
+  const packetPlanPath = writePacketReviewPlan(decision, diff);
   const metrics = buildMetrics({
     prNumber,
     headSha,
@@ -99,6 +100,8 @@ async function main() {
     result_path: resultPath,
     diff_base: diff.base,
     router_version: ROUTER_VERSION,
+    packet_review_planned: String(Boolean(packetPlanPath)),
+    packet_plan_path: packetPlanPath || '',
   });
 
   console.log(`OCR route: ${decision.mode} (${decision.reason})`);
@@ -335,6 +338,79 @@ function buildReviewPackets(files) {
     .map((packet, index) => ({ ...packet, packet_id: `pkt-${index + 1}` }));
 }
 
+// P1 (packet semantic review): materialize the scout-selected packets as an
+// executable plan. `ocr review` has no --include flag, so each group is scoped
+// by EXCLUDING the exact complement — every other changed supported file. The
+// exclusion list is bounded by the diff itself, never a glob over the repo.
+function writePacketReviewPlan(decision, diff) {
+  if (decision.mode !== 'large-lean-hotspots') return '';
+  const packets = decision.packets || [];
+  if (packets.length === 0) return '';
+  const runnerTemp = process.env.RUNNER_TEMP || '.';
+  const byFile = new Map();
+  for (const packet of packets) {
+    if (!byFile.has(packet.path)) byFile.set(packet.path, []);
+    byFile.get(packet.path).push(packet.packet_id);
+  }
+  const allSupported = diff.files.filter(f => f.supported && !isExcluded(f.path)).map(f => f.path);
+  const groups = [...byFile.entries()]
+    .map(([file, packetIds]) => ({
+      files: [file],
+      packet_ids: packetIds,
+      exclude: allSupported.filter(other => other !== file),
+    }))
+    .slice(0, PACKET_REVIEW_MAX_GROUPS);
+  const plan = {
+    schema_version: 1,
+    diff_base: diff.base,
+    head: diff.head,
+    total_groups_available: byFile.size,
+    groups,
+  };
+  const planPath = path.join(runnerTemp, 'ocr-packet-plan.json');
+  fs.writeFileSync(planPath, `${JSON.stringify(plan, null, 2)}\n`);
+  return planPath;
+}
+
+const PACKET_REVIEW_MAX_GROUPS = 4;
+
+// P5 (grounded scout dossiers): a bounded, node-side outline of each packet's
+// file — declarations plus soundness-relevant markers. Full LSP diagnostics
+// remain the packet reviewer's job (its MCP session has lean_diagnostic_messages);
+// the scout only needs enough structure to ask anchored questions.
+const OUTLINE_DECL_RE = /^\s*(?:@\[[^\]]*\]\s*)?(?:private\s+|protected\s+|noncomputable\s+|unsafe\s+|partial\s+)*(theorem|lemma|def|abbrev|instance|structure|inductive|class|axiom|opaque)\b[^:=]{0,120}/;
+const OUTLINE_MARKER_RE = /\b(sorry|admit|native_decide|axiom)\b/;
+const outlineCache = new Map();
+function leanOutlineForFile(filePath) {
+  if (!/\.lean$/.test(filePath)) return undefined;
+  if (outlineCache.has(filePath)) return outlineCache.get(filePath);
+  let outline;
+  try {
+    const text = fs.readFileSync(filePath, 'utf8');
+    const decls = [];
+    const markers = [];
+    const lines = text.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i];
+      const decl = OUTLINE_DECL_RE.exec(line);
+      if (decl && decls.length < 40) decls.push(`L${i + 1}: ${line.trim().slice(0, 140)}`);
+      if (OUTLINE_MARKER_RE.test(line) && !/^\s*--/.test(line) && markers.length < 20) {
+        markers.push(`L${i + 1}: ${line.trim().slice(0, 120)}`);
+      }
+    }
+    outline = {
+      declarations: decls,
+      soundness_markers: markers.length ? markers : undefined,
+    };
+    const raw = JSON.stringify(outline);
+    if (raw.length > 2000) outline = { declarations: decls.slice(0, 20), soundness_markers: markers.slice(0, 10), truncated: true };
+  } catch (err) {
+    outline = undefined;
+  }
+  outlineCache.set(filePath, outline);
+  return outline;
+}
+
 function renderHunkExcerpt(hunk, maxLines) {
   return hunk.lines.slice(0, maxLines).map(line => {
     const prefix = line.type === 'add' ? '+' : line.type === 'del' ? '-' : ' ';
@@ -521,6 +597,7 @@ function buildRiskDossier(decision, diff, options = {}) {
     summary: packet.summary,
     changed_lines: packet.changed_lines,
     diff_excerpt: packet.diff_excerpt,
+    file_outline: leanOutlineForFile(packet.path),
   }));
 
   const supported = diff.files.filter(f => f.supported);
@@ -1410,7 +1487,7 @@ function buildPacketizedResult(decision, metrics) {
     })),
     warnings: [{
       type: 'coverage',
-      message: 'Large Lean scout mode covers ranked hotspots only. Codex/human review must cover skipped hunks and proof obligations; OCR strong packet review is not wired yet.',
+      message: 'Large Lean scout mode covers ranked hotspots only. Scout-selected packets get a bounded semantic OCR pass (see packet coverage); Codex/human review must still cover unselected hunks and proof obligations.',
     }],
     summary: {
       files_reviewed: uniqueCount(packets.map(p => p.path)),
@@ -1462,7 +1539,6 @@ function renderPacketFinding(packet) {
       lines.push(`- L${sample.line}: ${renderCodeSample(sample.text)}`);
     }
   }
-  lines.push('_Scout triage coverage marker — not a final OCR semantic review or approval._');
   return lines.join('\n');
 }
 
@@ -1567,6 +1643,8 @@ module.exports = {
   appendRubricItem,
   unionScoutPackets,
   renderPacketFinding,
+  writePacketReviewPlan,
+  leanOutlineForFile,
   parseScoutJson,
   sanitizeScoutErrorDetail,
   buildRiskDossier,

--- a/.github/scripts/post-ocr-review.js
+++ b/.github/scripts/post-ocr-review.js
@@ -116,6 +116,7 @@ module.exports = async function postOcrReview({ github, context, core }) {
       issue_number: pull_number,
       body,
     });
+    await publishSemanticReviewCheck({ github, core, owner, repo, head_sha: commit_id, mode, result, retryable: true });
     return;
   }
 
@@ -129,6 +130,7 @@ module.exports = async function postOcrReview({ github, context, core }) {
       body,
       comments: selected.map(toReviewComment),
     });
+    await minimizeStaleScoutComments({ github, core, owner, repo, pull_number, commit_id });
   } catch (err) {
     core.warning(`Batch createReview failed: ${err.message}`);
     const fallbackBody = `${body.replace(successTag, retryableTag)}\n\n⚠️ Inline publication failed, so OCR findings are summarized here instead.\n\n${renderInlineFallback(selected)}\n\n${fenced(String(err.message || err))}`;
@@ -139,7 +141,87 @@ module.exports = async function postOcrReview({ github, context, core }) {
       body: fallbackBody,
     });
   }
+
+  await publishSemanticReviewCheck({ github, core, owner, repo, head_sha: commit_id, mode, result, retryable: retryableResult });
 };
+
+// P2: a second, honest check. The workflow job itself stays green whenever the
+// pipeline ran, so this check-run carries the real review meaning: success
+// only when a semantic review actually covered the diff (full OCR, or every
+// planned packet group); neutral for triage-only or partial coverage.
+async function publishSemanticReviewCheck({ github, core, owner, repo, head_sha, mode, result, retryable }) {
+  try {
+    let conclusion = 'neutral';
+    let title = 'Triage only — no semantic review';
+    const packet = result.summary?.packet_semantic;
+    if (retryable || result.status === 'error') {
+      conclusion = 'failure';
+      title = 'Review errored — treat as unreviewed';
+    } else if (mode === 'no-supported' || result.status === 'no-supported') {
+      conclusion = 'neutral';
+      title = 'No OCR-supported files in diff';
+    } else if (mode !== 'large-lean-hotspots' && result.status !== 'scout_triage') {
+      conclusion = 'success';
+      title = `Full OCR semantic review (${mode})`;
+    } else if (packet && packet.total_groups > 0) {
+      const covered = `${packet.covered_groups}/${packet.total_groups}`;
+      if (packet.covered_groups === packet.total_groups) {
+        conclusion = 'success';
+        title = `Packet semantic review: ${covered} groups covered`;
+      } else {
+        conclusion = 'neutral';
+        title = `Partial packet review: ${covered} groups — rest is triage-only`;
+      }
+    }
+    await github.rest.checks.create({
+      owner,
+      repo,
+      name: 'OCR semantic review',
+      head_sha,
+      status: 'completed',
+      conclusion,
+      output: {
+        title,
+        summary: 'Semantic-review coverage published by post-ocr-review.js. Neutral means the diff (or part of it) only received scout triage: do not read the green pipeline job as review coverage.',
+      },
+    });
+  } catch (err) {
+    core.warning(`Semantic review check not published: ${err.message}`);
+  }
+}
+
+// P4: once a newer head has a successful post, older heads' scout markers are
+// noise that reads like open findings. Minimize (fold as OUTDATED) every OCR
+// inline comment whose original commit differs from the current head.
+async function minimizeStaleScoutComments({ github, core, owner, repo, pull_number, commit_id }) {
+  try {
+    const comments = await github.paginate(github.rest.pulls.listReviewComments, {
+      owner,
+      repo,
+      pull_number,
+      per_page: 100,
+    });
+    const stale = comments.filter(c =>
+      c.user?.login === 'github-actions[bot]'
+      && c.original_commit_id
+      && c.original_commit_id !== commit_id
+      && /(Scout triage coverage marker|OCR scout — question de triage|OpenCodeReview)/.test(c.body || ''),
+    );
+    for (const comment of stale) {
+      try {
+        await github.graphql(
+          `mutation($id: ID!) { minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) { minimizedComment { isMinimized } } }`,
+          { id: comment.node_id },
+        );
+      } catch (err) {
+        core.warning(`minimizeComment failed for ${comment.id}: ${err.message}`);
+      }
+    }
+    if (stale.length) core.notice(`Minimized ${stale.length} stale OCR comment(s) from previous heads.`);
+  } catch (err) {
+    core.warning(`Stale scout comment minimization skipped: ${err.message}`);
+  }
+}
 
 async function hasExistingTag(github, { owner, repo, pull_number, tag }) {
   const issueComments = await github.paginate(github.rest.issues.listComments, {
@@ -315,8 +397,24 @@ function buildReviewBody({ tag, result, comments, selected, overflow, summaryOnl
   const summary = result.summary || {};
   const mode = metrics?.mode || summary.mode || 'unknown';
 
+  setPacketSemantic(result.summary?.packet_semantic);
   let body = `${tag}\n## OpenCodeReview first-pass review\n\n`;
   body += `${verdictLine({ status, mode, comments, retryable })}\n\n`;
+  const packetSemantic = result.summary?.packet_semantic;
+  if (mode === 'large-lean-hotspots' && packetSemantic) {
+    const uncovered = (packetSemantic.per_group || []).filter(g => g.status !== 'success');
+    if (uncovered.length > 0) {
+      body += `### Paquets non couverts par la review sémantique\n\n`;
+      for (const g of uncovered.slice(0, 10)) {
+        body += `- **${escapeMd((g.files || []).join(', '))}** — ${escapeMd(g.status)}${g.error ? ` (${escapeMd(firstLine(g.error))})` : ''}\n`;
+      }
+      body += `\n`;
+    }
+    const extraGroups = (packetSemantic.total_groups_available ?? 0) - (packetSemantic.total_groups ?? 0);
+    if (extraGroups > 0) {
+      body += `📝 ${extraGroups} groupe(s) de paquets au-delà du budget n'ont eu que le triage scout.\n\n`;
+    }
+  }
 
   if (message) body += `${escapeMd(message)}\n\n`;
   if (selected.length > 0) body += `✅ Posted ${selected.length} inline comment(s).\n`;
@@ -346,6 +444,9 @@ function buildReviewBody({ tag, result, comments, selected, overflow, summaryOnl
     body += `\n`;
   }
 
+  if (stderr && /deadline|timed? ?out/i.test(stderr)) {
+    body += `### Warnings\n\n- **timeout**: OCR stderr mentions a subtask deadline/timeout — findings may be incomplete; consider raising the mode timeout.\n\n`;
+  }
   if (stderr) {
     const interesting = stderr.split('\n').filter(line => /warning|error|failed|fatal/i.test(line)).slice(0, 20).join('\n');
     if (interesting) {
@@ -381,6 +482,10 @@ function severityRollup(comments) {
 
 // One plain-language line a reviewer can act on without decoding router
 // internals. Mode/status/version details live in the folded metrics block.
+let _packetSemantic = null;
+function setPacketSemantic(value) { _packetSemantic = value || null; }
+function metricsPacketSemantic() { return _packetSemantic; }
+
 function verdictLine({ status, mode, comments, retryable }) {
   const rollup = severityRollup(comments);
   const findings = comments.length
@@ -396,6 +501,12 @@ function verdictLine({ status, mode, comments, retryable }) {
     return `🔴 **Review errored** (${findings} before the failure) — treat this PR as unreviewed by OCR.`;
   }
   if (mode === 'large-lean-hotspots') {
+    const packet = metricsPacketSemantic();
+    if (packet && packet.total_groups > 0) {
+      const covered = `${packet.covered_groups}/${packet.total_groups}`;
+      const grade = packet.covered_groups === packet.total_groups ? '🟢' : '🟡';
+      return `${grade} **Scout triage + ${covered} paquet(s) reviewés sémantiquement.** ${findings}; les hunks hors paquets restent à couvrir par un humain ou Codex.`;
+    }
     return `🟡 **Scout triage only — not a full review.** ${findings}; a human or Codex must still cover the unflagged hunks and proof obligations.`;
   }
   if (comments.length > 0) {
@@ -532,7 +643,17 @@ function formatDuration(ms) {
 }
 
 function renderComment(c) {
-  let body = `**OpenCodeReview${badge(c)}**\n\n${String(c.content || '').trim()}`;
+  if (c.category === 'large-lean-hotspots') {
+    // P3: scout markers are coverage QUESTIONS, not findings. Lead with the
+    // caveat so a controller or human never mistakes one for a review verdict.
+    return `🟡 **OCR scout — question de triage (non-review)${badge(c)}**\n\n`
+      + `_Question de couverture pour le reviewer humain/Codex — pas une review sémantique finale ni une approbation._\n\n`
+      + `${String(c.content || '').trim()}`;
+  }
+  const label = c.category === 'packet-semantic'
+    ? `**OpenCodeReview — packet semantic review${badge(c)}**`
+    : `**OpenCodeReview${badge(c)}**`;
+  let body = `${label}\n\n${String(c.content || '').trim()}`;
   if (c.suggestion_code) {
     body += `\n\nSuggested change:\n${fenced(String(c.suggestion_code))}`;
   }
@@ -580,6 +701,7 @@ function escapeMd(s) {
 }
 
 module.exports.isRetryableResult = isRetryableResult;
+module.exports.renderComment = renderComment;
 module.exports.buildReviewBody = buildReviewBody;
 module.exports.extractOcrSummary = extractOcrSummary;
 module.exports.buildDedupKey = buildDedupKey;

--- a/.github/scripts/test-ocr-routing.js
+++ b/.github/scripts/test-ocr-routing.js
@@ -2006,6 +2006,130 @@ function testResolveLensesSubsetAndFallback() {
   assert.deepStrictEqual(unknown.map(l => l.id), router.LENSES.map(l => l.id));
 }
 
+
+function testPacketPlanScopesGroupsByComplementExclusion() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-packet-plan-'));
+  const previousRunnerTemp = process.env.RUNNER_TEMP;
+  process.env.RUNNER_TEMP = tmp;
+  try {
+    const decision = {
+      mode: 'large-lean-hotspots',
+      packets: [
+        { packet_id: 'pkt-1', path: 'Compiler/Proofs/A.lean' },
+        { packet_id: 'pkt-2', path: 'Compiler/Proofs/A.lean' },
+        { packet_id: 'pkt-3', path: 'Compiler/Proofs/B.lean' },
+      ],
+    };
+    const diff = {
+      base: 'basesha',
+      head: 'headsha',
+      files: [
+        { path: 'Compiler/Proofs/A.lean', supported: true },
+        { path: 'Compiler/Proofs/B.lean', supported: true },
+        { path: 'Compiler/Proofs/C.lean', supported: true },
+        { path: 'vendor/generated/out.json', supported: true },
+      ],
+    };
+    const planPath = router.writePacketReviewPlan(decision, diff);
+    assert.ok(planPath && fs.existsSync(planPath));
+    const plan = JSON.parse(fs.readFileSync(planPath, 'utf8'));
+    assert.strictEqual(plan.diff_base, 'basesha');
+    assert.strictEqual(plan.head, 'headsha');
+    assert.strictEqual(plan.groups.length, 2);
+    const groupA = plan.groups.find(g => g.files[0] === 'Compiler/Proofs/A.lean');
+    assert.deepStrictEqual(groupA.packet_ids, ['pkt-1', 'pkt-2']);
+    // Complement exclusion: every other changed *included* file, never the
+    // group's own file; router-excluded paths (artifacts/) must not leak in.
+    assert.ok(groupA.exclude.includes('Compiler/Proofs/B.lean'));
+    assert.ok(groupA.exclude.includes('Compiler/Proofs/C.lean'));
+    assert.ok(!groupA.exclude.includes('Compiler/Proofs/A.lean'));
+    assert.ok(!groupA.exclude.some(p => p.includes('/generated/')));
+  } finally {
+    if (previousRunnerTemp === undefined) delete process.env.RUNNER_TEMP;
+    else process.env.RUNNER_TEMP = previousRunnerTemp;
+  }
+}
+
+function testPacketPlanNotWrittenOutsideLargeLean() {
+  const planPath = router.writePacketReviewPlan({ mode: 'medium-lean', packets: [{ packet_id: 'pkt-1', path: 'A.lean' }] }, { base: 'b', head: 'h', files: [] });
+  assert.strictEqual(planPath, '');
+}
+
+function testLeanOutlineExtractsDeclarationsAndSoundnessMarkers() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-outline-'));
+  const leanPath = path.join(tmp, 'Sample.lean');
+  fs.writeFileSync(leanPath, [
+    'import Foo',
+    'theorem good : True := by trivial',
+    'def helper (n : Nat) : Nat := n',
+    'lemma pending : False := by sorry',
+    '-- sorry in a comment must not count',
+  ].join('\n'));
+  const outline = router.leanOutlineForFile(leanPath);
+  assert.ok(outline.declarations.some(d => d.includes('theorem good')));
+  assert.ok(outline.declarations.some(d => d.includes('def helper')));
+  assert.ok(outline.soundness_markers.some(m => m.includes('sorry')));
+  assert.strictEqual(outline.soundness_markers.some(m => m.includes('comment must not count')), false);
+  assert.strictEqual(router.leanOutlineForFile('README.md'), undefined);
+}
+
+function testPacketFindingCarriesNoTrailingCaveat() {
+  const body = router.renderPacketFinding({
+    path: 'Compiler/Proofs/A.lean',
+    summary: '10 changed line(s) near Compiler/Proofs/A.lean:1',
+    signals: [],
+    added_sample: [],
+    scout_reason: 'reason',
+    scout_question: 'question',
+  });
+  // The caveat now leads the posted comment (post-ocr-review renderComment),
+  // so the router body must not duplicate it at the tail.
+  assert.ok(!body.includes('coverage marker'));
+}
+
+
+function testScoutMarkerLeadsWithNonReviewCaveat() {
+  const body = postOcrReview.renderComment({
+    category: 'large-lean-hotspots',
+    severity: 'high',
+    content: '**Findings (3 lenses):**',
+  });
+  assert.ok(body.startsWith('🟡 **OCR scout — question de triage (non-review)'));
+  assert.ok(body.indexOf('pas une review sémantique') < body.indexOf('Findings'));
+}
+
+function testPacketSemanticVerdictLineReportsCoverage() {
+  const body = postOcrReview.buildReviewBody({
+    tag: '<!-- test -->',
+    result: {
+      status: 'scout_triage_with_packet_review',
+      summary: {
+        packet_semantic: {
+          covered_groups: 2,
+          total_groups: 3,
+          total_groups_available: 5,
+          per_group: [
+            { files: ['A.lean'], status: 'success', findings: 1 },
+            { files: ['B.lean'], status: 'success', findings: 0 },
+            { files: ['C.lean'], status: 'timeout', error: 'killed' },
+          ],
+        },
+      },
+    },
+    comments: [],
+    selected: [],
+    overflow: [],
+    summaryOnly: [],
+    warnings: [],
+    stderr: '',
+    metrics: { mode: 'large-lean-hotspots' },
+  });
+  assert.ok(body.includes('2/3 paquet(s) reviewés sémantiquement'));
+  assert.ok(body.includes('Paquets non couverts par la review sémantique'));
+  assert.ok(body.includes('C.lean'));
+  assert.ok(body.includes("2 groupe(s) de paquets au-delà du budget"));
+}
+
 async function run() {
   testNoSupportedFilesSkipped();
   testOneLeanFileNormal();
@@ -2104,6 +2228,12 @@ async function run() {
   await testLegacyLargeLeanBaseTagDedupsOnlyMatchingScoutConfig();
   testScoutProviderErrorsNeutralizeMentions();
   testLargeLeanScoutDedupVariesBySanitizedScoutConfig();
+  testPacketPlanScopesGroupsByComplementExclusion();
+  testPacketPlanNotWrittenOutsideLargeLean();
+  testLeanOutlineExtractsDeclarationsAndSoundnessMarkers();
+  testPacketFindingCarriesNoTrailingCaveat();
+  testScoutMarkerLeadsWithNonReviewCaveat();
+  testPacketSemanticVerdictLineReportsCoverage();
   console.log('OCR routing tests passed');
 }
 

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -16,6 +16,8 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  # post-ocr-review.js publishes the honest "OCR semantic review" check-run.
+  checks: write
 
 concurrency:
   group: ocr-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}-${{ github.event_name }}
@@ -141,13 +143,13 @@ jobs:
           node "$GITHUB_WORKSPACE/ocr-trusted/.github/scripts/ocr-router.js"
 
       - name: Setup uv
-        if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true' && steps.route.outputs.has_lean == 'true'
+        if: steps.pr.outputs.skip != 'true' && (steps.route.outputs.should_run_ocr == 'true' || steps.route.outputs.packet_review_planned == 'true') && steps.route.outputs.has_lean == 'true'
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           version: "0.11.31"
 
       - name: Prepare repository-pinned Lean toolchain for LSP evidence
-        if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true' && steps.route.outputs.has_lean == 'true'
+        if: steps.pr.outputs.skip != 'true' && (steps.route.outputs.should_run_ocr == 'true' || steps.route.outputs.packet_review_planned == 'true') && steps.route.outputs.has_lean == 'true'
         env:
           # Never reuse the runner's elan store for a PR-selected toolchain.
           # The run/attempt suffix also prevents stale self-hosted runner state
@@ -158,7 +160,7 @@ jobs:
           "$GITHUB_WORKSPACE/ocr-trusted/.github/scripts/prepare-lean-lsp.sh" "$GITHUB_WORKSPACE/repo"
 
       - name: Install OpenCodeReview
-        if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true'
+        if: steps.pr.outputs.skip != 'true' && (steps.route.outputs.should_run_ocr == 'true' || steps.route.outputs.packet_review_planned == 'true')
         run: |
           set -euo pipefail
           # Keep the OCR client out of the self-hosted runner's global npm
@@ -169,7 +171,7 @@ jobs:
           ocr version
 
       - name: Configure bounded Lean LSP evidence
-        if: steps.pr.outputs.skip != 'true' && steps.route.outputs.should_run_ocr == 'true' && steps.route.outputs.has_lean == 'true'
+        if: steps.pr.outputs.skip != 'true' && (steps.route.outputs.should_run_ocr == 'true' || steps.route.outputs.packet_review_planned == 'true') && steps.route.outputs.has_lean == 'true'
         env:
           HOME: ${{ runner.temp }}/ocr-home
           ELAN_HOME: ${{ runner.temp }}/ocr-elan-${{ github.run_id }}-${{ github.run_attempt }}
@@ -231,6 +233,28 @@ jobs:
             > "$RUNNER_TEMP/ocr-result.json" \
             2> "$RUNNER_TEMP/ocr-stderr.log" || true
           test -s "$RUNNER_TEMP/ocr-result.json" || echo '{"status":"error","comments":[],"message":"OCR produced no JSON output"}' > "$RUNNER_TEMP/ocr-result.json"
+
+      - name: Run OCR packet reviews
+        # P1: bounded semantic review of scout-selected packets on large-lean
+        # PRs. Disable with repo variable OCR_PACKET_REVIEW_ENABLED=false.
+        if: steps.pr.outputs.skip != 'true' && steps.route.outputs.packet_review_planned == 'true' && vars.OCR_PACKET_REVIEW_ENABLED != 'false'
+        working-directory: repo
+        env:
+          HOME: ${{ runner.temp }}/ocr-home
+          OCR_LLM_URL: ${{ secrets.OCR_LLM_URL }}
+          OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_KEY }}
+          OCR_LLM_MODEL: reviewer
+          OCR_USE_ANTHROPIC: "false"
+          OCR_LLM_TIMEOUT: "300"
+          OCR_PACKET_PLAN_PATH: ${{ steps.route.outputs.packet_plan_path }}
+          OCR_RESULT_PATH: ${{ runner.temp }}/ocr-result.json
+          OCR_METRICS_PATH: ${{ runner.temp }}/ocr-metrics.json
+          OCR_RULES_PATH: ${{ runner.temp }}/ocr-tools/rules.json
+          OCR_PACKET_TIMEOUT_MINUTES: ${{ vars.OCR_PACKET_TIMEOUT_MINUTES || '10' }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME"
+          node "$GITHUB_WORKSPACE/ocr-trusted/.github/scripts/ocr-packet-review.js"
 
       - name: Post OCR review
         if: steps.pr.outputs.skip != 'true' && always() && !cancelled() && steps.route.outcome == 'success' && (steps.route.outputs.should_run_ocr != 'true' || steps.ocr.outcome == 'success')


### PR DESCRIPTION
## Summary

Implements the six improvements from the OCR functioning review:

1. **P1 — packet semantic review unblocked**: `ocr-packet-review.js` runs the real `ocr review` per scout-selected packet group on large-lean PRs, scoped by excluding the exact complement of changed files (`ocr` has no `--include`); sequential, ~10 min/group (`OCR_PACKET_TIMEOUT_MINUTES`), ≤4 groups, per-group failure isolation. Kill switch: `OCR_PACKET_REVIEW_ENABLED=false`.
2. **P2 — honest status**: new **`OCR semantic review` check-run** (`checks: write`): success only for real semantic coverage (full OCR or all planned packet groups), neutral for triage-only/partial, failure on errors. `covered/total` packet groups now leads the summary body instead of hiding in the dedup tag.
3. **P3 — markers stop masquerading as findings**: inline scout comments open with `🟡 OCR scout — question de triage (non-review)` and the caveat precedes content.
4. **P4 — stale-thread hygiene**: on each successful post, OCR inline comments from previous heads are minimized (GraphQL `minimizeComment`, OUTDATED).
5. **P5 — grounded scout dossiers**: bounded node-side outline per packet file (declarations + `sorry`/`axiom`/`native_decide` markers, line-numbered); full LSP diagnostics remain with the packet reviewer's `lean_lsp` MCP session.
6. **P6**: uncovered packet groups listed unfolded, over-budget group count surfaced, stderr subtask-deadline aborts produce an explicit timeout warning.

## Validation

- `node .github/scripts/test-ocr-routing.js`: full suite green including 6 new cases (plan scoping/exclusion complement/caps, outline extraction incl. comment false-positives, caveat placement, coverage verdict + uncovered listing).
- `node --check` on all three scripts; workflow YAML parses.
- Live validation after merge: trigger `/ocr review` on PR #2219 (large-lean) and confirm packet reviews, the semantic-review check, retitled markers, and old-head minimization.

Deployment note: OCR trusted scripts load from the default branch (`pull_request_target`), so merging this PR IS the production deploy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes self-hosted CI review behavior (extra LLM `ocr review` calls, new check conclusions, GraphQL comment minimization) on untrusted PR code, though bounded by group/time limits and a repo kill switch.
> 
> **Overview**
> Large Lean PRs no longer stop at scout triage: the router writes **`ocr-packet-plan.json`** (per-file groups, complement **`--exclude`** scoping, ≤4 groups), and **`ocr-packet-review.js`** runs bounded **`ocr review`** per group with per-group failure isolation and **`OCR_PACKET_REVIEW_ENABLED`** kill switch.
> 
> **Posting and honesty:** **`post-ocr-review.js`** adds an **`OCR semantic review`** check-run (workflow gains **`checks: write`**) so success means real semantic coverage, not just a green job; the PR summary leads with **`covered/total`** packet groups, lists uncovered groups, and surfaces over-budget triage-only groups plus stderr timeout hints. Scout inline comments are explicitly **triage (non-review)**; stale bot comments on older heads are minimized as **OUTDATED**; packet-semantic findings get distinct labels.
> 
> **Scout input:** dossiers gain a bounded **`leanOutlineForFile`** (declarations + soundness markers). Docs and routing tests cover plan scoping, outlines, caveat placement, and coverage verdicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a4b54f1c06d00d7abf4ade6e4cb02e753e4d49b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->