### PR TITLE
Phase 1C #1: Prove void helper-call preservation (StmtListDirectInternalHelperCallStepInterface)

### DIFF
--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -1687,6 +1687,30 @@ theorem stmtListDirectInternalHelperStepInterfaces_of_headStepCatalog
         (stmts := fn.body)
         hcatalog.assign
 
+/-- Assemble the exact direct void-helper-call list interface from a body-local
+head-step catalog.  Unlike
+`stmtListDirectInternalHelperStepInterfaces_of_headStepCatalog`, this consumer
+does not expose or require the return-binding interface: the call proof is
+obtained solely from the catalog's void-call execution witnesses. -/
+theorem stmtListDirectInternalHelperCallStepInterface_of_headStepCatalog
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {fn : FunctionSpec}
+    (hcatalog :
+      DirectInternalHelperHeadStepCatalog runtimeContract spec fields fn) :
+    StmtListDirectInternalHelperCallStepInterface
+      runtimeContract spec fields scope fn.body := by
+  exact
+    stmtListDirectInternalHelperCallStepInterface_of_internalCallSteps_of_helperCallNames
+      (runtimeContract := runtimeContract)
+      (spec := spec)
+      (fields := fields)
+      (scope := scope)
+      (stmts := fn.body)
+      hcatalog.call
+
 private theorem internalFunctionYulName_head (calleeName : String) :
     (CompilationModel.internalFunctionYulName calleeName).toList.head? = some 'i' := by
   simp [CompilationModel.internalFunctionYulName, CompilationModel.internalFunctionPrefix]

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2894,6 +2894,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperCallStepInterface_of_internalCallSteps_of_helperCallNames
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_internalCallSteps_of_helperCallNames
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperStepInterfaces_of_headStepCatalog
+  Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperCallStepInterface_of_headStepCatalog
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_head  -- private
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_of_head  -- private
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_stop  -- private
@@ -6440,4 +6441,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6031 theorems/lemmas (4178 public, 1853 private, 0 sorry'd)
+-- Total: 6032 theorems/lemmas (4179 public, 1853 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

Closes void helper-call preservation interface slice (issue #2080, case 1/4).

This establishes `StmtListDirectInternalHelperCallStepInterface` — the first of four helper-call semantic forms needed to remove `helperSurfaceClosed`.

## Changes
- `Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean`: +24 lines (new proof)
- `PrintAxioms.lean`: +2/-1 (theorem counter update, 0 sorry'd)

## Verification
- No `sorry`/`admit`/`axiom` in changed source
- Single commit, parent is current `main` (d2d4a18a)

Generated by Codex GPT-5.6 Sol fast/low worker (mission c09adff1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, mechanical Lean proof wiring in IR generation generic induction; no runtime or security-sensitive code paths.
> 
> **Overview**
> Adds **`stmtListDirectInternalHelperCallStepInterface_of_headStepCatalog`**, which turns a body-local `DirectInternalHelperHeadStepCatalog` into **`StmtListDirectInternalHelperCallStepInterface`** for `fn.body` by reusing the catalog’s void-call witnesses (`hcatalog.call`) through the existing `stmtListDirectInternalHelperCallStepInterface_of_internalCallSteps_of_helperCallNames` assembly.
> 
> Unlike **`stmtListDirectInternalHelperStepInterfaces_of_headStepCatalog`**, callers only need the void-call side of the catalog—not the assign/return-binding interface—so void-helper-call preservation can be wired without pulling in unrelated assign obligations.
> 
> **`PrintAxioms.lean`** lists the new theorem and bumps the public theorem count (6031 → 6032).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cfa93af67a4ef38a09787f40ea274f84c6ec251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->