### PR TITLE
Phase 1C #3: Prove spec-functions-aware return-binding helper preservation (StmtListDirectInternalHelperAssignStepInterfaceWithInternals)

### DIFF
--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -689,6 +689,37 @@ structure DirectInternalHelperCallHeadStepCatalogWithInternals
           (Stmt.internalCall calleeName args)
           compiledIR
 
+/-- Spec-functions-aware return-binding-call-only sibling of
+`DirectInternalHelperHeadStepCatalog`.
+
+Direct internal-call-assignment heads compile their arguments through
+`compileInternalCallArgs ... spec.functions`, so their compiled IR is not
+determined by the default empty internal-function compiler argument recorded by
+`DirectInternalHelperHeadStepCatalog`. This catalog therefore carries the
+`CompiledStmtStepWithHelpersAndHelperIRWithInternals` witnesses directly for
+the exact return-binding call statements at their prefix-derived scopes.
+Indexing by the scoped occurrence avoids demanding witnesses for wrong-arity
+argument lists or scopes that do not occur in the body. -/
+structure DirectInternalHelperAssignHeadStepCatalogWithInternals
+    (runtimeContract : IRContract)
+    (spec : CompilationModel)
+    (fields : List Field)
+    (initialScope : List String)
+    (fn : FunctionSpec) : Prop where
+  assign :
+    ∀ {scope : List String} {names : List String} {calleeName : String}
+        {args : List Expr},
+      StmtOccursAtScope initialScope scope
+        (Stmt.internalCallAssign names calleeName args) fn.body →
+      ∃ compiledIR,
+        CompiledStmtStepWithHelpersAndHelperIRWithInternals
+          runtimeContract
+          spec
+          fields
+          scope
+          (Stmt.internalCallAssign names calleeName args)
+          compiledIR
+
 /-- Mid-level Tier 4 seam: future rank induction can package direct-helper
 singletons here by proving compilation succeeds for the head and that the exact
 singleton IR execution matches the source helper-aware step. The mechanical
@@ -1792,6 +1823,54 @@ theorem stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_headStepCa
               exact ⟨compiledIR, hcompiled⟩
           | _ =>
               simp [stmtTouchesDirectInternalHelperCallSurface] at hdirect
+        · apply ih
+          intro occurrenceScope tailStmt hocc
+          exact hembed (StmtOccursAtScope.tail hocc)
+  exact go (fun hocc => hocc)
+
+/-- Assemble the exact spec-functions-aware direct return-binding-helper-call
+list interface from a body-local assign-only `WithInternals` head-step catalog.
+This is the `WithInternals` counterpart of the assign half of
+`stmtListDirectInternalHelperStepInterfaces_of_headStepCatalog`: it records the
+`compileStmt ... spec.functions` head shape that direct internal call
+assignments actually compile through. The recursion retains each call's
+prefix-derived scope, so the catalog is only queried for call sites at scopes
+that occur in the body. -/
+theorem stmtListDirectInternalHelperAssignStepInterfaceWithInternals_of_headStepCatalog
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {fn : FunctionSpec}
+    (hcatalog :
+      DirectInternalHelperAssignHeadStepCatalogWithInternals
+        runtimeContract spec fields scope fn) :
+    StmtListDirectInternalHelperAssignStepInterfaceWithInternals
+      runtimeContract spec fields scope fn.body := by
+  have go :
+      ∀ {currentScope : List String} {stmts : List Stmt},
+        (∀ {occurrenceScope : List String} {stmt : Stmt},
+          StmtOccursAtScope currentScope occurrenceScope stmt stmts →
+          StmtOccursAtScope scope occurrenceScope stmt fn.body) →
+        StmtListDirectInternalHelperAssignStepInterfaceWithInternals
+          runtimeContract spec fields currentScope stmts := by
+    intro currentScope stmts hembed
+    induction stmts generalizing currentScope with
+    | nil =>
+        exact .nil
+    | cons stmt rest ih =>
+        refine .cons ?_ ?_
+        · intro hdirect
+          cases stmt with
+          | internalCallAssign names calleeName args =>
+              rcases hcatalog.assign
+                  (scope := currentScope) (names := names)
+                  (calleeName := calleeName) (args := args)
+                  (hembed StmtOccursAtScope.head) with
+                ⟨compiledIR, hcompiled⟩
+              exact ⟨compiledIR, hcompiled⟩
+          | _ =>
+              simp [stmtTouchesDirectInternalHelperAssignSurface] at hdirect
         · apply ih
           intro occurrenceScope tailStmt hocc
           exact hembed (StmtOccursAtScope.tail hocc)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2896,6 +2896,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperStepInterfaces_of_headStepCatalog
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperCallStepInterface_of_headStepCatalog
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_headStepCatalog
+  Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperAssignStepInterfaceWithInternals_of_headStepCatalog
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_head  -- private
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_of_head  -- private
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_stop  -- private
@@ -6442,4 +6443,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6033 theorems/lemmas (4180 public, 1853 private, 0 sorry'd)
+-- Total: 6034 theorems/lemmas (4181 public, 1853 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

- add an assign-only, spec-functions-aware head-step catalog for direct `Stmt.internalCallAssign` occurrences at their prefix-derived scopes
- derive `StmtListDirectInternalHelperAssignStepInterfaceWithInternals` by the same scoped list recursion used by predecessor PR #2223
- register the new public theorem in the generated axiom audit

## Verification

- fresh `lake build PrintAxioms` (2569 jobs, exit 0; no cached terminal-job replay)
- `lake env lean PrintAxioms.lean` (exit 0)
- `lake build` (2228 jobs, exit 0)
- generated totals: 6034 theorems/lemmas (4181 public, 1853 private, 0 sorry'd)
- no escape tokens in the source diff beyond the generated `0 sorry'd` total header
- source-bundle digests match the pinned predecessor base

Continues PR #2223 and addresses issue #2080, Phase 1C case 3/4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proof scaffolding only; no runtime, auth, or compilation behavior changes.
> 
> **Overview**
> Adds **`DirectInternalHelperAssignHeadStepCatalogWithInternals`**, an assign-only catalog that holds `CompiledStmtStepWithHelpersAndHelperIRWithInternals` witnesses for each `Stmt.internalCallAssign` at its **prefix-derived scope** (via `StmtOccursAtScope`), matching how those heads compile through `compileInternalCallArgs ... spec.functions` rather than the empty-internals path in the legacy catalog.
> 
> Proves **`stmtListDirectInternalHelperAssignStepInterfaceWithInternals_of_headStepCatalog`**, which walks the function body with the same scoped list recursion as the void-call `WithInternals` theorem from #2223 and lifts the catalog into **`StmtListDirectInternalHelperAssignStepInterfaceWithInternals`** for the whole body.
> 
> Registers the new public theorem in the generated **`PrintAxioms`** audit (6034 total lemmas).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de363d4635758abe7cb766df53687aa68520f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->