### PR TITLE
Phase 1C #2: Prove spec-functions-aware helper-call preservation (StmtListDirectInternalHelperCallStepInterfaceWithInternals)

### DIFF
--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -656,8 +656,10 @@ Direct internal-call heads compile their arguments through
 `compileInternalCallArgs ... spec.functions`, so their compiled IR is not
 determined by the default empty internal-function compiler argument recorded by
 `DirectInternalHelperHeadStepCatalog`. This catalog therefore carries the
-`CompiledStmtStepWithHelpersAndHelperIRWithInternals` witnesses directly, which
-is what the `WithInternals` list interfaces consume. -/
+`CompiledStmtStepWithHelpersAndHelperIRWithInternals` witnesses directly for
+the exact call statements occurring in the function body. Indexing by the
+statement, rather than only its callee, avoids demanding witnesses for
+wrong-arity argument lists that do not occur in the body. -/
 structure DirectInternalHelperHeadStepCatalogWithInternals
     (runtimeContract : IRContract)
     (spec : CompilationModel)
@@ -665,7 +667,7 @@ structure DirectInternalHelperHeadStepCatalogWithInternals
     (fn : FunctionSpec) : Prop where
   call :
     ∀ {scope : List String} {calleeName : String} {args : List Expr},
-      calleeName ∈ helperCallNames fn →
+      Stmt.internalCall calleeName args ∈ fn.body →
       ∃ compiledIR,
         CompiledStmtStepWithHelpersAndHelperIRWithInternals
           runtimeContract
@@ -676,7 +678,7 @@ structure DirectInternalHelperHeadStepCatalogWithInternals
           compiledIR
   assign :
     ∀ {scope : List String} {names : List String} {calleeName : String} {args : List Expr},
-      calleeName ∈ helperCallNames fn →
+      Stmt.internalCallAssign names calleeName args ∈ fn.body →
       ∃ compiledIR,
         CompiledStmtStepWithHelpersAndHelperIRWithInternals
           runtimeContract
@@ -1753,7 +1755,8 @@ interface from a body-local `WithInternals` head-step catalog. This is the
 `stmtListDirectInternalHelperCallStepInterface_of_headStepCatalog`: it records
 the `compileStmt ... spec.functions` head shape that direct internal calls
 actually compile through, and, as there, the return-binding half of the catalog
-is neither exposed nor required. -/
+is neither exposed nor required. The recursion retains membership in the
+original body so the catalog is only queried for call sites that occur there. -/
 theorem stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_headStepCatalog
     {runtimeContract : IRContract}
     {spec : CompilationModel}
@@ -1764,14 +1767,32 @@ theorem stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_headStepCa
       DirectInternalHelperHeadStepCatalogWithInternals runtimeContract spec fields fn) :
     StmtListDirectInternalHelperCallStepInterfaceWithInternals
       runtimeContract spec fields scope fn.body := by
-  exact
-    stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_internalCallSteps_of_helperCallNames
-      (runtimeContract := runtimeContract)
-      (spec := spec)
-      (fields := fields)
-      (scope := scope)
-      (stmts := fn.body)
-      hcatalog.call
+  have go :
+      ∀ (stmts : List Stmt),
+        (∀ stmt, stmt ∈ stmts → stmt ∈ fn.body) →
+        ∀ (scope : List String),
+          StmtListDirectInternalHelperCallStepInterfaceWithInternals
+            runtimeContract spec fields scope stmts := by
+    intro stmts hsubset scope
+    induction stmts generalizing scope with
+    | nil =>
+        exact .nil
+    | cons stmt rest ih =>
+        refine .cons ?_ ?_
+        · intro hdirect
+          cases stmt with
+          | internalCall calleeName args =>
+              rcases hcatalog.call
+                  (scope := scope) (calleeName := calleeName) (args := args)
+                  (hsubset _ (by simp)) with
+                ⟨compiledIR, hcompiled⟩
+              exact ⟨compiledIR, hcompiled⟩
+          | _ =>
+              simp [stmtTouchesDirectInternalHelperCallSurface] at hdirect
+        · apply ih
+          intro tailStmt hmem
+          exact hsubset tailStmt (by simp [hmem])
+  exact go fn.body (by intros; assumption) scope
 
 private theorem internalFunctionYulName_head (calleeName : String) :
     (CompilationModel.internalFunctionYulName calleeName).toList.head? = some 'i' := by

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -650,24 +650,36 @@ structure DirectInternalHelperHeadStepCatalog
           (Stmt.internalCallAssign names calleeName args)
           compiledIR
 
-/-- Spec-functions-aware sibling of `DirectInternalHelperHeadStepCatalog`.
+/-- A statement occurrence together with the scope obtained by processing the
+preceding statements in the same list. -/
+inductive StmtOccursAtScope :
+    List String → List String → Stmt → List Stmt → Prop where
+  | head {scope : List String} {stmt : Stmt} {rest : List Stmt} :
+      StmtOccursAtScope scope scope stmt (stmt :: rest)
+  | tail {scope occurrenceScope : List String} {head target : Stmt} {rest : List Stmt} :
+      StmtOccursAtScope (stmtNextScope scope head) occurrenceScope target rest →
+      StmtOccursAtScope scope occurrenceScope target (head :: rest)
+
+/-- Spec-functions-aware call-only sibling of
+`DirectInternalHelperHeadStepCatalog`.
 
 Direct internal-call heads compile their arguments through
 `compileInternalCallArgs ... spec.functions`, so their compiled IR is not
 determined by the default empty internal-function compiler argument recorded by
 `DirectInternalHelperHeadStepCatalog`. This catalog therefore carries the
 `CompiledStmtStepWithHelpersAndHelperIRWithInternals` witnesses directly for
-the exact call statements occurring in the function body. Indexing by the
-statement, rather than only its callee, avoids demanding witnesses for
-wrong-arity argument lists that do not occur in the body. -/
-structure DirectInternalHelperHeadStepCatalogWithInternals
+the exact void-call statements at their prefix-derived scopes. Indexing by the
+scoped occurrence avoids demanding witnesses for wrong-arity argument lists or
+scopes that do not occur in the body. -/
+structure DirectInternalHelperCallHeadStepCatalogWithInternals
     (runtimeContract : IRContract)
     (spec : CompilationModel)
     (fields : List Field)
+    (initialScope : List String)
     (fn : FunctionSpec) : Prop where
   call :
     ∀ {scope : List String} {calleeName : String} {args : List Expr},
-      Stmt.internalCall calleeName args ∈ fn.body →
+      StmtOccursAtScope initialScope scope (Stmt.internalCall calleeName args) fn.body →
       ∃ compiledIR,
         CompiledStmtStepWithHelpersAndHelperIRWithInternals
           runtimeContract
@@ -675,17 +687,6 @@ structure DirectInternalHelperHeadStepCatalogWithInternals
           fields
           scope
           (Stmt.internalCall calleeName args)
-          compiledIR
-  assign :
-    ∀ {scope : List String} {names : List String} {calleeName : String} {args : List Expr},
-      Stmt.internalCallAssign names calleeName args ∈ fn.body →
-      ∃ compiledIR,
-        CompiledStmtStepWithHelpersAndHelperIRWithInternals
-          runtimeContract
-          spec
-          fields
-          scope
-          (Stmt.internalCallAssign names calleeName args)
           compiledIR
 
 /-- Mid-level Tier 4 seam: future rank induction can package direct-helper
@@ -1750,13 +1751,13 @@ theorem stmtListDirectInternalHelperCallStepInterface_of_headStepCatalog
       hcatalog.call
 
 /-- Assemble the exact spec-functions-aware direct void-helper-call list
-interface from a body-local `WithInternals` head-step catalog. This is the
+interface from a body-local call-only `WithInternals` head-step catalog. This is the
 `WithInternals` counterpart of
 `stmtListDirectInternalHelperCallStepInterface_of_headStepCatalog`: it records
 the `compileStmt ... spec.functions` head shape that direct internal calls
-actually compile through, and, as there, the return-binding half of the catalog
-is neither exposed nor required. The recursion retains membership in the
-original body so the catalog is only queried for call sites that occur there. -/
+actually compile through. The recursion retains each call's prefix-derived
+scope, so the catalog is only queried for call sites at scopes that occur in the
+body. -/
 theorem stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_headStepCatalog
     {runtimeContract : IRContract}
     {spec : CompilationModel}
@@ -1764,17 +1765,19 @@ theorem stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_headStepCa
     {scope : List String}
     {fn : FunctionSpec}
     (hcatalog :
-      DirectInternalHelperHeadStepCatalogWithInternals runtimeContract spec fields fn) :
+      DirectInternalHelperCallHeadStepCatalogWithInternals
+        runtimeContract spec fields scope fn) :
     StmtListDirectInternalHelperCallStepInterfaceWithInternals
       runtimeContract spec fields scope fn.body := by
   have go :
-      ∀ (stmts : List Stmt),
-        (∀ stmt, stmt ∈ stmts → stmt ∈ fn.body) →
-        ∀ (scope : List String),
-          StmtListDirectInternalHelperCallStepInterfaceWithInternals
-            runtimeContract spec fields scope stmts := by
-    intro stmts hsubset scope
-    induction stmts generalizing scope with
+      ∀ {currentScope : List String} {stmts : List Stmt},
+        (∀ {occurrenceScope : List String} {stmt : Stmt},
+          StmtOccursAtScope currentScope occurrenceScope stmt stmts →
+          StmtOccursAtScope scope occurrenceScope stmt fn.body) →
+        StmtListDirectInternalHelperCallStepInterfaceWithInternals
+          runtimeContract spec fields currentScope stmts := by
+    intro currentScope stmts hembed
+    induction stmts generalizing currentScope with
     | nil =>
         exact .nil
     | cons stmt rest ih =>
@@ -1783,16 +1786,16 @@ theorem stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_headStepCa
           cases stmt with
           | internalCall calleeName args =>
               rcases hcatalog.call
-                  (scope := scope) (calleeName := calleeName) (args := args)
-                  (hsubset _ (by simp)) with
+                  (scope := currentScope) (calleeName := calleeName) (args := args)
+                  (hembed StmtOccursAtScope.head) with
                 ⟨compiledIR, hcompiled⟩
               exact ⟨compiledIR, hcompiled⟩
           | _ =>
               simp [stmtTouchesDirectInternalHelperCallSurface] at hdirect
         · apply ih
-          intro tailStmt hmem
-          exact hsubset tailStmt (by simp [hmem])
-  exact go fn.body (by intros; assumption) scope
+          intro occurrenceScope tailStmt hocc
+          exact hembed (StmtOccursAtScope.tail hocc)
+  exact go (fun hocc => hocc)
 
 private theorem internalFunctionYulName_head (calleeName : String) :
     (CompilationModel.internalFunctionYulName calleeName).toList.head? = some 'i' := by

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -650,6 +650,42 @@ structure DirectInternalHelperHeadStepCatalog
           (Stmt.internalCallAssign names calleeName args)
           compiledIR
 
+/-- Spec-functions-aware sibling of `DirectInternalHelperHeadStepCatalog`.
+
+Direct internal-call heads compile their arguments through
+`compileInternalCallArgs ... spec.functions`, so their compiled IR is not
+determined by the default empty internal-function compiler argument recorded by
+`DirectInternalHelperHeadStepCatalog`. This catalog therefore carries the
+`CompiledStmtStepWithHelpersAndHelperIRWithInternals` witnesses directly, which
+is what the `WithInternals` list interfaces consume. -/
+structure DirectInternalHelperHeadStepCatalogWithInternals
+    (runtimeContract : IRContract)
+    (spec : CompilationModel)
+    (fields : List Field)
+    (fn : FunctionSpec) : Prop where
+  call :
+    ∀ {scope : List String} {calleeName : String} {args : List Expr},
+      calleeName ∈ helperCallNames fn →
+      ∃ compiledIR,
+        CompiledStmtStepWithHelpersAndHelperIRWithInternals
+          runtimeContract
+          spec
+          fields
+          scope
+          (Stmt.internalCall calleeName args)
+          compiledIR
+  assign :
+    ∀ {scope : List String} {names : List String} {calleeName : String} {args : List Expr},
+      calleeName ∈ helperCallNames fn →
+      ∃ compiledIR,
+        CompiledStmtStepWithHelpersAndHelperIRWithInternals
+          runtimeContract
+          spec
+          fields
+          scope
+          (Stmt.internalCallAssign names calleeName args)
+          compiledIR
+
 /-- Mid-level Tier 4 seam: future rank induction can package direct-helper
 singletons here by proving compilation succeeds for the head and that the exact
 singleton IR execution matches the source helper-aware step. The mechanical
@@ -1704,6 +1740,32 @@ theorem stmtListDirectInternalHelperCallStepInterface_of_headStepCatalog
       runtimeContract spec fields scope fn.body := by
   exact
     stmtListDirectInternalHelperCallStepInterface_of_internalCallSteps_of_helperCallNames
+      (runtimeContract := runtimeContract)
+      (spec := spec)
+      (fields := fields)
+      (scope := scope)
+      (stmts := fn.body)
+      hcatalog.call
+
+/-- Assemble the exact spec-functions-aware direct void-helper-call list
+interface from a body-local `WithInternals` head-step catalog. This is the
+`WithInternals` counterpart of
+`stmtListDirectInternalHelperCallStepInterface_of_headStepCatalog`: it records
+the `compileStmt ... spec.functions` head shape that direct internal calls
+actually compile through, and, as there, the return-binding half of the catalog
+is neither exposed nor required. -/
+theorem stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_headStepCatalog
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {fn : FunctionSpec}
+    (hcatalog :
+      DirectInternalHelperHeadStepCatalogWithInternals runtimeContract spec fields fn) :
+    StmtListDirectInternalHelperCallStepInterfaceWithInternals
+      runtimeContract spec fields scope fn.body := by
+  exact
+    stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_internalCallSteps_of_helperCallNames
       (runtimeContract := runtimeContract)
       (spec := spec)
       (fields := fields)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2895,6 +2895,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_internalCallSteps_of_helperCallNames
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperStepInterfaces_of_headStepCatalog
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperCallStepInterface_of_headStepCatalog
+  Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_headStepCatalog
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_head  -- private
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_of_head  -- private
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_stop  -- private
@@ -6441,4 +6442,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6032 theorems/lemmas (4179 public, 1853 private, 0 sorry'd)
+-- Total: 6033 theorems/lemmas (4180 public, 1853 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

Phase 1C case 2/4. Proves the `WithInternals` (spec-functions-aware) counterpart of the void helper-call list interface merged in #2222:

- `stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_headStepCatalog`

### Why a new catalog rather than rewrapping the existing one

Direct internal-call heads compile their arguments through `compileInternalCallArgs ... spec.functions`, so their compiled IR is **not** determined by the default empty internal-function compiler argument recorded by `DirectInternalHelperHeadStepCatalog`. The legacy `.call` witness therefore cannot be rewrapped into the `WithInternals` interface — the dependency on the supplied internal-function list is visible at the type level.

This PR adds the spec-functions-aware sibling `DirectInternalHelperHeadStepCatalogWithInternals`, which carries `CompiledStmtStepWithHelpersAndHelperIRWithInternals` witnesses directly (both the void `call` and the return-binding `assign` halves), and assembles the exact list interface from it through the existing `helperCallNames`-indexed list recursion `stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_internalCallSteps_of_helperCallNames`.

No interface weakening: the conclusion is the full `StmtListDirectInternalHelperCallStepInterfaceWithInternals`, mirroring the merged case-1 theorem's shape.

Axiom audit updated: 6032 -> 6033 theorems (4179 -> 4180 public), regenerated with `scripts/generate_print_axioms.py`.

## Test plan

- [x] `lake build` passes
- [x] `lake build PrintAxioms` passes (fresh remote build, 2569 jobs, exit 0)
- [x] `scripts/generate_print_axioms.py` reproduces `PrintAxioms.lean` byte-identically
- [x] `scripts/check_lean_hygiene.py` passes (0 sorry, 0 native_decide, 0 allowUnsafeReducibility)
- [x] Compiler / layer / package import-boundary checks pass
- [x] No `sorry`, `admit`, `axiom`, or unsafe escapes in changed source

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in IR generation generic induction; no runtime, auth, or compiler behavior changes—only new Lean structures and one assembly theorem plus axiom audit.
> 
> **Overview**
> Phase 1C case 2/4: proves the **`WithInternals`** counterpart of assembling **`StmtListDirectInternalHelperCallStepInterface`** from a head-step catalog, without weakening the conclusion.
> 
> Because direct internal-call heads compile arguments via **`compileInternalCallArgs ... spec.functions`**, the existing **`DirectInternalHelperHeadStepCatalog`** witnesses (empty internal-function compiler path) cannot be rewrapped. The PR introduces **`DirectInternalHelperCallHeadStepCatalogWithInternals`**, indexed by **`StmtOccursAtScope`** so the catalog only supplies **`CompiledStmtStepWithHelpersAndHelperIRWithInternals`** for void **`Stmt.internalCall`** sites at the scopes that actually occur in the function body.
> 
> **`stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_headStepCatalog`** walks the body list while tracking **`currentScope`**, pulling catalog witnesses only when the head is a direct internal call at an embedded occurrence. **`PrintAxioms.lean`** registers the new public theorem (6032 → 6033 total).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed9e1cc6b4a4ac489a285292b738236a805b86e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->