### PR TITLE
docs(ci): fix CI host maintenance cadence — 'weekly' → 'daily'

### DIFF
--- a/docs/CI_RUNNERS.md
+++ b/docs/CI_RUNNERS.md
@@ -162,7 +162,7 @@ The latest benchmark report is in
 
 ## Maintenance Expectations
 
-Each CI host should have the weekly Verity maintenance timer installed. It
+Each CI host should have the daily Verity maintenance timer installed. It
 should:
 
 - run `scripts/ci_local_persistence.sh cleanup`;

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,7 +36,7 @@ sudo RUNNER_HOST_PROFILE=95.216.244.60 RUNNER_URL=https://github.com/<owner>/<re
 sudo RUNNER_HOST_PROFILE=dgx-spark RUNNER_URL=https://github.com/<owner>/<repo> RUNNER_TOKEN=<token> \
   scripts/install_self_hosted_runner.sh
 
-# Install weekly cache, journald, and Docker image cleanup.
+# Install daily cache, journald, and Docker image cleanup.
 sudo scripts/ci_host_maintenance.sh install-systemd
 ```
 

--- a/scripts/ci_host_maintenance.sh
+++ b/scripts/ci_host_maintenance.sh
@@ -22,7 +22,7 @@ Usage:
 
 Subcommands:
   run              Prune stale Verity CI cache entries, vacuum journald, and prune unused Docker data.
-  install-systemd  Install and enable a weekly systemd timer for this script.
+  install-systemd  Install and enable a daily systemd timer for this script.
 
 Environment:
   CACHE_ROOT                    Default: /srv/verity-ci-cache


### PR DESCRIPTION
Closes #2192

## Summary

The CI host maintenance systemd timer is already daily (`OnCalendar=*-*-* 04:30:00`, unit `Description=Daily Verity CI host maintenance`), but three descriptive strings still called it "weekly". This updates the stale text to match the actual cadence.

## Changed

| File | Line | Before | After |
|------|------|--------|-------|
| `scripts/ci_host_maintenance.sh` | 25 (help) | `…enable a weekly systemd timer…` | `…enable a daily systemd timer…` |
| `scripts/README.md` | 39 | `# Install weekly cache, journald, and Docker image cleanup.` | `# Install daily cache, journald, and Docker image cleanup.` |
| `docs/CI_RUNNERS.md` | 165 | `Each CI host should have the weekly Verity maintenance timer installed.` | `Each CI host should have the daily Verity maintenance timer installed.` |

## What was **not** changed

- **No timer behavior changed.** The `OnCalendar=*-*-* 04:30:00` schedule and `Persistent=true` / `RandomizedDelaySec=30m` settings are untouched.
- The `Description=Daily Verity CI host maintenance` line inside the generated `.timer` unit already said "Daily" — left as-is.
- The explanatory comment in `scripts/test_ci_infra_maintenance.py` (`# Daily, not weekly: the weekly run executed hours before the 2026-07-12 disk-full incident`) is a historical rationale for *why* the cadence was changed to daily, not a stale description. It was intentionally left in place.

## Verification

```text
$ grep -rn -i weekly scripts/ci_host_maintenance.sh scripts/README.md docs/CI_RUNNERS.md
(exit 1 — no matches)
$ grep -rn -i daily scripts/ci_host_maintenance.sh scripts/README.md docs/CI_RUNNERS.md
scripts/ci_host_maintenance.sh:25:  install-systemd  Install and enable a daily systemd timer for this script.
scripts/ci_host_maintenance.sh:231:Description=Daily Verity CI host maintenance
scripts/README.md:39:# Install daily cache, journald, and Docker image cleanup.
docs/CI_RUNNERS.md:165:Each CI host should have the daily Verity maintenance timer installed. It
```

Diff is 3 lines across 3 files. Text-only change; no runtime impact.

**Do not merge yet** — posted for review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, timer, or maintenance script behavior changes.
> 
> **Overview**
> Updates three stale **weekly** references so docs and help text match the **daily** `verity-ci-host-maintenance` systemd timer (`OnCalendar=*-*-* 04:30:00`), which was already described as daily in the generated unit.
> 
> Changes are wording only in `docs/CI_RUNNERS.md`, `scripts/README.md`, and the `install-systemd` line in `scripts/ci_host_maintenance.sh` usage text. **No timer schedule, maintenance logic, or install behavior is modified.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 447189ecdc4f687a9305f53d73b5b3407919c9a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->