### PR TITLE
fix(ci): mechanical Lean warning cleanup

### DIFF
--- a/Compiler/Proofs/IRGeneration/GenericInduction/EventBridge.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/EventBridge.lean
@@ -1118,7 +1118,7 @@ private theorem eventUnindexedStores_cons_continue
   rcases hok with ⟨heval, hsupport, hlt, hshape, hsize, hkind⟩
   constructor
   · simp [SourceSemantics.writeUnindexedEventScratchFrom, hkind]
-    convert hwriteTail using 1 <;> first | rfl | simp [eventUnindexedNextMemory]
+    convert hwriteTail using 1 <;> rfl
   · have hstmt :
         scalarEventUnindexedStoresFrom ((param, srcExpr, argExpr) :: rest)
             (wordIdx * 32) =
@@ -2473,8 +2473,8 @@ private theorem eventCollectExprListNames_subset_scope
 
 private theorem eventStmtNextScope_emit_included
     {scope : List String} {eventName : String} {args : List Expr}
-    (hcore : ∀ expr ∈ args, FunctionBody.ExprCompileCore expr)
-    (hinScope : ∀ expr ∈ args, FunctionBody.exprBoundNamesInScope expr scope) :
+    (_hcore : ∀ expr ∈ args, FunctionBody.ExprCompileCore expr)
+    (_hinScope : ∀ expr ∈ args, FunctionBody.exprBoundNamesInScope expr scope) :
     FunctionBody.scopeNamesIncluded
       (stmtNextScope scope (Stmt.emit eventName args)) scope := by
   intro name hmem

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
@@ -787,7 +787,7 @@ theorem findResolvedFieldAtSlotCopyFrom_of_member
             exact Or.inl (List.mem_reverse.mpr htargetInEntries)
           exact (firstFieldWriteSlotConflictCopyFrom_some_of_seen_slot_member
             htargetInSeen hfind hwrite hslot hunpacked) hnoConflict
-        · push_neg at hcapture
+        · push Not at hcapture
           rw [show
             (decide (SourceSemantics.wordNormalize (field.slot.getD idx) =
                 SourceSemantics.wordNormalize targetSlot) ||
@@ -6717,7 +6717,6 @@ theorem compiledStmtStep_ite
           FunctionBody.runtimeStateMatchesIR_setVar_irrelevant
             (name := tempName) (value := condVal) hruntime
         have hElse6 : sizeOf elseIR + 6 ≤ sizeOf compiledIR := by
-          change sizeOf elseIR + 6 ≤ sizeOf compiledIR
           simp_wf
           omega
         let branchExtraFuel :=
@@ -6809,7 +6808,6 @@ theorem compiledStmtStep_ite
           FunctionBody.runtimeStateMatchesIR_setVar_irrelevant
             (name := tempName) (value := condVal) hruntime
         have hThen5 : sizeOf thenIR + 5 ≤ sizeOf compiledIR := by
-          change sizeOf thenIR + 5 ≤ sizeOf compiledIR
           simp_wf
           omega
         let branchExtraFuel :=
@@ -6935,7 +6933,7 @@ private theorem compiledStmtStep_letStorageField
     (hnoConflict : firstFieldWriteSlotConflict fields = none)
     (hfind : findFieldWithResolvedSlot fields fieldName =
       some ({ name := fieldName, ty := FieldType.uint256 }, slot))
-    (hfieldInScope : fieldName ∈ scope) :
+    (_hfieldInScope : fieldName ∈ scope) :
     CompiledStmtStep fields scope (.letVar tmp (Expr.storage fieldName))
       [YulStmt.let_ tmp (YulExpr.call "sload" [YulExpr.lit slot])] where
   compileOk := by
@@ -7012,7 +7010,7 @@ private theorem compiledStmtStep_letStorageAddrField
     (hnoConflict : firstFieldWriteSlotConflict fields = none)
     (hfind : findFieldWithResolvedSlot fields fieldName =
       some ({ name := fieldName, ty := FieldType.address }, slot))
-    (hfieldInScope : fieldName ∈ scope) :
+    (_hfieldInScope : fieldName ∈ scope) :
     CompiledStmtStep fields scope (.letVar tmp (Expr.storageAddr fieldName))
       [YulStmt.let_ tmp (YulExpr.call "sload" [YulExpr.lit slot])] where
   compileOk := by
@@ -7097,7 +7095,7 @@ private theorem compiledStmtStep_assignStorageField
     (hnoConflict : firstFieldWriteSlotConflict fields = none)
     (hfind : findFieldWithResolvedSlot fields fieldName =
       some ({ name := fieldName, ty := FieldType.uint256 }, slot))
-    (hfieldInScope : fieldName ∈ scope) :
+    (_hfieldInScope : fieldName ∈ scope) :
     CompiledStmtStep fields scope (.assignVar name (Expr.storage fieldName))
       [YulStmt.assign name (YulExpr.call "sload" [YulExpr.lit slot])] where
   compileOk := by
@@ -7175,7 +7173,7 @@ private theorem compiledStmtStep_assignStorageAddrField
     (hnoConflict : firstFieldWriteSlotConflict fields = none)
     (hfind : findFieldWithResolvedSlot fields fieldName =
       some ({ name := fieldName, ty := FieldType.address }, slot))
-    (hfieldInScope : fieldName ∈ scope) :
+    (_hfieldInScope : fieldName ∈ scope) :
     CompiledStmtStep fields scope (.assignVar name (Expr.storageAddr fieldName))
       [YulStmt.assign name (YulExpr.call "sload" [YulExpr.lit slot])] where
   compileOk := by

--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -4463,8 +4463,7 @@ theorem interpretIRWithInternalsZeroConservativeExtensionGoal_of_dispatchGoal
     (contract : IRContract) :
     InterpretIRWithInternalsZeroConservativeExtensionDispatchGoal contract →
       InterpretIRWithInternalsZeroConservativeExtensionGoal contract := by
-  intro hdispatch
-  intro hlegacy tx initialState
+  intro hdispatch hlegacy tx initialState
   let stateWithTx := applyIRTransactionContext tx initialState
   cases hfind : contract.functions.find? (·.selector == tx.functionSelector) with
   | none =>

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -5164,7 +5164,7 @@ private theorem stmtTouchesUnsupportedContractSurface_eq_false_of_featureClosed
   | forEach _ _ _ | forEachSetBit _ _ _ => cases hcore
   | setStorageWord _ _ _ => cases hstate
   | _ =>
-      all_goals (simp only [stmtTouchesUnsupportedContractSurface]; first | assumption | cases hcore | cases heffects | cases hcalls)
+      all_goals (simp only [stmtTouchesUnsupportedContractSurface]; assumption)
 termination_by sizeOf stmt
 
 theorem stmtListTouchesUnsupportedContractSurface_eq_false_of_featureClosed
@@ -7565,13 +7565,13 @@ private theorem counter_noFallback :
     ∀ fn ∈ counterSupportedSpecModel.functions, fn.name != "fallback" := by
   intro fn hfn
   simp [counterSupportedSpecModel] at hfn
-  rcases hfn with rfl <;> decide
+  (rcases hfn with rfl; decide)
 
 private theorem counter_noReceive :
     ∀ fn ∈ counterSupportedSpecModel.functions, fn.name != "receive" := by
   intro fn hfn
   simp [counterSupportedSpecModel] at hfn
-  rcases hfn with rfl <;> decide
+  (rcases hfn with rfl; decide)
 
 private def counter_supported_function :
     ∀ fn, fn ∈ counterSupportedSpecModel.functions →
@@ -7664,13 +7664,13 @@ private theorem simpleStorage_noFallback :
     ∀ fn ∈ simpleStorageSupportedSpecModel.functions, fn.name != "fallback" := by
   intro fn hfn
   simp [simpleStorageSupportedSpecModel] at hfn
-  rcases hfn with rfl <;> decide
+  (rcases hfn with rfl; decide)
 
 private theorem simpleStorage_noReceive :
     ∀ fn ∈ simpleStorageSupportedSpecModel.functions, fn.name != "receive" := by
   intro fn hfn
   simp [simpleStorageSupportedSpecModel] at hfn
-  rcases hfn with rfl <;> decide
+  (rcases hfn with rfl; decide)
 
 private def simpleStorage_supported_function :
     ∀ fn, fn ∈ simpleStorageSupportedSpecModel.functions →

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeSignedArithLemmas.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeSignedArithLemmas.lean
@@ -60,7 +60,7 @@ private theorem uint256_fin_mul_neg1_val_of_zero (x : Fin EvmYul.UInt256.size)
 
 private theorem natAbs_ofNat_sub (a b : Nat) (h : a < b) :
     (Int.ofNat a - Int.ofNat b).natAbs = b - a := by
-  simp only [Int.ofNat_eq_coe]
+  simp only [Int.ofNat_eq_natCast]
   rw [show (a : Int) - ((b : Nat) : Int) = -(((b : Nat) : Int) - (a : Int)) from by omega]
   rw [Int.natAbs_neg]
   rw [show ((b : Nat) : Int) - (a : Int) = ((b - a : Nat) : Int) from by omega]
@@ -1181,7 +1181,7 @@ private theorem se_sign_clear (value : Nat) (hvS : value < EvmYul.UInt256.size)
     (h : ¬(EvmYul.UInt256.land ⟨⟨value, hvS⟩⟩ sb ≠
       ⟨⟨0, by rw [EvmYul.UInt256.size]; omega⟩⟩)) :
     value &&& 2^bp = 0 := by
-  push_neg at h
+  push Not at h
   have h1 := se_val_val_of_eq _ _ h
   rw [se_land_val, hsb] at h1
   rwa [Nat.mod_eq_of_lt (Nat.lt_of_le_of_lt Nat.and_le_left hvS)] at h1

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanPureBuiltinLemmas.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanPureBuiltinLemmas.lean
@@ -575,7 +575,7 @@ private theorem evalPureBuiltinViaEvmYulLean_byte_normalized (index value : Nat)
           ⟨255⟩)) = _
     unfold EvmYul.UInt256.shiftRight
     rw [if_neg hguard, hshift]; simp [hgt, EvmYul.UInt256.land, EvmYul.UInt256.toNat,
-      EvmYul.UInt256.ofNat, Id.run, Fin.land, Fin.shiftRight, Fin.ofNat,
+      EvmYul.UInt256.ofNat, Id.run, Fin.land, Fin.ofNat,
       Nat.shiftRight_eq_div_pow]
     rw [show (255 : Nat) % EvmYul.UInt256.size = 255 from by unfold EvmYul.UInt256.size; omega]
     change

--- a/Compiler/Yul/PrettyPrint.lean
+++ b/Compiler/Yul/PrettyPrint.lean
@@ -7,7 +7,7 @@ open YulExpr
 open Compiler.Hex (natToHexUnpadded natToHex)
 
 private def indentStr (n : Nat) : String :=
-  String.mk (List.replicate (n * 4) ' ')
+  String.ofList (List.replicate (n * 4) ' ')
 
 mutual
 def ppExpr : YulExpr → String

--- a/scripts/check_lean_warning_regression.py
+++ b/scripts/check_lean_warning_regression.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from property_utils import ROOT
 
 WARNING_RE = re.compile(r"^warning:\s+(.+?\.lean):\d+:\d+:\s+(.*)$")
+DEPENDENCY_SOURCE_PREFIXES = ("Conform/", "EvmYul/")
 
 
 def parse_warnings(log_path: Path) -> tuple[Counter[str], Counter[str]]:
@@ -35,9 +36,8 @@ def parse_warnings(log_path: Path) -> tuple[Counter[str], Counter[str]]:
             continue
         file_path, message = match.groups()
         # Skip warnings from dependency packages — we only track our own code.
-        # Match both absolute paths (``/.lake/packages/…``) and relative paths
-        # (``.lake/packages/…``, ``lake-packages/…``) to cover every form Lean
-        # may emit depending on the working directory.
+        # Match both package-directory paths and the source-root-relative paths
+        # emitted by the legacy remote runner for the pinned EVMYulLean package.
         if (
             "/lake-packages/" in file_path
             or "/.lake/packages/" in file_path
@@ -45,6 +45,7 @@ def parse_warnings(log_path: Path) -> tuple[Counter[str], Counter[str]]:
             or file_path.startswith(".lake/packages/")
             or file_path.startswith("./lake-packages/")
             or file_path.startswith("./.lake/packages/")
+            or file_path.startswith(DEPENDENCY_SOURCE_PREFIXES)
         ):
             continue
         by_file[file_path] += 1

--- a/scripts/test_check_lean_warning_regression.py
+++ b/scripts/test_check_lean_warning_regression.py
@@ -74,6 +74,39 @@ class CheckLeanWarningRegressionScriptTests(unittest.TestCase):
             self.assertNotEqual(proc.returncode, 0)
             self.assertIn("Total Lean warnings drifted: observed 0, baseline 1", proc.stderr)
 
+    def test_ignores_legacy_runner_dependency_source_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            log_path = root / "lake-build.log"
+            baseline_path = root / "lean_warning_baseline.json"
+            log_path.write_text(
+                "warning: Conform/Wheels.lean:1:1: dependency warning\n"
+                "warning: EvmYul/Pretty.lean:2:2: dependency warning\n",
+                encoding="utf-8",
+            )
+            baseline_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "total_warnings": 0,
+                        "by_file": {},
+                        "by_message": {},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--log", str(log_path), "--baseline", str(baseline_path)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Lean warnings observed: 0", proc.stdout)
+
     def test_rejects_invalid_baseline_counter_shape(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Summary

- remove all 23 mechanical Lean warnings from Verity-owned source files
- preserve the zero-warning baseline by recognizing root-relative `Conform/` and `EvmYul/` paths emitted by the legacy remote runner as pinned EVMYulLean dependency paths
- add regression coverage for dependency-path classification

The pinned Lean, Mathlib, and EVMYulLean revisions are unchanged. The six remaining raw build warnings come from pinned EVMYulLean sources and are excluded by the existing dependency-warning policy; no baseline bump is needed.

## Files and warning cleanup

| File | Before → after | Category | Change |
|---|---:|---|---|
| `Compiler/Proofs/IRGeneration/GenericInduction/EventBridge.lean` | 4 → 0 | A: dead tactics, unused variables | Remove unreachable tactic alternatives; prefix unused `hcore`/`hinScope` binders. |
| `Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean` | 7 → 0 | A: deprecation, dead tactics, unused variables | Replace `push_neg` with `push Not`; remove two no-op `change` tactics; prefix four unused `hfieldInScope` binders. |
| `Compiler/Proofs/IRGeneration/IRInterpreter.lean` | 1 → 0 | A: dead tactic sequencing | Combine adjacent introductions to remove the never-executed tactic warning. |
| `Compiler/Proofs/IRGeneration/SupportedSpec.lean` | 7 → 0 | A: dead tactics, `<;>` style | Remove unreachable alternatives and replace four sufficient `<;>` sequences with parenthesized `;`. |
| `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeSignedArithLemmas.lean` | 2 → 0 | A: deprecations | Replace `Int.ofNat_eq_coe` with `Int.ofNat_eq_natCast` and `push_neg` with `push Not`. |
| `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanPureBuiltinLemmas.lean` | 1 → 0 | A: unused simp argument | Remove unused `Fin.shiftRight`. |
| `Compiler/Yul/PrettyPrint.lean` | 1 → 0 | A: deprecation | Replace `String.mk` with `String.ofList`. |
| `scripts/check_lean_warning_regression.py` | n/a | CI classification | Recognize legacy root-relative paths from the pinned EVMYulLean dependency. |
| `scripts/test_check_lean_warning_regression.py` | n/a | Regression coverage | Test that `Conform/` and `EvmYul/` source paths are excluded as dependencies. |

Pinned dependency warnings left untouched: `Conform/Wheels.lean` (2), `EvmYul/EVM/Semantics.lean` (1), `EvmYul/Pretty.lean` (2), and `EvmYul/Semantics.lean` (1). These are dependency-owned and not category B acknowledgements.

## Category B

None. No warning baseline bump and no `docs/known-lean-warnings.md` file were needed.

## Verification

- `lake build` — successful: `Build completed successfully (2453 jobs).`
- `python3 scripts/check_lean_warning_regression.py --log /tmp/verity-warning-cleanup-local-build-final.log` — `Lean warnings observed: 0`; baseline check passed
- `make check` — all checks passed; 641 unit tests passed
- `python3 -m unittest scripts.test_check_lean_warning_regression` — 10 tests passed
- Lean hygiene — 0 `sorry`, 0 unexpected hygiene findings, 0 source axioms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof and pretty-print edits are linter-driven with no intended semantic change; CI only broadens which log paths count as dependencies.
>
> **Overview**
> Mechanical cleanup across Verity-owned Lean proofs and tooling to silence linter/compiler warnings without changing proof or compiler behavior.
>
> **Proof scripts** drop redundant tactics (`change` before `simp_wf`, over-broad `all_goals` case splits), rename unused hypothesis binders to `_h…`, simplify a `convert` step in event scratch writes, use `push Not` instead of deprecated `push_neg`, update `Int.ofNat_eq_coe` → `Int.ofNat_eq_natCast`, and trim obsolete `simp` lemmas in Yul backend proofs.
>
> **Yul pretty-printing** builds indent strings via `String.ofList` instead of `String.mk`.
>
> **CI** extends `check_lean_warning_regression.py` to treat legacy remote-runner paths under `Conform/` and `EvmYul/` as dependency warnings (alongside `.lake/packages`), with a new unit test for that classification.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c130395900f148383047c8475a1afb242377b399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
