### PR TITLE
Phase 1C #4: Prove expression-position helper-call preservation (Expr.internalCall via Stmt.letVar)

### DIFF
--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -720,26 +720,6 @@ structure DirectInternalHelperAssignHeadStepCatalogWithInternals
           (Stmt.internalCallAssign names calleeName args)
           compiledIR
 
-/-- Spec-functions-aware exact step interface for direct expression-position
-helper calls consumed by `Stmt.letVar`. -/
-inductive StmtListDirectInternalHelperExprCallStepInterfaceWithInternals
-    (runtimeContract : IRContract)
-    (spec : CompilationModel)
-    (fields : List Field) : List String → List Stmt → Prop where
-  | nil {scope : List String} :
-      StmtListDirectInternalHelperExprCallStepInterfaceWithInternals
-        runtimeContract spec fields scope []
-  | cons {scope : List String} {stmt : Stmt} {rest : List Stmt} :
-      (∀ {name calleeName : String} {args : List Expr},
-        stmt = Stmt.letVar name (Expr.internalCall calleeName args) →
-        ∃ compiledIR,
-          CompiledStmtStepWithHelpersAndHelperIRWithInternals
-            runtimeContract spec fields scope stmt compiledIR) →
-      StmtListDirectInternalHelperExprCallStepInterfaceWithInternals
-        runtimeContract spec fields (stmtNextScope scope stmt) rest →
-      StmtListDirectInternalHelperExprCallStepInterfaceWithInternals
-        runtimeContract spec fields scope (stmt :: rest)
-
 /-- Body-local head-step catalog for direct `Expr.internalCall` results bound
 by `Stmt.letVar`, indexed by their prefix-derived scopes. -/
 structure DirectInternalHelperExprCallHeadStepCatalogWithInternals
@@ -1913,9 +1893,11 @@ theorem stmtListDirectInternalHelperAssignStepInterfaceWithInternals_of_headStep
           exact hembed (StmtOccursAtScope.tail hocc)
   exact go (fun hocc => hocc)
 
-/-- Assemble the exact spec-functions-aware list interface for direct
-`Expr.internalCall` results consumed by `Stmt.letVar` from a body-local
-head-step catalog. -/
+/-- Assemble the consumed spec-functions-aware expression-helper list interface
+for bodies whose expression-helper surface consists exactly of direct
+`Expr.internalCall` results bound by `Stmt.letVar`. The coverage premise keeps
+the catalog narrow while making the resulting witness directly usable as the
+`hexpr` input of `fullHelperAwareListWitnessWithInternals_of_allInterfaces`. -/
 theorem stmtListDirectInternalHelperExprCallStepInterfaceWithInternals_of_headStepCatalog
     {runtimeContract : IRContract}
     {spec : CompilationModel}
@@ -1924,15 +1906,21 @@ theorem stmtListDirectInternalHelperExprCallStepInterfaceWithInternals_of_headSt
     {fn : FunctionSpec}
     (hcatalog :
       DirectInternalHelperExprCallHeadStepCatalogWithInternals
-        runtimeContract spec fields scope fn) :
-    StmtListDirectInternalHelperExprCallStepInterfaceWithInternals
+        runtimeContract spec fields scope fn)
+    (hcoverage :
+      ∀ {occurrenceScope : List String} {stmt : Stmt},
+        StmtOccursAtScope scope occurrenceScope stmt fn.body →
+        stmtTouchesExprInternalHelperSurface stmt = true →
+        ∃ name calleeName args,
+          stmt = Stmt.letVar name (Expr.internalCall calleeName args)) :
+    StmtListExprInternalHelperStepInterfaceWithInternals
       runtimeContract spec fields scope fn.body := by
   have go :
       ∀ {currentScope : List String} {stmts : List Stmt},
         (∀ {occurrenceScope : List String} {stmt : Stmt},
           StmtOccursAtScope currentScope occurrenceScope stmt stmts →
           StmtOccursAtScope scope occurrenceScope stmt fn.body) →
-        StmtListDirectInternalHelperExprCallStepInterfaceWithInternals
+        StmtListExprInternalHelperStepInterfaceWithInternals
           runtimeContract spec fields currentScope stmts := by
     intro currentScope stmts hembed
     induction stmts generalizing currentScope with
@@ -1940,8 +1928,9 @@ theorem stmtListDirectInternalHelperExprCallStepInterfaceWithInternals_of_headSt
         exact .nil
     | cons stmt rest ih =>
         refine .cons ?_ ?_
-        · intro name calleeName args hstmt
-          subst stmt
+        · intro hexpr
+          rcases hcoverage (hembed StmtOccursAtScope.head) hexpr with
+            ⟨name, calleeName, args, rfl⟩
           exact hcatalog.exprCall (hembed StmtOccursAtScope.head)
         · apply ih
           intro occurrenceScope tailStmt hocc

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -720,6 +720,43 @@ structure DirectInternalHelperAssignHeadStepCatalogWithInternals
           (Stmt.internalCallAssign names calleeName args)
           compiledIR
 
+/-- Spec-functions-aware exact step interface for direct expression-position
+helper calls consumed by `Stmt.letVar`. -/
+inductive StmtListDirectInternalHelperExprCallStepInterfaceWithInternals
+    (runtimeContract : IRContract)
+    (spec : CompilationModel)
+    (fields : List Field) : List String → List Stmt → Prop where
+  | nil {scope : List String} :
+      StmtListDirectInternalHelperExprCallStepInterfaceWithInternals
+        runtimeContract spec fields scope []
+  | cons {scope : List String} {stmt : Stmt} {rest : List Stmt} :
+      (∀ {name calleeName : String} {args : List Expr},
+        stmt = Stmt.letVar name (Expr.internalCall calleeName args) →
+        ∃ compiledIR,
+          CompiledStmtStepWithHelpersAndHelperIRWithInternals
+            runtimeContract spec fields scope stmt compiledIR) →
+      StmtListDirectInternalHelperExprCallStepInterfaceWithInternals
+        runtimeContract spec fields (stmtNextScope scope stmt) rest →
+      StmtListDirectInternalHelperExprCallStepInterfaceWithInternals
+        runtimeContract spec fields scope (stmt :: rest)
+
+/-- Body-local head-step catalog for direct `Expr.internalCall` results bound
+by `Stmt.letVar`, indexed by their prefix-derived scopes. -/
+structure DirectInternalHelperExprCallHeadStepCatalogWithInternals
+    (runtimeContract : IRContract)
+    (spec : CompilationModel)
+    (fields : List Field)
+    (initialScope : List String)
+    (fn : FunctionSpec) : Prop where
+  exprCall :
+    ∀ {scope : List String} {name calleeName : String} {args : List Expr},
+      StmtOccursAtScope initialScope scope
+        (Stmt.letVar name (Expr.internalCall calleeName args)) fn.body →
+      ∃ compiledIR,
+        CompiledStmtStepWithHelpersAndHelperIRWithInternals
+          runtimeContract spec fields scope
+          (Stmt.letVar name (Expr.internalCall calleeName args)) compiledIR
+
 /-- Mid-level Tier 4 seam: future rank induction can package direct-helper
 singletons here by proving compilation succeeds for the head and that the exact
 singleton IR execution matches the source helper-aware step. The mechanical
@@ -1871,6 +1908,41 @@ theorem stmtListDirectInternalHelperAssignStepInterfaceWithInternals_of_headStep
               exact ⟨compiledIR, hcompiled⟩
           | _ =>
               simp [stmtTouchesDirectInternalHelperAssignSurface] at hdirect
+        · apply ih
+          intro occurrenceScope tailStmt hocc
+          exact hembed (StmtOccursAtScope.tail hocc)
+  exact go (fun hocc => hocc)
+
+/-- Assemble the exact spec-functions-aware list interface for direct
+`Expr.internalCall` results consumed by `Stmt.letVar` from a body-local
+head-step catalog. -/
+theorem stmtListDirectInternalHelperExprCallStepInterfaceWithInternals_of_headStepCatalog
+    {runtimeContract : IRContract}
+    {spec : CompilationModel}
+    {fields : List Field}
+    {scope : List String}
+    {fn : FunctionSpec}
+    (hcatalog :
+      DirectInternalHelperExprCallHeadStepCatalogWithInternals
+        runtimeContract spec fields scope fn) :
+    StmtListDirectInternalHelperExprCallStepInterfaceWithInternals
+      runtimeContract spec fields scope fn.body := by
+  have go :
+      ∀ {currentScope : List String} {stmts : List Stmt},
+        (∀ {occurrenceScope : List String} {stmt : Stmt},
+          StmtOccursAtScope currentScope occurrenceScope stmt stmts →
+          StmtOccursAtScope scope occurrenceScope stmt fn.body) →
+        StmtListDirectInternalHelperExprCallStepInterfaceWithInternals
+          runtimeContract spec fields currentScope stmts := by
+    intro currentScope stmts hembed
+    induction stmts generalizing currentScope with
+    | nil =>
+        exact .nil
+    | cons stmt rest ih =>
+        refine .cons ?_ ?_
+        · intro name calleeName args hstmt
+          subst stmt
+          exact hcatalog.exprCall (hembed StmtOccursAtScope.head)
         · apply ih
           intro occurrenceScope tailStmt hocc
           exact hembed (StmtOccursAtScope.tail hocc)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2897,6 +2897,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperCallStepInterface_of_headStepCatalog
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperCallStepInterfaceWithInternals_of_headStepCatalog
   Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperAssignStepInterfaceWithInternals_of_headStepCatalog
+  Compiler.Proofs.IRGeneration.stmtListDirectInternalHelperExprCallStepInterfaceWithInternals_of_headStepCatalog
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_head  -- private
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_of_head  -- private
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_stop  -- private
@@ -6443,4 +6444,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6034 theorems/lemmas (4181 public, 1853 private, 0 sorry'd)
+-- Total: 6035 theorems/lemmas (4182 public, 1853 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

- proves expression-position helper-call preservation for `Expr.internalCall` through `Stmt.letVar`
- regenerates the PrintAxioms counter from 6034 to 6035
- completes Phase 1C case 4/4

References #2080 and predecessor cases #2222, #2223, and #2224.

## Validation

- `lake build PrintAxioms` passed
- forbidden-token scan passed
- PrintAxioms counter regenerated: 6034 → 6035

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only Lean additions mirroring existing call/assign catalog patterns; no runtime, auth, or compiler behavior changes.
> 
> **Overview**
> Adds **Phase 1C expression-position** plumbing so `Stmt.letVar` bindings of `Expr.internalCall` can feed the same helper-aware list induction as void-call and assign-call heads.
> 
> Introduces `DirectInternalHelperExprCallHeadStepCatalogWithInternals`, a scoped catalog of `CompiledStmtStepWithHelpersAndHelperIRWithInternals` witnesses for those `letVar` sites. **`stmtListDirectInternalHelperExprCallStepInterfaceWithInternals_of_headStepCatalog`** walks the function body (preserving prefix scopes via `StmtOccursAtScope`) and builds `StmtListExprInternalHelperStepInterfaceWithInternals` when a catalog and a **coverage** premise hold (every expr-helper surface hit is exactly `letVar name (internalCall …)`).
> 
> Registers the new theorem in `PrintAxioms.lean` (6034 → 6035 lemmas).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff37d06e562990882356f0a1f616e73859d35512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->