### PR TITLE
Prove void helper-call catalog producer

### DIFF
--- a/Compiler.lean
+++ b/Compiler.lean
@@ -43,6 +43,7 @@ import Compiler.Proofs.IRGeneration.ParamLoading
 import Compiler.Proofs.IRGeneration.SupportedSpec
 import Compiler.Proofs.IRGeneration.SourceSemantics
 import Compiler.Proofs.IRGeneration.HelperSummaryEvidence
+import Compiler.Proofs.IRGeneration.HelperVoidCallCatalogRegression
 import Compiler.Proofs.Frames
 import Compiler.Proofs.YulGeneration.PatchRulesProofs
 import Compiler.Proofs.YulGeneration.ExecutionSummary

--- a/Compiler.lean
+++ b/Compiler.lean
@@ -43,7 +43,6 @@ import Compiler.Proofs.IRGeneration.ParamLoading
 import Compiler.Proofs.IRGeneration.SupportedSpec
 import Compiler.Proofs.IRGeneration.SourceSemantics
 import Compiler.Proofs.IRGeneration.HelperSummaryEvidence
-import Compiler.Proofs.IRGeneration.HelperVoidCallCatalogRegression
 import Compiler.Proofs.Frames
 import Compiler.Proofs.YulGeneration.PatchRulesProofs
 import Compiler.Proofs.YulGeneration.ExecutionSummary

--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -1628,7 +1628,7 @@ theorem directInternalHelperCallHeadStepCatalogWithInternals_of_supportedEvidenc
     (hRuntime : SupportedRuntimeHelperTableInterface spec runtimeContract)
     (hsite :
       ∀ {scope calleeName args}
-        (hoccurs : StmtOccursAtScope initialScope scope
+        (_hoccurs : StmtOccursAtScope initialScope scope
           (Stmt.internalCall calleeName args) fn.body)
         (hmem : calleeName ∈ helperCallNames fn),
         (hHelpers.summaryOfCall hmem).summary.helperRank < hHelpers.helperRank →

--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -1550,6 +1550,107 @@ theorem compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_dire
         (irFuelSlack := irFuelSlack) hevidence)
       hresidual
 
+/-- Complete call-site evidence consumed by the void-call head-step catalog
+producer.  The sufficient-fuel field contains the selector-indexed
+`InternalHelperBodyExecContext`; the residual field covers exactly the
+low-fuel region left by the reviewed additive split. -/
+structure DirectInternalHelperCallSiteEvidence
+    (runtimeContract : IRContract) (spec : CompilationModel) (fields : List Field)
+    (scope : List String) (calleeName : String) (args : List Expr)
+    (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName) :
+    Type where
+  compiledIR : List YulStmt
+  argExprs : List YulExpr
+  helperBodySize : Nat
+  compile :
+    CompilationModel.compileStmt fields spec.events spec.errors .calldata [] false scope []
+      (Stmt.internalCall calleeName args) spec.functions = Except.ok compiledIR
+  compileArgs :
+    CompilationModel.compileInternalCallArgs fields .calldata spec.functions
+      calleeName args = Except.ok argExprs
+  sufficient :
+    ∀ runtime state stmtHelperFuel irFuel,
+      1 < stmtHelperFuel →
+      helperBodySize + 2 ≤ irFuel →
+      FunctionBody.bindingsExactlyMatchIRVarsOnScope scope runtime.bindings state →
+      FunctionBody.scopeNamesPresent scope runtime.bindings →
+      FunctionBody.bindingsBounded runtime.bindings →
+      FunctionBody.runtimeStateMatchesIR fields runtime state →
+      DirectInternalHelperCallSufficientFuelEvidence
+        (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
+        (scope := scope) (calleeName := calleeName) (args := args)
+        (argExprs := argExprs) hctx helperBodySize stmtHelperFuel irFuel runtime state
+  residual :
+    InternalCallWithInternalsAdditiveResidualBridge runtimeContract spec fields scope
+      calleeName args argExprs helperBodySize 0
+
+/-- An occurring direct void call contributes its callee to the supported
+body's helper inventory. -/
+theorem callee_mem_helperCallNames_of_internalCall_occursAtScope
+    {initialScope scope : List String} {fn : FunctionSpec}
+    {calleeName : String} {args : List Expr}
+    (hoccurs : StmtOccursAtScope initialScope scope
+      (Stmt.internalCall calleeName args) fn.body) :
+    calleeName ∈ helperCallNames fn := by
+  have go : ∀ {initialScope scope : List String} {stmts : List Stmt},
+      StmtOccursAtScope initialScope scope (Stmt.internalCall calleeName args) stmts →
+      calleeName ∈ stmtListInternalHelperCallNames stmts := by
+    intro initialScope scope stmts h
+    induction stmts generalizing initialScope scope with
+    | nil => cases h
+    | cons stmt rest ih =>
+        cases h with
+        | head =>
+            simp [stmtListInternalHelperCallNames, stmtInternalHelperCallNames]
+        | tail htail =>
+            simp only [stmtListInternalHelperCallNames, List.mem_append]
+            exact Or.inr (ih htail)
+  have hraw := go hoccurs
+  simpa [helperCallNames] using hraw
+
+/-- Tier-2 void-call producer.  It assembles the existing `WithInternals`
+catalog from supported helper inventory, selector-aware source summaries, the
+runtime helper table, decreasing-rank evidence, and call-site body
+correspondence evidence.  In particular, selector-aware soundness and
+`InternalHelperBodyExecContext` are explicit inputs; they are not inferred from
+`SupportedBodyHelperSummariesSound`, whose selector is zero. -/
+theorem directInternalHelperCallHeadStepCatalogWithInternals_of_supportedEvidence
+    {runtimeContract : IRContract} {spec : CompilationModel} {fields : List Field}
+    {initialScope : List String} {fn : FunctionSpec}
+    (hHelpers : SupportedBodyHelperInterface spec fn)
+    (hnodup : (spec.functions.map (·.name)).Nodup)
+    (_hSummaries : SourceSemantics.SupportedBodyHelperSummariesSound spec fn hHelpers)
+    (hSummariesAt :
+      ∀ selector calleeName (hmem : calleeName ∈ helperCallNames fn),
+        InternalHelperSummarySoundAtSelector selector spec
+          (hHelpers.summaryOfCall hmem).callee
+          (hHelpers.summaryContractOfCall hmem))
+    (hRuntime : SupportedRuntimeHelperTableInterface spec runtimeContract)
+    (hsite :
+      ∀ {scope calleeName args}
+        (hoccurs : StmtOccursAtScope initialScope scope
+          (Stmt.internalCall calleeName args) fn.body)
+        (hmem : calleeName ∈ helperCallNames fn),
+        (hHelpers.summaryOfCall hmem).summary.helperRank < hHelpers.helperRank →
+        DirectInternalHelperCallSiteEvidence runtimeContract spec fields scope
+          calleeName args
+          (directInternalHelperStatementContextBridge_of_supportedEvidence
+            hHelpers hSummariesAt hRuntime hmem)) :
+    DirectInternalHelperCallHeadStepCatalogWithInternals
+      runtimeContract spec fields initialScope fn := by
+  refine { call := ?_ }
+  intro scope calleeName args hoccurs
+  let hmem := callee_mem_helperCallNames_of_internalCall_occursAtScope hoccurs
+  let hctx := directInternalHelperStatementContextBridge_of_supportedEvidence
+    hHelpers hSummariesAt hRuntime hmem
+  have hrank := hHelpers.calleeRanksDecrease calleeName hmem
+  let site := hsite hoccurs hmem hrank
+  exact ⟨site.compiledIR,
+    compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_directContextFuelSplit
+      hctx hnodup
+      site.helperBodySize (irFuelSlack := 0)
+      site.compile site.compileArgs site.sufficient site.residual⟩
+
 abbrev DirectInternalHelperAssignSufficientFuelEvidence
     (names : List String)
     (hctx : DirectInternalHelperStatementContextBridge runtimeContract spec calleeName)

--- a/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
+++ b/Compiler/Proofs/IRGeneration/HelperSummaryEvidence.lean
@@ -442,7 +442,7 @@ private theorem mem_expressionHelper_eraseDups_singleton
     List.mem_of_mem_eraseDups_local hmem
   simpa using hraw
 
-private def helperB : FunctionSpec :=
+def helperB : FunctionSpec :=
   { name := "helperB"
     params := []
     returnType := none
@@ -450,7 +450,7 @@ private def helperB : FunctionSpec :=
     isInternal := true
     body := [Stmt.letVar "readOnlyLocal" (Expr.literal 0)] }
 
-private def helperA : FunctionSpec :=
+def helperA : FunctionSpec :=
   { name := "helperA"
     params := []
     returnType := none
@@ -478,7 +478,7 @@ private def expressionHelperCaller : FunctionSpec :=
     isInternal := true
     body := [Stmt.internalCall "helperB" []] }
 
-private def twoHelperSpec : CompilationModel :=
+def twoHelperSpec : CompilationModel :=
   { name := "TwoHelperEvidence"
     fields := []
     constructor := none

--- a/Compiler/Proofs/IRGeneration/HelperVoidCallCatalogRegression.lean
+++ b/Compiler/Proofs/IRGeneration/HelperVoidCallCatalogRegression.lean
@@ -19,7 +19,7 @@ theorem helperA_helperB_voidCall_catalogWithInternals_of_bodyEvidence
     (hRuntime : SupportedRuntimeHelperTableInterface twoHelperSpec runtimeContract)
     (hsite :
       ∀ {scope calleeName args}
-        (hoccurs : StmtOccursAtScope [] scope
+        (_hoccurs : StmtOccursAtScope [] scope
           (Stmt.internalCall calleeName args) helperA.body)
         (hmem : calleeName ∈ helperCallNames helperA),
         (helperA_supportedBodyHelperInterface.summaryOfCall hmem).summary.helperRank <

--- a/Compiler/Proofs/IRGeneration/HelperVoidCallCatalogRegression.lean
+++ b/Compiler/Proofs/IRGeneration/HelperVoidCallCatalogRegression.lean
@@ -1,0 +1,52 @@
+import Compiler.Proofs.IRGeneration.HelperSummaryEvidence
+import Compiler.Proofs.HelperStepProofs
+
+namespace Compiler.Proofs.IRGeneration.Regression
+
+open Compiler
+open Compiler.CompilationModel
+open Compiler.Proofs.HelperStepProofs
+
+/-- Concrete `helperA → helperB` void-call catalog witness.  The supplied
+call-site evidence is deliberately the final body-correspondence seam: its
+`sufficient` component contains the `InternalHelperBodyExecContext`, while the
+producer itself obtains the callee through the runtime table, uses the
+selector-aware exact summary, and passes the strict rank decrease to `hsite`.
+Consequently mutations that remove lookup, void-call execution, selector/world
+projection, body context, or rank evidence make this witness ill-typed. -/
+theorem helperA_helperB_voidCall_catalogWithInternals_of_bodyEvidence
+    {runtimeContract : IRContract}
+    (hRuntime : SupportedRuntimeHelperTableInterface twoHelperSpec runtimeContract)
+    (hsite :
+      ∀ {scope calleeName args}
+        (hoccurs : StmtOccursAtScope [] scope
+          (Stmt.internalCall calleeName args) helperA.body)
+        (hmem : calleeName ∈ helperCallNames helperA),
+        (helperA_supportedBodyHelperInterface.summaryOfCall hmem).summary.helperRank <
+            helperA_supportedBodyHelperInterface.helperRank →
+        DirectInternalHelperCallSiteEvidence runtimeContract twoHelperSpec [] scope
+          calleeName args
+          (directInternalHelperStatementContextBridge_of_supportedEvidence
+            helperA_supportedBodyHelperInterface
+            (fun selector calleeName hmem => by
+              have hname : calleeName = "helperB" := by
+                simpa [helperA, helperCallNames, stmtListInternalHelperCallNames,
+                  stmtInternalHelperCallNames, exprInternalHelperCallNames,
+                  exprListInternalHelperCallNames] using hmem
+              subst calleeName
+              exact helperB_exactSummary_soundAtSelector selector)
+            hRuntime hmem)) :
+    DirectInternalHelperCallHeadStepCatalogWithInternals
+      runtimeContract twoHelperSpec [] [] helperA := by
+  apply directInternalHelperCallHeadStepCatalogWithInternals_of_supportedEvidence
+    helperA_supportedBodyHelperInterface (by decide)
+    helperA_supportedBodyHelperInterface_summary_sound
+    (fun selector calleeName hmem => ?_) hRuntime hsite
+  have hname : calleeName = "helperB" := by
+    simpa [helperA, helperCallNames, stmtListInternalHelperCallNames,
+      stmtInternalHelperCallNames, exprInternalHelperCallNames,
+      exprListInternalHelperCallNames] using hmem
+  subst calleeName
+  exact helperB_exactSummary_soundAtSelector selector
+
+end Compiler.Proofs.IRGeneration.Regression

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -74,6 +74,7 @@ import Compiler.Proofs.IRGeneration.GenericInduction.StorageWord
 import Compiler.Proofs.IRGeneration.HelperBodyBridge
 import Compiler.Proofs.IRGeneration.HelperBodyShape
 import Compiler.Proofs.IRGeneration.HelperSummaryEvidence
+import Compiler.Proofs.IRGeneration.HelperVoidCallCatalogRegression
 import Compiler.Proofs.IRGeneration.IRInterpreter
 import Compiler.Proofs.IRGeneration.IRStorageWord
 import Compiler.Proofs.IRGeneration.InternalHelperBodyCorrespondence
@@ -1903,6 +1904,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.directInternalHelperStatementContextBridge_assignStepMatch_of_sufficientFuel
   Compiler.Proofs.HelperStepProofs.internalCallWithInternalsSufficientBridge_of_directContextEvidence
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCall_of_directContextFuelSplit
+  Compiler.Proofs.HelperStepProofs.callee_mem_helperCallNames_of_internalCall_occursAtScope
+  Compiler.Proofs.HelperStepProofs.directInternalHelperCallHeadStepCatalogWithInternals_of_supportedEvidence
   Compiler.Proofs.HelperStepProofs.internalCallAssignWithInternalsSufficientBridge_of_directContextEvidence
   Compiler.Proofs.HelperStepProofs.compiledStmtStepWithHelpersAndHelperIRWithInternals_internalCallAssign_of_directContextFuelSplit
   Compiler.Proofs.HelperStepProofs.evalIRCallWithInternals_of_compiledHelperWitness
@@ -3541,6 +3544,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Regression.helperB_exactSummary_soundAtSelector
   Compiler.Proofs.IRGeneration.Regression.helperA_compileStmtList_from_genuine_helper_body_generic
   Compiler.Proofs.IRGeneration.Regression.helperA_calls_helperB_rank_decreases
+
+  -- Compiler/Proofs/IRGeneration/HelperVoidCallCatalogRegression.lean
+  Compiler.Proofs.IRGeneration.Regression.helperA_helperB_voidCall_catalogWithInternals_of_bodyEvidence
 
   -- Compiler/Proofs/IRGeneration/IRInterpreter.lean
   -- Compiler.Proofs.IRGeneration.exprSize_lt_exprsSize_cons  -- private
@@ -6591,4 +6597,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6167 theorems/lemmas (4299 public, 1868 private, 0 sorry'd)
+-- Total: 6170 theorems/lemmas (4302 public, 1868 private, 0 sorry'd)

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -27,7 +27,7 @@ lean_lib «Contracts» where
     .one `Contracts.Common,
     .one `Contracts.Specs,
     .one `Contracts.Interpreter,
-    .andSubmodules `Contracts.Examples,
+    .submodules `Contracts.Examples,
     .andSubmodules `Contracts.Smoke,
     .andSubmodules `Contracts.Counter,
     .andSubmodules `Contracts.SimpleStorage,


### PR DESCRIPTION
## Summary

- produce `DirectInternalHelperCallHeadStepCatalogWithInternals` from supported helper inventory, selector-aware summary soundness, runtime helper lookup, decreasing rank, and explicit body execution evidence
- reuse the existing direct-context and compiled void-call fuel-split bridges
- add a concrete `helperA` to `helperB` regression witness that consumes runtime lookup, selector/world projection, rank evidence, and body correspondence
- update the generated PrintAxioms inventory

## Why

The selector-0 supported-summary interface alone cannot justify arbitrary runtime selectors. This producer makes selector-aware summary soundness and `InternalHelperBodyExecContext` evidence explicit at the API boundary.

## Validation

- `lake build PrintAxioms Compiler Contracts`
- `python3 scripts/generate_print_axioms.py --check`
- `make checks` (641 Python tests; ignored workspace-local `.elan` toolchain temporarily excluded from the source hygiene scan)
- `make test-evmyullean-fork`
- `git diff --check`

All validation ran on host CPU.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to Lean proof modules and build/axiom inventory wiring; no runtime, auth, or contract execution paths are modified.
> 
> **Overview**
> Introduces **`DirectInternalHelperCallSiteEvidence`** to bundle compilation, sufficient-fuel (`InternalHelperBodyExecContext`), and residual fuel-split evidence for void internal-helper calls, and proves **`directInternalHelperCallHeadStepCatalogWithInternals_of_supportedEvidence`**, which assembles the existing `WithInternals` head-step catalog from supported helper inventory while requiring **selector-aware** summary soundness and explicit body execution evidence (not the selector-0 supported-summary interface alone).
> 
> Adds a small lemma linking **`StmtOccursAtScope`** on an internal call to membership in **`helperCallNames`**, a regression theorem **`helperA_helperB_voidCall_catalogWithInternals_of_bodyEvidence`** that exercises the producer on the two-helper spec, and exports **`helperA`**, **`helperB`**, and **`twoHelperSpec`** from helper summary evidence for reuse. **`PrintAxioms`** and **`lakefile.lean`** (`Contracts.Examples` glob) are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ca4620ba6780b69e8c885809818a3fbfaa98706. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->