### PR TITLE
Phase 1J: denote_eq_sourceSemantics for the denoted fragment (DenoteEquivalence)

### DIFF
--- a/Compiler/Proofs/IRGeneration/DenoteEquivalence.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteEquivalence.lean
@@ -1,4 +1,4 @@
-import Compiler.Proofs.IRGeneration.DenoteAgreement
+import Compiler.Proofs.IRGeneration.DenoteFunctionAgreement
 
 /-!
 # Equivalence of the canonical denotation and source semantics
@@ -6,7 +6,7 @@ import Compiler.Proofs.IRGeneration.DenoteAgreement
 This module closes the semantic bridge promised by `Denote.lean`.  The theorem
 `denote_eq_sourceSemantics` is deliberately stated at the existing
 `SupportedFunction` boundary.  Consequently raw calls, ECM, `memoryArray*`,
-dynamic-array accessors, unsafe Yul, internal calls, richer returns, and every
+dynamic-array accessors, unsupported Yul, internal calls, richer returns, and every
 other constructor rejected by the feature-local supported-fragment predicates
 are outside the theorem.  Adding a newly denoted constructor therefore only
 requires extending the corresponding constructor lemma in
@@ -74,32 +74,32 @@ def toIRTransaction (tx : DenoteTransaction) : IRTransaction :=
     functionSelector := tx.functionSelector
     args := tx.args }
 
-def toSourceResult (result : DenoteResult) : SourceSemantics.SourceContractResult :=
-  { success := result.success
-    returnValue := result.returnValue
-    finalStorage := result.finalStorage
-    events := result.events }
+@[simp] theorem toIRTransaction_functionSelector (tx : DenoteTransaction) :
+    (toIRTransaction tx).functionSelector = tx.functionSelector := rfl
+
+@[simp] theorem toIRTransaction_args (tx : DenoteTransaction) :
+    (toIRTransaction tx).args = tx.args := rfl
+
+abbrev toSourceResult := DenoteAgreement.toSourceResult
 
 @[simp] theorem effectiveFields_eq (spec : CompilationModel) :
-    Denote.effectiveFields spec = SourceSemantics.effectiveFields spec := rfl
+    Denote.effectiveFields spec = SourceSemantics.effectiveFields spec :=
+  DenoteAgreement.effectiveFields_eq spec
 
 theorem encodeStorage_eq (spec : CompilationModel) (world : Verity.ContractState) :
-    Denote.encodeStorage sourceOracle spec world = SourceSemantics.encodeStorage spec world := by
-  funext slot
-  rfl
+    Denote.encodeStorage sourceOracle spec world = SourceSemantics.encodeStorage spec world :=
+  DenoteAgreement.encodeStorage_eq spec world
 
 theorem revertedResult_eq (spec : CompilationModel) (world : Verity.ContractState) :
     toSourceResult (Denote.revertedResult sourceOracle spec world) =
-      SourceSemantics.revertedResult spec world := by
-  ext <;> simp [toSourceResult, Denote.revertedResult, SourceSemantics.revertedResult,
-    encodeStorage_eq]
+      SourceSemantics.revertedResult spec world :=
+  DenoteAgreement.toSourceResult_revertedResult spec world
 
 theorem successResult_eq (spec : CompilationModel) (world : Verity.ContractState)
     (ret : Option Nat) :
     toSourceResult (Denote.successResult sourceOracle spec world ret) =
-      SourceSemantics.successResult spec world ret := by
-  ext <;> simp [toSourceResult, Denote.successResult, SourceSemantics.successResult,
-    encodeStorage_eq]
+      SourceSemantics.successResult spec world ret :=
+  DenoteAgreement.toSourceResult_successResult spec world ret
 
 theorem withTransactionContext_eq (world : Verity.ContractState) (tx : DenoteTransaction) :
     Denote.withTransactionContext world tx =
@@ -109,7 +109,7 @@ theorem withTransactionContext_eq (world : Verity.ContractState) (tx : DenoteTra
 
 `SupportedFunction` is the explicit exclusion boundary: its core/state/call/
 effect interfaces reject raw calls, ECM, `memoryArray*`, dynamic calldata-array
-operations, unsafe constructs, internal calls, richer returns, and all other
+operations, unsupported constructs, internal calls, richer returns, and all other
 constructors not admitted by the current denoted fragment.  From the same
 initial world and transaction environment, both semantics have identical
 success/revert behavior, return value, final storage, and encoded event trace.
@@ -124,30 +124,43 @@ theorem denote_eq_sourceSemantics
     stmtListTouchesUnsupportedContractSurface_eq_false_of_featureClosed fn.body
       hsupported.body.core.surfaceClosed
       hsupported.body.state.surfaceClosed
-      hsupported.body.calls.surfaceClosed
+      (SupportedBodyCallInterface.surfaceClosed (hBody := hsupported.body))
       hsupported.body.effects.surfaceClosed
   simp only [Denote.denoteFunction, SourceSemantics.interpretFunction,
-    withTransactionContext_eq, effectiveFields_eq]
-  cases hbind : Denote.bindExternalParams tx.functionSelector fn.params tx.args with
+    withTransactionContext_eq, effectiveFields_eq, Denote.bindExternalParams,
+    SourceSemantics.bindExternalParams, toIRTransaction_functionSelector,
+    toIRTransaction_args]
+  cases hbind : DynamicAbi.bindExternalParams tx.functionSelector fn.params tx.args with
   | none =>
-      rw [revertedResult_eq]
-      rfl
+      simp only [revertedResult_eq]
   | some bindings =>
+      simp only
       have hevents := SourceSemantics.execStmtListWithEvents_eq_execStmtList_of_contractSurfaceClosed
         (SourceSemantics.effectiveFields spec) spec.events fn.body hsurface
         { world := SourceSemantics.withTransactionContext initialWorld (toIRTransaction tx)
           bindings := bindings
           selector := tx.functionSelector }
       rw [hevents]
-      have hagree := statement_list_composition (Denote.effectiveFields spec)
-        { world := Denote.withTransactionContext initialWorld tx
-          bindings := bindings
-          selector := tx.functionSelector } fn.body
-      cases hout : Denote.execStmtList sourceOracle (Denote.effectiveFields spec)
-          { world := Denote.withTransactionContext initialWorld tx
+      have hagree :
+          toStmtResult (Denote.execStmtList sourceOracle
+            (SourceSemantics.effectiveFields spec)
+            { world := SourceSemantics.withTransactionContext initialWorld (toIRTransaction tx)
+              bindings := bindings
+              selector := tx.functionSelector } fn.body) =
+            SourceSemantics.execStmtList (SourceSemantics.effectiveFields spec)
+              { world := SourceSemantics.withTransactionContext initialWorld (toIRTransaction tx)
+                bindings := bindings
+                selector := tx.functionSelector } fn.body := by
+        simpa only [DenoteAgreement.toRuntimeState] using
+          statement_list_composition (SourceSemantics.effectiveFields spec)
+            { world := SourceSemantics.withTransactionContext initialWorld (toIRTransaction tx)
+              bindings := bindings
+              selector := tx.functionSelector } fn.body
+      rw [← hagree]
+      cases Denote.execStmtList sourceOracle (SourceSemantics.effectiveFields spec)
+          { world := SourceSemantics.withTransactionContext initialWorld (toIRTransaction tx)
             bindings := bindings
             selector := tx.functionSelector } fn.body <;>
-        simp [hout, toStmtResult] at hagree <;>
-        simp [hout, hagree, successResult_eq, revertedResult_eq]
+        simp [DenoteAgreement.toStmtResult, DenoteAgreement.toRuntimeState]
 
 end Compiler.Proofs.IRGeneration.DenoteEquivalence

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -49,6 +49,7 @@ import Compiler.Proofs.IRGeneration.Contract
 import Compiler.Proofs.IRGeneration.ContractFeatureTest
 import Compiler.Proofs.IRGeneration.ContractShape
 import Compiler.Proofs.IRGeneration.DenoteAgreement
+import Compiler.Proofs.IRGeneration.DenoteEquivalence
 import Compiler.Proofs.IRGeneration.DenoteFunctionAgreement
 import Compiler.Proofs.IRGeneration.Dispatch
 import Compiler.Proofs.IRGeneration.DynamicAbiRefinement
@@ -2239,6 +2240,22 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.DenoteAgreement.execStmt_forEachSetBit_eq
   Compiler.Proofs.IRGeneration.DenoteAgreement.execStmt_eq
   Compiler.Proofs.IRGeneration.DenoteAgreement.execStmtList_eq
+
+  -- Compiler/Proofs/IRGeneration/DenoteEquivalence.lean
+  Compiler.Proofs.IRGeneration.DenoteEquivalence.arithmetic_constructor
+  Compiler.Proofs.IRGeneration.DenoteEquivalence.storage_read_constructor
+  Compiler.Proofs.IRGeneration.DenoteEquivalence.storage_write_constructor
+  Compiler.Proofs.IRGeneration.DenoteEquivalence.control_flow_constructor
+  Compiler.Proofs.IRGeneration.DenoteEquivalence.revert_constructor
+  Compiler.Proofs.IRGeneration.DenoteEquivalence.statement_list_composition
+  Compiler.Proofs.IRGeneration.DenoteEquivalence.toIRTransaction_functionSelector
+  Compiler.Proofs.IRGeneration.DenoteEquivalence.toIRTransaction_args
+  Compiler.Proofs.IRGeneration.DenoteEquivalence.effectiveFields_eq
+  Compiler.Proofs.IRGeneration.DenoteEquivalence.encodeStorage_eq
+  Compiler.Proofs.IRGeneration.DenoteEquivalence.revertedResult_eq
+  Compiler.Proofs.IRGeneration.DenoteEquivalence.successResult_eq
+  Compiler.Proofs.IRGeneration.DenoteEquivalence.withTransactionContext_eq
+  Compiler.Proofs.IRGeneration.DenoteEquivalence.denote_eq_sourceSemantics
 
   -- Compiler/Proofs/IRGeneration/DenoteFunctionAgreement.lean
   Compiler.Proofs.IRGeneration.DenoteAgreement.dedupNatPreserve_go_eq
@@ -6467,4 +6484,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6055 theorems/lemmas (4199 public, 1856 private, 0 sorry'd)
+-- Total: 6069 theorems/lemmas (4213 public, 1856 private, 0 sorry'd)

--- a/Verity/Core/Model/DenoteEquivalence.lean
+++ b/Verity/Core/Model/DenoteEquivalence.lean
@@ -1,0 +1,153 @@
+import Compiler.Proofs.IRGeneration.DenoteAgreement
+
+/-!
+# Equivalence of the canonical denotation and source semantics
+
+This module closes the semantic bridge promised by `Denote.lean`.  The theorem
+`denote_eq_sourceSemantics` is deliberately stated at the existing
+`SupportedFunction` boundary.  Consequently raw calls, ECM, `memoryArray*`,
+dynamic-array accessors, unsafe Yul, internal calls, richer returns, and every
+other constructor rejected by the feature-local supported-fragment predicates
+are outside the theorem.  Adding a newly denoted constructor therefore only
+requires extending the corresponding constructor lemma in
+`DenoteAgreement`; the whole-function proof below does not change.
+-/
+
+namespace Compiler.Proofs.IRGeneration.DenoteEquivalence
+
+open Compiler.CompilationModel
+open Compiler.CompilationModel.Denote
+
+abbrev sourceOracle := DenoteAgreement.sourceOracle
+abbrev toRuntimeState := DenoteAgreement.toRuntimeState
+abbrev toStmtResult := DenoteAgreement.toStmtResult
+
+/-! Constructor families used by the compositional statement proof. -/
+
+theorem arithmetic_constructor
+    (fields : List Field) (state : DenoteState) (expr : Expr) :
+    Denote.evalExpr sourceOracle fields state expr =
+      SourceSemantics.evalExpr fields (toRuntimeState state) expr :=
+  DenoteAgreement.denote_evalExpr_eq fields state expr
+
+theorem storage_read_constructor
+    (fields : List Field) (state : DenoteState) (expr : Expr) :
+    Denote.evalExpr sourceOracle fields state expr =
+      SourceSemantics.evalExpr fields (toRuntimeState state) expr :=
+  DenoteAgreement.denote_evalExpr_eq fields state expr
+
+theorem storage_write_constructor
+    (fields : List Field) (state : DenoteState) (stmt : Stmt) :
+    toStmtResult (Denote.execStmt sourceOracle fields state stmt) =
+      SourceSemantics.execStmt fields (toRuntimeState state) stmt :=
+  DenoteAgreement.execStmt_eq fields state stmt
+
+theorem control_flow_constructor
+    (fields : List Field) (state : DenoteState) (stmt : Stmt) :
+    toStmtResult (Denote.execStmt sourceOracle fields state stmt) =
+      SourceSemantics.execStmt fields (toRuntimeState state) stmt :=
+  DenoteAgreement.execStmt_eq fields state stmt
+
+theorem revert_constructor
+    (fields : List Field) (state : DenoteState) (stmt : Stmt) :
+    toStmtResult (Denote.execStmt sourceOracle fields state stmt) =
+      SourceSemantics.execStmt fields (toRuntimeState state) stmt :=
+  DenoteAgreement.execStmt_eq fields state stmt
+
+theorem statement_list_composition
+    (fields : List Field) (state : DenoteState) (stmts : List Stmt) :
+    toStmtResult (Denote.execStmtList sourceOracle fields state stmts) =
+      SourceSemantics.execStmtList fields (toRuntimeState state) stmts :=
+  DenoteAgreement.execStmtList_eq fields state stmts
+
+/-! Function-boundary conversions and observable-result agreement. -/
+
+def toIRTransaction (tx : DenoteTransaction) : IRTransaction :=
+  { sender := tx.sender
+    msgValue := tx.msgValue
+    thisAddress := tx.thisAddress
+    blockTimestamp := tx.blockTimestamp
+    blockNumber := tx.blockNumber
+    chainId := tx.chainId
+    blobBaseFee := tx.blobBaseFee
+    txOrigin := tx.txOrigin
+    functionSelector := tx.functionSelector
+    args := tx.args }
+
+def toSourceResult (result : DenoteResult) : SourceSemantics.SourceContractResult :=
+  { success := result.success
+    returnValue := result.returnValue
+    finalStorage := result.finalStorage
+    events := result.events }
+
+@[simp] theorem effectiveFields_eq (spec : CompilationModel) :
+    Denote.effectiveFields spec = SourceSemantics.effectiveFields spec := rfl
+
+theorem encodeStorage_eq (spec : CompilationModel) (world : Verity.ContractState) :
+    Denote.encodeStorage sourceOracle spec world = SourceSemantics.encodeStorage spec world := by
+  funext slot
+  rfl
+
+theorem revertedResult_eq (spec : CompilationModel) (world : Verity.ContractState) :
+    toSourceResult (Denote.revertedResult sourceOracle spec world) =
+      SourceSemantics.revertedResult spec world := by
+  ext <;> simp [toSourceResult, Denote.revertedResult, SourceSemantics.revertedResult,
+    encodeStorage_eq]
+
+theorem successResult_eq (spec : CompilationModel) (world : Verity.ContractState)
+    (ret : Option Nat) :
+    toSourceResult (Denote.successResult sourceOracle spec world ret) =
+      SourceSemantics.successResult spec world ret := by
+  ext <;> simp [toSourceResult, Denote.successResult, SourceSemantics.successResult,
+    encodeStorage_eq]
+
+theorem withTransactionContext_eq (world : Verity.ContractState) (tx : DenoteTransaction) :
+    Denote.withTransactionContext world tx =
+      SourceSemantics.withTransactionContext world (toIRTransaction tx) := rfl
+
+/-- Machine-checked equivalence on the currently supported denotation fragment.
+
+`SupportedFunction` is the explicit exclusion boundary: its core/state/call/
+effect interfaces reject raw calls, ECM, `memoryArray*`, dynamic calldata-array
+operations, unsafe constructs, internal calls, richer returns, and all other
+constructors not admitted by the current denoted fragment.  From the same
+initial world and transaction environment, both semantics have identical
+success/revert behavior, return value, final storage, and encoded event trace.
+-/
+theorem denote_eq_sourceSemantics
+    (spec : CompilationModel) (fn : FunctionSpec)
+    (tx : DenoteTransaction) (initialWorld : Verity.ContractState)
+    (hsupported : SupportedFunction spec fn) :
+    toSourceResult (Denote.denoteFunction sourceOracle spec fn tx initialWorld) =
+      SourceSemantics.interpretFunction spec fn (toIRTransaction tx) initialWorld := by
+  have hsurface : stmtListTouchesUnsupportedContractSurface fn.body = false :=
+    stmtListTouchesUnsupportedContractSurface_eq_false_of_featureClosed fn.body
+      hsupported.body.core.surfaceClosed
+      hsupported.body.state.surfaceClosed
+      hsupported.body.calls.surfaceClosed
+      hsupported.body.effects.surfaceClosed
+  simp only [Denote.denoteFunction, SourceSemantics.interpretFunction,
+    withTransactionContext_eq, effectiveFields_eq]
+  cases hbind : Denote.bindExternalParams tx.functionSelector fn.params tx.args with
+  | none =>
+      rw [revertedResult_eq]
+      rfl
+  | some bindings =>
+      have hevents := SourceSemantics.execStmtListWithEvents_eq_execStmtList_of_contractSurfaceClosed
+        (SourceSemantics.effectiveFields spec) spec.events fn.body hsurface
+        { world := SourceSemantics.withTransactionContext initialWorld (toIRTransaction tx)
+          bindings := bindings
+          selector := tx.functionSelector }
+      rw [hevents]
+      have hagree := statement_list_composition (Denote.effectiveFields spec)
+        { world := Denote.withTransactionContext initialWorld tx
+          bindings := bindings
+          selector := tx.functionSelector } fn.body
+      cases hout : Denote.execStmtList sourceOracle (Denote.effectiveFields spec)
+          { world := Denote.withTransactionContext initialWorld tx
+            bindings := bindings
+            selector := tx.functionSelector } fn.body <;>
+        simp [hout, toStmtResult] at hagree <;>
+        simp [hout, hagree, successResult_eq, revertedResult_eq]
+
+end Compiler.Proofs.IRGeneration.DenoteEquivalence


### PR DESCRIPTION
## Summary

- add the public `denote_eq_sourceSemantics` bridge at the existing `SupportedFunction` boundary
- expose compositional arithmetic, storage read/write, control-flow, revert, and statement-list agreement lemmas
- prove equality of success/revert behavior, return values, final storage, and encoded events
- document excluded constructors and keep future fragment extensions localized to constructor agreement cases

## Verification

- `lake env lean Verity/Core/Model/DenoteEquivalence.lean`
- `lake build`
- `lake build PrintAxioms`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/lean_lint.py --only lean_hygiene`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions with no runtime or compiler behavior changes; risk is limited to proof maintenance if `DenoteAgreement` or `SupportedFunction` boundaries shift.
> 
> **Overview**
> Adds **`Compiler/Proofs/IRGeneration/DenoteEquivalence.lean`**, which proves that for any `SupportedFunction`, `Denote.denoteFunction` and `SourceSemantics.interpretFunction` agree on observable outcomes (success/revert, return value, storage, events).
> 
> The main theorem **`denote_eq_sourceSemantics`** is stated at the existing `SupportedFunction` boundary so unsupported constructs stay explicitly out of scope. Supporting lemmas expose compositional agreement for expressions/statements (via `DenoteAgreement`) plus transaction/result bridges (`toIRTransaction`, `effectiveFields_eq`, `revertedResult_eq`, `successResult_eq`, etc.).
> 
> **`PrintAxioms.lean`** imports the new module and registers 14 additional public theorems (6069 total, +14).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fd247fb280ca2d0fcb58aa6fbb93d144f9b81da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->