### PR TITLE
Phase 2 A.2: result-aware external-call loop

### DIFF
--- a/Compiler/Proofs/IRGeneration/GenericInduction/EventBridge.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/EventBridge.lean
@@ -1118,7 +1118,7 @@ private theorem eventUnindexedStores_cons_continue
   rcases hok with ⟨heval, hsupport, hlt, hshape, hsize, hkind⟩
   constructor
   · simp [SourceSemantics.writeUnindexedEventScratchFrom, hkind]
-    convert hwriteTail using 1 <;> first | rfl | simp [eventUnindexedNextMemory]
+    convert hwriteTail using 1 <;> rfl
   · have hstmt :
         scalarEventUnindexedStoresFrom ((param, srcExpr, argExpr) :: rest)
             (wordIdx * 32) =
@@ -2473,8 +2473,8 @@ private theorem eventCollectExprListNames_subset_scope
 
 private theorem eventStmtNextScope_emit_included
     {scope : List String} {eventName : String} {args : List Expr}
-    (hcore : ∀ expr ∈ args, FunctionBody.ExprCompileCore expr)
-    (hinScope : ∀ expr ∈ args, FunctionBody.exprBoundNamesInScope expr scope) :
+    (_hcore : ∀ expr ∈ args, FunctionBody.ExprCompileCore expr)
+    (_hinScope : ∀ expr ∈ args, FunctionBody.exprBoundNamesInScope expr scope) :
     FunctionBody.scopeNamesIncluded
       (stmtNextScope scope (Stmt.emit eventName args)) scope := by
   intro name hmem

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
@@ -787,7 +787,7 @@ theorem findResolvedFieldAtSlotCopyFrom_of_member
             exact Or.inl (List.mem_reverse.mpr htargetInEntries)
           exact (firstFieldWriteSlotConflictCopyFrom_some_of_seen_slot_member
             htargetInSeen hfind hwrite hslot hunpacked) hnoConflict
-        · push_neg at hcapture
+        · push Not at hcapture
           rw [show
             (decide (SourceSemantics.wordNormalize (field.slot.getD idx) =
                 SourceSemantics.wordNormalize targetSlot) ||
@@ -6717,7 +6717,6 @@ theorem compiledStmtStep_ite
           FunctionBody.runtimeStateMatchesIR_setVar_irrelevant
             (name := tempName) (value := condVal) hruntime
         have hElse6 : sizeOf elseIR + 6 ≤ sizeOf compiledIR := by
-          change sizeOf elseIR + 6 ≤ sizeOf compiledIR
           simp_wf
           omega
         let branchExtraFuel :=
@@ -6809,7 +6808,6 @@ theorem compiledStmtStep_ite
           FunctionBody.runtimeStateMatchesIR_setVar_irrelevant
             (name := tempName) (value := condVal) hruntime
         have hThen5 : sizeOf thenIR + 5 ≤ sizeOf compiledIR := by
-          change sizeOf thenIR + 5 ≤ sizeOf compiledIR
           simp_wf
           omega
         let branchExtraFuel :=
@@ -6935,7 +6933,7 @@ private theorem compiledStmtStep_letStorageField
     (hnoConflict : firstFieldWriteSlotConflict fields = none)
     (hfind : findFieldWithResolvedSlot fields fieldName =
       some ({ name := fieldName, ty := FieldType.uint256 }, slot))
-    (hfieldInScope : fieldName ∈ scope) :
+    (_hfieldInScope : fieldName ∈ scope) :
     CompiledStmtStep fields scope (.letVar tmp (Expr.storage fieldName))
       [YulStmt.let_ tmp (YulExpr.call "sload" [YulExpr.lit slot])] where
   compileOk := by
@@ -7012,7 +7010,7 @@ private theorem compiledStmtStep_letStorageAddrField
     (hnoConflict : firstFieldWriteSlotConflict fields = none)
     (hfind : findFieldWithResolvedSlot fields fieldName =
       some ({ name := fieldName, ty := FieldType.address }, slot))
-    (hfieldInScope : fieldName ∈ scope) :
+    (_hfieldInScope : fieldName ∈ scope) :
     CompiledStmtStep fields scope (.letVar tmp (Expr.storageAddr fieldName))
       [YulStmt.let_ tmp (YulExpr.call "sload" [YulExpr.lit slot])] where
   compileOk := by
@@ -7097,7 +7095,7 @@ private theorem compiledStmtStep_assignStorageField
     (hnoConflict : firstFieldWriteSlotConflict fields = none)
     (hfind : findFieldWithResolvedSlot fields fieldName =
       some ({ name := fieldName, ty := FieldType.uint256 }, slot))
-    (hfieldInScope : fieldName ∈ scope) :
+    (_hfieldInScope : fieldName ∈ scope) :
     CompiledStmtStep fields scope (.assignVar name (Expr.storage fieldName))
       [YulStmt.assign name (YulExpr.call "sload" [YulExpr.lit slot])] where
   compileOk := by
@@ -7175,7 +7173,7 @@ private theorem compiledStmtStep_assignStorageAddrField
     (hnoConflict : firstFieldWriteSlotConflict fields = none)
     (hfind : findFieldWithResolvedSlot fields fieldName =
       some ({ name := fieldName, ty := FieldType.address }, slot))
-    (hfieldInScope : fieldName ∈ scope) :
+    (_hfieldInScope : fieldName ∈ scope) :
     CompiledStmtStep fields scope (.assignVar name (Expr.storageAddr fieldName))
       [YulStmt.assign name (YulExpr.call "sload" [YulExpr.lit slot])] where
   compileOk := by

--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -4463,8 +4463,7 @@ theorem interpretIRWithInternalsZeroConservativeExtensionGoal_of_dispatchGoal
     (contract : IRContract) :
     InterpretIRWithInternalsZeroConservativeExtensionDispatchGoal contract →
       InterpretIRWithInternalsZeroConservativeExtensionGoal contract := by
-  intro hdispatch
-  intro hlegacy tx initialState
+  intro hdispatch hlegacy tx initialState
   let stateWithTx := applyIRTransactionContext tx initialState
   cases hfind : contract.functions.find? (·.selector == tx.functionSelector) with
   | none =>

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -5164,7 +5164,7 @@ private theorem stmtTouchesUnsupportedContractSurface_eq_false_of_featureClosed
   | forEach _ _ _ | forEachSetBit _ _ _ => cases hcore
   | setStorageWord _ _ _ => cases hstate
   | _ =>
-      all_goals (simp only [stmtTouchesUnsupportedContractSurface]; first | assumption | cases hcore | cases heffects | cases hcalls)
+      all_goals (simp only [stmtTouchesUnsupportedContractSurface]; assumption)
 termination_by sizeOf stmt
 
 theorem stmtListTouchesUnsupportedContractSurface_eq_false_of_featureClosed
@@ -7565,13 +7565,13 @@ private theorem counter_noFallback :
     ∀ fn ∈ counterSupportedSpecModel.functions, fn.name != "fallback" := by
   intro fn hfn
   simp [counterSupportedSpecModel] at hfn
-  rcases hfn with rfl <;> decide
+  (rcases hfn with rfl; decide)
 
 private theorem counter_noReceive :
     ∀ fn ∈ counterSupportedSpecModel.functions, fn.name != "receive" := by
   intro fn hfn
   simp [counterSupportedSpecModel] at hfn
-  rcases hfn with rfl <;> decide
+  (rcases hfn with rfl; decide)
 
 private def counter_supported_function :
     ∀ fn, fn ∈ counterSupportedSpecModel.functions →
@@ -7664,13 +7664,13 @@ private theorem simpleStorage_noFallback :
     ∀ fn ∈ simpleStorageSupportedSpecModel.functions, fn.name != "fallback" := by
   intro fn hfn
   simp [simpleStorageSupportedSpecModel] at hfn
-  rcases hfn with rfl <;> decide
+  (rcases hfn with rfl; decide)
 
 private theorem simpleStorage_noReceive :
     ∀ fn ∈ simpleStorageSupportedSpecModel.functions, fn.name != "receive" := by
   intro fn hfn
   simp [simpleStorageSupportedSpecModel] at hfn
-  rcases hfn with rfl <;> decide
+  (rcases hfn with rfl; decide)
 
 private def simpleStorage_supported_function :
     ∀ fn, fn ∈ simpleStorageSupportedSpecModel.functions →

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeSignedArithLemmas.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeSignedArithLemmas.lean
@@ -60,7 +60,7 @@ private theorem uint256_fin_mul_neg1_val_of_zero (x : Fin EvmYul.UInt256.size)
 
 private theorem natAbs_ofNat_sub (a b : Nat) (h : a < b) :
     (Int.ofNat a - Int.ofNat b).natAbs = b - a := by
-  simp only [Int.ofNat_eq_coe]
+  simp only [Int.ofNat_eq_natCast]
   rw [show (a : Int) - ((b : Nat) : Int) = -(((b : Nat) : Int) - (a : Int)) from by omega]
   rw [Int.natAbs_neg]
   rw [show ((b : Nat) : Int) - (a : Int) = ((b - a : Nat) : Int) from by omega]
@@ -1181,7 +1181,7 @@ private theorem se_sign_clear (value : Nat) (hvS : value < EvmYul.UInt256.size)
     (h : ¬(EvmYul.UInt256.land ⟨⟨value, hvS⟩⟩ sb ≠
       ⟨⟨0, by rw [EvmYul.UInt256.size]; omega⟩⟩)) :
     value &&& 2^bp = 0 := by
-  push_neg at h
+  push Not at h
   have h1 := se_val_val_of_eq _ _ h
   rw [se_land_val, hsb] at h1
   rwa [Nat.mod_eq_of_lt (Nat.lt_of_le_of_lt Nat.and_le_left hvS)] at h1

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanPureBuiltinLemmas.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanPureBuiltinLemmas.lean
@@ -575,7 +575,7 @@ private theorem evalPureBuiltinViaEvmYulLean_byte_normalized (index value : Nat)
           ⟨255⟩)) = _
     unfold EvmYul.UInt256.shiftRight
     rw [if_neg hguard, hshift]; simp [hgt, EvmYul.UInt256.land, EvmYul.UInt256.toNat,
-      EvmYul.UInt256.ofNat, Id.run, Fin.land, Fin.shiftRight, Fin.ofNat,
+      EvmYul.UInt256.ofNat, Id.run, Fin.land, Fin.ofNat,
       Nat.shiftRight_eq_div_pow]
     rw [show (255 : Nat) % EvmYul.UInt256.size = 255 from by unfold EvmYul.UInt256.size; omega]
     change

--- a/Compiler/Yul/PrettyPrint.lean
+++ b/Compiler/Yul/PrettyPrint.lean
@@ -7,7 +7,7 @@ open YulExpr
 open Compiler.Hex (natToHexUnpadded natToHex)
 
 private def indentStr (n : Nat) : String :=
-  String.mk (List.replicate (n * 4) ' ')
+  String.ofList (List.replicate (n * 4) ' ')
 
 mutual
 def ppExpr : YulExpr → String

--- a/Contracts/Examples/ResultAwareLoop.lean
+++ b/Contracts/Examples/ResultAwareLoop.lean
@@ -1,0 +1,36 @@
+import Verity.Proofs.LoopSimulationResultAware
+
+/-! A two-site external-call loop that stops on failure and reverts on revert. -/
+namespace Contracts.Examples.ResultAwareLoop
+
+open Compiler.CompilationModel.DenoteExternalCalls
+open Verity.Proofs.LoopSimulationResultAware
+
+def first : CallSite :=
+  { siteId := 1, kind := .call, target := 10, gas := 30 }
+
+def second : CallSite :=
+  { siteId := 2, kind := .delegatecall, target := 20, gas := 30 }
+
+/-- Successful calls continue from the observed post-call state, failures stop,
+and external reverts become loop reverts. -/
+def stopOnFailure : Body := fun _ _ observation =>
+  match observation.result with
+  | .success _ => .continue observation.state
+  | .failure _ => .stop observation.state
+  | .revert _ => .revert
+
+/-- A failure at the first site stops the loop before `second` is executed. -/
+example (adversary : AdversaryModel) (state : CallState) (data : List Nat)
+    (hfailure : adversary.result first state.world = .failure data) :
+    execResultAwareForEach adversary stopOnFailure state [first, second] =
+      .stop (denoteCall adversary first state).state := by
+  simp [execResultAwareForEach, stopOnFailure, denoteCall, hfailure]
+
+/-- A revert at the first site is propagated unchanged. -/
+example (adversary : AdversaryModel) (state : CallState) (data : List Nat)
+    (hrevert : adversary.result first state.world = .revert data) :
+    execResultAwareForEach adversary stopOnFailure state [first, second] = .revert := by
+  simp [execResultAwareForEach, stopOnFailure, denoteCall, hrevert]
+
+end Contracts.Examples.ResultAwareLoop

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 .PHONY: help setup setup-elan setup-solc setup-foundry \
         verify verify-packages verify-targeted profile-lean test test-foundry test-python axiom-report \
-        compile generate-yul check test-evmyullean-fork \
+        compile generate-yul check checks test-evmyullean-fork \
         refresh-status all clean
 
 # Pinned versions (must match .github/workflows/verify.yml)
@@ -167,6 +167,8 @@ check: ## Run local CI-equivalent checks job (no Lean build, no solc)
 	python3 scripts/update_doc_numbers.py --check
 	python3 -m unittest discover -s scripts -p 'test_*.py' -v
 	@echo "All checks passed."
+
+checks: check ## Compatibility alias for the CI-equivalent checks job
 
 refresh-status: ## Regenerate verification artifact
 	scripts/refresh_verification_artifacts.sh

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -32,6 +32,7 @@ import Contracts.SimpleToken.Proofs.Isolation
 import Contracts.SimpleToken.Proofs.Supply
 import Contracts.Vault.Proofs.Correctness
 import Contracts.Vault.Proofs.Native
+import Verity.Proofs.LoopSimulationResultAware
 import Verity.Proofs.Stdlib.Automation
 import Verity.Proofs.Stdlib.ListSum
 import Verity.Proofs.Stdlib.MappingAutomation
@@ -604,6 +605,12 @@ end Verity.AxiomAudit
   Contracts.Vault.Proofs.Native.vaultMinimal_functions_bridged
   Contracts.Vault.Proofs.Native.vaultMinimal_runtime_lowers_native
   Contracts.Vault.Proofs.Native.vaultMinimal_totalAssets_nativeResultsMatchOn_revert_of_nonzero_value
+
+  -- Verity/Proofs/LoopSimulationResultAware.lean
+  Verity.Proofs.LoopSimulationResultAware.execResultAwareForEach_append_of_earlyExit
+  Verity.Proofs.LoopSimulationResultAware.forEach_rel_execForEachLoop_result_aware
+  Verity.Proofs.LoopSimulationResultAware.execResultAwareForEach_success_bridge
+  Verity.Proofs.LoopSimulationResultAware.execResultAwareForEach_earlyExit_bridge
 
   -- Verity/Proofs/Stdlib/Automation.lean
   Verity.Proofs.Stdlib.Automation.isSuccess_success
@@ -6569,4 +6576,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6148 theorems/lemmas (4291 public, 1857 private, 0 sorry'd)
+-- Total: 6152 theorems/lemmas (4295 public, 1857 private, 0 sorry'd)

--- a/Verity/Proofs/LoopSimulationResultAware.lean
+++ b/Verity/Proofs/LoopSimulationResultAware.lean
@@ -1,0 +1,186 @@
+import Verity.Proofs.LoopSimulation
+import Verity.Core.Model.DenoteExternalCalls
+
+/-! # Result-aware external-call loops
+
+This complements the total-state loop bridge with a loop that can stop, return,
+or revert after observing an external call. The finite call-site list supplies
+the structural bound while each continuation may depend on the call result.
+-/
+
+namespace Verity.Proofs.LoopSimulationResultAware
+
+open Compiler.CompilationModel.DenoteExternalCalls
+open Compiler.Proofs.IRGeneration.SourceSemantics
+
+/-- The model-side result of one iteration or of the whole loop. -/
+inductive IterOutcome (α : Type) where
+  | continue (state : α)
+  | stop (state : α)
+  | return (value : Nat) (state : α)
+  | revert
+
+/-- A result-aware body sees the pre-call state, site, and full observation. -/
+abbrev Body := CallState → CallSite → CallObservation → IterOutcome CallState
+
+/-- Execute one external call per site until exhaustion or an early result. -/
+def execResultAwareForEach (adversary : AdversaryModel) (body : Body) :
+    CallState → List CallSite → IterOutcome CallState
+  | state, [] => .continue state
+  | state, site :: sites =>
+      let observation := denoteCall adversary site state
+      match body state site observation with
+      | .continue next => execResultAwareForEach adversary body next sites
+      | .stop next => .stop next
+      | .return value next => .return value next
+      | .revert => .revert
+
+/-- Relate every executable result to its model-side counterpart. -/
+def OutcomeRel (rel : RuntimeState → CallState → Prop) :
+    StmtResult → IterOutcome CallState → Prop
+  | .continue runtime, .continue model => rel runtime model
+  | .stop runtime, .stop model => rel runtime model
+  | .return runtimeValue runtime, .return modelValue model =>
+      runtimeValue = modelValue ∧ rel runtime model
+  | .revert, .revert => True
+  | _, _ => False
+
+/-- A model outcome is an early exit exactly when it is not `continue`. -/
+def IterOutcome.IsEarlyExit : IterOutcome α → Prop
+  | .continue _ => False
+  | .stop _ | .return _ _ | .revert => True
+
+/-- The matching executable-result predicate. -/
+def stmtResultIsEarlyExit : StmtResult → Prop
+  | .continue _ => False
+  | .stop _ | .return _ _ | .revert => True
+
+/-- Once a prefix exits, appending sites cannot change its result. -/
+theorem execResultAwareForEach_append_of_earlyExit
+    (adversary : AdversaryModel) (body : Body)
+    (state : CallState) (visited suffix : List CallSite)
+    (outcome : IterOutcome CallState)
+    (hexec : execResultAwareForEach adversary body state visited = outcome)
+    (hearly : outcome.IsEarlyExit) :
+    execResultAwareForEach adversary body state (visited ++ suffix) = outcome := by
+  induction visited generalizing state with
+  | nil =>
+      simp [execResultAwareForEach] at hexec
+      subst outcome
+      exact False.elim hearly
+  | cons site sites ih =>
+      simp only [List.cons_append, execResultAwareForEach] at hexec ⊢
+      cases hbody : body state site (denoteCall adversary site state) with
+      | «continue» next =>
+          simp only [hbody] at hexec ⊢
+          exact ih next hexec
+      | stop next => simpa only [hbody] using hexec
+      | «return» value next => simpa only [hbody] using hexec
+      | revert => simpa only [hbody] using hexec
+
+/-- Core bridge. Local body correspondence relates the complete loops,
+including all three early-result constructors. -/
+theorem forEach_rel_execForEachLoop_result_aware
+    (rel : RuntimeState → CallState → Prop)
+    (varName : String)
+    (runBody : RuntimeState → StmtResult)
+    (adversary : AdversaryModel) (body : Body)
+    (hbody : ∀ runtime model index site, rel runtime model →
+      OutcomeRel rel
+        (runBody
+          { runtime with bindings := (
+              Compiler.Proofs.IRGeneration.SourceSemantics.bindValue
+                runtime.bindings varName
+                (Compiler.Proofs.IRGeneration.SourceSemantics.wordNormalize index)) })
+        (body model site (denoteCall adversary site model)))
+    (runtime : RuntimeState) (model : CallState)
+    (index : Nat) (sites : List CallSite) (hinit : rel runtime model) :
+    OutcomeRel rel
+      (execForEachLoop varName runBody runtime index sites.length)
+      (execResultAwareForEach adversary body model sites) := by
+  induction sites generalizing runtime model index with
+  | nil => simpa [execResultAwareForEach, OutcomeRel] using hinit
+  | cons site sites ih =>
+      have hlocal := hbody runtime model index site hinit
+      simp only [List.length_cons, execForEachLoop,
+        execResultAwareForEach]
+      cases hsource : runBody
+          { runtime with bindings := (
+              Compiler.Proofs.IRGeneration.SourceSemantics.bindValue
+                runtime.bindings varName
+                (Compiler.Proofs.IRGeneration.SourceSemantics.wordNormalize index)) } <;>
+        cases hmodel : body model site (denoteCall adversary site model) <;>
+        simp only [hsource, hmodel, OutcomeRel] at hlocal ⊢
+      · exact ih _ _ (index + 1) hlocal
+      · exact hlocal
+      · exact hlocal
+
+/-- If the model loop continues, so does `execForEachLoop`, with related final
+states. -/
+theorem execResultAwareForEach_success_bridge
+    (rel : RuntimeState → CallState → Prop)
+    (varName : String)
+    (runBody : RuntimeState → StmtResult)
+    (adversary : AdversaryModel) (body : Body)
+    (hbody : ∀ runtime model index site, rel runtime model →
+      OutcomeRel rel
+        (runBody
+          { runtime with bindings := (
+              Compiler.Proofs.IRGeneration.SourceSemantics.bindValue
+                runtime.bindings varName
+                (Compiler.Proofs.IRGeneration.SourceSemantics.wordNormalize index)) })
+        (body model site (denoteCall adversary site model)))
+    (runtime : RuntimeState) (model finalModel : CallState)
+    (index : Nat) (sites : List CallSite) (hinit : rel runtime model)
+    (hmodel : execResultAwareForEach adversary body model sites = .continue finalModel) :
+    ∃ finalRuntime,
+      execForEachLoop varName runBody runtime index sites.length =
+          .continue finalRuntime ∧
+      rel finalRuntime finalModel := by
+  have hsound := forEach_rel_execForEachLoop_result_aware
+    rel varName runBody adversary body hbody runtime model index sites hinit
+  rw [hmodel] at hsound
+  cases hsource : execForEachLoop varName runBody runtime index sites.length with
+  | «continue» finalRuntime =>
+      simp [hsource, OutcomeRel] at hsound
+      exact ⟨finalRuntime, rfl, hsound⟩
+  | stop finalRuntime => simp [hsource, OutcomeRel] at hsound
+  | «return» value finalRuntime => simp [hsource, OutcomeRel] at hsound
+  | revert => simp [hsource, OutcomeRel] at hsound
+
+/-- If the model stops, returns, or reverts, the executable loop has the same
+result constructor and return value, with related carried states. -/
+theorem execResultAwareForEach_earlyExit_bridge
+    (rel : RuntimeState → CallState → Prop)
+    (varName : String)
+    (runBody : RuntimeState → StmtResult)
+    (adversary : AdversaryModel) (body : Body)
+    (hbody : ∀ runtime model index site, rel runtime model →
+      OutcomeRel rel
+        (runBody
+          { runtime with bindings := (
+              Compiler.Proofs.IRGeneration.SourceSemantics.bindValue
+                runtime.bindings varName
+                (Compiler.Proofs.IRGeneration.SourceSemantics.wordNormalize index)) })
+        (body model site (denoteCall adversary site model)))
+    (runtime : RuntimeState) (model : CallState)
+    (index : Nat) (sites : List CallSite) (hinit : rel runtime model)
+    (hearly : (execResultAwareForEach adversary body model sites).IsEarlyExit) :
+    stmtResultIsEarlyExit
+        (execForEachLoop varName runBody runtime index sites.length) ∧
+      OutcomeRel rel
+        (execForEachLoop varName runBody runtime index sites.length)
+        (execResultAwareForEach adversary body model sites) := by
+  have hsound := forEach_rel_execForEachLoop_result_aware
+    rel varName runBody adversary body hbody runtime model index sites hinit
+  generalize hsource : execForEachLoop varName runBody runtime index sites.length =
+      sourceOutcome at hsound ⊢
+  generalize hmodel : execResultAwareForEach adversary body model sites =
+      modelOutcome at hsound hearly ⊢
+  constructor
+  · cases sourceOutcome <;> cases modelOutcome <;>
+      simp [OutcomeRel, stmtResultIsEarlyExit, IterOutcome.IsEarlyExit]
+        at hsound hearly ⊢
+  · exact hsound
+
+end Verity.Proofs.LoopSimulationResultAware

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -17,7 +17,8 @@ lean_lib «Verity» where
     .submodules `Verity.Stdlib,
     .andSubmodules `Verity.Specs.Common,
     .submodules `Verity.Proofs.Stdlib,
-    .one `Verity.Proofs.LoopSimulation
+    .one `Verity.Proofs.LoopSimulation,
+    .one `Verity.Proofs.LoopSimulationResultAware
   ]
 
 lean_lib «Contracts» where

--- a/scripts/check_lean_warning_regression.py
+++ b/scripts/check_lean_warning_regression.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from property_utils import ROOT
 
 WARNING_RE = re.compile(r"^warning:\s+(.+?\.lean):\d+:\d+:\s+(.*)$")
+DEPENDENCY_SOURCE_PREFIXES = ("Conform/", "EvmYul/")
 
 
 def parse_warnings(log_path: Path) -> tuple[Counter[str], Counter[str]]:
@@ -35,9 +36,8 @@ def parse_warnings(log_path: Path) -> tuple[Counter[str], Counter[str]]:
             continue
         file_path, message = match.groups()
         # Skip warnings from dependency packages — we only track our own code.
-        # Match both absolute paths (``/.lake/packages/…``) and relative paths
-        # (``.lake/packages/…``, ``lake-packages/…``) to cover every form Lean
-        # may emit depending on the working directory.
+        # Match both package-directory paths and the source-root-relative paths
+        # emitted by the legacy remote runner for the pinned EVMYulLean package.
         if (
             "/lake-packages/" in file_path
             or "/.lake/packages/" in file_path
@@ -45,6 +45,7 @@ def parse_warnings(log_path: Path) -> tuple[Counter[str], Counter[str]]:
             or file_path.startswith(".lake/packages/")
             or file_path.startswith("./lake-packages/")
             or file_path.startswith("./.lake/packages/")
+            or file_path.startswith(DEPENDENCY_SOURCE_PREFIXES)
         ):
             continue
         by_file[file_path] += 1

--- a/scripts/test_check_lean_warning_regression.py
+++ b/scripts/test_check_lean_warning_regression.py
@@ -74,6 +74,39 @@ class CheckLeanWarningRegressionScriptTests(unittest.TestCase):
             self.assertNotEqual(proc.returncode, 0)
             self.assertIn("Total Lean warnings drifted: observed 0, baseline 1", proc.stderr)
 
+    def test_ignores_legacy_runner_dependency_source_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            log_path = root / "lake-build.log"
+            baseline_path = root / "lean_warning_baseline.json"
+            log_path.write_text(
+                "warning: Conform/Wheels.lean:1:1: dependency warning\n"
+                "warning: EvmYul/Pretty.lean:2:2: dependency warning\n",
+                encoding="utf-8",
+            )
+            baseline_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "total_warnings": 0,
+                        "by_file": {},
+                        "by_message": {},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--log", str(log_path), "--baseline", str(baseline_path)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Lean warnings observed: 0", proc.stdout)
+
     def test_rejects_invalid_baseline_counter_shape(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Summary

- add `IterOutcome`, a call-observation-aware `Body`, and list-driven `execResultAwareForEach`
- relate the model loop to `SourceSemantics.execForEachLoop` across `.continue`, `.stop`, `.return`, and `.revert`
- add `execResultAwareForEach_append_of_earlyExit`
- add `forEach_rel_execForEachLoop_result_aware`
- add `execResultAwareForEach_success_bridge`
- add `execResultAwareForEach_earlyExit_bridge`
- add a two-site worked example for failure and revert propagation
- add a `make checks` compatibility alias for the repository's existing `make check` gate

Addresses https://github.com/lfglabs-dev/verity/issues/2234 (Phase A.2).

## Verification

- `lake build` (2454 jobs, exit 0)
- `make checks` (640 tests, exit 0)
- `PrintAxioms.lean`: new theorems depend on at most `propext`; no new axioms beyond the allowed `propext` and `Quot.sound`
- forbidden `sorry` / `admit` / `axiom` / `unsafe` scan on the new Lean files is clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New proof library and examples; remaining edits are tactic/API and CI tooling with no runtime or auth impact.
> 
> **Overview**
> Introduces **`Verity.Proofs.LoopSimulationResultAware`**: `IterOutcome`, observation-driven **`execResultAwareForEach`**, and **`OutcomeRel`** linking the model to **`SourceSemantics.execForEachLoop`** for **continue, stop, return, and revert**, with append-on-early-exit and success/early-exit bridge theorems. **`Contracts.Examples.ResultAwareLoop`** gives a two-site example (failure stops before the second call; revert propagates). Wiring adds the module to **`lakefile.lean`** and **`PrintAxioms.lean`**.
> 
> Elsewhere the diff is mostly **Lean 4 / Mathlib compatibility** (`push Not`, `Int.ofNat_eq_natCast`, `String.ofList`, minor proof simplifications) and **CI hygiene** (`make checks` alias; warning regression ignores legacy `Conform/` / `EvmYul/` paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4185bdf21ba06f89c548cf713c9a8072cda901e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->