### PR TITLE
Phase 2 B.3: model top-up allocation storage

### DIFF
--- a/Compiler/Proofs/Storage/StructArrayStorage.lean
+++ b/Compiler/Proofs/Storage/StructArrayStorage.lean
@@ -578,7 +578,7 @@ theorem setStructMember_exec_matches_canonical_target
   · simp [SourceSemantics.execStmt, hslots, hmembers, findStructMember,
       structBridgeMember, sourceStructMemberWriteState, sourceStructMemberWriteWorld,
       SourceSemantics.evalExpr,
-      SourceSemantics.wordNormalize_eq_mod,
+      SourceSemantics.wordNormalize_eq_mod, Nat.mod_eq_of_lt hkey,
       Nat.mod_eq_of_lt hvalue]
   · simp [applyStateRewrite, StructMemberCoherent, sourceStructMemberWriteWorld,
       SourceSemantics.writeAddressKeyedMappingWordFieldSlots,

--- a/Compiler/Proofs/Storage/StructArrayStorage.lean
+++ b/Compiler/Proofs/Storage/StructArrayStorage.lean
@@ -485,8 +485,7 @@ theorem structMember_eq_sourceEval (storage : SolidityStorage)
   rw [SourceSemantics.evalExpr]
   simp only [SourceSemantics.evalExpr, hfield, hmembers, structBridgeMember,
     SourceSemantics.wordNormalize_eq_mod, Nat.mod_eq_of_lt hkey]
-  simp only [findStructMember, structBridgeField, SourceSemantics.readFieldWord,
-    Option.getD_some]
+  simp only [findStructMember, structBridgeField, SourceSemantics.readFieldWord]
   simpa [StructMemberCoherent, structMemberPointer_eq_abstractMappingSlot] using hcoherent
 
 /-- The semantic value of a packed member extracted from its canonical raw
@@ -571,25 +570,22 @@ theorem setStructMember_exec_matches_canonical_target
       "__struct_bridge" = some [baseSlot] := rfl
   have hmembers : findStructMembers [structBridgeField baseSlot wordOffset]
       "__struct_bridge" = some [structBridgeMember wordOffset] := rfl
-  have hmember : findStructMember [structBridgeMember wordOffset]
-      "__struct_bridge_member" = some (structBridgeMember wordOffset) := rfl
   have hfield : findFieldWithResolvedSlot [structBridgeField baseSlot wordOffset]
       "__struct_bridge" = some (structBridgeField baseSlot wordOffset, baseSlot) := rfl
   have htrans : SourceSemantics.fieldIsTransient [structBridgeField baseSlot wordOffset]
       "__struct_bridge" = false := rfl
   constructor
-  · simp [SourceSemantics.execStmt, hslots, hmembers, hmember, findStructMember,
+  · simp [SourceSemantics.execStmt, hslots, hmembers, findStructMember,
       structBridgeMember, sourceStructMemberWriteState, sourceStructMemberWriteWorld,
       SourceSemantics.evalExpr,
-      SourceSemantics.wordNormalize_eq_mod, Nat.mod_eq_of_lt hkey,
+      SourceSemantics.wordNormalize_eq_mod,
       Nat.mod_eq_of_lt hvalue]
   · simp [applyStateRewrite, StructMemberCoherent, sourceStructMemberWriteWorld,
       SourceSemantics.writeAddressKeyedMappingWordFieldSlots,
       SourceSemantics.writeMappingTargets, htrans,
       Verity.Core.UINT256_MODULUS, Compiler.Constants.evmModulus,
       Compiler.Proofs.abstractMappingSlot,
-      SourceSemantics.wordNormalize_eq_mod, Nat.mod_eq_of_lt hkey,
-      Nat.mod_eq_of_lt hvalue]
+      SourceSemantics.wordNormalize_eq_mod, Nat.mod_eq_of_lt hvalue]
 
 /-- Packed assignment is parameterized by the old canonical word, member
     location and bit layout.  Its canonical target is the complete
@@ -613,14 +609,12 @@ theorem setPackedStructMember_exec_matches_canonical_target
       "__packed_struct_bridge" = some [baseSlot] := rfl
   have hmembers : findStructMembers [packedStructBridgeField baseSlot wordOffset packed] "__packed_struct_bridge" =
       some [packedStructBridgeMember wordOffset packed] := rfl
-  have hmember : findStructMember [packedStructBridgeMember wordOffset packed] "__packed_struct_bridge_member" =
-      some (packedStructBridgeMember wordOffset packed) := rfl
   have hfield : findFieldWithResolvedSlot [packedStructBridgeField baseSlot wordOffset packed] "__packed_struct_bridge" =
       some (packedStructBridgeField baseSlot wordOffset packed, baseSlot) := rfl
   have htrans : SourceSemantics.fieldIsTransient [packedStructBridgeField baseSlot wordOffset packed]
       "__packed_struct_bridge" = false := rfl
   constructor
-  · simp [SourceSemantics.execStmt, hslots, hmembers, hmember, findStructMember,
+  · simp [SourceSemantics.execStmt, hslots, hmembers, findStructMember,
       packedStructBridgeMember, sourcePackedStructMemberWriteState, sourcePackedStructMemberWriteWorld,
       SourceSemantics.evalExpr, SourceSemantics.wordNormalize_eq_mod,
       Nat.mod_eq_of_lt hkey, Nat.mod_eq_of_lt hvalue, hvalid]
@@ -631,8 +625,7 @@ theorem setPackedStructMember_exec_matches_canonical_target
       SourceSemantics.writeAddressKeyedMappingPackedWordSlots, htrans, SourceSemantics.packedWordWrite,
       Verity.Core.UINT256_MODULUS, Compiler.Constants.evmModulus,
       Compiler.Proofs.abstractMappingSlot,
-      SourceSemantics.wordNormalize_eq_mod,
-      Nat.mod_eq_of_lt hkey, Nat.mod_eq_of_lt hvalue]
+      SourceSemantics.wordNormalize_eq_mod]
     rw [hcoherent]
 
 /-! ## Dynamic storage arrays
@@ -1292,7 +1285,7 @@ theorem setStorageArrayElement_exec_preserved
     simp only [arrayBridgeField]
     simp [SourceSemantics.evalExpr, SourceSemantics.wordNormalize_eq_mod,
       Nat.mod_eq_of_lt hindex, Nat.mod_eq_of_lt hvalue, arrayBridgeState, hset]
-  · simp [applyStateRewrite, storageArrayElementWrite, applyStorageWrite]
+  · simp [applyStateRewrite, storageArrayElementWrite]
 
 /-- Executable push appends at the source length, while the interpreted Yul
     writes that same element index and the same non-overflowing new length. -/
@@ -1300,7 +1293,7 @@ theorem pushStorageArray_exec_preserved
     (storage : SolidityStorage) (currentContract slot value : Nat)
     (values : List Verity.Core.Uint256)
     (hvalue : value < Compiler.Constants.evmModulus)
-    (hroom : values.length + 1 < Compiler.Constants.evmModulus)
+    (_hroom : values.length + 1 < Compiler.Constants.evmModulus)
     (hdistinct : storageArrayElementPointer slot values.length ≠ slotPointer slot) :
     SourceSemantics.execStmt [arrayBridgeField slot] (arrayBridgeState slot values)
         (.storageArrayPush "__array_bridge" (.literal value)) =
@@ -1323,10 +1316,8 @@ theorem pushStorageArray_exec_preserved
       Nat.mod_eq_of_lt hvalue, arrayBridgeState]
   · dsimp
     constructor
-    · simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite,
-        applyStorageWrite, hdistinct]
-    · simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite,
-        applyStorageWrite]
+    · simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite, hdistinct]
+    · simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite]
 
 /-- Executable pop reverts exactly for the empty source array.  The compiled
     interpreter independently observes the same empty condition from canonical
@@ -1372,10 +1363,8 @@ theorem popStorageArray_exec_preserved
     simp [arrayBridgeField, arrayBridgeState, hdrop]
   · dsimp
     constructor
-    · simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite,
-        applyStorageWrite, hdistinct]
-    · simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite,
-        applyStorageWrite]
+    · simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite, hdistinct]
+    · simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite]
 
 /-! ### End-to-end executable/canonical transition bridges
 
@@ -1414,7 +1403,7 @@ theorem setStorageArrayElement_compiled_exec_coherent
     · exact (setStorageArrayElement_exec_preserved storage currentContract slot index value
         values updated hword hvalue hset).1
     · constructor
-      · simp [applyStateRewrite, storageArrayElementWrite, applyStorageWrite,
+      · simp [applyStateRewrite, storageArrayElementWrite,
           Ne.symm hlengthSlot, SourceSemantics.writeStorageArray,
           sourceStorageArraySetAt_length values updated index value hset]
         simpa [arrayBridgeState] using hcoherent.1
@@ -1424,11 +1413,11 @@ theorem setStorageArrayElement_compiled_exec_coherent
         · subst j
           have hsame := sourceStorageArraySetAt_getElem?_same values updated index value hset
           rw [hsame] at hj; simp at hj; subst x
-          simp [applyStateRewrite, storageArrayElementWrite, applyStorageWrite,
-            IRStorageWord.ofNat_toNat, Verity.Core.UINT256_MODULUS,
+          simp [applyStateRewrite, storageArrayElementWrite,
+            Verity.Core.UINT256_MODULUS,
             Compiler.Constants.evmModulus, Nat.mod_eq_of_lt hvalue]
         · have hsep := helementSlots j (List.getElem?_eq_some_iff.mp hj).1 hji
-          simp [applyStateRewrite, storageArrayElementWrite, applyStorageWrite, hsep]
+          simp [applyStateRewrite, storageArrayElementWrite, hsep]
           apply hcoherent.2 j x
           simpa [arrayBridgeState] using sourceStorageArraySetAt_getElem?_of_ne
             values updated index j value x hset hji hj
@@ -1461,14 +1450,13 @@ theorem pushStorageArray_compiled_exec_coherent
         hvalue hroom hdistinct).1
     · constructor
       · simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite,
-          applyStorageWrite, SourceSemantics.writeStorageArray,
-          Verity.Core.UINT256_MODULUS, Compiler.Constants.evmModulus,
+          SourceSemantics.writeStorageArray, Verity.Core.UINT256_MODULUS,
           Nat.mod_eq_of_lt hroom]
       · intro j x hj; simp [SourceSemantics.writeStorageArray] at hj
         by_cases hjlast : j = values.length
         · subst j; simp at hj; subst x
           simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite,
-            applyStorageWrite, hdistinct, IRStorageWord.ofNat_toNat,
+            hdistinct,
             Verity.Core.UINT256_MODULUS, Compiler.Constants.evmModulus,
             Nat.mod_eq_of_lt hvalue]
         · have hjlt : j < values.length := by
@@ -1476,7 +1464,7 @@ theorem pushStorageArray_compiled_exec_coherent
             simp at this; omega
           have hsep := helementSlots j hjlt; have hlengthSep := hlengthElements j hjlt
           simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite,
-            applyStorageWrite, hsep, hlengthSep]
+            hsep, hlengthSep]
           apply hcoherent.2 j x
           have hx : values[j] = x := by simpa [List.getElem?_append, hjlt] using hj
           have hold : values[j]? = some x := by rw [List.getElem?_eq_getElem hjlt, hx]
@@ -1510,8 +1498,7 @@ theorem popStorageArray_compiled_exec_coherent
     change updated.length < 2 ^ 256
     have hwordlt := IRStorageWord.toNat_lt_size (storage currentContract (slotPointer slot))
     rw [hlength, ← hlen] at hwordlt
-    simp [EvmYul.UInt256.size, Compiler.Constants.evmModulus,
-      Verity.Core.UINT256_MODULUS] at hwordlt
+    simp [EvmYul.UInt256.size] at hwordlt
     omega
   constructor
   · simpa [hnew] using popStorageArray_eq_compiledStorageArrayPop storage currentContract slot hnonempty
@@ -1520,14 +1507,13 @@ theorem popStorageArray_compiled_exec_coherent
         hdrop hdistinct).1
     · constructor
       · simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite,
-          applyStorageWrite, SourceSemantics.writeStorageArray,
-          Verity.Core.UINT256_MODULUS, Compiler.Constants.evmModulus,
+          SourceSemantics.writeStorageArray, Verity.Core.UINT256_MODULUS,
           Nat.mod_eq_of_lt hupdatedRoom]
       · intro j x hj; simp [SourceSemantics.writeStorageArray] at hj
         have hjlt := (List.getElem?_eq_some_iff.mp hj).1
         have hsep := helementSlots j hjlt; have hlengthSep := hlengthElements j hjlt
         simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite,
-          applyStorageWrite, hsep, hlengthSep]
+          hsep, hlengthSep]
         apply hcoherent.2 j x; simpa [arrayBridgeState] using
           sourceStorageArrayDropLast_getElem? values updated j x hdrop hj
 

--- a/Contracts/ERC20/Proofs/Basic.lean
+++ b/Contracts/ERC20/Proofs/Basic.lean
@@ -94,6 +94,7 @@ private theorem mint_unfold (s : ContractState) (toAddr : Address) (amount : Uin
     (mint toAddr amount).run s = ContractResult.success ()
       { «storage» := fun slotIdx =>
           if slotIdx == 1 then EVM.Uint256.add (s.storage 1) amount else s.storage slotIdx,
+        contractStorage := s.contractStorage,
         transientStorage := s.transientStorage,
         storageAddr := s.storageAddr,
         storageMap := fun slotIdx addr =>
@@ -190,6 +191,7 @@ private theorem transfer_unfold_other (s : ContractState) (toAddr : Address) (am
     (h_no_overflow : (s.storageMap 2 toAddr : Nat) + (amount : Nat) ≤ MAX_UINT256) :
     (transfer toAddr amount).run s = ContractResult.success ()
       { «storage» := s.storage,
+        contractStorage := s.contractStorage,
         transientStorage := s.transientStorage,
         storageAddr := s.storageAddr,
         storageMap := fun slotIdx addr =>

--- a/Contracts/Ledger/Proofs/Basic.lean
+++ b/Contracts/Ledger/Proofs/Basic.lean
@@ -48,6 +48,7 @@ theorem getBalance_preserves_state (s : ContractState) (addr : Address) :
 private theorem deposit_unfold (s : ContractState) (amount : Uint256) :
     (deposit amount).run s = ContractResult.success ()
     { «storage» := s.storage,
+      contractStorage := s.contractStorage,
       transientStorage := s.transientStorage,
       storageAddr := s.storageAddr,
       storageMap := fun slotIdx addr =>
@@ -108,6 +109,7 @@ private theorem withdraw_unfold (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :
   (withdraw amount).run s = ContractResult.success ()
     { «storage» := s.storage,
+      contractStorage := s.contractStorage,
       transientStorage := s.transientStorage,
       storageAddr := s.storageAddr,
       storageMap := fun slotIdx addr =>
@@ -180,6 +182,7 @@ private theorem transfer_unfold_other (s : ContractState) (toAddr : Address) (am
   (h_ne : s.sender ≠ toAddr) :
   (transfer toAddr amount).run s = ContractResult.success ()
     { «storage» := s.storage,
+      contractStorage := s.contractStorage,
       transientStorage := s.transientStorage,
       storageAddr := s.storageAddr,
       storageMap := fun slotIdx addr =>
@@ -285,6 +288,7 @@ theorem transfer_succeeds_recipient_overflow (s : ContractState) (toAddr : Addre
   ∃ s', (transfer toAddr amount).run s = ContractResult.success () s' := by
   let s' : ContractState :=
     { «storage» := s.storage,
+      contractStorage := s.contractStorage,
       transientStorage := s.transientStorage,
       storageAddr := s.storageAddr,
       storageMap := fun slotIdx addr =>

--- a/Contracts/Owned/Proofs/Basic.lean
+++ b/Contracts/Owned/Proofs/Basic.lean
@@ -123,6 +123,7 @@ theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) :
   (transferOwnership newOwner).run s = ContractResult.success ()
     { «storage» := s.storage,
+      contractStorage := s.contractStorage,
       transientStorage := s.transientStorage,
       storageAddr := fun slotIdx => if (slotIdx == 0) = true then newOwner else s.storageAddr slotIdx,
       storageMap := s.storageMap,

--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -112,6 +112,7 @@ theorem increment_unfold (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
   (increment.run s) = ContractResult.success ()
     { «storage» := fun slotIdx => if (slotIdx == 1) = true then EVM.Uint256.add (s.storage 1) 1 else s.storage slotIdx,
+      contractStorage := s.contractStorage,
       transientStorage := s.transientStorage,
       storageAddr := s.storageAddr,
       storageMap := s.storageMap,
@@ -166,6 +167,7 @@ theorem decrement_unfold (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
   (decrement.run s) = ContractResult.success ()
     { «storage» := fun slotIdx => if (slotIdx == 1) = true then EVM.Uint256.sub (s.storage 1) 1 else s.storage slotIdx,
+      contractStorage := s.contractStorage,
       transientStorage := s.transientStorage,
       storageAddr := s.storageAddr,
       storageMap := s.storageMap,
@@ -219,6 +221,7 @@ theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) :
   (transferOwnership newOwner).run s = ContractResult.success ()
     { «storage» := s.storage,
+      contractStorage := s.contractStorage,
       transientStorage := s.transientStorage,
       storageAddr := fun slotIdx => if (slotIdx == 0) = true then newOwner else s.storageAddr slotIdx,
       storageMap := s.storageMap,

--- a/Contracts/SafeCounter/Proofs/Basic.lean
+++ b/Contracts/SafeCounter/Proofs/Basic.lean
@@ -57,6 +57,7 @@ private theorem increment_unfold (s : ContractState)
   (h_no_overflow : (s.storage 0 : Nat) + 1 ≤ MAX_UINT256) :
   (increment).run s = ContractResult.success ()
     { «storage» := fun k => if (k == 0) = true then s.storage 0 + 1 else s.storage k,
+      contractStorage := s.contractStorage,
       transientStorage := s.transientStorage,
       storageAddr := s.storageAddr,
       storageMap := s.storageMap,
@@ -124,6 +125,7 @@ private theorem decrement_unfold (s : ContractState)
   (h_no_underflow : (s.storage 0 : Nat) ≥ 1) :
   (decrement).run s = ContractResult.success ()
     { «storage» := fun k => if (k == 0) = true then s.storage 0 - 1 else s.storage k,
+      contractStorage := s.contractStorage,
       transientStorage := s.transientStorage,
       storageAddr := s.storageAddr,
       storageMap := s.storageMap,

--- a/Contracts/SimpleToken/Proofs/Basic.lean
+++ b/Contracts/SimpleToken/Proofs/Basic.lean
@@ -173,7 +173,6 @@ private theorem mint_unfold (s : ContractState) (toAddr : Address) (amount : Uin
   simp only [Contracts.SimpleToken.onlyOwner, isOwner,
     Contracts.SimpleToken.ownerSlot, Contracts.SimpleToken.balancesSlot,
     Contracts.SimpleToken.totalSupplySlot, h_owner, beq_self_eq_true, ite_true]
-  -- Unfold and rewrite safeAdd results for both checks
   unfold requireSomeUint
   rw [h_safe_bal]
   simp only [Verity.pure, Pure.pure, Verity.bind, Bind.bind,

--- a/Contracts/SimpleToken/Proofs/Basic.lean
+++ b/Contracts/SimpleToken/Proofs/Basic.lean
@@ -142,6 +142,7 @@ private theorem mint_unfold (s : ContractState) (toAddr : Address) (amount : Uin
   (mint toAddr amount).run s = ContractResult.success ()
     { «storage» := fun slotIdx =>
         if (slotIdx == 2) = true then EVM.Uint256.add (s.storage 2) amount else s.storage slotIdx,
+        contractStorage := s.contractStorage,
         transientStorage := s.transientStorage,
         storageAddr := s.storageAddr,
         storageMap := fun slotIdx addr =>
@@ -284,6 +285,7 @@ private theorem transfer_unfold_other (s : ContractState) (toAddr : Address) (am
   (h_no_overflow : (s.storageMap 1 toAddr : Nat) + (amount : Nat) ≤ MAX_UINT256) :
   (transfer toAddr amount).run s = ContractResult.success ()
     { «storage» := s.storage,
+        contractStorage := s.contractStorage,
         transientStorage := s.transientStorage,
         storageAddr := s.storageAddr,
         storageMap := fun slotIdx addr =>

--- a/Verity/Core/Model/TopupAllocation.lean
+++ b/Verity/Core/Model/TopupAllocation.lean
@@ -1,0 +1,148 @@
+import Verity.Core.Model.AllocationExtraction
+import Compiler.Proofs.Storage.StructArrayStorage
+
+/-!
+# Top-up allocation and two-word storage bounds
+
+This module specializes allocation extraction to the two canonical words rooted
+at `TopUpGateway.GATEWAY_STORAGE_POSITION` in the pinned Solidity source.  It
+also records the arithmetic and packed-word obligations needed by the deposit
+flow without extending the trusted base.
+-/
+
+namespace Verity.Core.Model.TopupAllocation
+
+open Compiler.CompilationModel
+open Compiler.Proofs.Storage
+open Verity.Core.Model.AllocationExtraction
+
+/-- `keccak256(abi.encode(uint256(keccak256("lido.TopUpGateway.storage")) - 1))
+    & ~bytes32(uint256(0xff))`, as pinned by `TopUpGateway.sol`. -/
+def gatewayStoragePosition : Nat :=
+  0x22e512057841e2bc1e6d80030c8bb8b4935377af2e64ba9bf8e6a3e88fb32200
+
+def gatewayWord0Slot : ByteArray := slotPointer gatewayStoragePosition
+
+def gatewayWord1Slot : ByteArray := slotPointer (gatewayStoragePosition + 1)
+
+/-- The two words of the TopUpGateway namespaced-storage footprint. -/
+inductive GatewayWord where
+  | word0
+  | word1
+  deriving Repr, DecidableEq
+
+/-- Classify a canonical allocation entry when it belongs to the gateway's
+    two-word namespace. -/
+def classifyGatewayWord (entry : AllocEntry) : Option GatewayWord :=
+  if entry.slot = gatewayStoragePosition then some .word0
+  else if entry.slot = gatewayStoragePosition + 1 then some .word1
+  else none
+
+/-- Typed view of the allocation extracted for the TopUpGateway deposit flow.
+    `raw` retains the complete extractor result; `namespaceSlots` contains only
+    the two words owned by this namespace, tagged by word. -/
+structure GatewayAllocation where
+  raw : Allocation
+  namespaceSlots : List (AllocEntry × GatewayWord)
+
+/-- Specialize the canonical allocation extractor to TopUpGateway's two-word
+    deposit namespace. -/
+def extractGatewayAllocation (spec : CompilationModel) (fn : FunctionSpec) :
+    GatewayAllocation :=
+  let allocation := extractAllocation spec fn
+  { raw := allocation
+    namespaceSlots := allocation.slots.filterMap fun entry =>
+      (classifyGatewayWord entry).map (entry, ·) }
+
+theorem extractGatewayAllocation_raw
+    (spec : CompilationModel) (fn : FunctionSpec) :
+    (extractGatewayAllocation spec fn).raw = extractAllocation spec fn := by
+  rfl
+
+/-- Every typed namespace entry comes from the canonical extraction result. -/
+theorem extractGatewayAllocation_namespace_mem_raw
+    (spec : CompilationModel) (fn : FunctionSpec)
+    (entry : AllocEntry) (word : GatewayWord)
+    (hmem : (entry, word) ∈ (extractGatewayAllocation spec fn).namespaceSlots) :
+    entry ∈ (extractAllocation spec fn).slots := by
+  simp only [extractGatewayAllocation, List.mem_filterMap] at hmem
+  obtain ⟨source, hsource, hclassified⟩ := hmem
+  rw [Option.map_eq_some_iff] at hclassified
+  obtain ⟨classified, _, hpair⟩ := hclassified
+  injection hpair with hentry _
+  subst entry
+  exact hsource
+
+/-- The two `uint128`-bounded operands used by the deposit accumulator cannot
+    wrap a 256-bit EVM word. -/
+theorem depositAmount_add_noWrap
+    (amount accumulated : Nat)
+    (hamount : amount < 2 ^ 128)
+    (haccumulated : accumulated < 2 ^ 128) :
+    amount + accumulated < 2 ^ 256 := by
+  have hhalf : amount + accumulated < 2 ^ 129 := by omega
+  have hpowers : (2 : Nat) ^ 129 ≤ 2 ^ 256 := by norm_num
+  omega
+
+/-! ## Packed two-word preservation
+
+The active flag is the one-bit packed observation in word 0.  Word 1 contains
+the 128-bit deposit counter followed by the 128-bit amount accumulator.  The
+invariant intentionally mentions the active flag and counter; accumulator
+updates are free provided the low counter field remains correct.
+-/
+
+def activeFlag (storage : SolidityStorage) (contract : ContractId) : Nat :=
+  (yulReadPackedWord (storage contract gatewayWord0Slot) 0 1).toNat
+
+def depositCounter (storage : SolidityStorage) (contract : ContractId) : Nat :=
+  (yulReadPackedWord (storage contract gatewayWord1Slot) 0 128).toNat
+
+def amountAccumulator (storage : SolidityStorage) (contract : ContractId) : Nat :=
+  (yulReadPackedWord (storage contract gatewayWord1Slot) 128 128).toNat
+
+/-- Active-flag consistency and deposit-counter correctness across both words. -/
+def GatewayStorageInvariant (storage : SolidityStorage) (contract : ContractId)
+    (expectedActive expectedCounter : Nat) : Prop :=
+  activeFlag storage contract = expectedActive ∧
+    depositCounter storage contract = expectedCounter
+
+/-- A single canonical write to either gateway word preserves the two-word
+    invariant when the field in the word being replaced has the expected value.
+    This is the precise preservation condition required of a packed
+    read-modify-write; the neighbouring word is protected by slot separation. -/
+theorem applyStorageWrite_preserves_gatewayInvariant
+    (storage : SolidityStorage) (write : StorageWrite) (contract : ContractId)
+    (expectedActive expectedCounter : Nat)
+    (hinvariant : GatewayStorageInvariant storage contract expectedActive expectedCounter)
+    (hcontract : write.contract = contract)
+    (htarget : write.slot = gatewayWord0Slot ∨ write.slot = gatewayWord1Slot)
+    (hactive : write.slot = gatewayWord0Slot →
+      (yulReadPackedWord write.value 0 1).toNat = expectedActive)
+    (hcounter : write.slot = gatewayWord1Slot →
+      (yulReadPackedWord write.value 0 128).toNat = expectedCounter)
+    (hdistinct : gatewayWord0Slot ≠ gatewayWord1Slot) :
+    GatewayStorageInvariant (applyStorageWrite write storage) contract
+      expectedActive expectedCounter := by
+  rcases hinvariant with ⟨holdActive, holdCounter⟩
+  rcases htarget with hword0 | hword1
+  · constructor
+    · simp [activeFlag, applyStorageWrite, hcontract, hword0,
+        hactive hword0]
+    · have hne : gatewayWord1Slot ≠ write.slot := by
+        intro heq
+        apply hdistinct
+        exact hword0.symm.trans heq.symm
+      simpa [GatewayStorageInvariant, depositCounter, applyStorageWrite, hcontract, hne]
+        using holdCounter
+  · constructor
+    · have hne : gatewayWord0Slot ≠ write.slot := by
+        intro heq
+        apply hdistinct
+        exact heq.trans hword1
+      simpa [GatewayStorageInvariant, activeFlag, applyStorageWrite, hcontract, hne]
+        using holdActive
+    · simp [depositCounter, applyStorageWrite, hcontract, hword1,
+        hcounter hword1]
+
+end Verity.Core.Model.TopupAllocation


### PR DESCRIPTION
## Summary

- specialize canonical allocation extraction for the TopUpGateway two-word namespace
- model the active flag, deposit counter, and amount accumulator as packed storage observations
- prove uint128 deposit accumulation cannot wrap a uint256 word
- prove the two-word gateway invariant is preserved by canonical writes satisfying the updated field obligation

## Verification

- `lake build`
- `lake build PrintAxioms`
- `python3 scripts/generate_print_axioms.py --check`
- forbidden-token scan over the changed Lean path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive modeling and proof/script maintenance; no runtime or auth paths. Risk is limited to Lean proof breakage if `ContractState` or storage lemmas drift.
> 
> **Overview**
> **Phase 2 B.3** adds a Lean model for **TopUpGateway**’s two-word namespaced storage and tightens related proofs.
> 
> **New `Verity/Core/Model/TopupAllocation.lean`** pins the gateway storage position and defines `extractGatewayAllocation` to tag the two namespace slots from canonical allocation extraction. It models **active flag**, **deposit counter**, and **amount accumulator** as packed reads, proves **uint128** deposit sums cannot wrap a **uint256**, and proves **`GatewayStorageInvariant`** is preserved by canonical writes when the updated packed field matches expectations.
> 
> **`StructArrayStorage.lean`** proof edits only: drop redundant `hmember` / `applyStorageWrite` simp steps, mark unused `hroom` as `_hroom`, and trim modulus simp in struct-member and dynamic-array coherence theorems.
> 
> **Contract proof helpers** (ERC20, Ledger, Owned, OwnedCounter, SafeCounter, SimpleToken) now include **`contractStorage := s.contractStorage`** in explicit success-state records so unfold lemmas match the extended **`ContractState`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77f92e43aa53890ac4121e93e2a1bcfedc81726e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->