### PR TITLE
feat(macro): support external calls in contract bodies

### DIFF
--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -7,6 +7,7 @@ import Contracts.Smoke.StructsAndArrays
 import Contracts.Smoke.HelperCalls
 import Contracts.Smoke.StructMappings
 import Contracts.Smoke.ExternalCalls
+import Contracts.Smoke.ExternalCallInBodySmoke
 import Contracts.Smoke.SpecGenAndChecks
 import Contracts.Smoke.Effects
 import Contracts.Smoke.Namespaces

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -154,6 +154,13 @@ verity_contract ExternalCallInBodySmoke where
     let result ← getMappingUint values (callExternal narrowEcho(0xdeadbeef))
     return result
 
+  function reentrancy_trusted tupleNestedExternalResult () : Uint32 := do
+    let (result, _) := (callExternal dirtyUint(), 0)
+    return result
+
+  function reentrancy_trusted tupleNestedExternalReturn () : Tuple [Uint32, Uint256] := do
+    return (callExternal dirtyUint(), 0)
+
   function reentrancy_trusted pureDirtyInt () : Int32 := do
     let result := callExternal dirtyInt()
     return result
@@ -342,6 +349,13 @@ example : (ExternalCallInBodySmoke.mappingNestedExternalArg_modelBody).take 1 =
 example : ExternalCallInBodySmoke.mappingNestedExternalArg_model.body =
     ExternalCallInBodySmoke.mappingNestedExternalArg_modelBody :=
   ExternalCallInBodySmoke.mappingNestedExternalArg_semantic_preservation
+
+example : ExternalCallInBodySmoke.tupleNestedExternalResult_modelBody =
+    [.letVar "result" (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1))),
+     .return (.localVar "result")] := rfl
+
+example : ExternalCallInBodySmoke.tupleNestedExternalReturn_modelBody =
+    [.returnValues [(.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1))), .literal 0]] := rfl
 
 example : ExternalCallInBodySmoke.legacyNarrowArgs_model.body =
     ExternalCallInBodySmoke.legacyNarrowArgs_modelBody :=

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -20,6 +20,9 @@ def linkedOperandEcmModule : Compiler.ECM.ExternalCallModule where
 -- `callExternal` is declaration-driven; target/value fields belong to `evmCall`.
 verity_contract ExternalCallInBodySmoke where
   storage
+  errors
+    error Failure(Uint256)
+
   linked_externals
     external getDepositableEther() -> (Uint256)
     external deposit(Uint256, Bytes)
@@ -31,9 +34,6 @@ verity_contract ExternalCallInBodySmoke where
     external consumeUint8(Uint8)
     external consumeUint16(Uint16)
     external consume(Uint256)
-  errors
-    error Failure(Uint256)
-
   function reentrancy_trusted linkedRead () : Uint256 := do
     let depositable ← callExternal getDepositableEther()
     return depositable

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -16,11 +16,16 @@ def linkedOperandEcmModule : Compiler.ECM.ExternalCallModule where
   axioms := []
   compile := fun _ctx _args => pure []
 
+def linkedWordPassthrough (value : Uint256) : Uint256 := value
+
 -- P0 #1003 coverage for linked calls and explicit low-level body syntax.
 -- `callExternal` is declaration-driven; target/value fields belong to `evmCall`.
 verity_contract ExternalCallInBodySmoke where
   storage
     values : Uint256 → Uint256 := slot 0
+  struct NarrowPair where
+    narrow : Uint32,
+    wide : Uint256
   errors
     error Failure(Uint256)
 
@@ -30,6 +35,8 @@ verity_contract ExternalCallInBodySmoke where
     external narrowEcho(Bytes4) -> (Uint256)
     external dirtyUint() -> (Uint32)
     external dirtyUint_try() -> (Bool, Uint32)
+    external dirtyPair() -> (NarrowPair)
+    external dirtyPair_try() -> (Bool, NarrowPair)
     external dirtyInt() -> (Int32)
     external dirtyBytes() -> (Bytes4)
     external dirtySink(Uint32) -> (Uint32)
@@ -82,6 +89,17 @@ verity_contract ExternalCallInBodySmoke where
   function reentrancy_trusted tryNotifyBool (flag : Bool) : Bool := do
     let success ← tryExternalCall "notifyBool" [flag]
     return success
+
+  function reentrancy_trusted tryDirtyPair () : Uint32 := do
+    let (_success, result) ← tryExternalCall "dirtyPair" []
+    return result.narrow
+
+  function reentrancy_trusted safeBindDirtyUint () : Uint256 := do
+    let result ← requireSomeUint (safeAdd (callExternal dirtyUint()) 1) "overflow"
+    return result
+
+  function reentrancy_trusted leanHelperNestedExternal () : Uint256 := do
+    return linkedWordPassthrough (callExternal narrowEcho(0xdeadbeef))
 
   function reentrancy_trusted bindNestedExternalArg () : Uint32 := do
     let result ← callExternal dirtySink(callExternal dirtyUint())
@@ -208,12 +226,14 @@ example : ExternalCallInBodySmoke.nestedDirtyUint_modelBody =
 example : ExternalCallInBodySmoke.nestedExternalArg_modelBody =
     [.return (.bitAnd
       (.externalCall "dirtySink"
-        [(.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))])
-      (.literal (2 ^ 32 - 1)))] := rfl
+        [(.bitAnd
+          (.bitAnd (.externalCall "dirtyUint" []) (.literal 4294967295))
+          (.literal 4294967295))])
+      (.literal 4294967295))] := rfl
 
 example : ExternalCallInBodySmoke.storeDirtyUint_modelBody =
     [.mstore (.literal 0)
-      (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))] := rfl
+      (.bitAnd (.externalCall "dirtyUint" []) (.literal 4294967295)), .stop] := rfl
 
 example : (ExternalCallInBodySmoke.bindDirtyUint_modelBody).take 2 =
     [ .externalCallBind ["result"] "dirtyUint" []
@@ -231,37 +251,63 @@ example : (ExternalCallInBodySmoke.callResultDirtyUint_modelBody).take 2 =
 example : (ExternalCallInBodySmoke.tryNotifyBool_modelBody).take 1 =
     [.tryExternalCallBind "success" [] "notifyBool" [.param "flag"]] := rfl
 
+example : (ExternalCallInBodySmoke.tryDirtyPair_modelBody).take 3 =
+    [ .tryExternalCallBind "_success" ["result_narrow", "result_wide"] "dirtyPair" []
+    , .assignVar "result_narrow"
+        (.bitAnd (.localVar "result_narrow") (.literal (2 ^ 32 - 1)))
+    , .return (.localVar "result_narrow") ] := rfl
+
+example : (ExternalCallInBodySmoke.safeBindDirtyUint_modelBody).take 2 =
+    [ .require
+        (.ge
+          (.add (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1))) (.literal 1))
+          (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1))))
+        "overflow"
+    , .letVar "result"
+        (.add (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1))) (.literal 1)) ] := rfl
+
+example : ExternalCallInBodySmoke.leanHelperNestedExternal_modelBody =
+    [.return (.externalCall "narrowEcho"
+      [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])] := rfl
+
 example : (ExternalCallInBodySmoke.bindNestedExternalArg_modelBody).take 1 =
     [.externalCallBind ["result"] "dirtySink"
-      [(.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))]] := rfl
+      [(.bitAnd
+        (.bitAnd (.externalCall "dirtyUint" []) (.literal 4294967295))
+        (.literal 4294967295))]] := rfl
 
 example : ExternalCallInBodySmoke.statementNestedExternalArg_modelBody =
     [.externalCallBind [] "consume"
       [(.externalCall "narrowEcho"
-        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])],
+      .stop] := rfl
 
 example : ExternalCallInBodySmoke.logDirtyUint_modelBody =
     [.rawLog [(.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))]
-      (.literal 0) (.literal 0)] := rfl
+      (.literal 0) (.literal 0), .stop] := rfl
 
 example : ExternalCallInBodySmoke.legacyNarrowArgs_modelBody =
     [ .externalCallBind [] "consumeUint8" [(.bitAnd (.literal 0x100) (.literal 255))]
-    , .externalCallBind [] "consumeUint16" [(.bitAnd (.literal 0x10000) (.literal 65535))] ] := rfl
+    , .externalCallBind [] "consumeUint16" [(.bitAnd (.literal 0x10000) (.literal 65535))]
+    , .stop ] := rfl
 
 example : ExternalCallInBodySmoke.emitNestedExternalArg_modelBody =
     [.emit "Seen"
       [(.externalCall "narrowEcho"
-        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])],
+      .stop] := rfl
 
 example : ExternalCallInBodySmoke.customErrorNestedExternalArg_modelBody =
     [.requireError (.literal 1) "Failure"
       [(.externalCall "narrowEcho"
-        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])],
+      .stop] := rfl
 
 example : ExternalCallInBodySmoke.helperNestedExternalArg_modelBody =
-    [.internalCall "__verity_internal_helper_consumeHelper"
+    [.internalCall "internal_consumeHelper"
       [(.externalCall "narrowEcho"
-        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])],
+      .stop] := rfl
 
 example : (ExternalCallInBodySmoke.monadicLoadDirtyUint_modelBody).take 1 =
     [.letVar "value" (.mload
@@ -270,7 +316,8 @@ example : (ExternalCallInBodySmoke.monadicLoadDirtyUint_modelBody).take 1 =
 example : ExternalCallInBodySmoke.ecmNestedExternalArg_modelBody =
     [.ecm linkedOperandEcmModule
       [(.externalCall "narrowEcho"
-        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])],
+      .stop] := rfl
 
 example : (ExternalCallInBodySmoke.erc20BalanceNestedExternalArg_modelBody).take 1 =
     [.ecm (Compiler.Modules.ERC20.balanceOfModule "result")

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -30,19 +30,19 @@ verity_contract ExternalCallInBodySmoke where
     let roundtrip ← memoryLoad(0)
     let success ← evmCall(50000, target, amount, 0, 32, 64, 32)
     let observed ← evmStaticCall(50000, target, 0, 32, 64, 32)
-    let size : Uint256 ← returnDataSize()
+    let size ← returnDataSize()
     returnDataCopy(96, 0, size)
     return (add (add (add pureRoundtrip roundtrip) success) observed)
 
-example : ExternalCallInBodySmoke.linkedRead_modelBody.take 1 =
+example : (ExternalCallInBodySmoke.linkedRead_modelBody).take 1 =
     [Compiler.CompilationModel.Stmt.externalCallBind
       ["depositable"] "getDepositableEther" []] := rfl
 
-example : ExternalCallInBodySmoke.linkedWrite_modelBody.take 1 =
+example : (ExternalCallInBodySmoke.linkedWrite_modelBody).take 1 =
     [Compiler.CompilationModel.Stmt.externalCallBind [] "deposit"
       [ .param "amount", .param "pubkey_data_offset", .param "pubkey_length" ]] := rfl
 
-example : ExternalCallInBodySmoke.lowLevel_modelBody.take 7 =
+example : (ExternalCallInBodySmoke.lowLevel_modelBody).take 7 =
     [ Compiler.CompilationModel.Stmt.mstore (.literal 0) (.param "amount")
     , Compiler.CompilationModel.Stmt.letVar "pureRoundtrip" (.add (.mload (.literal 0)) (.literal 0))
     , Compiler.CompilationModel.Stmt.letVar "roundtrip" (.mload (.literal 0))

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -30,7 +30,7 @@ verity_contract ExternalCallInBodySmoke where
     let roundtrip ← memoryLoad(0)
     let success ← evmCall(50000, target, amount, 0, 32, 64, 32)
     let observed ← evmStaticCall(50000, target, 0, 32, 64, 32)
-    let size ← returnDataSize()
+    let size : Uint256 ← returnDataSize()
     returnDataCopy(96, 0, size)
     return (add (add (add pureRoundtrip roundtrip) success) observed)
 

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -87,7 +87,7 @@ verity_contract ExternalCallInBodySmoke where
     emit "Seen" [callExternal narrowEcho(0xdeadbeef)]
 
   function reentrancy_trusted customErrorNestedExternalArg () : Unit := do
-    requireError 1 Failure(callExternal narrowEcho(0xdeadbeef))
+    requireError true Failure(callExternal narrowEcho(0xdeadbeef))
 
   function consumeHelper (_value : Uint256) : Unit := do
     pure ()
@@ -103,6 +103,18 @@ verity_contract ExternalCallInBodySmoke where
 
   function reentrancy_trusted ecmNestedExternalArg () : Unit := do
     ecmDo linkedOperandEcmModule [callExternal narrowEcho(0xdeadbeef)]
+
+  function reentrancy_trusted erc20BalanceNestedExternalArg () : Uint256 := do
+    let result ← balanceOf 1 (callExternal narrowEcho(0xdeadbeef))
+    return result
+
+  function reentrancy_trusted erc20AllowanceNestedExternalArg () : Uint256 := do
+    let result ← allowance 1 2 (callExternal narrowEcho(0xdeadbeef))
+    return result
+
+  function reentrancy_trusted erc20SupplyNestedExternalArg () : Uint256 := do
+    let result ← totalSupply (callExternal narrowEcho(0xdeadbeef))
+    return result
 
   function reentrancy_trusted pureDirtyInt () : Int32 := do
     let result := callExternal dirtyInt()
@@ -225,6 +237,21 @@ example : (ExternalCallInBodySmoke.monadicLoadDirtyUint_modelBody).take 1 =
 
 example : ExternalCallInBodySmoke.ecmNestedExternalArg_modelBody =
     [.ecm linkedOperandEcmModule
+      [(.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+
+example : (ExternalCallInBodySmoke.erc20BalanceNestedExternalArg_modelBody).take 1 =
+    [.ecm (Compiler.Modules.ERC20.balanceOfModule "result")
+      [(.literal 1), (.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+
+example : (ExternalCallInBodySmoke.erc20AllowanceNestedExternalArg_modelBody).take 1 =
+    [.ecm (Compiler.Modules.ERC20.allowanceModule "result")
+      [(.literal 1), (.literal 2), (.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+
+example : (ExternalCallInBodySmoke.erc20SupplyNestedExternalArg_modelBody).take 1 =
+    [.ecm (Compiler.Modules.ERC20.totalSupplyModule "result")
       [(.externalCall "narrowEcho"
         [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
 

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -494,7 +494,7 @@ verity_contract MalformedPureLinkedCallRejected where
     let result := callExternal scalarPair(payload)
     return result
 
-/-- error: callExternal 'pair' return type expands to 2 values and cannot be bound to one source variable -/
+/-- error: callExternal 'pair' return type cannot be bound to one source variable; bind composite results explicitly -/
 #guard_msgs in
 verity_contract CompositeLinkedCallBindRejected where
   storage
@@ -502,6 +502,18 @@ verity_contract CompositeLinkedCallBindRejected where
     external pair(Uint256) -> (Tuple [Uint256, Uint256])
   function bad (value : Uint256) : Tuple [Uint256, Uint256] := do
     let result ← callExternal pair(value)
+    return result
+
+/-- error: callExternal 'single' return type cannot be bound to one source variable; bind composite results explicitly -/
+#guard_msgs in
+verity_contract SingleLeafCompositeLinkedCallBindRejected where
+  storage
+  struct Single where
+    value : Uint256
+  linked_externals
+    external single() -> (Single)
+  function bad () : Single := do
+    let result ← callExternal single()
     return result
 
 /-- error: callExternal 'pair' return type cannot be used as a pure single-word expression -/

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -208,6 +208,20 @@ verity_contract ExternalCallInBodySmoke where
     let parenthesized ← (returnDataSize())
     return parenthesized
 
+verity_contract AdtLinkedPayloadSmoke where
+  inductive
+    Maybe := | Nothing | Just(value : Uint32)
+  storage
+    result : Maybe := slot 0
+  linked_externals
+    external dirtyUint() -> (Uint32)
+  function store () : Unit := do
+    setStorage result (adt "Just" [callExternal dirtyUint()])
+
+example : (AdtLinkedPayloadSmoke.store_modelBody).take 1 =
+    [.setStorage "result" (.adtConstruct "Maybe" "Just"
+      [(.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))])] := rfl
+
 example : (ExternalCallInBodySmoke.linkedRead_modelBody).take 1 =
     [Compiler.CompilationModel.Stmt.externalCallBind
       ["depositable"] "getDepositableEther" []] := rfl

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -39,6 +39,8 @@ verity_contract ExternalCallInBodySmoke where
     external dirtyPair_try() -> (Bool, NarrowPair)
     external dirtyInt() -> (Int32)
     external dirtyBytes() -> (Bytes4)
+    external dirtyAddress() -> (Address)
+    external dirtyBool() -> (Bool)
     external dirtySink(Uint32) -> (Uint32)
     external consumeUint8(Uint8)
     external consumeUint16(Uint16)
@@ -94,8 +96,12 @@ verity_contract ExternalCallInBodySmoke where
     let (_success, result) ← tryExternalCall "dirtyPair" []
     return result.narrow
 
-  function reentrancy_trusted safeBindDirtyUint () : Uint256 := do
-    let result ← requireSomeUint (safeAdd (callExternal dirtyUint()) 1) "overflow"
+  function reentrancy_trusted bindDirtyAddress () : Address := do
+    let result ← callExternal dirtyAddress()
+    return result
+
+  function reentrancy_trusted bindDirtyBool () : Bool := do
+    let result ← callExternal dirtyBool()
     return result
 
   function reentrancy_trusted leanHelperNestedExternal () : Uint256 := do
@@ -256,7 +262,8 @@ example : (ExternalCallInBodySmoke.callResultDirtyUint_modelBody).take 2 =
         (.bitAnd (.localVar "result_returndata") (.literal (2 ^ 32 - 1))) ] := rfl
 
 example : (ExternalCallInBodySmoke.tryNotifyBool_modelBody).take 1 =
-    [.tryExternalCallBind "success" [] "notifyBool" [.param "flag"]] := rfl
+    [.tryExternalCallBind "success" [] "notifyBool"
+      [(.logicalNot (.eq (.param "flag") (.literal 0)))]] := rfl
 
 example : (ExternalCallInBodySmoke.tryDirtyPair_modelBody).take 3 =
     [ .tryExternalCallBind "_success" ["result_narrow", "result_wide"] "dirtyPair" []
@@ -264,14 +271,13 @@ example : (ExternalCallInBodySmoke.tryDirtyPair_modelBody).take 3 =
         (.bitAnd (.localVar "result_narrow") (.literal (2 ^ 32 - 1)))
     , .return (.localVar "result_narrow") ] := rfl
 
-example : (ExternalCallInBodySmoke.safeBindDirtyUint_modelBody).take 2 =
-    [ .require
-        (.ge
-          (.add (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1))) (.literal 1))
-          (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1))))
-        "overflow"
-    , .letVar "result"
-        (.add (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1))) (.literal 1)) ] := rfl
+example : (ExternalCallInBodySmoke.bindDirtyAddress_modelBody).take 2 =
+    [ .externalCallBind ["result"] "dirtyAddress" []
+    , .assignVar "result" (.bitAnd (.localVar "result") (.literal (2 ^ 160 - 1))) ] := rfl
+
+example : (ExternalCallInBodySmoke.bindDirtyBool_modelBody).take 2 =
+    [ .externalCallBind ["result"] "dirtyBool" []
+    , .assignVar "result" (.logicalNot (.eq (.localVar "result") (.literal 0))) ] := rfl
 
 example : ExternalCallInBodySmoke.leanHelperNestedExternal_modelBody =
     [.return (.externalCall "narrowEcho"
@@ -538,6 +544,16 @@ verity_contract CompositePureLinkedCallRejected where
     external pair(Uint256) -> (Tuple [Uint256, Uint256])
   function bad (value : Uint256) : Tuple [Uint256, Uint256] := do
     let result := callExternal pair(value)
+    return result
+
+/-- error: requireSomeUint operands cannot contain callExternal because safe-arithmetic lowering reuses operands in both the guard and result; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulSafeArithmeticOperandRejected where
+  storage
+  linked_externals
+    external dirtyUint() -> (Uint32)
+  function bad () : Uint256 := do
+    let result ← requireSomeUint (safeAdd (callExternal dirtyUint()) 1) "overflow"
     return result
 
 /-- error: memory-store value requires a word-like value (Uint256, Int256, Uint8, Address, or Bytes32), got Verity.Macro.ValueType.bytes -/

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -72,4 +72,14 @@ verity_contract MalformedEvmCallRejected where
   function bad (target : Uint256) : Uint256 := do
     return evmCall(1, target)
 
+/-- error: callExternal 'scalarPair' expects 2 args, got 1 -/
+#guard_msgs in
+verity_contract MalformedLinkedCallRejected where
+  storage
+  linked_externals
+    external scalarPair(Uint256, Uint256) -> (Uint256)
+  function bad (payload : Bytes) : Uint256 := do
+    let result ← callExternal scalarPair(payload)
+    return result
+
 end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -19,7 +19,11 @@ verity_contract ExternalCallInBodySmoke where
     external dirtyInt() -> (Int32)
     external dirtyBytes() -> (Bytes4)
     external dirtySink(Uint32) -> (Uint32)
+    external consumeUint8(Uint8)
+    external consumeUint16(Uint16)
     external consume(Uint256)
+  errors
+    error Failure(Uint256)
 
   function reentrancy_trusted linkedRead () : Uint256 := do
     let depositable ← callExternal getDepositableEther()
@@ -65,6 +69,22 @@ verity_contract ExternalCallInBodySmoke where
     local_obligations [low_level_frame := assumed "Logging a linked-call result is an explicit refinement boundary."]
     : Unit := do
     rawLog [callExternal dirtyUint()] 0 0
+
+  function reentrancy_trusted legacyNarrowArgs () : Unit := do
+    callExternal consumeUint8(0x100)
+    callExternal consumeUint16(0x10000)
+
+  function reentrancy_trusted emitNestedExternalArg () : Unit := do
+    emit "Seen" [callExternal narrowEcho(0xdeadbeef)]
+
+  function reentrancy_trusted customErrorNestedExternalArg () : Unit := do
+    requireError 1 Failure(callExternal narrowEcho(0xdeadbeef))
+
+  function consumeHelper (_value : Uint256) : Unit := do
+    pure ()
+
+  function reentrancy_trusted helperNestedExternalArg () : Unit := do
+    consumeHelper (callExternal narrowEcho(0xdeadbeef))
 
   function reentrancy_trusted pureDirtyInt () : Int32 := do
     let result := callExternal dirtyInt()
@@ -161,6 +181,41 @@ example : ExternalCallInBodySmoke.statementNestedExternalArg_modelBody =
 example : ExternalCallInBodySmoke.logDirtyUint_modelBody =
     [.rawLog [(.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))]
       (.literal 0) (.literal 0)] := rfl
+
+example : ExternalCallInBodySmoke.legacyNarrowArgs_modelBody =
+    [ .externalCallBind [] "consumeUint8" [(.bitAnd (.literal 0x100) (.literal 255))]
+    , .externalCallBind [] "consumeUint16" [(.bitAnd (.literal 0x10000) (.literal 65535))] ] := rfl
+
+example : ExternalCallInBodySmoke.emitNestedExternalArg_modelBody =
+    [.emit "Seen"
+      [(.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+
+example : ExternalCallInBodySmoke.customErrorNestedExternalArg_modelBody =
+    [.requireError (.literal 1) "Failure"
+      [(.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+
+example : ExternalCallInBodySmoke.helperNestedExternalArg_modelBody =
+    [.internalCall "__verity_internal_helper_consumeHelper"
+      [(.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+
+example : ExternalCallInBodySmoke.legacyNarrowArgs_model.body =
+    ExternalCallInBodySmoke.legacyNarrowArgs_modelBody :=
+  ExternalCallInBodySmoke.legacyNarrowArgs_semantic_preservation
+
+example : ExternalCallInBodySmoke.emitNestedExternalArg_model.body =
+    ExternalCallInBodySmoke.emitNestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.emitNestedExternalArg_semantic_preservation
+
+example : ExternalCallInBodySmoke.customErrorNestedExternalArg_model.body =
+    ExternalCallInBodySmoke.customErrorNestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.customErrorNestedExternalArg_semantic_preservation
+
+example : ExternalCallInBodySmoke.helperNestedExternalArg_model.body =
+    ExternalCallInBodySmoke.helperNestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.helperNestedExternalArg_semantic_preservation
 
 example : (ExternalCallInBodySmoke.pureDirtyInt_modelBody).take 1 =
     [.letVar "result" (.signextend (.literal 3) (.externalCall "dirtyInt" []))] := rfl

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -20,6 +20,7 @@ def linkedOperandEcmModule : Compiler.ECM.ExternalCallModule where
 -- `callExternal` is declaration-driven; target/value fields belong to `evmCall`.
 verity_contract ExternalCallInBodySmoke where
   storage
+    values : Uint256 → Uint256 := slot 0
   errors
     error Failure(Uint256)
 
@@ -114,6 +115,10 @@ verity_contract ExternalCallInBodySmoke where
 
   function reentrancy_trusted erc20SupplyNestedExternalArg () : Uint256 := do
     let result ← totalSupply (callExternal narrowEcho(0xdeadbeef))
+    return result
+
+  function reentrancy_trusted mappingNestedExternalArg () : Uint256 := do
+    let result ← getMappingUint values (callExternal narrowEcho(0xdeadbeef))
     return result
 
   function reentrancy_trusted pureDirtyInt () : Int32 := do
@@ -254,6 +259,15 @@ example : (ExternalCallInBodySmoke.erc20SupplyNestedExternalArg_modelBody).take 
     [.ecm (Compiler.Modules.ERC20.totalSupplyModule "result")
       [(.externalCall "narrowEcho"
         [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+
+example : (ExternalCallInBodySmoke.mappingNestedExternalArg_modelBody).take 1 =
+    [.letVar "result" (.mappingUint "values"
+      (.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)]))] := rfl
+
+example : ExternalCallInBodySmoke.mappingNestedExternalArg_model.body =
+    ExternalCallInBodySmoke.mappingNestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.mappingNestedExternalArg_semantic_preservation
 
 example : ExternalCallInBodySmoke.legacyNarrowArgs_model.body =
     ExternalCallInBodySmoke.legacyNarrowArgs_modelBody :=

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -107,4 +107,28 @@ verity_contract CompositeLinkedCallBindRejected where
     let result ← callExternal pair(value)
     return result
 
+/-- error: callExternal 'pair' return type cannot be used as a pure single-word expression -/
+#guard_msgs in
+verity_contract CompositePureLinkedCallRejected where
+  storage
+  linked_externals
+    external pair(Uint256) -> (Tuple [Uint256, Uint256])
+  function bad (value : Uint256) : Tuple [Uint256, Uint256] := do
+    let result := callExternal pair(value)
+    return result
+
+/-- error: memory-store value must be word-like, got Bytes -/
+#guard_msgs in
+verity_contract DynamicMemoryStoreRejected where
+  storage
+  function bad (payload : Bytes) : Unit := do
+    memoryStore(0, payload)
+
+/-- error: returndata-copy destination offset must be word-like, got Bytes -/
+#guard_msgs in
+verity_contract DynamicReturnDataCopyRejected where
+  storage
+  function bad (payload : Bytes) : Unit := do
+    returnDataCopy(payload, 0, 32)
+
 end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -18,6 +18,8 @@ def linkedOperandEcmModule : Compiler.ECM.ExternalCallModule where
 
 def linkedWordPassthrough (value : Uint256) : Uint256 := value
 
+def linkedWordTwice (value : Uint256) : Uint256 := value + value
+
 -- P0 #1003 coverage for linked calls and explicit low-level body syntax.
 -- `callExternal` is declaration-driven; target/value fields belong to `evmCall`.
 verity_contract ExternalCallInBodySmoke where
@@ -623,6 +625,27 @@ verity_contract EffectfulShortCircuitOperandRejected where
     external dirtyBool() -> (Bool)
   function bad (flag : Bool) : Bool := do
     return flag && callExternal dirtyBool()
+
+/-- error: Lean helper 'linkedWordTwice' arguments cannot contain callExternal because transparent-helper inlining may reuse or discard arguments; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulTransparentHelperArgumentRejected where
+  storage
+  linked_externals
+    external dirtyWord() -> (Uint256)
+  function bad () : Uint256 := do
+    return linkedWordTwice (callExternal dirtyWord())
+
+/-- error: dynamic projection indices cannot contain callExternal because ABI lowering reuses the index for offset and length; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulDynamicProjectionIndexRejected where
+  storage
+  struct Payload where
+    values : Array Uint256
+  linked_externals
+    external dirtyUint() -> (Uint32)
+    external consume(Array Uint256)
+  function bad (payloads : Array Payload) : Unit := do
+    callExternal consume((arrayElement payloads (callExternal dirtyUint())).values)
 
 /-- error: memory-store value requires a word-like value (Uint256, Int256, Uint8, Address, or Bytes32), got Verity.Macro.ValueType.bytes -/
 #guard_msgs in

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -19,6 +19,7 @@ verity_contract ExternalCallInBodySmoke where
     external dirtyInt() -> (Int32)
     external dirtyBytes() -> (Bytes4)
     external dirtySink(Uint32) -> (Uint32)
+    external consume(Uint256)
 
   function reentrancy_trusted linkedRead () : Uint256 := do
     let depositable ← callExternal getDepositableEther()
@@ -52,6 +53,18 @@ verity_contract ExternalCallInBodySmoke where
   function reentrancy_trusted bindDirtyUint () : Uint32 := do
     let result ← callExternal dirtyUint()
     return result
+
+  function reentrancy_trusted bindNestedExternalArg () : Uint32 := do
+    let result ← callExternal dirtySink(callExternal dirtyUint())
+    return result
+
+  function reentrancy_trusted statementNestedExternalArg () : Unit := do
+    callExternal consume(callExternal narrowEcho(0xdeadbeef))
+
+  function reentrancy_trusted logDirtyUint ()
+    local_obligations [low_level_frame := assumed "Logging a linked-call result is an explicit refinement boundary."]
+    : Unit := do
+    rawLog [callExternal dirtyUint()] 0 0
 
   function reentrancy_trusted pureDirtyInt () : Int32 := do
     let result := callExternal dirtyInt()
@@ -136,6 +149,19 @@ example : (ExternalCallInBodySmoke.bindDirtyUint_modelBody).take 2 =
     [ .externalCallBind ["result"] "dirtyUint" []
     , .assignVar "result" (.bitAnd (.localVar "result") (.literal (2 ^ 32 - 1))) ] := rfl
 
+example : (ExternalCallInBodySmoke.bindNestedExternalArg_modelBody).take 1 =
+    [.externalCallBind ["result"] "dirtySink"
+      [(.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))]] := rfl
+
+example : ExternalCallInBodySmoke.statementNestedExternalArg_modelBody =
+    [.externalCallBind [] "consume"
+      [(.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+
+example : ExternalCallInBodySmoke.logDirtyUint_modelBody =
+    [.rawLog [(.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))]
+      (.literal 0) (.literal 0)] := rfl
+
 example : (ExternalCallInBodySmoke.pureDirtyInt_modelBody).take 1 =
     [.letVar "result" (.signextend (.literal 3) (.externalCall "dirtyInt" []))] := rfl
 
@@ -175,6 +201,18 @@ example : ExternalCallInBodySmoke.storeDirtyUint_model.body =
 example : ExternalCallInBodySmoke.bindDirtyUint_model.body =
     ExternalCallInBodySmoke.bindDirtyUint_modelBody :=
   ExternalCallInBodySmoke.bindDirtyUint_semantic_preservation
+
+example : ExternalCallInBodySmoke.bindNestedExternalArg_model.body =
+    ExternalCallInBodySmoke.bindNestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.bindNestedExternalArg_semantic_preservation
+
+example : ExternalCallInBodySmoke.statementNestedExternalArg_model.body =
+    ExternalCallInBodySmoke.statementNestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.statementNestedExternalArg_semantic_preservation
+
+example : ExternalCallInBodySmoke.logDirtyUint_model.body =
+    ExternalCallInBodySmoke.logDirtyUint_modelBody :=
+  ExternalCallInBodySmoke.logDirtyUint_semantic_preservation
 
 example : ExternalCallInBodySmoke.pureDirtyInt_model.body =
     ExternalCallInBodySmoke.pureDirtyInt_modelBody :=

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -34,6 +34,11 @@ verity_contract ExternalCallInBodySmoke where
     returnDataCopy(96, 0, size)
     return (add (add (add pureRoundtrip roundtrip) success) observed)
 
+  function reentrancy_trusted composedReturnDataSize ()
+    local_obligations [low_level_frame := assumed "Reading returndata size is an explicit refinement boundary."]
+    : Uint256 := do
+    return (add (returnDataSize()) 1)
+
 example : (ExternalCallInBodySmoke.linkedRead_modelBody).take 1 =
     [Compiler.CompilationModel.Stmt.externalCallBind
       ["depositable"] "getDepositableEther" []] := rfl
@@ -80,6 +85,26 @@ verity_contract MalformedLinkedCallRejected where
     external scalarPair(Uint256, Uint256) -> (Uint256)
   function bad (payload : Bytes) : Uint256 := do
     let result ← callExternal scalarPair(payload)
+    return result
+
+/-- error: callExternal 'scalarPair' expects 2 args, got 1 -/
+#guard_msgs in
+verity_contract MalformedPureLinkedCallRejected where
+  storage
+  linked_externals
+    external scalarPair(Uint256, Uint256) -> (Uint256)
+  function bad (payload : Bytes) : Uint256 := do
+    let result := callExternal scalarPair(payload)
+    return result
+
+/-- error: callExternal 'pair' return type expands to 2 values and cannot be bound to one source variable -/
+#guard_msgs in
+verity_contract CompositeLinkedCallBindRejected where
+  storage
+  linked_externals
+    external pair(Uint256) -> (Tuple [Uint256, Uint256])
+  function bad (value : Uint256) : Tuple [Uint256, Uint256] := do
+    let result ← callExternal pair(value)
     return result
 
 end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -14,6 +14,7 @@ verity_contract ExternalCallInBodySmoke where
   linked_externals
     external getDepositableEther() -> (Uint256)
     external deposit(Uint256, Bytes)
+    external narrowEcho(Bytes4) -> (Uint256)
 
   function reentrancy_trusted linkedRead () : Uint256 := do
     let depositable ← callExternal getDepositableEther()
@@ -21,6 +22,10 @@ verity_contract ExternalCallInBodySmoke where
 
   function reentrancy_trusted linkedWrite (amount : Uint256, pubkey : Bytes) : Unit := do
     callExternal deposit(amount, pubkey)
+
+  function reentrancy_trusted pureNarrow () : Uint256 := do
+    let result := callExternal narrowEcho(0xdeadbeef)
+    return result
 
   function reentrancy_trusted lowLevel (target : Uint256, amount : Uint256)
     local_obligations [low_level_frame := assumed "Raw EVM call, memory, and returndata choreography is an explicit refinement boundary."]
@@ -54,6 +59,15 @@ example : (ExternalCallInBodySmoke.linkedRead_modelBody).take 1 =
 example : (ExternalCallInBodySmoke.linkedWrite_modelBody).take 1 =
     [Compiler.CompilationModel.Stmt.externalCallBind [] "deposit"
       [ .param "amount", .param "pubkey_data_offset", .param "pubkey_length" ]] := rfl
+
+example : (ExternalCallInBodySmoke.pureNarrow_modelBody).take 1 =
+    [Compiler.CompilationModel.Stmt.letVar "result"
+      (.externalCall "narrowEcho" [
+        .literal 100720434702924942364018397558880508427273416251376888068364465368051161759744])] := rfl
+
+example : ExternalCallInBodySmoke.pureNarrow_model.body =
+    ExternalCallInBodySmoke.pureNarrow_modelBody :=
+  ExternalCallInBodySmoke.pureNarrow_semantic_preservation
 
 example : (ExternalCallInBodySmoke.lowLevel_modelBody).take 7 =
     [ Compiler.CompilationModel.Stmt.mstore (.literal 0) (.param "amount")

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -7,6 +7,15 @@ open Verity hiding pure bind
 open Verity.EVM.Uint256
 open Verity.Stdlib.Math
 
+def linkedOperandEcmModule : Compiler.ECM.ExternalCallModule where
+  name := "linkedOperandEcm"
+  numArgs := 1
+  resultVars := []
+  writesState := false
+  readsState := false
+  axioms := []
+  compile := fun _ctx _args => pure []
+
 -- P0 #1003 coverage for linked calls and explicit low-level body syntax.
 -- `callExternal` is declaration-driven; target/value fields belong to `evmCall`.
 verity_contract ExternalCallInBodySmoke where
@@ -85,6 +94,15 @@ verity_contract ExternalCallInBodySmoke where
 
   function reentrancy_trusted helperNestedExternalArg () : Unit := do
     consumeHelper (callExternal narrowEcho(0xdeadbeef))
+
+  function reentrancy_trusted monadicLoadDirtyUint ()
+    local_obligations [low_level_frame := assumed "Reading memory through a linked-call offset is an explicit refinement boundary."]
+    : Uint256 := do
+    let value ← memoryLoad(callExternal dirtyUint())
+    return value
+
+  function reentrancy_trusted ecmNestedExternalArg () : Unit := do
+    ecmDo linkedOperandEcmModule [callExternal narrowEcho(0xdeadbeef)]
 
   function reentrancy_trusted pureDirtyInt () : Int32 := do
     let result := callExternal dirtyInt()
@@ -201,6 +219,15 @@ example : ExternalCallInBodySmoke.helperNestedExternalArg_modelBody =
       [(.externalCall "narrowEcho"
         [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
 
+example : (ExternalCallInBodySmoke.monadicLoadDirtyUint_modelBody).take 1 =
+    [.letVar "value" (.mload
+      (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1))))] := rfl
+
+example : ExternalCallInBodySmoke.ecmNestedExternalArg_modelBody =
+    [.ecm linkedOperandEcmModule
+      [(.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+
 example : ExternalCallInBodySmoke.legacyNarrowArgs_model.body =
     ExternalCallInBodySmoke.legacyNarrowArgs_modelBody :=
   ExternalCallInBodySmoke.legacyNarrowArgs_semantic_preservation
@@ -216,6 +243,14 @@ example : ExternalCallInBodySmoke.customErrorNestedExternalArg_model.body =
 example : ExternalCallInBodySmoke.helperNestedExternalArg_model.body =
     ExternalCallInBodySmoke.helperNestedExternalArg_modelBody :=
   ExternalCallInBodySmoke.helperNestedExternalArg_semantic_preservation
+
+example : ExternalCallInBodySmoke.monadicLoadDirtyUint_model.body =
+    ExternalCallInBodySmoke.monadicLoadDirtyUint_modelBody :=
+  ExternalCallInBodySmoke.monadicLoadDirtyUint_semantic_preservation
+
+example : ExternalCallInBodySmoke.ecmNestedExternalArg_model.body =
+    ExternalCallInBodySmoke.ecmNestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.ecmNestedExternalArg_semantic_preservation
 
 example : (ExternalCallInBodySmoke.pureDirtyInt_modelBody).take 1 =
     [.letVar "result" (.signextend (.literal 3) (.externalCall "dirtyInt" []))] := rfl

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -20,6 +20,8 @@ def linkedWordPassthrough (value : Uint256) : Uint256 := value
 
 def linkedWordTwice (value : Uint256) : Uint256 := value + value
 
+def linkedBoolTruthy (value : Bool) : Bool := if value then true else false
+
 -- P0 #1003 coverage for linked calls and explicit low-level body syntax.
 -- `callExternal` is declaration-driven; target/value fields belong to `evmCall`.
 verity_contract ExternalCallInBodySmoke where
@@ -626,7 +628,7 @@ verity_contract EffectfulShortCircuitOperandRejected where
   function bad (flag : Bool) : Bool := do
     return flag && callExternal dirtyBool()
 
-/-- error: Lean helper 'linkedWordTwice' arguments cannot contain callExternal because transparent-helper inlining may reuse or discard arguments; bind the external result first -/
+/-- error: Lean helper 'linkedWordTwice' arguments cannot contain callExternal unless the helper is a direct passthrough because transparent-helper and expression lowering may duplicate or discard arguments; bind the external result first -/
 #guard_msgs in
 verity_contract EffectfulTransparentHelperArgumentRejected where
   storage
@@ -634,6 +636,24 @@ verity_contract EffectfulTransparentHelperArgumentRejected where
     external dirtyWord() -> (Uint256)
   function bad () : Uint256 := do
     return linkedWordTwice (callExternal dirtyWord())
+
+/-- error: Lean helper 'linkedBoolTruthy' arguments cannot contain callExternal unless the helper is a direct passthrough because transparent-helper and expression lowering may duplicate or discard arguments; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulTransparentHelperLoweringRejected where
+  storage
+  linked_externals
+    external dirtyBool() -> (Bool)
+  function bad () : Bool := do
+    return linkedBoolTruthy (callExternal dirtyBool())
+
+/-- error: mulDivUp divisor cannot contain callExternal because expression lowering reuses it; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulMulDivUpDivisorRejected where
+  storage
+  linked_externals
+    external dirtyWord() -> (Uint256)
+  function bad () : Uint256 := do
+    return mulDivUp 10 2 (callExternal dirtyWord())
 
 /-- error: dynamic projection indices cannot contain callExternal because ABI lowering reuses the index for offset and length; bind the external result first -/
 #guard_msgs in
@@ -646,6 +666,17 @@ verity_contract EffectfulDynamicProjectionIndexRejected where
     external consume(Array Uint256)
   function bad (payloads : Array Payload) : Unit := do
     callExternal consume((arrayElement payloads (callExternal dirtyUint())).values)
+
+/-- error: ECM dynamic projection indices cannot contain callExternal because ABI lowering reuses the index for offset and length; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulEcmDynamicProjectionIndexRejected where
+  storage
+  struct Payload where
+    values : Array Uint256
+  linked_externals
+    external dirtyUint() -> (Uint32)
+  function bad (payloads : Array Payload) : Unit := do
+    ecmBind [] linkedOperandEcmModule [(arrayElement payloads (callExternal dirtyUint())).values]
 
 /-- error: memory-store value requires a word-like value (Uint256, Int256, Uint8, Address, or Bytes32), got Verity.Macro.ValueType.bytes -/
 #guard_msgs in

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -655,6 +655,35 @@ verity_contract EffectfulMulDivUpDivisorRejected where
   function bad () : Uint256 := do
     return mulDivUp 10 2 (callExternal dirtyWord())
 
+/-- error: msb operand cannot contain callExternal because expression lowering reuses it in the zero check and clz; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulMsbOperandRejected where
+  storage
+  linked_externals
+    external dirtyWord() -> (Uint256)
+  function bad () : Uint256 := do
+    return msb (callExternal dirtyWord())
+
+/-- error: structMembers key cannot contain callExternal when selecting multiple members because lowering reuses the key; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulStructMembersKeyRejected where
+  storage
+    records : MappingStruct(Uint256, [first : Uint256 @word 0, second : Uint256 @word 1]) := slot 0
+  linked_externals
+    external dirtyKey() -> (Uint256)
+  function bad () : Tuple [Uint256, Uint256] := do
+    return structMembers records (callExternal dirtyKey()) ["first", "second"]
+
+/-- error: structMembers2 keys cannot contain callExternal when selecting multiple members because lowering reuses the keys; bind external results first -/
+#guard_msgs in
+verity_contract EffectfulStructMembers2KeyRejected where
+  storage
+    records : MappingStruct2(Uint256, Uint256, [first : Uint256 @word 0, second : Uint256 @word 1]) := slot 0
+  linked_externals
+    external dirtyKey() -> (Uint256)
+  function bad (outerKey : Uint256) : Tuple [Uint256, Uint256] := do
+    return structMembers2 records outerKey (callExternal dirtyKey()) ["first", "second"]
+
 /-- error: dynamic projection indices cannot contain callExternal because ABI lowering reuses the index for offset and length; bind the external result first -/
 #guard_msgs in
 verity_contract EffectfulDynamicProjectionIndexRejected where

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -117,14 +117,14 @@ verity_contract CompositePureLinkedCallRejected where
     let result := callExternal pair(value)
     return result
 
-/-- error: memory-store value must be word-like, got Bytes -/
+/-- error: memory-store value requires a word-like value (Uint256, Int256, Uint8, Address, or Bytes32), got Verity.Macro.ValueType.bytes -/
 #guard_msgs in
 verity_contract DynamicMemoryStoreRejected where
   storage
   function bad (payload : Bytes) : Unit := do
     memoryStore(0, payload)
 
-/-- error: returndata-copy destination offset must be word-like, got Bytes -/
+/-- error: returndata-copy destination offset requires a word-like value (Uint256, Int256, Uint8, Address, or Bytes32), got Verity.Macro.ValueType.bytes -/
 #guard_msgs in
 verity_contract DynamicReturnDataCopyRejected where
   storage

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -41,9 +41,11 @@ verity_contract ExternalCallInBodySmoke where
 
   function reentrancy_trusted discardedReturnDataSize ()
     local_obligations [low_level_frame := assumed "Reading returndata size is an explicit refinement boundary."]
-    : Unit := do
+    : Uint256 := do
     let _ ← returnDataSize()
-    return ()
+    let _ ← (returnDataSize())
+    let parenthesized ← (returnDataSize())
+    return parenthesized
 
 example : (ExternalCallInBodySmoke.linkedRead_modelBody).take 1 =
     [Compiler.CompilationModel.Stmt.externalCallBind
@@ -76,8 +78,10 @@ example : ExternalCallInBodySmoke.lowLevel_model.body =
     ExternalCallInBodySmoke.lowLevel_modelBody :=
   ExternalCallInBodySmoke.lowLevel_semantic_preservation
 
-example : (ExternalCallInBodySmoke.discardedReturnDataSize_modelBody).take 1 =
-    [Compiler.CompilationModel.Stmt.letVar "__discard" .returndataSize] := rfl
+example : (ExternalCallInBodySmoke.discardedReturnDataSize_modelBody).take 3 =
+    [ Compiler.CompilationModel.Stmt.letVar "__discard" .returndataSize
+    , Compiler.CompilationModel.Stmt.letVar "__discard_1" .returndataSize
+    , Compiler.CompilationModel.Stmt.letVar "parenthesized" .returndataSize ] := rfl
 
 example : ExternalCallInBodySmoke.discardedReturnDataSize_model.body =
     ExternalCallInBodySmoke.discardedReturnDataSize_modelBody :=

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -171,6 +171,15 @@ verity_contract ExternalCallInBodySmoke where
   function reentrancy_trusted tupleNestedExternalReturn () : Tuple [Uint32, Uint256] := do
     return (callExternal dirtyUint(), 0)
 
+  function reentrancy_trusted tupleArrayLinkedIndexDestructure
+      (cuts : Array (Tuple [Uint256, Uint256])) : Uint256 := do
+    let (first, _) := arrayElement cuts (callExternal dirtyUint())
+    return first
+
+  function reentrancy_trusted tupleArrayLinkedIndexReturn
+      (cuts : Array (Tuple [Uint256, Uint256])) : Tuple [Uint256, Uint256] := do
+    return arrayElement cuts (callExternal dirtyUint())
+
   function reentrancy_trusted pureDirtyInt () : Int32 := do
     let result := callExternal dirtyInt()
     return result
@@ -741,5 +750,29 @@ verity_contract DynamicReturnDataCopyRejected where
   storage
   function bad (payload : Bytes) : Unit := do
     returnDataCopy(payload, 0, 32)
+
+example : ExternalCallInBodySmoke.tupleArrayLinkedIndexDestructure_modelBody =
+    [ Compiler.CompilationModel.Stmt.letVar "arrayElement_index"
+        (Compiler.CompilationModel.Expr.bitAnd
+          (Compiler.CompilationModel.Expr.externalCall "dirtyUint" [])
+          (Compiler.CompilationModel.Expr.literal 0xffffffff))
+    , Compiler.CompilationModel.Stmt.letVar "first"
+        (Compiler.CompilationModel.Expr.arrayElementWord "cuts"
+          (Compiler.CompilationModel.Expr.localVar "arrayElement_index") 2 0)
+    , Compiler.CompilationModel.Stmt.return
+        (Compiler.CompilationModel.Expr.localVar "first") ] := by
+  rfl
+
+example : ExternalCallInBodySmoke.tupleArrayLinkedIndexReturn_modelBody =
+    [ Compiler.CompilationModel.Stmt.letVar "arrayElement_index"
+        (Compiler.CompilationModel.Expr.bitAnd
+          (Compiler.CompilationModel.Expr.externalCall "dirtyUint" [])
+          (Compiler.CompilationModel.Expr.literal 0xffffffff))
+    , Compiler.CompilationModel.Stmt.returnValues
+        [ Compiler.CompilationModel.Expr.arrayElementWord "cuts"
+            (Compiler.CompilationModel.Expr.localVar "arrayElement_index") 2 0
+        , Compiler.CompilationModel.Expr.arrayElementWord "cuts"
+            (Compiler.CompilationModel.Expr.localVar "arrayElement_index") 2 1 ] ] := by
+  rfl
 
 end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -53,9 +53,17 @@ example : (ExternalCallInBodySmoke.lowLevel_modelBody).take 7 =
     , Compiler.CompilationModel.Stmt.letVar "size" .returndataSize
     , Compiler.CompilationModel.Stmt.returndataCopy (.literal 96) (.literal 0) (.localVar "size") ] := rfl
 
-#check ExternalCallInBodySmoke.linkedRead_semantic_preservation
-#check ExternalCallInBodySmoke.linkedWrite_semantic_preservation
-#check ExternalCallInBodySmoke.lowLevel_semantic_preservation
+example : ExternalCallInBodySmoke.linkedRead_model.body =
+    ExternalCallInBodySmoke.linkedRead_modelBody :=
+  ExternalCallInBodySmoke.linkedRead_semantic_preservation
+
+example : ExternalCallInBodySmoke.linkedWrite_model.body =
+    ExternalCallInBodySmoke.linkedWrite_modelBody :=
+  ExternalCallInBodySmoke.linkedWrite_semantic_preservation
+
+example : ExternalCallInBodySmoke.lowLevel_model.body =
+    ExternalCallInBodySmoke.lowLevel_modelBody :=
+  ExternalCallInBodySmoke.lowLevel_semantic_preservation
 
 /-- error: unsupported expression in verity_contract body (see #1003 for planned macro support expansions) -/
 #guard_msgs in

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -29,12 +29,15 @@ verity_contract ExternalCallInBodySmoke where
     external deposit(Uint256, Bytes)
     external narrowEcho(Bytes4) -> (Uint256)
     external dirtyUint() -> (Uint32)
+    external dirtyUint_try() -> (Bool, Uint32)
     external dirtyInt() -> (Int32)
     external dirtyBytes() -> (Bytes4)
     external dirtySink(Uint32) -> (Uint32)
     external consumeUint8(Uint8)
     external consumeUint16(Uint16)
     external consume(Uint256)
+    external notifyBool(Bool)
+    external notifyBool_try(Bool) -> (Bool)
   function reentrancy_trusted linkedRead () : Uint256 := do
     let depositable ← callExternal getDepositableEther()
     return depositable
@@ -67,6 +70,18 @@ verity_contract ExternalCallInBodySmoke where
   function reentrancy_trusted bindDirtyUint () : Uint32 := do
     let result ← callExternal dirtyUint()
     return result
+
+  function reentrancy_trusted tryDirtyUint () : Uint32 := do
+    let (_success, result) ← tryExternalCall "dirtyUint" []
+    return result
+
+  function reentrancy_trusted callResultDirtyUint () : Uint32 := do
+    let result ← callResult "dirtyUint" []
+    return result.returndata
+
+  function reentrancy_trusted tryNotifyBool (flag : Bool) : Bool := do
+    let success ← tryExternalCall "notifyBool" [flag]
+    return success
 
   function reentrancy_trusted bindNestedExternalArg () : Uint32 := do
     let result ← callExternal dirtySink(callExternal dirtyUint())
@@ -203,6 +218,18 @@ example : ExternalCallInBodySmoke.storeDirtyUint_modelBody =
 example : (ExternalCallInBodySmoke.bindDirtyUint_modelBody).take 2 =
     [ .externalCallBind ["result"] "dirtyUint" []
     , .assignVar "result" (.bitAnd (.localVar "result") (.literal (2 ^ 32 - 1))) ] := rfl
+
+example : (ExternalCallInBodySmoke.tryDirtyUint_modelBody).take 2 =
+    [ .tryExternalCallBind "_success" ["result"] "dirtyUint" []
+    , .assignVar "result" (.bitAnd (.localVar "result") (.literal (2 ^ 32 - 1))) ] := rfl
+
+example : (ExternalCallInBodySmoke.callResultDirtyUint_modelBody).take 2 =
+    [ .tryExternalCallBind "result_success" ["result_returndata"] "dirtyUint" []
+    , .assignVar "result_returndata"
+        (.bitAnd (.localVar "result_returndata") (.literal (2 ^ 32 - 1))) ] := rfl
+
+example : (ExternalCallInBodySmoke.tryNotifyBool_modelBody).take 1 =
+    [.tryExternalCallBind "success" [] "notifyBool" [.param "flag"]] := rfl
 
 example : (ExternalCallInBodySmoke.bindNestedExternalArg_modelBody).take 1 =
     [.externalCallBind ["result"] "dirtySink"

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -574,7 +574,7 @@ verity_contract EffectfulSafeArithmeticOperandRejected where
     let result ← requireSomeUint (safeAdd (callExternal dirtyUint()) 1) "overflow"
     return result
 
-/-- error: conditional branches cannot contain callExternal because expression lowering evaluates both branches; use statement-level control flow -/
+/-- error: conditional operands cannot contain callExternal because expression lowering duplicates the condition and evaluates both branches; use statement-level control flow -/
 #guard_msgs in
 verity_contract EffectfulConditionalBranchRejected where
   storage
@@ -582,6 +582,38 @@ verity_contract EffectfulConditionalBranchRejected where
     external dirtyUint() -> (Uint32)
   function bad (flag : Bool) : Uint32 := do
     return ite flag (callExternal dirtyUint()) 0
+
+/-- error: conditional operands cannot contain callExternal because expression lowering duplicates the condition and evaluates both branches; use statement-level control flow -/
+#guard_msgs in
+verity_contract EffectfulConditionalConditionRejected where
+  storage
+  linked_externals
+    external dirtyBool() -> (Bool)
+  function bad () : Uint256 := do
+    return ite (callExternal dirtyBool()) 1 0
+
+/-- error: duplicated expression operands cannot contain callExternal; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulDuplicatedOperandRejected where
+  storage
+  linked_externals
+    external dirtyUint() -> (Uint32)
+  function bad () : Uint256 := do
+    return min (callExternal dirtyUint()) 1
+
+/-- error: tryExternalCall 'dirtyPair' flattened result variable 'result_narrow' conflicts with an existing local -/
+#guard_msgs in
+verity_contract FlattenedTryResultCollisionRejected where
+  storage
+  struct NarrowPair where
+    narrow : Uint32,
+    wide : Uint256
+  linked_externals
+    external dirtyPair() -> (NarrowPair)
+  function bad () : Uint32 := do
+    let result_narrow := 7
+    let (_success, result) ← tryExternalCall "dirtyPair" []
+    return result.narrow
 
 /-- error: short-circuit logical operands cannot contain callExternal because expression lowering evaluates both operands; bind the external result first -/
 #guard_msgs in

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -39,6 +39,12 @@ verity_contract ExternalCallInBodySmoke where
     : Uint256 := do
     return (add (returnDataSize()) 1)
 
+  function reentrancy_trusted discardedReturnDataSize ()
+    local_obligations [low_level_frame := assumed "Reading returndata size is an explicit refinement boundary."]
+    : Unit := do
+    let _ ← returnDataSize()
+    return ()
+
 example : (ExternalCallInBodySmoke.linkedRead_modelBody).take 1 =
     [Compiler.CompilationModel.Stmt.externalCallBind
       ["depositable"] "getDepositableEther" []] := rfl
@@ -69,6 +75,13 @@ example : ExternalCallInBodySmoke.linkedWrite_model.body =
 example : ExternalCallInBodySmoke.lowLevel_model.body =
     ExternalCallInBodySmoke.lowLevel_modelBody :=
   ExternalCallInBodySmoke.lowLevel_semantic_preservation
+
+example : (ExternalCallInBodySmoke.discardedReturnDataSize_modelBody).take 1 =
+    [Compiler.CompilationModel.Stmt.letVar "__discard" .returndataSize] := rfl
+
+example : ExternalCallInBodySmoke.discardedReturnDataSize_model.body =
+    ExternalCallInBodySmoke.discardedReturnDataSize_modelBody :=
+  ExternalCallInBodySmoke.discardedReturnDataSize_semantic_preservation
 
 /-- error: unsupported expression in verity_contract body (see #1003 for planned macro support expansions) -/
 #guard_msgs in

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -664,6 +664,27 @@ verity_contract EffectfulMsbOperandRejected where
   function bad () : Uint256 := do
     return msb (callExternal dirtyWord())
 
+/-- error: boolToWord operand cannot contain callExternal because expression lowering evaluates its condition more than once; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulBoolToWordOperandRejected where
+  storage
+  linked_externals
+    external dirtyBool() -> (Bool)
+  function bad () : Uint256 := do
+    return boolToWord (callExternal dirtyBool())
+
+/-- error: arrayElement alias index cannot contain callExternal because the alias re-evaluates its index at each projection; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulArrayElementAliasIndexRejected where
+  storage
+  struct Payload where
+    values : Array Uint256
+  linked_externals
+    external dirtyIndex() -> (Uint256)
+  function bad (payloads : Array Payload) : Uint256 := do
+    let item := arrayElement payloads (callExternal dirtyIndex())
+    return arrayLength item.values
+
 /-- error: structMembers key cannot contain callExternal when selecting multiple members because lowering reuses the key; bind the external result first -/
 #guard_msgs in
 verity_contract EffectfulStructMembersKeyRejected where

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -605,6 +605,20 @@ verity_contract EffectfulConditionalConditionRejected where
   function bad () : Uint256 := do
     return ite (callExternal dirtyBool()) 1 0
 
+/-- error: conditional operands cannot contain callExternal because expression lowering duplicates the condition and evaluates both branches; use statement-level control flow -/
+#guard_msgs in
+verity_contract EffectfulEvmCallConditionalBranchRejected where
+  storage
+  function bad (target : Address) : Uint256 := do
+    return ite false (evmCall(50000, target, 0, 0, 0, 0, 0)) 0
+
+/-- error: conditional operands cannot contain callExternal because expression lowering duplicates the condition and evaluates both branches; use statement-level control flow -/
+#guard_msgs in
+verity_contract EffectfulEvmStaticCallConditionalBranchRejected where
+  storage
+  function bad (target : Address) : Uint256 := do
+    return ite false (evmStaticCall(50000, target, 0, 0, 0, 0)) 0
+
 /-- error: duplicated expression operands cannot contain callExternal; bind the external result first -/
 #guard_msgs in
 verity_contract EffectfulDuplicatedOperandRejected where

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -15,6 +15,9 @@ verity_contract ExternalCallInBodySmoke where
     external getDepositableEther() -> (Uint256)
     external deposit(Uint256, Bytes)
     external narrowEcho(Bytes4) -> (Uint256)
+    external dirtyUint() -> (Uint32)
+    external dirtyInt() -> (Int32)
+    external dirtyBytes() -> (Bytes4)
 
   function reentrancy_trusted linkedRead () : Uint256 := do
     let depositable ← callExternal getDepositableEther()
@@ -25,6 +28,30 @@ verity_contract ExternalCallInBodySmoke where
 
   function reentrancy_trusted pureNarrow () : Uint256 := do
     let result := callExternal narrowEcho(0xdeadbeef)
+    return result
+
+  function reentrancy_trusted pureDirtyUint () : Uint32 := do
+    let result := callExternal dirtyUint()
+    return result
+
+  function reentrancy_trusted bindDirtyUint () : Uint32 := do
+    let result ← callExternal dirtyUint()
+    return result
+
+  function reentrancy_trusted pureDirtyInt () : Int32 := do
+    let result := callExternal dirtyInt()
+    return result
+
+  function reentrancy_trusted bindDirtyInt () : Int32 := do
+    let result ← callExternal dirtyInt()
+    return result
+
+  function reentrancy_trusted pureDirtyBytes () : Bytes4 := do
+    let result := callExternal dirtyBytes()
+    return result
+
+  function reentrancy_trusted bindDirtyBytes () : Bytes4 := do
+    let result ← callExternal dirtyBytes()
     return result
 
   function reentrancy_trusted lowLevel (target : Uint256, amount : Uint256)
@@ -68,6 +95,53 @@ example : (ExternalCallInBodySmoke.pureNarrow_modelBody).take 1 =
 example : ExternalCallInBodySmoke.pureNarrow_model.body =
     ExternalCallInBodySmoke.pureNarrow_modelBody :=
   ExternalCallInBodySmoke.pureNarrow_semantic_preservation
+
+example : (ExternalCallInBodySmoke.pureDirtyUint_modelBody).take 1 =
+    [.letVar "result" (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))] := rfl
+
+example : (ExternalCallInBodySmoke.bindDirtyUint_modelBody).take 2 =
+    [ .externalCallBind ["result"] "dirtyUint" []
+    , .assignVar "result" (.bitAnd (.localVar "result") (.literal (2 ^ 32 - 1))) ] := rfl
+
+example : (ExternalCallInBodySmoke.pureDirtyInt_modelBody).take 1 =
+    [.letVar "result" (.signextend (.literal 3) (.externalCall "dirtyInt" []))] := rfl
+
+example : (ExternalCallInBodySmoke.bindDirtyInt_modelBody).take 2 =
+    [ .externalCallBind ["result"] "dirtyInt" []
+    , .assignVar "result" (.signextend (.literal 3) (.localVar "result")) ] := rfl
+
+example : (ExternalCallInBodySmoke.pureDirtyBytes_modelBody).take 1 =
+    [.letVar "result" (.bitAnd (.externalCall "dirtyBytes" [])
+      (.literal ((2 ^ 32 - 1) * 2 ^ 224)))] := rfl
+
+example : (ExternalCallInBodySmoke.bindDirtyBytes_modelBody).take 2 =
+    [ .externalCallBind ["result"] "dirtyBytes" []
+    , .assignVar "result" (.bitAnd (.localVar "result")
+        (.literal ((2 ^ 32 - 1) * 2 ^ 224))) ] := rfl
+
+example : ExternalCallInBodySmoke.pureDirtyUint_model.body =
+    ExternalCallInBodySmoke.pureDirtyUint_modelBody :=
+  ExternalCallInBodySmoke.pureDirtyUint_semantic_preservation
+
+example : ExternalCallInBodySmoke.bindDirtyUint_model.body =
+    ExternalCallInBodySmoke.bindDirtyUint_modelBody :=
+  ExternalCallInBodySmoke.bindDirtyUint_semantic_preservation
+
+example : ExternalCallInBodySmoke.pureDirtyInt_model.body =
+    ExternalCallInBodySmoke.pureDirtyInt_modelBody :=
+  ExternalCallInBodySmoke.pureDirtyInt_semantic_preservation
+
+example : ExternalCallInBodySmoke.bindDirtyInt_model.body =
+    ExternalCallInBodySmoke.bindDirtyInt_modelBody :=
+  ExternalCallInBodySmoke.bindDirtyInt_semantic_preservation
+
+example : ExternalCallInBodySmoke.pureDirtyBytes_model.body =
+    ExternalCallInBodySmoke.pureDirtyBytes_modelBody :=
+  ExternalCallInBodySmoke.pureDirtyBytes_semantic_preservation
+
+example : ExternalCallInBodySmoke.bindDirtyBytes_model.body =
+    ExternalCallInBodySmoke.bindDirtyBytes_modelBody :=
+  ExternalCallInBodySmoke.bindDirtyBytes_semantic_preservation
 
 example : (ExternalCallInBodySmoke.lowLevel_modelBody).take 7 =
     [ Compiler.CompilationModel.Stmt.mstore (.literal 0) (.param "amount")

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -34,6 +34,12 @@ verity_contract ExternalCallInBodySmoke where
     let result := callExternal dirtyUint()
     return result
 
+  function reentrancy_trusted directDirtyUint () : Uint32 := do
+    return callExternal dirtyUint()
+
+  function reentrancy_trusted nestedDirtyUint () : Bool := do
+    return (callExternal dirtyUint()) == 1
+
   function reentrancy_trusted bindDirtyUint () : Uint32 := do
     let result ← callExternal dirtyUint()
     return result
@@ -99,6 +105,14 @@ example : ExternalCallInBodySmoke.pureNarrow_model.body =
 example : (ExternalCallInBodySmoke.pureDirtyUint_modelBody).take 1 =
     [.letVar "result" (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))] := rfl
 
+example : ExternalCallInBodySmoke.directDirtyUint_modelBody =
+    [.return (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))] := rfl
+
+example : ExternalCallInBodySmoke.nestedDirtyUint_modelBody =
+    [.return (.eq
+      (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))
+      (.literal 1))] := rfl
+
 example : (ExternalCallInBodySmoke.bindDirtyUint_modelBody).take 2 =
     [ .externalCallBind ["result"] "dirtyUint" []
     , .assignVar "result" (.bitAnd (.localVar "result") (.literal (2 ^ 32 - 1))) ] := rfl
@@ -122,6 +136,14 @@ example : (ExternalCallInBodySmoke.bindDirtyBytes_modelBody).take 2 =
 example : ExternalCallInBodySmoke.pureDirtyUint_model.body =
     ExternalCallInBodySmoke.pureDirtyUint_modelBody :=
   ExternalCallInBodySmoke.pureDirtyUint_semantic_preservation
+
+example : ExternalCallInBodySmoke.directDirtyUint_model.body =
+    ExternalCallInBodySmoke.directDirtyUint_modelBody :=
+  ExternalCallInBodySmoke.directDirtyUint_semantic_preservation
+
+example : ExternalCallInBodySmoke.nestedDirtyUint_model.body =
+    ExternalCallInBodySmoke.nestedDirtyUint_modelBody :=
+  ExternalCallInBodySmoke.nestedDirtyUint_semantic_preservation
 
 example : ExternalCallInBodySmoke.bindDirtyUint_model.body =
     ExternalCallInBodySmoke.bindDirtyUint_modelBody :=

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -282,8 +282,9 @@ example : (ExternalCallInBodySmoke.tryNotifyBool_modelBody).take 2 =
       [(.logicalNot (.eq (.param "flag") (.literal 0)))],
      .assignVar "success" (.logicalNot (.eq (.localVar "success") (.literal 0)))] := rfl
 
-example : (ExternalCallInBodySmoke.tryDirtyPair_modelBody).take 3 =
+example : (ExternalCallInBodySmoke.tryDirtyPair_modelBody).take 4 =
     [ .tryExternalCallBind "_success" ["result_narrow", "result_wide"] "dirtyPair" []
+    , .assignVar "_success" (.logicalNot (.eq (.localVar "_success") (.literal 0)))
     , .assignVar "result_narrow"
         (.bitAnd (.localVar "result_narrow") (.literal (2 ^ 32 - 1)))
     , .return (.localVar "result_narrow") ] := rfl

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -18,6 +18,7 @@ verity_contract ExternalCallInBodySmoke where
     external dirtyUint() -> (Uint32)
     external dirtyInt() -> (Int32)
     external dirtyBytes() -> (Bytes4)
+    external dirtySink(Uint32) -> (Uint32)
 
   function reentrancy_trusted linkedRead () : Uint256 := do
     let depositable ← callExternal getDepositableEther()
@@ -39,6 +40,14 @@ verity_contract ExternalCallInBodySmoke where
 
   function reentrancy_trusted nestedDirtyUint () : Bool := do
     return (callExternal dirtyUint()) == 1
+
+  function reentrancy_trusted nestedExternalArg () : Uint32 := do
+    return callExternal dirtySink(callExternal dirtyUint())
+
+  function reentrancy_trusted storeDirtyUint ()
+    local_obligations [low_level_frame := assumed "Writing a linked-call result to memory is an explicit refinement boundary."]
+    : Unit := do
+    memoryStore(0, callExternal dirtyUint())
 
   function reentrancy_trusted bindDirtyUint () : Uint32 := do
     let result ← callExternal dirtyUint()
@@ -113,6 +122,16 @@ example : ExternalCallInBodySmoke.nestedDirtyUint_modelBody =
       (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))
       (.literal 1))] := rfl
 
+example : ExternalCallInBodySmoke.nestedExternalArg_modelBody =
+    [.return (.bitAnd
+      (.externalCall "dirtySink"
+        [(.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))])
+      (.literal (2 ^ 32 - 1)))] := rfl
+
+example : ExternalCallInBodySmoke.storeDirtyUint_modelBody =
+    [.mstore (.literal 0)
+      (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))] := rfl
+
 example : (ExternalCallInBodySmoke.bindDirtyUint_modelBody).take 2 =
     [ .externalCallBind ["result"] "dirtyUint" []
     , .assignVar "result" (.bitAnd (.localVar "result") (.literal (2 ^ 32 - 1))) ] := rfl
@@ -144,6 +163,14 @@ example : ExternalCallInBodySmoke.directDirtyUint_model.body =
 example : ExternalCallInBodySmoke.nestedDirtyUint_model.body =
     ExternalCallInBodySmoke.nestedDirtyUint_modelBody :=
   ExternalCallInBodySmoke.nestedDirtyUint_semantic_preservation
+
+example : ExternalCallInBodySmoke.nestedExternalArg_model.body =
+    ExternalCallInBodySmoke.nestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.nestedExternalArg_semantic_preservation
+
+example : ExternalCallInBodySmoke.storeDirtyUint_model.body =
+    ExternalCallInBodySmoke.storeDirtyUint_modelBody :=
+  ExternalCallInBodySmoke.storeDirtyUint_semantic_preservation
 
 example : ExternalCallInBodySmoke.bindDirtyUint_model.body =
     ExternalCallInBodySmoke.bindDirtyUint_modelBody :=

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -268,16 +268,19 @@ example : (ExternalCallInBodySmoke.bindDirtyUint_modelBody).take 2 =
 
 example : (ExternalCallInBodySmoke.tryDirtyUint_modelBody).take 2 =
     [ .tryExternalCallBind "_success" ["result"] "dirtyUint" []
-    , .assignVar "result" (.bitAnd (.localVar "result") (.literal (2 ^ 32 - 1))) ] := rfl
+    , .assignVar "_success" (.logicalNot (.eq (.localVar "_success") (.literal 0))) ] := rfl
 
-example : (ExternalCallInBodySmoke.callResultDirtyUint_modelBody).take 2 =
+example : (ExternalCallInBodySmoke.callResultDirtyUint_modelBody).take 3 =
     [ .tryExternalCallBind "result_success" ["result_returndata"] "dirtyUint" []
+    , .assignVar "result_success"
+        (.logicalNot (.eq (.localVar "result_success") (.literal 0)))
     , .assignVar "result_returndata"
         (.bitAnd (.localVar "result_returndata") (.literal (2 ^ 32 - 1))) ] := rfl
 
-example : (ExternalCallInBodySmoke.tryNotifyBool_modelBody).take 1 =
+example : (ExternalCallInBodySmoke.tryNotifyBool_modelBody).take 2 =
     [.tryExternalCallBind "success" [] "notifyBool"
-      [(.logicalNot (.eq (.param "flag") (.literal 0)))]] := rfl
+      [(.logicalNot (.eq (.param "flag") (.literal 0)))],
+     .assignVar "success" (.logicalNot (.eq (.localVar "success") (.literal 0)))] := rfl
 
 example : (ExternalCallInBodySmoke.tryDirtyPair_modelBody).take 3 =
     [ .tryExternalCallBind "_success" ["result_narrow", "result_wide"] "dirtyPair" []
@@ -569,6 +572,24 @@ verity_contract EffectfulSafeArithmeticOperandRejected where
   function bad () : Uint256 := do
     let result ← requireSomeUint (safeAdd (callExternal dirtyUint()) 1) "overflow"
     return result
+
+/-- error: conditional branches cannot contain callExternal because expression lowering evaluates both branches; use statement-level control flow -/
+#guard_msgs in
+verity_contract EffectfulConditionalBranchRejected where
+  storage
+  linked_externals
+    external dirtyUint() -> (Uint32)
+  function bad (flag : Bool) : Uint32 := do
+    return ite flag (callExternal dirtyUint()) 0
+
+/-- error: short-circuit logical operands cannot contain callExternal because expression lowering evaluates both operands; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulShortCircuitOperandRejected where
+  storage
+  linked_externals
+    external dirtyBool() -> (Bool)
+  function bad (flag : Bool) : Bool := do
+    return flag && callExternal dirtyBool()
 
 /-- error: memory-store value requires a word-like value (Uint256, Int256, Uint8, Address, or Bytes32), got Verity.Macro.ValueType.bytes -/
 #guard_msgs in

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -1,0 +1,67 @@
+import Contracts.Common
+
+namespace Contracts.Smoke
+
+open Contracts
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+open Verity.Stdlib.Math
+
+-- P0 #1003 coverage for linked calls and explicit low-level body syntax.
+-- `callExternal` is declaration-driven; target/value fields belong to `evmCall`.
+verity_contract ExternalCallInBodySmoke where
+  storage
+  linked_externals
+    external getDepositableEther() -> (Uint256)
+    external deposit(Uint256, Bytes)
+
+  function reentrancy_trusted linkedRead () : Uint256 := do
+    let depositable ← callExternal getDepositableEther()
+    return depositable
+
+  function reentrancy_trusted linkedWrite (amount : Uint256, pubkey : Bytes) : Unit := do
+    callExternal deposit(amount, pubkey)
+
+  function reentrancy_trusted lowLevel (target : Uint256, amount : Uint256)
+    local_obligations [low_level_frame := assumed "Raw EVM call, memory, and returndata choreography is an explicit refinement boundary."]
+    : Uint256 := do
+    memoryStore(0, amount)
+    let pureRoundtrip := add (memoryLoad(0)) 0
+    let roundtrip ← memoryLoad(0)
+    let success ← evmCall(50000, target, amount, 0, 32, 64, 32)
+    let observed ← evmStaticCall(50000, target, 0, 32, 64, 32)
+    let size ← returnDataSize()
+    returnDataCopy(96, 0, size)
+    return (add (add (add pureRoundtrip roundtrip) success) observed)
+
+example : ExternalCallInBodySmoke.linkedRead_modelBody.head? =
+    some (Compiler.CompilationModel.Stmt.externalCallBind
+      ["depositable"] "getDepositableEther" []) := rfl
+
+example : ExternalCallInBodySmoke.linkedWrite_modelBody.head? =
+    some (Compiler.CompilationModel.Stmt.externalCallBind [] "deposit"
+      [ .param "amount", .param "pubkey_data_offset", .param "pubkey_length" ]) := rfl
+
+example : ExternalCallInBodySmoke.lowLevel_modelBody.take 7 =
+    [ Compiler.CompilationModel.Stmt.mstore (.literal 0) (.param "amount")
+    , Compiler.CompilationModel.Stmt.letVar "pureRoundtrip" (.add (.mload (.literal 0)) (.literal 0))
+    , Compiler.CompilationModel.Stmt.letVar "roundtrip" (.mload (.literal 0))
+    , Compiler.CompilationModel.Stmt.letVar "success" (.call (.literal 50000) (.param "target") (.param "amount")
+        (.literal 0) (.literal 32) (.literal 64) (.literal 32))
+    , Compiler.CompilationModel.Stmt.letVar "observed" (.staticcall (.literal 50000) (.param "target")
+        (.literal 0) (.literal 32) (.literal 64) (.literal 32))
+    , Compiler.CompilationModel.Stmt.letVar "size" .returndataSize
+    , Compiler.CompilationModel.Stmt.returndataCopy (.literal 96) (.literal 0) (.localVar "size") ] := rfl
+
+#check ExternalCallInBodySmoke.linkedRead_semantic_preservation
+#check ExternalCallInBodySmoke.linkedWrite_semantic_preservation
+#check ExternalCallInBodySmoke.lowLevel_semantic_preservation
+
+/-- error: unsupported expression in verity_contract body (see #1003 for planned macro support expansions) -/
+#guard_msgs in
+verity_contract MalformedEvmCallRejected where
+  storage
+  function bad (target : Uint256) : Uint256 := do
+    return evmCall(1, target)
+
+end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -34,13 +34,13 @@ verity_contract ExternalCallInBodySmoke where
     returnDataCopy(96, 0, size)
     return (add (add (add pureRoundtrip roundtrip) success) observed)
 
-example : ExternalCallInBodySmoke.linkedRead_modelBody.head? =
-    some (Compiler.CompilationModel.Stmt.externalCallBind
-      ["depositable"] "getDepositableEther" []) := rfl
+example : ExternalCallInBodySmoke.linkedRead_modelBody.take 1 =
+    [Compiler.CompilationModel.Stmt.externalCallBind
+      ["depositable"] "getDepositableEther" []] := rfl
 
-example : ExternalCallInBodySmoke.linkedWrite_modelBody.head? =
-    some (Compiler.CompilationModel.Stmt.externalCallBind [] "deposit"
-      [ .param "amount", .param "pubkey_data_offset", .param "pubkey_length" ]) := rfl
+example : ExternalCallInBodySmoke.linkedWrite_modelBody.take 1 =
+    [Compiler.CompilationModel.Stmt.externalCallBind [] "deposit"
+      [ .param "amount", .param "pubkey_data_offset", .param "pubkey_length" ]] := rfl
 
 example : ExternalCallInBodySmoke.lowLevel_modelBody.take 7 =
     [ Compiler.CompilationModel.Stmt.mstore (.literal 0) (.param "amount")

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -177,6 +177,8 @@ example :
           [ Compiler.CompilationModel.Expr.param "leaves_data_offset"
           , Compiler.CompilationModel.Expr.param "leaves_length"
           ]
+      , Compiler.CompilationModel.Stmt.assignVar "_success"
+          (.logicalNot (.eq (.localVar "_success") (.literal 0)))
       , Compiler.CompilationModel.Stmt.return
           (Compiler.CompilationModel.Expr.localVar "h")
       ] := rfl
@@ -222,6 +224,8 @@ example :
               (Compiler.CompilationModel.Expr.param "idx")
               1
           ]
+      , Compiler.CompilationModel.Stmt.assignVar "_success"
+          (.logicalNot (.eq (.localVar "_success") (.literal 0)))
       , Compiler.CompilationModel.Stmt.return
           (Compiler.CompilationModel.Expr.localVar "h")
       ] := rfl
@@ -257,6 +261,8 @@ example :
               (Compiler.CompilationModel.Expr.param "idx")
               3
           ]
+      , Compiler.CompilationModel.Stmt.assignVar "_success"
+          (.logicalNot (.eq (.localVar "_success") (.literal 0)))
       , Compiler.CompilationModel.Stmt.return
           (Compiler.CompilationModel.Expr.localVar "h")
       ] := rfl

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -141,6 +141,10 @@ syntax (name := returnDataCopyTerm) "returnDataCopy(" term "," term "," term ")"
 syntax:max (name := keccakStringTerm) "keccakString " str : term
 
 macro_rules
+  | `(doElem| let _ ← (returnDataSize())) =>
+      `(doElem| let _ ← (fun s => .success 0 s))
+  | `(doElem| let $name:ident ← (returnDataSize())) =>
+      `(doElem| let $name ← (fun s => .success 0 s))
   | `(doElem| let _ ← returnDataSize()) =>
       `(doElem| let _ ← (fun s => .success 0 s))
   | `(doElem| let $name:ident ← returnDataSize()) =>

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -145,7 +145,8 @@ macro_rules
   | `(evmCall($[$_args:term],*)) => `(by exact default)
   | `(evmStaticCall($[$_args:term],*)) => `(by exact default)
   | `(memoryLoad($_offset)) => `(by exact default)
-  | `(returnDataSize()) => `(by exact default)
+  | `(returnDataSize()) =>
+      `(by first | exact (pure returndataSize) | exact returndataSize)
   | `(memoryStore($_offset, $_value)) => `(by exact default)
   | `(returnDataCopy($_destOffset, $_sourceOffset, $_size)) => `(by exact default)
   | `(intrinsic $_name:term $_lowering:term $_args:term) =>

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -145,8 +145,7 @@ macro_rules
   | `(evmCall($[$_args:term],*)) => `(by exact default)
   | `(evmStaticCall($[$_args:term],*)) => `(by exact default)
   | `(memoryLoad($_offset)) => `(by exact default)
-  | `(returnDataSize()) =>
-      `(by first | exact (pure returndataSize) | exact returndataSize)
+  | `(returnDataSize()) => `(by exact default)
   | `(memoryStore($_offset, $_value)) => `(by exact default)
   | `(returnDataCopy($_destOffset, $_sourceOffset, $_size)) => `(by exact default)
   | `(intrinsic $_name:term $_lowering:term $_args:term) =>

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -142,12 +142,12 @@ syntax:max (name := keccakStringTerm) "keccakString " str : term
 
 macro_rules
   | `(doElem| let $name:ident ← returnDataSize()) =>
-      `(doElem| let $name ← (fun s => _root_.Verity.ContractResult.success 0 s))
+      `(doElem| let $name ← (fun s => .success 0 s))
   | `(callExternal $_name:ident ($[$_args:term],*)) => `(by exact default)
   | `(evmCall($[$_args:term],*)) => `(by exact default)
   | `(evmStaticCall($[$_args:term],*)) => `(by exact default)
   | `(memoryLoad($_offset)) => `(by exact default)
-  | `(returnDataSize()) => `(term| (0 : _root_.Verity.Uint256))
+  | `(returnDataSize()) => `(0)
   | `(memoryStore($_offset, $_value)) => `(by exact default)
   | `(returnDataCopy($_destOffset, $_sourceOffset, $_size)) => `(by exact default)
   | `(intrinsic $_name:term $_lowering:term $_args:term) =>

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -145,7 +145,7 @@ macro_rules
   | `(evmCall($[$_args:term],*)) => `(by exact default)
   | `(evmStaticCall($[$_args:term],*)) => `(by exact default)
   | `(memoryLoad($_offset)) => `(by exact default)
-  | `(returnDataSize()) => `(by exact default)
+  | `(returnDataSize()) => `(0)
   | `(memoryStore($_offset, $_value)) => `(by exact default)
   | `(returnDataCopy($_destOffset, $_sourceOffset, $_size)) => `(by exact default)
   | `(intrinsic $_name:term $_lowering:term $_args:term) =>

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -141,15 +141,13 @@ syntax (name := returnDataCopyTerm) "returnDataCopy(" term "," term "," term ")"
 syntax:max (name := keccakStringTerm) "keccakString " str : term
 
 macro_rules
+  | `(doElem| let $name:ident ← returnDataSize()) =>
+      `(doElem| let $name ← (fun s => _root_.Verity.ContractResult.success 0 s))
   | `(callExternal $_name:ident ($[$_args:term],*)) => `(by exact default)
   | `(evmCall($[$_args:term],*)) => `(by exact default)
   | `(evmStaticCall($[$_args:term],*)) => `(by exact default)
   | `(memoryLoad($_offset)) => `(by exact default)
-  | `(returnDataSize()) =>
-      `(by
-          first
-          | exact (0 : _root_.Verity.Uint256)
-          | exact (fun s => .success 0 s))
+  | `(returnDataSize()) => `(term| (0 : _root_.Verity.Uint256))
   | `(memoryStore($_offset, $_value)) => `(by exact default)
   | `(returnDataCopy($_destOffset, $_sourceOffset, $_size)) => `(by exact default)
   | `(intrinsic $_name:term $_lowering:term $_args:term) =>

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -145,7 +145,7 @@ macro_rules
   | `(evmCall($[$_args:term],*)) => `(by exact default)
   | `(evmStaticCall($[$_args:term],*)) => `(by exact default)
   | `(memoryLoad($_offset)) => `(by exact default)
-  | `(returnDataSize()) => `(_root_.Verity.pure (0 : _root_.Verity.Uint256))
+  | `(returnDataSize()) => `(fun s => .success 0 s)
   | `(memoryStore($_offset, $_value)) => `(by exact default)
   | `(returnDataCopy($_destOffset, $_sourceOffset, $_size)) => `(by exact default)
   | `(intrinsic $_name:term $_lowering:term $_args:term) =>

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -141,6 +141,8 @@ syntax (name := returnDataCopyTerm) "returnDataCopy(" term "," term "," term ")"
 syntax:max (name := keccakStringTerm) "keccakString " str : term
 
 macro_rules
+  | `(doElem| let _ ← returnDataSize()) =>
+      `(doElem| let _ ← (fun s => .success 0 s))
   | `(doElem| let $name:ident ← returnDataSize()) =>
       `(doElem| let $name ← (fun s => .success 0 s))
   | `(callExternal $_name:ident ($[$_args:term],*)) => `(by exact default)

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -121,6 +121,17 @@ syntax "adt " str : term
 syntax "adt " str " [" sepBy(term, ",") "]" : term
 syntax "tryCatch " term:max ppSpace term:max : doElem
 
+-- Explicit function-body spellings for the P0 low-level interaction surface.
+-- `callExternal` is declaration-driven; `evmCall`/`evmStaticCall` expose the
+-- EVM fields directly and intentionally use distinct names.
+syntax (name := callExternalTerm) "callExternal " ident "(" sepBy(term, ",") ")" : term
+syntax (name := evmCallTerm) "evmCall(" sepBy(term, ",") ")" : term
+syntax (name := evmStaticCallTerm) "evmStaticCall(" sepBy(term, ",") ")" : term
+syntax (name := memoryLoadTerm) "memoryLoad(" term ")" : term
+syntax (name := returnDataSizeTerm) "returnDataSize()" : term
+syntax (name := memoryStoreTerm) "memoryStore(" term "," term ")" : term
+syntax (name := returnDataCopyTerm) "returnDataCopy(" term "," term "," term ")" : term
+
 -- Compile-time Keccak-256 of a string literal (#1973). The hash is
 -- materialised at elaboration time (outside contracts) or contract
 -- translation time (inside `verity_contract` bodies). Non-literal
@@ -130,6 +141,13 @@ syntax "tryCatch " term:max ppSpace term:max : doElem
 syntax:max (name := keccakStringTerm) "keccakString " str : term
 
 macro_rules
+  | `(callExternal $_name:ident ($[$_args:term],*)) => `(by exact default)
+  | `(evmCall($[$_args:term],*)) => `(by exact default)
+  | `(evmStaticCall($[$_args:term],*)) => `(by exact default)
+  | `(memoryLoad($_offset)) => `(by exact default)
+  | `(returnDataSize()) => `(by exact default)
+  | `(memoryStore($_offset, $_value)) => `(by exact default)
+  | `(returnDataCopy($_destOffset, $_sourceOffset, $_size)) => `(by exact default)
   | `(intrinsic $_name:term $_lowering:term $_args:term) =>
       `(panic! "verity intrinsic has no default EDSL semantics; add a consumer macro_rules override")
   | `(intrinsic_cancun $_name:term $_lowering:term $_args:term) =>

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -145,7 +145,7 @@ macro_rules
   | `(evmCall($[$_args:term],*)) => `(by exact default)
   | `(evmStaticCall($[$_args:term],*)) => `(by exact default)
   | `(memoryLoad($_offset)) => `(by exact default)
-  | `(returnDataSize()) => `(0)
+  | `(returnDataSize()) => `(_root_.Verity.pure (0 : _root_.Verity.Uint256))
   | `(memoryStore($_offset, $_value)) => `(by exact default)
   | `(returnDataCopy($_destOffset, $_sourceOffset, $_size)) => `(by exact default)
   | `(intrinsic $_name:term $_lowering:term $_args:term) =>

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -145,7 +145,11 @@ macro_rules
   | `(evmCall($[$_args:term],*)) => `(by exact default)
   | `(evmStaticCall($[$_args:term],*)) => `(by exact default)
   | `(memoryLoad($_offset)) => `(by exact default)
-  | `(returnDataSize()) => `(fun s => .success 0 s)
+  | `(returnDataSize()) =>
+      `(by
+          first
+          | exact (0 : _root_.Verity.Uint256)
+          | exact (fun s => .success 0 s))
   | `(memoryStore($_offset, $_value)) => `(by exact default)
   | `(returnDataCopy($_destOffset, $_sourceOffset, $_size)) => `(by exact default)
   | `(intrinsic $_name:term $_lowering:term $_args:term) =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1303,8 +1303,8 @@ private partial def translateDoElem
                   let source ← match staticStructDirectFieldLocals? varName retTy with
                     | some fieldLocals => pure (LocalSource.externalStaticStruct fieldLocals)
                     | none => do
-                        if flatNames.size != 1 then
-                          throwErrorAt rhs s!"callExternal '{extName}' return type expands to {flatNames.size} values and cannot be bound to one source variable"
+                        if flatNames.length != 1 then
+                          throwErrorAt rhs s!"callExternal '{extName}' return type expands to {flatNames.length} values and cannot be bound to one source variable"
                         pure LocalSource.value
                   pure
                     (#[(← `(Compiler.CompilationModel.Stmt.externalCallBind

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1180,7 +1180,8 @@ private partial def translateDoElem
                       pure (some (stmts, locals.push syntheticLocal ++ typedPairs, mutableLocals))
                   | none => throwErrorAt rhs "unable to infer tuple local types"
               | none =>
-                  match (← tupleLiteralOrStructValueExprs? fields constDecls immutableDecls params locals rhs) with
+                  match (← tupleLiteralOrStructValueExprs? fields constDecls immutableDecls params locals rhs
+                    (some (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals))) with
                   | some valueExprs =>
                       if names.size != valueExprs.size then
                         throwErrorAt patDecl s!"tuple destructuring binds {names.size} names, but the source provides {valueExprs.size} values"
@@ -1529,7 +1530,8 @@ private partial def translateDoElem
           | some (stmts, syntheticLocal) =>
               pure (stmts, locals.push syntheticLocal, mutableLocals)
           | none =>
-              match (← tupleReturnValueExprs? fields constDecls immutableDecls params locals value) with
+              match (← tupleReturnValueExprs? fields constDecls immutableDecls params locals value
+                (some (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals))) with
               | some valueExprs =>
                   pure (#[(← `(Compiler.CompilationModel.Stmt.returnValues [ $[$valueExprs],* ]))], locals, mutableLocals)
               | none =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1322,6 +1322,8 @@ private partial def translateDoElem
                 | none => throwErrorAt externalName s!"unknown linked external '{extName}'"
               match ext.returnTys.toList with
               | [retTy] =>
+                  unless isSingleWordStaticValueType retTy do
+                    throwErrorAt rhs s!"callExternal '{extName}' return type cannot be bound to one source variable; bind composite results explicitly"
                   validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
                     extName ext.params args
                   let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -958,6 +958,8 @@ private def translateEffectStmt
       `(Compiler.CompilationModel.Stmt.revertReturndata)
   | `(term| returnValues $values:term) =>
       let valueExprs ← expectExprList fields constDecls immutableDecls params locals values
+        (some (translateDeclaredPureExpr
+          fields constDecls immutableDecls externalDecls params locals))
       `(Compiler.CompilationModel.Stmt.returnValues [ $[$valueExprs],* ])
   | `(term| returnArray $name:term) =>
       `(Compiler.CompilationModel.Stmt.returnArray $(strTerm (← expectStringOrIdent name)))
@@ -974,6 +976,8 @@ private def translateEffectStmt
       `(Compiler.CompilationModel.Stmt.emit $(strTerm evName) [ $[$argExprs],* ])
   | `(term| rawLog $topics:term $dataOffset:term $dataSize:term) =>
       let topicExprs ← expectExprList fields constDecls immutableDecls params locals topics
+        (some (translateDeclaredPureExpr
+          fields constDecls immutableDecls externalDecls params locals))
       `(Compiler.CompilationModel.Stmt.rawLog
           [ $[$topicExprs],* ]
           $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals dataOffset)
@@ -1000,7 +1004,9 @@ private def translateEffectStmt
         throwErrorAt stx s!"callExternal '{extName}' returns values; bind it with `let ... ← ...`"
       validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
         extName ext.params args
-      let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args (some ext.params)
+      let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
+        (some ext.params) (some (translateDeclaredPureExpr
+          fields constDecls immutableDecls externalDecls params locals))
       `(Compiler.CompilationModel.Stmt.externalCallBind [] $(strTerm extName) [ $[$argExprs],* ])
   | `(term| setStructMember $field:term $key:term $member:term $value:term) =>
       let fieldName := ← expectStringOrIdent field
@@ -1308,7 +1314,9 @@ private partial def translateDoElem
               | [retTy] =>
                   validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
                     extName ext.params args
-                  let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args (some ext.params)
+                  let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
+                    (some ext.params) (some (translateDeclaredPureExpr
+                      fields constDecls immutableDecls externalDecls params locals))
                   let flatNames ← flattenExternalResultNames varName retTy
                   if flatNames.length != 1 then
                     throwErrorAt rhs s!"callExternal '{extName}' return type expands to {flatNames.length} values and cannot be bound to one source variable"

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1300,12 +1300,12 @@ private partial def translateDoElem
                   let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
                   let flatNames ← flattenExternalResultNames varName retTy
                   let resultTerms := flatNames.toArray.map strTerm
-                  let source := match staticStructDirectFieldLocals? varName retTy with
-                    | some fieldLocals => LocalSource.externalStaticStruct fieldLocals
+                  let source ← match staticStructDirectFieldLocals? varName retTy with
+                    | some fieldLocals => pure (LocalSource.externalStaticStruct fieldLocals)
                     | none => do
                         if flatNames.size != 1 then
                           throwErrorAt rhs s!"callExternal '{extName}' return type expands to {flatNames.size} values and cannot be bound to one source variable"
-                        LocalSource.value
+                        pure LocalSource.value
                   pure
                     (#[(← `(Compiler.CompilationModel.Stmt.externalCallBind
                         [ $[$resultTerms],* ] $(strTerm extName) [ $[$argExprs],* ]))],

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -464,6 +464,8 @@ private partial def validateEffectStmtExprTypes
         | none => throwErrorAt name s!"unknown linked external '{extName}'"
       unless ext.returnTys.isEmpty do
         throwErrorAt stx s!"callExternal '{extName}' returns values; bind it with `let ... ← ...`"
+      validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+        extName ext.params args
       let _ ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
   | `(term| revertReturndata) =>
       pure ()
@@ -991,6 +993,8 @@ private def translateEffectStmt
         | none => throwErrorAt name s!"unknown linked external '{extName}'"
       unless ext.returnTys.isEmpty do
         throwErrorAt stx s!"callExternal '{extName}' returns values; bind it with `let ... ← ...`"
+      validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+        extName ext.params args
       let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
       `(Compiler.CompilationModel.Stmt.externalCallBind [] $(strTerm extName) [ $[$argExprs],* ])
   | `(term| setStructMember $field:term $key:term $member:term $value:term) =>
@@ -1291,6 +1295,8 @@ private partial def translateDoElem
                 | none => throwErrorAt externalName s!"unknown linked external '{extName}'"
               match ext.returnTys.toList with
               | [retTy] =>
+                  validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+                    extName ext.params args
                   let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
                   let flatNames ← flattenExternalResultNames varName retTy
                   let resultTerms := flatNames.toArray.map strTerm

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -540,6 +540,7 @@ private def translateERC20BindStmt?
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
     (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
     (functions : Array FunctionDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
@@ -553,8 +554,8 @@ private def translateERC20BindStmt?
           throwErrorAt rhs
             s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
       | none =>
-          let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-          let ownerExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals owner
+          let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
+          let ownerExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals owner
           pure <| some (← `(Compiler.CompilationModel.Stmt.ecm
             (Compiler.Modules.ERC20.balanceOfModule $(strTerm varName))
             [$tokenExpr, $ownerExpr]))
@@ -564,9 +565,9 @@ private def translateERC20BindStmt?
           throwErrorAt rhs
             s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
       | none =>
-          let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-          let ownerExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals owner
-          let spenderExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals spender
+          let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
+          let ownerExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals owner
+          let spenderExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals spender
           pure <| some (← `(Compiler.CompilationModel.Stmt.ecm
             (Compiler.Modules.ERC20.allowanceModule $(strTerm varName))
             [$tokenExpr, $ownerExpr, $spenderExpr]))
@@ -576,7 +577,7 @@ private def translateERC20BindStmt?
           throwErrorAt rhs
             s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
       | none =>
-          let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
+          let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
           pure <| some (← `(Compiler.CompilationModel.Stmt.ecm
             (Compiler.Modules.ERC20.totalSupplyModule $(strTerm varName))
             [$tokenExpr]))
@@ -1445,7 +1446,7 @@ private partial def translateDoElem
                         fields constDecls immutableDecls externalDecls functions params locals rhs
                       pure (safeStmts, locals.push (mkTypedLocal varName safeTy), mutableLocals)
                   | none =>
-                      match (← translateERC20BindStmt? fields constDecls immutableDecls functions params locals varName rhs) with
+                      match (← translateERC20BindStmt? fields constDecls immutableDecls externalDecls functions params locals varName rhs) with
                       | some stmt =>
                           pure (#[(stmt)], locals.push (mkTypedLocal varName .uint256), mutableLocals)
                       | none =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -38,13 +38,16 @@ private def translateCustomErrorArgExprs
     (locals : Array TypedLocal)
     (errorDecls : Array ErrorDecl)
     (errorName : String)
-    (args : Array Term) : CommandElabM (Array Term) := do
+    (args : Array Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Array Term) := do
   let some errorDecl := errorDecls.find? (fun decl => decl.name == errorName)
     | throwError s!"unknown custom error '{errorName}'"
   if args.size != errorDecl.params.size then
     throwError s!"custom error '{errorName}' expects {errorDecl.params.size} args, got {args.size}"
   args.zip errorDecl.params |>.mapM fun (arg, expectedTy) => do
-    let raw ← translatePureExprWithTypes fields constDecls immutableDecls params locals arg
+    let raw ← match translateExpr? with
+      | some translate => translate arg
+      | none => translatePureExprWithTypes fields constDecls immutableDecls params locals arg
     normalizeTranslatedExprForType expectedTy arg raw
 
 mutual
@@ -973,6 +976,8 @@ private def translateEffectStmt
   | `(term| emit $eventName:term $args:term) =>
       let evName := ← expectStringOrIdent eventName
       let argExprs ← expectEmitExprList fields constDecls immutableDecls params locals args
+        (some (translateDeclaredPureExpr
+          fields constDecls immutableDecls externalDecls params locals))
       `(Compiler.CompilationModel.Stmt.emit $(strTerm evName) [ $[$argExprs],* ])
   | `(term| rawLog $topics:term $dataOffset:term $dataSize:term) =>
       let topicExprs ← expectExprList fields constDecls immutableDecls params locals topics
@@ -1055,6 +1060,8 @@ private def translateEffectStmt
               s!"helper call '{fn.name}' returns {renderValueType fn.returnTy}; use `let ... ← {fn.name} ...` or tuple destructuring"
           let argExprs ← translateInternalHelperCallArgs
             fields constDecls immutableDecls params locals fn argTerms
+            (some (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals))
           `(Compiler.CompilationModel.Stmt.internalCall
               $(strTerm (internalHelperSpecNameFor fn))
               [ $[$argExprs],* ])
@@ -1410,6 +1417,8 @@ private partial def translateDoElem
               | some (fn, argTerms, elemTy) =>
                   let argExprs ← translateInternalHelperCallArgs
                     fields constDecls immutableDecls params locals fn argTerms
+                    (some (translateDeclaredPureExpr
+                      fields constDecls immutableDecls externalDecls params locals))
                   let resultNameTerms := #[
                     strTerm (memoryArrayDataOffsetName varName),
                     strTerm (memoryArrayLengthName varName)
@@ -1585,6 +1594,8 @@ private partial def translateDoElem
       | `(doElem| requireError $cond:term $errorName:ident($args,*)) =>
           let argExprs ← translateCustomErrorArgExprs fields constDecls immutableDecls params locals
             errorDecls (toString errorName.getId) args.getElems
+            (some (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals))
           pure
             (#[(← `(Compiler.CompilationModel.Stmt.requireError
                     $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals cond)
@@ -1595,6 +1606,8 @@ private partial def translateDoElem
       | `(doElem| revert $errorName:ident($args,*)) =>
           let argExprs ← translateCustomErrorArgExprs fields constDecls immutableDecls params locals
             errorDecls (toString errorName.getId) args.getElems
+            (some (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals))
           pure
             (#[(← `(Compiler.CompilationModel.Stmt.revertError
                     $(strTerm (toString errorName.getId))
@@ -1604,6 +1617,8 @@ private partial def translateDoElem
       | `(doElem| revertError $errorName:ident($args,*)) =>
           let argExprs ← translateCustomErrorArgExprs fields constDecls immutableDecls params locals
             errorDecls (toString errorName.getId) args.getElems
+            (some (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals))
           pure
             (#[(← `(Compiler.CompilationModel.Stmt.revertError
                     $(strTerm (toString errorName.getId))
@@ -1650,6 +1665,8 @@ private partial def translateDoElem
                     let tempName := freshSyntheticLocalName "emit_array" params branchLocals mutableLocals
                     let argExprs ← translateInternalHelperCallArgs
                       fields constDecls immutableDecls params branchLocals fn argTerms
+                      (some (translateDeclaredPureExpr
+                        fields constDecls immutableDecls externalDecls params branchLocals))
                     let resultNameTerms := #[
                       strTerm (memoryArrayDataOffsetName tempName),
                       strTerm (memoryArrayLengthName tempName)
@@ -1665,7 +1682,10 @@ private partial def translateDoElem
                     let tempTerm : Term := ⟨(mkIdent (Name.mkSimple tempName)).raw⟩
                     emitArgs := emitArgs.push (← translateEmitArgExpr fields constDecls immutableDecls params branchLocals tempTerm)
                 | none =>
-                    emitArgs := emitArgs.push (← translateEmitArgExpr fields constDecls immutableDecls params branchLocals arg)
+                    emitArgs := emitArgs.push (← translateEmitArgExpr
+                      fields constDecls immutableDecls params branchLocals arg
+                      (some (translateDeclaredPureExpr
+                        fields constDecls immutableDecls externalDecls params branchLocals)))
               stmts := stmts.push (← `(Compiler.CompilationModel.Stmt.emit $(strTerm evName) [ $[$emitArgs],* ]))
               pure (stmts, locals, mutableLocals)
           | _ => throwErrorAt values "expected list literal [..]"

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -380,11 +380,13 @@ private partial def validateEffectStmtExprTypes
       requireDeclaredValueType value "setMemoryArrayElement value" elemTy
         (← inferPureExprType fields constDecls immutableDecls externalDecls params locals value)
       pure ()
-  | `(term| mstore $offset:term $value:term) | `(term| tstore $offset:term $value:term) => do
+  | `(term| mstore $offset:term $value:term) | `(term| memoryStore($offset, $value))
+    | `(term| tstore $offset:term $value:term) => do
       let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals offset
       let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals value
   | `(term| calldatacopy $destOffset:term $sourceOffset:term $size:term)
-    | `(term| returndataCopy $destOffset:term $sourceOffset:term $size:term) => do
+    | `(term| returndataCopy $destOffset:term $sourceOffset:term $size:term)
+    | `(term| returnDataCopy($destOffset, $sourceOffset, $size)) => do
       let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals destOffset
       let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals sourceOffset
       let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals size
@@ -438,6 +440,14 @@ private partial def validateEffectStmtExprTypes
           for x in xs do
             let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals x
       | _ => throwErrorAt args "expected list literal [..]"
+  | `(term| callExternal $name:ident ($[$args:term],*)) => do
+      let extName := toString name.getId
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown linked external '{extName}'"
+      unless ext.returnTys.isEmpty do
+        throwErrorAt stx s!"callExternal '{extName}' returns values; bind it with `let ... ← ...`"
+      let _ ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
   | `(term| revertReturndata) =>
       pure ()
   | _ =>
@@ -901,7 +911,7 @@ private def translateEffectStmt
       `(Compiler.CompilationModel.Stmt.unsafeBlock
           "write memory-backed uint256 array element"
           [Compiler.CompilationModel.Stmt.mstore $elementOffsetExpr $valueExpr])
-  | `(term| mstore $offset:term $value:term) =>
+  | `(term| mstore $offset:term $value:term) | `(term| memoryStore($offset, $value)) =>
       `(Compiler.CompilationModel.Stmt.mstore
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset)
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
@@ -914,7 +924,8 @@ private def translateEffectStmt
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals destOffset)
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals sourceOffset)
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals size))
-  | `(term| returndataCopy $destOffset:term $sourceOffset:term $size:term) =>
+  | `(term| returndataCopy $destOffset:term $sourceOffset:term $size:term)
+    | `(term| returnDataCopy($destOffset, $sourceOffset, $size)) =>
       `(Compiler.CompilationModel.Stmt.returndataCopy
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals destOffset)
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals sourceOffset)
@@ -956,6 +967,15 @@ private def translateEffectStmt
           [ $[$resultNameTerms],* ]
           $(strTerm targetFn)
           [ $[$argExprs],* ])
+  | `(term| callExternal $name:ident ($[$args:term],*)) =>
+      let extName := toString name.getId
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown linked external '{extName}'"
+      unless ext.returnTys.isEmpty do
+        throwErrorAt stx s!"callExternal '{extName}' returns values; bind it with `let ... ← ...`"
+      let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
+      `(Compiler.CompilationModel.Stmt.externalCallBind [] $(strTerm extName) [ $[$argExprs],* ])
   | `(term| setStructMember $field:term $key:term $member:term $value:term) =>
       let fieldName := ← expectStringOrIdent field
       let memberName := ← expectStringOrIdent member
@@ -1244,6 +1264,26 @@ private partial def translateDoElem
           if localNames.contains varName then
             throwErrorAt name s!"duplicate local variable '{varName}'"
           match stripParens rhs with
+          | `(term| callExternal $externalName:ident ($[$args:term],*)) =>
+              let extName := toString externalName.getId
+              let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+                | some ext => pure ext
+                | none => throwErrorAt externalName s!"unknown linked external '{extName}'"
+              match ext.returnTys.toList with
+              | [retTy] =>
+                  let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
+                  let flatNames ← flattenExternalResultNames varName retTy
+                  let resultTerms := flatNames.toArray.map strTerm
+                  let source := match staticStructDirectFieldLocals? varName retTy with
+                    | some fieldLocals => LocalSource.externalStaticStruct fieldLocals
+                    | none => LocalSource.value
+                  pure
+                    (#[(← `(Compiler.CompilationModel.Stmt.externalCallBind
+                        [ $[$resultTerms],* ] $(strTerm extName) [ $[$argExprs],* ]))],
+                      locals.push { name := varName, ty := retTy, source := source },
+                      mutableLocals)
+              | [] => throwErrorAt rhs s!"callExternal '{extName}' returns Unit; invoke it as a statement"
+              | _ => throwErrorAt rhs s!"callExternal '{extName}' returns multiple values; use externalCallBind with explicit result names"
           | `(term| callResult $_extName:term $_args:term) =>
               match (← callResultBindStmt? fields constDecls immutableDecls externalDecls params locals rhs varName) with
               | some (stmt, resultLocal) => pure (#[stmt], locals.push resultLocal, mutableLocals)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -656,9 +656,9 @@ private def translateEffectStmt
           throwErrorAt stx
             s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
       | _ =>
-          let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-          let toExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals to
-          let amountExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals amount
+          let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
+          let toExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals to
+          let amountExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals amount
           `(Compiler.CompilationModel.Stmt.ecm
               Compiler.Modules.ERC20.safeTransferModule
               [$tokenExpr, $toExpr, $amountExpr])
@@ -668,10 +668,10 @@ private def translateEffectStmt
           throwErrorAt stx
             s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
       | _ =>
-          let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-          let fromExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals fromAddr
-          let toExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals to
-          let amountExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals amount
+          let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
+          let fromExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals fromAddr
+          let toExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals to
+          let amountExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals amount
           `(Compiler.CompilationModel.Stmt.ecm
               Compiler.Modules.ERC20.safeTransferFromModule
               [$tokenExpr, $fromExpr, $toExpr, $amountExpr])
@@ -681,9 +681,9 @@ private def translateEffectStmt
            throwErrorAt stx
              s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
        | _ =>
-           let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-           let spenderExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals spender
-           let amountExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals amount
+           let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
+           let spenderExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals spender
+           let amountExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals amount
            `(Compiler.CompilationModel.Stmt.ecm
                Compiler.Modules.ERC20.safeApproveModule
                [$tokenExpr, $spenderExpr, $amountExpr])
@@ -693,9 +693,9 @@ private def translateEffectStmt
            throwErrorAt stx
              s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
        | _ =>
-           let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-           let toExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals to
-           let amountExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals amount
+           let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
+           let toExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals to
+           let amountExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals amount
            `(Compiler.CompilationModel.Stmt.ecm
                Compiler.Modules.ERC20.legacyStringSafeTransferModule
                [$tokenExpr, $toExpr, $amountExpr])
@@ -705,10 +705,10 @@ private def translateEffectStmt
            throwErrorAt stx
              s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
        | _ =>
-           let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-           let fromExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals fromAddr
-           let toExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals to
-           let amountExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals amount
+           let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
+           let fromExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals fromAddr
+           let toExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals to
+           let amountExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals amount
            `(Compiler.CompilationModel.Stmt.ecm
                Compiler.Modules.ERC20.legacyStringSafeTransferFromModule
                [$tokenExpr, $fromExpr, $toExpr, $amountExpr])
@@ -728,7 +728,7 @@ private def translateEffectStmt
       | none =>
           match f.ty with
           | .scalar .uint256 | .scalar .int256 | .scalar (.newtype _ .uint256) =>
-              `(Compiler.CompilationModel.Stmt.setStorage $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              `(Compiler.CompilationModel.Stmt.setStorage $(strTerm f.name) $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
           | .scalar (.adt adtName _) =>
               `(Compiler.CompilationModel.Stmt.setStorage
                   $(strTerm f.name)
@@ -743,7 +743,7 @@ private def translateEffectStmt
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with
       | .scalar .address | .scalar (.newtype _ .address) =>
-          `(Compiler.CompilationModel.Stmt.setStorageAddr $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+          `(Compiler.CompilationModel.Stmt.setStorageAddr $(strTerm f.name) $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .scalar .uint256 | .scalar (.newtype _ .uint256) =>
           throwErrorAt stx s!"field '{f.name}' is Uint256-valued; use setStorage"
       | .dynamicArray _ =>
@@ -757,7 +757,7 @@ private def translateEffectStmt
           `(Compiler.CompilationModel.Stmt.setStorageWord
               $(strTerm f.name)
               $(natTerm (← natFromSyntax wordOffset))
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .dynamicArray _ =>
           throwErrorAt stx s!"field '{f.name}' is a storage dynamic array; setPackedStorage requires a scalar root slot"
       | .mappingAddressToUint256 | .mappingUintToUint256 | .mapping2AddressToAddressToUint256
@@ -769,13 +769,13 @@ private def translateEffectStmt
       | .mappingAddressToUint256 =>
           `(Compiler.CompilationModel.Stmt.setMapping
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .mappingUintToUint256 =>
           `(Compiler.CompilationModel.Stmt.setMappingUint
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .mapping2AddressToAddressToUint256 =>
           throwErrorAt stx s!"field '{f.name}' is a double mapping; use setMapping2"
       | .mappingChain _ =>
@@ -791,8 +791,8 @@ private def translateEffectStmt
       | .mappingAddressToUint256 =>
           `(Compiler.CompilationModel.Stmt.setMapping
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .mappingUintToUint256 =>
           throwErrorAt stx s!"field '{f.name}' is Uint256-keyed; use setMappingUintAddr"
       | .mapping2AddressToAddressToUint256 =>
@@ -810,8 +810,8 @@ private def translateEffectStmt
       | .mappingUintToUint256 =>
           `(Compiler.CompilationModel.Stmt.setMappingUint
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .mappingAddressToUint256 =>
           throwErrorAt stx s!"field '{f.name}' is Address-keyed; use setMapping"
       | .mapping2AddressToAddressToUint256 =>
@@ -829,8 +829,8 @@ private def translateEffectStmt
       | .mappingUintToUint256 =>
           `(Compiler.CompilationModel.Stmt.setMappingUint
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .mappingAddressToUint256 =>
           throwErrorAt stx s!"field '{f.name}' is Address-keyed; use setMappingAddr"
       | .mapping2AddressToAddressToUint256 =>
@@ -848,9 +848,9 @@ private def translateEffectStmt
       | .mappingAddressToUint256 | .mappingUintToUint256 =>
           `(Compiler.CompilationModel.Stmt.setMappingWord
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key)
               $wordOffset
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .mapping2AddressToAddressToUint256 =>
           throwErrorAt stx s!"field '{f.name}' is a double mapping; use setMapping2Word"
       | .mappingStruct _ _ =>
@@ -868,9 +868,9 @@ private def translateEffectStmt
       | .mapping2AddressToAddressToUint256 =>
           `(Compiler.CompilationModel.Stmt.setMapping2
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key1)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key2)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .mappingStruct2 _ _ _ =>
           throwErrorAt stx s!"field '{f.name}' is a nested struct mapping; use setStructMember2"
       | .mappingStruct _ _ =>
@@ -883,11 +883,11 @@ private def translateEffectStmt
       | some keyTypes =>
           if keyTerms.size != keyTypes.length then
             throwErrorAt stx s!"field '{f.name}' expects {keyTypes.length} mapping keys, but setMappingN received {keyTerms.size}"
-          let keyExprs ← keyTerms.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+          let keyExprs ← keyTerms.mapM (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals)
           `(Compiler.CompilationModel.Stmt.setMappingChain
               $(strTerm f.name)
               [ $[$keyExprs],* ]
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | none =>
           match f.ty with
           | .mappingStruct _ _ | .mappingStruct2 _ _ _ =>
@@ -899,7 +899,7 @@ private def translateEffectStmt
       | .dynamicArray _ =>
           `(Compiler.CompilationModel.Stmt.storageArrayPush
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | _ => throwErrorAt stx s!"field '{f.name}' is not a storage dynamic array"
   | `(term| popStorageArray $field:ident) =>
       let f ← lookupStorageField fields (toString field.getId)
@@ -913,19 +913,19 @@ private def translateEffectStmt
       | .dynamicArray _ =>
           `(Compiler.CompilationModel.Stmt.setStorageArrayElement
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals index)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | _ => throwErrorAt stx s!"field '{f.name}' is not a storage dynamic array"
   | `(term| require $cond $msg) =>
       `(Compiler.CompilationModel.Stmt.require
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals cond)
           $(strTerm (← expectStringLiteral msg)))
   | `(term| setMemoryArrayElement $name:term $index:term $value:term) => do
       let (arrayName, elemTy) ← requireSupportedMemoryArrayLocal name "setMemoryArrayElement" locals
       unless isSingleWordStaticValueType elemTy do
         throwErrorAt name s!"setMemoryArrayElement currently supports only Array<wordLike> memory locals, got Array {renderValueType elemTy}"
-      let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
-      let valueExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals value
+      let indexExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals index
+      let valueExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value
       let dataOffsetExpr : Term ←
         `(Compiler.CompilationModel.Expr.localVar $(strTerm (memoryArrayDataOffsetName arrayName)))
       let elementOffsetExpr : Term ←
@@ -937,23 +937,23 @@ private def translateEffectStmt
           [Compiler.CompilationModel.Stmt.mstore $elementOffsetExpr $valueExpr])
   | `(term| mstore $offset:term $value:term) | `(term| memoryStore($offset, $value)) =>
       `(Compiler.CompilationModel.Stmt.mstore
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals offset)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
   | `(term| tstore $offset:term $value:term) =>
       `(Compiler.CompilationModel.Stmt.tstore
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals offset)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
   | `(term| calldatacopy $destOffset:term $sourceOffset:term $size:term) =>
       `(Compiler.CompilationModel.Stmt.calldatacopy
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals destOffset)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals sourceOffset)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals size))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals destOffset)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals sourceOffset)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals size))
   | `(term| returndataCopy $destOffset:term $sourceOffset:term $size:term)
     | `(term| returnDataCopy($destOffset, $sourceOffset, $size)) =>
       `(Compiler.CompilationModel.Stmt.returndataCopy
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals destOffset)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals sourceOffset)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals size))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals destOffset)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals sourceOffset)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals size))
   | `(term| revertReturndata) =>
       `(Compiler.CompilationModel.Stmt.revertReturndata)
   | `(term| returnValues $values:term) =>
@@ -967,7 +967,7 @@ private def translateEffectStmt
       `(Compiler.CompilationModel.Stmt.returnStorageWords $(strTerm (← expectStringOrIdent name)))
   | `(term| returnCodeData $pointer:term) =>
       `(Compiler.CompilationModel.Stmt.returnCodeData
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals pointer))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals pointer))
   | `(term| emit $eventName:term $args:term) =>
       let evName := ← expectStringOrIdent eventName
       let argExprs ← expectEmitExprList fields constDecls immutableDecls params locals args
@@ -976,8 +976,8 @@ private def translateEffectStmt
       let topicExprs ← expectExprList fields constDecls immutableDecls params locals topics
       `(Compiler.CompilationModel.Stmt.rawLog
           [ $[$topicExprs],* ]
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals dataOffset)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals dataSize))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals dataOffset)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals dataSize))
   | `(term| externalCallBind $names:term $fnName:term $args:term) =>
       let resultNames := ← expectStringList names
       let resultNameTerms := resultNames.map strTerm
@@ -1008,28 +1008,28 @@ private def translateEffectStmt
       let _ ← lookupStructMemberDecl fields fieldName memberName false
       `(Compiler.CompilationModel.Stmt.setStructMember
           $(strTerm fieldName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key)
           $(strTerm memberName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
   | `(term| setStructMember2 $field:term $key1:term $key2:term $member:term $value:term) =>
       let fieldName := ← expectStringOrIdent field
       let memberName := ← expectStringOrIdent member
       let _ ← lookupStructMemberDecl fields fieldName memberName true
       `(Compiler.CompilationModel.Stmt.setStructMember2
           $(strTerm fieldName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key1)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key2)
           $(strTerm memberName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
   | _ =>
       -- void typed interface call in statement position lowers to the
       -- no-return ECM (selector + args call, failure-returndata bubbled, but
       -- no returndatasize check and no return decode).
       match ← resolveTypedInterfaceCall? fields constDecls immutableDecls externalDecls params locals stx with
       | some (ext, target, argTerms, none, selector) =>
-          let targetExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals target
+          let targetExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals target
           let argExprs ← argTerms.mapM
-            (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+            (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals)
           let isStaticTerm ← if ext.isView then `(true) else `(false)
           `(Compiler.CompilationModel.Stmt.ecm
               (Compiler.Modules.Calls.noReturnModule

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -620,13 +620,15 @@ private def translateAdtConstructForStorage
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
     (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (adtName : String)
     (value : Term) : CommandElabM Term := do
   match adtConstructorSyntax? value with
   | some (variantName, args) =>
-      let argExprs ← args.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+      let argExprs ← args.mapM
+        (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals)
       `(Compiler.CompilationModel.Expr.adtConstruct
           $(strTerm adtName)
           $(strTerm variantName)
@@ -730,7 +732,7 @@ private def translateEffectStmt
       | some adtName =>
           `(Compiler.CompilationModel.Stmt.setStorage
               $(strTerm f.name)
-              $(← translateAdtConstructForStorage fields constDecls immutableDecls params locals adtName value))
+              $(← translateAdtConstructForStorage fields constDecls immutableDecls externalDecls params locals adtName value))
       | none =>
           match f.ty with
           | .scalar .uint256 | .scalar .int256 | .scalar (.newtype _ .uint256) =>
@@ -738,7 +740,7 @@ private def translateEffectStmt
           | .scalar (.adt adtName _) =>
               `(Compiler.CompilationModel.Stmt.setStorage
                   $(strTerm f.name)
-                  $(← translateAdtConstructForStorage fields constDecls immutableDecls params locals adtName value))
+                  $(← translateAdtConstructForStorage fields constDecls immutableDecls externalDecls params locals adtName value))
           | .scalar .address | .scalar (.newtype _ .address) =>
               throwErrorAt stx s!"field '{f.name}' is Address-valued; use setStorageAddr"
           | .dynamicArray _ =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1167,8 +1167,8 @@ private partial def translateDoElem
                           | none => throwErrorAt rhs "unable to infer tuple local types"
                   | none =>
                       match (← tryExternalCallBindStmt? fields constDecls immutableDecls externalDecls params locals rhs names) with
-                      | some (stmt, typedPairs) =>
-                          pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
+                      | some (stmts, typedPairs) =>
+                          pure (some (stmts, locals ++ typedPairs, mutableLocals))
                       | none => throwErrorAt rhs "tuple destructuring currently requires a tuple literal, tuple-typed parameter, structMembers/structMembers2 source, internal helper call, or tryExternalCall"
           | _ =>
               match (← arrayElementTupleDestructureStmts? fields constDecls immutableDecls params locals mutableLocals rhs names) with
@@ -1210,8 +1210,8 @@ private partial def translateDoElem
                               | none => throwErrorAt rhs "unable to infer tuple local types"
                       | none =>
                           match (← tryExternalCallBindStmt? fields constDecls immutableDecls externalDecls params locals rhs names) with
-                          | some (stmt, typedPairs) =>
-                              pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
+                          | some (stmts, typedPairs) =>
+                              pure (some (stmts, locals ++ typedPairs, mutableLocals))
                           | none =>
                               let valueExprs ← tupleValueExprs fields constDecls immutableDecls params locals rhs
                               if names.size != valueExprs.size then
@@ -1248,8 +1248,8 @@ private partial def translateDoElem
                   | none => throwErrorAt rhs "unable to infer tuple local types"
           | none =>
               match (← tryExternalCallBindStmt? fields constDecls immutableDecls externalDecls params locals rhs names) with
-              | some (stmt, typedPairs) =>
-                  pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
+              | some (stmts, typedPairs) =>
+                  pure (some (stmts, locals ++ typedPairs, mutableLocals))
               | none => throwErrorAt rhs "tuple bind sources must be internal helper calls or tryExternalCall"
       | none => pure none
     else
@@ -1345,7 +1345,7 @@ private partial def translateDoElem
               | _ => throwErrorAt rhs s!"callExternal '{extName}' returns multiple values; use externalCallBind with explicit result names"
           | `(term| callResult $_extName:term $_args:term) =>
               match (← callResultBindStmt? fields constDecls immutableDecls externalDecls params locals rhs varName) with
-              | some (stmt, resultLocal) => pure (#[stmt], locals.push resultLocal, mutableLocals)
+              | some (stmts, resultLocal) => pure (stmts, locals.push resultLocal, mutableLocals)
               | none => throwErrorAt rhs "invalid callResult bind"
           | `(term| ecmCall $moduleFactory:term $args:term) =>
               let argExprs ← expectEcmExprList fields constDecls immutableDecls params locals args

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1176,7 +1176,8 @@ private partial def translateDoElem
                           pure (some (stmts, locals ++ typedPairs, mutableLocals))
                       | none => throwErrorAt rhs "tuple destructuring currently requires a tuple literal, tuple-typed parameter, structMembers/structMembers2 source, internal helper call, or tryExternalCall"
           | _ =>
-              match (← arrayElementTupleDestructureStmts? fields constDecls immutableDecls params locals mutableLocals rhs names) with
+              match (← arrayElementTupleDestructureStmts? fields constDecls immutableDecls params locals mutableLocals rhs names
+                (some (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals))) with
               | some (stmts, syntheticLocal) =>
                   let valueTys ← inferTupleSourceTypes? fields constDecls immutableDecls externalDecls functions params locals rhs
                   match valueTys with
@@ -1536,7 +1537,8 @@ private partial def translateDoElem
               locals,
               mutableLocals)
       | `(doElem| return $value:term) =>
-          match (← arrayElementTupleReturnStmts? fields constDecls immutableDecls params locals mutableLocals value) with
+          match (← arrayElementTupleReturnStmts? fields constDecls immutableDecls params locals mutableLocals value
+            (some (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals))) with
           | some (stmts, syntheticLocal) =>
               pure (stmts, locals.push syntheticLocal, mutableLocals)
           | none =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1000,7 +1000,7 @@ private def translateEffectStmt
         throwErrorAt stx s!"callExternal '{extName}' returns values; bind it with `let ... ← ...`"
       validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
         extName ext.params args
-      let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
+      let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args (some ext.params)
       `(Compiler.CompilationModel.Stmt.externalCallBind [] $(strTerm extName) [ $[$argExprs],* ])
   | `(term| setStructMember $field:term $key:term $member:term $value:term) =>
       let fieldName := ← expectStringOrIdent field
@@ -1302,7 +1302,7 @@ private partial def translateDoElem
               | [retTy] =>
                   validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
                     extName ext.params args
-                  let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
+                  let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args (some ext.params)
                   let flatNames ← flattenExternalResultNames varName retTy
                   if flatNames.length != 1 then
                     throwErrorAt rhs s!"callExternal '{extName}' return type expands to {flatNames.length} values and cannot be bound to one source variable"

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -174,6 +174,9 @@ private partial def validateDoElemExprTypes
       | `(doElem| let $name:ident := $rhs:term) =>
           match arrayElementAliasSource? params rhs with
           | some (paramName, index, elemTy) =>
+              if syntaxContainsCallExternal index then
+                throwErrorAt index
+                  "arrayElement alias index cannot contain callExternal because the alias re-evaluates its index at each projection; bind the external result first"
               requireWordLikeType index "arrayElement alias index"
                 (← inferPureExprType fields constDecls immutableDecls externalDecls params locals index)
               pure <| locals.push
@@ -1293,6 +1296,9 @@ private partial def translateDoElem
             throwErrorAt name s!"duplicate local variable '{varName}'"
           match arrayElementAliasSource? params rhs with
           | some (paramName, index, elemTy) =>
+              if syntaxContainsCallExternal index then
+                throwErrorAt index
+                  "arrayElement alias index cannot contain callExternal because the alias re-evaluates its index at each projection; bind the external result first"
               requireWordLikeType index "arrayElement alias index"
                 (← inferPureExprType fields constDecls immutableDecls externalDecls params locals index)
               pure

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -718,6 +718,8 @@ private def translateEffectStmt
    | `(term| ecmDo $module:term $args:term) =>
       validateEffectOnlyEcmModuleTerm module
       let argExprs ← expectExprList fields constDecls immutableDecls params locals args
+        (some (translateDeclaredPureExpr
+          fields constDecls immutableDecls externalDecls params locals))
       `(Compiler.CompilationModel.Stmt.ecm
           $module
           [ $[$argExprs],* ])
@@ -1346,6 +1348,8 @@ private partial def translateDoElem
               | none => throwErrorAt rhs "invalid callResult bind"
           | `(term| ecmCall $moduleFactory:term $args:term) =>
               let argExprs ← expectEcmExprList fields constDecls immutableDecls params locals args
+                (some (translateDeclaredPureExpr
+                  fields constDecls immutableDecls externalDecls params locals))
               let moduleTerm ← `(term| (($moduleFactory) $(strTerm varName)))
               validateSingleResultEcmModuleTerm moduleTerm varName
               pure
@@ -1645,6 +1649,8 @@ private partial def translateDoElem
           ensureFreshLocalNames localNames (resultVars.map some) names
           validateResultEcmModuleTerm module resultVars
           let argExprs ← expectEcmExprList fields constDecls immutableDecls params locals args
+            (some (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals))
           let typedLocals := resultVars.map (fun name => mkTypedLocal name .uint256)
           pure
             (#[(← `(Compiler.CompilationModel.Stmt.ecm

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1302,7 +1302,10 @@ private partial def translateDoElem
                   let resultTerms := flatNames.toArray.map strTerm
                   let source := match staticStructDirectFieldLocals? varName retTy with
                     | some fieldLocals => LocalSource.externalStaticStruct fieldLocals
-                    | none => LocalSource.value
+                    | none =>
+                        if flatNames.size != 1 then
+                          throwErrorAt rhs s!"callExternal '{extName}' return type expands to {flatNames.size} values and cannot be bound to one source variable"
+                        LocalSource.value
                   pure
                     (#[(← `(Compiler.CompilationModel.Stmt.externalCallBind
                         [ $[$resultTerms],* ] $(strTerm extName) [ $[$argExprs],* ]))],

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1304,20 +1304,13 @@ private partial def translateDoElem
                     extName ext.params args
                   let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
                   let flatNames ← flattenExternalResultNames varName retTy
-                  for flatName in flatNames do
-                    if localNames.contains flatName then
-                      throwErrorAt rhs s!"callExternal '{extName}' generated result name '{flatName}' collides with an existing local"
+                  if flatNames.length != 1 then
+                    throwErrorAt rhs s!"callExternal '{extName}' return type expands to {flatNames.length} values and cannot be bound to one source variable"
                   let resultTerms := flatNames.toArray.map strTerm
-                  let source ← match staticStructDirectFieldLocals? varName retTy with
-                    | some fieldLocals => pure (LocalSource.externalStaticStruct fieldLocals)
-                    | none => do
-                        if flatNames.length != 1 then
-                          throwErrorAt rhs s!"callExternal '{extName}' return type expands to {flatNames.length} values and cannot be bound to one source variable"
-                        pure LocalSource.value
                   pure
                     (#[(← `(Compiler.CompilationModel.Stmt.externalCallBind
                         [ $[$resultTerms],* ] $(strTerm extName) [ $[$argExprs],* ]))],
-                      locals.push { name := varName, ty := retTy, source := source },
+                      locals.push { name := varName, ty := retTy, source := LocalSource.value },
                       mutableLocals)
               | [] => throwErrorAt rhs s!"callExternal '{extName}' returns Unit; invoke it as a statement"
               | _ => throwErrorAt rhs s!"callExternal '{extName}' returns multiple values; use externalCallBind with explicit result names"

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1258,7 +1258,10 @@ private partial def translateDoElem
           let varName := toString name.getId
           if localNames.contains varName then
             throwErrorAt name s!"duplicate local variable '{varName}'"
-          let rhsExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals rhs
+          let rhsExpr ← match stripParens rhs with
+            | `(term| callExternal $_ ($[$_],*)) =>
+                translateBindSource fields constDecls immutableDecls externalDecls functions params locals rhs
+            | _ => translatePureExprWithTypes fields constDecls immutableDecls params locals rhs
           let ty ← inferPureExprType fields constDecls immutableDecls externalDecls params locals rhs
           let interfaceName? ← interfaceNameOfTerm? params locals rhs
           pure
@@ -1281,7 +1284,10 @@ private partial def translateDoElem
                       source := .arrayElement paramName index elemTy },
                   mutableLocals)
           | none =>
-              let rhsExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals rhs
+              let rhsExpr ← match stripParens rhs with
+                | `(term| callExternal $_ ($[$_],*)) =>
+                    translateBindSource fields constDecls immutableDecls externalDecls functions params locals rhs
+                | _ => translatePureExprWithTypes fields constDecls immutableDecls params locals rhs
               let ty ← inferPureExprType fields constDecls immutableDecls externalDecls params locals rhs
               let interfaceName? ← interfaceNameOfTerm? params locals rhs
               pure

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1313,9 +1313,14 @@ private partial def translateDoElem
                   if flatNames.length != 1 then
                     throwErrorAt rhs s!"callExternal '{extName}' return type expands to {flatNames.length} values and cannot be bound to one source variable"
                   let resultTerms := flatNames.toArray.map strTerm
+                  let bindStmt ← `(Compiler.CompilationModel.Stmt.externalCallBind
+                    [ $[$resultTerms],* ] $(strTerm extName) [ $[$argExprs],* ])
+                  let normalization? ← normalizeBoundValueStmt? retTy rhs varName
+                  let stmts := match normalization? with
+                    | some normalization => #[bindStmt, normalization]
+                    | none => #[bindStmt]
                   pure
-                    (#[(← `(Compiler.CompilationModel.Stmt.externalCallBind
-                        [ $[$resultTerms],* ] $(strTerm extName) [ $[$argExprs],* ]))],
+                    (stmts,
                       locals.push { name := varName, ty := retTy, source := LocalSource.value },
                       mutableLocals)
               | [] => throwErrorAt rhs s!"callExternal '{extName}' returns Unit; invoke it as a statement"
@@ -1453,28 +1458,7 @@ private partial def translateDoElem
                                         $(natTerm argExprs.size)
                                         false)
                                       [ $targetExpr, $[$argExprs],* ])
-                              let normalization? ←
-                                match retTy with
-                                | .uintN bits => do
-                                    let normalization ← `(Compiler.CompilationModel.Stmt.assignVar $(strTerm varName)
-                                      (Compiler.CompilationModel.Expr.bitAnd
-                                        (Compiler.CompilationModel.Expr.localVar $(strTerm varName))
-                                        (Compiler.CompilationModel.Expr.literal $(natTerm (2 ^ bits - 1)))))
-                                    pure (some normalization)
-                                | .intN bits => do
-                                    let normalization ← `(Compiler.CompilationModel.Stmt.assignVar $(strTerm varName)
-                                      (Compiler.CompilationModel.Expr.signextend
-                                        (Compiler.CompilationModel.Expr.literal $(natTerm (bits / 8 - 1)))
-                                        (Compiler.CompilationModel.Expr.localVar $(strTerm varName))))
-                                    pure (some normalization)
-                                | .bytesN bytes => do
-                                    let normalization ← `(Compiler.CompilationModel.Stmt.assignVar $(strTerm varName)
-                                      (Compiler.CompilationModel.Expr.bitAnd
-                                        (Compiler.CompilationModel.Expr.localVar $(strTerm varName))
-                                        (Compiler.CompilationModel.Expr.literal
-                                          $(natTerm ((2 ^ (8 * bytes) - 1) * 2 ^ (8 * (32 - bytes)))))))
-                                    pure (some normalization)
-                                | _ => pure none
+                              let normalization? ← normalizeBoundValueStmt? retTy rhs varName
                               let stmts := match normalization? with | some normalization => #[stmt, normalization] | none => #[stmt]
                               pure
                                 (stmts,

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1374,7 +1374,19 @@ private partial def translateDoElem
               -- Zero-return tryExternalCall: `let success ← tryExternalCall "fn" [args]`
               -- produces Stmt.tryExternalCallBind successVar [] externalName args
               let targetFn := ← expectStringOrIdent extName
-              let argExprs ← expectExprList fields constDecls immutableDecls params locals args
+              let ext ←
+                match externalDecls.find? (fun ext => ext.name == targetFn) with
+                | some ext => pure ext
+                | none => throwErrorAt rhs s!"unknown external function '{targetFn}'"
+              let argTerms ← match stripParens args with
+                | `(term| [ $[$xs],* ]) => pure xs
+                | _ => throwErrorAt args "expected list literal [..]"
+              validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+                targetFn ext.params argTerms
+              let argExprs ← translateLinkedExternalCallArgs
+                fields constDecls immutableDecls params locals argTerms (some ext.params)
+                (some (translateDeclaredPureExpr
+                  fields constDecls immutableDecls externalDecls params locals))
               pure
                 (#[(← `(Compiler.CompilationModel.Stmt.tryExternalCallBind
                         $(strTerm varName)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1451,7 +1451,7 @@ private partial def translateDoElem
                           source := .memoryArray },
                       mutableLocals)
               | none =>
-                  let safeBind? ← translateSafeRequireBind fields constDecls immutableDecls params locals varName rhs
+                  let safeBind? ← translateSafeRequireBind fields constDecls immutableDecls externalDecls params locals varName rhs
                   match safeBind? with
                   | some safeStmts =>
                       let safeTy ← inferBindSourceType
@@ -1777,7 +1777,7 @@ private def immutableInitStmtTerms
       | _ =>
           throwErrorAt imm.ident s!"immutable '{imm.name}' uses unsupported type"
     let checkedInit? ←
-      translateSafeRequireBind fields constDecls #[] ctorParams #[]
+      translateSafeRequireBind fields constDecls #[] #[] ctorParams #[]
         "__immutable_init_value" imm.body
     match checkedInit? with
     | some stmts =>
@@ -1880,7 +1880,24 @@ private def isVoidTypedInterfaceCall?
     | pure false
   pure ext.returnTys.isEmpty
 
+private def annotateExecutableLinkedCall?
+    (externalDecls : Array ExternalDecl)
+    (term : Term) : CommandElabM Term := do
+  match stripParens term with
+  | `(term| callExternal $name:ident ($[$_args:term],*)) =>
+      let extName := toString name.getId
+      match externalDecls.find? (fun ext => ext.name == extName) with
+      | some ext =>
+          match ext.returnTys.toList with
+          | [retTy] =>
+              let retTyTerm ← contractValueTypeTerm retTy
+              `(($term : $retTyTerm))
+          | _ => pure term
+      | none => pure term
+  | _ => pure term
+
 mutual
+
 private partial def rewriteForEachExecutableDoSeq
     (externalDecls : Array ExternalDecl)
     (params : Array ParamDecl)
@@ -1935,7 +1952,20 @@ private partial def rewriteForEachExecutableDoElem
           let retTyTerm ← contractValueTypeTerm retTy
           pure (#[← `(doElem| let $name:ident := (panic! "typed interface calls are compiler-only in executable wrappers" : $retTyTerm))],
             locals.push (mkTypedLocal (toString name.getId) retTy))
-      | none => pure (#[elem], locals)
+      | none =>
+          match stripParens rhs with
+          | `(term| tryExternalCall $extNameTerm:term $_args:term) =>
+              let extName := ← expectStringOrIdent extNameTerm
+              match externalDecls.find? (fun ext => ext.name == extName) with
+              | some ext =>
+                  match ext.returnTys.toList with
+                  | [] =>
+                      pure (#[← `(doElem| let ($name:ident, _) ←
+                        ($rhs : _root_.Verity.Contract (Bool × Unit)))],
+                        locals.push (mkTypedLocal (toString name.getId) .bool))
+                  | _ => pure (#[elem], locals)
+              | none => pure (#[elem], locals)
+          | _ => pure (#[elem], locals)
   | `(doElem| let $pat:term ← $rhs:term) =>
       match tupleBinderNames? pat with
       | some _ =>
@@ -1985,6 +2015,12 @@ private partial def rewriteForEachExecutableDoElem
   | `(doElem| unsafe $_reason:str do $body:doSeq) =>
       let body ← rewriteForEachExecutableDoSeq externalDecls params locals body
       pure (#[← `(doElem| do $body)], locals)
+  | `(doElem| emit $eventName:term [ $[$args:term],* ]) =>
+      let args ← args.mapM (annotateExecutableLinkedCall? externalDecls)
+      pure (#[← `(doElem| emit $eventName [ $[$args],* ])], locals)
+  | `(doElem| requireError $cond:term $errorName:ident($args,*)) =>
+      let args ← args.getElems.mapM (annotateExecutableLinkedCall? externalDecls)
+      pure (#[← `(doElem| requireError $cond $errorName:ident($args,*))], locals)
   | `(doElem| $stmt:term) =>
       -- a void typed interface call in statement position is compiler-only;
       -- drop it from the executable wrapper (it returns nothing to bind).

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1392,12 +1392,14 @@ private partial def translateDoElem
                 fields constDecls immutableDecls params locals argTerms (some ext.params)
                 (some (translateDeclaredPureExpr
                   fields constDecls immutableDecls externalDecls params locals))
+              let bindStmt ← `(Compiler.CompilationModel.Stmt.tryExternalCallBind
+                  $(strTerm varName)
+                  []
+                  $(strTerm targetFn)
+                  [ $[$argExprs],* ])
+              let successNormalization ← normalizeBoundValueStmt? .bool rhs varName
               pure
-                (#[(← `(Compiler.CompilationModel.Stmt.tryExternalCallBind
-                        $(strTerm varName)
-                        []
-                        $(strTerm targetFn)
-                        [ $[$argExprs],* ]))],
+                (#[bindStmt] ++ successNormalization.toArray,
                   locals.push (mkTypedLocal varName .bool),
                   mutableLocals)
           | `(term| allocArray $len:term) =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1302,7 +1302,7 @@ private partial def translateDoElem
                   let resultTerms := flatNames.toArray.map strTerm
                   let source := match staticStructDirectFieldLocals? varName retTy with
                     | some fieldLocals => LocalSource.externalStaticStruct fieldLocals
-                    | none =>
+                    | none => do
                         if flatNames.size != 1 then
                           throwErrorAt rhs s!"callExternal '{extName}' return type expands to {flatNames.size} values and cannot be bound to one source variable"
                         LocalSource.value

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1261,7 +1261,7 @@ private partial def translateDoElem
           let rhsExpr ← match stripParens rhs with
             | `(term| callExternal $_ ($[$_],*)) =>
                 translateBindSource fields constDecls immutableDecls externalDecls functions params locals rhs
-            | _ => translatePureExprWithTypes fields constDecls immutableDecls params locals rhs
+            | _ => translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals rhs
           let ty ← inferPureExprType fields constDecls immutableDecls externalDecls params locals rhs
           let interfaceName? ← interfaceNameOfTerm? params locals rhs
           pure
@@ -1287,7 +1287,7 @@ private partial def translateDoElem
               let rhsExpr ← match stripParens rhs with
                 | `(term| callExternal $_ ($[$_],*)) =>
                     translateBindSource fields constDecls immutableDecls externalDecls functions params locals rhs
-                | _ => translatePureExprWithTypes fields constDecls immutableDecls params locals rhs
+                | _ => translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals rhs
               let ty ← inferPureExprType fields constDecls immutableDecls externalDecls params locals rhs
               let interfaceName? ← interfaceNameOfTerm? params locals rhs
               pure
@@ -1340,10 +1340,10 @@ private partial def translateDoElem
                   locals.push (mkTypedLocal varName .uint256),
                   mutableLocals)
           | `(term| ecrecover $hash:term $v:term $r:term $s:term) =>
-              let hashExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals hash
-              let vExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals v
-              let rExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals r
-              let sExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals s
+              let hashExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals hash
+              let vExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals v
+              let rExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals r
+              let sExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals s
               pure
                 (#[(← `(Compiler.CompilationModel.Stmt.ecm
                         (Compiler.Modules.Precompiles.ecrecoverModule $(strTerm varName))
@@ -1366,7 +1366,7 @@ private partial def translateDoElem
           | `(term| allocArray $len:term) =>
               requireWordLikeType len "allocArray length"
                 (← inferPureExprType fields constDecls immutableDecls externalDecls params locals len)
-              let lenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals len
+              let lenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals len
               let lengthName := memoryArrayLengthName varName
               let dataOffsetName := memoryArrayDataOffsetName varName
               let lengthLocal : Term ← `(Compiler.CompilationModel.Expr.localVar $(strTerm lengthName))
@@ -1430,9 +1430,9 @@ private partial def translateDoElem
                       | none =>
                           match ← resolveTypedInterfaceCall? fields constDecls immutableDecls externalDecls params locals rhs with
                           | some (ext, target, argTerms, some retTy, selector) =>
-                              let targetExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals target
+                              let targetExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals target
                               let argExprs ← argTerms.mapM
-                                (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+                                (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals)
                               let stmt ←
                                 if ext.isView then
                                   match staticAbiWordCount? retTy with
@@ -1482,7 +1482,7 @@ private partial def translateDoElem
             throwErrorAt name s!"cannot assign immutable variable '{varName}'; declare it with 'let mut'"
           let some localInfo := locals.find? (fun entry => entry.name == varName)
             | throwErrorAt name s!"cannot resolve type of mutable variable '{varName}'"
-          let rawRhsExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals rhs
+          let rawRhsExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals rhs
           let rhsExpr ← normalizeTranslatedExprForType localInfo.ty rhs rawRhsExpr
           pure
             (#[(← `(Compiler.CompilationModel.Stmt.assignVar $(strTerm varName) $rhsExpr))],
@@ -1506,14 +1506,14 @@ private partial def translateDoElem
                             let normalized := (literal % 2 ^ (8 * bytes)) * 2 ^ (8 * (32 - bytes))
                             `(Compiler.CompilationModel.Expr.literal $(natTerm normalized))
                         | _ =>
-                            translatePureExprWithTypes fields constDecls immutableDecls params locals value
+                            translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value
                     | _ =>
-                        translatePureExprWithTypes fields constDecls immutableDecls params locals value
+                        translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value
                   pure (#[(← `(Compiler.CompilationModel.Stmt.return $valueExpr))], locals, mutableLocals)
       | `(doElem| pure ()) =>
           pure (#[], locals, mutableLocals)
       | `(doElem| if $cond:term then $thenBranch:doSeq else $elseBranch:doSeq) =>
-          let condExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals cond
+          let condExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals cond
           let thenStmts ← translateDoSeqToStmtTerms fields constDecls immutableDecls externalDecls errorDecls functions returnTy params locals mutableLocals thenBranch
           let elseStmts ← translateDoSeqToStmtTerms fields constDecls immutableDecls externalDecls errorDecls functions returnTy params locals mutableLocals elseBranch
           pure
@@ -1528,7 +1528,7 @@ private partial def translateDoElem
             freshSyntheticLocalName "verity_try_success" params locals mutableLocals
           let (payloadName?, catchElems) ← parseTryCatchHandler handler
           validateTryCatchHandlerDoesNotUsePayload handler payloadName? catchElems
-          let attemptExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals attempt
+          let attemptExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals attempt
           let catchTranslation ←
             translateDoElems fields constDecls immutableDecls externalDecls errorDecls functions returnTy params locals mutableLocals catchElems
           let catchStmts := catchTranslation.1
@@ -1546,7 +1546,7 @@ private partial def translateDoElem
             mutableLocals)
       | `(doElem| forEach $name:term $count:term $body:term) =>
           let loopVar := ← expectStringOrIdent name
-          let countExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals count
+          let countExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals count
           let bodyStmts ←
             match stripParens body with
             | `(term| do $[$inner:doElem]*) =>
@@ -1561,7 +1561,7 @@ private partial def translateDoElem
               mutableLocals)
       | `(doElem| forEachSetBit $name:term $bitmap:term $body:term) =>
           let loopVar := ← expectStringOrIdent name
-          let bitmapExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals bitmap
+          let bitmapExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals bitmap
           let bodyStmts ←
             match stripParens body with
             | `(term| do $[$inner:doElem]*) =>
@@ -1579,7 +1579,7 @@ private partial def translateDoElem
             errorDecls (toString errorName.getId) args.getElems
           pure
             (#[(← `(Compiler.CompilationModel.Stmt.requireError
-                    $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond)
+                    $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals cond)
                     $(strTerm (toString errorName.getId))
                     [ $[$argExprs],* ]))],
               locals,
@@ -1605,7 +1605,7 @@ private partial def translateDoElem
       | `(doElem| panic($code:term)) =>
           pure
             (#[(← `(Compiler.CompilationModel.Stmt.panicCode
-                    $(← translatePureExprWithTypes fields constDecls immutableDecls params locals code)))],
+                    $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals code)))],
               locals,
               mutableLocals)
       | `(doElem| unsafe $reason:str do $body:doSeq) =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -399,14 +399,19 @@ private partial def validateEffectStmtExprTypes
       pure ()
   | `(term| mstore $offset:term $value:term) | `(term| memoryStore($offset, $value))
     | `(term| tstore $offset:term $value:term) => do
-      let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals offset
-      let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals value
+      requireWordLikeType offset "memory-store offset"
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals offset)
+      requireWordLikeType value "memory-store value"
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals value)
   | `(term| calldatacopy $destOffset:term $sourceOffset:term $size:term)
     | `(term| returndataCopy $destOffset:term $sourceOffset:term $size:term)
     | `(term| returnDataCopy($destOffset, $sourceOffset, $size)) => do
-      let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals destOffset
-      let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals sourceOffset
-      let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals size
+      requireWordLikeType destOffset "returndata-copy destination offset"
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals destOffset)
+      requireWordLikeType sourceOffset "returndata-copy source offset"
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals sourceOffset)
+      requireWordLikeType size "returndata-copy size"
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals size)
   | `(term| rawLog $topics:term $dataOffset:term $dataSize:term) => do
       match stripParens topics with
       | `(term| [ $[$xs],* ]) =>
@@ -1299,6 +1304,9 @@ private partial def translateDoElem
                     extName ext.params args
                   let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
                   let flatNames ← flattenExternalResultNames varName retTy
+                  for flatName in flatNames do
+                    if localNames.contains flatName then
+                      throwErrorAt rhs s!"callExternal '{extName}' generated result name '{flatName}' collides with an existing local"
                   let resultTerms := flatNames.toArray.map strTerm
                   let source ← match staticStructDirectFieldLocals? varName retTy with
                     | some fieldLocals => pure (LocalSource.externalStaticStruct fieldLocals)

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -1749,17 +1749,6 @@ partial def peelLambdaBody (value : Expr) (arity : Nat) : Option Expr :=
       | .lam _ _ body _ => peelLambdaBody body n
       | _ => none
 
-partial def countBVarUses (target : Nat) (expr : Expr) : Nat :=
-  match expr with
-  | .bvar idx => if idx == target then 1 else 0
-  | .app fn arg => countBVarUses target fn + countBVarUses target arg
-  | .lam _ type body _ | .forallE _ type body _ =>
-      countBVarUses target type + countBVarUses (target + 1) body
-  | .letE _ type value body _ =>
-      countBVarUses target type + countBVarUses target value + countBVarUses (target + 1) body
-  | .mdata _ body | .proj _ _ body => countBVarUses target body
-  | _ => 0
-
 partial def leanDefAppSyntax? (stx : Term) : Option (Syntax × String × Array Term) :=
   let stx := stripParens stx
   match stx.raw with
@@ -2186,7 +2175,14 @@ partial def inferPureExprType
               requireSupportedArrayElementSourceType name "arrayElement" sourceTy
         | _ =>
             requireSupportedArrayElementSourceType name "arrayElement" sourceTy
-  | `(term| mulDivDown $a $b $c) | `(term| mulDivUp $a $b $c) => do
+  | `(term| mulDivDown $a $b $c) => do
+      for arg in [a, b, c] do
+        requireWordLikeType arg "mulDiv" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
+      pure .uint256
+  | `(term| mulDivUp $a $b $c) => do
+      if syntaxContainsCallExternal c then
+        throwErrorAt c
+          "mulDivUp divisor cannot contain callExternal because expression lowering reuses it; bind the external result first"
       for arg in [a, b, c] do
         requireWordLikeType arg "mulDiv" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
       pure .uint256
@@ -3068,9 +3064,9 @@ partial def translateLeanDefCall?
   for (arg, argIdx) in argTerms.zipIdx do
     if syntaxContainsCallExternal arg.raw then
       let bvarIdx := argTerms.size - 1 - argIdx
-      unless countBVarUses bvarIdx body == 1 do
+      unless body == .bvar bvarIdx do
         throwErrorAt stx
-          s!"Lean helper '{fnDisplay}' arguments cannot contain callExternal because transparent-helper inlining may reuse or discard arguments; bind the external result first"
+          s!"Lean helper '{fnDisplay}' arguments cannot contain callExternal unless the helper is a direct passthrough because transparent-helper and expression lowering may duplicate or discard arguments; bind the external result first"
   let inferArgType (arg : Term) :=
     match linkedExternalLowerer? with
     | some lowerer => lowerer.inferType arg visitingConstants
@@ -4826,6 +4822,9 @@ def expectEcmExprList
             if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 arrayElementDynamicMemberProjection? params x then
               if externalCallDynamicArgSupported fieldTy then
+                  if syntaxContainsCallExternal index then
+                    throwErrorAt index
+                      "ECM dynamic projection indices cannot contain callExternal because ABI lowering reuses the index for offset and length; bind the external result first"
                   let indexExpr ← translateExpr index
                   out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                     $(strTerm paramName)
@@ -4840,6 +4839,9 @@ def expectEcmExprList
             else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 localArrayElementDynamicMemberProjection? locals x then
               if externalCallDynamicArgSupported fieldTy then
+                  if syntaxContainsCallExternal index then
+                    throwErrorAt index
+                      "ECM dynamic projection indices cannot contain callExternal because ABI lowering reuses the index for offset and length; bind the external result first"
                   let indexExpr ← translateExpr index
                   out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                     $(strTerm paramName)

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -3988,7 +3988,12 @@ def arrayElementTupleElemExprs?
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (rhs : Term) : CommandElabM (Option (Array Term)) := do
+    (rhs : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Option (Array Term)) := do
+  let translateExpr (expr : Term) : CommandElabM Term :=
+    match translateExpr? with
+    | some translate => translate expr
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals expr
   match stripParens rhs with
   | `(term| arrayElement $name:term $index:term) =>
       -- verity#1849, G2: compound projections never destructure into a tuple.
@@ -4007,7 +4012,7 @@ def arrayElementTupleElemExprs?
             | none =>
                 throwErrorAt rhs
                   "arrayElement tuple destructuring requires a static ABI-word tuple element type"
-          let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+          let indexExpr ← translateExpr index
           let mut offset := 0
           let mut exprs : Array Term := #[]
           for elemTy in elemTys do
@@ -4038,7 +4043,12 @@ def arrayElementTupleDestructureStmts?
     (locals : Array TypedLocal)
     (mutableLocals : Array String)
     (rhs : Term)
-    (names : Array (Option String)) : CommandElabM (Option (Array Term × TypedLocal)) := do
+    (names : Array (Option String))
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Option (Array Term × TypedLocal)) := do
+  let translateExpr (expr : Term) : CommandElabM Term :=
+    match translateExpr? with
+    | some translate => translate expr
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals expr
   match stripParens rhs with
   | `(term| arrayElement $name:term $index:term) =>
       -- verity#1849, G2: compound projections never destructure into a tuple.
@@ -4056,7 +4066,7 @@ def arrayElementTupleDestructureStmts?
               s!"tuple destructuring binds {names.size} names, but the source provides {elemTys.length} values"
           let syntheticUsed := mutableLocals ++ names.filterMap id
           let indexName := freshSyntheticLocalName "arrayElement_index" params locals syntheticUsed
-          let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+          let indexExpr ← translateExpr index
           let indexStmt ←
             `(Compiler.CompilationModel.Stmt.letVar $(strTerm indexName) $indexExpr)
           let indexLocal ←
@@ -4123,7 +4133,12 @@ def arrayElementTupleReturnStmts?
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (mutableLocals : Array String)
-    (rhs : Term) : CommandElabM (Option (Array Term × TypedLocal)) := do
+    (rhs : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Option (Array Term × TypedLocal)) := do
+  let translateExpr (expr : Term) : CommandElabM Term :=
+    match translateExpr? with
+    | some translate => translate expr
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals expr
   match stripParens rhs with
   | `(term| arrayElement $name:term $index:term) =>
       -- verity#1849, G2: compound projections (`(arrayElement <p> <i>).<dynField>`)
@@ -4145,7 +4160,7 @@ def arrayElementTupleReturnStmts?
                 throwErrorAt rhs
                   "arrayElement tuple return requires a static ABI-word tuple element type"
           let indexName := freshSyntheticLocalName "arrayElement_index" params locals mutableLocals
-          let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+          let indexExpr ← translateExpr index
           let indexStmt ←
             `(Compiler.CompilationModel.Stmt.letVar $(strTerm indexName) $indexExpr)
           let indexLocal ←
@@ -4240,7 +4255,7 @@ def tupleLiteralOrStructValueExprs?
   | some elems =>
       pure (some (← elems.mapM translateExpr))
   | none =>
-      match ← arrayElementTupleElemExprs? fields constDecls immutableDecls params locals rhs with
+      match ← arrayElementTupleElemExprs? fields constDecls immutableDecls params locals rhs translateExpr? with
       | some exprs => pure (some exprs)
       | none =>
           match ← structCtorValueExprs? with

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -4319,7 +4319,7 @@ def translateInternalHelperCallArgs
                 out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
           | none =>
               if let some (paramName, index, _elemTy) := arrayElementDynamicTupleArg? params arg then
-                let indexExpr ← translateExpr index
+                let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
                 out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicDataOffset
                   $(strTerm paramName)
                   $indexExpr))

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -4766,6 +4766,22 @@ def translateBindSource
     (rhs : Term) : CommandElabM Term := do
   let rhs := stripParens rhs
   match rhs with
+  | `(term| callExternal $name:ident ($[$args:term],*)) =>
+      let extName := toString name.getId
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown linked external '{extName}'"
+      validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+        extName ext.params args
+      match ext.returnTys.toList with
+      | [retTy] =>
+          unless isSingleWordStaticValueType retTy do
+            throwErrorAt name s!"callExternal '{extName}' return type cannot be used as a pure single-word expression"
+          let argExprs ← translateLinkedExternalCallArgs
+            fields constDecls immutableDecls params locals args (some ext.params)
+          `(Compiler.CompilationModel.Expr.externalCall $(strTerm extName) [ $[$argExprs],* ])
+      | [] => throwErrorAt name s!"callExternal '{extName}' returns no values"
+      | _ => throwErrorAt name s!"callExternal '{extName}' returns multiple values"
   | `(term| memoryLoad($_))
     | `(term| returnDataSize())
     | `(term| evmCall($_, $_, $_, $_, $_, $_, $_))

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -2170,8 +2170,14 @@ partial def inferPureExprType
           | _ => throwErrorAt name s!"externalCall '{extName}' returns {ext.returnTys.size} values; use `let (success, ...) ← tryExternalCall \"{extName}\" [...]` for multi-return"
       | none => pure .uint256
   | `(term| callExternal $name:ident ($[$xs:term],*)) =>
+      let extName := toString name.getId
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown linked external '{extName}'"
+      validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+        extName ext.params xs
       inferPureExprType fields constDecls immutableDecls externalDecls params locals
-        (← `(externalCall $(strTerm (toString name.getId)) [ $[$xs],* ])) visitingConstants
+        (← `(externalCall $(strTerm extName) [ $[$xs],* ])) visitingConstants
   | `(term| intrinsic_cancun $name:term $_lowering:term $args:term)
   | `(term| intrinsic_prague $name:term $_lowering:term $args:term)
   | `(term| intrinsic_fusaka $name:term $_lowering:term $args:term)

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -1749,6 +1749,17 @@ partial def peelLambdaBody (value : Expr) (arity : Nat) : Option Expr :=
       | .lam _ _ body _ => peelLambdaBody body n
       | _ => none
 
+partial def countBVarUses (target : Nat) (expr : Expr) : Nat :=
+  match expr with
+  | .bvar idx => if idx == target then 1 else 0
+  | .app fn arg => countBVarUses target fn + countBVarUses target arg
+  | .lam _ type body _ | .forallE _ type body _ =>
+      countBVarUses target type + countBVarUses (target + 1) body
+  | .letE _ type value body _ =>
+      countBVarUses target type + countBVarUses target value + countBVarUses (target + 1) body
+  | .mdata _ body | .proj _ _ body => countBVarUses target body
+  | _ => 0
+
 partial def leanDefAppSyntax? (stx : Term) : Option (Syntax × String × Array Term) :=
   let stx := stripParens stx
   match stx.raw with
@@ -3052,6 +3063,14 @@ partial def translateLeanDefCall?
   let some info ← leanDefInfo? fnName
     | pure none
   let (paramTypeExprs, resultTypeExpr) := peelForallTypes info.type
+  let some body := peelLambdaBody info.value argTerms.size
+    | throwErrorAt stx s!"Lean helper '{fnDisplay}' body is not a transparent function definition"
+  for (arg, argIdx) in argTerms.zipIdx do
+    if syntaxContainsCallExternal arg.raw then
+      let bvarIdx := argTerms.size - 1 - argIdx
+      unless countBVarUses bvarIdx body == 1 do
+        throwErrorAt stx
+          s!"Lean helper '{fnDisplay}' arguments cannot contain callExternal because transparent-helper inlining may reuse or discard arguments; bind the external result first"
   let inferArgType (arg : Term) :=
     match linkedExternalLowerer? with
     | some lowerer => lowerer.inferType arg visitingConstants
@@ -3063,8 +3082,6 @@ partial def translateLeanDefCall?
   | none =>
       throwErrorAt stx
         s!"Lean helper '{fnDisplay}' uses an unsupported return type; supported pure helper returns are Uint256, Int256, Address, Bytes32/Uint256, and Bool"
-  let some body := peelLambdaBody info.value argTerms.size
-    | throwErrorAt stx s!"Lean helper '{fnDisplay}' body is not a transparent function definition"
   let argExprs ← argTerms.mapM
     (translatePureExprWithTypes fields constDecls immutableDecls params locals · visitingConstants linkedExternalLowerer?)
   pure (some (← translateLeanExprFromDef fields constDecls immutableDecls params locals stx.raw fnDisplay argExprs body))
@@ -4457,6 +4474,9 @@ def translateLinkedExternalCallArgs
             else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 arrayElementDynamicMemberProjection? params arg then
               if externalCallDynamicArgSupported fieldTy then
+                if syntaxContainsCallExternal index then
+                  throwErrorAt index
+                    "dynamic projection indices cannot contain callExternal because ABI lowering reuses the index for offset and length; bind the external result first"
                 let indexExpr ← translateExpr index
                 out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                   $(strTerm paramName)
@@ -4471,6 +4491,9 @@ def translateLinkedExternalCallArgs
             else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 localArrayElementDynamicMemberProjection? locals arg then
               if externalCallDynamicArgSupported fieldTy then
+                if syntaxContainsCallExternal index then
+                  throwErrorAt index
+                    "dynamic projection indices cannot contain callExternal because ABI lowering reuses the index for offset and length; bind the external result first"
                 let indexExpr ← translateExpr index
                 out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                   $(strTerm paramName)

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -3055,7 +3055,8 @@ partial def translatePureExprWithTypes
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (stx : Term)
-    (visitingConstants : List String := []) : CommandElabM Term := do
+    (visitingConstants : List String := [])
+    (linkedExternalLowerer? : Option (Ident → Array Term → CommandElabM Term) := none) : CommandElabM Term := do
   let stx := stripParens stx
   let localNames := typedLocalNames locals
   let translateIntrinsic (name lowering args minForkTerm : Term) : CommandElabM Term := do
@@ -3063,12 +3064,12 @@ partial def translatePureExprWithTypes
     let argsExprs ←
       match stripParens args with
       | `(term| [ $[$xs],* ]) =>
-          xs.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals · visitingConstants)
+          xs.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals · visitingConstants linkedExternalLowerer?)
       | _ => throwErrorAt args "expected list literal [..]"
     `(Compiler.CompilationModel.Expr.intrinsic $(strTerm intrinsicName) $lowering
         $minForkTerm [ $[$argsExprs],* ])
   if let some (paramName, index, _fieldTy, elemTy, wordOffset) := arrayElementStructProjection? params stx then
-    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
     if valueTypeUsesDynamicData elemTy then
       `(Compiler.CompilationModel.Expr.arrayElementDynamicWord
         $(strTerm paramName)
@@ -3086,7 +3087,7 @@ partial def translatePureExprWithTypes
         $(natTerm wordOffset))
   else
   if let some (paramName, index, _fieldTy, elemTy, wordOffset) := localArrayElementStructProjection? locals stx then
-    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
     if valueTypeUsesDynamicData elemTy then
       `(Compiler.CompilationModel.Expr.arrayElementDynamicWord
         $(strTerm paramName)
@@ -3147,7 +3148,7 @@ partial def translatePureExprWithTypes
             | none => throwErrorAt target "abiHeadWord requires a direct parameter, dynamic local alias, or `arrayElement <param> <index>` target"
       match index? with
       | some index =>
-          let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+          let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
           if valueTypeUsesDynamicData ty then
             `(Compiler.CompilationModel.Expr.arrayElementDynamicWord
               $(strTerm paramName)
@@ -3220,18 +3221,18 @@ partial def translatePureExprWithTypes
         `(Compiler.CompilationModel.Expr.literal 0)
   | `(term| isZeroAddress $a:term) =>
       `(Compiler.CompilationModel.Expr.eq
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
           (Compiler.CompilationModel.Expr.literal 0))
-  | `(term| wordToAddress $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants
-  | `(term| addressToWord $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants
-  | `(term| toInt256 $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants
-  | `(term| toUint256 $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants
+  | `(term| wordToAddress $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
+  | `(term| addressToWord $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
+  | `(term| toInt256 $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
+  | `(term| toUint256 $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
   | `(term| narrowUInt $bits:num $a:term) => do
       let width ← natFromSyntax bits
       unless width >= 8 && width < 256 && width % 8 == 0 do
         throwErrorAt bits "narrowUInt width must be a byte multiple from 8 through 248"
       `(Compiler.CompilationModel.Expr.bitAnd
-        $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
+        $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
         (Compiler.CompilationModel.Expr.literal $(natTerm (2 ^ width - 1))))
   | `(term| narrowInt $bits:num $a:term) => do
       let width ← natFromSyntax bits
@@ -3239,18 +3240,18 @@ partial def translatePureExprWithTypes
         throwErrorAt bits "narrowInt width must be a byte multiple from 8 through 248"
       `(Compiler.CompilationModel.Expr.signextend
         (Compiler.CompilationModel.Expr.literal $(natTerm (width / 8 - 1)))
-        $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants))
+        $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?))
   | `(term| narrowBytes $bytes:num $a:term) => do
       let width ← natFromSyntax bytes
       unless width >= 1 && width < 32 do
         throwErrorAt bytes "narrowBytes width must be from 1 through 31"
       let mask := (2 ^ (8 * width) - 1) * 2 ^ (8 * (32 - width))
       `(Compiler.CompilationModel.Expr.bitAnd
-        $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
+        $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
         (Compiler.CompilationModel.Expr.literal $(natTerm mask)))
   | `(term| boolToWord $a:term) =>
       `(Compiler.CompilationModel.Expr.ite
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
           (Compiler.CompilationModel.Expr.literal 1)
           (Compiler.CompilationModel.Expr.literal 0))
   | `(term| $n:num) => `(Compiler.CompilationModel.Expr.literal $n)
@@ -3258,8 +3259,8 @@ partial def translatePureExprWithTypes
     | `(term| sub $a $b) | `(term| $a - $b)
     | `(term| mul $a $b) | `(term| $a * $b) => do
       let resultTy ← inferPureExprType fields constDecls immutableDecls #[] params locals stx visitingConstants
-      let lhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants
-      let rhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants
+      let lhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
+      let rhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?
       let raw ← match stx with
         | `(term| add $_ $_) | `(term| $_ + $_) => `(Compiler.CompilationModel.Expr.add $lhs $rhs)
         | `(term| sub $_ $_) | `(term| $_ - $_) => `(Compiler.CompilationModel.Expr.sub $lhs $rhs)
@@ -3274,45 +3275,45 @@ partial def translatePureExprWithTypes
       | _ => pure raw
   | `(term| pow $a $b) | `(term| $a ^ $b) =>
       `(Compiler.CompilationModel.Expr.externalCall Compiler.CompilationModel.builtinExpName
-          [$(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants),
-           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants)])
+          [$(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?),
+           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)])
   | `(term| div $a $b) | `(term| $a / $b) => do
       let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
       let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
-        let raw ← `(Compiler.CompilationModel.Expr.sdiv $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        let raw ← `(Compiler.CompilationModel.Expr.sdiv $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
         match lhsTy with
         | .intN bits =>
             `(Compiler.CompilationModel.Expr.signextend
                 (Compiler.CompilationModel.Expr.literal $(natTerm (bits / 8 - 1))) $raw)
         | _ => pure raw
       else
-        `(Compiler.CompilationModel.Expr.div $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| sdiv $a $b) => `(Compiler.CompilationModel.Expr.sdiv $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        `(Compiler.CompilationModel.Expr.div $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| sdiv $a $b) => `(Compiler.CompilationModel.Expr.sdiv $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| mod $a $b) | `(term| $a % $b) => do
       let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
       let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
-        let raw ← `(Compiler.CompilationModel.Expr.smod $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        let raw ← `(Compiler.CompilationModel.Expr.smod $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
         match lhsTy with
         | .intN bits =>
             `(Compiler.CompilationModel.Expr.signextend
                 (Compiler.CompilationModel.Expr.literal $(natTerm (bits / 8 - 1))) $raw)
         | _ => pure raw
       else
-        `(Compiler.CompilationModel.Expr.mod $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| smod $a $b) => `(Compiler.CompilationModel.Expr.smod $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| bitAnd $a $b) => `(Compiler.CompilationModel.Expr.bitAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| bitOr $a $b) => `(Compiler.CompilationModel.Expr.bitOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| bitXor $a $b) => `(Compiler.CompilationModel.Expr.bitXor $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| bitNot $a) => `(Compiler.CompilationModel.Expr.bitNot $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants))
-  | `(term| shl $shift $value) => `(Compiler.CompilationModel.Expr.shl $(← translatePureExprWithTypes fields constDecls immutableDecls params locals shift visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants))
-  | `(term| shr $shift $value) => `(Compiler.CompilationModel.Expr.shr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals shift visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants))
-  | `(term| sar $shift $value) => `(Compiler.CompilationModel.Expr.sar $(← translatePureExprWithTypes fields constDecls immutableDecls params locals shift visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants))
-  | `(term| byte $index $value) => `(Compiler.CompilationModel.Expr.byte $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants))
-  | `(term| signextend $byteIndex $value) => `(Compiler.CompilationModel.Expr.signextend $(← translatePureExprWithTypes fields constDecls immutableDecls params locals byteIndex visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants))
+        `(Compiler.CompilationModel.Expr.mod $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| smod $a $b) => `(Compiler.CompilationModel.Expr.smod $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| bitAnd $a $b) => `(Compiler.CompilationModel.Expr.bitAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| bitOr $a $b) => `(Compiler.CompilationModel.Expr.bitOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| bitXor $a $b) => `(Compiler.CompilationModel.Expr.bitXor $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| bitNot $a) => `(Compiler.CompilationModel.Expr.bitNot $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?))
+  | `(term| shl $shift $value) => `(Compiler.CompilationModel.Expr.shl $(← translatePureExprWithTypes fields constDecls immutableDecls params locals shift visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?))
+  | `(term| shr $shift $value) => `(Compiler.CompilationModel.Expr.shr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals shift visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?))
+  | `(term| sar $shift $value) => `(Compiler.CompilationModel.Expr.sar $(← translatePureExprWithTypes fields constDecls immutableDecls params locals shift visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?))
+  | `(term| byte $index $value) => `(Compiler.CompilationModel.Expr.byte $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?))
+  | `(term| signextend $byteIndex $value) => `(Compiler.CompilationModel.Expr.signextend $(← translatePureExprWithTypes fields constDecls immutableDecls params locals byteIndex visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?))
   | `(term| $a == $b) => do
       let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
       let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
@@ -3320,8 +3321,8 @@ partial def translatePureExprWithTypes
         let (lhsName, rhsName) ← dynamicEqParamNames stx params a b lhsTy rhsTy
         `(Compiler.CompilationModel.Expr.dynamicBytesEq $(strTerm lhsName) $(strTerm rhsName))
       else
-        let lhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants
-        let rhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants
+        let lhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
+        let rhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?
         let lhs ← match rhsTy with
           | .bytesN bytes =>
               if isNatLiteralTerm a then
@@ -3346,8 +3347,8 @@ partial def translatePureExprWithTypes
         `(Compiler.CompilationModel.Expr.logicalNot
             (Compiler.CompilationModel.Expr.dynamicBytesEq $(strTerm lhsName) $(strTerm rhsName)))
       else
-        let lhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants
-        let rhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants
+        let lhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
+        let rhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?
         let lhs ← match rhsTy with
           | .bytesN bytes =>
               if isNatLiteralTerm a then
@@ -3372,28 +3373,28 @@ partial def translatePureExprWithTypes
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
         `(Compiler.CompilationModel.Expr.logicalNot
             (Compiler.CompilationModel.Expr.slt
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants)))
+              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)))
       else
-        `(Compiler.CompilationModel.Expr.ge $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        `(Compiler.CompilationModel.Expr.ge $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| $a > $b) => do
       let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
       let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
-        `(Compiler.CompilationModel.Expr.sgt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        `(Compiler.CompilationModel.Expr.sgt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
       else
-        `(Compiler.CompilationModel.Expr.gt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| sgt $a $b) => `(Compiler.CompilationModel.Expr.sgt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        `(Compiler.CompilationModel.Expr.gt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| sgt $a $b) => `(Compiler.CompilationModel.Expr.sgt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| $a < $b) => do
       let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
       let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
-        `(Compiler.CompilationModel.Expr.slt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        `(Compiler.CompilationModel.Expr.slt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
       else
-        `(Compiler.CompilationModel.Expr.lt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| slt $a $b) => `(Compiler.CompilationModel.Expr.slt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        `(Compiler.CompilationModel.Expr.lt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| slt $a $b) => `(Compiler.CompilationModel.Expr.slt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| $a <= $b) => do
       let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
       let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
@@ -3401,35 +3402,35 @@ partial def translatePureExprWithTypes
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
         `(Compiler.CompilationModel.Expr.logicalNot
             (Compiler.CompilationModel.Expr.sgt
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants)))
+              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)))
       else
-        `(Compiler.CompilationModel.Expr.le $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| $a && $b) => `(Compiler.CompilationModel.Expr.logicalAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| $a || $b) => `(Compiler.CompilationModel.Expr.logicalOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| logicalAnd $a $b) => `(Compiler.CompilationModel.Expr.logicalAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| logicalOr $a $b) => `(Compiler.CompilationModel.Expr.logicalOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| logicalNot $a) => `(Compiler.CompilationModel.Expr.logicalNot $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants))
-  | `(term| and $a $b) => `(Compiler.CompilationModel.Expr.bitAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| or $a $b) => `(Compiler.CompilationModel.Expr.bitOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| xor $a $b) => `(Compiler.CompilationModel.Expr.bitXor $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| not $a) => `(Compiler.CompilationModel.Expr.bitNot $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants))
+        `(Compiler.CompilationModel.Expr.le $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| $a && $b) => `(Compiler.CompilationModel.Expr.logicalAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| $a || $b) => `(Compiler.CompilationModel.Expr.logicalOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| logicalAnd $a $b) => `(Compiler.CompilationModel.Expr.logicalAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| logicalOr $a $b) => `(Compiler.CompilationModel.Expr.logicalOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| logicalNot $a) => `(Compiler.CompilationModel.Expr.logicalNot $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?))
+  | `(term| and $a $b) => `(Compiler.CompilationModel.Expr.bitAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| or $a $b) => `(Compiler.CompilationModel.Expr.bitOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| xor $a $b) => `(Compiler.CompilationModel.Expr.bitXor $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| not $a) => `(Compiler.CompilationModel.Expr.bitNot $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?))
   | `(term| mload $offset) | `(term| memoryLoad($offset)) =>
       `(Compiler.CompilationModel.Expr.mload
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants linkedExternalLowerer?))
   | `(term| tload $offset) =>
       `(Compiler.CompilationModel.Expr.tload
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants linkedExternalLowerer?))
   | `(term| calldataload $offset) =>
       `(Compiler.CompilationModel.Expr.calldataload
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants linkedExternalLowerer?))
   | `(term| extcodesize $addr) =>
       `(Compiler.CompilationModel.Expr.extcodesize
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals addr visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals addr visitingConstants linkedExternalLowerer?))
   | `(term| keccak256 $offset $size) =>
       `(Compiler.CompilationModel.Expr.keccak256
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals size visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals size visitingConstants linkedExternalLowerer?))
   -- Compile-time Keccak-256 of a string literal (#1973): hash the literal
   -- now and emit a plain numeric literal. The parser already rejects
   -- non-literal arguments, so the digest is unconditionally static.
@@ -3438,63 +3439,67 @@ partial def translatePureExprWithTypes
       `(Compiler.CompilationModel.Expr.literal $(natTerm digest))
   | `(term| call $gas $target $value $inOffset $inSize $outOffset $outSize) =>
       `(Compiler.CompilationModel.Expr.call
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants linkedExternalLowerer?))
   | `(term| evmCall($gas, $target, $value, $inOffset, $inSize, $outOffset, $outSize)) =>
       `(Compiler.CompilationModel.Expr.call
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants linkedExternalLowerer?))
   | `(term| staticcall $gas $target $inOffset $inSize $outOffset $outSize) =>
       `(Compiler.CompilationModel.Expr.staticcall
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants linkedExternalLowerer?))
   | `(term| evmStaticCall($gas, $target, $inOffset, $inSize, $outOffset, $outSize)) =>
       `(Compiler.CompilationModel.Expr.staticcall
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants linkedExternalLowerer?))
   | `(term| callExternal $name:ident ($[$xs:term],*)) =>
-      translatePureExprWithTypes fields constDecls immutableDecls params locals
-        (← `(externalCall $(strTerm (toString name.getId)) [ $[$xs],* ])) visitingConstants
+      match linkedExternalLowerer? with
+      | some lower => lower name xs
+      | none =>
+          translatePureExprWithTypes fields constDecls immutableDecls params locals
+            (← `(externalCall $(strTerm (toString name.getId)) [ $[$xs],* ]))
+            visitingConstants linkedExternalLowerer?
   | `(term| delegatecall $gas $target $inOffset $inSize $outOffset $outSize) =>
       `(Compiler.CompilationModel.Expr.delegatecall
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants linkedExternalLowerer?))
   | `(term| arrayLength $name:term) =>
       -- verity#1849, G1: `arrayLength (arrayElement <param> <i>).<dynField>`
       -- lowers through `Expr.arrayElementDynamicMemberLength`, reading the
       -- length word of the dynamic member at the resolved head offset.
       if let some (paramName, index, _fieldTy, _elemTy, wordOffset) :=
           arrayElementDynamicMemberProjection? params name then
-        let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+        let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
         `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
             $(strTerm paramName)
             $indexExpr
             $(natTerm wordOffset))
       else if let some (paramName, index, _fieldTy, _elemTy, wordOffset) :=
           localArrayElementDynamicMemberProjection? locals name then
-        let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+        let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
         `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
             $(strTerm paramName)
             $indexExpr
@@ -3514,8 +3519,8 @@ partial def translatePureExprWithTypes
       -- lowers through `Expr.arrayElementDynamicMemberElement`.
         if let some (paramName, outerIndex, _fieldTy, _elemTy, wordOffset) :=
           arrayElementDynamicMemberProjection? params name then
-        let outerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals outerIndex visitingConstants
-        let innerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+        let outerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals outerIndex visitingConstants linkedExternalLowerer?
+        let innerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
         `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberElement
             $(strTerm paramName)
             $outerIndexExpr
@@ -3523,8 +3528,8 @@ partial def translatePureExprWithTypes
             $innerIndexExpr)
         else if let some (paramName, outerIndex, _fieldTy, _elemTy, wordOffset) :=
           localArrayElementDynamicMemberProjection? locals name then
-        let outerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals outerIndex visitingConstants
-        let innerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+        let outerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals outerIndex visitingConstants linkedExternalLowerer?
+        let innerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
         `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberElement
             $(strTerm paramName)
             $outerIndexExpr
@@ -3532,7 +3537,7 @@ partial def translatePureExprWithTypes
             $innerIndexExpr)
         else if let some (paramName, _fieldTy, wordOffset) :=
           paramDynamicMemberProjection? params name then
-        let innerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+        let innerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
         `(Compiler.CompilationModel.Expr.paramDynamicMemberElement
             $(strTerm paramName)
             $(natTerm wordOffset)
@@ -3540,11 +3545,11 @@ partial def translatePureExprWithTypes
         else if let some (name, _) := localMemoryArray? locals name then
         `(Compiler.CompilationModel.Expr.memoryArrayElement
             $(strTerm name)
-            $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants))
+            $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?))
         else
           `(Compiler.CompilationModel.Expr.arrayElement
               $(strTerm (← expectStringOrIdent name))
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants))
+              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?))
       let elemTy ← inferPureExprType fields constDecls immutableDecls #[] params locals stx visitingConstants
       match elemTy with
       | .uintN bits =>
@@ -3560,43 +3565,43 @@ partial def translatePureExprWithTypes
       | _ => pure raw
   | `(term| ceilDiv $a $b) =>
       `(Compiler.CompilationModel.Expr.ceilDiv
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| mulDivDown $a $b $c) =>
       `(Compiler.CompilationModel.Expr.mulDivDown
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants linkedExternalLowerer?))
   | `(term| mulDivUp $a $b $c) =>
       `(Compiler.CompilationModel.Expr.mulDivUp
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants linkedExternalLowerer?))
   | `(term| mulDiv512Down $a $b $c) =>
       `(Compiler.CompilationModel.Expr.mulDiv512Down
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants linkedExternalLowerer?))
   | `(term| mulDiv512Up $a $b $c) =>
       `(Compiler.CompilationModel.Expr.mulDiv512Up
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants linkedExternalLowerer?))
   | `(term| wMulDown $a $b) =>
       `(Compiler.CompilationModel.Expr.wMulDown
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| wDivUp $a $b) =>
       `(Compiler.CompilationModel.Expr.wDivUp
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| min $a $b) => `(Compiler.CompilationModel.Expr.min $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| max $a $b) => `(Compiler.CompilationModel.Expr.max $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| min $a $b) => `(Compiler.CompilationModel.Expr.min $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| max $a $b) => `(Compiler.CompilationModel.Expr.max $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| ite $cond $thenVal $elseVal) =>
       `(Compiler.CompilationModel.Expr.ite
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals thenVal visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals elseVal visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals thenVal visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals elseVal visitingConstants linkedExternalLowerer?))
   -- Native Lean `if ... then ... else ...` term, equivalent to
   -- `ite cond thenVal elseVal` for the macro lowering.  Lets contract
   -- authors write idiomatic expressions like
@@ -3604,9 +3609,9 @@ partial def translatePureExprWithTypes
   -- without falling back to per-shape helper functions.
   | `(term| if $cond:term then $thenVal:term else $elseVal:term) =>
       `(Compiler.CompilationModel.Expr.ite
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals thenVal visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals elseVal visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals thenVal visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals elseVal visitingConstants linkedExternalLowerer?))
   | `(term| externalCall $name:term $args:term) =>
       let extName := ← expectStringOrIdent name
       let argsExprs ←
@@ -3620,12 +3625,12 @@ partial def translatePureExprWithTypes
                     out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
                     out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
                   else
-                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants linkedExternalLowerer?)
               | none =>
                   if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                       arrayElementDynamicMemberProjection? params arg then
                     if externalCallDynamicArgSupported fieldTy then
-                      let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+                      let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
                       out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                         $(strTerm paramName)
                         $indexExpr
@@ -3635,11 +3640,11 @@ partial def translatePureExprWithTypes
                         $indexExpr
                         $(natTerm wordOffset)))
                     else
-                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants linkedExternalLowerer?)
                   else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                       localArrayElementDynamicMemberProjection? locals arg then
                     if externalCallDynamicArgSupported fieldTy then
-                      let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+                      let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
                       out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                         $(strTerm paramName)
                         $indexExpr
@@ -3649,7 +3654,7 @@ partial def translatePureExprWithTypes
                         $indexExpr
                         $(natTerm wordOffset)))
                     else
-                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants linkedExternalLowerer?)
                   else if let some (paramName, fieldTy, wordOffset) :=
                       paramDynamicMemberProjection? params arg then
                     if externalCallDynamicArgSupported fieldTy then
@@ -3660,9 +3665,9 @@ partial def translatePureExprWithTypes
                         $(strTerm paramName)
                         $(natTerm wordOffset)))
                     else
-                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants linkedExternalLowerer?)
                   else
-                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants linkedExternalLowerer?)
             pure out
         | _ => throwErrorAt args "expected list literal [..]"
       `(Compiler.CompilationModel.Expr.externalCall $(strTerm extName) [ $[$argsExprs],* ])
@@ -3686,13 +3691,13 @@ partial def translatePureExprWithTypes
       let minForkTerm ← hardForkTermFromParsed minFork
       translateIntrinsic name lowering args minForkTerm
   | `(term| clz $x:term) =>
-      let xExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals x visitingConstants
+      let xExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals x visitingConstants linkedExternalLowerer?
       `(Compiler.CompilationModel.Expr.intrinsic "clz"
           (Verity.Core.Intrinsics.YulLowering.verbatim 1 1 "1e")
           Verity.Core.Intrinsics.HardFork.osaka
           [$xExpr])
   | `(term| msb $x:term) =>
-      let xExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals x visitingConstants
+      let xExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals x visitingConstants linkedExternalLowerer?
       let clzExpr ← `(Compiler.CompilationModel.Expr.intrinsic "clz"
           (Verity.Core.Intrinsics.YulLowering.verbatim 1 1 "1e")
           Verity.Core.Intrinsics.HardFork.osaka
@@ -3704,15 +3709,15 @@ partial def translatePureExprWithTypes
   | `(term| fork_if_at_least $fork:ident then $thenExpr:term else $elseExpr:term) =>
       `(Compiler.CompilationModel.Expr.forkIfAtLeast
           $(← hardForkTermFromIdent fork)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals thenExpr visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals elseExpr visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals thenExpr visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals elseExpr visitingConstants linkedExternalLowerer?))
   | `(term| structMember $field:term $key:term $member:term) =>
       let fieldName := ← expectStringOrIdent field
       let memberName := ← expectStringOrIdent member
       let _ ← lookupStructMemberDecl fields fieldName memberName false
       `(Compiler.CompilationModel.Expr.structMember
           $(strTerm fieldName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key visitingConstants linkedExternalLowerer?)
           $(strTerm memberName))
   | `(term| structMember2 $field:term $key1:term $key2:term $member:term) =>
       let fieldName := ← expectStringOrIdent field
@@ -3720,8 +3725,8 @@ partial def translatePureExprWithTypes
       let _ ← lookupStructMemberDecl fields fieldName memberName true
       `(Compiler.CompilationModel.Expr.structMember2
           $(strTerm fieldName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1 visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2 visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1 visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2 visitingConstants linkedExternalLowerer?)
           $(strTerm memberName))
   | _ =>
       match ← translateLeanDefCall? fields constDecls immutableDecls #[] params locals stx visitingConstants with
@@ -4450,6 +4455,34 @@ def translateLinkedExternalCallArgs
             else
               out := out.push (← translateScalar)
   pure out
+
+def translateDeclaredPureExpr
+    (fields : Array StorageFieldDecl)
+    (constDecls : Array ConstantDecl)
+    (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (stx : Term) : CommandElabM Term := do
+  let lower : Ident → Array Term → CommandElabM Term := fun name args => do
+    let extName := toString name.getId
+    let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+      | some ext => pure ext
+      | none => throwErrorAt name s!"unknown linked external '{extName}'"
+    validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+      extName ext.params args
+    match ext.returnTys.toList with
+    | [retTy] =>
+        unless isSingleWordStaticValueType retTy do
+          throwErrorAt name s!"callExternal '{extName}' return type cannot be used as a pure single-word expression"
+        let argExprs ← translateLinkedExternalCallArgs
+          fields constDecls immutableDecls params locals args (some ext.params)
+        let callExpr ←
+          `(Compiler.CompilationModel.Expr.externalCall $(strTerm extName) [ $[$argExprs],* ])
+        normalizeTranslatedExprForType retTy stx callExpr
+    | [] => throwErrorAt name s!"callExternal '{extName}' returns no values"
+    | _ => throwErrorAt name s!"callExternal '{extName}' returns multiple values"
+  translatePureExprWithTypes fields constDecls immutableDecls params locals stx [] (some lower)
 
 def tupleInternalCallAssignStmt?
     (fields : Array StorageFieldDecl)

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -2670,14 +2670,13 @@ partial def inferTupleSourceTypes?
                   | _ => pure none
         | `(term| tryExternalCall $name:term $args:term) =>
             let extName := ← expectStringOrIdent name
-            match stripParens args with
-            | `(term| [ $[$xs],* ]) =>
-                for x in xs do
-                  requireWordOrDirectArrayType x s!"tryExternalCall '{extName}' argument"
-                    (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x)
-            | _ => throwErrorAt args "expected list literal [..]"
             match externalDecls.find? (fun ext => ext.name == extName) with
-            | some ext =>
+            | some ext => do
+                match stripParens args with
+                | `(term| [ $[$xs],* ]) =>
+                    validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+                      extName ext.params xs
+                | _ => throwErrorAt args "expected list literal [..]"
                 -- tryExternalCall returns (success : Bool, result₁ : T₁, ..., resultₙ : Tₙ)
                 pure (some (#[.bool] ++ ext.returnTys))
             | none =>
@@ -4567,12 +4566,11 @@ def tupleInternalCallAssignStmt?
       | none =>
           pure none
 
-/-- Try to translate a tuple‐destructured `tryExternalCall "name" [args]` RHS into
-    a `Stmt.tryExternalCallBind` term.  Returns `none` when the RHS is not a
-    `tryExternalCall` application.  Returns the statement term and the inferred
-    types for each bound name (Bool for success flag, Uint256 for all result
-    vars — precise return types require external decl lookup which happens in
-    the validation pass).  (#1727, Axis 1 Step 5f) -/
+/-- Try to translate a tuple‐destructured `tryExternalCall "name" [args]` RHS.
+    Returns `none` when the RHS is not a `tryExternalCall` application.  Returns
+    the generated statements and inferred types for each bound name.  Narrow result
+    words are normalized immediately after the call bind.  (#1727, Axis 1
+    Step 5f) -/
 def tryExternalCallBindStmt?
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
@@ -4581,7 +4579,7 @@ def tryExternalCallBindStmt?
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (rhs : Term)
-    (names : Array (Option String)) : CommandElabM (Option (Term × Array TypedLocal)) := do
+    (names : Array (Option String)) : CommandElabM (Option (Array Term × Array TypedLocal)) := do
   let rhs := stripParens rhs
   match rhs with
   | `(term| tryExternalCall $name:term $args:term) =>
@@ -4620,21 +4618,28 @@ def tryExternalCallBindStmt?
       let resultTys := ext.returnTys
       let mut flattenedResultVars : Array String := #[]
       let mut visibleLocals : Array TypedLocal := #[mkTypedLocal successVar .bool]
+      let mut normalizations : Array Term := #[]
       for (resultVar, resultTy) in resultVars.toArray.zip resultTys do
         let flatNames ← flattenExternalResultNames resultVar resultTy
+        unless flatNames.length == 1 || (staticStructDirectFieldLocals? resultVar resultTy).isSome do
+          throwErrorAt rhs
+            s!"tryExternalCall '{extName}' cannot bind flattened composite return type {renderValueType resultTy} to source variable '{resultVar}'"
         flattenedResultVars := flattenedResultVars ++ flatNames.toArray
         let source :=
           match staticStructDirectFieldLocals? resultVar resultTy with
           | some fieldLocals => LocalSource.externalStaticStruct fieldLocals
           | none => LocalSource.value
         visibleLocals := visibleLocals.push { name := resultVar, ty := resultTy, source := source }
+        if flatNames.length == 1 then
+          if let some normalization ← normalizeBoundValueStmt? resultTy rhs resultVar then
+            normalizations := normalizations.push normalization
       let resultVarTerms := flattenedResultVars.map strTerm
       let stmt ← `(Compiler.CompilationModel.Stmt.tryExternalCallBind
           $successVarTerm
           [ $[$resultVarTerms],* ]
           $(strTerm extName)
           [ $[$argExprs],* ])
-      pure (some (stmt, visibleLocals))
+      pure (some (#[stmt] ++ normalizations, visibleLocals))
   | _ => pure none
 
 /-- Translate `let r ← callResult "name" [args]` into the existing try-call
@@ -4648,7 +4653,7 @@ def callResultBindStmt?
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (rhs : Term)
-    (resultName : String) : CommandElabM (Option (Term × TypedLocal)) := do
+    (resultName : String) : CommandElabM (Option (Array Term × TypedLocal)) := do
   let rhs := stripParens rhs
   match rhs with
   | `(term| callResult $name:term $args:term) =>
@@ -4674,12 +4679,14 @@ def callResultBindStmt?
       let usedAfterSuccess : Array TypedLocal := locals.push (mkTypedLocal successVar .bool)
       let mut fieldLocals : List (String × String) := [("success", successVar)]
       let mut resultVars : Array String := #[]
+      let mut resultVarTys : Array ValueType := #[]
       let mut resultFields : List (String × ValueType) := [("success", .bool)]
       match ext.returnTys.toList with
       | [] => pure ()
       | [retTy] =>
           let payloadVar := freshSyntheticLocalName s!"{resultName}_returndata" params usedAfterSuccess #[]
           resultVars := resultVars.push payloadVar
+          resultVarTys := resultVarTys.push retTy
           fieldLocals := fieldLocals ++ [("returndata", payloadVar)]
           resultFields := resultFields ++ [("returndata", retTy)]
       | retTys =>
@@ -4689,6 +4696,7 @@ def callResultBindStmt?
             let payloadVar := freshSyntheticLocalName s!"{resultName}_{fieldName}" params indexedLocals #[]
             indexedLocals := indexedLocals.push (mkTypedLocal payloadVar retTy)
             resultVars := resultVars.push payloadVar
+            resultVarTys := resultVarTys.push retTy
             fieldLocals := fieldLocals ++ [(fieldName, payloadVar)]
             resultFields := resultFields ++ [(fieldName, retTy)]
       let resultVarTerms := resultVars.map strTerm
@@ -4697,11 +4705,15 @@ def callResultBindStmt?
           [ $[$resultVarTerms],* ]
           $(strTerm extName)
           [ $[$argExprs],* ])
+      let mut normalizations : Array Term := #[]
+      for (resultVar, resultTy) in resultVars.zip resultVarTys do
+        if let some normalization ← normalizeBoundValueStmt? resultTy rhs resultVar then
+          normalizations := normalizations.push normalization
       let resultLocal : TypedLocal :=
         { name := resultName
           ty := .struct "Call.Result" resultFields
           source := .externalStaticStruct fieldLocals }
-      pure (some (stmt, resultLocal))
+      pure (some (#[stmt] ++ normalizations, resultLocal))
   | _ => pure none
 
 def expectExprList

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -1994,6 +1994,9 @@ partial def inferPureExprType
       requireWordLikeType a "narrowBytes" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
       pure (.bytesN width)
   | `(term| boolToWord $a:term) =>
+      if syntaxContainsCallExternal a then
+        throwErrorAt a
+          "boolToWord operand cannot contain callExternal because expression lowering evaluates its condition more than once; bind the external result first"
       requireBoolType a "boolToWord" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
       pure .uint256
   | `(term| $n:num) =>
@@ -3302,6 +3305,9 @@ partial def translatePureExprWithTypes
         $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
         (Compiler.CompilationModel.Expr.literal $(natTerm mask)))
   | `(term| boolToWord $a:term) =>
+      if syntaxContainsCallExternal a then
+        throwErrorAt a
+          "boolToWord operand cannot contain callExternal because expression lowering evaluates its condition more than once; bind the external result first"
       `(Compiler.CompilationModel.Expr.ite
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
           (Compiler.CompilationModel.Expr.literal 1)

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -2255,7 +2255,14 @@ partial def inferPureExprType
               (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x visitingConstants)
           pure .uint256
       | _ => throwErrorAt args "expected list literal [..]"
-  | `(term| clz $x:term) | `(term| msb $x:term) =>
+  | `(term| clz $x:term) =>
+      requireWordLikeType x "bitmap primitive argument"
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x visitingConstants)
+      pure .uint256
+  | `(term| msb $x:term) => do
+      if syntaxContainsCallExternal x then
+        throwErrorAt x
+          "msb operand cannot contain callExternal because expression lowering reuses it in the zero check and clz; bind the external result first"
       requireWordLikeType x "bitmap primitive argument"
         (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x visitingConstants)
       pure .uint256
@@ -2651,6 +2658,9 @@ partial def inferTupleSourceTypes?
         | `(term| structMembers $field:term $key:term $members:term) => do
             let fieldName := ← expectStringOrIdent field
             let memberNames := ← expectStringList members
+            if memberNames.size > 1 && syntaxContainsCallExternal key then
+              throwErrorAt key
+                "structMembers key cannot contain callExternal when selecting multiple members because lowering reuses the key; bind the external result first"
             let memberDecls ← memberNames.mapM fun memberName =>
               lookupStructMemberDecl fields fieldName memberName false
             requireWordLikeType key "structMembers key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key)
@@ -2658,6 +2668,10 @@ partial def inferTupleSourceTypes?
         | `(term| structMembers2 $field:term $key1:term $key2:term $members:term) => do
             let fieldName := ← expectStringOrIdent field
             let memberNames := ← expectStringList members
+            if memberNames.size > 1 &&
+                (syntaxContainsCallExternal key1 || syntaxContainsCallExternal key2) then
+              throwErrorAt rhs
+                "structMembers2 keys cannot contain callExternal when selecting multiple members because lowering reuses the keys; bind external results first"
             let memberDecls ← memberNames.mapM fun memberName =>
               lookupStructMemberDecl fields fieldName memberName true
             requireWordLikeType key1 "structMembers2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key1)
@@ -3735,6 +3749,9 @@ partial def translatePureExprWithTypes
           Verity.Core.Intrinsics.HardFork.osaka
           [$xExpr])
   | `(term| msb $x:term) =>
+      if syntaxContainsCallExternal x then
+        throwErrorAt x
+          "msb operand cannot contain callExternal because expression lowering reuses it in the zero check and clz; bind the external result first"
       let xExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals x visitingConstants linkedExternalLowerer?
       let clzExpr ← `(Compiler.CompilationModel.Expr.intrinsic "clz"
           (Verity.Core.Intrinsics.YulLowering.verbatim 1 1 "1e")
@@ -4187,6 +4204,9 @@ def tupleLiteralOrStructValueExprs?
     | `(term| structMembers $field:term $key:term $members:term) => do
         let fieldName := ← expectStringOrIdent field
         let memberNames := ← expectStringList members
+        if memberNames.size > 1 && syntaxContainsCallExternal key then
+          throwErrorAt key
+            "structMembers key cannot contain callExternal when selecting multiple members because lowering reuses the key; bind the external result first"
         let exprs ← memberNames.mapM fun memberName => do
           let _ ← lookupStructMemberDecl fields fieldName memberName false
           `(Compiler.CompilationModel.Expr.structMember
@@ -4197,6 +4217,10 @@ def tupleLiteralOrStructValueExprs?
     | `(term| structMembers2 $field:term $key1:term $key2:term $members:term) => do
         let fieldName := ← expectStringOrIdent field
         let memberNames := ← expectStringList members
+        if memberNames.size > 1 &&
+            (syntaxContainsCallExternal key1 || syntaxContainsCallExternal key2) then
+          throwErrorAt rhs
+            "structMembers2 keys cannot contain callExternal when selecting multiple members because lowering reuses the keys; bind external results first"
         let exprs ← memberNames.mapM fun memberName => do
           let _ ← lookupStructMemberDecl fields fieldName memberName true
           `(Compiler.CompilationModel.Expr.structMember2

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -4369,9 +4369,15 @@ def translateLinkedExternalCallArgs
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (argTerms : Array Term) : CommandElabM (Array Term) := do
+    (argTerms : Array Term)
+    (expectedTypes : Option (Array ValueType) := none) : CommandElabM (Array Term) := do
   let mut out : Array Term := #[]
-  for arg in argTerms do
+  for (arg, argIdx) in argTerms.zipIdx do
+    let translateScalar : CommandElabM Term := do
+      let raw ← translatePureExprWithTypes fields constDecls immutableDecls params locals arg
+      match expectedTypes >>= (·[argIdx]?) with
+      | some expectedTy => normalizeTranslatedExprForType expectedTy arg raw
+      | none => pure raw
     match ← translateAbiEncodeProjection? fields constDecls immutableDecls params locals arg with
     | some exprs =>
         out := out ++ exprs
@@ -4382,9 +4388,12 @@ def translateLinkedExternalCallArgs
               out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
               out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
             else
-              out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+              out := out.push (← translateScalar)
         | none =>
-            if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
+            if let some (name, _) := localMemoryArray? locals arg then
+              out := out.push (← `(Compiler.CompilationModel.Expr.localVar $(strTerm s!"{name}_data_offset")))
+              out := out.push (← `(Compiler.CompilationModel.Expr.localVar $(strTerm s!"{name}_length")))
+            else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 arrayElementDynamicMemberProjection? params arg then
               if externalCallDynamicArgSupported fieldTy then
                 let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
@@ -4424,7 +4433,7 @@ def translateLinkedExternalCallArgs
               else
                 throwErrorAt arg s!"linked external dynamic-member argument currently supports only Array<wordLike>/bytes/string members, got {renderValueType fieldTy}"
             else
-              out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+              out := out.push (← translateScalar)
   pure out
 
 def tupleInternalCallAssignStmt?

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -4319,7 +4319,7 @@ def translateInternalHelperCallArgs
                 out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
           | none =>
               if let some (paramName, index, _elemTy) := arrayElementDynamicTupleArg? params arg then
-                let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                let indexExpr ← translateExpr index
                 out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicDataOffset
                   $(strTerm paramName)
                   $indexExpr))
@@ -4390,11 +4390,16 @@ def translateLinkedExternalCallArgs
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (argTerms : Array Term)
-    (expectedTypes : Option (Array ValueType) := none) : CommandElabM (Array Term) := do
+    (expectedTypes : Option (Array ValueType) := none)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Array Term) := do
+  let translateExpr (arg : Term) : CommandElabM Term :=
+    match translateExpr? with
+    | some translate => translate arg
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals arg
   let mut out : Array Term := #[]
   for (arg, argIdx) in argTerms.zipIdx do
     let translateScalar : CommandElabM Term := do
-      let raw ← translatePureExprWithTypes fields constDecls immutableDecls params locals arg
+      let raw ← translateExpr arg
       match expectedTypes >>= (·[argIdx]?) with
       | some expectedTy => normalizeTranslatedExprForType expectedTy arg raw
       | none => pure raw
@@ -4416,7 +4421,7 @@ def translateLinkedExternalCallArgs
             else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 arrayElementDynamicMemberProjection? params arg then
               if externalCallDynamicArgSupported fieldTy then
-                let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                let indexExpr ← translateExpr index
                 out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                   $(strTerm paramName)
                   $indexExpr
@@ -4430,7 +4435,7 @@ def translateLinkedExternalCallArgs
             else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 localArrayElementDynamicMemberProjection? locals arg then
               if externalCallDynamicArgSupported fieldTy then
-                let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                let indexExpr ← translateExpr index
                 out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                   $(strTerm paramName)
                   $indexExpr
@@ -4456,7 +4461,7 @@ def translateLinkedExternalCallArgs
               out := out.push (← translateScalar)
   pure out
 
-def translateDeclaredPureExpr
+partial def translateDeclaredPureExpr
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
     (immutableDecls : Array ImmutableDecl)
@@ -4477,6 +4482,8 @@ def translateDeclaredPureExpr
           throwErrorAt name s!"callExternal '{extName}' return type cannot be used as a pure single-word expression"
         let argExprs ← translateLinkedExternalCallArgs
           fields constDecls immutableDecls params locals args (some ext.params)
+          (some (translateDeclaredPureExpr
+            fields constDecls immutableDecls externalDecls params locals))
         let callExpr ←
           `(Compiler.CompilationModel.Expr.externalCall $(strTerm extName) [ $[$argExprs],* ])
         normalizeTranslatedExprForType retTy stx callExpr

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -4116,12 +4116,17 @@ def tupleLiteralOrStructValueExprs?
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (rhs : Term) : CommandElabM (Option (Array Term)) := do
+    (rhs : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Option (Array Term)) := do
+  let translateExpr (expr : Term) : CommandElabM Term :=
+    match translateExpr? with
+    | some translate => translate expr
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals expr
   let structCtorValueExprs? : CommandElabM (Option (Array Term)) := do
     match qualifiedFunctionAppSyntax? (stripParens rhs) with
     | some (name, ctorArgs) =>
         if name.toString.endsWith ".mk" then
-          pure (some (← ctorArgs.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)))
+          pure (some (← ctorArgs.mapM translateExpr))
         else
           pure none
     | none =>
@@ -4131,7 +4136,7 @@ def tupleLiteralOrStructValueExprs?
             | .ident _ raw _ _ =>
                 if raw.toString.endsWith ".mk" then
                   let ctorArgs := (args.getD 1 Syntax.missing).getArgs.map (fun syn => ⟨syn⟩)
-                  pure (some (← ctorArgs.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)))
+                  pure (some (← ctorArgs.mapM translateExpr))
                 else
                   pure none
             | _ => pure none
@@ -4145,7 +4150,7 @@ def tupleLiteralOrStructValueExprs?
           let _ ← lookupStructMemberDecl fields fieldName memberName false
           `(Compiler.CompilationModel.Expr.structMember
               $(strTerm fieldName)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
+              $(← translateExpr key)
               $(strTerm memberName))
         pure (some exprs)
     | `(term| structMembers2 $field:term $key1:term $key2:term $members:term) => do
@@ -4155,14 +4160,14 @@ def tupleLiteralOrStructValueExprs?
           let _ ← lookupStructMemberDecl fields fieldName memberName true
           `(Compiler.CompilationModel.Expr.structMember2
               $(strTerm fieldName)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2)
+              $(← translateExpr key1)
+              $(← translateExpr key2)
               $(strTerm memberName))
         pure (some exprs)
     | _ => pure none
   match tupleElemsFromTerm? rhs with
   | some elems =>
-      pure (some (← elems.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)))
+      pure (some (← elems.mapM translateExpr))
   | none =>
       match ← arrayElementTupleElemExprs? fields constDecls immutableDecls params locals rhs with
       | some exprs => pure (some exprs)
@@ -4195,8 +4200,9 @@ def tupleReturnValueExprs?
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (rhs : Term) : CommandElabM (Option (Array Term)) := do
-  match (← tupleLiteralOrStructValueExprs? fields constDecls immutableDecls params locals rhs) with
+    (rhs : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Option (Array Term)) := do
+  match (← tupleLiteralOrStructValueExprs? fields constDecls immutableDecls params locals rhs translateExpr?) with
   | some exprs => pure (some exprs)
   | none =>
       match stripParens rhs with

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -4855,6 +4855,8 @@ def translateBindSource
     (locals : Array TypedLocal)
     (rhs : Term) : CommandElabM Term := do
   let rhs := stripParens rhs
+  let translateOperand := translateDeclaredPureExpr
+    fields constDecls immutableDecls externalDecls params locals
   match rhs with
   | `(term| callExternal $name:ident ($[$args:term],*)) =>
       let extName := toString name.getId
@@ -4919,15 +4921,15 @@ def translateBindSource
       | .dynamicArray _ =>
           `(Compiler.CompilationModel.Expr.storageArrayElement
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index))
+              $(← translateOperand index))
       | _ => throwErrorAt rhs s!"field '{f.name}' is not a storage dynamic array"
   | `(term| getMapping $field:ident $key:term) =>
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with
       | .mappingAddressToUint256 =>
-          `(Compiler.CompilationModel.Expr.mapping $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key))
+          `(Compiler.CompilationModel.Expr.mapping $(strTerm f.name) $(← translateOperand key))
       | .mappingUintToUint256 =>
-          `(Compiler.CompilationModel.Expr.mappingUint $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key))
+          `(Compiler.CompilationModel.Expr.mappingUint $(strTerm f.name) $(← translateOperand key))
       | .mapping2AddressToAddressToUint256 =>
           throwErrorAt rhs s!"field '{f.name}' is a double mapping; use getMapping2"
       | .mappingChain _ =>
@@ -4941,7 +4943,7 @@ def translateBindSource
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with
       | .mappingAddressToUint256 =>
-          `(Compiler.CompilationModel.Expr.mapping $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key))
+          `(Compiler.CompilationModel.Expr.mapping $(strTerm f.name) $(← translateOperand key))
       | .mappingUintToUint256 =>
           throwErrorAt rhs s!"field '{f.name}' is Uint256-keyed; use getMappingUintAddr"
       | .mapping2AddressToAddressToUint256 =>
@@ -4957,7 +4959,7 @@ def translateBindSource
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with
       | .mappingUintToUint256 =>
-          `(Compiler.CompilationModel.Expr.mappingUint $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key))
+          `(Compiler.CompilationModel.Expr.mappingUint $(strTerm f.name) $(← translateOperand key))
       | .mappingAddressToUint256 =>
           throwErrorAt rhs s!"field '{f.name}' is Address-keyed; use getMapping"
       | .mapping2AddressToAddressToUint256 =>
@@ -4973,7 +4975,7 @@ def translateBindSource
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with
       | .mappingUintToUint256 =>
-          `(Compiler.CompilationModel.Expr.mappingUint $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key))
+          `(Compiler.CompilationModel.Expr.mappingUint $(strTerm f.name) $(← translateOperand key))
       | .mappingAddressToUint256 =>
           throwErrorAt rhs s!"field '{f.name}' is Address-keyed; use getMappingAddr"
       | .mapping2AddressToAddressToUint256 =>
@@ -4991,7 +4993,7 @@ def translateBindSource
       | .mappingAddressToUint256 | .mappingUintToUint256 =>
           `(Compiler.CompilationModel.Expr.mappingWord
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
+              $(← translateOperand key)
               $wordOffset)
       | .mapping2AddressToAddressToUint256 =>
           throwErrorAt rhs s!"field '{f.name}' is a double mapping; use getMapping2Word"
@@ -5010,8 +5012,8 @@ def translateBindSource
       | .mapping2AddressToAddressToUint256 =>
           `(Compiler.CompilationModel.Expr.mapping2
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2))
+              $(← translateOperand key1)
+              $(← translateOperand key2))
       | .mappingStruct2 _ _ _ =>
           throwErrorAt rhs s!"field '{f.name}' is a nested struct mapping; use structMember2"
       | .mappingStruct _ _ =>
@@ -5024,7 +5026,7 @@ def translateBindSource
       | some keyTypes =>
           if keyTerms.size != keyTypes.length then
             throwErrorAt rhs s!"field '{f.name}' expects {keyTypes.length} mapping keys, but getMappingN received {keyTerms.size}"
-          let keyExprs ← keyTerms.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+          let keyExprs ← keyTerms.mapM translateOperand
           `(Compiler.CompilationModel.Expr.mappingChain
               $(strTerm f.name)
               [ $[$keyExprs],* ])
@@ -5039,7 +5041,7 @@ def translateBindSource
       let _ ← lookupStructMemberDecl fields fieldName memberName false
       `(Compiler.CompilationModel.Expr.structMember
           $(strTerm fieldName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
+          $(← translateOperand key)
           $(strTerm memberName))
   | `(term| structMember2 $field:term $key1:term $key2:term $member:term) =>
       let fieldName := ← expectStringOrIdent field
@@ -5047,8 +5049,8 @@ def translateBindSource
       let _ ← lookupStructMemberDecl fields fieldName memberName true
       `(Compiler.CompilationModel.Expr.structMember2
           $(strTerm fieldName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2)
+          $(← translateOperand key1)
+          $(← translateOperand key2)
           $(strTerm memberName))
   | `(term| msgSender) | `(term| Verity.msgSender) => `(Compiler.CompilationModel.Expr.caller)
   | `(term| msgValue) | `(term| Verity.msgValue) => `(Compiler.CompilationModel.Expr.msgValue)
@@ -5068,7 +5070,7 @@ def translateBindSource
       `(Compiler.CompilationModel.Expr.chainid)
   | `(term| tload $offset:term) =>
       `(Compiler.CompilationModel.Expr.tload
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset))
+          $(← translateOperand offset))
   | _ =>
       match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals rhs with
       | some (fn, argTerms) =>
@@ -5083,8 +5085,7 @@ def translateBindSource
       | none =>
           match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
           | some (qualifiedName, argTerms) =>
-              let argExprs ← argTerms.mapM
-                (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+              let argExprs ← argTerms.mapM translateOperand
               `(Compiler.CompilationModel.Expr.internalCall
                   $(strTerm (qualifiedInternalHelperName functions qualifiedName))
                   [ $[$argExprs],* ])

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -215,6 +215,21 @@ def normalizeTranslatedExprForType
   | .newtype _ baseType => normalizeTranslatedExprForType baseType source expr
   | _ => pure expr
 
+def normalizeBoundValueStmt?
+    (expectedTy : ValueType) (source : Term) (name : String) : CommandElabM (Option Term) := do
+  let needsNormalization :=
+    match expectedTy with
+    | .uintN _ | .intN _ | .bytesN _ => true
+    | .newtype _ baseType =>
+        match baseType with
+        | .uintN _ | .intN _ | .bytesN _ => true
+        | _ => false
+    | _ => false
+  unless needsNormalization do return none
+  let localExpr ← `(Compiler.CompilationModel.Expr.localVar $(strTerm name))
+  let normalized ← normalizeTranslatedExprForType expectedTy source localExpr
+  return some (← `(Compiler.CompilationModel.Stmt.assignVar $(strTerm name) $normalized))
+
 def immutableHiddenName (imm : ImmutableDecl) : String :=
   s!"__immutable_{imm.name}"
 
@@ -4779,7 +4794,9 @@ def translateBindSource
             throwErrorAt name s!"callExternal '{extName}' return type cannot be used as a pure single-word expression"
           let argExprs ← translateLinkedExternalCallArgs
             fields constDecls immutableDecls params locals args (some ext.params)
-          `(Compiler.CompilationModel.Expr.externalCall $(strTerm extName) [ $[$argExprs],* ])
+          let callExpr ←
+            `(Compiler.CompilationModel.Expr.externalCall $(strTerm extName) [ $[$argExprs],* ])
+          normalizeTranslatedExprForType retTy rhs callExpr
       | [] => throwErrorAt name s!"callExternal '{extName}' returns no values"
       | _ => throwErrorAt name s!"callExternal '{extName}' returns multiple values"
   | `(term| memoryLoad($_))

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -2165,7 +2165,10 @@ partial def inferPureExprType
       match externalDecls.find? (fun ext => ext.name == extName) with
       | some ext =>
           match ext.returnTys.toList with
-          | [retTy] => pure retTy
+          | [retTy] =>
+              unless isSingleWordStaticValueType retTy do
+                throwErrorAt name s!"callExternal '{extName}' return type cannot be used as a pure single-word expression"
+              pure retTy
           | [] => throwErrorAt name s!"externalCall '{extName}' returns no values; use `let success ← tryExternalCall \"{extName}\" [...]` instead"
           | _ => throwErrorAt name s!"externalCall '{extName}' returns {ext.returnTys.size} values; use `let (success, ...) ← tryExternalCall \"{extName}\" [...]` for multi-return"
       | none => pure .uint256

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -2240,6 +2240,25 @@ partial def lookupNamedValueType?
     <|> immutableDecls.findSome? (fun imm => if imm.name == name then some imm.ty else none)
     <|> constDecls.findSome? (fun constant => if constant.name == name then some constant.ty else none)
 
+partial def validateLinkedExternalCallArgs
+    (fields : Array StorageFieldDecl)
+    (constDecls : Array ConstantDecl)
+    (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (externalName : String)
+    (expectedTypes : Array ValueType)
+    (args : Array Term) : CommandElabM Unit := do
+  unless args.size == expectedTypes.size do
+    throwError s!"callExternal '{externalName}' expects {expectedTypes.size} args, got {args.size}"
+  for ((arg, expectedTy), argIdx) in args.zip expectedTypes |>.zipIdx do
+    let actualTy ← inferPureExprType
+      fields constDecls immutableDecls externalDecls params locals arg
+    unless argumentTypeMatchesParam arg actualTy expectedTy do
+      throwErrorAt arg
+        s!"callExternal '{externalName}' argument {argIdx + 1} expects {renderValueType expectedTy}, got {renderValueType actualTy}"
+
 partial def inferBindSourceType
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
@@ -2261,6 +2280,8 @@ partial def inferBindSourceType
       let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
         | some ext => pure ext
         | none => throwErrorAt name s!"unknown linked external '{extName}'"
+      validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+        extName ext.params _args
       match ext.returnTys.toList with
       | [retTy] => pure retTy
       | [] => throwErrorAt rhs s!"callExternal '{extName}' returns Unit; invoke it as a statement"

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -2179,8 +2179,13 @@ partial def inferPureExprType
         | none => throwErrorAt name s!"unknown linked external '{extName}'"
       validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
         extName ext.params xs
-      inferPureExprType fields constDecls immutableDecls externalDecls params locals
-        (← `(externalCall $(strTerm extName) [ $[$xs],* ])) visitingConstants
+      match ext.returnTys.toList with
+      | [retTy] =>
+          unless isSingleWordStaticValueType retTy do
+            throwErrorAt name s!"callExternal '{extName}' return type cannot be used as a pure single-word expression"
+          pure retTy
+      | [] => throwErrorAt name s!"callExternal '{extName}' returns no values"
+      | _ => throwErrorAt name s!"callExternal '{extName}' returns multiple values"
   | `(term| intrinsic_cancun $name:term $_lowering:term $args:term)
   | `(term| intrinsic_prague $name:term $_lowering:term $args:term)
   | `(term| intrinsic_fusaka $name:term $_lowering:term $args:term)

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -4711,7 +4711,12 @@ def expectEcmExprList
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (stx : Term) : CommandElabM (Array Term) := do
+    (stx : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Array Term) := do
+  let translateExpr (x : Term) :=
+    match translateExpr? with
+    | some translate => translate x
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals x
   match stripParens stx with
   | `(term| [ $[$xs],* ]) =>
       let mut out : Array Term := #[]
@@ -4724,12 +4729,12 @@ def expectEcmExprList
             else
               match ← translateAbiEncodeProjection? fields constDecls immutableDecls params locals x with
               | some exprs => out := out ++ exprs
-              | none => out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+              | none => out := out.push (← translateExpr x)
         | none =>
             if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 arrayElementDynamicMemberProjection? params x then
               if externalCallDynamicArgSupported fieldTy then
-                  let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                  let indexExpr ← translateExpr index
                   out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                     $(strTerm paramName)
                     $indexExpr
@@ -4739,11 +4744,11 @@ def expectEcmExprList
                     $indexExpr
                     $(natTerm wordOffset)))
               else
-                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+                out := out.push (← translateExpr x)
             else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 localArrayElementDynamicMemberProjection? locals x then
               if externalCallDynamicArgSupported fieldTy then
-                  let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                  let indexExpr ← translateExpr index
                   out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                     $(strTerm paramName)
                     $indexExpr
@@ -4753,7 +4758,7 @@ def expectEcmExprList
                     $indexExpr
                     $(natTerm wordOffset)))
               else
-                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+                out := out.push (← translateExpr x)
             else if let some (paramName, fieldTy, wordOffset) :=
                 paramDynamicMemberProjection? params x then
               if externalCallDynamicArgSupported fieldTy then
@@ -4764,11 +4769,11 @@ def expectEcmExprList
                     $(strTerm paramName)
                     $(natTerm wordOffset)))
               else
-                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+                out := out.push (← translateExpr x)
             else
               match ← translateAbiEncodeProjection? fields constDecls immutableDecls params locals x with
               | some exprs => out := out ++ exprs
-              | none => out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+              | none => out := out.push (← translateExpr x)
       pure out
   | _ => throwErrorAt stx "expected list literal [..]"
 
@@ -4875,7 +4880,7 @@ def translateBindSource
     | `(term| returnDataSize())
     | `(term| evmCall($_, $_, $_, $_, $_, $_, $_))
     | `(term| evmStaticCall($_, $_, $_, $_, $_, $_)) =>
-      translatePureExprWithTypes fields constDecls immutableDecls params locals rhs
+      translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals rhs
   | `(term| getStorage $field:ident) =>
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -4778,7 +4778,12 @@ def translateEmitArgExpr
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (stx : Term) : CommandElabM Term := do
+    (stx : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM Term := do
+  let translateExpr (x : Term) :=
+    match translateExpr? with
+    | some translate => translate x
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals x
   if let some (name, _) := localMemoryArray? locals stx then
     `(Compiler.CompilationModel.Expr.memoryArrayLength $(strTerm name))
   else if let some (paramName, index, _fieldTy, _elemTy, wordOffset) :=

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -196,6 +196,12 @@ end
 def normalizeTranslatedExprForType
     (expectedTy : ValueType) (source : Term) (expr : Term) : CommandElabM Term := do
   match expectedTy with
+  | .uint8 =>
+      `(Compiler.CompilationModel.Expr.bitAnd $expr
+          (Compiler.CompilationModel.Expr.literal 255))
+  | .uint16 =>
+      `(Compiler.CompilationModel.Expr.bitAnd $expr
+          (Compiler.CompilationModel.Expr.literal 65535))
   | .uintN bits =>
       `(Compiler.CompilationModel.Expr.bitAnd $expr
           (Compiler.CompilationModel.Expr.literal $(natTerm (2 ^ bits - 1))))
@@ -219,10 +225,10 @@ def normalizeBoundValueStmt?
     (expectedTy : ValueType) (source : Term) (name : String) : CommandElabM (Option Term) := do
   let needsNormalization :=
     match expectedTy with
-    | .uintN _ | .intN _ | .bytesN _ => true
+    | .uint8 | .uint16 | .uintN _ | .intN _ | .bytesN _ => true
     | .newtype _ baseType =>
         match baseType with
-        | .uintN _ | .intN _ | .bytesN _ => true
+        | .uint8 | .uint16 | .uintN _ | .intN _ | .bytesN _ => true
         | _ => false
     | _ => false
   unless needsNormalization do return none
@@ -4244,7 +4250,12 @@ def translateInternalHelperCallArgs
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (fn : FunctionDecl)
-    (argTerms : Array Term) : CommandElabM (Array Term) := do
+    (argTerms : Array Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Array Term) := do
+  let translateExpr (arg : Term) : CommandElabM Term :=
+    match translateExpr? with
+    | some translate => translate arg
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals arg
   let mut out : Array Term := #[]
   for idx in [:argTerms.size] do
     let some arg := argTerms[idx]? | pure ()
@@ -4263,7 +4274,7 @@ def translateInternalHelperCallArgs
                 arrayElementDynamicMemberProjection? params arg then
               match fieldTy with
               | .array _ =>
-                  let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                  let indexExpr ← translateExpr index
                   out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                     $(strTerm paramName)
                     $indexExpr
@@ -4278,7 +4289,7 @@ def translateInternalHelperCallArgs
                 localArrayElementDynamicMemberProjection? locals arg then
               match fieldTy with
               | .array _ =>
-                  let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                  let indexExpr ← translateExpr index
                   out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                     $(strTerm paramName)
                     $indexExpr
@@ -4316,10 +4327,10 @@ def translateInternalHelperCallArgs
                 | _ =>
                     out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
               else
-                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                out := out.push (← translateExpr arg)
           | none =>
               if let some (paramName, index, _elemTy) := arrayElementDynamicTupleArg? params arg then
-                let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                let indexExpr ← translateExpr index
                 out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicDataOffset
                   $(strTerm paramName)
                   $indexExpr))
@@ -4327,7 +4338,7 @@ def translateInternalHelperCallArgs
                   arrayElementDynamicMemberProjection? params arg then
                 match fnParam.ty, fieldTy with
                 | .bytes, .bytes | .string, .string =>
-                    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                    let indexExpr ← translateExpr index
                     out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                       $(strTerm paramName)
                       $indexExpr
@@ -4337,12 +4348,12 @@ def translateInternalHelperCallArgs
                       $indexExpr
                       $(natTerm wordOffset)))
                 | _, _ =>
-                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                    out := out.push (← translateExpr arg)
               else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                   localArrayElementDynamicMemberProjection? locals arg then
                 match fnParam.ty, fieldTy with
                 | .bytes, .bytes | .string, .string =>
-                    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                    let indexExpr ← translateExpr index
                     out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                       $(strTerm paramName)
                       $indexExpr
@@ -4352,7 +4363,7 @@ def translateInternalHelperCallArgs
                       $indexExpr
                       $(natTerm wordOffset)))
                 | _, _ =>
-                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                    out := out.push (← translateExpr arg)
               else if let some (paramName, fieldTy, wordOffset) :=
                   paramDynamicMemberProjection? params arg then
                 match fnParam.ty, fieldTy with
@@ -4364,23 +4375,23 @@ def translateInternalHelperCallArgs
                       $(strTerm paramName)
                       $(natTerm wordOffset)))
                 | _, _ =>
-                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                    out := out.push (← translateExpr arg)
               else
-                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                out := out.push (← translateExpr arg)
         else
           if isStaticCompositeInternalHelperType fnParam.ty then
             match directParamNameWithType? params arg with
             | some (name, ty) =>
                 let bindingNames := staticInternalHelperBindingNames name ty
                 if bindingNames.isEmpty then
-                  out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                  out := out.push (← translateExpr arg)
                 else
                   for bindingName in bindingNames do
                     out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm bindingName)))
             | none =>
-                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                out := out.push (← translateExpr arg)
           else
-            out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+            out := out.push (← translateExpr arg)
   pure out
 
 def translateLinkedExternalCallArgs
@@ -4468,7 +4479,12 @@ partial def translateDeclaredPureExpr
     (externalDecls : Array ExternalDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (stx : Term) : CommandElabM Term := do
+    (stx : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM Term := do
+  let translateExpr (arg : Term) : CommandElabM Term :=
+    match translateExpr? with
+    | some translate => translate arg
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals arg
   let lower : Ident → Array Term → CommandElabM Term := fun name args => do
     let extName := toString name.getId
     let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
@@ -4518,6 +4534,8 @@ def tupleInternalCallAssignStmt?
       ensureCallableAsInternalHelper rhs fn
       let argExprs ← translateInternalHelperCallArgs
         fields constDecls immutableDecls params locals fn argTerms
+        (some (translateDeclaredPureExpr
+          fields constDecls immutableDecls externalDecls params locals))
       pure (some (← `(Compiler.CompilationModel.Stmt.internalCallAssign
         [ $[$resultNameTerms],* ]
         $(strTerm (internalHelperSpecNameFor fn))
@@ -4765,14 +4783,14 @@ def translateEmitArgExpr
     `(Compiler.CompilationModel.Expr.memoryArrayLength $(strTerm name))
   else if let some (paramName, index, _fieldTy, _elemTy, wordOffset) :=
       localArrayElementDynamicMemberProjection? locals stx then
-    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+    let indexExpr ← translateExpr index
     `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
         $(strTerm paramName)
         $indexExpr
         $(natTerm wordOffset))
   else if let some (paramName, index, _fieldTy, _elemTy, wordOffset) :=
       arrayElementDynamicMemberProjection? params stx then
-    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+    let indexExpr ← translateExpr index
     `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
         $(strTerm paramName)
         $indexExpr
@@ -4788,7 +4806,7 @@ def translateEmitArgExpr
         $(strTerm paramName)
         $(natTerm wordOffset))
   else
-    translatePureExprWithTypes fields constDecls immutableDecls params locals stx
+    translateExpr stx
 
 def expectEmitExprList
     (fields : Array StorageFieldDecl)
@@ -4796,10 +4814,12 @@ def expectEmitExprList
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (stx : Term) : CommandElabM (Array Term) := do
+    (stx : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Array Term) := do
   match stripParens stx with
   | `(term| [ $[$xs],* ]) =>
-      xs.mapM (translateEmitArgExpr fields constDecls immutableDecls params locals)
+      xs.mapM fun x => translateEmitArgExpr
+        fields constDecls immutableDecls params locals x translateExpr?
   | _ => throwErrorAt stx "expected list literal [..]"
 
 def inferEmitArgExprType
@@ -5045,6 +5065,8 @@ def translateBindSource
           ensureCallableAsInternalHelper rhs fn
           let argExprs ← translateInternalHelperCallArgs
             fields constDecls immutableDecls params locals fn argTerms
+            (some (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals))
           `(Compiler.CompilationModel.Expr.internalCall
               $(strTerm (internalHelperSpecNameFor fn))
               [ $[$argExprs],* ])

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -4671,14 +4671,19 @@ def expectExprList
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (stx : Term) : CommandElabM (Array Term) := do
+    (stx : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Array Term) := do
+  let translateExpr (x : Term) :=
+    match translateExpr? with
+    | some translate => translate x
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals x
   match stripParens stx with
   | `(term| [ $[$xs],* ]) =>
       let mut out : Array Term := #[]
       for x in xs do
         match ← translateAbiEncodeProjection? fields constDecls immutableDecls params locals x with
         | some exprs => out := out ++ exprs
-        | none => out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+        | none => out := out.push (← translateExpr x)
       pure out
   | _ => throwErrorAt stx "expected list literal [..]"
 
@@ -4834,6 +4839,8 @@ def translateBindSource
             throwErrorAt name s!"callExternal '{extName}' return type cannot be used as a pure single-word expression"
           let argExprs ← translateLinkedExternalCallArgs
             fields constDecls immutableDecls params locals args (some ext.params)
+            (some (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals))
           let callExpr ←
             `(Compiler.CompilationModel.Expr.externalCall $(strTerm extName) [ $[$argExprs],* ])
           normalizeTranslatedExprForType retTy rhs callExpr

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -2489,37 +2489,17 @@ partial def inferBindSourceType
       pure .uint256
   | `(term| tryExternalCall $name:term $args:term) => do
       let extName := ← expectStringOrIdent name
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt rhs s!"unknown external function '{extName}'"
       match stripParens args with
       | `(term| [ $[$xs],* ]) =>
-          for x in xs do
-            -- verity#1849, G3: accept `Array <wordLike>` / `bytes` / `string`
-            -- direct param refs alongside word-like args.
-            if let some (_, _, fieldTy, _elemTy, _) := arrayElementDynamicMemberProjection? params x then
-              match fieldTy with
-              | .array elemTy =>
-                  unless externalCallDynamicArgSupported (.array elemTy) do
-                    throwErrorAt x s!"tryExternalCall '{extName}' dynamic-member argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
-              | _ =>
-                  throwErrorAt x s!"tryExternalCall '{extName}' dynamic-member argument requires an Array-typed member, got {renderValueType fieldTy}"
-            else if let some (_, _, fieldTy, _elemTy, _) := localArrayElementDynamicMemberProjection? locals x then
-              match fieldTy with
-              | .array elemTy =>
-                  unless externalCallDynamicArgSupported (.array elemTy) do
-                    throwErrorAt x s!"tryExternalCall '{extName}' dynamic-member alias argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
-              | _ =>
-                  throwErrorAt x s!"tryExternalCall '{extName}' dynamic-member alias argument requires an Array-typed member, got {renderValueType fieldTy}"
-            else
-              requireWordOrDirectArrayType x s!"tryExternalCall '{extName}' argument"
-                (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x)
+          validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+            extName ext.params xs
       | _ => throwErrorAt args "expected list literal [..]"
-      match externalDecls.find? (fun ext => ext.name == extName) with
-      | some ext =>
-          if ext.returnTys.size > 0 then
-            throwErrorAt rhs s!"tryExternalCall '{extName}' returns {ext.returnTys.size} value(s); use tuple destructuring: `let (success, ...) ← tryExternalCall ...`"
-          -- Zero-return external: success flag only
-          pure .bool
-      | none =>
-          throwErrorAt rhs s!"unknown external function '{extName}'"
+      if ext.returnTys.size > 0 then
+        throwErrorAt rhs s!"tryExternalCall '{extName}' returns {ext.returnTys.size} value(s); use tuple destructuring: `let (success, ...) ← tryExternalCall ...`"
+      pure .bool
   | `(term| requireSomeUint $optExpr:term $_msg:term) =>
       match stripParens optExpr with
       | `(term| safeAdd $a:term $b:term)
@@ -3035,7 +3015,8 @@ partial def translateLeanDefCall?
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (stx : Term)
-    (visitingConstants : List String) : CommandElabM (Option Term) := do
+    (visitingConstants : List String)
+    (linkedExternalLowerer? : Option LinkedExternalLowerer := none) : CommandElabM (Option Term) := do
   let some (head, fnDisplay, argTerms) := leanDefAppSyntax? stx
     | pure none
   let some fnName ← resolveLeanDefName? head
@@ -3043,8 +3024,11 @@ partial def translateLeanDefCall?
   let some info ← leanDefInfo? fnName
     | pure none
   let (paramTypeExprs, resultTypeExpr) := peelForallTypes info.type
-  let argTypes ← argTerms.mapM
-    (inferPureExprType fields constDecls immutableDecls externalDecls params locals · visitingConstants)
+  let inferArgType (arg : Term) :=
+    match linkedExternalLowerer? with
+    | some lowerer => lowerer.inferType arg visitingConstants
+    | none => inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants
+  let argTypes ← argTerms.mapM inferArgType
   checkLeanDefCallArgs stx.raw fnDisplay argTerms paramTypeExprs argTypes
   match valueTypeFromLeanTypeExpr? resultTypeExpr with
   | some ty => requireSupportedLocalBindingType stx.raw s!"Lean helper '{fnDisplay}' return" ty
@@ -3054,7 +3038,7 @@ partial def translateLeanDefCall?
   let some body := peelLambdaBody info.value argTerms.size
     | throwErrorAt stx s!"Lean helper '{fnDisplay}' body is not a transparent function definition"
   let argExprs ← argTerms.mapM
-    (translatePureExprWithTypes fields constDecls immutableDecls params locals · visitingConstants)
+    (translatePureExprWithTypes fields constDecls immutableDecls params locals · visitingConstants linkedExternalLowerer?)
   pure (some (← translateLeanExprFromDef fields constDecls immutableDecls params locals stx.raw fnDisplay argExprs body))
 
 partial def translatePureExprWithTypes
@@ -3742,7 +3726,7 @@ partial def translatePureExprWithTypes
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2 visitingConstants linkedExternalLowerer?)
           $(strTerm memberName))
   | _ =>
-      match ← translateLeanDefCall? fields constDecls immutableDecls #[] params locals stx visitingConstants with
+      match ← translateLeanDefCall? fields constDecls immutableDecls #[] params locals stx visitingConstants linkedExternalLowerer? with
       | some expr => pure expr
       | none => throwErrorAt stx "unsupported expression in verity_contract body (see #1003 for planned macro support expansions)"
 end
@@ -4630,7 +4614,12 @@ def tryExternalCallBindStmt?
           | some fieldLocals => LocalSource.externalStaticStruct fieldLocals
           | none => LocalSource.value
         visibleLocals := visibleLocals.push { name := resultVar, ty := resultTy, source := source }
-        if flatNames.length == 1 then
+        if let .struct _ fields := resultTy then
+          if let some fieldLocals := staticStructDirectFieldLocals? resultVar resultTy then
+            for ((_, fieldTy), (_, fieldLocal)) in fields.zip fieldLocals do
+              if let some normalization ← normalizeBoundValueStmt? fieldTy rhs fieldLocal then
+                normalizations := normalizations.push normalization
+        else if flatNames.length == 1 then
           if let some normalization ← normalizeBoundValueStmt? resultTy rhs resultVar then
             normalizations := normalizations.push normalization
       let resultVarTerms := flattenedResultVars.map strTerm
@@ -5130,10 +5119,13 @@ def translateSafeRequireBind
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
     (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (varName : String)
     (rhs : Term) : CommandElabM (Option (Array Term)) := do
+  let translateOperand :=
+    translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals
   let narrowBitsOf (term : Term) : CommandElabM Nat := do
     match stripParens term with
     | `(term| $name:ident) =>
@@ -5148,20 +5140,20 @@ def translateSafeRequireBind
       CommandElabM (Term × Term) := do
     match stripParens optExpr with
     | `(term| safeAdd $a:term $b:term) =>
-        let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-        let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+        let aExpr ← translateOperand a
+        let bExpr ← translateOperand b
         let valueExpr : Term ← `(Compiler.CompilationModel.Expr.add $aExpr $bExpr)
         let guardExpr : Term ← `(Compiler.CompilationModel.Expr.ge $valueExpr $aExpr)
         pure (guardExpr, valueExpr)
     | `(term| safeSub $a:term $b:term) =>
-        let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-        let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+        let aExpr ← translateOperand a
+        let bExpr ← translateOperand b
         let valueExpr : Term ← `(Compiler.CompilationModel.Expr.sub $aExpr $bExpr)
         let guardExpr : Term ← `(Compiler.CompilationModel.Expr.ge $aExpr $bExpr)
         pure (guardExpr, valueExpr)
     | `(term| safeMul $a:term $b:term) =>
-        let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-        let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+        let aExpr ← translateOperand a
+        let bExpr ← translateOperand b
         let valueExpr : Term ← `(Compiler.CompilationModel.Expr.mul $aExpr $bExpr)
         let zeroExpr : Term ← `(Compiler.CompilationModel.Expr.literal 0)
         let divisorZeroExpr : Term ← `(Compiler.CompilationModel.Expr.eq $bExpr $zeroExpr)
@@ -5170,8 +5162,8 @@ def translateSafeRequireBind
         let guardExpr : Term ← `(Compiler.CompilationModel.Expr.logicalOr $divisorZeroExpr $noOverflowExpr)
         pure (guardExpr, valueExpr)
     | `(term| safeDiv $a:term $b:term) =>
-        let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-        let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+        let aExpr ← translateOperand a
+        let bExpr ← translateOperand b
         let valueExpr : Term ← `(Compiler.CompilationModel.Expr.div $aExpr $bExpr)
         let zeroExpr : Term ← `(Compiler.CompilationModel.Expr.literal 0)
         let guardExpr : Term ←
@@ -5184,8 +5176,8 @@ def translateSafeRequireBind
   match rhs with
   | `(term| narrowAddPanic $a:term $b:term) =>
       let bits ← narrowBitsOf a
-      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let aExpr ← translateOperand a
+      let bExpr ← translateOperand b
       let valueExpr : Term ← `(Compiler.CompilationModel.Expr.add $aExpr $bExpr)
       let guardExpr : Term ← `(Compiler.CompilationModel.Expr.lt $valueExpr
         (Compiler.CompilationModel.Expr.literal $(natTerm (2 ^ bits))))
@@ -5194,8 +5186,8 @@ def translateSafeRequireBind
         (← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $valueExpr))
       ])
   | `(term| narrowSubPanic $a:term $b:term) =>
-      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let aExpr ← translateOperand a
+      let bExpr ← translateOperand b
       let valueExpr : Term ← `(Compiler.CompilationModel.Expr.sub $aExpr $bExpr)
       let guardExpr : Term ← `(Compiler.CompilationModel.Expr.ge $aExpr $bExpr)
       pure (some #[
@@ -5204,8 +5196,8 @@ def translateSafeRequireBind
       ])
   | `(term| narrowMulPanic $a:term $b:term) =>
       let bits ← narrowBitsOf a
-      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let aExpr ← translateOperand a
+      let bExpr ← translateOperand b
       let valueExpr : Term ← `(Compiler.CompilationModel.Expr.mul $aExpr $bExpr)
       -- Check the mathematical product before evaluating the wrapping EVM `mul`.
       -- Looking only at `valueExpr < 2^bits` is unsound for widths above 128:
@@ -5236,7 +5228,7 @@ def translateSafeRequireBind
   -- error name and argument list.
   | `(term| requireSomeUintError $optExpr:term $errorName:ident($args,*)) =>
       let errorNameLit := strTerm (toString errorName.getId)
-      let argExprs ← args.getElems.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+      let argExprs ← args.getElems.mapM translateOperand
       let (guardExpr, valueExpr) ← translateSafeUintGuardAndValue optExpr "requireSomeUintError"
       pure (some #[
         (← `(Compiler.CompilationModel.Stmt.requireError $guardExpr $errorNameLit [ $[$argExprs],* ])),
@@ -5250,8 +5242,8 @@ def translateSafeRequireBind
   -- and `Panic(0x12)` (division by zero) opcodes.
   | `(term| addPanic $a:term $b:term) =>
       let msgLit := strTerm "Panic(0x11): arithmetic overflow"
-      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let aExpr ← translateOperand a
+      let bExpr ← translateOperand b
       let valueExpr : Term ← `(Compiler.CompilationModel.Expr.add $aExpr $bExpr)
       let guardExpr : Term ← `(Compiler.CompilationModel.Expr.ge $valueExpr $aExpr)
       pure (some #[
@@ -5260,8 +5252,8 @@ def translateSafeRequireBind
       ])
   | `(term| subPanic $a:term $b:term) =>
       let msgLit := strTerm "Panic(0x11): arithmetic underflow"
-      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let aExpr ← translateOperand a
+      let bExpr ← translateOperand b
       let valueExpr : Term ← `(Compiler.CompilationModel.Expr.sub $aExpr $bExpr)
       let guardExpr : Term ← `(Compiler.CompilationModel.Expr.ge $aExpr $bExpr)
       pure (some #[
@@ -5270,8 +5262,8 @@ def translateSafeRequireBind
       ])
   | `(term| mulPanic $a:term $b:term) =>
       let msgLit := strTerm "Panic(0x11): arithmetic overflow"
-      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let aExpr ← translateOperand a
+      let bExpr ← translateOperand b
       let valueExpr : Term ← `(Compiler.CompilationModel.Expr.mul $aExpr $bExpr)
       let zeroExpr : Term ← `(Compiler.CompilationModel.Expr.literal 0)
       let divisorZeroExpr : Term ← `(Compiler.CompilationModel.Expr.eq $bExpr $zeroExpr)
@@ -5284,8 +5276,8 @@ def translateSafeRequireBind
       ])
   | `(term| divPanic $a:term $b:term) =>
       let msgLit := strTerm "Panic(0x12): division by zero"
-      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let aExpr ← translateOperand a
+      let bExpr ← translateOperand b
       let valueExpr : Term ← `(Compiler.CompilationModel.Expr.div $aExpr $bExpr)
       let zeroExpr : Term ← `(Compiler.CompilationModel.Expr.literal 0)
       let guardExpr : Term ←

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -1821,6 +1821,15 @@ partial def inferLeanDefCallType?
       throwErrorAt stx
         s!"Lean helper '{fnDisplay}' uses an unsupported return type; supported pure helper returns are Uint256, Int256, Address, Bytes32/Uint256, and Bool"
 
+partial def syntaxContainsCallExternal (stx : Syntax) : Bool :=
+  match stx with
+  | .node _ _ args =>
+      if let `(term| callExternal $_name:ident ($[$_args:term],*)) := stx then
+        true
+      else
+        args.any syntaxContainsCallExternal
+  | _ => false
+
 partial def inferPureExprType
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
@@ -2048,6 +2057,9 @@ partial def inferPureExprType
       discard <| classifyWordArithmeticResultType stx "ordering comparison" lhsTy rhsTy
       pure .bool
   | `(term| $a && $b) | `(term| $a || $b) => do
+      if syntaxContainsCallExternal a || syntaxContainsCallExternal b then
+        throwErrorAt stx
+          "short-circuit logical operands cannot contain callExternal because expression lowering evaluates both operands; bind the external result first"
       requireBoolType a "logical operator" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
       requireBoolType b "logical operator" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals b visitingConstants)
       pure .bool
@@ -2166,6 +2178,9 @@ partial def inferPureExprType
         requireWordLikeType arg "mulDiv512" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
       pure .uint256
   | `(term| ite $cond $thenVal $elseVal) => do
+      if syntaxContainsCallExternal thenVal || syntaxContainsCallExternal elseVal then
+        throwErrorAt stx
+          "conditional branches cannot contain callExternal because expression lowering evaluates both branches; use statement-level control flow"
       requireBoolType cond "ite condition" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals cond visitingConstants)
       let thenTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals thenVal visitingConstants
       let elseTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals elseVal visitingConstants
@@ -3855,15 +3870,6 @@ partial def syntaxMentionsIdent (stx : Syntax) (name : String) : Bool :=
   | .node _ _ args => args.any (fun child => syntaxMentionsIdent child name)
   | _ => false
 
-partial def syntaxContainsCallExternal (stx : Syntax) : Bool :=
-  match stx with
-  | .node _ _ args =>
-      if let `(term| callExternal $_name:ident ($[$_args:term],*)) := stx then
-        true
-      else
-        args.any syntaxContainsCallExternal
-  | _ => false
-
 def freshSyntheticLocalName
     (base : String)
     (params : Array ParamDecl)
@@ -4625,6 +4631,8 @@ def tryExternalCallBindStmt?
       let mut flattenedResultVars : Array String := #[]
       let mut visibleLocals : Array TypedLocal := #[mkTypedLocal successVar .bool]
       let mut normalizations : Array Term := #[]
+      if let some normalization ← normalizeBoundValueStmt? .bool rhs successVar then
+        normalizations := normalizations.push normalization
       for (resultVar, resultTy) in resultVars.toArray.zip resultTys do
         let flatNames ← flattenExternalResultNames resultVar resultTy
         unless flatNames.length == 1 || (staticStructDirectFieldLocals? resultVar resultTy).isSome do
@@ -4717,6 +4725,8 @@ def callResultBindStmt?
           $(strTerm extName)
           [ $[$argExprs],* ])
       let mut normalizations : Array Term := #[]
+      if let some normalization ← normalizeBoundValueStmt? .bool rhs successVar then
+        normalizations := normalizations.push normalization
       for (resultVar, resultTy) in resultVars.zip resultVarTys do
         if let some normalization ← normalizeBoundValueStmt? resultTy rhs resultVar then
           normalizations := normalizations.push normalization

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -1824,7 +1824,16 @@ partial def inferLeanDefCallType?
 partial def syntaxContainsCallExternal (stx : Syntax) : Bool :=
   match stx with
   | .node _ _ args =>
-      if let `(term| callExternal $_name:ident ($[$_args:term],*)) := stx then
+      if stx.getKind == `Verity.Macro.evmCallTerm ||
+          stx.getKind == `Verity.Macro.evmStaticCallTerm then
+        true
+      else if let `(term| callExternal $_name:ident ($[$_args:term],*)) := stx then
+        true
+      else if let `(term| call $_gas $_target $_value $_inOffset $_inSize $_outOffset $_outSize) := stx then
+        true
+      else if let `(term| staticcall $_gas $_target $_inOffset $_inSize $_outOffset $_outSize) := stx then
+        true
+      else if let `(term| delegatecall $_gas $_target $_inOffset $_inSize $_outOffset $_outSize) := stx then
         true
       else
         args.any syntaxContainsCallExternal

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -2776,6 +2776,10 @@ partial def resolveQualifiedFunctionApp?
     pure (some (fnName, argTerms))
 end
 
+structure LinkedExternalLowerer where
+  lower : Ident → Array Term → CommandElabM Term
+  inferType : Term → List String → CommandElabM ValueType
+
 mutual
 partial def validateConstantBody
     (constDecls : Array ConstantDecl)
@@ -3062,9 +3066,13 @@ partial def translatePureExprWithTypes
     (locals : Array TypedLocal)
     (stx : Term)
     (visitingConstants : List String := [])
-    (linkedExternalLowerer? : Option (Ident → Array Term → CommandElabM Term) := none) : CommandElabM Term := do
+    (linkedExternalLowerer? : Option LinkedExternalLowerer := none) : CommandElabM Term := do
   let stx := stripParens stx
   let localNames := typedLocalNames locals
+  let inferExprType (expr : Term) : CommandElabM ValueType :=
+    match linkedExternalLowerer? with
+    | some lowerer => lowerer.inferType expr visitingConstants
+    | none => inferPureExprType fields constDecls immutableDecls #[] params locals expr visitingConstants
   let translateIntrinsic (name lowering args minForkTerm : Term) : CommandElabM Term := do
     let intrinsicName := ← expectStringOrIdent name
     let argsExprs ←
@@ -3264,7 +3272,7 @@ partial def translatePureExprWithTypes
   | `(term| add $a $b) | `(term| $a + $b)
     | `(term| sub $a $b) | `(term| $a - $b)
     | `(term| mul $a $b) | `(term| $a * $b) => do
-      let resultTy ← inferPureExprType fields constDecls immutableDecls #[] params locals stx visitingConstants
+      let resultTy ← inferExprType stx
       let lhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
       let rhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?
       let raw ← match stx with
@@ -3284,8 +3292,8 @@ partial def translatePureExprWithTypes
           [$(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?),
            $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)])
   | `(term| div $a $b) | `(term| $a / $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
         let raw ← `(Compiler.CompilationModel.Expr.sdiv $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
@@ -3298,8 +3306,8 @@ partial def translatePureExprWithTypes
         `(Compiler.CompilationModel.Expr.div $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| sdiv $a $b) => `(Compiler.CompilationModel.Expr.sdiv $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| mod $a $b) | `(term| $a % $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
         let raw ← `(Compiler.CompilationModel.Expr.smod $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
@@ -3321,8 +3329,8 @@ partial def translatePureExprWithTypes
   | `(term| byte $index $value) => `(Compiler.CompilationModel.Expr.byte $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?))
   | `(term| signextend $byteIndex $value) => `(Compiler.CompilationModel.Expr.signextend $(← translatePureExprWithTypes fields constDecls immutableDecls params locals byteIndex visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?))
   | `(term| $a == $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       if (lhsTy == .string && rhsTy == .string) || (lhsTy == .bytes && rhsTy == .bytes) then
         let (lhsName, rhsName) ← dynamicEqParamNames stx params a b lhsTy rhsTy
         `(Compiler.CompilationModel.Expr.dynamicBytesEq $(strTerm lhsName) $(strTerm rhsName))
@@ -3346,8 +3354,8 @@ partial def translatePureExprWithTypes
         `(Compiler.CompilationModel.Expr.eq
           $lhs $rhs)
   | `(term| $a != $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       if (lhsTy == .string && rhsTy == .string) || (lhsTy == .bytes && rhsTy == .bytes) then
         let (lhsName, rhsName) ← dynamicEqParamNames stx params a b lhsTy rhsTy
         `(Compiler.CompilationModel.Expr.logicalNot
@@ -3373,8 +3381,8 @@ partial def translatePureExprWithTypes
             (Compiler.CompilationModel.Expr.eq
               $lhs $rhs))
   | `(term| $a >= $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
         `(Compiler.CompilationModel.Expr.logicalNot
@@ -3384,8 +3392,8 @@ partial def translatePureExprWithTypes
       else
         `(Compiler.CompilationModel.Expr.ge $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| $a > $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
         `(Compiler.CompilationModel.Expr.sgt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
@@ -3393,8 +3401,8 @@ partial def translatePureExprWithTypes
         `(Compiler.CompilationModel.Expr.gt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| sgt $a $b) => `(Compiler.CompilationModel.Expr.sgt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| $a < $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
         `(Compiler.CompilationModel.Expr.slt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
@@ -3402,8 +3410,8 @@ partial def translatePureExprWithTypes
         `(Compiler.CompilationModel.Expr.lt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| slt $a $b) => `(Compiler.CompilationModel.Expr.slt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| $a <= $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
         `(Compiler.CompilationModel.Expr.logicalNot
@@ -3479,7 +3487,7 @@ partial def translatePureExprWithTypes
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants linkedExternalLowerer?))
   | `(term| callExternal $name:ident ($[$xs:term],*)) =>
       match linkedExternalLowerer? with
-      | some lower => lower name xs
+      | some lowerer => lowerer.lower name xs
       | none =>
           translatePureExprWithTypes fields constDecls immutableDecls params locals
             (← `(externalCall $(strTerm (toString name.getId)) [ $[$xs],* ]))
@@ -3556,7 +3564,7 @@ partial def translatePureExprWithTypes
           `(Compiler.CompilationModel.Expr.arrayElement
               $(strTerm (← expectStringOrIdent name))
               $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?))
-      let elemTy ← inferPureExprType fields constDecls immutableDecls #[] params locals stx visitingConstants
+      let elemTy ← inferExprType stx
       match elemTy with
       | .uintN bits =>
           `(Compiler.CompilationModel.Expr.bitAnd $raw
@@ -4472,6 +4480,7 @@ def translateLinkedExternalCallArgs
               out := out.push (← translateScalar)
   pure out
 
+set_option linter.unusedVariables false in
 partial def translateDeclaredPureExpr
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
@@ -4505,7 +4514,11 @@ partial def translateDeclaredPureExpr
         normalizeTranslatedExprForType retTy stx callExpr
     | [] => throwErrorAt name s!"callExternal '{extName}' returns no values"
     | _ => throwErrorAt name s!"callExternal '{extName}' returns multiple values"
-  translatePureExprWithTypes fields constDecls immutableDecls params locals stx [] (some lower)
+  let lowerer : LinkedExternalLowerer :=
+    { lower := lower
+      inferType := fun expr visiting =>
+        inferPureExprType fields constDecls immutableDecls externalDecls params locals expr visiting }
+  translatePureExprWithTypes fields constDecls immutableDecls params locals stx [] (some lowerer)
 
 def tupleInternalCallAssignStmt?
     (fields : Array StorageFieldDecl)
@@ -4545,7 +4558,8 @@ def tupleInternalCallAssignStmt?
       | some (qualifiedName, argTerms) =>
           let _ ← unsafe qualifiedTupleBindTypedLocals rhs.raw qualifiedName names
           let argExprs ← argTerms.mapM
-            (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+            (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals)
           pure (some (← `(Compiler.CompilationModel.Stmt.internalCallAssign
             [ $[$resultNameTerms],* ]
             $(strTerm (qualifiedInternalHelperName functions qualifiedName))
@@ -4572,9 +4586,18 @@ def tryExternalCallBindStmt?
   match rhs with
   | `(term| tryExternalCall $name:term $args:term) =>
       let extName := ← expectStringOrIdent name
+      let ext ←
+        match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt rhs s!"unknown external function '{extName}'"
       let argExprs ← match stripParens args with
-        | `(term| [ $[$xs],* ]) =>
+        | `(term| [ $[$xs],* ]) => do
+            validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+              extName ext.params xs
             translateLinkedExternalCallArgs fields constDecls immutableDecls params locals xs
+              (some ext.params)
+              (some (translateDeclaredPureExpr
+                fields constDecls immutableDecls externalDecls params locals))
         | _ => throwErrorAt args "expected list literal [..]"
       -- names[0] is the success flag, names[1..] are result vars
       let initialUsedNames := (params.toList.map (fun p => p.name)) ++ (typedLocalNames locals).toList ++ (names.filterMap id).toList
@@ -4592,16 +4615,9 @@ def tryExternalCallBindStmt?
         | none => "_try_success"
       let resultVars := targetNames.drop 1
       let successVarTerm := strTerm successVar
-      let resultTys ←
-        match externalDecls.find? (fun ext => ext.name == extName) with
-        | some ext =>
-            if ext.returnTys.size != resultVars.length then
-              throwErrorAt rhs s!"tryExternalCall '{extName}' binds {resultVars.length} result value(s), but the external declaration returns {ext.returnTys.size}"
-            pure ext.returnTys
-        | none =>
-            -- Validation reports the unknown external with full context; keep
-            -- translation moving with word-shaped placeholders.
-            pure (Array.replicate resultVars.length .uint256)
+      if ext.returnTys.size != resultVars.length then
+        throwErrorAt rhs s!"tryExternalCall '{extName}' binds {resultVars.length} result value(s), but the external declaration returns {ext.returnTys.size}"
+      let resultTys := ext.returnTys
       let mut flattenedResultVars : Array String := #[]
       let mut visibleLocals : Array TypedLocal := #[mkTypedLocal successVar .bool]
       for (resultVar, resultTy) in resultVars.toArray.zip resultTys do
@@ -4637,14 +4653,19 @@ def callResultBindStmt?
   match rhs with
   | `(term| callResult $name:term $args:term) =>
       let extName := ← expectStringOrIdent name
-      let argExprs ← match stripParens args with
-        | `(term| [ $[$xs],* ]) =>
-            translateLinkedExternalCallArgs fields constDecls immutableDecls params locals xs
-        | _ => throwErrorAt args "expected list literal [..]"
       let ext ←
         match externalDecls.find? (fun ext => ext.name == extName) with
         | some ext => pure ext
         | none => throwErrorAt rhs s!"unknown external function '{extName}'"
+      let argExprs ← match stripParens args with
+        | `(term| [ $[$xs],* ]) => do
+            validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+              extName ext.params xs
+            translateLinkedExternalCallArgs fields constDecls immutableDecls params locals xs
+              (some ext.params)
+              (some (translateDeclaredPureExpr
+                fields constDecls immutableDecls externalDecls params locals))
+        | _ => throwErrorAt args "expected list literal [..]"
       for retTy in ext.returnTys do
         unless isSingleWordStaticValueType retTy do
           throwErrorAt rhs

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -218,6 +218,13 @@ def normalizeTranslatedExprForType
           let mask := (2 ^ (8 * bytes) - 1) * 2 ^ (8 * (32 - bytes))
           `(Compiler.CompilationModel.Expr.bitAnd $expr
               (Compiler.CompilationModel.Expr.literal $(natTerm mask)))
+  | .address =>
+      `(Compiler.CompilationModel.Expr.bitAnd $expr
+          (Compiler.CompilationModel.Expr.literal $(natTerm (2 ^ 160 - 1))))
+  | .bool =>
+      `(Compiler.CompilationModel.Expr.logicalNot
+          (Compiler.CompilationModel.Expr.eq $expr
+            (Compiler.CompilationModel.Expr.literal 0)))
   | .newtype _ baseType => normalizeTranslatedExprForType baseType source expr
   | _ => pure expr
 
@@ -225,10 +232,10 @@ def normalizeBoundValueStmt?
     (expectedTy : ValueType) (source : Term) (name : String) : CommandElabM (Option Term) := do
   let needsNormalization :=
     match expectedTy with
-    | .uint8 | .uint16 | .uintN _ | .intN _ | .bytesN _ => true
+    | .uint8 | .uint16 | .uintN _ | .intN _ | .bytesN _ | .address | .bool => true
     | .newtype _ baseType =>
         match baseType with
-        | .uint8 | .uint16 | .uintN _ | .intN _ | .bytesN _ => true
+        | .uint8 | .uint16 | .uintN _ | .intN _ | .bytesN _ | .address | .bool => true
         | _ => false
     | _ => false
   unless needsNormalization do return none
@@ -3848,6 +3855,15 @@ partial def syntaxMentionsIdent (stx : Syntax) (name : String) : Bool :=
   | .node _ _ args => args.any (fun child => syntaxMentionsIdent child name)
   | _ => false
 
+partial def syntaxContainsCallExternal (stx : Syntax) : Bool :=
+  match stx with
+  | .node _ _ args =>
+      if let `(term| callExternal $_name:ident ($[$_args:term],*)) := stx then
+        true
+      else
+        args.any syntaxContainsCallExternal
+  | _ => false
+
 def freshSyntheticLocalName
     (base : String)
     (params : Array ParamDecl)
@@ -5144,6 +5160,9 @@ def translateSafeRequireBind
     | _ => throwErrorAt term "narrow arithmetic currently requires direct UintN operands"
   let translateSafeUintGuardAndValue (optExpr : Term) (label : String) :
       CommandElabM (Term × Term) := do
+    if syntaxContainsCallExternal optExpr then
+      throwErrorAt optExpr
+        s!"{label} operands cannot contain callExternal because safe-arithmetic lowering reuses operands in both the guard and result; bind the external result first"
     match stripParens optExpr with
     | `(term| safeAdd $a:term $b:term) =>
         let aExpr ← translateOperand a

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -2011,9 +2011,15 @@ partial def inferPureExprType
       let lhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants
       let rhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals b visitingConstants
       classifyUnsignedWordArithmeticResultType stx "bitwise word arithmetic" lhsTy rhsTy
-  | `(term| pow $a $b) | `(term| $a ^ $b)
-  | `(term| min $a $b) | `(term| max $a $b) | `(term| wMulDown $a $b) | `(term| wDivUp $a $b)
+  | `(term| min $a $b) | `(term| max $a $b) | `(term| wDivUp $a $b)
   | `(term| ceilDiv $a $b) => do
+      if syntaxContainsCallExternal a || syntaxContainsCallExternal b then
+        throwErrorAt stx
+          "duplicated expression operands cannot contain callExternal; bind the external result first"
+      let lhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants
+      let rhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals b visitingConstants
+      classifyUnsignedWordArithmeticResultType stx "unsigned word arithmetic" lhsTy rhsTy
+  | `(term| pow $a $b) | `(term| $a ^ $b) | `(term| wMulDown $a $b) => do
       let lhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants
       let rhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals b visitingConstants
       classifyUnsignedWordArithmeticResultType stx "unsigned word arithmetic" lhsTy rhsTy
@@ -2178,9 +2184,9 @@ partial def inferPureExprType
         requireWordLikeType arg "mulDiv512" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
       pure .uint256
   | `(term| ite $cond $thenVal $elseVal) => do
-      if syntaxContainsCallExternal thenVal || syntaxContainsCallExternal elseVal then
+      if syntaxContainsCallExternal cond || syntaxContainsCallExternal thenVal || syntaxContainsCallExternal elseVal then
         throwErrorAt stx
-          "conditional branches cannot contain callExternal because expression lowering evaluates both branches; use statement-level control flow"
+          "conditional operands cannot contain callExternal because expression lowering duplicates the condition and evaluates both branches; use statement-level control flow"
       requireBoolType cond "ite condition" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals cond visitingConstants)
       let thenTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals thenVal visitingConstants
       let elseTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals elseVal visitingConstants
@@ -4629,6 +4635,7 @@ def tryExternalCallBindStmt?
         throwErrorAt rhs s!"tryExternalCall '{extName}' binds {resultVars.length} result value(s), but the external declaration returns {ext.returnTys.size}"
       let resultTys := ext.returnTys
       let mut flattenedResultVars : Array String := #[]
+      let existingNames := (params.map (fun p => p.name)) ++ typedLocalNames locals
       let mut visibleLocals : Array TypedLocal := #[mkTypedLocal successVar .bool]
       let mut normalizations : Array Term := #[]
       if let some normalization ← normalizeBoundValueStmt? .bool rhs successVar then
@@ -4638,6 +4645,14 @@ def tryExternalCallBindStmt?
         unless flatNames.length == 1 || (staticStructDirectFieldLocals? resultVar resultTy).isSome do
           throwErrorAt rhs
             s!"tryExternalCall '{extName}' cannot bind flattened composite return type {renderValueType resultTy} to source variable '{resultVar}'"
+        for flatName in flatNames do
+          if existingNames.contains flatName then
+            throwErrorAt rhs
+              s!"tryExternalCall '{extName}' flattened result variable '{flatName}' conflicts with an existing local"
+          if flatName == successVar || flattenedResultVars.contains flatName ||
+              (flatName != resultVar && resultVars.contains flatName) then
+            throwErrorAt rhs
+              s!"tryExternalCall '{extName}' generates duplicate flattened result variable '{flatName}'"
         flattenedResultVars := flattenedResultVars ++ flatNames.toArray
         let source :=
           match staticStructDirectFieldLocals? resultVar resultTy with

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -1881,7 +1881,7 @@ partial def inferPureExprType
             match contextAccessorBareName? name with
             | some accessor => inferContextAccessorOrLocal accessor
             | none => throwErrorAt stx s!"unknown variable '{name}'"
-  | `(term| calldatasize) | `(term| returndataSize) =>
+  | `(term| calldatasize) | `(term| returndataSize) | `(term| returnDataSize()) =>
       pure .uint256
   | `(term| zeroAddress) =>
       match lookupTypedLocalType? locals "zeroAddress" <|> params.findSome? (fun p =>
@@ -1994,7 +1994,7 @@ partial def inferPureExprType
   | `(term| ! $a) => do
       requireBoolType a "logical not" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
       pure .bool
-  | `(term| mload $offset) | `(term| tload $offset) | `(term| calldataload $offset)
+  | `(term| mload $offset) | `(term| memoryLoad($offset)) | `(term| tload $offset) | `(term| calldataload $offset)
     | `(term| extcodesize $offset) => do
       requireWordLikeType offset "word offset expression" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals offset visitingConstants)
       pure .uint256
@@ -2010,10 +2010,18 @@ partial def inferPureExprType
       for arg in [gas, target, value, inOffset, inSize, outOffset, outSize] do
         requireWordLikeType arg "low-level call" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
       pure .uint256
+  | `(term| evmCall($gas, $target, $value, $inOffset, $inSize, $outOffset, $outSize)) => do
+      for arg in [gas, target, value, inOffset, inSize, outOffset, outSize] do
+        requireWordLikeType arg "low-level call" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
+      pure .uint256
   | `(term| staticcall $gas $target $inOffset $inSize $outOffset $outSize)
     | `(term| delegatecall $gas $target $inOffset $inSize $outOffset $outSize) => do
       for arg in [gas, target, inOffset, inSize, outOffset, outSize] do
         requireWordLikeType arg "low-level call" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
+      pure .uint256
+  | `(term| evmStaticCall($gas, $target, $inOffset, $inSize, $outOffset, $outSize)) => do
+      for arg in [gas, target, inOffset, inSize, outOffset, outSize] do
+        requireWordLikeType arg "low-level staticcall" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
       pure .uint256
   | `(term| arrayLength $name:term) =>
       -- verity#1849, G1: accept `arrayLength (arrayElement <param> <i>).<dynField>`
@@ -2122,6 +2130,9 @@ partial def inferPureExprType
           | [] => throwErrorAt name s!"externalCall '{extName}' returns no values; use `let success ← tryExternalCall \"{extName}\" [...]` instead"
           | _ => throwErrorAt name s!"externalCall '{extName}' returns {ext.returnTys.size} values; use `let (success, ...) ← tryExternalCall \"{extName}\" [...]` for multi-return"
       | none => pure .uint256
+  | `(term| callExternal $name:ident ($[$xs:term],*)) =>
+      inferPureExprType fields constDecls immutableDecls externalDecls params locals
+        (← `(externalCall $(strTerm (toString name.getId)) [ $[$xs],* ])) visitingConstants
   | `(term| intrinsic_cancun $name:term $_lowering:term $args:term)
   | `(term| intrinsic_prague $name:term $_lowering:term $args:term)
   | `(term| intrinsic_fusaka $name:term $_lowering:term $args:term)
@@ -2201,6 +2212,20 @@ partial def inferBindSourceType
     (rhs : Term) : CommandElabM ValueType := do
   let rhs := stripParens rhs
   match rhs with
+  | `(term| memoryLoad($_))
+    | `(term| returnDataSize())
+    | `(term| evmCall($_, $_, $_, $_, $_, $_, $_))
+    | `(term| evmStaticCall($_, $_, $_, $_, $_, $_)) =>
+      inferPureExprType fields constDecls immutableDecls externalDecls params locals rhs
+  | `(term| callExternal $name:ident ($[$_args:term],*)) =>
+      let extName := toString name.getId
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown linked external '{extName}'"
+      match ext.returnTys.toList with
+      | [retTy] => pure retTy
+      | [] => throwErrorAt rhs s!"callExternal '{extName}' returns Unit; invoke it as a statement"
+      | _ => throwErrorAt rhs s!"callExternal '{extName}' returns multiple values; use externalCallBind with explicit result names"
   | `(term| callResult $name:term $_args:term) =>
       let extName := ← expectStringOrIdent name
       let ext ←
@@ -3097,7 +3122,7 @@ partial def translatePureExprWithTypes
       else
         translateConstantExpr fields constDecls immutableDecls visitingConstants name
   | `(term| calldatasize) => `(Compiler.CompilationModel.Expr.calldatasize)
-  | `(term| returndataSize) => `(Compiler.CompilationModel.Expr.returndataSize)
+  | `(term| returndataSize) | `(term| returnDataSize()) => `(Compiler.CompilationModel.Expr.returndataSize)
   | `(term| zeroAddress) =>
       if params.any (fun p => p.name == "zeroAddress") || localNames.contains "zeroAddress" then
         lookupVarExpr params localNames "zeroAddress"
@@ -3263,7 +3288,7 @@ partial def translatePureExprWithTypes
   | `(term| or $a $b) => `(Compiler.CompilationModel.Expr.bitOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| xor $a $b) => `(Compiler.CompilationModel.Expr.bitXor $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| not $a) => `(Compiler.CompilationModel.Expr.bitNot $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants))
-  | `(term| mload $offset) =>
+  | `(term| mload $offset) | `(term| memoryLoad($offset)) =>
       `(Compiler.CompilationModel.Expr.mload
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants))
   | `(term| tload $offset) =>
@@ -3294,6 +3319,15 @@ partial def translatePureExprWithTypes
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants)
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants)
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants))
+  | `(term| evmCall($gas, $target, $value, $inOffset, $inSize, $outOffset, $outSize)) =>
+      `(Compiler.CompilationModel.Expr.call
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants))
   | `(term| staticcall $gas $target $inOffset $inSize $outOffset $outSize) =>
       `(Compiler.CompilationModel.Expr.staticcall
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants)
@@ -3302,6 +3336,17 @@ partial def translatePureExprWithTypes
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants)
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants)
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants))
+  | `(term| evmStaticCall($gas, $target, $inOffset, $inSize, $outOffset, $outSize)) =>
+      `(Compiler.CompilationModel.Expr.staticcall
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants))
+  | `(term| callExternal $name:ident ($[$xs:term],*)) =>
+      translatePureExprWithTypes fields constDecls immutableDecls params locals
+        (← `(externalCall $(strTerm (toString name.getId)) [ $[$xs],* ])) visitingConstants
   | `(term| delegatecall $gas $target $inOffset $inSize $outOffset $outSize) =>
       `(Compiler.CompilationModel.Expr.delegatecall
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants)
@@ -4600,6 +4645,11 @@ def translateBindSource
     (rhs : Term) : CommandElabM Term := do
   let rhs := stripParens rhs
   match rhs with
+  | `(term| memoryLoad($_))
+    | `(term| returnDataSize())
+    | `(term| evmCall($_, $_, $_, $_, $_, $_, $_))
+    | `(term| evmStaticCall($_, $_, $_, $_, $_, $_)) =>
+      translatePureExprWithTypes fields constDecls immutableDecls params locals rhs
   | `(term| getStorage $field:ident) =>
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with

--- a/artifacts/macro_property_tests/PropertyAdtLinkedPayloadSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyAdtLinkedPayloadSmoke.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyAdtLinkedPayloadSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/ExternalCallInBodySmoke.lean
+ */
+contract PropertyAdtLinkedPayloadSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("AdtLinkedPayloadSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: store has no unexpected revert
+    function testAuto_Store_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("store()"));
+        require(ok, "store reverted unexpectedly");
+    }
+}

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -32,4 +32,13 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("linkedWrite(uint256,bytes)", uint256(1), hex"CAFE"));
         require(ok, "linkedWrite reverted unexpectedly");
     }
+    // Property 3: TODO decode and assert `pureNarrow` result
+    function testTODO_PureNarrow_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureNarrow()"));
+        require(ok, "pureNarrow reverted unexpectedly");
+        assertEq(ret.length, 32, "pureNarrow ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
 }

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -137,7 +137,43 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("ecmNestedExternalArg()"));
         require(ok, "ecmNestedExternalArg reverted unexpectedly");
     }
-    // Property 17: TODO decode and assert `pureDirtyInt` result
+    // Property 17: TODO decode and assert `erc20BalanceNestedExternalArg` result
+    function testTODO_Erc20BalanceNestedExternalArg_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20BalanceNestedExternalArg()"));
+        require(ok, "erc20BalanceNestedExternalArg reverted unexpectedly");
+        assertEq(ret.length, 32, "erc20BalanceNestedExternalArg ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 18: TODO decode and assert `erc20AllowanceNestedExternalArg` result
+    function testTODO_Erc20AllowanceNestedExternalArg_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20AllowanceNestedExternalArg()"));
+        require(ok, "erc20AllowanceNestedExternalArg reverted unexpectedly");
+        assertEq(ret.length, 32, "erc20AllowanceNestedExternalArg ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 19: TODO decode and assert `erc20SupplyNestedExternalArg` result
+    function testTODO_Erc20SupplyNestedExternalArg_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20SupplyNestedExternalArg()"));
+        require(ok, "erc20SupplyNestedExternalArg reverted unexpectedly");
+        assertEq(ret.length, 32, "erc20SupplyNestedExternalArg ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 20: TODO decode and assert `mappingNestedExternalArg` result
+    function testTODO_MappingNestedExternalArg_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("mappingNestedExternalArg()"));
+        require(ok, "mappingNestedExternalArg reverted unexpectedly");
+        assertEq(ret.length, 32, "mappingNestedExternalArg ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 21: TODO decode and assert `pureDirtyInt` result
     function testTODO_PureDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
@@ -146,7 +182,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 18: TODO decode and assert `bindDirtyInt` result
+    // Property 22: TODO decode and assert `bindDirtyInt` result
     function testTODO_BindDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
@@ -155,7 +191,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 19: TODO decode and assert `pureDirtyBytes` result
+    // Property 23: TODO decode and assert `pureDirtyBytes` result
     function testTODO_PureDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
@@ -164,7 +200,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 20: TODO decode and assert `bindDirtyBytes` result
+    // Property 24: TODO decode and assert `bindDirtyBytes` result
     function testTODO_BindDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -131,7 +131,13 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("helperNestedExternalArg()"));
         require(ok, "helperNestedExternalArg reverted unexpectedly");
     }
-    // Property 16: TODO decode and assert `pureDirtyInt` result
+    // Property 16: ecmNestedExternalArg has no unexpected revert
+    function testAuto_EcmNestedExternalArg_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("ecmNestedExternalArg()"));
+        require(ok, "ecmNestedExternalArg reverted unexpectedly");
+    }
+    // Property 17: TODO decode and assert `pureDirtyInt` result
     function testTODO_PureDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
@@ -140,7 +146,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 17: TODO decode and assert `bindDirtyInt` result
+    // Property 18: TODO decode and assert `bindDirtyInt` result
     function testTODO_BindDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
@@ -149,7 +155,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 18: TODO decode and assert `pureDirtyBytes` result
+    // Property 19: TODO decode and assert `pureDirtyBytes` result
     function testTODO_PureDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
@@ -158,7 +164,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 19: TODO decode and assert `bindDirtyBytes` result
+    // Property 20: TODO decode and assert `bindDirtyBytes` result
     function testTODO_BindDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -113,7 +113,34 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 12: TODO decode and assert `bindNestedExternalArg` result
+    // Property 12: TODO decode and assert `tryDirtyPair` result
+    function testTODO_TryDirtyPair_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryDirtyPair()"));
+        require(ok, "tryDirtyPair reverted unexpectedly");
+        assertEq(ret.length, 32, "tryDirtyPair ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 13: TODO decode and assert `safeBindDirtyUint` result
+    function testTODO_SafeBindDirtyUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("safeBindDirtyUint()"));
+        require(ok, "safeBindDirtyUint reverted unexpectedly");
+        assertEq(ret.length, 32, "safeBindDirtyUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 14: TODO decode and assert `leanHelperNestedExternal` result
+    function testTODO_LeanHelperNestedExternal_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("leanHelperNestedExternal()"));
+        require(ok, "leanHelperNestedExternal reverted unexpectedly");
+        assertEq(ret.length, 32, "leanHelperNestedExternal ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 15: TODO decode and assert `bindNestedExternalArg` result
     function testTODO_BindNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindNestedExternalArg()"));
@@ -122,49 +149,49 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 13: statementNestedExternalArg has no unexpected revert
+    // Property 16: statementNestedExternalArg has no unexpected revert
     function testAuto_StatementNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("statementNestedExternalArg()"));
         require(ok, "statementNestedExternalArg reverted unexpectedly");
     }
-    // Property 14: legacyNarrowArgs has no unexpected revert
+    // Property 17: legacyNarrowArgs has no unexpected revert
     function testAuto_LegacyNarrowArgs_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("legacyNarrowArgs()"));
         require(ok, "legacyNarrowArgs reverted unexpectedly");
     }
-    // Property 15: emitNestedExternalArg has no unexpected revert
+    // Property 18: emitNestedExternalArg has no unexpected revert
     function testAuto_EmitNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("emitNestedExternalArg()"));
         require(ok, "emitNestedExternalArg reverted unexpectedly");
     }
-    // Property 16: customErrorNestedExternalArg has no unexpected revert
+    // Property 19: customErrorNestedExternalArg has no unexpected revert
     function testAuto_CustomErrorNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("customErrorNestedExternalArg()"));
         require(ok, "customErrorNestedExternalArg reverted unexpectedly");
     }
-    // Property 17: consumeHelper has no unexpected revert
+    // Property 20: consumeHelper has no unexpected revert
     function testAuto_ConsumeHelper_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("consumeHelper(uint256)", uint256(1)));
         require(ok, "consumeHelper reverted unexpectedly");
     }
-    // Property 18: helperNestedExternalArg has no unexpected revert
+    // Property 21: helperNestedExternalArg has no unexpected revert
     function testAuto_HelperNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("helperNestedExternalArg()"));
         require(ok, "helperNestedExternalArg reverted unexpectedly");
     }
-    // Property 19: ecmNestedExternalArg has no unexpected revert
+    // Property 22: ecmNestedExternalArg has no unexpected revert
     function testAuto_EcmNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("ecmNestedExternalArg()"));
         require(ok, "ecmNestedExternalArg reverted unexpectedly");
     }
-    // Property 20: TODO decode and assert `erc20BalanceNestedExternalArg` result
+    // Property 23: TODO decode and assert `erc20BalanceNestedExternalArg` result
     function testTODO_Erc20BalanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20BalanceNestedExternalArg()"));
@@ -173,7 +200,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 21: TODO decode and assert `erc20AllowanceNestedExternalArg` result
+    // Property 24: TODO decode and assert `erc20AllowanceNestedExternalArg` result
     function testTODO_Erc20AllowanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20AllowanceNestedExternalArg()"));
@@ -182,7 +209,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 22: TODO decode and assert `erc20SupplyNestedExternalArg` result
+    // Property 25: TODO decode and assert `erc20SupplyNestedExternalArg` result
     function testTODO_Erc20SupplyNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20SupplyNestedExternalArg()"));
@@ -191,7 +218,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 23: TODO decode and assert `mappingNestedExternalArg` result
+    // Property 26: TODO decode and assert `mappingNestedExternalArg` result
     function testTODO_MappingNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("mappingNestedExternalArg()"));
@@ -200,7 +227,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 24: TODO decode and assert `pureDirtyInt` result
+    // Property 27: TODO decode and assert `pureDirtyInt` result
     function testTODO_PureDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
@@ -209,7 +236,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 25: TODO decode and assert `bindDirtyInt` result
+    // Property 28: TODO decode and assert `bindDirtyInt` result
     function testTODO_BindDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
@@ -218,7 +245,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 26: TODO decode and assert `pureDirtyBytes` result
+    // Property 29: TODO decode and assert `pureDirtyBytes` result
     function testTODO_PureDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
@@ -227,7 +254,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 27: TODO decode and assert `bindDirtyBytes` result
+    // Property 30: TODO decode and assert `bindDirtyBytes` result
     function testTODO_BindDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyExternalCallInBodySmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/ExternalCallInBodySmoke.lean
+ */
+contract PropertyExternalCallInBodySmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("ExternalCallInBodySmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `linkedRead` result
+    function testTODO_LinkedRead_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("linkedRead()"));
+        require(ok, "linkedRead reverted unexpectedly");
+        assertEq(ret.length, 32, "linkedRead ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: linkedWrite has no unexpected revert
+    function testAuto_LinkedWrite_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("linkedWrite(uint256,bytes)", uint256(1), hex"CAFE"));
+        require(ok, "linkedWrite reverted unexpectedly");
+    }
+}

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -227,7 +227,25 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 27: TODO decode and assert `pureDirtyInt` result
+    // Property 27: TODO decode and assert `tupleNestedExternalResult` result
+    function testTODO_TupleNestedExternalResult_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalResult()"));
+        require(ok, "tupleNestedExternalResult reverted unexpectedly");
+        assertEq(ret.length, 32, "tupleNestedExternalResult ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 28: TODO decode and assert `tupleNestedExternalReturn` result
+    function testTODO_TupleNestedExternalReturn_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalReturn()"));
+        require(ok, "tupleNestedExternalReturn reverted unexpectedly");
+        require(ret.length >= 64, "tupleNestedExternalReturn ABI tuple return payload unexpectedly short");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 29: TODO decode and assert `pureDirtyInt` result
     function testTODO_PureDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
@@ -236,7 +254,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 28: TODO decode and assert `bindDirtyInt` result
+    // Property 30: TODO decode and assert `bindDirtyInt` result
     function testTODO_BindDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
@@ -245,7 +263,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 29: TODO decode and assert `pureDirtyBytes` result
+    // Property 31: TODO decode and assert `pureDirtyBytes` result
     function testTODO_PureDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
@@ -254,7 +272,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 30: TODO decode and assert `bindDirtyBytes` result
+    // Property 32: TODO decode and assert `bindDirtyBytes` result
     function testTODO_BindDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -68,7 +68,16 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 7: TODO decode and assert `bindDirtyUint` result
+    // Property 7: TODO decode and assert `nestedExternalArg` result
+    function testTODO_NestedExternalArg_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("nestedExternalArg()"));
+        require(ok, "nestedExternalArg reverted unexpectedly");
+        assertEq(ret.length, 32, "nestedExternalArg ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 8: TODO decode and assert `bindDirtyUint` result
     function testTODO_BindDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyUint()"));
@@ -77,7 +86,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 8: TODO decode and assert `pureDirtyInt` result
+    // Property 9: TODO decode and assert `pureDirtyInt` result
     function testTODO_PureDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
@@ -86,7 +95,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 9: TODO decode and assert `bindDirtyInt` result
+    // Property 10: TODO decode and assert `bindDirtyInt` result
     function testTODO_BindDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
@@ -95,7 +104,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 10: TODO decode and assert `pureDirtyBytes` result
+    // Property 11: TODO decode and assert `pureDirtyBytes` result
     function testTODO_PureDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
@@ -104,7 +113,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 11: TODO decode and assert `bindDirtyBytes` result
+    // Property 12: TODO decode and assert `bindDirtyBytes` result
     function testTODO_BindDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -50,7 +50,25 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 5: TODO decode and assert `bindDirtyUint` result
+    // Property 5: TODO decode and assert `directDirtyUint` result
+    function testTODO_DirectDirtyUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("directDirtyUint()"));
+        require(ok, "directDirtyUint reverted unexpectedly");
+        assertEq(ret.length, 32, "directDirtyUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 6: TODO decode and assert `nestedDirtyUint` result
+    function testTODO_NestedDirtyUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("nestedDirtyUint()"));
+        require(ok, "nestedDirtyUint reverted unexpectedly");
+        assertEq(ret.length, 32, "nestedDirtyUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 7: TODO decode and assert `bindDirtyUint` result
     function testTODO_BindDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyUint()"));
@@ -59,7 +77,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 6: TODO decode and assert `pureDirtyInt` result
+    // Property 8: TODO decode and assert `pureDirtyInt` result
     function testTODO_PureDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
@@ -68,7 +86,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 7: TODO decode and assert `bindDirtyInt` result
+    // Property 9: TODO decode and assert `bindDirtyInt` result
     function testTODO_BindDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
@@ -77,7 +95,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 8: TODO decode and assert `pureDirtyBytes` result
+    // Property 10: TODO decode and assert `pureDirtyBytes` result
     function testTODO_PureDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
@@ -86,7 +104,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 9: TODO decode and assert `bindDirtyBytes` result
+    // Property 11: TODO decode and assert `bindDirtyBytes` result
     function testTODO_BindDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -122,16 +122,25 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 13: TODO decode and assert `safeBindDirtyUint` result
-    function testTODO_SafeBindDirtyUint_DecodeAndAssert() public {
+    // Property 13: TODO decode and assert `bindDirtyAddress` result
+    function testTODO_BindDirtyAddress_DecodeAndAssert() public {
         vm.prank(alice);
-        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("safeBindDirtyUint()"));
-        require(ok, "safeBindDirtyUint reverted unexpectedly");
-        assertEq(ret.length, 32, "safeBindDirtyUint ABI return length mismatch (expected 32 bytes)");
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyAddress()"));
+        require(ok, "bindDirtyAddress reverted unexpectedly");
+        assertEq(ret.length, 32, "bindDirtyAddress ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 14: TODO decode and assert `leanHelperNestedExternal` result
+    // Property 14: TODO decode and assert `bindDirtyBool` result
+    function testTODO_BindDirtyBool_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBool()"));
+        require(ok, "bindDirtyBool reverted unexpectedly");
+        assertEq(ret.length, 32, "bindDirtyBool ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 15: TODO decode and assert `leanHelperNestedExternal` result
     function testTODO_LeanHelperNestedExternal_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("leanHelperNestedExternal()"));
@@ -140,7 +149,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 15: TODO decode and assert `bindNestedExternalArg` result
+    // Property 16: TODO decode and assert `bindNestedExternalArg` result
     function testTODO_BindNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindNestedExternalArg()"));
@@ -149,49 +158,49 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 16: statementNestedExternalArg has no unexpected revert
+    // Property 17: statementNestedExternalArg has no unexpected revert
     function testAuto_StatementNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("statementNestedExternalArg()"));
         require(ok, "statementNestedExternalArg reverted unexpectedly");
     }
-    // Property 17: legacyNarrowArgs has no unexpected revert
+    // Property 18: legacyNarrowArgs has no unexpected revert
     function testAuto_LegacyNarrowArgs_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("legacyNarrowArgs()"));
         require(ok, "legacyNarrowArgs reverted unexpectedly");
     }
-    // Property 18: emitNestedExternalArg has no unexpected revert
+    // Property 19: emitNestedExternalArg has no unexpected revert
     function testAuto_EmitNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("emitNestedExternalArg()"));
         require(ok, "emitNestedExternalArg reverted unexpectedly");
     }
-    // Property 19: customErrorNestedExternalArg has no unexpected revert
+    // Property 20: customErrorNestedExternalArg has no unexpected revert
     function testAuto_CustomErrorNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("customErrorNestedExternalArg()"));
         require(ok, "customErrorNestedExternalArg reverted unexpectedly");
     }
-    // Property 20: consumeHelper has no unexpected revert
+    // Property 21: consumeHelper has no unexpected revert
     function testAuto_ConsumeHelper_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("consumeHelper(uint256)", uint256(1)));
         require(ok, "consumeHelper reverted unexpectedly");
     }
-    // Property 21: helperNestedExternalArg has no unexpected revert
+    // Property 22: helperNestedExternalArg has no unexpected revert
     function testAuto_HelperNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("helperNestedExternalArg()"));
         require(ok, "helperNestedExternalArg reverted unexpectedly");
     }
-    // Property 22: ecmNestedExternalArg has no unexpected revert
+    // Property 23: ecmNestedExternalArg has no unexpected revert
     function testAuto_EcmNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("ecmNestedExternalArg()"));
         require(ok, "ecmNestedExternalArg reverted unexpectedly");
     }
-    // Property 23: TODO decode and assert `erc20BalanceNestedExternalArg` result
+    // Property 24: TODO decode and assert `erc20BalanceNestedExternalArg` result
     function testTODO_Erc20BalanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20BalanceNestedExternalArg()"));
@@ -200,7 +209,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 24: TODO decode and assert `erc20AllowanceNestedExternalArg` result
+    // Property 25: TODO decode and assert `erc20AllowanceNestedExternalArg` result
     function testTODO_Erc20AllowanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20AllowanceNestedExternalArg()"));
@@ -209,7 +218,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 25: TODO decode and assert `erc20SupplyNestedExternalArg` result
+    // Property 26: TODO decode and assert `erc20SupplyNestedExternalArg` result
     function testTODO_Erc20SupplyNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20SupplyNestedExternalArg()"));
@@ -218,7 +227,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 26: TODO decode and assert `mappingNestedExternalArg` result
+    // Property 27: TODO decode and assert `mappingNestedExternalArg` result
     function testTODO_MappingNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("mappingNestedExternalArg()"));
@@ -227,7 +236,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 27: TODO decode and assert `tupleNestedExternalResult` result
+    // Property 28: TODO decode and assert `tupleNestedExternalResult` result
     function testTODO_TupleNestedExternalResult_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalResult()"));
@@ -236,7 +245,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 28: TODO decode and assert `tupleNestedExternalReturn` result
+    // Property 29: TODO decode and assert `tupleNestedExternalReturn` result
     function testTODO_TupleNestedExternalReturn_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalReturn()"));
@@ -245,7 +254,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 29: TODO decode and assert `pureDirtyInt` result
+    // Property 30: TODO decode and assert `pureDirtyInt` result
     function testTODO_PureDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
@@ -254,7 +263,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 30: TODO decode and assert `bindDirtyInt` result
+    // Property 31: TODO decode and assert `bindDirtyInt` result
     function testTODO_BindDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
@@ -263,7 +272,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 31: TODO decode and assert `pureDirtyBytes` result
+    // Property 32: TODO decode and assert `pureDirtyBytes` result
     function testTODO_PureDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
@@ -272,7 +281,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 32: TODO decode and assert `bindDirtyBytes` result
+    // Property 33: TODO decode and assert `bindDirtyBytes` result
     function testTODO_BindDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -86,7 +86,34 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 9: TODO decode and assert `bindNestedExternalArg` result
+    // Property 9: TODO decode and assert `tryDirtyUint` result
+    function testTODO_TryDirtyUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryDirtyUint()"));
+        require(ok, "tryDirtyUint reverted unexpectedly");
+        assertEq(ret.length, 32, "tryDirtyUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 10: TODO decode and assert `callResultDirtyUint` result
+    function testTODO_CallResultDirtyUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("callResultDirtyUint()"));
+        require(ok, "callResultDirtyUint reverted unexpectedly");
+        assertEq(ret.length, 32, "callResultDirtyUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 11: TODO decode and assert `tryNotifyBool` result
+    function testTODO_TryNotifyBool_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryNotifyBool(bool)", true));
+        require(ok, "tryNotifyBool reverted unexpectedly");
+        assertEq(ret.length, 32, "tryNotifyBool ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 12: TODO decode and assert `bindNestedExternalArg` result
     function testTODO_BindNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindNestedExternalArg()"));
@@ -95,49 +122,49 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 10: statementNestedExternalArg has no unexpected revert
+    // Property 13: statementNestedExternalArg has no unexpected revert
     function testAuto_StatementNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("statementNestedExternalArg()"));
         require(ok, "statementNestedExternalArg reverted unexpectedly");
     }
-    // Property 11: legacyNarrowArgs has no unexpected revert
+    // Property 14: legacyNarrowArgs has no unexpected revert
     function testAuto_LegacyNarrowArgs_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("legacyNarrowArgs()"));
         require(ok, "legacyNarrowArgs reverted unexpectedly");
     }
-    // Property 12: emitNestedExternalArg has no unexpected revert
+    // Property 15: emitNestedExternalArg has no unexpected revert
     function testAuto_EmitNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("emitNestedExternalArg()"));
         require(ok, "emitNestedExternalArg reverted unexpectedly");
     }
-    // Property 13: customErrorNestedExternalArg has no unexpected revert
+    // Property 16: customErrorNestedExternalArg has no unexpected revert
     function testAuto_CustomErrorNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("customErrorNestedExternalArg()"));
         require(ok, "customErrorNestedExternalArg reverted unexpectedly");
     }
-    // Property 14: consumeHelper has no unexpected revert
+    // Property 17: consumeHelper has no unexpected revert
     function testAuto_ConsumeHelper_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("consumeHelper(uint256)", uint256(1)));
         require(ok, "consumeHelper reverted unexpectedly");
     }
-    // Property 15: helperNestedExternalArg has no unexpected revert
+    // Property 18: helperNestedExternalArg has no unexpected revert
     function testAuto_HelperNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("helperNestedExternalArg()"));
         require(ok, "helperNestedExternalArg reverted unexpectedly");
     }
-    // Property 16: ecmNestedExternalArg has no unexpected revert
+    // Property 19: ecmNestedExternalArg has no unexpected revert
     function testAuto_EcmNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("ecmNestedExternalArg()"));
         require(ok, "ecmNestedExternalArg reverted unexpectedly");
     }
-    // Property 17: TODO decode and assert `erc20BalanceNestedExternalArg` result
+    // Property 20: TODO decode and assert `erc20BalanceNestedExternalArg` result
     function testTODO_Erc20BalanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20BalanceNestedExternalArg()"));
@@ -146,7 +173,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 18: TODO decode and assert `erc20AllowanceNestedExternalArg` result
+    // Property 21: TODO decode and assert `erc20AllowanceNestedExternalArg` result
     function testTODO_Erc20AllowanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20AllowanceNestedExternalArg()"));
@@ -155,7 +182,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 19: TODO decode and assert `erc20SupplyNestedExternalArg` result
+    // Property 22: TODO decode and assert `erc20SupplyNestedExternalArg` result
     function testTODO_Erc20SupplyNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20SupplyNestedExternalArg()"));
@@ -164,7 +191,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 20: TODO decode and assert `mappingNestedExternalArg` result
+    // Property 23: TODO decode and assert `mappingNestedExternalArg` result
     function testTODO_MappingNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("mappingNestedExternalArg()"));
@@ -173,7 +200,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 21: TODO decode and assert `pureDirtyInt` result
+    // Property 24: TODO decode and assert `pureDirtyInt` result
     function testTODO_PureDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
@@ -182,7 +209,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 22: TODO decode and assert `bindDirtyInt` result
+    // Property 25: TODO decode and assert `bindDirtyInt` result
     function testTODO_BindDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
@@ -191,7 +218,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 23: TODO decode and assert `pureDirtyBytes` result
+    // Property 26: TODO decode and assert `pureDirtyBytes` result
     function testTODO_PureDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
@@ -200,7 +227,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 24: TODO decode and assert `bindDirtyBytes` result
+    // Property 27: TODO decode and assert `bindDirtyBytes` result
     function testTODO_BindDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -86,7 +86,52 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 9: TODO decode and assert `pureDirtyInt` result
+    // Property 9: TODO decode and assert `bindNestedExternalArg` result
+    function testTODO_BindNestedExternalArg_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindNestedExternalArg()"));
+        require(ok, "bindNestedExternalArg reverted unexpectedly");
+        assertEq(ret.length, 32, "bindNestedExternalArg ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 10: statementNestedExternalArg has no unexpected revert
+    function testAuto_StatementNestedExternalArg_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("statementNestedExternalArg()"));
+        require(ok, "statementNestedExternalArg reverted unexpectedly");
+    }
+    // Property 11: legacyNarrowArgs has no unexpected revert
+    function testAuto_LegacyNarrowArgs_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("legacyNarrowArgs()"));
+        require(ok, "legacyNarrowArgs reverted unexpectedly");
+    }
+    // Property 12: emitNestedExternalArg has no unexpected revert
+    function testAuto_EmitNestedExternalArg_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("emitNestedExternalArg()"));
+        require(ok, "emitNestedExternalArg reverted unexpectedly");
+    }
+    // Property 13: customErrorNestedExternalArg has no unexpected revert
+    function testAuto_CustomErrorNestedExternalArg_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("customErrorNestedExternalArg()"));
+        require(ok, "customErrorNestedExternalArg reverted unexpectedly");
+    }
+    // Property 14: consumeHelper has no unexpected revert
+    function testAuto_ConsumeHelper_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("consumeHelper(uint256)", uint256(1)));
+        require(ok, "consumeHelper reverted unexpectedly");
+    }
+    // Property 15: helperNestedExternalArg has no unexpected revert
+    function testAuto_HelperNestedExternalArg_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("helperNestedExternalArg()"));
+        require(ok, "helperNestedExternalArg reverted unexpectedly");
+    }
+    // Property 16: TODO decode and assert `pureDirtyInt` result
     function testTODO_PureDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
@@ -95,7 +140,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 10: TODO decode and assert `bindDirtyInt` result
+    // Property 17: TODO decode and assert `bindDirtyInt` result
     function testTODO_BindDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
@@ -104,7 +149,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 11: TODO decode and assert `pureDirtyBytes` result
+    // Property 18: TODO decode and assert `pureDirtyBytes` result
     function testTODO_PureDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
@@ -113,7 +158,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 12: TODO decode and assert `bindDirtyBytes` result
+    // Property 19: TODO decode and assert `bindDirtyBytes` result
     function testTODO_BindDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -41,4 +41,58 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
+    // Property 4: TODO decode and assert `pureDirtyUint` result
+    function testTODO_PureDirtyUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyUint()"));
+        require(ok, "pureDirtyUint reverted unexpectedly");
+        assertEq(ret.length, 32, "pureDirtyUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 5: TODO decode and assert `bindDirtyUint` result
+    function testTODO_BindDirtyUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyUint()"));
+        require(ok, "bindDirtyUint reverted unexpectedly");
+        assertEq(ret.length, 32, "bindDirtyUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 6: TODO decode and assert `pureDirtyInt` result
+    function testTODO_PureDirtyInt_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
+        require(ok, "pureDirtyInt reverted unexpectedly");
+        assertEq(ret.length, 32, "pureDirtyInt ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 7: TODO decode and assert `bindDirtyInt` result
+    function testTODO_BindDirtyInt_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
+        require(ok, "bindDirtyInt reverted unexpectedly");
+        assertEq(ret.length, 32, "bindDirtyInt ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 8: TODO decode and assert `pureDirtyBytes` result
+    function testTODO_PureDirtyBytes_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
+        require(ok, "pureDirtyBytes reverted unexpectedly");
+        assertEq(ret.length, 32, "pureDirtyBytes ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 9: TODO decode and assert `bindDirtyBytes` result
+    function testTODO_BindDirtyBytes_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));
+        require(ok, "bindDirtyBytes reverted unexpectedly");
+        assertEq(ret.length, 32, "bindDirtyBytes ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
 }


### PR DESCRIPTION
## Summary

- add declaration-driven linked external calls and explicit low-level EVM call/memory/returndata syntax to `verity_contract` bodies
- validate source ABI shapes before flattening; reject unsupported composite binds/pure returns and generated-name hazards
- support `returnDataSize()` in pure and bind contexts without a global `Inhabited Contract` instance
- add positive IR/semantic-preservation coverage and fail-closed regression cases

## Dependency

Targets `feat/uint-narrow-types` and depends on #2240. Candidate `c2ee709cdebad3c43c09c3ebf499275f1a33447c` contains live dependency head `ed5c9105c8649aeb4a183278d13adbb49e11bd04`. No merge was performed.

## Validation

- `make check` — pass (641 tests)
- latest exact Babylon focused/full success before final review fixes: candidate `81f9f4a0689fc21e1adfb6d903a8d3fc0ad51efe`, focused job `3e8fa70a-808b-45dd-8ba3-108dbf6a44bd`, full job `60870907-2fec-40e8-8f97-9e69342c902b`, digest `e6080dbef8c338a662ddc990dbb1dbf12ed0c4570cd4a02aac36eb608dbef605`
- current candidate remote revalidation is pending: the remote service rejected dispatch with `invalid remote build token`; no older receipt is being treated as a current gate

Closes #1003

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large compiler/macro surface change affecting how contract bodies lower to IR and external-call evaluation semantics; mistakes could silently duplicate calls or mis-narrow return data.
> 
> **Overview**
> Adds **declaration-driven `callExternal`** and explicit low-level **`evmCall` / `evmStaticCall` / `memoryLoad` / `memoryStore` / `returnDataCopy` / `returnDataSize()`** syntax to `verity_contract` bodies, with parser stubs in `Syntax.lean` for non-contract contexts.
> 
> The **macro translator** lowers these forms to compilation-model IR: linked calls become `externalCall` / `externalCallBind` with **ABI narrowing** (`bitAnd`, `signextend`, bool normalization) after binds; `tryExternalCall` success flags get the same bool fix as existing smoke tests. Expression translation routes through **`translateDeclaredPureExpr`** so nested `callExternal` works in args, emits, ECM, ERC-20 helpers, and custom errors.
> 
> **Fail-closed validation** rejects effectful misuse: `callExternal` inside conditionals, duplicated operands, safe arithmetic, short-circuit logic, non-passthrough Lean helpers, composite single-variable binds, malformed arity, and non-word-like memory/returndata offsets.
> 
> New **`ExternalCallInBodySmoke`** (~800 lines) provides IR `rfl` examples, semantic-preservation checks, and `#guard_msgs` negative cases; existing **`ExternalCalls`** smoke expectations update for `_success` normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b19eb6c023fceb298f63bb033758cec560f0f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->