### PR TITLE
fix(ocr): classify packet budget exhaustion as timeout

### DIFF
--- a/.github/scripts/ocr-packet-review.js
+++ b/.github/scripts/ocr-packet-review.js
@@ -110,7 +110,12 @@ function reviewGroup(plan, group, rulesPath) {
     return { ...base, status: 'success', findings: comments.length, comments };
   } catch (err) {
     const detail = String(err && err.message ? err.message : err).slice(0, 300);
-    const status = err && err.killed ? 'timeout' : 'error';
+    // execFileSync surfaces its timeout as code ETIMEDOUT (killed stays false
+    // on some platforms) — observed live on PR #2219 group 2. Label budget
+    // exhaustion as timeout so the summary suggests raising
+    // OCR_PACKET_TIMEOUT_MINUTES rather than implying a crash.
+    const timedOut = Boolean(err && (err.killed || err.code === 'ETIMEDOUT' || /ETIMEDOUT/.test(detail)));
+    const status = timedOut ? 'timeout' : 'error';
     return { ...base, status, error: detail };
   }
 }


### PR DESCRIPTION
One-word status fix observed during live validation of #2220 on PR #2219: `spawnSync ocr ETIMEDOUT` (node-side budget ceiling, killed=false on Linux) was labeled `error`; it is a `timeout`, and the uncovered-packets list should point readers at `OCR_PACKET_TIMEOUT_MINUTES`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-branch status labeling in CI packet review; no auth, data, or production runtime impact.
> 
> **Overview**
> **Packet review** now treats Node `execFileSync` budget hits (`ETIMEDOUT`, including when `killed` is false on Linux) as **`timeout`** instead of **`error`**.
> 
> That status flows into `packet_semantic` per-group results and the uncovered-packets summary, so operators see a time-budget miss and are nudged toward **`OCR_PACKET_TIMEOUT_MINUTES`** rather than a generic crash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e45bfe83b800d10957327d31418dc8bc91857254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->