### PR TITLE
Phase 1D #4: prove canonical storage rewrite closure

### DIFF
--- a/Compiler/Proofs/Storage/SolidityStorage.lean
+++ b/Compiler/Proofs/Storage/SolidityStorage.lean
@@ -499,25 +499,45 @@ theorem applyYulSstores_eq_applyStateRewrite (currentContract : ContractId)
         Bool.and_self, if_true]
       exact ih (applyStorageWrite write storage) htail
 
-/-- Project the live IR storage of one executing contract into canonical,
-    contract-indexed Solidity storage. Other contracts are outside this
-    invocation and are represented by zero. -/
-def irStorageProjection (currentContract : ContractId) (state : IRState) :
+/-- A storage key whose width makes big-endian decoding injective on the
+    projection surface. -/
+abbrev CanonicalStorageKey := { slot : ByteArray // slot.size = 32 }
+
+/-- Storage observations are exposed only at canonical EVM-width keys. -/
+abbrev CanonicalSolidityStorage := ContractId → CanonicalStorageKey → Word
+
+/-- Restrict an abstract byte-array-addressed storage to canonical queries. -/
+def canonicalStorageProjection (storage : SolidityStorage) : CanonicalSolidityStorage :=
+  fun contract slot => storage contract slot.1
+
+/-- Internal byte-array view used while applying source rewrites. The public
+    projection below prevents non-canonical aliases from being queried. -/
+private def irStorageView (currentContract : ContractId) (state : IRState) :
     SolidityStorage :=
   fun contract slot =>
-    if contract = currentContract ∧ slot.size = 32 then
+    if contract = currentContract then
       state.storage (IRStorageSlot.ofNat (EvmYul.fromByteArrayBigEndian slot))
     else 0
 
+/-- Project live IR storage onto canonical 32-byte keys only. -/
+def irStorageProjection (currentContract : ContractId) (state : IRState) :
+    CanonicalSolidityStorage :=
+  canonicalStorageProjection (irStorageView currentContract state)
+
 /-- Project the source runtime storage of one executing contract through the
     same `encodeStorageAt` view used by `runtimeStateMatchesIR`. -/
-def sourceStorageProjection (fields : List Field) (currentContract : ContractId)
+private def sourceStorageView (fields : List Field) (currentContract : ContractId)
     (runtime : SourceSemantics.RuntimeState) : SolidityStorage :=
   fun contract slot =>
-    if contract = currentContract ∧ slot.size = 32 then
+    if contract = currentContract then
       IRStorageWord.ofNat (SourceSemantics.encodeStorageAt fields runtime.world
         (IRStorageSlot.ofNat (EvmYul.fromByteArrayBigEndian slot)).toNat)
     else 0
+
+/-- Project source runtime storage onto canonical 32-byte keys only. -/
+def sourceStorageProjection (fields : List Field) (currentContract : ContractId)
+    (runtime : SourceSemantics.RuntimeState) : CanonicalSolidityStorage :=
+  canonicalStorageProjection (sourceStorageView fields currentContract runtime)
 
 /-- The storage conjunct of `runtimeStateMatchesIR`, expressed on the canonical
     contract/key storage surface consumed by state rewrites. -/
@@ -529,12 +549,11 @@ theorem runtimeStateMatchesIR_storageProjections_eq
       sourceStorageProjection fields currentContract runtime := by
   funext contract slot
   by_cases hcontract : contract = currentContract
-  · by_cases hslot : slot.size = 32
-    · simp only [irStorageProjection, sourceStorageProjection, hcontract, hslot,
-        and_self, if_true]
-      rw [hruntime.1]
-    · simp [irStorageProjection, sourceStorageProjection, hslot]
-  · simp [irStorageProjection, sourceStorageProjection, hcontract]
+  · simp only [irStorageProjection, sourceStorageProjection, canonicalStorageProjection,
+      irStorageView, sourceStorageView, hcontract, if_true]
+    rw [hruntime.1]
+  · simp [irStorageProjection, sourceStorageProjection, canonicalStorageProjection,
+      irStorageView, sourceStorageView, hcontract]
 
 /-- A valid compiled/source rewrite preserves the live runtime/IR storage
     relation, projected onto the canonical contract/key surface. The premise is
@@ -545,12 +564,19 @@ theorem applyStateRewrite_preserves_canonicalStorageRel
     (runtime : SourceSemantics.RuntimeState) (state : IRState)
     (hruntime : FunctionBody.runtimeStateMatchesIR fields runtime state)
     (hvalid : ValidSstoreDiff currentContract diff) :
-    applyYulSstores currentContract diff
-        (irStorageProjection currentContract state) =
-      applyStateRewrite diff
-        (sourceStorageProjection fields currentContract runtime) := by
-  rw [applyYulSstores_eq_applyStateRewrite currentContract diff _ hvalid,
-    runtimeStateMatchesIR_storageProjections_eq fields currentContract runtime state hruntime]
+    canonicalStorageProjection (applyYulSstores currentContract diff
+        (irStorageView currentContract state)) =
+      canonicalStorageProjection (applyStateRewrite diff
+        (sourceStorageView fields currentContract runtime)) := by
+  have hviews : irStorageView currentContract state =
+      sourceStorageView fields currentContract runtime := by
+    funext contract slot
+    by_cases hcontract : contract = currentContract
+    · simp only [irStorageView, sourceStorageView, hcontract, if_true]
+      rw [hruntime.1]
+    · simp [irStorageView, sourceStorageView, hcontract]
+  rw [applyYulSstores_eq_applyStateRewrite currentContract diff _ hvalid]
+  rw [hviews]
 
 /-! ### Canonical storage preservation for compiled statement lists -/
 

--- a/Compiler/Proofs/Storage/SolidityStorage.lean
+++ b/Compiler/Proofs/Storage/SolidityStorage.lean
@@ -499,19 +499,55 @@ theorem applyYulSstores_eq_applyStateRewrite (currentContract : ContractId)
         Bool.and_self, if_true]
       exact ih (applyStorageWrite write storage) htail
 
-/-- Canonical storage agreement is closed under a valid compiled/source state
-    rewrite: equal pre-states produce equal post-states.  The live canonical
-    relation is equality itself, as used by `runtimeStateMatchesIR`; keeping it
-    explicit here avoids introducing a parallel storage relation. -/
+/-- Project the live IR storage of one executing contract into canonical,
+    contract-indexed Solidity storage. Other contracts are outside this
+    invocation and are represented by zero. -/
+def irStorageProjection (currentContract : ContractId) (state : IRState) :
+    SolidityStorage :=
+  fun contract slot =>
+    if contract = currentContract then
+      state.storage (IRStorageSlot.ofNat (EvmYul.fromByteArrayBigEndian slot))
+    else 0
+
+/-- Project the source runtime storage of one executing contract through the
+    same `encodeStorageAt` view used by `runtimeStateMatchesIR`. -/
+def sourceStorageProjection (fields : List Field) (currentContract : ContractId)
+    (runtime : SourceSemantics.RuntimeState) : SolidityStorage :=
+  fun contract slot =>
+    if contract = currentContract then
+      IRStorageWord.ofNat (SourceSemantics.encodeStorageAt fields runtime.world
+        (IRStorageSlot.ofNat (EvmYul.fromByteArrayBigEndian slot)).toNat)
+    else 0
+
+/-- The storage conjunct of `runtimeStateMatchesIR`, expressed on the canonical
+    contract/key storage surface consumed by state rewrites. -/
+theorem runtimeStateMatchesIR_storageProjections_eq
+    (fields : List Field) (currentContract : ContractId)
+    (runtime : SourceSemantics.RuntimeState) (state : IRState)
+    (hruntime : FunctionBody.runtimeStateMatchesIR fields runtime state) :
+    irStorageProjection currentContract state =
+      sourceStorageProjection fields currentContract runtime := by
+  funext contract slot
+  by_cases hcontract : contract = currentContract
+  · simp only [irStorageProjection, sourceStorageProjection, hcontract, if_true]
+    rw [hruntime.1]
+  · simp [irStorageProjection, sourceStorageProjection, hcontract]
+
+/-- A valid compiled/source rewrite preserves the live runtime/IR storage
+    relation, projected onto the canonical contract/key surface. The premise is
+    the actual `runtimeStateMatchesIR` invariant rather than an unrelated
+    equality between two abstract storages. -/
 theorem applyStateRewrite_preserves_canonicalStorageRel
-    (currentContract : ContractId) (diff : StorageDiff)
-    (yulStorage sourceStorage : SolidityStorage)
-    (hstorage : yulStorage = sourceStorage)
+    (fields : List Field) (currentContract : ContractId) (diff : StorageDiff)
+    (runtime : SourceSemantics.RuntimeState) (state : IRState)
+    (hruntime : FunctionBody.runtimeStateMatchesIR fields runtime state)
     (hvalid : ValidSstoreDiff currentContract diff) :
-    applyYulSstores currentContract diff yulStorage =
-      applyStateRewrite diff sourceStorage := by
-  subst sourceStorage
-  exact applyYulSstores_eq_applyStateRewrite currentContract diff yulStorage hvalid
+    applyYulSstores currentContract diff
+        (irStorageProjection currentContract state) =
+      applyStateRewrite diff
+        (sourceStorageProjection fields currentContract runtime) := by
+  rw [applyYulSstores_eq_applyStateRewrite currentContract diff _ hvalid,
+    runtimeStateMatchesIR_storageProjections_eq fields currentContract runtime state hruntime]
 
 /-! ### Canonical storage preservation for compiled statement lists -/
 

--- a/Compiler/Proofs/Storage/SolidityStorage.lean
+++ b/Compiler/Proofs/Storage/SolidityStorage.lean
@@ -499,6 +499,20 @@ theorem applyYulSstores_eq_applyStateRewrite (currentContract : ContractId)
         Bool.and_self, if_true]
       exact ih (applyStorageWrite write storage) htail
 
+/-- Canonical storage agreement is closed under a valid compiled/source state
+    rewrite: equal pre-states produce equal post-states.  The live canonical
+    relation is equality itself, as used by `runtimeStateMatchesIR`; keeping it
+    explicit here avoids introducing a parallel storage relation. -/
+theorem applyStateRewrite_preserves_canonicalStorageRel
+    (currentContract : ContractId) (diff : StorageDiff)
+    (yulStorage sourceStorage : SolidityStorage)
+    (hstorage : yulStorage = sourceStorage)
+    (hvalid : ValidSstoreDiff currentContract diff) :
+    applyYulSstores currentContract diff yulStorage =
+      applyStateRewrite diff sourceStorage := by
+  subst sourceStorage
+  exact applyYulSstores_eq_applyStateRewrite currentContract diff yulStorage hvalid
+
 /-! ### Canonical storage preservation for compiled statement lists -/
 
 /-- Expose the real single-slot mapping-write compiler branch with literal key

--- a/Compiler/Proofs/Storage/SolidityStorage.lean
+++ b/Compiler/Proofs/Storage/SolidityStorage.lean
@@ -505,7 +505,7 @@ theorem applyYulSstores_eq_applyStateRewrite (currentContract : ContractId)
 def irStorageProjection (currentContract : ContractId) (state : IRState) :
     SolidityStorage :=
   fun contract slot =>
-    if contract = currentContract then
+    if contract = currentContract ∧ slot.size = 32 then
       state.storage (IRStorageSlot.ofNat (EvmYul.fromByteArrayBigEndian slot))
     else 0
 
@@ -514,7 +514,7 @@ def irStorageProjection (currentContract : ContractId) (state : IRState) :
 def sourceStorageProjection (fields : List Field) (currentContract : ContractId)
     (runtime : SourceSemantics.RuntimeState) : SolidityStorage :=
   fun contract slot =>
-    if contract = currentContract then
+    if contract = currentContract ∧ slot.size = 32 then
       IRStorageWord.ofNat (SourceSemantics.encodeStorageAt fields runtime.world
         (IRStorageSlot.ofNat (EvmYul.fromByteArrayBigEndian slot)).toNat)
     else 0
@@ -529,8 +529,11 @@ theorem runtimeStateMatchesIR_storageProjections_eq
       sourceStorageProjection fields currentContract runtime := by
   funext contract slot
   by_cases hcontract : contract = currentContract
-  · simp only [irStorageProjection, sourceStorageProjection, hcontract, if_true]
-    rw [hruntime.1]
+  · by_cases hslot : slot.size = 32
+    · simp only [irStorageProjection, sourceStorageProjection, hcontract, hslot,
+        and_self, if_true]
+      rw [hruntime.1]
+    · simp [irStorageProjection, sourceStorageProjection, hslot]
   · simp [irStorageProjection, sourceStorageProjection, hcontract]
 
 /-- A valid compiled/source rewrite preserves the live runtime/IR storage

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4369,6 +4369,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.compiledSstoreStmts_eq
   Compiler.Proofs.Storage.applyYulSstores_eq_compiledYulSstores
   Compiler.Proofs.Storage.applyYulSstores_eq_applyStateRewrite
+  Compiler.Proofs.Storage.applyStateRewrite_preserves_canonicalStorageRel
   Compiler.Proofs.Storage.compiledMappingSstore_eq_canonicalSstore
   Compiler.Proofs.Storage.compilerStmtList_obeys_canonical_storage
   Compiler.Proofs.Storage.compilerStmtListWithInternals_obeys_canonical_storage
@@ -6539,4 +6540,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6121 theorems/lemmas (4265 public, 1856 private, 0 sorry'd)
+-- Total: 6122 theorems/lemmas (4266 public, 1856 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4369,6 +4369,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.compiledSstoreStmts_eq
   Compiler.Proofs.Storage.applyYulSstores_eq_compiledYulSstores
   Compiler.Proofs.Storage.applyYulSstores_eq_applyStateRewrite
+  Compiler.Proofs.Storage.runtimeStateMatchesIR_storageProjections_eq
   Compiler.Proofs.Storage.applyStateRewrite_preserves_canonicalStorageRel
   Compiler.Proofs.Storage.compiledMappingSstore_eq_canonicalSstore
   Compiler.Proofs.Storage.compilerStmtList_obeys_canonical_storage
@@ -6540,4 +6541,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6122 theorems/lemmas (4266 public, 1856 private, 0 sorry'd)
+-- Total: 6123 theorems/lemmas (4267 public, 1856 private, 0 sorry'd)


### PR DESCRIPTION
## Summary

- add the public `applyStateRewrite_preserves_canonicalStorageRel` closure theorem
- preserve the live canonical relation directly as pre-state equality instead of reintroducing the rejected parallel relation/outcome wrapper
- consume `applyYulSstores_eq_applyStateRewrite` and `ValidSstoreDiff`
- regenerate `PrintAxioms.lean` (6122 declarations, 0 sorry'd)

## Validation

- focused elaboration: `lake env lean Compiler/Proofs/Storage/SolidityStorage.lean`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_proof_length.py`
- `python3 scripts/test_check_proof_length.py`
- `git diff --check`
- changed-Lean forbidden-token escape scan
- pinned remote `lake build` / `lake build PrintAxioms` receipts will be recorded when terminal

The authoritative base was independently fetched and verified as `07603ffb1709cfecee356c0b566ce17cc531d2c9` (merged #2229). EVMYulLean remains pinned by the repository lockfile.

Transport note: the mandated remote full-source client rejects this repository's tracked bracketed Next.js path and gitlink; after client-only accommodation, the server rejects the complete request at its 32 MiB decompressed JSON cap. Exact-head remote validation is therefore also being run through the supported immutable Git/overlay transport.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in Lean storage correctness; no runtime, auth, or executable compiler behavior changes.
> 
> **Overview**
> Adds **canonical storage projections** from live IR state and source runtime (`irStorageProjection`, `sourceStorageProjection`) so storage rewrites can be stated on the same `ContractId` × 32-byte key surface as `applyStateRewrite`.
> 
> Proves **`runtimeStateMatchesIR_storageProjections_eq`**, which re-expresses the storage part of `runtimeStateMatchesIR` as equality of those projections, and **`applyStateRewrite_preserves_canonicalStorageRel`**: for a `ValidSstoreDiff`, applying compiled Yul `sstore`s to the IR projection matches applying the source rewrite to the source projection while `runtimeStateMatchesIR` holds—via existing `applyYulSstores_eq_applyStateRewrite` rather than a separate abstract relation.
> 
> Registers both lemmas in **`PrintAxioms.lean`** (6123 declarations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0564d080f8d758d6ade6bb51ea63167faeaf411e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->