### PR TITLE
feat: separate contract storage namespaces

### DIFF
--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -71,6 +71,9 @@ structure Event where
 -- State monad for contract execution
 structure ContractState where
   storage : Nat → Uint256                -- Uint256 storage mapping
+  /-- Storage worlds for explicitly identified contracts. Contract id `0` is
+      represented by `storage` through the compatibility lenses below. -/
+  contractStorage : Nat → Nat → Uint256 := fun _ _ => 0
   transientStorage : Nat → Uint256       -- EIP-1153 transient storage mapping
   storageAddr : Nat → Address            -- Address storage mapping
   storageMap : Nat → Address → Uint256  -- Mapping storage (Address → Uint256)
@@ -115,6 +118,20 @@ def readSlot (s : ContractState) (slot : Nat) : Uint256 :=
 
 def writeSlot (s : ContractState) (slot : Nat) (value : Uint256) : ContractState :=
   { s with storage := fun sl => if sl == slot then value else s.storage sl }
+
+/-- Read a word from a contract-separated storage world. Contract id `0`
+    deliberately denotes the legacy, unqualified `storage` world. -/
+def readContractSlot (s : ContractState) (contract : Nat) (slot : Nat) : Uint256 :=
+  if contract == 0 then s.readSlot slot else s.contractStorage contract slot
+
+/-- Write a word in a contract-separated storage world. Contract id `0`
+    deliberately updates the legacy, unqualified `storage` world. -/
+def writeContractSlot (s : ContractState) (contract : Nat) (slot : Nat)
+    (value : Uint256) : ContractState :=
+  if contract == 0 then s.writeSlot slot value
+  else
+    { s with contractStorage := fun c sl =>
+        if c == contract && sl == slot then value else s.contractStorage c sl }
 
 def readAddrSlot (s : ContractState) (slot : Nat) : Address :=
   s.storageAddr slot
@@ -164,6 +181,32 @@ def writeArray (s : ContractState) (slot : Nat) (values : List Uint256) : Contra
     (h : slot' ≠ slot) (v : Uint256) :
     (s.writeSlot slot v).readSlot slot' = s.readSlot slot' := by
   simp [readSlot, writeSlot, h]
+
+@[storage_simps] theorem readContractSlot_zero (s : ContractState) (slot : Nat) :
+    s.readContractSlot 0 slot = s.readSlot slot := by
+  simp [readContractSlot]
+
+@[storage_simps] theorem readContractSlot_writeContractSlot_same
+    (s : ContractState) (contract slot : Nat) (v : Uint256) :
+    (s.writeContractSlot contract slot v).readContractSlot contract slot = v := by
+  by_cases h : contract = 0
+  · subst contract
+    simp [readContractSlot, writeContractSlot, readSlot, writeSlot]
+  · simp [readContractSlot, writeContractSlot, h]
+
+@[storage_simps] theorem readContractSlot_writeContractSlot_other_contract
+    (s : ContractState) {contract contract' slot : Nat} (h : contract' ≠ contract)
+    (v : Uint256) :
+    (s.writeContractSlot contract slot v).readContractSlot contract' slot =
+      s.readContractSlot contract' slot := by
+  by_cases hc : contract = 0
+  · subst contract
+    have hc' : contract' ≠ 0 := h
+    simp [readContractSlot, writeContractSlot, writeSlot, hc']
+  · by_cases hc' : contract' = 0
+    · subst contract'
+      simp [readContractSlot, writeContractSlot, readSlot, hc]
+    · simp [readContractSlot, writeContractSlot, hc, hc', h]
 
 @[storage_simps] theorem readAddrSlot_writeAddrSlot_same (s : ContractState) (slot : Nat)
     (v : Address) : (s.writeAddrSlot slot v).readAddrSlot slot = v := by

--- a/Verity/Core/Model/AllocationExtraction.lean
+++ b/Verity/Core/Model/AllocationExtraction.lean
@@ -190,10 +190,9 @@ decreasing_by simp_wf; omega
 def storageAccesses (fn : FunctionSpec) : List (String × AllocKind) :=
   storageAccessesBody fn.body
 
-/-- Stable contract discriminator.  The declarative model currently has a
-contract name rather than a numeric address, so allocation summaries use the
-same neutral contract id as the single-contract source semantics. -/
-def contractId (_spec : CompilationModel) : ContractId := 0
+/-- Stable, explicit contract discriminator. Existing model literals default
+to identity `1`; multi-contract models set distinct identities. -/
+def contractId (spec : CompilationModel) : ContractId := spec.contractId
 
 def resolveAccess (spec : CompilationModel) (access : String × AllocKind) : Option AllocEntry :=
   match findFieldWithResolvedSlot spec.fields access.1 with
@@ -206,16 +205,23 @@ def extractAllocation (spec : CompilationModel) (fn : FunctionSpec) : Allocation
   { slots := (storageAccesses fn).filterMap (resolveAccess spec)
     returns := functionReturns fn }
 
-/-- Allocation entries already contain resolved canonical slots; this
-projection names that boundary explicitly for downstream proofs. -/
-def canonicalSlot (_spec : CompilationModel) (_contract : ContractId) (slot : Nat) : Nat := slot
+/-- Contract-sensitive canonical slot name. Contract id `0` deliberately keeps
+the historical slot number; positive ids occupy exponentially separated names. -/
+def canonicalSlot (_spec : CompilationModel) (contract : ContractId) (slot : Nat) : Nat :=
+  if contract = 0 then slot else 2 ^ contract * (2 * slot + 1)
 
 theorem extractAllocation_canonical
     (spec : CompilationModel) (fn : FunctionSpec)
     (_h : validateFunctionSpec fn = .ok ()) :
     ∀ entry ∈ (extractAllocation spec fn).slots,
-      entry.slot = canonicalSlot spec entry.contract entry.slot := by
-  intro entry _
+      canonicalSlot spec entry.contract entry.slot =
+        canonicalSlot spec (contractId spec) entry.slot := by
+  intro entry hentry
+  simp only [extractAllocation, List.mem_filterMap] at hentry
+  obtain ⟨access, _, hresolve⟩ := hentry
+  unfold resolveAccess at hresolve
+  split at hresolve <;> simp_all
+  cases hresolve
   rfl
 
 /-- Allocation visible after a call boundary: only successful calls commit. -/

--- a/Verity/Core/Model/ContractNamespaceTest.lean
+++ b/Verity/Core/Model/ContractNamespaceTest.lean
@@ -1,0 +1,42 @@
+import Verity.Core.Model.AllocationExtraction
+
+namespace Verity.Core.Model.ContractNamespaceTest
+
+open Compiler.CompilationModel
+open AllocationExtraction
+
+private def model (id : Nat) : CompilationModel :=
+  { name := "namespace-test", contractId := id, fields := [], constructor := none,
+    functions := [] }
+
+/-- The same local slot in distinct positive contract worlds cannot alias. -/
+example (slot : Nat) :
+    canonicalSlot (model 1) 1 slot ≠ canonicalSlot (model 2) 2 slot := by
+  simp [canonicalSlot]
+
+example (slot : Nat) :
+    canonicalSlot (model 2) 2 slot ≠ canonicalSlot (model 3) 3 slot := by
+  simp [canonicalSlot]
+
+/-- The legacy single-contract canonical slot remains unchanged. -/
+example (slot : Nat) : canonicalSlot (model 0) 0 slot = slot := by
+  simp [canonicalSlot]
+
+/-- Legacy single-contract reads remain exactly the id-zero namespace. -/
+example (state : Verity.ContractState) (slot : Nat) :
+    state.readContractSlot 0 slot = state.readSlot slot := by
+  exact Verity.ContractState.readContractSlot_zero state slot
+
+/-- Legacy single-contract writes update the original storage field. -/
+example (state : Verity.ContractState) (slot : Nat) (value : Verity.Uint256) :
+    (state.writeContractSlot 0 slot value).readSlot slot = value := by
+  simp [Verity.ContractState.writeContractSlot]
+
+/-- A write in one contract world is invisible at the same slot in another. -/
+example (state : Verity.ContractState) (slot : Nat) (value : Verity.Uint256) :
+    (state.writeContractSlot 1 slot value).readContractSlot 2 slot =
+      state.readContractSlot 2 slot := by
+  apply Verity.ContractState.readContractSlot_writeContractSlot_other_contract
+  omega
+
+end Verity.Core.Model.ContractNamespaceTest

--- a/Verity/Core/Model/Types.lean
+++ b/Verity/Core/Model/Types.lean
@@ -1499,6 +1499,9 @@ structure ConstructorSpec where
 
 structure CompilationModel where
   name : String
+  /-- Stable contract identity used by contract-separated storage semantics.
+      Existing model literals remain source-compatible and default to `1`. -/
+  contractId : Nat := 1
   fields : List Field
   immutables : List ImmutableSpec := []
   /-- Explicit owner/admin/minter/relayer-style access-control declarations.

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 831,
+    "core_lines": 874,
     "example_contracts": 16
   },
   "proofs": {


### PR DESCRIPTION
## Summary

- add backward-compatible `CompilationModel.contractId : Nat := 1`
- add contract-qualified `ContractState` word reads/writes, with contract ID `0` preserving the legacy storage lens
- make allocation `contractId` explicit and `canonicalSlot` contract-sensitive while retaining ID-zero slot compatibility
- add focused proofs/tests for distinct contract IDs and legacy single-contract behavior

## Verification

- `lean-slot lake build Verity.Core.Model.ContractNamespaceTest` (1,229 jobs, exit 0)
- `lean-slot lake build` (2,460 jobs, exit 0)
- remote focused build on `old-agent`: job `f21d77cc-50d8-43a2-9a1b-de6c2a5be65e`, exit 0, 1,507s, 1,236 jobs
- remote full build on `old-agent`: job `5729fb32-4b79-4bd6-9bf9-93875c864783`, exit 0, 4,573s, 2,467 jobs
- `git diff --check`
- forbidden escape scan over changed Lean files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core execution state and allocation slot naming used in proofs; legacy id-0 paths are preserved but multi-contract semantics are new surface area.
> 
> **Overview**
> Introduces **per-contract storage worlds** while keeping single-contract behavior unchanged.
> 
> `ContractState` gains `contractStorage` plus `readContractSlot` / `writeContractSlot`; contract id **0** still maps to the legacy `storage` field. New `storage_simps` lemmas cover same-slot writes and cross-contract isolation.
> 
> `CompilationModel` adds **`contractId` (default `1`)**. Allocation extraction uses `spec.contractId` instead of a fixed `0`, and **`canonicalSlot`** namespaces positive contract ids via `2^contract * (2*slot + 1)` while id `0` keeps raw slot numbers. `extractAllocation_canonical` is updated accordingly.
> 
> **`ContractNamespaceTest`** adds examples for non-aliasing canonical slots, legacy id-zero slots, and contract-qualified read/write behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7b0fb7865a41c7e13bea67d58fbdaf09b4e750e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->