### PR TITLE
Phase 1D #1: canonical storage/state and mapping slots (SolidityStorage + four lemmas)

### DIFF
--- a/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
@@ -6946,10 +6946,7 @@ private theorem compiledStmtStep_letStorageField
   preserves runtime state extraFuel hexact hscope hbounded hruntime hslack := by
     have hEvalSrc : SourceSemantics.evalExpr fields runtime (.storage fieldName) =
         some (runtime.world.storage (SourceSemantics.wordNormalize slot)).val := by
-      change (match findFieldWithResolvedSlot fields fieldName with
-        | some (field, s) => some (SourceSemantics.readFieldWord runtime.world field s).val
-        | none => none) = _
-      rw [hfind]
+      rw [SourceSemantics.evalExpr, hfind]
       rfl
     have hresolved := findResolvedFieldAtSlotCopy_of_findFieldWithResolvedSlot_singleton
       hnoConflict hfind
@@ -7111,10 +7108,7 @@ private theorem compiledStmtStep_assignStorageField
   preserves runtime state extraFuel hexact hscope hbounded hruntime hslack := by
     have hEvalSrc : SourceSemantics.evalExpr fields runtime (.storage fieldName) =
         some (runtime.world.storage (SourceSemantics.wordNormalize slot)).val := by
-      change (match findFieldWithResolvedSlot fields fieldName with
-        | some (field, s) => some (SourceSemantics.readFieldWord runtime.world field s).val
-        | none => none) = _
-      rw [hfind]
+      rw [SourceSemantics.evalExpr, hfind]
       rfl
     have hresolved := findResolvedFieldAtSlotCopy_of_findFieldWithResolvedSlot_singleton
       hnoConflict hfind

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -1157,7 +1157,14 @@ def evalExpr (fields : List Field) (state : RuntimeState) : Expr → Option Nat
   | .immutable name => some (state.immutable name).val
   | .storage fieldName =>
       match findFieldWithResolvedSlot fields fieldName with
-      | some (field, slot) => some (readFieldWord state.world field slot).val
+      | some (field, slot) =>
+          let rawWord := (readFieldWord state.world field slot).val
+          match field.packedBits with
+          | none => some rawWord
+          | some packed =>
+              some (Verity.Core.Uint256.and
+                (Verity.Core.Uint256.shr packed.offset rawWord)
+                (packedMaskNat packed)).val
       | none => none
   | .storageAddr fieldName =>
       match findFieldWithResolvedSlot fields fieldName with
@@ -1543,7 +1550,14 @@ private theorem evalExpr_storage
     (fieldName : String) :
       evalExpr fields state (.storage fieldName) =
         match findFieldWithResolvedSlot fields fieldName with
-        | some (field, slot) => some (readFieldWord state.world field slot).val
+        | some (field, slot) =>
+            let rawWord := (readFieldWord state.world field slot).val
+            match field.packedBits with
+            | none => some rawWord
+            | some packed =>
+                some (Verity.Core.Uint256.and
+                  (Verity.Core.Uint256.shr packed.offset rawWord)
+                  (packedMaskNat packed)).val
         | none => none := rfl
 
 private theorem evalExpr_storageAddr
@@ -3527,7 +3541,14 @@ mutual
     | .immutable name => some (state.immutable name).val
     | .storage fieldName =>
         match findFieldWithResolvedSlot fields fieldName with
-        | some (field, slot) => some (readFieldWord state.world field slot).val
+        | some (field, slot) =>
+            let rawWord := (readFieldWord state.world field slot).val
+            match field.packedBits with
+            | none => some rawWord
+            | some packed =>
+                some (Verity.Core.Uint256.and
+                  (Verity.Core.Uint256.shr packed.offset rawWord)
+                  (packedMaskNat packed)).val
         | none => none
     | .storageAddr fieldName =>
         match findFieldWithResolvedSlot fields fieldName with

--- a/Compiler/Proofs/Storage/SolidityStorage.lean
+++ b/Compiler/Proofs/Storage/SolidityStorage.lean
@@ -1,5 +1,6 @@
 import Compiler.Proofs.MappingSlot
 import Compiler.CompilationModel.ExpressionCompile
+import Compiler.CodegenCommon
 import Verity.Core.Model.Types
 
 namespace Compiler.Proofs.Storage
@@ -36,6 +37,41 @@ theorem mappingSlot_preimage (baseSlot key : Nat) :
       preimage = abiEncodeMappingSlot baseSlot key ∧
       mappingSlotPointer baseSlot key = KeccakEngine.keccak256 preimage := by
   exact ⟨abiEncodeMappingSlot baseSlot key, rfl, rfl⟩
+
+/-- Structurally interpret the emitted `mappingSlot` helper. Matching every
+    statement keeps the bridge sensitive to the two stores' order and addresses,
+    as well as the hash range. -/
+def compiledMappingSlotPointer
+    (stmt : Compiler.Yul.YulStmt) (scratchBase baseSlot key : Nat) : Option ByteArray :=
+  match stmt with
+  | .funcDef "mappingSlot" ["baseSlot", "key"] ["slot"] [
+      .exprStmt (.call "mstore" [.lit keyPtr, .ident "key"]),
+      .exprStmt (.call "mstore" [.lit slotPtr, .ident "baseSlot"]),
+      .assign "slot" (.call "keccak256" [.lit hashPtr, .lit hashSize])] =>
+      if keyPtr == scratchBase && slotPtr == scratchBase + 32 &&
+          hashPtr == scratchBase && hashSize == 64 then
+        some (KeccakEngine.keccak256 (abiEncodeMappingSlot baseSlot key))
+      else
+        none
+  | _ => none
+
+/-- The emitted `mappingSlot` helper computes the canonical Solidity mapping
+    pointer. Any change to its line-by-line Yul shape is observable here. -/
+theorem compiledMappingSlotPointer_eq_mappingSlotPointer
+    (scratchBase baseSlot key : Nat) :
+    compiledMappingSlotPointer
+        (Compiler.CodegenCommon.mappingSlotFuncAt scratchBase)
+        scratchBase baseSlot key =
+      some (mappingSlotPointer baseSlot key) := by
+  simp [compiledMappingSlotPointer, Compiler.CodegenCommon.mappingSlotFuncAt,
+    mappingSlotPointer]
+
+/-- The pointer returned by the emitted helper is the same mapping slot used by
+    source evaluation through `abstractMappingSlot`. -/
+theorem mappingSlotPointer_eq_abstractMappingSlot (baseSlot key : Nat) :
+    EvmYul.fromByteArrayBigEndian (mappingSlotPointer baseSlot key) =
+      Compiler.Proofs.abstractMappingSlot baseSlot key := by
+  rfl
 
 /-- Mask for a packed Solidity field of `width` low-order bits. -/
 def packedMask (width : Nat) : Nat := 2 ^ width - 1
@@ -74,7 +110,7 @@ def compiledPackedRead (word : Word) (offset width : Nat) : Word :=
 /-- The helper for a Yul packed read is the interpretation of the real compiler
     path in `ExpressionCompile.lean`. -/
 theorem yulReadPackedWord_eq_compiledExpr (word : Word) (offset width : Nat)
-    (hwidth : width < 256) :
+    (hwidth : width ≤ 256) :
     yulReadPackedWord word offset width = compiledPackedRead word offset width := by
   have hfield :
       Compiler.CompilationModel.findFieldWithResolvedSlot
@@ -94,10 +130,16 @@ theorem yulReadPackedWord_eq_compiledExpr (word : Word) (offset width : Nat)
             .lit (packedMask width)]) := by
     simp only [Compiler.CompilationModel.compileExprWithInternals, hmapping,
       Bool.false_eq_true, if_false, hfield]
-    simp [packedReadBridgeField, Compiler.CompilationModel.packedMaskNat,
-      Nat.not_le.mpr hwidth, packedMask]
-    change Except.ok _ = Except.ok _
-    rfl
+    by_cases hlt : width < 256
+    · simp [packedReadBridgeField, Compiler.CompilationModel.packedMaskNat,
+        Nat.not_le.mpr hlt, packedMask]
+      change Except.ok _ = Except.ok _
+      rfl
+    · have heq : width = 256 := Nat.le_antisymm hwidth (Nat.le_of_not_gt hlt)
+      subst width
+      simp [packedReadBridgeField, Compiler.CompilationModel.packedMaskNat, packedMask]
+      change Except.ok _ = Except.ok _
+      rfl
   unfold compiledPackedRead
   rw [hcompile]
   simp [isCompiledPackedReadExpr]

--- a/Compiler/Proofs/Storage/SolidityStorage.lean
+++ b/Compiler/Proofs/Storage/SolidityStorage.lean
@@ -1,5 +1,7 @@
 import Compiler.Proofs.MappingSlot
 import Compiler.CompilationModel.ExpressionCompile
+import Compiler.CompilationModel.StorageWrites
+import Compiler.Proofs.IRGeneration.SourceSemantics
 import Compiler.CodegenCommon
 import Verity.Core.Model.Types
 
@@ -76,10 +78,6 @@ theorem mappingSlotPointer_eq_abstractMappingSlot (baseSlot key : Nat) :
 /-- Mask for a packed Solidity field of `width` low-order bits. -/
 def packedMask (width : Nat) : Nat := 2 ^ width - 1
 
-/-- Source-level extraction of a packed field from its containing storage word. -/
-def sourceReadPackedWord (word : Word) (offset width : Nat) : Word :=
-  IRStorageWord.ofNat ((word.toNat / 2 ^ offset) % 2 ^ width)
-
 /-- Yul's `and(shr(offset, sload(pointer)), mask)` interpretation. -/
 def yulReadPackedWord (word : Word) (offset width : Nat) : Word :=
   IRStorageWord.ofNat ((word.toNat / 2 ^ offset) % 2 ^ width)
@@ -144,17 +142,171 @@ theorem yulReadPackedWord_eq_compiledExpr (word : Word) (offset width : Nat)
   rw [hcompile]
   simp [isCompiledPackedReadExpr]
 
+/-! ### The executable source packed read
+
+`yulReadPackedWord_eq_compiledExpr` pins the compiler end of a packed read.
+The definitions below pin the source end against the *executable* evaluator
+`SourceSemantics.evalExpr`, so `sourceReadPackedWord` is a consequence of the
+evaluator the rest of the source semantics runs on, rather than a restatement
+of the Yul model. -/
+
+/-- Struct member carrying the packed placement under test. -/
+def packedReadBridgeMember (offset width : Nat) : Compiler.CompilationModel.StructMember :=
+  { name := "value", wordOffset := 0, packed := some { offset := offset, width := width } }
+
+/-- Storage field whose struct value carries that packed member. -/
+def packedReadBridgeStructField (offset width : Nat) : Compiler.CompilationModel.Field :=
+  { name := "__packed_read_bridge_struct",
+    ty := .mappingStruct .uint256 [packedReadBridgeMember offset width],
+    slot := some 0 }
+
+/-- The source expression that drives the packed branch of `evalExpr`. -/
+def packedReadBridgeSourceExpr : Compiler.CompilationModel.Expr :=
+  .structMember "__packed_read_bridge_struct" (.literal 0) "value"
+
+/-- Structural predicate on the source IR: `e` is a struct-member read whose
+    resolved member is packed at exactly `offset`/`width`. This is the shape the
+    executable evaluator dispatches on, so a change to the member placement or to
+    the expression constructor is observable here. -/
+def isSourcePackedRead (fields : List Compiler.CompilationModel.Field)
+    (e : Compiler.CompilationModel.Expr) (offset width : Nat) : Bool :=
+  match e with
+  | .structMember field _ memberName =>
+      match Compiler.CompilationModel.findStructMembers fields field with
+      | some members =>
+          match Compiler.CompilationModel.findStructMember members memberName with
+          | some member =>
+              match member.packed with
+              | some packed => packed.offset == offset && packed.width == width
+              | none => false
+          | none => false
+      | none => false
+  | _ => false
+
+/-- A runtime state holding `word` in every storage slot, so the bridge observes
+    the packed extraction itself rather than slot arithmetic. -/
+def packedReadBridgeState (word : Word) : SourceSemantics.RuntimeState :=
+  { world := { Verity.defaultState with
+                storage := fun _ => Verity.Core.Uint256.ofNat word.toNat },
+    bindings := [] }
+
+/-- The packed read performed by the executable source evaluator. -/
+def sourceEvalPackedRead (word : Word) (offset width : Nat) : Option Nat :=
+  if isSourcePackedRead [packedReadBridgeStructField offset width]
+      packedReadBridgeSourceExpr offset width then
+    SourceSemantics.evalExpr [packedReadBridgeStructField offset width]
+      (packedReadBridgeState word) packedReadBridgeSourceExpr
+  else
+    none
+
+/-- Source-level extraction of a packed field, read off the executable source
+    evaluator instead of restating the Yul model. -/
+def sourceReadPackedWord (word : Word) (offset width : Nat) : Word :=
+  match sourceEvalPackedRead word offset width with
+  | some value => IRStorageWord.ofNat value
+  | none => IRStorageWord.ofNat 0
+
+private theorem land_packedMaskNat (x : Nat) (packed : Compiler.CompilationModel.PackedBits)
+    (hx : x < 2 ^ 256) :
+    Nat.land x (Compiler.CompilationModel.packedMaskNat packed) = x % 2 ^ packed.width := by
+  unfold Compiler.CompilationModel.packedMaskNat
+  by_cases hw : packed.width ≥ 256
+  · have h256 : (2 : Nat) ^ 256 ≤ 2 ^ packed.width := Nat.pow_le_pow_right (by decide) hw
+    have heq : Compiler.CompilationModel.uint256Modulus - 1 = 2 ^ 256 - 1 := rfl
+    have hand : Nat.land x (2 ^ 256 - 1) = x % 2 ^ 256 := Nat.and_two_pow_sub_one_eq_mod x 256
+    rw [if_pos hw, heq, hand, Nat.mod_eq_of_lt hx,
+      Nat.mod_eq_of_lt (Nat.lt_of_lt_of_le hx h256)]
+  · rw [if_neg hw]
+    exact Nat.and_two_pow_sub_one_eq_mod x packed.width
+
+private theorem packedMaskNat_lt (packed : Compiler.CompilationModel.PackedBits) :
+    Compiler.CompilationModel.packedMaskNat packed < 2 ^ 256 := by
+  have hmod : Compiler.CompilationModel.uint256Modulus = 2 ^ 256 := rfl
+  have hpos : (0 : Nat) < 2 ^ 256 := by positivity
+  unfold Compiler.CompilationModel.packedMaskNat
+  by_cases hw : packed.width ≥ 256
+  · rw [if_pos hw, hmod]; omega
+  · rw [if_neg hw]
+    have hle : (2 : Nat) ^ packed.width ≤ 2 ^ 256 := Nat.pow_le_pow_right (by decide) (by omega)
+    have hp : (0 : Nat) < 2 ^ packed.width := by positivity
+    omega
+
+private theorem uint256_packed_extract (raw : Nat)
+    (packed : Compiler.CompilationModel.PackedBits)
+    (hraw : raw < 2 ^ 256) (hoffset : packed.offset < 256) :
+    (Verity.Core.Uint256.and
+        (Verity.Core.Uint256.shr (Verity.Core.Uint256.ofNat packed.offset)
+          (Verity.Core.Uint256.ofNat raw))
+        (Verity.Core.Uint256.ofNat
+          (Compiler.CompilationModel.packedMaskNat packed))).val
+      = (raw / 2 ^ packed.offset) % 2 ^ packed.width := by
+  have hbig : (256 : Nat) < 2 ^ 256 := by norm_num
+  have hoff : packed.offset < 2 ^ 256 := Nat.lt_trans hoffset hbig
+  have hdiv : raw / 2 ^ packed.offset < 2 ^ 256 :=
+    Nat.lt_of_le_of_lt (Nat.div_le_self _ _) hraw
+  show Nat.land ((raw % 2 ^ 256) >>> (packed.offset % 2 ^ 256) % 2 ^ 256)
+      (Compiler.CompilationModel.packedMaskNat packed % 2 ^ 256) % 2 ^ 256
+    = (raw / 2 ^ packed.offset) % 2 ^ packed.width
+  rw [Nat.mod_eq_of_lt hraw, Nat.mod_eq_of_lt hoff, Nat.shiftRight_eq_div_pow,
+    Nat.mod_eq_of_lt hdiv, Nat.mod_eq_of_lt (packedMaskNat_lt packed),
+    land_packedMaskNat _ packed hdiv,
+    Nat.mod_eq_of_lt (Nat.lt_of_le_of_lt (Nat.mod_le _ _) hdiv)]
+
+/-- The bridge expression really is a source packed read at `offset`/`width`. -/
+theorem isSourcePackedRead_bridge (offset width : Nat) :
+    isSourcePackedRead [packedReadBridgeStructField offset width]
+      packedReadBridgeSourceExpr offset width = true := by
+  simp [isSourcePackedRead, packedReadBridgeSourceExpr, packedReadBridgeStructField,
+    packedReadBridgeMember, Compiler.CompilationModel.findStructMembers,
+    Compiler.CompilationModel.findStructMember]
+
+/-- The compiler's packed read agrees with the packed read the executable source
+    evaluator performs. Changing the emitted operand order, mask or offset breaks
+    the left-hand side; changing the evaluator's `and`/`shr`/mask breaks the right.
+    -/
+theorem compiledPackedRead_eq_sourceEvalPackedRead (word : Word) (offset width : Nat)
+    (hoffset : offset < 256) (hwidth : width ≤ 256) :
+    sourceEvalPackedRead word offset width =
+      some (compiledPackedRead word offset width).toNat := by
+  have hraw : word.toNat % Verity.Core.Uint256.modulus < 2 ^ 256 :=
+    Nat.mod_lt _ Verity.Core.Uint256.modulus_pos
+  have heval : SourceSemantics.evalExpr [packedReadBridgeStructField offset width]
+      (packedReadBridgeState word) packedReadBridgeSourceExpr =
+      some (Verity.Core.Uint256.and
+        (Verity.Core.Uint256.shr (Verity.Core.Uint256.ofNat offset)
+          (Verity.Core.Uint256.ofNat (word.toNat % Verity.Core.Uint256.modulus)))
+        (Verity.Core.Uint256.ofNat
+          (Compiler.CompilationModel.packedMaskNat { offset := offset, width := width }))).val :=
+    rfl
+  have hextract := uint256_packed_extract (word.toNat % Verity.Core.Uint256.modulus)
+    { offset := offset, width := width } hraw hoffset
+  rw [← yulReadPackedWord_eq_compiledExpr word offset width hwidth]
+  unfold sourceEvalPackedRead
+  rw [if_pos (isSourcePackedRead_bridge offset width), heval, hextract]
+  have hword : word.toNat % Verity.Core.Uint256.modulus = word.toNat :=
+    Nat.mod_eq_of_lt (IRStorageWord.toNat_lt_size word)
+  have hsize : (word.toNat / 2 ^ offset) % 2 ^ width < EvmYul.UInt256.size :=
+    Nat.lt_of_le_of_lt (Nat.mod_le _ _)
+      (Nat.lt_of_le_of_lt (Nat.div_le_self _ _) (IRStorageWord.toNat_lt_size word))
+  rw [hword, yulReadPackedWord, IRStorageWord.toNat_ofNat, Nat.mod_eq_of_lt hsize]
+
 /-- A source packed-word read produces the same word as the corresponding Yul
-    `sload`/`shr`/`and` sequence. -/
-theorem sourceRead_of_packedWord (word : Word) (offset width : Nat) :
+    `sload`/`shr`/`and` sequence. The left-hand side now runs the executable
+    source evaluator, so this is a real bridge rather than a restatement. -/
+theorem sourceRead_of_packedWord (word : Word) (offset width : Nat)
+    (hoffset : offset < 256) (hwidth : width ≤ 256) :
     sourceReadPackedWord word offset width = yulReadPackedWord word offset width := by
-  rfl
+  unfold sourceReadPackedWord
+  rw [compiledPackedRead_eq_sourceEvalPackedRead word offset width hoffset hwidth,
+    ← yulReadPackedWord_eq_compiledExpr word offset width hwidth]
+  exact IRStorageWord.ofNat_toNat _
 
 /-- The reverse bridge lets a Yul packed-word read be interpreted as the source
     read of the same Solidity field. -/
-theorem packedWord_of_sourceRead (word : Word) (offset width : Nat) :
+theorem packedWord_of_sourceRead (word : Word) (offset width : Nat)
+    (hoffset : offset < 256) (hwidth : width ≤ 256) :
     yulReadPackedWord word offset width = sourceReadPackedWord word offset width := by
-  exact (sourceRead_of_packedWord word offset width).symm
+  exact (sourceRead_of_packedWord word offset width hoffset hwidth).symm
 
 /-- One canonical source storage delta. A list represents sequential writes. -/
 structure StorageWrite where
@@ -170,9 +322,96 @@ def applyStateRewrite (diff : StorageDiff) (storage : SolidityStorage) : Solidit
     if contract = write.contract ∧ slot = write.slot then write.value
     else current contract slot) storage
 
-/-- Canonical interpretation of the equivalent sequence of Yul `sstore` calls.
-    It is definitionally the same state transformer as the source rewrite. -/
-def applyYulSstores : StorageDiff → SolidityStorage → SolidityStorage :=
-  applyStateRewrite
+/-- Apply a single canonical source storage write. -/
+def applyStorageWrite (write : StorageWrite) (storage : SolidityStorage) : SolidityStorage :=
+  fun contract slot =>
+    if contract = write.contract ∧ slot = write.slot then write.value
+    else storage contract slot
+
+theorem applyStateRewrite_cons (write : StorageWrite) (writes : StorageDiff)
+    (storage : SolidityStorage) :
+    applyStateRewrite (write :: writes) storage =
+      applyStateRewrite writes (applyStorageWrite write storage) := rfl
+
+/-! ### Interpreting the emitted `sstore` calls
+
+`applyStateRewrite` is the source-side state transformer. The definitions below
+recover the same transformer by pattern-matching the Yul that
+`Compiler/CompilationModel/StorageWrites.lean` actually emits for a storage
+assignment, so the two are related by a proof rather than by an alias. -/
+
+/-- Synthetic single-slot storage field used to expose the real `sstore`
+    lowering in `compileSetStorage`. -/
+def sstoreBridgeField (slot : Nat) : Compiler.CompilationModel.Field :=
+  { name := "__sstore_bridge", ty := .uint256, slot := some slot }
+
+/-- The statements the real compiler emits for a plain single-slot store. -/
+def compiledSstoreStmts (slot value : Nat) : List Compiler.Yul.YulStmt :=
+  match Compiler.CompilationModel.compileSetStorage
+      [sstoreBridgeField slot] .calldata "__sstore_bridge" (.literal value) with
+  | .ok stmts => stmts
+  | .error _ => []
+
+/-- The emitted lowering is exactly one `sstore(slot, value)` call. Any change to
+    the statement shape, the store builtin or the slot operand is observable here. -/
+theorem compiledSstoreStmts_eq (slot value : Nat) :
+    compiledSstoreStmts slot value =
+      [.exprStmt (.call "sstore" [.lit slot,
+        .lit (value % Compiler.CompilationModel.uint256Modulus)])] := by
+  have hfield : Compiler.CompilationModel.findFieldWithResolvedSlot
+      [({ name := "__sstore_bridge", ty := .uint256, slot := some slot } :
+          Compiler.CompilationModel.Field)] "__sstore_bridge"
+      = some ({ name := "__sstore_bridge", ty := .uint256, slot := some slot }, slot) := rfl
+  simp only [compiledSstoreStmts, Compiler.CompilationModel.compileSetStorage,
+    sstoreBridgeField, Compiler.CompilationModel.isMapping, hfield,
+    Compiler.CompilationModel.compileExprWithInternals]
+  rfl
+
+/-- The canonical Yul slot literal denoted by a source storage write. -/
+def writeSlotLit (write : StorageWrite) : Nat :=
+  EvmYul.fromByteArrayBigEndian write.slot
+
+/-- The `sstore` sequence the compiler emits for a whole source storage diff. -/
+def compiledSstoreProgram (diff : StorageDiff) : List Compiler.Yul.YulStmt :=
+  diff.flatMap fun write => compiledSstoreStmts (writeSlotLit write) write.value.toNat
+
+/-- Structurally interpret emitted Yul statements as storage updates. Each
+    statement must be exactly the `sstore(slot, value)` call that
+    `compileSetStorage` emits for the corresponding source write; any other
+    statement shape, slot operand or value operand leaves storage untouched. -/
+def compiledYulSstores :
+    List Compiler.Yul.YulStmt → StorageDiff → SolidityStorage → SolidityStorage
+  | .exprStmt (.call "sstore" [.lit slot, .lit value]) :: stmts, write :: writes, storage =>
+      if slot == writeSlotLit write &&
+          value == write.value.toNat % Compiler.CompilationModel.uint256Modulus then
+        compiledYulSstores stmts writes (applyStorageWrite write storage)
+      else storage
+  | _, _, storage => storage
+
+/-- Canonical interpretation of the equivalent sequence of Yul `sstore` calls:
+    walk the statements the compiler emits for `diff` and apply each store. -/
+def applyYulSstores (diff : StorageDiff) (storage : SolidityStorage) : SolidityStorage :=
+  compiledYulSstores (compiledSstoreProgram diff) diff storage
+
+theorem applyYulSstores_eq_compiledYulSstores (diff : StorageDiff) (storage : SolidityStorage) :
+    applyYulSstores diff storage =
+      compiledYulSstores (compiledSstoreProgram diff) diff storage := rfl
+
+/-- The emitted `sstore` sequence, structurally interpreted, performs exactly the
+    canonical source storage rewrite. -/
+theorem applyYulSstores_eq_applyStateRewrite (diff : StorageDiff) (storage : SolidityStorage) :
+    applyYulSstores diff storage = applyStateRewrite diff storage := by
+  unfold applyYulSstores
+  induction diff generalizing storage with
+  | nil => rfl
+  | cons write writes ih =>
+      have hprog : compiledSstoreProgram (write :: writes) =
+          .exprStmt (.call "sstore" [.lit (writeSlotLit write),
+              .lit (write.value.toNat % Compiler.CompilationModel.uint256Modulus)]) ::
+            compiledSstoreProgram writes := by
+        simp [compiledSstoreProgram, compiledSstoreStmts_eq]
+      rw [hprog, applyStateRewrite_cons]
+      simp only [compiledYulSstores, beq_self_eq_true, Bool.and_self, if_true]
+      exact ih (applyStorageWrite write storage)
 
 end Compiler.Proofs.Storage

--- a/Compiler/Proofs/Storage/SolidityStorage.lean
+++ b/Compiler/Proofs/Storage/SolidityStorage.lean
@@ -1,0 +1,81 @@
+import Compiler.Proofs.MappingSlot
+import Verity.Core.Model.Types
+
+namespace Compiler.Proofs.Storage
+
+open Compiler.Proofs
+open Compiler.Proofs.IRGeneration
+
+/-- Stable identity used to separate the storage of distinct contracts. -/
+abbrev ContractId := Nat
+
+/-- A canonical EVM storage word. -/
+abbrev Word := IRStorageWord
+
+/-- Canonical, contract-indexed Solidity storage, addressed by 32-byte slot keys. -/
+abbrev SolidityStorage := ContractId → ByteArray → Word
+
+/-- The canonical byte pointer for a Solidity mapping entry. Solidity hashes the
+    ABI word for the key followed by the ABI word for the mapping's base slot. -/
+def mappingSlotPointer (baseSlot key : Nat) : ByteArray :=
+  KeccakEngine.keccak256 (abiEncodeMappingSlot baseSlot key)
+
+/-- Reading a mapping key is precisely reading its canonical Keccak pointer. -/
+theorem mappingSlot_of_key (storage : SolidityStorage) (id : ContractId)
+    (baseSlot key : Nat) :
+    storage id (mappingSlotPointer baseSlot key) =
+      storage id (KeccakEngine.keccak256 (abiEncodeMappingSlot baseSlot key)) := by
+  rfl
+
+/-- Every pointer constructed for a mapping entry carries the canonical Solidity
+    ABI preimage `(key, baseSlot)`. This is the usable preimage direction and does
+    not postulate injectivity of Keccak. -/
+theorem mappingSlot_preimage (baseSlot key : Nat) :
+    ∃ preimage : ByteArray,
+      preimage = abiEncodeMappingSlot baseSlot key ∧
+      mappingSlotPointer baseSlot key = KeccakEngine.keccak256 preimage := by
+  exact ⟨abiEncodeMappingSlot baseSlot key, rfl, rfl⟩
+
+/-- Mask for a packed Solidity field of `width` low-order bits. -/
+def packedMask (width : Nat) : Nat := 2 ^ width - 1
+
+/-- Source-level extraction of a packed field from its containing storage word. -/
+def sourceReadPackedWord (word : Word) (offset width : Nat) : Word :=
+  IRStorageWord.ofNat ((word.toNat / 2 ^ offset) % 2 ^ width)
+
+/-- Yul's `and(shr(offset, sload(pointer)), mask)` interpretation. -/
+def yulReadPackedWord (word : Word) (offset width : Nat) : Word :=
+  IRStorageWord.ofNat ((word.toNat / 2 ^ offset) % 2 ^ width)
+
+/-- A source packed-word read produces the same word as the corresponding Yul
+    `sload`/`shr`/`and` sequence. -/
+theorem sourceRead_of_packedWord (word : Word) (offset width : Nat) :
+    sourceReadPackedWord word offset width = yulReadPackedWord word offset width := by
+  rfl
+
+/-- The reverse bridge lets a Yul packed-word read be interpreted as the source
+    read of the same Solidity field. -/
+theorem packedWord_of_sourceRead (word : Word) (offset width : Nat) :
+    yulReadPackedWord word offset width = sourceReadPackedWord word offset width := by
+  exact (sourceRead_of_packedWord word offset width).symm
+
+/-- One canonical source storage delta. A list represents sequential writes. -/
+structure StorageWrite where
+  contract : ContractId
+  slot : ByteArray
+  value : Word
+
+abbrev StorageDiff := List StorageWrite
+
+/-- Apply source storage writes in program order. Later writes to a slot win. -/
+def applyStateRewrite (diff : StorageDiff) (storage : SolidityStorage) : SolidityStorage :=
+  diff.foldl (fun current write contract slot =>
+    if contract = write.contract ∧ slot = write.slot then write.value
+    else current contract slot) storage
+
+/-- Canonical interpretation of the equivalent sequence of Yul `sstore` calls.
+    It is definitionally the same state transformer as the source rewrite. -/
+def applyYulSstores : StorageDiff → SolidityStorage → SolidityStorage :=
+  applyStateRewrite
+
+end Compiler.Proofs.Storage

--- a/Compiler/Proofs/Storage/SolidityStorage.lean
+++ b/Compiler/Proofs/Storage/SolidityStorage.lean
@@ -1,4 +1,5 @@
 import Compiler.Proofs.MappingSlot
+import Compiler.CompilationModel.ExpressionCompile
 import Verity.Core.Model.Types
 
 namespace Compiler.Proofs.Storage
@@ -46,6 +47,60 @@ def sourceReadPackedWord (word : Word) (offset width : Nat) : Word :=
 /-- Yul's `and(shr(offset, sload(pointer)), mask)` interpretation. -/
 def yulReadPackedWord (word : Word) (offset width : Nat) : Word :=
   IRStorageWord.ofNat ((word.toNat / 2 ^ offset) % 2 ^ width)
+
+/-- Synthetic scalar field used to expose the packed-storage compiler branch. -/
+def packedReadBridgeField (offset width : Nat) : Compiler.CompilationModel.Field :=
+  { name := "__packed_read_bridge", ty := .uint256, slot := some 0,
+    packedBits := some { offset := offset, width := width } }
+
+/-- Interpret the exact packed-storage expression emitted by
+    `compileExprWithInternals`. The deliberately structural match makes changes
+    to the emitted operator order, offset, load, slot, or mask observable here. -/
+def isCompiledPackedReadExpr : Compiler.Yul.YulExpr → Nat → Nat → Bool
+  | .call "and" [.call "shr" [.lit shift, .call "sload" [.lit 0]], .lit mask],
+      offset, width => shift == offset && mask == packedMask width
+  | _, _, _ => false
+
+def compiledPackedRead (word : Word) (offset width : Nat) : Word :=
+  let emitted := Compiler.CompilationModel.compileExprWithInternals
+      [packedReadBridgeField offset width] .calldata []
+      (.storage "__packed_read_bridge")
+  match emitted with
+  | .ok expr =>
+      if isCompiledPackedReadExpr expr offset width then yulReadPackedWord word offset width
+      else IRStorageWord.ofNat 0
+  | .error _ => IRStorageWord.ofNat 0
+
+/-- The helper for a Yul packed read is the interpretation of the real compiler
+    path in `ExpressionCompile.lean`. -/
+theorem yulReadPackedWord_eq_compiledExpr (word : Word) (offset width : Nat)
+    (hwidth : width < 256) :
+    yulReadPackedWord word offset width = compiledPackedRead word offset width := by
+  have hfield :
+      Compiler.CompilationModel.findFieldWithResolvedSlot
+        [packedReadBridgeField offset width] "__packed_read_bridge" =
+        some (packedReadBridgeField offset width, 0) := by
+    rfl
+  have hmapping :
+      Compiler.CompilationModel.isMapping
+        [packedReadBridgeField offset width] "__packed_read_bridge" = false := by
+    rfl
+  have hcompile :
+      Compiler.CompilationModel.compileExprWithInternals
+          [packedReadBridgeField offset width] .calldata []
+          (.storage "__packed_read_bridge") =
+        .ok (.call "and"
+          [.call "shr" [.lit offset, .call "sload" [.lit 0]],
+            .lit (packedMask width)]) := by
+    simp only [Compiler.CompilationModel.compileExprWithInternals, hmapping,
+      Bool.false_eq_true, if_false, hfield]
+    simp [packedReadBridgeField, Compiler.CompilationModel.packedMaskNat,
+      Nat.not_le.mpr hwidth, packedMask]
+    change Except.ok _ = Except.ok _
+    rfl
+  unfold compiledPackedRead
+  rw [hcompile]
+  simp [isCompiledPackedReadExpr]
 
 /-- A source packed-word read produces the same word as the corresponding Yul
     `sload`/`shr`/`and` sequence. -/

--- a/Compiler/Proofs/Storage/SolidityStorage.lean
+++ b/Compiler/Proofs/Storage/SolidityStorage.lean
@@ -24,13 +24,6 @@ abbrev SolidityStorage := ContractId → ByteArray → Word
 def mappingSlotPointer (baseSlot key : Nat) : ByteArray :=
   KeccakEngine.keccak256 (abiEncodeMappingSlot baseSlot key)
 
-/-- Reading a mapping key is precisely reading its canonical Keccak pointer. -/
-theorem mappingSlot_of_key (storage : SolidityStorage) (id : ContractId)
-    (baseSlot key : Nat) :
-    storage id (mappingSlotPointer baseSlot key) =
-      storage id (KeccakEngine.keccak256 (abiEncodeMappingSlot baseSlot key)) := by
-  rfl
-
 /-- Every pointer constructed for a mapping entry carries the canonical Solidity
     ABI preimage `(key, baseSlot)`. This is the usable preimage direction and does
     not postulate injectivity of Keccak. -/
@@ -74,6 +67,70 @@ theorem mappingSlotPointer_eq_abstractMappingSlot (baseSlot key : Nat) :
     EvmYul.fromByteArrayBigEndian (mappingSlotPointer baseSlot key) =
       Compiler.Proofs.abstractMappingSlot baseSlot key := by
   rfl
+
+/-- Synthetic mapping field used to expose the executable source mapping case. -/
+def mappingSlotBridgeField (baseSlot : Nat) : Compiler.CompilationModel.Field :=
+  { name := "__mapping_slot_bridge",
+    ty := .mappingTyped (.simple .uint256), slot := some baseSlot }
+
+/-- A slot-reflecting world makes a source read return its actual storage slot. -/
+def mappingSlotBridgeState : SourceSemantics.RuntimeState :=
+  { world := { Verity.defaultState with storage := fun slot => slot }, bindings := [] }
+
+/-- A source mapping expression evaluated in a slot-reflecting world exposes
+    the exact slot passed to `readFieldWord`. -/
+def sourceMappingSlotRead (baseSlot key : Nat) : Option Nat :=
+  SourceSemantics.evalExpr [mappingSlotBridgeField baseSlot] mappingSlotBridgeState
+    (.mapping "__mapping_slot_bridge" (.literal key))
+
+/-- The emitted helper's decoded result is precisely the slot consumed by the
+    executable source mapping-read case. This joins the generated helper and
+    `evalExpr` through `abstractMappingSlot`, rather than merely unfolding two
+    copies of the Keccak definition. -/
+theorem compiledMappingSlotPointer_eq_sourceMappingSlotRead
+    (scratchBase baseSlot key : Nat) (hkey : key < Compiler.Constants.evmModulus) :
+    Option.map EvmYul.fromByteArrayBigEndian
+        (compiledMappingSlotPointer
+          (Compiler.CodegenCommon.mappingSlotFuncAt scratchBase)
+          scratchBase baseSlot key) =
+      sourceMappingSlotRead baseSlot key := by
+  rw [compiledMappingSlotPointer_eq_mappingSlotPointer,
+    Option.map_some, mappingSlotPointer_eq_abstractMappingSlot]
+  have hfield : Compiler.CompilationModel.findFieldWithResolvedSlot
+      [mappingSlotBridgeField baseSlot] "__mapping_slot_bridge" =
+      some (mappingSlotBridgeField baseSlot, baseSlot) := by
+    rfl
+  unfold sourceMappingSlotRead
+  rw [SourceSemantics.evalExpr]
+  simp only [SourceSemantics.evalExpr]
+  rw [hfield]
+  simp [mappingSlotBridgeField, mappingSlotBridgeState, SourceSemantics.readFieldWord,
+    SourceSemantics.wordNormalize]
+  change Compiler.Proofs.solidityMappingSlot baseSlot key =
+    Compiler.Proofs.solidityMappingSlot baseSlot
+      (key % Compiler.Constants.evmModulus) % Compiler.Constants.evmModulus
+  rw [Nat.mod_eq_of_lt (Compiler.Proofs.solidityMappingSlot_lt_evmModulus
+    baseSlot (key % Compiler.Constants.evmModulus))]
+  rw [Nat.mod_eq_of_lt hkey]
+
+/-- Reading a mapping key uses the pointer returned by the emitted `mappingSlot`
+    helper, and decoding that same pointer yields the slot consumed by the
+    executable source evaluator. -/
+theorem mappingSlot_of_key (storage : SolidityStorage) (id : ContractId)
+    (scratchBase baseSlot key : Nat) (hkey : key < Compiler.Constants.evmModulus) :
+    Option.map (storage id)
+        (compiledMappingSlotPointer
+          (Compiler.CodegenCommon.mappingSlotFuncAt scratchBase)
+          scratchBase baseSlot key) =
+        some (storage id (mappingSlotPointer baseSlot key)) ∧
+      Option.map EvmYul.fromByteArrayBigEndian
+        (compiledMappingSlotPointer
+          (Compiler.CodegenCommon.mappingSlotFuncAt scratchBase)
+          scratchBase baseSlot key) =
+        sourceMappingSlotRead baseSlot key := by
+  constructor
+  · rw [compiledMappingSlotPointer_eq_mappingSlotPointer, Option.map_some]
+  · exact compiledMappingSlotPointer_eq_sourceMappingSlotRead scratchBase baseSlot key hkey
 
 /-- Mask for a packed Solidity field of `width` low-order bits. -/
 def packedMask (width : Nat) : Nat := 2 ^ width - 1
@@ -150,19 +207,11 @@ The definitions below pin the source end against the *executable* evaluator
 evaluator the rest of the source semantics runs on, rather than a restatement
 of the Yul model. -/
 
-/-- Struct member carrying the packed placement under test. -/
-def packedReadBridgeMember (offset width : Nat) : Compiler.CompilationModel.StructMember :=
-  { name := "value", wordOffset := 0, packed := some { offset := offset, width := width } }
-
-/-- Storage field whose struct value carries that packed member. -/
-def packedReadBridgeStructField (offset width : Nat) : Compiler.CompilationModel.Field :=
-  { name := "__packed_read_bridge_struct",
-    ty := .mappingStruct .uint256 [packedReadBridgeMember offset width],
-    slot := some 0 }
-
-/-- The source expression that drives the packed branch of `evalExpr`. -/
+/-- The source expression compiled and evaluated by the bridge. Keeping this as
+    the same `Expr.storage` value on both sides prevents the proof from silently
+    comparing two different evaluator/compiler cases. -/
 def packedReadBridgeSourceExpr : Compiler.CompilationModel.Expr :=
-  .structMember "__packed_read_bridge_struct" (.literal 0) "value"
+  .storage "__packed_read_bridge"
 
 /-- Structural predicate on the source IR: `e` is a struct-member read whose
     resolved member is packed at exactly `offset`/`width`. This is the shape the
@@ -171,14 +220,11 @@ def packedReadBridgeSourceExpr : Compiler.CompilationModel.Expr :=
 def isSourcePackedRead (fields : List Compiler.CompilationModel.Field)
     (e : Compiler.CompilationModel.Expr) (offset width : Nat) : Bool :=
   match e with
-  | .structMember field _ memberName =>
-      match Compiler.CompilationModel.findStructMembers fields field with
-      | some members =>
-          match Compiler.CompilationModel.findStructMember members memberName with
-          | some member =>
-              match member.packed with
-              | some packed => packed.offset == offset && packed.width == width
-              | none => false
+  | .storage fieldName =>
+      match Compiler.CompilationModel.findFieldWithResolvedSlot fields fieldName with
+      | some (field, _) =>
+          match field.packedBits with
+          | some packed => packed.offset == offset && packed.width == width
           | none => false
       | none => false
   | _ => false
@@ -192,9 +238,9 @@ def packedReadBridgeState (word : Word) : SourceSemantics.RuntimeState :=
 
 /-- The packed read performed by the executable source evaluator. -/
 def sourceEvalPackedRead (word : Word) (offset width : Nat) : Option Nat :=
-  if isSourcePackedRead [packedReadBridgeStructField offset width]
+  if isSourcePackedRead [packedReadBridgeField offset width]
       packedReadBridgeSourceExpr offset width then
-    SourceSemantics.evalExpr [packedReadBridgeStructField offset width]
+    SourceSemantics.evalExpr [packedReadBridgeField offset width]
       (packedReadBridgeState word) packedReadBridgeSourceExpr
   else
     none
@@ -254,11 +300,17 @@ private theorem uint256_packed_extract (raw : Nat)
 
 /-- The bridge expression really is a source packed read at `offset`/`width`. -/
 theorem isSourcePackedRead_bridge (offset width : Nat) :
-    isSourcePackedRead [packedReadBridgeStructField offset width]
+    isSourcePackedRead [packedReadBridgeField offset width]
       packedReadBridgeSourceExpr offset width = true := by
-  simp [isSourcePackedRead, packedReadBridgeSourceExpr, packedReadBridgeStructField,
-    packedReadBridgeMember, Compiler.CompilationModel.findStructMembers,
-    Compiler.CompilationModel.findStructMember]
+  have hfield :
+      Compiler.CompilationModel.findFieldWithResolvedSlot
+        [packedReadBridgeField offset width] "__packed_read_bridge" =
+        some (packedReadBridgeField offset width, 0) := by
+    rfl
+  unfold isSourcePackedRead
+  dsimp only [packedReadBridgeSourceExpr]
+  rw [hfield]
+  simp [packedReadBridgeField]
 
 /-- The compiler's packed read agrees with the packed read the executable source
     evaluator performs. Changing the emitted operand order, mask or offset breaks
@@ -270,14 +322,22 @@ theorem compiledPackedRead_eq_sourceEvalPackedRead (word : Word) (offset width :
       some (compiledPackedRead word offset width).toNat := by
   have hraw : word.toNat % Verity.Core.Uint256.modulus < 2 ^ 256 :=
     Nat.mod_lt _ Verity.Core.Uint256.modulus_pos
-  have heval : SourceSemantics.evalExpr [packedReadBridgeStructField offset width]
+  have heval : SourceSemantics.evalExpr [packedReadBridgeField offset width]
       (packedReadBridgeState word) packedReadBridgeSourceExpr =
       some (Verity.Core.Uint256.and
         (Verity.Core.Uint256.shr (Verity.Core.Uint256.ofNat offset)
           (Verity.Core.Uint256.ofNat (word.toNat % Verity.Core.Uint256.modulus)))
         (Verity.Core.Uint256.ofNat
-          (Compiler.CompilationModel.packedMaskNat { offset := offset, width := width }))).val :=
-    rfl
+          (Compiler.CompilationModel.packedMaskNat { offset := offset, width := width }))).val := by
+    have hfield :
+        Compiler.CompilationModel.findFieldWithResolvedSlot
+          [packedReadBridgeField offset width] "__packed_read_bridge" =
+          some (packedReadBridgeField offset width, 0) := by
+      rfl
+    unfold packedReadBridgeSourceExpr
+    rw [SourceSemantics.evalExpr, hfield]
+    simp [packedReadBridgeField, packedReadBridgeState,
+      SourceSemantics.readFieldWord, SourceSemantics.wordNormalize]
   have hextract := uint256_packed_extract (word.toNat % Verity.Core.Uint256.modulus)
     { offset := offset, width := width } hraw hoffset
   rw [← yulReadPackedWord_eq_compiledExpr word offset width hwidth]
@@ -371,47 +431,70 @@ theorem compiledSstoreStmts_eq (slot value : Nat) :
 def writeSlotLit (write : StorageWrite) : Nat :=
   EvmYul.fromByteArrayBigEndian write.slot
 
-/-- The `sstore` sequence the compiler emits for a whole source storage diff. -/
-def compiledSstoreProgram (diff : StorageDiff) : List Compiler.Yul.YulStmt :=
-  diff.flatMap fun write => compiledSstoreStmts (writeSlotLit write) write.value.toNat
+/-- A source diff is executable as one Yul contract invocation only when every
+    write belongs to that contract and every key has the canonical EVM width. -/
+def ValidSstoreDiff (currentContract : ContractId) (diff : StorageDiff) : Prop :=
+  ∀ write ∈ diff, write.contract = currentContract ∧ write.slot.size = 32
+
+/-- The `sstore` sequence the compiler emits for a whole valid source storage
+    diff. The contract and canonical-key checks are deliberately retained in
+    the program boundary instead of being reconstructed after decoding slots. -/
+def compiledSstoreProgram (currentContract : ContractId) (diff : StorageDiff) :
+    List Compiler.Yul.YulStmt :=
+  diff.flatMap fun write =>
+    if write.contract == currentContract && write.slot.size == 32 then
+      compiledSstoreStmts (writeSlotLit write) write.value.toNat
+    else []
 
 /-- Structurally interpret emitted Yul statements as storage updates. Each
     statement must be exactly the `sstore(slot, value)` call that
     `compileSetStorage` emits for the corresponding source write; any other
     statement shape, slot operand or value operand leaves storage untouched. -/
 def compiledYulSstores :
-    List Compiler.Yul.YulStmt → StorageDiff → SolidityStorage → SolidityStorage
-  | .exprStmt (.call "sstore" [.lit slot, .lit value]) :: stmts, write :: writes, storage =>
-      if slot == writeSlotLit write &&
+    ContractId → List Compiler.Yul.YulStmt → StorageDiff → SolidityStorage → SolidityStorage
+  | currentContract, .exprStmt (.call "sstore" [.lit slot, .lit value]) :: stmts,
+      write :: writes, storage =>
+      if write.contract == currentContract && write.slot.size == 32 &&
+          slot == writeSlotLit write &&
           value == write.value.toNat % Compiler.CompilationModel.uint256Modulus then
-        compiledYulSstores stmts writes (applyStorageWrite write storage)
+        compiledYulSstores currentContract stmts writes (applyStorageWrite write storage)
       else storage
-  | _, _, storage => storage
+  | _, _, _, storage => storage
 
 /-- Canonical interpretation of the equivalent sequence of Yul `sstore` calls:
     walk the statements the compiler emits for `diff` and apply each store. -/
-def applyYulSstores (diff : StorageDiff) (storage : SolidityStorage) : SolidityStorage :=
-  compiledYulSstores (compiledSstoreProgram diff) diff storage
+def applyYulSstores (currentContract : ContractId) (diff : StorageDiff)
+    (storage : SolidityStorage) : SolidityStorage :=
+  compiledYulSstores currentContract (compiledSstoreProgram currentContract diff) diff storage
 
-theorem applyYulSstores_eq_compiledYulSstores (diff : StorageDiff) (storage : SolidityStorage) :
-    applyYulSstores diff storage =
-      compiledYulSstores (compiledSstoreProgram diff) diff storage := rfl
+theorem applyYulSstores_eq_compiledYulSstores (currentContract : ContractId)
+    (diff : StorageDiff) (storage : SolidityStorage) :
+    applyYulSstores currentContract diff storage =
+      compiledYulSstores currentContract (compiledSstoreProgram currentContract diff) diff storage :=
+  rfl
 
 /-- The emitted `sstore` sequence, structurally interpreted, performs exactly the
     canonical source storage rewrite. -/
-theorem applyYulSstores_eq_applyStateRewrite (diff : StorageDiff) (storage : SolidityStorage) :
-    applyYulSstores diff storage = applyStateRewrite diff storage := by
+theorem applyYulSstores_eq_applyStateRewrite (currentContract : ContractId)
+    (diff : StorageDiff) (storage : SolidityStorage)
+    (hvalid : ValidSstoreDiff currentContract diff) :
+    applyYulSstores currentContract diff storage = applyStateRewrite diff storage := by
   unfold applyYulSstores
   induction diff generalizing storage with
   | nil => rfl
   | cons write writes ih =>
-      have hprog : compiledSstoreProgram (write :: writes) =
+      have hhead := hvalid write (by simp)
+      have htail : ValidSstoreDiff currentContract writes := by
+        intro tail hmem
+        exact hvalid tail (by simp [hmem])
+      have hprog : compiledSstoreProgram currentContract (write :: writes) =
           .exprStmt (.call "sstore" [.lit (writeSlotLit write),
               .lit (write.value.toNat % Compiler.CompilationModel.uint256Modulus)]) ::
-            compiledSstoreProgram writes := by
-        simp [compiledSstoreProgram, compiledSstoreStmts_eq]
+            compiledSstoreProgram currentContract writes := by
+        simp [compiledSstoreProgram, hhead.1, hhead.2, compiledSstoreStmts_eq]
       rw [hprog, applyStateRewrite_cons]
-      simp only [compiledYulSstores, beq_self_eq_true, Bool.and_self, if_true]
-      exact ih (applyStorageWrite write storage)
+      simp only [compiledYulSstores, hhead.1, hhead.2, beq_self_eq_true,
+        Bool.and_self, if_true]
+      exact ih (applyStorageWrite write storage) htail
 
 end Compiler.Proofs.Storage

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4339,8 +4339,17 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.compiledMappingSlotPointer_eq_mappingSlotPointer
   Compiler.Proofs.Storage.mappingSlotPointer_eq_abstractMappingSlot
   Compiler.Proofs.Storage.yulReadPackedWord_eq_compiledExpr
+  -- Compiler.Proofs.Storage.land_packedMaskNat  -- private
+  -- Compiler.Proofs.Storage.packedMaskNat_lt  -- private
+  -- Compiler.Proofs.Storage.uint256_packed_extract  -- private
+  Compiler.Proofs.Storage.isSourcePackedRead_bridge
+  Compiler.Proofs.Storage.compiledPackedRead_eq_sourceEvalPackedRead
   Compiler.Proofs.Storage.sourceRead_of_packedWord
   Compiler.Proofs.Storage.packedWord_of_sourceRead
+  Compiler.Proofs.Storage.applyStateRewrite_cons
+  Compiler.Proofs.Storage.compiledSstoreStmts_eq
+  Compiler.Proofs.Storage.applyYulSstores_eq_compiledYulSstores
+  Compiler.Proofs.Storage.applyYulSstores_eq_applyStateRewrite
 
   -- Compiler/Proofs/StorageBounds.lean
   Compiler.Proofs.StorageBounds.storageArray_element_val_lt
@@ -6454,4 +6463,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6042 theorems/lemmas (4189 public, 1853 private, 0 sorry'd)
+-- Total: 6051 theorems/lemmas (4195 public, 1856 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4336,6 +4336,8 @@ end Verity.AxiomAudit
   -- Compiler/Proofs/Storage/SolidityStorage.lean
   Compiler.Proofs.Storage.mappingSlot_of_key
   Compiler.Proofs.Storage.mappingSlot_preimage
+  Compiler.Proofs.Storage.compiledMappingSlotPointer_eq_mappingSlotPointer
+  Compiler.Proofs.Storage.mappingSlotPointer_eq_abstractMappingSlot
   Compiler.Proofs.Storage.yulReadPackedWord_eq_compiledExpr
   Compiler.Proofs.Storage.sourceRead_of_packedWord
   Compiler.Proofs.Storage.packedWord_of_sourceRead
@@ -6452,4 +6454,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6040 theorems/lemmas (4187 public, 1853 private, 0 sorry'd)
+-- Total: 6042 theorems/lemmas (4189 public, 1853 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -82,9 +82,9 @@ import Compiler.Proofs.IRGeneration.SupportedFragment
 import Compiler.Proofs.IRGeneration.SupportedSpec
 import Compiler.Proofs.KeccakBound
 import Compiler.Proofs.MappingSlot
+import Compiler.Proofs.Storage.SolidityStorage
 import Compiler.Proofs.StorageBounds
 import Compiler.Proofs.StorageLens
-import Compiler.Proofs.Storage.SolidityStorage
 import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBodyClosure.Base
 import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBodyClosure.Generic
 import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBodyClosure.Safe
@@ -198,12 +198,6 @@ syntax (name := verityPrintAxioms) "#verity_print_axioms " "[" ident* "]" : comm
 end Verity.AxiomAudit
 
 #verity_print_axioms [
-
-  -- Compiler/Proofs/Storage/SolidityStorage.lean
-  Compiler.Proofs.Storage.mappingSlot_of_key
-  Compiler.Proofs.Storage.mappingSlot_preimage
-  Compiler.Proofs.Storage.sourceRead_of_packedWord
-  Compiler.Proofs.Storage.packedWord_of_sourceRead
 
   -- Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeStepLemmas.lean
   Compiler.Proofs.YulGeneration.Backends.Native.step_calldataload_ok
@@ -4339,6 +4333,12 @@ end Verity.AxiomAudit
   Compiler.Proofs.solidityMappingSlot_add_lt_evmModulus
   Compiler.Proofs.solidityMappingSlot_add_wordOffset_lt_evmModulus
 
+  -- Compiler/Proofs/Storage/SolidityStorage.lean
+  Compiler.Proofs.Storage.mappingSlot_of_key
+  Compiler.Proofs.Storage.mappingSlot_preimage
+  Compiler.Proofs.Storage.sourceRead_of_packedWord
+  Compiler.Proofs.Storage.packedWord_of_sourceRead
+
   -- Compiler/Proofs/StorageBounds.lean
   Compiler.Proofs.StorageBounds.storageArray_element_val_lt
   Compiler.Proofs.StorageBounds.storageArray_element_bounded
@@ -6451,4 +6451,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6035 theorems/lemmas (4182 public, 1853 private, 0 sorry'd)
+-- Total: 6039 theorems/lemmas (4186 public, 1853 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4334,10 +4334,11 @@ end Verity.AxiomAudit
   Compiler.Proofs.solidityMappingSlot_add_wordOffset_lt_evmModulus
 
   -- Compiler/Proofs/Storage/SolidityStorage.lean
-  Compiler.Proofs.Storage.mappingSlot_of_key
   Compiler.Proofs.Storage.mappingSlot_preimage
   Compiler.Proofs.Storage.compiledMappingSlotPointer_eq_mappingSlotPointer
   Compiler.Proofs.Storage.mappingSlotPointer_eq_abstractMappingSlot
+  Compiler.Proofs.Storage.compiledMappingSlotPointer_eq_sourceMappingSlotRead
+  Compiler.Proofs.Storage.mappingSlot_of_key
   Compiler.Proofs.Storage.yulReadPackedWord_eq_compiledExpr
   -- Compiler.Proofs.Storage.land_packedMaskNat  -- private
   -- Compiler.Proofs.Storage.packedMaskNat_lt  -- private
@@ -6463,4 +6464,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6051 theorems/lemmas (4195 public, 1856 private, 0 sorry'd)
+-- Total: 6052 theorems/lemmas (4196 public, 1856 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -84,6 +84,7 @@ import Compiler.Proofs.KeccakBound
 import Compiler.Proofs.MappingSlot
 import Compiler.Proofs.StorageBounds
 import Compiler.Proofs.StorageLens
+import Compiler.Proofs.Storage.SolidityStorage
 import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBodyClosure.Base
 import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBodyClosure.Generic
 import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBodyClosure.Safe
@@ -197,6 +198,12 @@ syntax (name := verityPrintAxioms) "#verity_print_axioms " "[" ident* "]" : comm
 end Verity.AxiomAudit
 
 #verity_print_axioms [
+
+  -- Compiler/Proofs/Storage/SolidityStorage.lean
+  Compiler.Proofs.Storage.mappingSlot_of_key
+  Compiler.Proofs.Storage.mappingSlot_preimage
+  Compiler.Proofs.Storage.sourceRead_of_packedWord
+  Compiler.Proofs.Storage.packedWord_of_sourceRead
 
   -- Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeStepLemmas.lean
   Compiler.Proofs.YulGeneration.Backends.Native.step_calldataload_ok

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4336,6 +4336,7 @@ end Verity.AxiomAudit
   -- Compiler/Proofs/Storage/SolidityStorage.lean
   Compiler.Proofs.Storage.mappingSlot_of_key
   Compiler.Proofs.Storage.mappingSlot_preimage
+  Compiler.Proofs.Storage.yulReadPackedWord_eq_compiledExpr
   Compiler.Proofs.Storage.sourceRead_of_packedWord
   Compiler.Proofs.Storage.packedWord_of_sourceRead
 
@@ -6451,4 +6452,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6039 theorems/lemmas (4186 public, 1853 private, 0 sorry'd)
+-- Total: 6040 theorems/lemmas (4187 public, 1853 private, 0 sorry'd)

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -656,7 +656,14 @@ def evalExpr (oracle : DenoteOracle) (fields : List Field) (state : DenoteState)
   | .immutable name => some (state.immutable name).val
   | .storage fieldName =>
       match findFieldWithResolvedSlot fields fieldName with
-      | some (field, slot) => some (readFieldWord state.world field slot).val
+      | some (field, slot) =>
+          let rawWord := (readFieldWord state.world field slot).val
+          match field.packedBits with
+          | none => some rawWord
+          | some packed =>
+              some (Verity.Core.Uint256.and
+                (Verity.Core.Uint256.shr packed.offset rawWord)
+                (packedMaskNat packed)).val
       | none => none
   | .storageAddr fieldName =>
       match findFieldWithResolvedSlot fields fieldName with


### PR DESCRIPTION
Closes the foundational slice of #2081 by adding canonical contract-indexed Solidity storage, Keccak mapping-slot/preimage bridges, packed-word source/Yul read equivalence, and a shared source/Yul state-rewrite transformer.\n\nValidation:\n- lake build\n- lake build PrintAxioms\n- forbidden-token scan: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formal storage read semantics for packed fields across source and denote models; risk is proof-correctness and downstream verification dependencies, not live runtime services.
> 
> **Overview**
> Introduces **`Compiler/Proofs/Storage/SolidityStorage.lean`** as the Phase 1D foundation: contract-indexed canonical storage, Keccak **mapping-slot** bridges (emitted `mappingSlot` helper ↔ `abstractMappingSlot` ↔ `evalExpr`), **packed-word** equivalence (compiler `and`/`shr`/`sload` ↔ executable `SourceSemantics`), and **`sstore`** sequences interpreted as the same **`applyStateRewrite`** as source writes. New lemmas are wired into **`PrintAxioms`**.
> 
> **Source semantics** for `Expr.storage` now **masks packed fields** (`shr` + `and` with `packedMaskNat`) in `SourceSemantics.lean`, `Verity/Core/Model/Denote.lean`, and `evalExprWithHelpers`, aligning evaluation with the existing Yul lowering in `ExpressionCompile`.
> 
> **IR generation proofs** in `GenericInduction/Storage.lean` simplify `hEvalSrc` steps by rewriting via `SourceSemantics.evalExpr` instead of manual `match`/`change` on `findFieldWithResolvedSlot`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 880acb13d8cbb26079b50a5b6b1068b64231fde5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->