### PR TITLE
feat(macro): integrate external calls in contract bodies (#2245)

### DIFF
--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -7,6 +7,7 @@ import Contracts.Smoke.StructsAndArrays
 import Contracts.Smoke.HelperCalls
 import Contracts.Smoke.StructMappings
 import Contracts.Smoke.ExternalCalls
+import Contracts.Smoke.ExternalCallInBodySmoke
 import Contracts.Smoke.SpecGenAndChecks
 import Contracts.Smoke.Effects
 import Contracts.Smoke.Namespaces

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -1,0 +1,792 @@
+import Contracts.Common
+
+namespace Contracts.Smoke
+
+open Contracts
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+open Verity.Stdlib.Math
+
+def linkedOperandEcmModule : Compiler.ECM.ExternalCallModule where
+  name := "linkedOperandEcm"
+  numArgs := 1
+  resultVars := []
+  writesState := false
+  readsState := false
+  axioms := []
+  compile := fun _ctx _args => pure []
+
+def linkedWordPassthrough (value : Uint256) : Uint256 := value
+
+def linkedWordTwice (value : Uint256) : Uint256 := value + value
+
+def linkedBoolTruthy (value : Bool) : Bool := if value then true else false
+
+-- P0 #1003 coverage for linked calls and explicit low-level body syntax.
+-- `callExternal` is declaration-driven; target/value fields belong to `evmCall`.
+verity_contract ExternalCallInBodySmoke where
+  storage
+    values : Uint256 → Uint256 := slot 0
+  struct NarrowPair where
+    narrow : Uint32,
+    wide : Uint256
+  errors
+    error Failure(Uint256)
+
+  linked_externals
+    external getDepositableEther() -> (Uint256)
+    external deposit(Uint256, Bytes)
+    external narrowEcho(Bytes4) -> (Uint256)
+    external dirtyUint() -> (Uint32)
+    external dirtyUint_try() -> (Bool, Uint32)
+    external dirtyPair() -> (NarrowPair)
+    external dirtyPair_try() -> (Bool, NarrowPair)
+    external dirtyInt() -> (Int32)
+    external dirtyBytes() -> (Bytes4)
+    external dirtyAddress() -> (Address)
+    external dirtyBool() -> (Bool)
+    external dirtySink(Uint32) -> (Uint32)
+    external consumeUint8(Uint8)
+    external consumeUint16(Uint16)
+    external consume(Uint256)
+    external notifyBool(Bool)
+    external notifyBool_try(Bool) -> (Bool)
+  function reentrancy_trusted linkedRead () : Uint256 := do
+    let depositable ← callExternal getDepositableEther()
+    return depositable
+
+  function reentrancy_trusted linkedWrite (amount : Uint256, pubkey : Bytes) : Unit := do
+    callExternal deposit(amount, pubkey)
+
+  function reentrancy_trusted pureNarrow () : Uint256 := do
+    let result := callExternal narrowEcho(0xdeadbeef)
+    return result
+
+  function reentrancy_trusted pureDirtyUint () : Uint32 := do
+    let result := callExternal dirtyUint()
+    return result
+
+  function reentrancy_trusted directDirtyUint () : Uint32 := do
+    return callExternal dirtyUint()
+
+  function reentrancy_trusted nestedDirtyUint () : Bool := do
+    return (callExternal dirtyUint()) == 1
+
+  function reentrancy_trusted nestedExternalArg () : Uint32 := do
+    return callExternal dirtySink(callExternal dirtyUint())
+
+  function reentrancy_trusted storeDirtyUint ()
+    local_obligations [low_level_frame := assumed "Writing a linked-call result to memory is an explicit refinement boundary."]
+    : Unit := do
+    memoryStore(0, callExternal dirtyUint())
+
+  function reentrancy_trusted bindDirtyUint () : Uint32 := do
+    let result ← callExternal dirtyUint()
+    return result
+
+  function reentrancy_trusted tryDirtyUint () : Uint32 := do
+    let (_success, result) ← tryExternalCall "dirtyUint" []
+    return result
+
+  function reentrancy_trusted callResultDirtyUint () : Uint32 := do
+    let result ← callResult "dirtyUint" []
+    return result.returndata
+
+  function reentrancy_trusted tryNotifyBool (flag : Bool) : Bool := do
+    let success ← tryExternalCall "notifyBool" [flag]
+    return success
+
+  function reentrancy_trusted tryDirtyPair () : Uint32 := do
+    let (_success, result) ← tryExternalCall "dirtyPair" []
+    return result.narrow
+
+  function reentrancy_trusted bindDirtyAddress () : Address := do
+    let result ← callExternal dirtyAddress()
+    return result
+
+  function reentrancy_trusted bindDirtyBool () : Bool := do
+    let result ← callExternal dirtyBool()
+    return result
+
+  function reentrancy_trusted leanHelperNestedExternal () : Uint256 := do
+    return linkedWordPassthrough (callExternal narrowEcho(0xdeadbeef))
+
+  function reentrancy_trusted bindNestedExternalArg () : Uint32 := do
+    let result ← callExternal dirtySink(callExternal dirtyUint())
+    return result
+
+  function reentrancy_trusted statementNestedExternalArg () : Unit := do
+    callExternal consume(callExternal narrowEcho(0xdeadbeef))
+
+  function reentrancy_trusted logDirtyUint ()
+    local_obligations [low_level_frame := assumed "Logging a linked-call result is an explicit refinement boundary."]
+    : Unit := do
+    rawLog [callExternal dirtyUint()] 0 0
+
+  function reentrancy_trusted legacyNarrowArgs () : Unit := do
+    callExternal consumeUint8(0x100)
+    callExternal consumeUint16(0x10000)
+
+  function reentrancy_trusted emitNestedExternalArg () : Unit := do
+    emit "Seen" [callExternal narrowEcho(0xdeadbeef)]
+
+  function reentrancy_trusted customErrorNestedExternalArg () : Unit := do
+    requireError true Failure(callExternal narrowEcho(0xdeadbeef))
+
+  function consumeHelper (_value : Uint256) : Unit := do
+    pure ()
+
+  function reentrancy_trusted helperNestedExternalArg () : Unit := do
+    consumeHelper (callExternal narrowEcho(0xdeadbeef))
+
+  function reentrancy_trusted monadicLoadDirtyUint ()
+    local_obligations [low_level_frame := assumed "Reading memory through a linked-call offset is an explicit refinement boundary."]
+    : Uint256 := do
+    let value ← memoryLoad(callExternal dirtyUint())
+    return value
+
+  function reentrancy_trusted ecmNestedExternalArg () : Unit := do
+    ecmDo linkedOperandEcmModule [callExternal narrowEcho(0xdeadbeef)]
+
+  function reentrancy_trusted erc20BalanceNestedExternalArg () : Uint256 := do
+    let result ← balanceOf 1 (callExternal narrowEcho(0xdeadbeef))
+    return result
+
+  function reentrancy_trusted erc20AllowanceNestedExternalArg () : Uint256 := do
+    let result ← allowance 1 2 (callExternal narrowEcho(0xdeadbeef))
+    return result
+
+  function reentrancy_trusted erc20SupplyNestedExternalArg () : Uint256 := do
+    let result ← totalSupply (callExternal narrowEcho(0xdeadbeef))
+    return result
+
+  function reentrancy_trusted mappingNestedExternalArg () : Uint256 := do
+    let result ← getMappingUint values (callExternal narrowEcho(0xdeadbeef))
+    return result
+
+  function reentrancy_trusted tupleNestedExternalResult () : Uint32 := do
+    let (result, _) := (callExternal dirtyUint(), 0)
+    return result
+
+  function reentrancy_trusted tupleNestedExternalReturn () : Tuple [Uint32, Uint256] := do
+    return (callExternal dirtyUint(), 0)
+
+  function reentrancy_trusted tupleArrayLinkedIndexDestructure
+      (cuts : Array (Tuple [Uint256, Uint256])) : Uint256 := do
+    let (first, _) := arrayElement cuts (callExternal dirtyUint())
+    return first
+
+  function reentrancy_trusted tupleArrayLinkedIndexReturn
+      (cuts : Array (Tuple [Uint256, Uint256])) : Tuple [Uint256, Uint256] := do
+    return arrayElement cuts (callExternal dirtyUint())
+
+  function reentrancy_trusted pureDirtyInt () : Int32 := do
+    let result := callExternal dirtyInt()
+    return result
+
+  function reentrancy_trusted bindDirtyInt () : Int32 := do
+    let result ← callExternal dirtyInt()
+    return result
+
+  function reentrancy_trusted pureDirtyBytes () : Bytes4 := do
+    let result := callExternal dirtyBytes()
+    return result
+
+  function reentrancy_trusted bindDirtyBytes () : Bytes4 := do
+    let result ← callExternal dirtyBytes()
+    return result
+
+  function reentrancy_trusted lowLevel (target : Uint256, amount : Uint256)
+    local_obligations [low_level_frame := assumed "Raw EVM call, memory, and returndata choreography is an explicit refinement boundary."]
+    : Uint256 := do
+    memoryStore(0, amount)
+    let pureRoundtrip := add (memoryLoad(0)) 0
+    let roundtrip ← memoryLoad(0)
+    let success ← evmCall(50000, target, amount, 0, 32, 64, 32)
+    let observed ← evmStaticCall(50000, target, 0, 32, 64, 32)
+    let size ← returnDataSize()
+    returnDataCopy(96, 0, size)
+    return (add (add (add pureRoundtrip roundtrip) success) observed)
+
+  function reentrancy_trusted composedReturnDataSize ()
+    local_obligations [low_level_frame := assumed "Reading returndata size is an explicit refinement boundary."]
+    : Uint256 := do
+    return (add (returnDataSize()) 1)
+
+  function reentrancy_trusted discardedReturnDataSize ()
+    local_obligations [low_level_frame := assumed "Reading returndata size is an explicit refinement boundary."]
+    : Uint256 := do
+    let _ ← returnDataSize()
+    let _ ← (returnDataSize())
+    let parenthesized ← (returnDataSize())
+    return parenthesized
+
+verity_contract AdtLinkedPayloadSmoke where
+  inductive
+    Maybe := | Nothing | Just(value : Uint32)
+  storage
+    result : Maybe := slot 0
+  linked_externals
+    external dirtyUint() -> (Uint32)
+  function store () : Unit := do
+    setStorage result (adt "Just" [callExternal dirtyUint()])
+
+example : (AdtLinkedPayloadSmoke.store_modelBody).take 1 =
+    [.setStorage "result" (.adtConstruct "Maybe" "Just"
+      [(.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))])] := rfl
+
+example : (ExternalCallInBodySmoke.linkedRead_modelBody).take 1 =
+    [Compiler.CompilationModel.Stmt.externalCallBind
+      ["depositable"] "getDepositableEther" []] := rfl
+
+example : (ExternalCallInBodySmoke.linkedWrite_modelBody).take 1 =
+    [Compiler.CompilationModel.Stmt.externalCallBind [] "deposit"
+      [ .param "amount", .param "pubkey_data_offset", .param "pubkey_length" ]] := rfl
+
+example : (ExternalCallInBodySmoke.pureNarrow_modelBody).take 1 =
+    [Compiler.CompilationModel.Stmt.letVar "result"
+      (.externalCall "narrowEcho" [
+        .literal 100720434702924942364018397558880508427273416251376888068364465368051161759744])] := rfl
+
+example : ExternalCallInBodySmoke.pureNarrow_model.body =
+    ExternalCallInBodySmoke.pureNarrow_modelBody :=
+  ExternalCallInBodySmoke.pureNarrow_semantic_preservation
+
+example : (ExternalCallInBodySmoke.pureDirtyUint_modelBody).take 1 =
+    [.letVar "result" (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))] := rfl
+
+example : ExternalCallInBodySmoke.directDirtyUint_modelBody =
+    [.return (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))] := rfl
+
+example : ExternalCallInBodySmoke.nestedDirtyUint_modelBody =
+    [.return (.eq
+      (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))
+      (.literal 1))] := rfl
+
+example : ExternalCallInBodySmoke.nestedExternalArg_modelBody =
+    [.return (.bitAnd
+      (.externalCall "dirtySink"
+        [(.bitAnd
+          (.bitAnd (.externalCall "dirtyUint" []) (.literal 4294967295))
+          (.literal 4294967295))])
+      (.literal 4294967295))] := rfl
+
+example : ExternalCallInBodySmoke.storeDirtyUint_modelBody =
+    [.mstore (.literal 0)
+      (.bitAnd (.externalCall "dirtyUint" []) (.literal 4294967295)), .stop] := rfl
+
+example : (ExternalCallInBodySmoke.bindDirtyUint_modelBody).take 2 =
+    [ .externalCallBind ["result"] "dirtyUint" []
+    , .assignVar "result" (.bitAnd (.localVar "result") (.literal (2 ^ 32 - 1))) ] := rfl
+
+example : (ExternalCallInBodySmoke.tryDirtyUint_modelBody).take 2 =
+    [ .tryExternalCallBind "_success" ["result"] "dirtyUint" []
+    , .assignVar "_success" (.logicalNot (.eq (.localVar "_success") (.literal 0))) ] := rfl
+
+example : (ExternalCallInBodySmoke.callResultDirtyUint_modelBody).take 3 =
+    [ .tryExternalCallBind "result_success" ["result_returndata"] "dirtyUint" []
+    , .assignVar "result_success"
+        (.logicalNot (.eq (.localVar "result_success") (.literal 0)))
+    , .assignVar "result_returndata"
+        (.bitAnd (.localVar "result_returndata") (.literal (2 ^ 32 - 1))) ] := rfl
+
+example : (ExternalCallInBodySmoke.tryNotifyBool_modelBody).take 2 =
+    [.tryExternalCallBind "success" [] "notifyBool"
+      [(.logicalNot (.eq (.param "flag") (.literal 0)))],
+     .assignVar "success" (.logicalNot (.eq (.localVar "success") (.literal 0)))] := rfl
+
+example : (ExternalCallInBodySmoke.tryDirtyPair_modelBody).take 4 =
+    [ .tryExternalCallBind "_success" ["result_narrow", "result_wide"] "dirtyPair" []
+    , .assignVar "_success" (.logicalNot (.eq (.localVar "_success") (.literal 0)))
+    , .assignVar "result_narrow"
+        (.bitAnd (.localVar "result_narrow") (.literal (2 ^ 32 - 1)))
+    , .return (.localVar "result_narrow") ] := rfl
+
+example : (ExternalCallInBodySmoke.bindDirtyAddress_modelBody).take 2 =
+    [ .externalCallBind ["result"] "dirtyAddress" []
+    , .assignVar "result" (.bitAnd (.localVar "result") (.literal (2 ^ 160 - 1))) ] := rfl
+
+example : (ExternalCallInBodySmoke.bindDirtyBool_modelBody).take 2 =
+    [ .externalCallBind ["result"] "dirtyBool" []
+    , .assignVar "result" (.logicalNot (.eq (.localVar "result") (.literal 0))) ] := rfl
+
+example : ExternalCallInBodySmoke.leanHelperNestedExternal_modelBody =
+    [.return (.externalCall "narrowEcho"
+      [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])] := rfl
+
+example : (ExternalCallInBodySmoke.bindNestedExternalArg_modelBody).take 1 =
+    [.externalCallBind ["result"] "dirtySink"
+      [(.bitAnd
+        (.bitAnd (.externalCall "dirtyUint" []) (.literal 4294967295))
+        (.literal 4294967295))]] := rfl
+
+example : ExternalCallInBodySmoke.statementNestedExternalArg_modelBody =
+    [.externalCallBind [] "consume"
+      [(.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])],
+      .stop] := rfl
+
+example : ExternalCallInBodySmoke.logDirtyUint_modelBody =
+    [.rawLog [(.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1)))]
+      (.literal 0) (.literal 0), .stop] := rfl
+
+example : ExternalCallInBodySmoke.legacyNarrowArgs_modelBody =
+    [ .externalCallBind [] "consumeUint8" [(.bitAnd (.literal 0x100) (.literal 255))]
+    , .externalCallBind [] "consumeUint16" [(.bitAnd (.literal 0x10000) (.literal 65535))]
+    , .stop ] := rfl
+
+example : ExternalCallInBodySmoke.emitNestedExternalArg_modelBody =
+    [.emit "Seen"
+      [(.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])],
+      .stop] := rfl
+
+example : ExternalCallInBodySmoke.customErrorNestedExternalArg_modelBody =
+    [.requireError (.literal 1) "Failure"
+      [(.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])],
+      .stop] := rfl
+
+example : ExternalCallInBodySmoke.helperNestedExternalArg_modelBody =
+    [.internalCall "internal_consumeHelper"
+      [(.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])],
+      .stop] := rfl
+
+example : (ExternalCallInBodySmoke.monadicLoadDirtyUint_modelBody).take 1 =
+    [.letVar "value" (.mload
+      (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1))))] := rfl
+
+example : ExternalCallInBodySmoke.ecmNestedExternalArg_modelBody =
+    [.ecm linkedOperandEcmModule
+      [(.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])],
+      .stop] := rfl
+
+example : (ExternalCallInBodySmoke.erc20BalanceNestedExternalArg_modelBody).take 1 =
+    [.ecm (Compiler.Modules.ERC20.balanceOfModule "result")
+      [(.literal 1), (.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+
+example : (ExternalCallInBodySmoke.erc20AllowanceNestedExternalArg_modelBody).take 1 =
+    [.ecm (Compiler.Modules.ERC20.allowanceModule "result")
+      [(.literal 1), (.literal 2), (.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+
+example : (ExternalCallInBodySmoke.erc20SupplyNestedExternalArg_modelBody).take 1 =
+    [.ecm (Compiler.Modules.ERC20.totalSupplyModule "result")
+      [(.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)])]] := rfl
+
+example : (ExternalCallInBodySmoke.mappingNestedExternalArg_modelBody).take 1 =
+    [.letVar "result" (.mappingUint "values"
+      (.externalCall "narrowEcho"
+        [(.literal 100720434702924942364018397558880508427273416251376888068364465368051161759744)]))] := rfl
+
+example : ExternalCallInBodySmoke.mappingNestedExternalArg_model.body =
+    ExternalCallInBodySmoke.mappingNestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.mappingNestedExternalArg_semantic_preservation
+
+example : ExternalCallInBodySmoke.tupleNestedExternalResult_modelBody =
+    [.letVar "result" (.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1))),
+     .return (.localVar "result")] := rfl
+
+example : ExternalCallInBodySmoke.tupleNestedExternalReturn_modelBody =
+    [.returnValues [(.bitAnd (.externalCall "dirtyUint" []) (.literal (2 ^ 32 - 1))), .literal 0]] := rfl
+
+example : ExternalCallInBodySmoke.legacyNarrowArgs_model.body =
+    ExternalCallInBodySmoke.legacyNarrowArgs_modelBody :=
+  ExternalCallInBodySmoke.legacyNarrowArgs_semantic_preservation
+
+example : ExternalCallInBodySmoke.emitNestedExternalArg_model.body =
+    ExternalCallInBodySmoke.emitNestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.emitNestedExternalArg_semantic_preservation
+
+example : ExternalCallInBodySmoke.customErrorNestedExternalArg_model.body =
+    ExternalCallInBodySmoke.customErrorNestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.customErrorNestedExternalArg_semantic_preservation
+
+example : ExternalCallInBodySmoke.helperNestedExternalArg_model.body =
+    ExternalCallInBodySmoke.helperNestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.helperNestedExternalArg_semantic_preservation
+
+example : ExternalCallInBodySmoke.monadicLoadDirtyUint_model.body =
+    ExternalCallInBodySmoke.monadicLoadDirtyUint_modelBody :=
+  ExternalCallInBodySmoke.monadicLoadDirtyUint_semantic_preservation
+
+example : ExternalCallInBodySmoke.ecmNestedExternalArg_model.body =
+    ExternalCallInBodySmoke.ecmNestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.ecmNestedExternalArg_semantic_preservation
+
+example : (ExternalCallInBodySmoke.pureDirtyInt_modelBody).take 1 =
+    [.letVar "result" (.signextend (.literal 3) (.externalCall "dirtyInt" []))] := rfl
+
+example : (ExternalCallInBodySmoke.bindDirtyInt_modelBody).take 2 =
+    [ .externalCallBind ["result"] "dirtyInt" []
+    , .assignVar "result" (.signextend (.literal 3) (.localVar "result")) ] := rfl
+
+example : (ExternalCallInBodySmoke.pureDirtyBytes_modelBody).take 1 =
+    [.letVar "result" (.bitAnd (.externalCall "dirtyBytes" [])
+      (.literal ((2 ^ 32 - 1) * 2 ^ 224)))] := rfl
+
+example : (ExternalCallInBodySmoke.bindDirtyBytes_modelBody).take 2 =
+    [ .externalCallBind ["result"] "dirtyBytes" []
+    , .assignVar "result" (.bitAnd (.localVar "result")
+        (.literal ((2 ^ 32 - 1) * 2 ^ 224))) ] := rfl
+
+example : ExternalCallInBodySmoke.pureDirtyUint_model.body =
+    ExternalCallInBodySmoke.pureDirtyUint_modelBody :=
+  ExternalCallInBodySmoke.pureDirtyUint_semantic_preservation
+
+example : ExternalCallInBodySmoke.directDirtyUint_model.body =
+    ExternalCallInBodySmoke.directDirtyUint_modelBody :=
+  ExternalCallInBodySmoke.directDirtyUint_semantic_preservation
+
+example : ExternalCallInBodySmoke.nestedDirtyUint_model.body =
+    ExternalCallInBodySmoke.nestedDirtyUint_modelBody :=
+  ExternalCallInBodySmoke.nestedDirtyUint_semantic_preservation
+
+example : ExternalCallInBodySmoke.nestedExternalArg_model.body =
+    ExternalCallInBodySmoke.nestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.nestedExternalArg_semantic_preservation
+
+example : ExternalCallInBodySmoke.storeDirtyUint_model.body =
+    ExternalCallInBodySmoke.storeDirtyUint_modelBody :=
+  ExternalCallInBodySmoke.storeDirtyUint_semantic_preservation
+
+example : ExternalCallInBodySmoke.bindDirtyUint_model.body =
+    ExternalCallInBodySmoke.bindDirtyUint_modelBody :=
+  ExternalCallInBodySmoke.bindDirtyUint_semantic_preservation
+
+example : ExternalCallInBodySmoke.bindNestedExternalArg_model.body =
+    ExternalCallInBodySmoke.bindNestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.bindNestedExternalArg_semantic_preservation
+
+example : ExternalCallInBodySmoke.statementNestedExternalArg_model.body =
+    ExternalCallInBodySmoke.statementNestedExternalArg_modelBody :=
+  ExternalCallInBodySmoke.statementNestedExternalArg_semantic_preservation
+
+example : ExternalCallInBodySmoke.logDirtyUint_model.body =
+    ExternalCallInBodySmoke.logDirtyUint_modelBody :=
+  ExternalCallInBodySmoke.logDirtyUint_semantic_preservation
+
+example : ExternalCallInBodySmoke.pureDirtyInt_model.body =
+    ExternalCallInBodySmoke.pureDirtyInt_modelBody :=
+  ExternalCallInBodySmoke.pureDirtyInt_semantic_preservation
+
+example : ExternalCallInBodySmoke.bindDirtyInt_model.body =
+    ExternalCallInBodySmoke.bindDirtyInt_modelBody :=
+  ExternalCallInBodySmoke.bindDirtyInt_semantic_preservation
+
+example : ExternalCallInBodySmoke.pureDirtyBytes_model.body =
+    ExternalCallInBodySmoke.pureDirtyBytes_modelBody :=
+  ExternalCallInBodySmoke.pureDirtyBytes_semantic_preservation
+
+example : ExternalCallInBodySmoke.bindDirtyBytes_model.body =
+    ExternalCallInBodySmoke.bindDirtyBytes_modelBody :=
+  ExternalCallInBodySmoke.bindDirtyBytes_semantic_preservation
+
+example : (ExternalCallInBodySmoke.lowLevel_modelBody).take 7 =
+    [ Compiler.CompilationModel.Stmt.mstore (.literal 0) (.param "amount")
+    , Compiler.CompilationModel.Stmt.letVar "pureRoundtrip" (.add (.mload (.literal 0)) (.literal 0))
+    , Compiler.CompilationModel.Stmt.letVar "roundtrip" (.mload (.literal 0))
+    , Compiler.CompilationModel.Stmt.letVar "success" (.call (.literal 50000) (.param "target") (.param "amount")
+        (.literal 0) (.literal 32) (.literal 64) (.literal 32))
+    , Compiler.CompilationModel.Stmt.letVar "observed" (.staticcall (.literal 50000) (.param "target")
+        (.literal 0) (.literal 32) (.literal 64) (.literal 32))
+    , Compiler.CompilationModel.Stmt.letVar "size" .returndataSize
+    , Compiler.CompilationModel.Stmt.returndataCopy (.literal 96) (.literal 0) (.localVar "size") ] := rfl
+
+example : ExternalCallInBodySmoke.linkedRead_model.body =
+    ExternalCallInBodySmoke.linkedRead_modelBody :=
+  ExternalCallInBodySmoke.linkedRead_semantic_preservation
+
+example : ExternalCallInBodySmoke.linkedWrite_model.body =
+    ExternalCallInBodySmoke.linkedWrite_modelBody :=
+  ExternalCallInBodySmoke.linkedWrite_semantic_preservation
+
+example : ExternalCallInBodySmoke.lowLevel_model.body =
+    ExternalCallInBodySmoke.lowLevel_modelBody :=
+  ExternalCallInBodySmoke.lowLevel_semantic_preservation
+
+example : (ExternalCallInBodySmoke.discardedReturnDataSize_modelBody).take 3 =
+    [ Compiler.CompilationModel.Stmt.letVar "__discard" .returndataSize
+    , Compiler.CompilationModel.Stmt.letVar "__discard_1" .returndataSize
+    , Compiler.CompilationModel.Stmt.letVar "parenthesized" .returndataSize ] := rfl
+
+example : ExternalCallInBodySmoke.discardedReturnDataSize_model.body =
+    ExternalCallInBodySmoke.discardedReturnDataSize_modelBody :=
+  ExternalCallInBodySmoke.discardedReturnDataSize_semantic_preservation
+
+/-- error: unsupported expression in verity_contract body (see #1003 for planned macro support expansions) -/
+#guard_msgs in
+verity_contract MalformedEvmCallRejected where
+  storage
+  function bad (target : Uint256) : Uint256 := do
+    return evmCall(1, target)
+
+/-- error: callExternal 'scalarPair' expects 2 args, got 1 -/
+#guard_msgs in
+verity_contract MalformedLinkedCallRejected where
+  storage
+  linked_externals
+    external scalarPair(Uint256, Uint256) -> (Uint256)
+  function bad (payload : Bytes) : Uint256 := do
+    let result ← callExternal scalarPair(payload)
+    return result
+
+/-- error: callExternal 'scalarPair' expects 2 args, got 1 -/
+#guard_msgs in
+verity_contract MalformedPureLinkedCallRejected where
+  storage
+  linked_externals
+    external scalarPair(Uint256, Uint256) -> (Uint256)
+  function bad (payload : Bytes) : Uint256 := do
+    let result := callExternal scalarPair(payload)
+    return result
+
+/-- error: callExternal 'pair' return type cannot be bound to one source variable; bind composite results explicitly -/
+#guard_msgs in
+verity_contract CompositeLinkedCallBindRejected where
+  storage
+  linked_externals
+    external pair(Uint256) -> (Tuple [Uint256, Uint256])
+  function bad (value : Uint256) : Tuple [Uint256, Uint256] := do
+    let result ← callExternal pair(value)
+    return result
+
+/-- error: callExternal 'single' return type cannot be bound to one source variable; bind composite results explicitly -/
+#guard_msgs in
+verity_contract SingleLeafCompositeLinkedCallBindRejected where
+  storage
+  struct Single where
+    value : Uint256
+  linked_externals
+    external single() -> (Single)
+  function bad () : Single := do
+    let result ← callExternal single()
+    return result
+
+/-- error: callExternal 'pair' return type cannot be used as a pure single-word expression -/
+#guard_msgs in
+verity_contract CompositePureLinkedCallRejected where
+  storage
+  linked_externals
+    external pair(Uint256) -> (Tuple [Uint256, Uint256])
+  function bad (value : Uint256) : Tuple [Uint256, Uint256] := do
+    let result := callExternal pair(value)
+    return result
+
+/-- error: requireSomeUint operands cannot contain callExternal because safe-arithmetic lowering reuses operands in both the guard and result; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulSafeArithmeticOperandRejected where
+  storage
+  linked_externals
+    external dirtyUint() -> (Uint32)
+  function bad () : Uint256 := do
+    let result ← requireSomeUint (safeAdd (callExternal dirtyUint()) 1) "overflow"
+    return result
+
+/-- error: conditional operands cannot contain callExternal because expression lowering duplicates the condition and evaluates both branches; use statement-level control flow -/
+#guard_msgs in
+verity_contract EffectfulConditionalBranchRejected where
+  storage
+  linked_externals
+    external dirtyUint() -> (Uint32)
+  function bad (flag : Bool) : Uint32 := do
+    return ite flag (callExternal dirtyUint()) 0
+
+/-- error: conditional operands cannot contain callExternal because expression lowering duplicates the condition and evaluates both branches; use statement-level control flow -/
+#guard_msgs in
+verity_contract EffectfulConditionalConditionRejected where
+  storage
+  linked_externals
+    external dirtyBool() -> (Bool)
+  function bad () : Uint256 := do
+    return ite (callExternal dirtyBool()) 1 0
+
+/-- error: conditional operands cannot contain callExternal because expression lowering duplicates the condition and evaluates both branches; use statement-level control flow -/
+#guard_msgs in
+verity_contract EffectfulEvmCallConditionalBranchRejected where
+  storage
+  function bad (target : Address) : Uint256 := do
+    return ite false (evmCall(50000, target, 0, 0, 0, 0, 0)) 0
+
+/-- error: conditional operands cannot contain callExternal because expression lowering duplicates the condition and evaluates both branches; use statement-level control flow -/
+#guard_msgs in
+verity_contract EffectfulEvmStaticCallConditionalBranchRejected where
+  storage
+  function bad (target : Address) : Uint256 := do
+    return ite false (evmStaticCall(50000, target, 0, 0, 0, 0)) 0
+
+/-- error: duplicated expression operands cannot contain callExternal; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulDuplicatedOperandRejected where
+  storage
+  linked_externals
+    external dirtyUint() -> (Uint32)
+  function bad () : Uint256 := do
+    return min (callExternal dirtyUint()) 1
+
+/-- error: tryExternalCall 'dirtyPair' flattened result variable 'result_narrow' conflicts with an existing local -/
+#guard_msgs in
+verity_contract FlattenedTryResultCollisionRejected where
+  storage
+  struct NarrowPair where
+    narrow : Uint32,
+    wide : Uint256
+  linked_externals
+    external dirtyPair() -> (NarrowPair)
+  function bad () : Uint32 := do
+    let result_narrow := 7
+    let (_success, result) ← tryExternalCall "dirtyPair" []
+    return result.narrow
+
+/-- error: short-circuit logical operands cannot contain callExternal because expression lowering evaluates both operands; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulShortCircuitOperandRejected where
+  storage
+  linked_externals
+    external dirtyBool() -> (Bool)
+  function bad (flag : Bool) : Bool := do
+    return flag && callExternal dirtyBool()
+
+/-- error: Lean helper 'linkedWordTwice' arguments cannot contain callExternal unless the helper is a direct passthrough because transparent-helper and expression lowering may duplicate or discard arguments; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulTransparentHelperArgumentRejected where
+  storage
+  linked_externals
+    external dirtyWord() -> (Uint256)
+  function bad () : Uint256 := do
+    return linkedWordTwice (callExternal dirtyWord())
+
+/-- error: Lean helper 'linkedBoolTruthy' arguments cannot contain callExternal unless the helper is a direct passthrough because transparent-helper and expression lowering may duplicate or discard arguments; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulTransparentHelperLoweringRejected where
+  storage
+  linked_externals
+    external dirtyBool() -> (Bool)
+  function bad () : Bool := do
+    return linkedBoolTruthy (callExternal dirtyBool())
+
+/-- error: mulDivUp divisor cannot contain callExternal because expression lowering reuses it; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulMulDivUpDivisorRejected where
+  storage
+  linked_externals
+    external dirtyWord() -> (Uint256)
+  function bad () : Uint256 := do
+    return mulDivUp 10 2 (callExternal dirtyWord())
+
+/-- error: msb operand cannot contain callExternal because expression lowering reuses it in the zero check and clz; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulMsbOperandRejected where
+  storage
+  linked_externals
+    external dirtyWord() -> (Uint256)
+  function bad () : Uint256 := do
+    return msb (callExternal dirtyWord())
+
+/-- error: boolToWord operand cannot contain callExternal because expression lowering evaluates its condition more than once; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulBoolToWordOperandRejected where
+  storage
+  linked_externals
+    external dirtyBool() -> (Bool)
+  function bad () : Uint256 := do
+    return boolToWord (callExternal dirtyBool())
+
+/-- error: arrayElement alias index cannot contain callExternal because the alias re-evaluates its index at each projection; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulArrayElementAliasIndexRejected where
+  storage
+  struct Payload where
+    values : Array Uint256
+  linked_externals
+    external dirtyIndex() -> (Uint256)
+  function bad (payloads : Array Payload) : Uint256 := do
+    let item := arrayElement payloads (callExternal dirtyIndex())
+    return arrayLength item.values
+
+/-- error: structMembers key cannot contain callExternal when selecting multiple members because lowering reuses the key; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulStructMembersKeyRejected where
+  storage
+    records : MappingStruct(Uint256, [first : Uint256 @word 0, second : Uint256 @word 1]) := slot 0
+  linked_externals
+    external dirtyKey() -> (Uint256)
+  function bad () : Tuple [Uint256, Uint256] := do
+    return structMembers records (callExternal dirtyKey()) ["first", "second"]
+
+/-- error: structMembers2 keys cannot contain callExternal when selecting multiple members because lowering reuses the keys; bind external results first -/
+#guard_msgs in
+verity_contract EffectfulStructMembers2KeyRejected where
+  storage
+    records : MappingStruct2(Uint256, Uint256, [first : Uint256 @word 0, second : Uint256 @word 1]) := slot 0
+  linked_externals
+    external dirtyKey() -> (Uint256)
+  function bad (outerKey : Uint256) : Tuple [Uint256, Uint256] := do
+    return structMembers2 records outerKey (callExternal dirtyKey()) ["first", "second"]
+
+/-- error: dynamic projection indices cannot contain callExternal because ABI lowering reuses the index for offset and length; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulDynamicProjectionIndexRejected where
+  storage
+  struct Payload where
+    values : Array Uint256
+  linked_externals
+    external dirtyUint() -> (Uint32)
+    external consume(Array Uint256)
+  function bad (payloads : Array Payload) : Unit := do
+    callExternal consume((arrayElement payloads (callExternal dirtyUint())).values)
+
+/-- error: ECM dynamic projection indices cannot contain callExternal because ABI lowering reuses the index for offset and length; bind the external result first -/
+#guard_msgs in
+verity_contract EffectfulEcmDynamicProjectionIndexRejected where
+  storage
+  struct Payload where
+    values : Array Uint256
+  linked_externals
+    external dirtyUint() -> (Uint32)
+  function bad (payloads : Array Payload) : Unit := do
+    ecmBind [] linkedOperandEcmModule [(arrayElement payloads (callExternal dirtyUint())).values]
+
+/-- error: memory-store value requires a word-like value (Uint256, Int256, Uint8, Address, or Bytes32), got Verity.Macro.ValueType.bytes -/
+#guard_msgs in
+verity_contract DynamicMemoryStoreRejected where
+  storage
+  function bad (payload : Bytes) : Unit := do
+    memoryStore(0, payload)
+
+/-- error: returndata-copy destination offset requires a word-like value (Uint256, Int256, Uint8, Address, or Bytes32), got Verity.Macro.ValueType.bytes -/
+#guard_msgs in
+verity_contract DynamicReturnDataCopyRejected where
+  storage
+  function bad (payload : Bytes) : Unit := do
+    returnDataCopy(payload, 0, 32)
+
+example : ExternalCallInBodySmoke.tupleArrayLinkedIndexDestructure_modelBody =
+    [ Compiler.CompilationModel.Stmt.letVar "arrayElement_index"
+        (Compiler.CompilationModel.Expr.bitAnd
+          (Compiler.CompilationModel.Expr.externalCall "dirtyUint" [])
+          (Compiler.CompilationModel.Expr.literal 0xffffffff))
+    , Compiler.CompilationModel.Stmt.letVar "first"
+        (Compiler.CompilationModel.Expr.arrayElementWord "cuts"
+          (Compiler.CompilationModel.Expr.localVar "arrayElement_index") 2 0)
+    , Compiler.CompilationModel.Stmt.return
+        (Compiler.CompilationModel.Expr.localVar "first") ] := by
+  rfl
+
+example : ExternalCallInBodySmoke.tupleArrayLinkedIndexReturn_modelBody =
+    [ Compiler.CompilationModel.Stmt.letVar "arrayElement_index"
+        (Compiler.CompilationModel.Expr.bitAnd
+          (Compiler.CompilationModel.Expr.externalCall "dirtyUint" [])
+          (Compiler.CompilationModel.Expr.literal 0xffffffff))
+    , Compiler.CompilationModel.Stmt.returnValues
+        [ Compiler.CompilationModel.Expr.arrayElementWord "cuts"
+            (Compiler.CompilationModel.Expr.localVar "arrayElement_index") 2 0
+        , Compiler.CompilationModel.Expr.arrayElementWord "cuts"
+            (Compiler.CompilationModel.Expr.localVar "arrayElement_index") 2 1 ] ] := by
+  rfl
+
+end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -177,6 +177,8 @@ example :
           [ Compiler.CompilationModel.Expr.param "leaves_data_offset"
           , Compiler.CompilationModel.Expr.param "leaves_length"
           ]
+      , Compiler.CompilationModel.Stmt.assignVar "_success"
+          (.logicalNot (.eq (.localVar "_success") (.literal 0)))
       , Compiler.CompilationModel.Stmt.return
           (Compiler.CompilationModel.Expr.localVar "h")
       ] := rfl
@@ -222,6 +224,8 @@ example :
               (Compiler.CompilationModel.Expr.param "idx")
               1
           ]
+      , Compiler.CompilationModel.Stmt.assignVar "_success"
+          (.logicalNot (.eq (.localVar "_success") (.literal 0)))
       , Compiler.CompilationModel.Stmt.return
           (Compiler.CompilationModel.Expr.localVar "h")
       ] := rfl
@@ -257,6 +261,8 @@ example :
               (Compiler.CompilationModel.Expr.param "idx")
               3
           ]
+      , Compiler.CompilationModel.Stmt.assignVar "_success"
+          (.logicalNot (.eq (.localVar "_success") (.literal 0)))
       , Compiler.CompilationModel.Stmt.return
           (Compiler.CompilationModel.Expr.localVar "h")
       ] := rfl

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -130,6 +130,17 @@ syntax "adt " str : term
 syntax "adt " str " [" sepBy(term, ",") "]" : term
 syntax "tryCatch " term:max ppSpace term:max : doElem
 
+-- Explicit function-body spellings for the P0 low-level interaction surface.
+-- `callExternal` is declaration-driven; `evmCall`/`evmStaticCall` expose the
+-- EVM fields directly and intentionally use distinct names.
+syntax (name := callExternalTerm) "callExternal " ident "(" sepBy(term, ",") ")" : term
+syntax (name := evmCallTerm) "evmCall(" sepBy(term, ",") ")" : term
+syntax (name := evmStaticCallTerm) "evmStaticCall(" sepBy(term, ",") ")" : term
+syntax (name := memoryLoadTerm) "memoryLoad(" term ")" : term
+syntax (name := returnDataSizeTerm) "returnDataSize()" : term
+syntax (name := memoryStoreTerm) "memoryStore(" term "," term ")" : term
+syntax (name := returnDataCopyTerm) "returnDataCopy(" term "," term "," term ")" : term
+
 -- Compile-time Keccak-256 of a string literal (#1973). The hash is
 -- materialised at elaboration time (outside contracts) or contract
 -- translation time (inside `verity_contract` bodies). Non-literal
@@ -139,6 +150,21 @@ syntax "tryCatch " term:max ppSpace term:max : doElem
 syntax:max (name := keccakStringTerm) "keccakString " str : term
 
 macro_rules
+  | `(doElem| let _ ← (returnDataSize())) =>
+      `(doElem| let _ ← (fun s => .success 0 s))
+  | `(doElem| let $name:ident ← (returnDataSize())) =>
+      `(doElem| let $name ← (fun s => .success 0 s))
+  | `(doElem| let _ ← returnDataSize()) =>
+      `(doElem| let _ ← (fun s => .success 0 s))
+  | `(doElem| let $name:ident ← returnDataSize()) =>
+      `(doElem| let $name ← (fun s => .success 0 s))
+  | `(callExternal $_name:ident ($[$_args:term],*)) => `(by exact default)
+  | `(evmCall($[$_args:term],*)) => `(by exact default)
+  | `(evmStaticCall($[$_args:term],*)) => `(by exact default)
+  | `(memoryLoad($_offset)) => `(by exact default)
+  | `(returnDataSize()) => `(0)
+  | `(memoryStore($_offset, $_value)) => `(by exact default)
+  | `(returnDataCopy($_destOffset, $_sourceOffset, $_size)) => `(by exact default)
   | `(intrinsic $_name:term $_lowering:term $_args:term) =>
       `(panic! "verity intrinsic has no default EDSL semantics; add a consumer macro_rules override")
   | `(intrinsic_cancun $_name:term $_lowering:term $_args:term) =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -38,13 +38,16 @@ private def translateCustomErrorArgExprs
     (locals : Array TypedLocal)
     (errorDecls : Array ErrorDecl)
     (errorName : String)
-    (args : Array Term) : CommandElabM (Array Term) := do
+    (args : Array Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Array Term) := do
   let some errorDecl := errorDecls.find? (fun decl => decl.name == errorName)
     | throwError s!"unknown custom error '{errorName}'"
   if args.size != errorDecl.params.size then
     throwError s!"custom error '{errorName}' expects {errorDecl.params.size} args, got {args.size}"
   args.zip errorDecl.params |>.mapM fun (arg, expectedTy) => do
-    let raw ← translatePureExprWithTypes fields constDecls immutableDecls params locals arg
+    let raw ← match translateExpr? with
+      | some translate => translate arg
+      | none => translatePureExprWithTypes fields constDecls immutableDecls params locals arg
     normalizeTranslatedExprForType expectedTy arg raw
 
 mutual
@@ -184,6 +187,9 @@ private partial def validateDoElemExprTypes
       | `(doElem| let $name:ident := $rhs:term) =>
           match arrayElementAliasSource? params rhs with
           | some (paramName, index, elemTy) =>
+              if syntaxContainsCallExternal index then
+                throwErrorAt index
+                  "arrayElement alias index cannot contain callExternal because the alias re-evaluates its index at each projection; bind the external result first"
               requireWordLikeType index "arrayElement alias index"
                 (← inferPureExprType fields constDecls immutableDecls externalDecls params locals index)
               pure <| locals.push
@@ -441,14 +447,21 @@ private partial def validateEffectStmtExprTypes
       requireDeclaredValueType value "setMemoryArrayElement value" elemTy
         (← inferPureExprType fields constDecls immutableDecls externalDecls params locals value)
       pure ()
-  | `(term| mstore $offset:term $value:term) | `(term| tstore $offset:term $value:term) => do
-      let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals offset
-      let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals value
+  | `(term| mstore $offset:term $value:term) | `(term| memoryStore($offset, $value))
+    | `(term| tstore $offset:term $value:term) => do
+      requireWordLikeType offset "memory-store offset"
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals offset)
+      requireWordLikeType value "memory-store value"
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals value)
   | `(term| calldatacopy $destOffset:term $sourceOffset:term $size:term)
-    | `(term| returndataCopy $destOffset:term $sourceOffset:term $size:term) => do
-      let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals destOffset
-      let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals sourceOffset
-      let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals size
+    | `(term| returndataCopy $destOffset:term $sourceOffset:term $size:term)
+    | `(term| returnDataCopy($destOffset, $sourceOffset, $size)) => do
+      requireWordLikeType destOffset "returndata-copy destination offset"
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals destOffset)
+      requireWordLikeType sourceOffset "returndata-copy source offset"
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals sourceOffset)
+      requireWordLikeType size "returndata-copy size"
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals size)
   | `(term| rawLog $topics:term $dataOffset:term $dataSize:term) => do
       match stripParens topics with
       | `(term| [ $[$xs],* ]) =>
@@ -499,6 +512,16 @@ private partial def validateEffectStmtExprTypes
           for x in xs do
             let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals x
       | _ => throwErrorAt args "expected list literal [..]"
+  | `(term| callExternal $name:ident ($[$args:term],*)) => do
+      let extName := toString name.getId
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown linked external '{extName}'"
+      unless ext.returnTys.isEmpty do
+        throwErrorAt stx s!"callExternal '{extName}' returns values; bind it with `let ... ← ...`"
+      validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+        extName ext.params args
+      let _ ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
   | `(term| revertReturndata) =>
       pure ()
   | _ =>
@@ -586,6 +609,7 @@ private def translateERC20BindStmt?
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
     (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
     (functions : Array FunctionDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
@@ -599,8 +623,8 @@ private def translateERC20BindStmt?
           throwErrorAt rhs
             s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
       | none =>
-          let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-          let ownerExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals owner
+          let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
+          let ownerExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals owner
           pure <| some (← `(Compiler.CompilationModel.Stmt.ecm
             (Compiler.Modules.ERC20.balanceOfModule $(strTerm varName))
             [$tokenExpr, $ownerExpr]))
@@ -610,9 +634,9 @@ private def translateERC20BindStmt?
           throwErrorAt rhs
             s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
       | none =>
-          let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-          let ownerExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals owner
-          let spenderExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals spender
+          let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
+          let ownerExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals owner
+          let spenderExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals spender
           pure <| some (← `(Compiler.CompilationModel.Stmt.ecm
             (Compiler.Modules.ERC20.allowanceModule $(strTerm varName))
             [$tokenExpr, $ownerExpr, $spenderExpr]))
@@ -622,7 +646,7 @@ private def translateERC20BindStmt?
           throwErrorAt rhs
             s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
       | none =>
-          let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
+          let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
           pure <| some (← `(Compiler.CompilationModel.Stmt.ecm
             (Compiler.Modules.ERC20.totalSupplyModule $(strTerm varName))
             [$tokenExpr]))
@@ -665,13 +689,15 @@ private def translateAdtConstructForStorage
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
     (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (adtName : String)
     (value : Term) : CommandElabM Term := do
   match adtConstructorSyntax? value with
   | some (variantName, args) =>
-      let argExprs ← args.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+      let argExprs ← args.mapM
+        (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals)
       `(Compiler.CompilationModel.Expr.adtConstruct
           $(strTerm adtName)
           $(strTerm variantName)
@@ -705,9 +731,9 @@ private def translateEffectStmt
           throwErrorAt stx
             s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
       | _ =>
-          let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-          let toExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals to
-          let amountExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals amount
+          let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
+          let toExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals to
+          let amountExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals amount
           `(Compiler.CompilationModel.Stmt.ecm
               Compiler.Modules.ERC20.safeTransferModule
               [$tokenExpr, $toExpr, $amountExpr])
@@ -717,10 +743,10 @@ private def translateEffectStmt
           throwErrorAt stx
             s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
       | _ =>
-          let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-          let fromExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals fromAddr
-          let toExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals to
-          let amountExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals amount
+          let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
+          let fromExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals fromAddr
+          let toExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals to
+          let amountExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals amount
           `(Compiler.CompilationModel.Stmt.ecm
               Compiler.Modules.ERC20.safeTransferFromModule
               [$tokenExpr, $fromExpr, $toExpr, $amountExpr])
@@ -730,9 +756,9 @@ private def translateEffectStmt
            throwErrorAt stx
              s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
        | _ =>
-           let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-           let spenderExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals spender
-           let amountExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals amount
+           let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
+           let spenderExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals spender
+           let amountExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals amount
            `(Compiler.CompilationModel.Stmt.ecm
                Compiler.Modules.ERC20.safeApproveModule
                [$tokenExpr, $spenderExpr, $amountExpr])
@@ -742,9 +768,9 @@ private def translateEffectStmt
            throwErrorAt stx
              s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
        | _ =>
-           let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-           let toExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals to
-           let amountExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals amount
+           let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
+           let toExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals to
+           let amountExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals amount
            `(Compiler.CompilationModel.Stmt.ecm
                Compiler.Modules.ERC20.legacyStringSafeTransferModule
                [$tokenExpr, $toExpr, $amountExpr])
@@ -754,16 +780,18 @@ private def translateEffectStmt
            throwErrorAt stx
              s!"ERC-20 helper form '{localFn.name}' conflicts with contract function '{localFn.name}'; rename the function or avoid the direct helper syntax here"
        | _ =>
-           let tokenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals token
-           let fromExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals fromAddr
-           let toExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals to
-           let amountExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals amount
+           let tokenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals token
+           let fromExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals fromAddr
+           let toExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals to
+           let amountExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals amount
            `(Compiler.CompilationModel.Stmt.ecm
                Compiler.Modules.ERC20.legacyStringSafeTransferFromModule
                [$tokenExpr, $fromExpr, $toExpr, $amountExpr])
    | `(term| ecmDo $module:term $args:term) =>
       validateEffectOnlyEcmModuleTerm module
       let argExprs ← expectExprList fields constDecls immutableDecls params locals args
+        (some (translateDeclaredPureExpr
+          fields constDecls immutableDecls externalDecls params locals))
       `(Compiler.CompilationModel.Stmt.ecm
           $module
           [ $[$argExprs],* ])
@@ -773,16 +801,16 @@ private def translateEffectStmt
       | some adtName =>
           `(Compiler.CompilationModel.Stmt.setStorage
               $(strTerm f.name)
-              $(← translateAdtConstructForStorage fields constDecls immutableDecls params locals adtName value))
+              $(← translateAdtConstructForStorage fields constDecls immutableDecls externalDecls params locals adtName value))
       | none =>
           match f.ty with
           | .scalar .uint256 | .scalar .int256 | .scalar .uint16 | .scalar (.uintN _)
           | .scalar (.newtype _ .uint256) =>
-              `(Compiler.CompilationModel.Stmt.setStorage $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              `(Compiler.CompilationModel.Stmt.setStorage $(strTerm f.name) $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
           | .scalar (.adt adtName _) =>
               `(Compiler.CompilationModel.Stmt.setStorage
                   $(strTerm f.name)
-                  $(← translateAdtConstructForStorage fields constDecls immutableDecls params locals adtName value))
+                  $(← translateAdtConstructForStorage fields constDecls immutableDecls externalDecls params locals adtName value))
           | .scalar .address | .scalar (.newtype _ .address) =>
               throwErrorAt stx s!"field '{f.name}' is Address-valued; use setStorageAddr"
           | .dynamicArray _ =>
@@ -793,7 +821,7 @@ private def translateEffectStmt
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with
       | .scalar .address | .scalar (.newtype _ .address) =>
-          `(Compiler.CompilationModel.Stmt.setStorageAddr $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+          `(Compiler.CompilationModel.Stmt.setStorageAddr $(strTerm f.name) $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .scalar .uint256 | .scalar (.newtype _ .uint256) =>
           throwErrorAt stx s!"field '{f.name}' is Uint256-valued; use setStorage"
       | .dynamicArray _ | .scalar (.fixedArray (.uintN 128) _) =>
@@ -807,7 +835,7 @@ private def translateEffectStmt
           `(Compiler.CompilationModel.Stmt.setStorageWord
               $(strTerm f.name)
               $(natTerm (← natFromSyntax wordOffset))
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .dynamicArray _ =>
           throwErrorAt stx s!"field '{f.name}' is a storage dynamic array; setPackedStorage requires a scalar root slot"
       | .mappingAddressToUint256 | .mappingUintToUint256 | .mapping2AddressToAddressToUint256
@@ -820,13 +848,13 @@ private def translateEffectStmt
       | .mappingAddressToUint256 | .mappingAddressToEnum _ _ =>
           `(Compiler.CompilationModel.Stmt.setMapping
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .mappingUintToUint256 | .mappingUintToEnum _ _ =>
           `(Compiler.CompilationModel.Stmt.setMappingUint
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .mapping2AddressToAddressToUint256 | .mapping2AddressToAddressToEnum _ _ =>
           throwErrorAt stx s!"field '{f.name}' is a double mapping; use setMapping2"
       | .mappingChain _ | .mappingChainEnum _ _ _ =>
@@ -842,8 +870,8 @@ private def translateEffectStmt
       | .mappingAddressToUint256 =>
           `(Compiler.CompilationModel.Stmt.setMapping
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .mappingUintToUint256 =>
           throwErrorAt stx s!"field '{f.name}' is Uint256-keyed; use setMappingUintAddr"
       | .mappingAddressToEnum _ _ | .mappingUintToEnum _ _ =>
@@ -863,8 +891,8 @@ private def translateEffectStmt
       | .mappingUintToUint256 | .mappingUintToEnum _ _ =>
           `(Compiler.CompilationModel.Stmt.setMappingUint
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .mappingAddressToUint256 | .mappingAddressToEnum _ _ =>
           throwErrorAt stx s!"field '{f.name}' is Address-keyed; use setMapping"
       | .mapping2AddressToAddressToUint256 | .mapping2AddressToAddressToEnum _ _ =>
@@ -882,8 +910,8 @@ private def translateEffectStmt
       | .mappingUintToUint256 =>
           `(Compiler.CompilationModel.Stmt.setMappingUint
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .mappingAddressToUint256 =>
           throwErrorAt stx s!"field '{f.name}' is Address-keyed; use setMappingAddr"
       | .mappingAddressToEnum _ _ | .mappingUintToEnum _ _ =>
@@ -904,9 +932,9 @@ private def translateEffectStmt
         | .mappingAddressToEnum _ _ | .mappingUintToEnum _ _ =>
           `(Compiler.CompilationModel.Stmt.setMappingWord
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key)
               $wordOffset
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .mapping2AddressToAddressToUint256 | .mapping2AddressToAddressToEnum _ _ =>
           throwErrorAt stx s!"field '{f.name}' is a double mapping; use setMapping2Word"
       | .mappingStruct _ _ =>
@@ -924,9 +952,9 @@ private def translateEffectStmt
       | .mapping2AddressToAddressToUint256 | .mapping2AddressToAddressToEnum _ _ =>
           `(Compiler.CompilationModel.Stmt.setMapping2
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key1)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key2)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | .mappingStruct2 _ _ _ =>
           throwErrorAt stx s!"field '{f.name}' is a nested struct mapping; use setStructMember2"
       | .mappingStruct _ _ =>
@@ -939,11 +967,11 @@ private def translateEffectStmt
       | some keyTypes =>
           if keyTerms.size != keyTypes.length then
             throwErrorAt stx s!"field '{f.name}' expects {keyTypes.length} mapping keys, but setMappingN received {keyTerms.size}"
-          let keyExprs ← keyTerms.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+          let keyExprs ← keyTerms.mapM (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals)
           `(Compiler.CompilationModel.Stmt.setMappingChain
               $(strTerm f.name)
               [ $[$keyExprs],* ]
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | none =>
           match f.ty with
           | .mappingStruct _ _ | .mappingStruct2 _ _ _ =>
@@ -955,7 +983,7 @@ private def translateEffectStmt
       | .dynamicArray _ =>
           `(Compiler.CompilationModel.Stmt.storageArrayPush
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | _ => throwErrorAt stx s!"field '{f.name}' is not a storage dynamic array"
   | `(term| popStorageArray $field:ident) =>
       let f ← lookupStorageField fields (toString field.getId)
@@ -969,19 +997,19 @@ private def translateEffectStmt
       | .dynamicArray _ | .scalar (.fixedArray (.uintN 128) _) =>
           `(Compiler.CompilationModel.Stmt.setStorageArrayElement
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals index)
+              $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
       | _ => throwErrorAt stx s!"field '{f.name}' is not a storage dynamic array"
   | `(term| require $cond $msg) =>
       `(Compiler.CompilationModel.Stmt.require
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals cond)
           $(strTerm (← expectStringLiteral msg)))
   | `(term| setMemoryArrayElement $name:term $index:term $value:term) => do
       let (arrayName, elemTy) ← requireSupportedMemoryArrayLocal name "setMemoryArrayElement" locals
       unless isSingleWordStaticValueType elemTy do
         throwErrorAt name s!"setMemoryArrayElement currently supports only Array<wordLike> memory locals, got Array {renderValueType elemTy}"
-      let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
-      let valueExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals value
+      let indexExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals index
+      let valueExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value
       let dataOffsetExpr : Term ←
         `(Compiler.CompilationModel.Expr.localVar $(strTerm (memoryArrayDataOffsetName arrayName)))
       let elementOffsetExpr : Term ←
@@ -991,28 +1019,31 @@ private def translateEffectStmt
       `(Compiler.CompilationModel.Stmt.unsafeBlock
           "write memory-backed uint256 array element"
           [Compiler.CompilationModel.Stmt.mstore $elementOffsetExpr $valueExpr])
-  | `(term| mstore $offset:term $value:term) =>
+  | `(term| mstore $offset:term $value:term) | `(term| memoryStore($offset, $value)) =>
       `(Compiler.CompilationModel.Stmt.mstore
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals offset)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
   | `(term| tstore $offset:term $value:term) =>
       `(Compiler.CompilationModel.Stmt.tstore
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals offset)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
   | `(term| calldatacopy $destOffset:term $sourceOffset:term $size:term) =>
       `(Compiler.CompilationModel.Stmt.calldatacopy
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals destOffset)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals sourceOffset)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals size))
-  | `(term| returndataCopy $destOffset:term $sourceOffset:term $size:term) =>
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals destOffset)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals sourceOffset)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals size))
+  | `(term| returndataCopy $destOffset:term $sourceOffset:term $size:term)
+    | `(term| returnDataCopy($destOffset, $sourceOffset, $size)) =>
       `(Compiler.CompilationModel.Stmt.returndataCopy
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals destOffset)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals sourceOffset)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals size))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals destOffset)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals sourceOffset)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals size))
   | `(term| revertReturndata) =>
       `(Compiler.CompilationModel.Stmt.revertReturndata)
   | `(term| returnValues $values:term) =>
       let valueExprs ← expectExprList fields constDecls immutableDecls params locals values
+        (some (translateDeclaredPureExpr
+          fields constDecls immutableDecls externalDecls params locals))
       `(Compiler.CompilationModel.Stmt.returnValues [ $[$valueExprs],* ])
   | `(term| returnArray $name:term) =>
       `(Compiler.CompilationModel.Stmt.returnArray $(strTerm (← expectStringOrIdent name)))
@@ -1022,17 +1053,21 @@ private def translateEffectStmt
       `(Compiler.CompilationModel.Stmt.returnStorageWords $(strTerm (← expectStringOrIdent name)))
   | `(term| returnCodeData $pointer:term) =>
       `(Compiler.CompilationModel.Stmt.returnCodeData
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals pointer))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals pointer))
   | `(term| emit $eventName:term $args:term) =>
       let evName := ← expectStringOrIdent eventName
       let argExprs ← expectEmitExprList fields constDecls immutableDecls params locals args
+        (some (translateDeclaredPureExpr
+          fields constDecls immutableDecls externalDecls params locals))
       `(Compiler.CompilationModel.Stmt.emit $(strTerm evName) [ $[$argExprs],* ])
   | `(term| rawLog $topics:term $dataOffset:term $dataSize:term) =>
       let topicExprs ← expectExprList fields constDecls immutableDecls params locals topics
+        (some (translateDeclaredPureExpr
+          fields constDecls immutableDecls externalDecls params locals))
       `(Compiler.CompilationModel.Stmt.rawLog
           [ $[$topicExprs],* ]
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals dataOffset)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals dataSize))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals dataOffset)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals dataSize))
   | `(term| externalCallBind $names:term $fnName:term $args:term) =>
       let resultNames := ← expectStringList names
       let resultNameTerms := resultNames.map strTerm
@@ -1046,34 +1081,47 @@ private def translateEffectStmt
           [ $[$resultNameTerms],* ]
           $(strTerm targetFn)
           [ $[$argExprs],* ])
+  | `(term| callExternal $name:ident ($[$args:term],*)) =>
+      let extName := toString name.getId
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown linked external '{extName}'"
+      unless ext.returnTys.isEmpty do
+        throwErrorAt stx s!"callExternal '{extName}' returns values; bind it with `let ... ← ...`"
+      validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+        extName ext.params args
+      let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
+        (some ext.params) (some (translateDeclaredPureExpr
+          fields constDecls immutableDecls externalDecls params locals))
+      `(Compiler.CompilationModel.Stmt.externalCallBind [] $(strTerm extName) [ $[$argExprs],* ])
   | `(term| setStructMember $field:term $key:term $member:term $value:term) =>
       let fieldName := ← expectStringOrIdent field
       let memberName := ← expectStringOrIdent member
       let _ ← lookupStructMemberDecl fields fieldName memberName false
       `(Compiler.CompilationModel.Stmt.setStructMember
           $(strTerm fieldName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key)
           $(strTerm memberName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
   | `(term| setStructMember2 $field:term $key1:term $key2:term $member:term $value:term) =>
       let fieldName := ← expectStringOrIdent field
       let memberName := ← expectStringOrIdent member
       let _ ← lookupStructMemberDecl fields fieldName memberName true
       `(Compiler.CompilationModel.Stmt.setStructMember2
           $(strTerm fieldName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key1)
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals key2)
           $(strTerm memberName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
+          $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
   | _ =>
       -- void typed interface call in statement position lowers to the
       -- no-return ECM (selector + args call, failure-returndata bubbled, but
       -- no returndatasize check and no return decode).
       match ← resolveTypedInterfaceCall? fields constDecls immutableDecls externalDecls params locals stx with
       | some (ext, target, argTerms, none, selector) =>
-          let targetExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals target
+          let targetExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals target
           let argExprs ← argTerms.mapM
-            (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+            (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals)
           let isStaticTerm ← if ext.isView then `(true) else `(false)
           `(Compiler.CompilationModel.Stmt.ecm
               (Compiler.Modules.Calls.noReturnModule
@@ -1093,6 +1141,8 @@ private def translateEffectStmt
               s!"helper call '{fn.name}' returns {renderValueType fn.returnTy}; use `let ... ← {fn.name} ...` or tuple destructuring"
           let argExprs ← translateInternalHelperCallArgs
             fields constDecls immutableDecls params locals fn argTerms
+            (some (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals))
           `(Compiler.CompilationModel.Stmt.internalCall
               $(strTerm (internalHelperSpecNameFor fn))
               [ $[$argExprs],* ])
@@ -1195,11 +1245,12 @@ private partial def translateDoElem
                           | none => throwErrorAt rhs "unable to infer tuple local types"
                   | none =>
                       match (← tryExternalCallBindStmt? fields constDecls immutableDecls externalDecls params locals rhs names) with
-                      | some (stmt, typedPairs) =>
-                          pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
+                      | some (stmts, typedPairs) =>
+                          pure (some (stmts, locals ++ typedPairs, mutableLocals))
                       | none => throwErrorAt rhs "tuple destructuring currently requires a tuple literal, tuple-typed parameter, structMembers/structMembers2 source, internal helper call, or tryExternalCall"
           | _ =>
-              match (← arrayElementTupleDestructureStmts? fields constDecls immutableDecls params locals mutableLocals rhs names) with
+              match (← arrayElementTupleDestructureStmts? fields constDecls immutableDecls params locals mutableLocals rhs names
+                (some (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals))) with
               | some (stmts, syntheticLocal) =>
                   let valueTys ← inferTupleSourceTypes? fields constDecls immutableDecls externalDecls functions params locals rhs
                   match valueTys with
@@ -1208,7 +1259,8 @@ private partial def translateDoElem
                       pure (some (stmts, locals.push syntheticLocal ++ typedPairs, mutableLocals))
                   | none => throwErrorAt rhs "unable to infer tuple local types"
               | none =>
-                  match (← tupleLiteralOrStructValueExprs? fields constDecls immutableDecls params locals rhs) with
+                  match (← tupleLiteralOrStructValueExprs? fields constDecls immutableDecls params locals rhs
+                    (some (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals))) with
                   | some valueExprs =>
                       if names.size != valueExprs.size then
                         throwErrorAt patDecl s!"tuple destructuring binds {names.size} names, but the source provides {valueExprs.size} values"
@@ -1238,8 +1290,8 @@ private partial def translateDoElem
                               | none => throwErrorAt rhs "unable to infer tuple local types"
                       | none =>
                           match (← tryExternalCallBindStmt? fields constDecls immutableDecls externalDecls params locals rhs names) with
-                          | some (stmt, typedPairs) =>
-                              pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
+                          | some (stmts, typedPairs) =>
+                              pure (some (stmts, locals ++ typedPairs, mutableLocals))
                           | none =>
                               let valueExprs ← tupleValueExprs fields constDecls immutableDecls params locals rhs
                               if names.size != valueExprs.size then
@@ -1276,8 +1328,8 @@ private partial def translateDoElem
                   | none => throwErrorAt rhs "unable to infer tuple local types"
           | none =>
               match (← tryExternalCallBindStmt? fields constDecls immutableDecls externalDecls params locals rhs names) with
-              | some (stmt, typedPairs) =>
-                  pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
+              | some (stmts, typedPairs) =>
+                  pure (some (stmts, locals ++ typedPairs, mutableLocals))
               | none => throwErrorAt rhs "tuple bind sources must be internal helper calls or tryExternalCall"
       | none => pure none
     else
@@ -1302,7 +1354,10 @@ private partial def translateDoElem
           let varName := toString name.getId
           if localNames.contains varName then
             throwErrorAt name s!"duplicate local variable '{varName}'"
-          let rhsExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals rhs
+          let rhsExpr ← match stripParens rhs with
+            | `(term| callExternal $_ ($[$_],*)) =>
+                translateBindSource fields constDecls immutableDecls externalDecls functions params locals rhs
+            | _ => translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals rhs
           let ty ← inferPureExprType fields constDecls immutableDecls externalDecls params locals rhs
           let interfaceName? ← interfaceNameOfTerm? params locals rhs
           pure
@@ -1315,6 +1370,9 @@ private partial def translateDoElem
             throwErrorAt name s!"duplicate local variable '{varName}'"
           match arrayElementAliasSource? params rhs with
           | some (paramName, index, elemTy) =>
+              if syntaxContainsCallExternal index then
+                throwErrorAt index
+                  "arrayElement alias index cannot contain callExternal because the alias re-evaluates its index at each projection; bind the external result first"
               requireWordLikeType index "arrayElement alias index"
                 (← inferPureExprType fields constDecls immutableDecls externalDecls params locals index)
               pure
@@ -1325,7 +1383,10 @@ private partial def translateDoElem
                       source := .arrayElement paramName index elemTy },
                   mutableLocals)
           | none =>
-              let rhsExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals rhs
+              let rhsExpr ← match stripParens rhs with
+                | `(term| callExternal $_ ($[$_],*)) =>
+                    translateBindSource fields constDecls immutableDecls externalDecls functions params locals rhs
+                | _ => translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals rhs
               let ty ← inferPureExprType fields constDecls immutableDecls externalDecls params locals rhs
               let interfaceName? ← interfaceNameOfTerm? params locals rhs
               pure
@@ -1337,12 +1398,44 @@ private partial def translateDoElem
           if localNames.contains varName then
             throwErrorAt name s!"duplicate local variable '{varName}'"
           match stripParens rhs with
+          | `(term| callExternal $externalName:ident ($[$args:term],*)) =>
+              let extName := toString externalName.getId
+              let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+                | some ext => pure ext
+                | none => throwErrorAt externalName s!"unknown linked external '{extName}'"
+              match ext.returnTys.toList with
+              | [retTy] =>
+                  unless isSingleWordStaticValueType retTy do
+                    throwErrorAt rhs s!"callExternal '{extName}' return type cannot be bound to one source variable; bind composite results explicitly"
+                  validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+                    extName ext.params args
+                  let argExprs ← translateLinkedExternalCallArgs fields constDecls immutableDecls params locals args
+                    (some ext.params) (some (translateDeclaredPureExpr
+                      fields constDecls immutableDecls externalDecls params locals))
+                  let flatNames ← flattenExternalResultNames varName retTy
+                  if flatNames.length != 1 then
+                    throwErrorAt rhs s!"callExternal '{extName}' return type expands to {flatNames.length} values and cannot be bound to one source variable"
+                  let resultTerms := flatNames.toArray.map strTerm
+                  let bindStmt ← `(Compiler.CompilationModel.Stmt.externalCallBind
+                    [ $[$resultTerms],* ] $(strTerm extName) [ $[$argExprs],* ])
+                  let normalization? ← normalizeBoundValueStmt? retTy rhs varName
+                  let stmts := match normalization? with
+                    | some normalization => #[bindStmt, normalization]
+                    | none => #[bindStmt]
+                  pure
+                    (stmts,
+                      locals.push { name := varName, ty := retTy, source := LocalSource.value },
+                      mutableLocals)
+              | [] => throwErrorAt rhs s!"callExternal '{extName}' returns Unit; invoke it as a statement"
+              | _ => throwErrorAt rhs s!"callExternal '{extName}' returns multiple values; use externalCallBind with explicit result names"
           | `(term| callResult $_extName:term $_args:term) =>
               match (← callResultBindStmt? fields constDecls immutableDecls externalDecls params locals rhs varName) with
-              | some (stmt, resultLocal) => pure (#[stmt], locals.push resultLocal, mutableLocals)
+              | some (stmts, resultLocal) => pure (stmts, locals.push resultLocal, mutableLocals)
               | none => throwErrorAt rhs "invalid callResult bind"
           | `(term| ecmCall $moduleFactory:term $args:term) =>
               let argExprs ← expectEcmExprList fields constDecls immutableDecls params locals args
+                (some (translateDeclaredPureExpr
+                  fields constDecls immutableDecls externalDecls params locals))
               let moduleTerm ← `(term| (($moduleFactory) $(strTerm varName)))
               validateSingleResultEcmModuleTerm moduleTerm varName
               pure
@@ -1352,10 +1445,10 @@ private partial def translateDoElem
                   locals.push (mkTypedLocal varName .uint256),
                   mutableLocals)
           | `(term| ecrecover $hash:term $v:term $r:term $s:term) =>
-              let hashExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals hash
-              let vExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals v
-              let rExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals r
-              let sExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals s
+              let hashExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals hash
+              let vExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals v
+              let rExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals r
+              let sExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals s
               pure
                 (#[(← `(Compiler.CompilationModel.Stmt.ecm
                         (Compiler.Modules.Precompiles.ecrecoverModule $(strTerm varName))
@@ -1366,19 +1459,33 @@ private partial def translateDoElem
               -- Zero-return tryExternalCall: `let success ← tryExternalCall "fn" [args]`
               -- produces Stmt.tryExternalCallBind successVar [] externalName args
               let targetFn := ← expectStringOrIdent extName
-              let argExprs ← expectExprList fields constDecls immutableDecls params locals args
+              let ext ←
+                match externalDecls.find? (fun ext => ext.name == targetFn) with
+                | some ext => pure ext
+                | none => throwErrorAt rhs s!"unknown external function '{targetFn}'"
+              let argTerms ← match stripParens args with
+                | `(term| [ $[$xs],* ]) => pure xs
+                | _ => throwErrorAt args "expected list literal [..]"
+              validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+                targetFn ext.params argTerms
+              let argExprs ← translateLinkedExternalCallArgs
+                fields constDecls immutableDecls params locals argTerms (some ext.params)
+                (some (translateDeclaredPureExpr
+                  fields constDecls immutableDecls externalDecls params locals))
+              let bindStmt ← `(Compiler.CompilationModel.Stmt.tryExternalCallBind
+                  $(strTerm varName)
+                  []
+                  $(strTerm targetFn)
+                  [ $[$argExprs],* ])
+              let successNormalization ← normalizeBoundValueStmt? .bool rhs varName
               pure
-                (#[(← `(Compiler.CompilationModel.Stmt.tryExternalCallBind
-                        $(strTerm varName)
-                        []
-                        $(strTerm targetFn)
-                        [ $[$argExprs],* ]))],
+                (#[bindStmt] ++ successNormalization.toArray,
                   locals.push (mkTypedLocal varName .bool),
                   mutableLocals)
           | `(term| allocArray $len:term) =>
               requireWordLikeType len "allocArray length"
                 (← inferPureExprType fields constDecls immutableDecls externalDecls params locals len)
-              let lenExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals len
+              let lenExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals len
               let lengthName := memoryArrayLengthName varName
               let dataOffsetName := memoryArrayDataOffsetName varName
               let lengthLocal : Term ← `(Compiler.CompilationModel.Expr.localVar $(strTerm lengthName))
@@ -1414,6 +1521,8 @@ private partial def translateDoElem
               | some (fn, argTerms, elemTy) =>
                   let argExprs ← translateInternalHelperCallArgs
                     fields constDecls immutableDecls params locals fn argTerms
+                    (some (translateDeclaredPureExpr
+                      fields constDecls immutableDecls externalDecls params locals))
                   let resultNameTerms := #[
                     strTerm (memoryArrayDataOffsetName varName),
                     strTerm (memoryArrayLengthName varName)
@@ -1429,22 +1538,22 @@ private partial def translateDoElem
                           source := .memoryArray },
                       mutableLocals)
               | none =>
-                  let safeBind? ← translateSafeRequireBind fields constDecls immutableDecls params locals varName rhs
+                  let safeBind? ← translateSafeRequireBind fields constDecls immutableDecls externalDecls params locals varName rhs
                   match safeBind? with
                   | some safeStmts =>
                       let safeTy ← inferBindSourceType
                         fields constDecls immutableDecls externalDecls functions params locals rhs
                       pure (safeStmts, locals.push (mkTypedLocal varName safeTy), mutableLocals)
                   | none =>
-                      match (← translateERC20BindStmt? fields constDecls immutableDecls functions params locals varName rhs) with
+                      match (← translateERC20BindStmt? fields constDecls immutableDecls externalDecls functions params locals varName rhs) with
                       | some stmt =>
                           pure (#[(stmt)], locals.push (mkTypedLocal varName .uint256), mutableLocals)
                       | none =>
                           match ← resolveTypedInterfaceCall? fields constDecls immutableDecls externalDecls params locals rhs with
                           | some (ext, target, argTerms, some retTy, selector) =>
-                              let targetExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals target
+                              let targetExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals target
                               let argExprs ← argTerms.mapM
-                                (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+                                (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals)
                               let stmt ←
                                 if ext.isView then
                                   match staticAbiWordCount? retTy with
@@ -1470,28 +1579,7 @@ private partial def translateDoElem
                                         $(natTerm argExprs.size)
                                         false)
                                       [ $targetExpr, $[$argExprs],* ])
-                              let normalization? ←
-                                match retTy with
-                                | .uintN bits => do
-                                    let normalization ← `(Compiler.CompilationModel.Stmt.assignVar $(strTerm varName)
-                                      (Compiler.CompilationModel.Expr.bitAnd
-                                        (Compiler.CompilationModel.Expr.localVar $(strTerm varName))
-                                        (Compiler.CompilationModel.Expr.literal $(natTerm (2 ^ bits - 1)))))
-                                    pure (some normalization)
-                                | .intN bits => do
-                                    let normalization ← `(Compiler.CompilationModel.Stmt.assignVar $(strTerm varName)
-                                      (Compiler.CompilationModel.Expr.signextend
-                                        (Compiler.CompilationModel.Expr.literal $(natTerm (bits / 8 - 1)))
-                                        (Compiler.CompilationModel.Expr.localVar $(strTerm varName))))
-                                    pure (some normalization)
-                                | .bytesN bytes => do
-                                    let normalization ← `(Compiler.CompilationModel.Stmt.assignVar $(strTerm varName)
-                                      (Compiler.CompilationModel.Expr.bitAnd
-                                        (Compiler.CompilationModel.Expr.localVar $(strTerm varName))
-                                        (Compiler.CompilationModel.Expr.literal
-                                          $(natTerm ((2 ^ (8 * bytes) - 1) * 2 ^ (8 * (32 - bytes)))))))
-                                    pure (some normalization)
-                                | _ => pure none
+                              let normalization? ← normalizeBoundValueStmt? retTy rhs varName
                               let stmts := match normalization? with | some normalization => #[stmt, normalization] | none => #[stmt]
                               pure
                                 (stmts,
@@ -1515,18 +1603,20 @@ private partial def translateDoElem
             throwErrorAt name s!"cannot assign immutable variable '{varName}'; declare it with 'let mut'"
           let some localInfo := locals.find? (fun entry => entry.name == varName)
             | throwErrorAt name s!"cannot resolve type of mutable variable '{varName}'"
-          let rawRhsExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals rhs
+          let rawRhsExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals rhs
           let rhsExpr ← normalizeTranslatedExprForType localInfo.ty rhs rawRhsExpr
           pure
             (#[(← `(Compiler.CompilationModel.Stmt.assignVar $(strTerm varName) $rhsExpr))],
               locals,
               mutableLocals)
       | `(doElem| return $value:term) =>
-          match (← arrayElementTupleReturnStmts? fields constDecls immutableDecls params locals mutableLocals value) with
+          match (← arrayElementTupleReturnStmts? fields constDecls immutableDecls params locals mutableLocals value
+            (some (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals))) with
           | some (stmts, syntheticLocal) =>
               pure (stmts, locals.push syntheticLocal, mutableLocals)
           | none =>
-              match (← tupleReturnValueExprs? fields constDecls immutableDecls params locals value) with
+              match (← tupleReturnValueExprs? fields constDecls immutableDecls params locals value
+                (some (translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals))) with
               | some valueExprs =>
                   pure (#[(← `(Compiler.CompilationModel.Stmt.returnValues [ $[$valueExprs],* ]))], locals, mutableLocals)
               | none =>
@@ -1539,14 +1629,14 @@ private partial def translateDoElem
                             let normalized := (literal % 2 ^ (8 * bytes)) * 2 ^ (8 * (32 - bytes))
                             `(Compiler.CompilationModel.Expr.literal $(natTerm normalized))
                         | _ =>
-                            translatePureExprWithTypes fields constDecls immutableDecls params locals value
+                            translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value
                     | _ =>
-                        translatePureExprWithTypes fields constDecls immutableDecls params locals value
+                        translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value
                   pure (#[(← `(Compiler.CompilationModel.Stmt.return $valueExpr))], locals, mutableLocals)
       | `(doElem| pure ()) =>
           pure (#[], locals, mutableLocals)
       | `(doElem| if $cond:term then $thenBranch:doSeq else $elseBranch:doSeq) =>
-          let condExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals cond
+          let condExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals cond
           let thenStmts ← translateDoSeqToStmtTerms fields constDecls immutableDecls externalDecls errorDecls functions returnTy params locals mutableLocals thenBranch
           let elseStmts ← translateDoSeqToStmtTerms fields constDecls immutableDecls externalDecls errorDecls functions returnTy params locals mutableLocals elseBranch
           pure
@@ -1561,7 +1651,7 @@ private partial def translateDoElem
             freshSyntheticLocalName "verity_try_success" params locals mutableLocals
           let (payloadName?, catchElems) ← parseTryCatchHandler handler
           validateTryCatchHandlerDoesNotUsePayload handler payloadName? catchElems
-          let attemptExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals attempt
+          let attemptExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals attempt
           let catchTranslation ←
             translateDoElems fields constDecls immutableDecls externalDecls errorDecls functions returnTy params locals mutableLocals catchElems
           let catchStmts := catchTranslation.1
@@ -1579,7 +1669,7 @@ private partial def translateDoElem
             mutableLocals)
       | `(doElem| forEach $name:term $count:term $body:term) =>
           let loopVar := ← expectStringOrIdent name
-          let countExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals count
+          let countExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals count
           let bodyStmts ←
             match stripParens body with
             | `(term| do $[$inner:doElem]*) =>
@@ -1594,7 +1684,7 @@ private partial def translateDoElem
               mutableLocals)
       | `(doElem| forEachSetBit $name:term $bitmap:term $body:term) =>
           let loopVar := ← expectStringOrIdent name
-          let bitmapExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals bitmap
+          let bitmapExpr ← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals bitmap
           let bodyStmts ←
             match stripParens body with
             | `(term| do $[$inner:doElem]*) =>
@@ -1610,9 +1700,11 @@ private partial def translateDoElem
       | `(doElem| requireError $cond:term $errorName:ident($args,*)) =>
           let argExprs ← translateCustomErrorArgExprs fields constDecls immutableDecls params locals
             errorDecls (toString errorName.getId) args.getElems
+            (some (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals))
           pure
             (#[(← `(Compiler.CompilationModel.Stmt.requireError
-                    $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond)
+                    $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals cond)
                     $(strTerm (toString errorName.getId))
                     [ $[$argExprs],* ]))],
               locals,
@@ -1620,6 +1712,8 @@ private partial def translateDoElem
       | `(doElem| revert $errorName:ident($args,*)) =>
           let argExprs ← translateCustomErrorArgExprs fields constDecls immutableDecls params locals
             errorDecls (toString errorName.getId) args.getElems
+            (some (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals))
           pure
             (#[(← `(Compiler.CompilationModel.Stmt.revertError
                     $(strTerm (toString errorName.getId))
@@ -1629,6 +1723,8 @@ private partial def translateDoElem
       | `(doElem| revertError $errorName:ident($args,*)) =>
           let argExprs ← translateCustomErrorArgExprs fields constDecls immutableDecls params locals
             errorDecls (toString errorName.getId) args.getElems
+            (some (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals))
           pure
             (#[(← `(Compiler.CompilationModel.Stmt.revertError
                     $(strTerm (toString errorName.getId))
@@ -1638,7 +1734,7 @@ private partial def translateDoElem
       | `(doElem| panic($code:term)) =>
           pure
             (#[(← `(Compiler.CompilationModel.Stmt.panicCode
-                    $(← translatePureExprWithTypes fields constDecls immutableDecls params locals code)))],
+                    $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals code)))],
               locals,
               mutableLocals)
       | `(doElem| unsafe $reason:str do $body:doSeq) =>
@@ -1655,6 +1751,8 @@ private partial def translateDoElem
           ensureFreshLocalNames localNames (resultVars.map some) names
           validateResultEcmModuleTerm module resultVars
           let argExprs ← expectEcmExprList fields constDecls immutableDecls params locals args
+            (some (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals))
           let typedLocals := resultVars.map (fun name => mkTypedLocal name .uint256)
           pure
             (#[(← `(Compiler.CompilationModel.Stmt.ecm
@@ -1675,6 +1773,8 @@ private partial def translateDoElem
                     let tempName := freshSyntheticLocalName "emit_array" params branchLocals mutableLocals
                     let argExprs ← translateInternalHelperCallArgs
                       fields constDecls immutableDecls params branchLocals fn argTerms
+                      (some (translateDeclaredPureExpr
+                        fields constDecls immutableDecls externalDecls params branchLocals))
                     let resultNameTerms := #[
                       strTerm (memoryArrayDataOffsetName tempName),
                       strTerm (memoryArrayLengthName tempName)
@@ -1690,7 +1790,10 @@ private partial def translateDoElem
                     let tempTerm : Term := ⟨(mkIdent (Name.mkSimple tempName)).raw⟩
                     emitArgs := emitArgs.push (← translateEmitArgExpr fields constDecls immutableDecls params branchLocals tempTerm)
                 | none =>
-                    emitArgs := emitArgs.push (← translateEmitArgExpr fields constDecls immutableDecls params branchLocals arg)
+                    emitArgs := emitArgs.push (← translateEmitArgExpr
+                      fields constDecls immutableDecls params branchLocals arg
+                      (some (translateDeclaredPureExpr
+                        fields constDecls immutableDecls externalDecls params branchLocals)))
               stmts := stmts.push (← `(Compiler.CompilationModel.Stmt.emit $(strTerm evName) [ $[$emitArgs],* ]))
               pure (stmts, locals, mutableLocals)
           | _ => throwErrorAt values "expected list literal [..]"
@@ -1769,7 +1872,7 @@ private def immutableInitStmtTerms
       | _ =>
           throwErrorAt imm.ident s!"immutable '{imm.name}' uses unsupported type"
     let checkedInit? ←
-      translateSafeRequireBind fields constDecls #[] ctorParams #[]
+      translateSafeRequireBind fields constDecls #[] #[] ctorParams #[]
         "__immutable_init_value" imm.body
     match checkedInit? with
     | some stmts =>
@@ -1872,7 +1975,24 @@ private def isVoidTypedInterfaceCall?
     | pure false
   pure ext.returnTys.isEmpty
 
+private def annotateExecutableLinkedCall?
+    (externalDecls : Array ExternalDecl)
+    (term : Term) : CommandElabM Term := do
+  match stripParens term with
+  | `(term| callExternal $name:ident ($[$_args:term],*)) =>
+      let extName := toString name.getId
+      match externalDecls.find? (fun ext => ext.name == extName) with
+      | some ext =>
+          match ext.returnTys.toList with
+          | [retTy] =>
+              let retTyTerm ← contractValueTypeTerm retTy
+              `(($term : $retTyTerm))
+          | _ => pure term
+      | none => pure term
+  | _ => pure term
+
 mutual
+
 private partial def rewriteForEachExecutableDoSeq
     (fields : Array StorageFieldDecl)
     (externalDecls : Array ExternalDecl)
@@ -1969,7 +2089,20 @@ private partial def rewriteForEachExecutableDoElem
               let retTyTerm ← contractValueTypeTerm retTy
               pure (#[← `(doElem| let $name:ident := (panic! "typed interface calls are compiler-only in executable wrappers" : $retTyTerm))],
                 locals.push (mkTypedLocal (toString name.getId) retTy))
-          | none => pure (#[elem], locals)
+          | none =>
+              match stripParens rhs with
+              | `(term| tryExternalCall $extNameTerm:term $_args:term) =>
+                  let extName := ← expectStringOrIdent extNameTerm
+                  match externalDecls.find? (fun ext => ext.name == extName) with
+                  | some ext =>
+                      match ext.returnTys.toList with
+                      | [] =>
+                          pure (#[← `(doElem| let ($name:ident, _) ←
+                            ($rhs : _root_.Verity.Contract (Bool × Unit)))],
+                            locals.push (mkTypedLocal (toString name.getId) .bool))
+                      | _ => pure (#[elem], locals)
+                  | none => pure (#[elem], locals)
+              | _ => pure (#[elem], locals)
   | `(doElem| let $pat:term ← $rhs:term) =>
       match tupleBinderNames? pat with
       | some _ =>
@@ -2019,6 +2152,12 @@ private partial def rewriteForEachExecutableDoElem
   | `(doElem| unsafe $_reason:str do $body:doSeq) =>
       let body ← rewriteForEachExecutableDoSeq fields externalDecls params locals body
       pure (#[← `(doElem| do $body)], locals)
+  | `(doElem| emit $eventName:term [ $[$args:term],* ]) =>
+      let args ← args.mapM (annotateExecutableLinkedCall? externalDecls)
+      pure (#[← `(doElem| emit $eventName [ $[$args],* ])], locals)
+  | `(doElem| requireError $cond:term $errorName:ident($args,*)) =>
+      let args ← args.getElems.mapM (annotateExecutableLinkedCall? externalDecls)
+      pure (#[← `(doElem| requireError $cond $errorName:ident($args,*))], locals)
   | `(doElem| $stmt:term) =>
       -- a void typed interface call in statement position is compiler-only;
       -- drop it from the executable wrapper (it returns nothing to bind).

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -200,6 +200,12 @@ end
 def normalizeTranslatedExprForType
     (expectedTy : ValueType) (source : Term) (expr : Term) : CommandElabM Term := do
   match expectedTy with
+  | .uint8 =>
+      `(Compiler.CompilationModel.Expr.bitAnd $expr
+          (Compiler.CompilationModel.Expr.literal 255))
+  | .uint16 =>
+      `(Compiler.CompilationModel.Expr.bitAnd $expr
+          (Compiler.CompilationModel.Expr.literal 65535))
   | .uintN bits =>
       `(Compiler.CompilationModel.Expr.bitAnd $expr
           (Compiler.CompilationModel.Expr.literal $(natTerm (2 ^ bits - 1))))
@@ -216,9 +222,31 @@ def normalizeTranslatedExprForType
           let mask := (2 ^ (8 * bytes) - 1) * 2 ^ (8 * (32 - bytes))
           `(Compiler.CompilationModel.Expr.bitAnd $expr
               (Compiler.CompilationModel.Expr.literal $(natTerm mask)))
+  | .address =>
+      `(Compiler.CompilationModel.Expr.bitAnd $expr
+          (Compiler.CompilationModel.Expr.literal $(natTerm (2 ^ 160 - 1))))
+  | .bool =>
+      `(Compiler.CompilationModel.Expr.logicalNot
+          (Compiler.CompilationModel.Expr.eq $expr
+            (Compiler.CompilationModel.Expr.literal 0)))
   | .newtype _ baseType => normalizeTranslatedExprForType baseType source expr
   | .enum _ _ => `(Compiler.CompilationModel.Expr.bitAnd $expr (Compiler.CompilationModel.Expr.literal 255))
   | _ => pure expr
+
+def normalizeBoundValueStmt?
+    (expectedTy : ValueType) (source : Term) (name : String) : CommandElabM (Option Term) := do
+  let needsNormalization :=
+    match expectedTy with
+    | .uint8 | .uint16 | .uintN _ | .intN _ | .bytesN _ | .address | .bool => true
+    | .newtype _ baseType =>
+        match baseType with
+        | .uint8 | .uint16 | .uintN _ | .intN _ | .bytesN _ | .address | .bool => true
+        | _ => false
+    | _ => false
+  unless needsNormalization do return none
+  let localExpr ← `(Compiler.CompilationModel.Expr.localVar $(strTerm name))
+  let normalized ← normalizeTranslatedExprForType expectedTy source localExpr
+  return some (← `(Compiler.CompilationModel.Stmt.assignVar $(strTerm name) $normalized))
 
 def immutableHiddenName (imm : ImmutableDecl) : String :=
   s!"__immutable_{imm.name}"
@@ -1843,6 +1871,24 @@ partial def inferLeanDefCallType?
       throwErrorAt stx
         s!"Lean helper '{fnDisplay}' uses an unsupported return type; supported pure helper returns are Uint256, Int256, Address, Bytes32/Uint256, and Bool"
 
+partial def syntaxContainsCallExternal (stx : Syntax) : Bool :=
+  match stx with
+  | .node _ _ args =>
+      if stx.getKind == `Verity.Macro.evmCallTerm ||
+          stx.getKind == `Verity.Macro.evmStaticCallTerm then
+        true
+      else if let `(term| callExternal $_name:ident ($[$_args:term],*)) := stx then
+        true
+      else if let `(term| call $_gas $_target $_value $_inOffset $_inSize $_outOffset $_outSize) := stx then
+        true
+      else if let `(term| staticcall $_gas $_target $_inOffset $_inSize $_outOffset $_outSize) := stx then
+        true
+      else if let `(term| delegatecall $_gas $_target $_inOffset $_inSize $_outOffset $_outSize) := stx then
+        true
+      else
+        args.any syntaxContainsCallExternal
+  | _ => false
+
 partial def inferPureExprType
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
@@ -1970,7 +2016,7 @@ partial def inferPureExprType
             match contextAccessorBareName? name with
             | some accessor => inferContextAccessorOrLocal accessor
             | none => throwErrorAt stx s!"unknown variable '{name}'"
-  | `(term| calldatasize) | `(term| returndataSize) =>
+  | `(term| calldatasize) | `(term| returndataSize) | `(term| returnDataSize()) =>
       pure .uint256
   | `(term| zeroAddress) =>
       match lookupTypedLocalType? locals "zeroAddress" <|> params.findSome? (fun p =>
@@ -2007,6 +2053,9 @@ partial def inferPureExprType
       requireWordLikeType a "narrowBytes" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
       pure (.bytesN width)
   | `(term| boolToWord $a:term) =>
+      if syntaxContainsCallExternal a then
+        throwErrorAt a
+          "boolToWord operand cannot contain callExternal because expression lowering evaluates its condition more than once; bind the external result first"
       requireBoolType a "boolToWord" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
       pure .uint256
   | `(term| $n:num) =>
@@ -2024,9 +2073,15 @@ partial def inferPureExprType
       let lhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants
       let rhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals b visitingConstants
       classifyUnsignedWordArithmeticResultType stx "bitwise word arithmetic" lhsTy rhsTy
-  | `(term| pow $a $b) | `(term| $a ^ $b)
-  | `(term| min $a $b) | `(term| max $a $b) | `(term| wMulDown $a $b) | `(term| wDivUp $a $b)
+  | `(term| min $a $b) | `(term| max $a $b) | `(term| wDivUp $a $b)
   | `(term| ceilDiv $a $b) => do
+      if syntaxContainsCallExternal a || syntaxContainsCallExternal b then
+        throwErrorAt stx
+          "duplicated expression operands cannot contain callExternal; bind the external result first"
+      let lhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants
+      let rhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals b visitingConstants
+      classifyUnsignedWordArithmeticResultType stx "unsigned word arithmetic" lhsTy rhsTy
+  | `(term| pow $a $b) | `(term| $a ^ $b) | `(term| wMulDown $a $b) => do
       let lhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants
       let rhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals b visitingConstants
       classifyUnsignedWordArithmeticResultType stx "unsigned word arithmetic" lhsTy rhsTy
@@ -2070,6 +2125,9 @@ partial def inferPureExprType
       discard <| classifyWordArithmeticResultType stx "ordering comparison" lhsTy rhsTy
       pure .bool
   | `(term| $a && $b) | `(term| $a || $b) => do
+      if syntaxContainsCallExternal a || syntaxContainsCallExternal b then
+        throwErrorAt stx
+          "short-circuit logical operands cannot contain callExternal because expression lowering evaluates both operands; bind the external result first"
       requireBoolType a "logical operator" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
       requireBoolType b "logical operator" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals b visitingConstants)
       pure .bool
@@ -2083,7 +2141,7 @@ partial def inferPureExprType
   | `(term| ! $a) => do
       requireBoolType a "logical not" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
       pure .bool
-  | `(term| mload $offset) | `(term| tload $offset) | `(term| calldataload $offset)
+  | `(term| mload $offset) | `(term| memoryLoad($offset)) | `(term| tload $offset) | `(term| calldataload $offset)
     | `(term| extcodesize $offset) => do
       requireWordLikeType offset "word offset expression" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals offset visitingConstants)
       pure .uint256
@@ -2099,10 +2157,18 @@ partial def inferPureExprType
       for arg in [gas, target, value, inOffset, inSize, outOffset, outSize] do
         requireWordLikeType arg "low-level call" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
       pure .uint256
+  | `(term| evmCall($gas, $target, $value, $inOffset, $inSize, $outOffset, $outSize)) => do
+      for arg in [gas, target, value, inOffset, inSize, outOffset, outSize] do
+        requireWordLikeType arg "low-level call" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
+      pure .uint256
   | `(term| staticcall $gas $target $inOffset $inSize $outOffset $outSize)
     | `(term| delegatecall $gas $target $inOffset $inSize $outOffset $outSize) => do
       for arg in [gas, target, inOffset, inSize, outOffset, outSize] do
         requireWordLikeType arg "low-level call" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
+      pure .uint256
+  | `(term| evmStaticCall($gas, $target, $inOffset, $inSize, $outOffset, $outSize)) => do
+      for arg in [gas, target, inOffset, inSize, outOffset, outSize] do
+        requireWordLikeType arg "low-level staticcall" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
       pure .uint256
   | `(term| arrayLength $name:term) =>
       -- verity#1849, G1: accept `arrayLength (arrayElement <param> <i>).<dynField>`
@@ -2171,7 +2237,14 @@ partial def inferPureExprType
               requireSupportedArrayElementSourceType name "arrayElement" sourceTy
         | _ =>
             requireSupportedArrayElementSourceType name "arrayElement" sourceTy
-  | `(term| mulDivDown $a $b $c) | `(term| mulDivUp $a $b $c) => do
+  | `(term| mulDivDown $a $b $c) => do
+      for arg in [a, b, c] do
+        requireWordLikeType arg "mulDiv" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
+      pure .uint256
+  | `(term| mulDivUp $a $b $c) => do
+      if syntaxContainsCallExternal c then
+        throwErrorAt c
+          "mulDivUp divisor cannot contain callExternal because expression lowering reuses it; bind the external result first"
       for arg in [a, b, c] do
         requireWordLikeType arg "mulDiv" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
       pure .uint256
@@ -2180,6 +2253,9 @@ partial def inferPureExprType
         requireWordLikeType arg "mulDiv512" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)
       pure .uint256
   | `(term| ite $cond $thenVal $elseVal) => do
+      if syntaxContainsCallExternal cond || syntaxContainsCallExternal thenVal || syntaxContainsCallExternal elseVal then
+        throwErrorAt stx
+          "conditional operands cannot contain callExternal because expression lowering duplicates the condition and evaluates both branches; use statement-level control flow"
       requireBoolType cond "ite condition" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals cond visitingConstants)
       let thenTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals thenVal visitingConstants
       let elseTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals elseVal visitingConstants
@@ -2207,10 +2283,27 @@ partial def inferPureExprType
       match externalDecls.find? (fun ext => ext.name == extName) with
       | some ext =>
           match ext.returnTys.toList with
-          | [retTy] => pure retTy
+          | [retTy] =>
+              unless isSingleWordStaticValueType retTy do
+                throwErrorAt name s!"callExternal '{extName}' return type cannot be used as a pure single-word expression"
+              pure retTy
           | [] => throwErrorAt name s!"externalCall '{extName}' returns no values; use `let success ← tryExternalCall \"{extName}\" [...]` instead"
           | _ => throwErrorAt name s!"externalCall '{extName}' returns {ext.returnTys.size} values; use `let (success, ...) ← tryExternalCall \"{extName}\" [...]` for multi-return"
       | none => pure .uint256
+  | `(term| callExternal $name:ident ($[$xs:term],*)) =>
+      let extName := toString name.getId
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown linked external '{extName}'"
+      validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+        extName ext.params xs
+      match ext.returnTys.toList with
+      | [retTy] =>
+          unless isSingleWordStaticValueType retTy do
+            throwErrorAt name s!"callExternal '{extName}' return type cannot be used as a pure single-word expression"
+          pure retTy
+      | [] => throwErrorAt name s!"callExternal '{extName}' returns no values"
+      | _ => throwErrorAt name s!"callExternal '{extName}' returns multiple values"
   | `(term| intrinsic_cancun $name:term $_lowering:term $args:term)
   | `(term| intrinsic_prague $name:term $_lowering:term $args:term)
   | `(term| intrinsic_fusaka $name:term $_lowering:term $args:term)
@@ -2224,7 +2317,14 @@ partial def inferPureExprType
               (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x visitingConstants)
           pure .uint256
       | _ => throwErrorAt args "expected list literal [..]"
-  | `(term| clz $x:term) | `(term| msb $x:term) =>
+  | `(term| clz $x:term) =>
+      requireWordLikeType x "bitmap primitive argument"
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x visitingConstants)
+      pure .uint256
+  | `(term| msb $x:term) => do
+      if syntaxContainsCallExternal x then
+        throwErrorAt x
+          "msb operand cannot contain callExternal because expression lowering reuses it in the zero check and clz; bind the external result first"
       requireWordLikeType x "bitmap primitive argument"
         (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x visitingConstants)
       pure .uint256
@@ -2279,6 +2379,25 @@ partial def lookupNamedValueType?
     <|> immutableDecls.findSome? (fun imm => if imm.name == name then some imm.ty else none)
     <|> constDecls.findSome? (fun constant => if constant.name == name then some constant.ty else none)
 
+partial def validateLinkedExternalCallArgs
+    (fields : Array StorageFieldDecl)
+    (constDecls : Array ConstantDecl)
+    (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (externalName : String)
+    (expectedTypes : Array ValueType)
+    (args : Array Term) : CommandElabM Unit := do
+  unless args.size == expectedTypes.size do
+    throwError s!"callExternal '{externalName}' expects {expectedTypes.size} args, got {args.size}"
+  for ((arg, expectedTy), argIdx) in args.zip expectedTypes |>.zipIdx do
+    let actualTy ← inferPureExprType
+      fields constDecls immutableDecls externalDecls params locals arg
+    unless argumentTypeMatchesParam arg actualTy expectedTy do
+      throwErrorAt arg
+        s!"callExternal '{externalName}' argument {argIdx + 1} expects {renderValueType expectedTy}, got {renderValueType actualTy}"
+
 partial def inferBindSourceType
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
@@ -2290,6 +2409,22 @@ partial def inferBindSourceType
     (rhs : Term) : CommandElabM ValueType := do
   let rhs := stripParens rhs
   match rhs with
+  | `(term| memoryLoad($_))
+    | `(term| returnDataSize())
+    | `(term| evmCall($_, $_, $_, $_, $_, $_, $_))
+    | `(term| evmStaticCall($_, $_, $_, $_, $_, $_)) =>
+      inferPureExprType fields constDecls immutableDecls externalDecls params locals rhs
+  | `(term| callExternal $name:ident ($[$_args:term],*)) =>
+      let extName := toString name.getId
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown linked external '{extName}'"
+      validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+        extName ext.params _args
+      match ext.returnTys.toList with
+      | [retTy] => pure retTy
+      | [] => throwErrorAt rhs s!"callExternal '{extName}' returns Unit; invoke it as a statement"
+      | _ => throwErrorAt rhs s!"callExternal '{extName}' returns multiple values; use externalCallBind with explicit result names"
   | `(term| callResult $name:term $_args:term) =>
       let extName := ← expectStringOrIdent name
       let ext ←
@@ -2469,37 +2604,17 @@ partial def inferBindSourceType
       pure .uint256
   | `(term| tryExternalCall $name:term $args:term) => do
       let extName := ← expectStringOrIdent name
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt rhs s!"unknown external function '{extName}'"
       match stripParens args with
       | `(term| [ $[$xs],* ]) =>
-          for x in xs do
-            -- verity#1849, G3: accept `Array <wordLike>` / `bytes` / `string`
-            -- direct param refs alongside word-like args.
-            if let some (_, _, fieldTy, _elemTy, _) := arrayElementDynamicMemberProjection? params x then
-              match fieldTy with
-              | .array elemTy =>
-                  unless externalCallDynamicArgSupported (.array elemTy) do
-                    throwErrorAt x s!"tryExternalCall '{extName}' dynamic-member argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
-              | _ =>
-                  throwErrorAt x s!"tryExternalCall '{extName}' dynamic-member argument requires an Array-typed member, got {renderValueType fieldTy}"
-            else if let some (_, _, fieldTy, _elemTy, _) := localArrayElementDynamicMemberProjection? locals x then
-              match fieldTy with
-              | .array elemTy =>
-                  unless externalCallDynamicArgSupported (.array elemTy) do
-                    throwErrorAt x s!"tryExternalCall '{extName}' dynamic-member alias argument currently supports only Array<wordLike> members, got {renderValueType fieldTy}"
-              | _ =>
-                  throwErrorAt x s!"tryExternalCall '{extName}' dynamic-member alias argument requires an Array-typed member, got {renderValueType fieldTy}"
-            else
-              requireWordOrDirectArrayType x s!"tryExternalCall '{extName}' argument"
-                (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x)
+          validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+            extName ext.params xs
       | _ => throwErrorAt args "expected list literal [..]"
-      match externalDecls.find? (fun ext => ext.name == extName) with
-      | some ext =>
-          if ext.returnTys.size > 0 then
-            throwErrorAt rhs s!"tryExternalCall '{extName}' returns {ext.returnTys.size} value(s); use tuple destructuring: `let (success, ...) ← tryExternalCall ...`"
-          -- Zero-return external: success flag only
-          pure .bool
-      | none =>
-          throwErrorAt rhs s!"unknown external function '{extName}'"
+      if ext.returnTys.size > 0 then
+        throwErrorAt rhs s!"tryExternalCall '{extName}' returns {ext.returnTys.size} value(s); use tuple destructuring: `let (success, ...) ← tryExternalCall ...`"
+      pure .bool
   | `(term| requireSomeUint $optExpr:term $_msg:term) =>
       match stripParens optExpr with
       | `(term| safeAdd $a:term $b:term)
@@ -2616,6 +2731,9 @@ partial def inferTupleSourceTypes?
         | `(term| structMembers $field:term $key:term $members:term) => do
             let fieldName := ← expectStringOrIdent field
             let memberNames := ← expectStringList members
+            if memberNames.size > 1 && syntaxContainsCallExternal key then
+              throwErrorAt key
+                "structMembers key cannot contain callExternal when selecting multiple members because lowering reuses the key; bind the external result first"
             let memberDecls ← memberNames.mapM fun memberName =>
               lookupStructMemberDecl fields fieldName memberName false
             requireWordLikeType key "structMembers key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key)
@@ -2623,6 +2741,10 @@ partial def inferTupleSourceTypes?
         | `(term| structMembers2 $field:term $key1:term $key2:term $members:term) => do
             let fieldName := ← expectStringOrIdent field
             let memberNames := ← expectStringList members
+            if memberNames.size > 1 &&
+                (syntaxContainsCallExternal key1 || syntaxContainsCallExternal key2) then
+              throwErrorAt rhs
+                "structMembers2 keys cannot contain callExternal when selecting multiple members because lowering reuses the keys; bind external results first"
             let memberDecls ← memberNames.mapM fun memberName =>
               lookupStructMemberDecl fields fieldName memberName true
             requireWordLikeType key1 "structMembers2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key1)
@@ -2650,14 +2772,13 @@ partial def inferTupleSourceTypes?
                   | _ => pure none
         | `(term| tryExternalCall $name:term $args:term) =>
             let extName := ← expectStringOrIdent name
-            match stripParens args with
-            | `(term| [ $[$xs],* ]) =>
-                for x in xs do
-                  requireWordOrDirectArrayType x s!"tryExternalCall '{extName}' argument"
-                    (← inferPureExprType fields constDecls immutableDecls externalDecls params locals x)
-            | _ => throwErrorAt args "expected list literal [..]"
             match externalDecls.find? (fun ext => ext.name == extName) with
-            | some ext =>
+            | some ext => do
+                match stripParens args with
+                | `(term| [ $[$xs],* ]) =>
+                    validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+                      extName ext.params xs
+                | _ => throwErrorAt args "expected list literal [..]"
                 -- tryExternalCall returns (success : Bool, result₁ : T₁, ..., resultₙ : Tₙ)
                 pure (some (#[.bool] ++ ext.returnTys))
             | none =>
@@ -2755,6 +2876,10 @@ partial def resolveQualifiedFunctionApp?
         (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg)
     pure (some (fnName, argTerms))
 end
+
+structure LinkedExternalLowerer where
+  lower : Ident → Array Term → CommandElabM Term
+  inferType : Term → List String → CommandElabM ValueType
 
 mutual
 partial def validateConstantBody
@@ -3012,7 +3137,8 @@ partial def translateLeanDefCall?
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (stx : Term)
-    (visitingConstants : List String) : CommandElabM (Option Term) := do
+    (visitingConstants : List String)
+    (linkedExternalLowerer? : Option LinkedExternalLowerer := none) : CommandElabM (Option Term) := do
   let some (head, fnDisplay, argTerms) := leanDefAppSyntax? stx
     | pure none
   let some fnName ← resolveLeanDefName? head
@@ -3020,18 +3146,27 @@ partial def translateLeanDefCall?
   let some info ← leanDefInfo? fnName
     | pure none
   let (paramTypeExprs, resultTypeExpr) := peelForallTypes info.type
-  let argTypes ← argTerms.mapM
-    (inferPureExprType fields constDecls immutableDecls externalDecls params locals · visitingConstants)
+  let some body := peelLambdaBody info.value argTerms.size
+    | throwErrorAt stx s!"Lean helper '{fnDisplay}' body is not a transparent function definition"
+  for (arg, argIdx) in argTerms.zipIdx do
+    if syntaxContainsCallExternal arg.raw then
+      let bvarIdx := argTerms.size - 1 - argIdx
+      unless body == .bvar bvarIdx do
+        throwErrorAt stx
+          s!"Lean helper '{fnDisplay}' arguments cannot contain callExternal unless the helper is a direct passthrough because transparent-helper and expression lowering may duplicate or discard arguments; bind the external result first"
+  let inferArgType (arg : Term) :=
+    match linkedExternalLowerer? with
+    | some lowerer => lowerer.inferType arg visitingConstants
+    | none => inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants
+  let argTypes ← argTerms.mapM inferArgType
   checkLeanDefCallArgs stx.raw fnDisplay argTerms paramTypeExprs argTypes
   match valueTypeFromLeanTypeExpr? resultTypeExpr with
   | some ty => requireSupportedLocalBindingType stx.raw s!"Lean helper '{fnDisplay}' return" ty
   | none =>
       throwErrorAt stx
         s!"Lean helper '{fnDisplay}' uses an unsupported return type; supported pure helper returns are Uint256, Int256, Address, Bytes32/Uint256, and Bool"
-  let some body := peelLambdaBody info.value argTerms.size
-    | throwErrorAt stx s!"Lean helper '{fnDisplay}' body is not a transparent function definition"
   let argExprs ← argTerms.mapM
-    (translatePureExprWithTypes fields constDecls immutableDecls params locals · visitingConstants)
+    (translatePureExprWithTypes fields constDecls immutableDecls params locals · visitingConstants linkedExternalLowerer?)
   pure (some (← translateLeanExprFromDef fields constDecls immutableDecls params locals stx.raw fnDisplay argExprs body))
 
 partial def translatePureExprWithTypes
@@ -3041,20 +3176,25 @@ partial def translatePureExprWithTypes
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (stx : Term)
-    (visitingConstants : List String := []) : CommandElabM Term := do
+    (visitingConstants : List String := [])
+    (linkedExternalLowerer? : Option LinkedExternalLowerer := none) : CommandElabM Term := do
   let stx := stripParens stx
   let localNames := typedLocalNames locals
+  let inferExprType (expr : Term) : CommandElabM ValueType :=
+    match linkedExternalLowerer? with
+    | some lowerer => lowerer.inferType expr visitingConstants
+    | none => inferPureExprType fields constDecls immutableDecls #[] params locals expr visitingConstants
   let translateIntrinsic (name lowering args minForkTerm : Term) : CommandElabM Term := do
     let intrinsicName := ← expectStringOrIdent name
     let argsExprs ←
       match stripParens args with
       | `(term| [ $[$xs],* ]) =>
-          xs.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals · visitingConstants)
+          xs.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals · visitingConstants linkedExternalLowerer?)
       | _ => throwErrorAt args "expected list literal [..]"
     `(Compiler.CompilationModel.Expr.intrinsic $(strTerm intrinsicName) $lowering
         $minForkTerm [ $[$argsExprs],* ])
   if let some (paramName, index, _fieldTy, elemTy, wordOffset) := arrayElementStructProjection? params stx then
-    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
     if valueTypeUsesDynamicData elemTy then
       `(Compiler.CompilationModel.Expr.arrayElementDynamicWord
         $(strTerm paramName)
@@ -3072,7 +3212,7 @@ partial def translatePureExprWithTypes
         $(natTerm wordOffset))
   else
   if let some (paramName, index, _fieldTy, elemTy, wordOffset) := localArrayElementStructProjection? locals stx then
-    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
     if valueTypeUsesDynamicData elemTy then
       `(Compiler.CompilationModel.Expr.arrayElementDynamicWord
         $(strTerm paramName)
@@ -3133,7 +3273,7 @@ partial def translatePureExprWithTypes
             | none => throwErrorAt target "abiHeadWord requires a direct parameter, dynamic local alias, or `arrayElement <param> <index>` target"
       match index? with
       | some index =>
-          let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+          let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
           if valueTypeUsesDynamicData ty then
             `(Compiler.CompilationModel.Expr.arrayElementDynamicWord
               $(strTerm paramName)
@@ -3198,7 +3338,7 @@ partial def translatePureExprWithTypes
       else
         translateConstantExpr fields constDecls immutableDecls visitingConstants name
   | `(term| calldatasize) => `(Compiler.CompilationModel.Expr.calldatasize)
-  | `(term| returndataSize) => `(Compiler.CompilationModel.Expr.returndataSize)
+  | `(term| returndataSize) | `(term| returnDataSize()) => `(Compiler.CompilationModel.Expr.returndataSize)
   | `(term| zeroAddress) =>
       if params.any (fun p => p.name == "zeroAddress") || localNames.contains "zeroAddress" then
         lookupVarExpr params localNames "zeroAddress"
@@ -3206,18 +3346,18 @@ partial def translatePureExprWithTypes
         `(Compiler.CompilationModel.Expr.literal 0)
   | `(term| isZeroAddress $a:term) =>
       `(Compiler.CompilationModel.Expr.eq
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
           (Compiler.CompilationModel.Expr.literal 0))
-  | `(term| wordToAddress $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants
-  | `(term| addressToWord $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants
-  | `(term| toInt256 $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants
-  | `(term| toUint256 $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants
+  | `(term| wordToAddress $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
+  | `(term| addressToWord $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
+  | `(term| toInt256 $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
+  | `(term| toUint256 $a:term) => translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
   | `(term| narrowUInt $bits:num $a:term) => do
       let width ← natFromSyntax bits
       unless width >= 8 && width < 256 && width % 8 == 0 do
         throwErrorAt bits "narrowUInt width must be a byte multiple from 8 through 248"
       `(Compiler.CompilationModel.Expr.bitAnd
-        $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
+        $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
         (Compiler.CompilationModel.Expr.literal $(natTerm (2 ^ width - 1))))
   | `(term| narrowInt $bits:num $a:term) => do
       let width ← natFromSyntax bits
@@ -3225,27 +3365,30 @@ partial def translatePureExprWithTypes
         throwErrorAt bits "narrowInt width must be a byte multiple from 8 through 248"
       `(Compiler.CompilationModel.Expr.signextend
         (Compiler.CompilationModel.Expr.literal $(natTerm (width / 8 - 1)))
-        $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants))
+        $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?))
   | `(term| narrowBytes $bytes:num $a:term) => do
       let width ← natFromSyntax bytes
       unless width >= 1 && width < 32 do
         throwErrorAt bytes "narrowBytes width must be from 1 through 31"
       let mask := (2 ^ (8 * width) - 1) * 2 ^ (8 * (32 - width))
       `(Compiler.CompilationModel.Expr.bitAnd
-        $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
+        $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
         (Compiler.CompilationModel.Expr.literal $(natTerm mask)))
   | `(term| boolToWord $a:term) =>
+      if syntaxContainsCallExternal a then
+        throwErrorAt a
+          "boolToWord operand cannot contain callExternal because expression lowering evaluates its condition more than once; bind the external result first"
       `(Compiler.CompilationModel.Expr.ite
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
           (Compiler.CompilationModel.Expr.literal 1)
           (Compiler.CompilationModel.Expr.literal 0))
   | `(term| $n:num) => `(Compiler.CompilationModel.Expr.literal $n)
   | `(term| add $a $b) | `(term| $a + $b)
     | `(term| sub $a $b) | `(term| $a - $b)
     | `(term| mul $a $b) | `(term| $a * $b) => do
-      let resultTy ← inferPureExprType fields constDecls immutableDecls #[] params locals stx visitingConstants
-      let lhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants
-      let rhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants
+      let resultTy ← inferExprType stx
+      let lhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
+      let rhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?
       let raw ← match stx with
         | `(term| add $_ $_) | `(term| $_ + $_) => `(Compiler.CompilationModel.Expr.add $lhs $rhs)
         | `(term| sub $_ $_) | `(term| $_ - $_) => `(Compiler.CompilationModel.Expr.sub $lhs $rhs)
@@ -3260,54 +3403,54 @@ partial def translatePureExprWithTypes
       | _ => pure raw
   | `(term| pow $a $b) | `(term| $a ^ $b) =>
       `(Compiler.CompilationModel.Expr.externalCall Compiler.CompilationModel.builtinExpName
-          [$(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants),
-           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants)])
+          [$(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?),
+           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)])
   | `(term| div $a $b) | `(term| $a / $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
-        let raw ← `(Compiler.CompilationModel.Expr.sdiv $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        let raw ← `(Compiler.CompilationModel.Expr.sdiv $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
         match lhsTy with
         | .intN bits =>
             `(Compiler.CompilationModel.Expr.signextend
                 (Compiler.CompilationModel.Expr.literal $(natTerm (bits / 8 - 1))) $raw)
         | _ => pure raw
       else
-        `(Compiler.CompilationModel.Expr.div $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| sdiv $a $b) => `(Compiler.CompilationModel.Expr.sdiv $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        `(Compiler.CompilationModel.Expr.div $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| sdiv $a $b) => `(Compiler.CompilationModel.Expr.sdiv $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| mod $a $b) | `(term| $a % $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
-        let raw ← `(Compiler.CompilationModel.Expr.smod $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        let raw ← `(Compiler.CompilationModel.Expr.smod $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
         match lhsTy with
         | .intN bits =>
             `(Compiler.CompilationModel.Expr.signextend
                 (Compiler.CompilationModel.Expr.literal $(natTerm (bits / 8 - 1))) $raw)
         | _ => pure raw
       else
-        `(Compiler.CompilationModel.Expr.mod $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| smod $a $b) => `(Compiler.CompilationModel.Expr.smod $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| bitAnd $a $b) => `(Compiler.CompilationModel.Expr.bitAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| bitOr $a $b) => `(Compiler.CompilationModel.Expr.bitOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| bitXor $a $b) => `(Compiler.CompilationModel.Expr.bitXor $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| bitNot $a) => `(Compiler.CompilationModel.Expr.bitNot $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants))
-  | `(term| shl $shift $value) => `(Compiler.CompilationModel.Expr.shl $(← translatePureExprWithTypes fields constDecls immutableDecls params locals shift visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants))
-  | `(term| shr $shift $value) => `(Compiler.CompilationModel.Expr.shr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals shift visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants))
-  | `(term| sar $shift $value) => `(Compiler.CompilationModel.Expr.sar $(← translatePureExprWithTypes fields constDecls immutableDecls params locals shift visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants))
-  | `(term| byte $index $value) => `(Compiler.CompilationModel.Expr.byte $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants))
-  | `(term| signextend $byteIndex $value) => `(Compiler.CompilationModel.Expr.signextend $(← translatePureExprWithTypes fields constDecls immutableDecls params locals byteIndex visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants))
+        `(Compiler.CompilationModel.Expr.mod $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| smod $a $b) => `(Compiler.CompilationModel.Expr.smod $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| bitAnd $a $b) => `(Compiler.CompilationModel.Expr.bitAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| bitOr $a $b) => `(Compiler.CompilationModel.Expr.bitOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| bitXor $a $b) => `(Compiler.CompilationModel.Expr.bitXor $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| bitNot $a) => `(Compiler.CompilationModel.Expr.bitNot $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?))
+  | `(term| shl $shift $value) => `(Compiler.CompilationModel.Expr.shl $(← translatePureExprWithTypes fields constDecls immutableDecls params locals shift visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?))
+  | `(term| shr $shift $value) => `(Compiler.CompilationModel.Expr.shr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals shift visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?))
+  | `(term| sar $shift $value) => `(Compiler.CompilationModel.Expr.sar $(← translatePureExprWithTypes fields constDecls immutableDecls params locals shift visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?))
+  | `(term| byte $index $value) => `(Compiler.CompilationModel.Expr.byte $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?))
+  | `(term| signextend $byteIndex $value) => `(Compiler.CompilationModel.Expr.signextend $(← translatePureExprWithTypes fields constDecls immutableDecls params locals byteIndex visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?))
   | `(term| $a == $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       if (lhsTy == .string && rhsTy == .string) || (lhsTy == .bytes && rhsTy == .bytes) then
         let (lhsName, rhsName) ← dynamicEqParamNames stx params a b lhsTy rhsTy
         `(Compiler.CompilationModel.Expr.dynamicBytesEq $(strTerm lhsName) $(strTerm rhsName))
       else
-        let lhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants
-        let rhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants
+        let lhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
+        let rhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?
         let lhs ← match rhsTy with
           | .bytesN bytes =>
               if isNatLiteralTerm a then
@@ -3325,15 +3468,15 @@ partial def translatePureExprWithTypes
         `(Compiler.CompilationModel.Expr.eq
           $lhs $rhs)
   | `(term| $a != $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       if (lhsTy == .string && rhsTy == .string) || (lhsTy == .bytes && rhsTy == .bytes) then
         let (lhsName, rhsName) ← dynamicEqParamNames stx params a b lhsTy rhsTy
         `(Compiler.CompilationModel.Expr.logicalNot
             (Compiler.CompilationModel.Expr.dynamicBytesEq $(strTerm lhsName) $(strTerm rhsName)))
       else
-        let lhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants
-        let rhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants
+        let lhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?
+        let rhs ← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?
         let lhs ← match rhsTy with
           | .bytesN bytes =>
               if isNatLiteralTerm a then
@@ -3352,70 +3495,70 @@ partial def translatePureExprWithTypes
             (Compiler.CompilationModel.Expr.eq
               $lhs $rhs))
   | `(term| $a >= $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
         `(Compiler.CompilationModel.Expr.logicalNot
             (Compiler.CompilationModel.Expr.slt
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants)))
+              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)))
       else
-        `(Compiler.CompilationModel.Expr.ge $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        `(Compiler.CompilationModel.Expr.ge $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| $a > $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
-        `(Compiler.CompilationModel.Expr.sgt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        `(Compiler.CompilationModel.Expr.sgt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
       else
-        `(Compiler.CompilationModel.Expr.gt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| sgt $a $b) => `(Compiler.CompilationModel.Expr.sgt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        `(Compiler.CompilationModel.Expr.gt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| sgt $a $b) => `(Compiler.CompilationModel.Expr.sgt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| $a < $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
-        `(Compiler.CompilationModel.Expr.slt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        `(Compiler.CompilationModel.Expr.slt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
       else
-        `(Compiler.CompilationModel.Expr.lt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| slt $a $b) => `(Compiler.CompilationModel.Expr.slt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+        `(Compiler.CompilationModel.Expr.lt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| slt $a $b) => `(Compiler.CompilationModel.Expr.slt $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| $a <= $b) => do
-      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals a visitingConstants
-      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params locals b visitingConstants
+      let lhsTy ← inferExprType a
+      let rhsTy ← inferExprType b
       let (lhsTy, rhsTy) := preferNarrowNumericLiteralPeer a b lhsTy rhsTy
       if lhsTy == rhsTy && isSignedWordValueType lhsTy then
         `(Compiler.CompilationModel.Expr.logicalNot
             (Compiler.CompilationModel.Expr.sgt
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants)))
+              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)))
       else
-        `(Compiler.CompilationModel.Expr.le $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| $a && $b) => `(Compiler.CompilationModel.Expr.logicalAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| $a || $b) => `(Compiler.CompilationModel.Expr.logicalOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| logicalAnd $a $b) => `(Compiler.CompilationModel.Expr.logicalAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| logicalOr $a $b) => `(Compiler.CompilationModel.Expr.logicalOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| logicalNot $a) => `(Compiler.CompilationModel.Expr.logicalNot $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants))
-  | `(term| and $a $b) => `(Compiler.CompilationModel.Expr.bitAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| or $a $b) => `(Compiler.CompilationModel.Expr.bitOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| xor $a $b) => `(Compiler.CompilationModel.Expr.bitXor $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| not $a) => `(Compiler.CompilationModel.Expr.bitNot $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants))
-  | `(term| mload $offset) =>
+        `(Compiler.CompilationModel.Expr.le $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| $a && $b) => `(Compiler.CompilationModel.Expr.logicalAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| $a || $b) => `(Compiler.CompilationModel.Expr.logicalOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| logicalAnd $a $b) => `(Compiler.CompilationModel.Expr.logicalAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| logicalOr $a $b) => `(Compiler.CompilationModel.Expr.logicalOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| logicalNot $a) => `(Compiler.CompilationModel.Expr.logicalNot $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?))
+  | `(term| and $a $b) => `(Compiler.CompilationModel.Expr.bitAnd $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| or $a $b) => `(Compiler.CompilationModel.Expr.bitOr $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| xor $a $b) => `(Compiler.CompilationModel.Expr.bitXor $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| not $a) => `(Compiler.CompilationModel.Expr.bitNot $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?))
+  | `(term| mload $offset) | `(term| memoryLoad($offset)) =>
       `(Compiler.CompilationModel.Expr.mload
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants linkedExternalLowerer?))
   | `(term| tload $offset) =>
       `(Compiler.CompilationModel.Expr.tload
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants linkedExternalLowerer?))
   | `(term| calldataload $offset) =>
       `(Compiler.CompilationModel.Expr.calldataload
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants linkedExternalLowerer?))
   | `(term| extcodesize $addr) =>
       `(Compiler.CompilationModel.Expr.extcodesize
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals addr visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals addr visitingConstants linkedExternalLowerer?))
   | `(term| keccak256 $offset $size) =>
       `(Compiler.CompilationModel.Expr.keccak256
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals size visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals size visitingConstants linkedExternalLowerer?))
   -- Compile-time Keccak-256 of a string literal (#1973): hash the literal
   -- now and emit a plain numeric literal. The parser already rejects
   -- non-literal arguments, so the digest is unconditionally static.
@@ -3424,43 +3567,67 @@ partial def translatePureExprWithTypes
       `(Compiler.CompilationModel.Expr.literal $(natTerm digest))
   | `(term| call $gas $target $value $inOffset $inSize $outOffset $outSize) =>
       `(Compiler.CompilationModel.Expr.call
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants linkedExternalLowerer?))
+  | `(term| evmCall($gas, $target, $value, $inOffset, $inSize, $outOffset, $outSize)) =>
+      `(Compiler.CompilationModel.Expr.call
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants linkedExternalLowerer?))
   | `(term| staticcall $gas $target $inOffset $inSize $outOffset $outSize) =>
       `(Compiler.CompilationModel.Expr.staticcall
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants linkedExternalLowerer?))
+  | `(term| evmStaticCall($gas, $target, $inOffset, $inSize, $outOffset, $outSize)) =>
+      `(Compiler.CompilationModel.Expr.staticcall
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants linkedExternalLowerer?))
+  | `(term| callExternal $name:ident ($[$xs:term],*)) =>
+      match linkedExternalLowerer? with
+      | some lowerer => lowerer.lower name xs
+      | none =>
+          translatePureExprWithTypes fields constDecls immutableDecls params locals
+            (← `(externalCall $(strTerm (toString name.getId)) [ $[$xs],* ]))
+            visitingConstants linkedExternalLowerer?
   | `(term| delegatecall $gas $target $inOffset $inSize $outOffset $outSize) =>
       `(Compiler.CompilationModel.Expr.delegatecall
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals gas visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals target visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals inSize visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outOffset visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals outSize visitingConstants linkedExternalLowerer?))
   | `(term| arrayLength $name:term) =>
       -- verity#1849, G1: `arrayLength (arrayElement <param> <i>).<dynField>`
       -- lowers through `Expr.arrayElementDynamicMemberLength`, reading the
       -- length word of the dynamic member at the resolved head offset.
       if let some (paramName, index, _fieldTy, _elemTy, wordOffset) :=
           arrayElementDynamicMemberProjection? params name then
-        let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+        let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
         `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
             $(strTerm paramName)
             $indexExpr
             $(natTerm wordOffset))
       else if let some (paramName, index, _fieldTy, _elemTy, wordOffset) :=
           localArrayElementDynamicMemberProjection? locals name then
-        let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+        let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
         `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
             $(strTerm paramName)
             $indexExpr
@@ -3480,8 +3647,8 @@ partial def translatePureExprWithTypes
       -- lowers through `Expr.arrayElementDynamicMemberElement`.
         if let some (paramName, outerIndex, _fieldTy, _elemTy, wordOffset) :=
           arrayElementDynamicMemberProjection? params name then
-        let outerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals outerIndex visitingConstants
-        let innerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+        let outerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals outerIndex visitingConstants linkedExternalLowerer?
+        let innerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
         `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberElement
             $(strTerm paramName)
             $outerIndexExpr
@@ -3489,8 +3656,8 @@ partial def translatePureExprWithTypes
             $innerIndexExpr)
         else if let some (paramName, outerIndex, _fieldTy, _elemTy, wordOffset) :=
           localArrayElementDynamicMemberProjection? locals name then
-        let outerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals outerIndex visitingConstants
-        let innerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+        let outerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals outerIndex visitingConstants linkedExternalLowerer?
+        let innerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
         `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberElement
             $(strTerm paramName)
             $outerIndexExpr
@@ -3498,7 +3665,7 @@ partial def translatePureExprWithTypes
             $innerIndexExpr)
         else if let some (paramName, _fieldTy, wordOffset) :=
           paramDynamicMemberProjection? params name then
-        let innerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+        let innerIndexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
         `(Compiler.CompilationModel.Expr.paramDynamicMemberElement
             $(strTerm paramName)
             $(natTerm wordOffset)
@@ -3506,12 +3673,12 @@ partial def translatePureExprWithTypes
         else if let some (name, _) := localMemoryArray? locals name then
         `(Compiler.CompilationModel.Expr.memoryArrayElement
             $(strTerm name)
-            $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants))
+            $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?))
         else
           `(Compiler.CompilationModel.Expr.arrayElement
               $(strTerm (← expectStringOrIdent name))
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants))
-      let elemTy ← inferPureExprType fields constDecls immutableDecls #[] params locals stx visitingConstants
+              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?))
+      let elemTy ← inferExprType stx
       match elemTy with
       | .uintN bits =>
           `(Compiler.CompilationModel.Expr.bitAnd $raw
@@ -3526,43 +3693,43 @@ partial def translatePureExprWithTypes
       | _ => pure raw
   | `(term| ceilDiv $a $b) =>
       `(Compiler.CompilationModel.Expr.ceilDiv
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| mulDivDown $a $b $c) =>
       `(Compiler.CompilationModel.Expr.mulDivDown
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants linkedExternalLowerer?))
   | `(term| mulDivUp $a $b $c) =>
       `(Compiler.CompilationModel.Expr.mulDivUp
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants linkedExternalLowerer?))
   | `(term| mulDiv512Down $a $b $c) =>
       `(Compiler.CompilationModel.Expr.mulDiv512Down
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants linkedExternalLowerer?))
   | `(term| mulDiv512Up $a $b $c) =>
       `(Compiler.CompilationModel.Expr.mulDiv512Up
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals c visitingConstants linkedExternalLowerer?))
   | `(term| wMulDown $a $b) =>
       `(Compiler.CompilationModel.Expr.wMulDown
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| wDivUp $a $b) =>
       `(Compiler.CompilationModel.Expr.wDivUp
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| min $a $b) => `(Compiler.CompilationModel.Expr.min $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| max $a $b) => `(Compiler.CompilationModel.Expr.max $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| min $a $b) => `(Compiler.CompilationModel.Expr.min $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
+  | `(term| max $a $b) => `(Compiler.CompilationModel.Expr.max $(← translatePureExprWithTypes fields constDecls immutableDecls params locals a visitingConstants linkedExternalLowerer?) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals b visitingConstants linkedExternalLowerer?))
   | `(term| ite $cond $thenVal $elseVal) =>
       `(Compiler.CompilationModel.Expr.ite
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals thenVal visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals elseVal visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals thenVal visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals elseVal visitingConstants linkedExternalLowerer?))
   -- Native Lean `if ... then ... else ...` term, equivalent to
   -- `ite cond thenVal elseVal` for the macro lowering.  Lets contract
   -- authors write idiomatic expressions like
@@ -3570,9 +3737,9 @@ partial def translatePureExprWithTypes
   -- without falling back to per-shape helper functions.
   | `(term| if $cond:term then $thenVal:term else $elseVal:term) =>
       `(Compiler.CompilationModel.Expr.ite
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals thenVal visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals elseVal visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals cond visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals thenVal visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals elseVal visitingConstants linkedExternalLowerer?))
   | `(term| externalCall $name:term $args:term) =>
       let extName := ← expectStringOrIdent name
       let argsExprs ←
@@ -3586,12 +3753,12 @@ partial def translatePureExprWithTypes
                     out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
                     out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
                   else
-                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants linkedExternalLowerer?)
               | none =>
                   if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                       arrayElementDynamicMemberProjection? params arg then
                     if externalCallDynamicArgSupported fieldTy then
-                      let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+                      let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
                       out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                         $(strTerm paramName)
                         $indexExpr
@@ -3601,11 +3768,11 @@ partial def translatePureExprWithTypes
                         $indexExpr
                         $(natTerm wordOffset)))
                     else
-                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants linkedExternalLowerer?)
                   else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                       localArrayElementDynamicMemberProjection? locals arg then
                     if externalCallDynamicArgSupported fieldTy then
-                      let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+                      let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants linkedExternalLowerer?
                       out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                         $(strTerm paramName)
                         $indexExpr
@@ -3615,7 +3782,7 @@ partial def translatePureExprWithTypes
                         $indexExpr
                         $(natTerm wordOffset)))
                     else
-                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants linkedExternalLowerer?)
                   else if let some (paramName, fieldTy, wordOffset) :=
                       paramDynamicMemberProjection? params arg then
                     if externalCallDynamicArgSupported fieldTy then
@@ -3626,9 +3793,9 @@ partial def translatePureExprWithTypes
                         $(strTerm paramName)
                         $(natTerm wordOffset)))
                     else
-                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+                      out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants linkedExternalLowerer?)
                   else
-                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants)
+                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants linkedExternalLowerer?)
             pure out
         | _ => throwErrorAt args "expected list literal [..]"
       `(Compiler.CompilationModel.Expr.externalCall $(strTerm extName) [ $[$argsExprs],* ])
@@ -3652,13 +3819,16 @@ partial def translatePureExprWithTypes
       let minForkTerm ← hardForkTermFromParsed minFork
       translateIntrinsic name lowering args minForkTerm
   | `(term| clz $x:term) =>
-      let xExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals x visitingConstants
+      let xExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals x visitingConstants linkedExternalLowerer?
       `(Compiler.CompilationModel.Expr.intrinsic "clz"
           (Verity.Core.Intrinsics.YulLowering.verbatim 1 1 "1e")
           Verity.Core.Intrinsics.HardFork.osaka
           [$xExpr])
   | `(term| msb $x:term) =>
-      let xExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals x visitingConstants
+      if syntaxContainsCallExternal x then
+        throwErrorAt x
+          "msb operand cannot contain callExternal because expression lowering reuses it in the zero check and clz; bind the external result first"
+      let xExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals x visitingConstants linkedExternalLowerer?
       let clzExpr ← `(Compiler.CompilationModel.Expr.intrinsic "clz"
           (Verity.Core.Intrinsics.YulLowering.verbatim 1 1 "1e")
           Verity.Core.Intrinsics.HardFork.osaka
@@ -3670,15 +3840,15 @@ partial def translatePureExprWithTypes
   | `(term| fork_if_at_least $fork:ident then $thenExpr:term else $elseExpr:term) =>
       `(Compiler.CompilationModel.Expr.forkIfAtLeast
           $(← hardForkTermFromIdent fork)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals thenExpr visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals elseExpr visitingConstants))
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals thenExpr visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals elseExpr visitingConstants linkedExternalLowerer?))
   | `(term| structMember $field:term $key:term $member:term) =>
       let fieldName := ← expectStringOrIdent field
       let memberName := ← expectStringOrIdent member
       let _ ← lookupStructMemberDecl fields fieldName memberName false
       `(Compiler.CompilationModel.Expr.structMember
           $(strTerm fieldName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key visitingConstants linkedExternalLowerer?)
           $(strTerm memberName))
   | `(term| structMember2 $field:term $key1:term $key2:term $member:term) =>
       let fieldName := ← expectStringOrIdent field
@@ -3686,11 +3856,11 @@ partial def translatePureExprWithTypes
       let _ ← lookupStructMemberDecl fields fieldName memberName true
       `(Compiler.CompilationModel.Expr.structMember2
           $(strTerm fieldName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1 visitingConstants)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2 visitingConstants)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1 visitingConstants linkedExternalLowerer?)
+          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2 visitingConstants linkedExternalLowerer?)
           $(strTerm memberName))
   | _ =>
-      match ← translateLeanDefCall? fields constDecls immutableDecls #[] params locals stx visitingConstants with
+      match ← translateLeanDefCall? fields constDecls immutableDecls #[] params locals stx visitingConstants linkedExternalLowerer? with
       | some expr => pure expr
       | none => throwErrorAt stx "unsupported expression in verity_contract body (see #1003 for planned macro support expansions)"
 end
@@ -3888,7 +4058,12 @@ def arrayElementTupleElemExprs?
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (rhs : Term) : CommandElabM (Option (Array Term)) := do
+    (rhs : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Option (Array Term)) := do
+  let translateExpr (expr : Term) : CommandElabM Term :=
+    match translateExpr? with
+    | some translate => translate expr
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals expr
   match stripParens rhs with
   | `(term| arrayElement $name:term $index:term) =>
       -- verity#1849, G2: compound projections never destructure into a tuple.
@@ -3907,7 +4082,7 @@ def arrayElementTupleElemExprs?
             | none =>
                 throwErrorAt rhs
                   "arrayElement tuple destructuring requires a static ABI-word tuple element type"
-          let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+          let indexExpr ← translateExpr index
           let mut offset := 0
           let mut exprs : Array Term := #[]
           for elemTy in elemTys do
@@ -3938,7 +4113,12 @@ def arrayElementTupleDestructureStmts?
     (locals : Array TypedLocal)
     (mutableLocals : Array String)
     (rhs : Term)
-    (names : Array (Option String)) : CommandElabM (Option (Array Term × TypedLocal)) := do
+    (names : Array (Option String))
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Option (Array Term × TypedLocal)) := do
+  let translateExpr (expr : Term) : CommandElabM Term :=
+    match translateExpr? with
+    | some translate => translate expr
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals expr
   match stripParens rhs with
   | `(term| arrayElement $name:term $index:term) =>
       -- verity#1849, G2: compound projections never destructure into a tuple.
@@ -3956,7 +4136,7 @@ def arrayElementTupleDestructureStmts?
               s!"tuple destructuring binds {names.size} names, but the source provides {elemTys.length} values"
           let syntheticUsed := mutableLocals ++ names.filterMap id
           let indexName := freshSyntheticLocalName "arrayElement_index" params locals syntheticUsed
-          let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+          let indexExpr ← translateExpr index
           let indexStmt ←
             `(Compiler.CompilationModel.Stmt.letVar $(strTerm indexName) $indexExpr)
           let indexLocal ←
@@ -4023,7 +4203,12 @@ def arrayElementTupleReturnStmts?
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (mutableLocals : Array String)
-    (rhs : Term) : CommandElabM (Option (Array Term × TypedLocal)) := do
+    (rhs : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Option (Array Term × TypedLocal)) := do
+  let translateExpr (expr : Term) : CommandElabM Term :=
+    match translateExpr? with
+    | some translate => translate expr
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals expr
   match stripParens rhs with
   | `(term| arrayElement $name:term $index:term) =>
       -- verity#1849, G2: compound projections (`(arrayElement <p> <i>).<dynField>`)
@@ -4045,7 +4230,7 @@ def arrayElementTupleReturnStmts?
                 throwErrorAt rhs
                   "arrayElement tuple return requires a static ABI-word tuple element type"
           let indexName := freshSyntheticLocalName "arrayElement_index" params locals mutableLocals
-          let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+          let indexExpr ← translateExpr index
           let indexStmt ←
             `(Compiler.CompilationModel.Stmt.letVar $(strTerm indexName) $indexExpr)
           let indexLocal ←
@@ -4080,12 +4265,17 @@ def tupleLiteralOrStructValueExprs?
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (rhs : Term) : CommandElabM (Option (Array Term)) := do
+    (rhs : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Option (Array Term)) := do
+  let translateExpr (expr : Term) : CommandElabM Term :=
+    match translateExpr? with
+    | some translate => translate expr
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals expr
   let structCtorValueExprs? : CommandElabM (Option (Array Term)) := do
     match qualifiedFunctionAppSyntax? (stripParens rhs) with
     | some (name, ctorArgs) =>
         if name.toString.endsWith ".mk" then
-          pure (some (← ctorArgs.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)))
+          pure (some (← ctorArgs.mapM translateExpr))
         else
           pure none
     | none =>
@@ -4095,7 +4285,7 @@ def tupleLiteralOrStructValueExprs?
             | .ident _ raw _ _ =>
                 if raw.toString.endsWith ".mk" then
                   let ctorArgs := (args.getD 1 Syntax.missing).getArgs.map (fun syn => ⟨syn⟩)
-                  pure (some (← ctorArgs.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)))
+                  pure (some (← ctorArgs.mapM translateExpr))
                 else
                   pure none
             | _ => pure none
@@ -4105,30 +4295,37 @@ def tupleLiteralOrStructValueExprs?
     | `(term| structMembers $field:term $key:term $members:term) => do
         let fieldName := ← expectStringOrIdent field
         let memberNames := ← expectStringList members
+        if memberNames.size > 1 && syntaxContainsCallExternal key then
+          throwErrorAt key
+            "structMembers key cannot contain callExternal when selecting multiple members because lowering reuses the key; bind the external result first"
         let exprs ← memberNames.mapM fun memberName => do
           let _ ← lookupStructMemberDecl fields fieldName memberName false
           `(Compiler.CompilationModel.Expr.structMember
               $(strTerm fieldName)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
+              $(← translateExpr key)
               $(strTerm memberName))
         pure (some exprs)
     | `(term| structMembers2 $field:term $key1:term $key2:term $members:term) => do
         let fieldName := ← expectStringOrIdent field
         let memberNames := ← expectStringList members
+        if memberNames.size > 1 &&
+            (syntaxContainsCallExternal key1 || syntaxContainsCallExternal key2) then
+          throwErrorAt rhs
+            "structMembers2 keys cannot contain callExternal when selecting multiple members because lowering reuses the keys; bind external results first"
         let exprs ← memberNames.mapM fun memberName => do
           let _ ← lookupStructMemberDecl fields fieldName memberName true
           `(Compiler.CompilationModel.Expr.structMember2
               $(strTerm fieldName)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2)
+              $(← translateExpr key1)
+              $(← translateExpr key2)
               $(strTerm memberName))
         pure (some exprs)
     | _ => pure none
   match tupleElemsFromTerm? rhs with
   | some elems =>
-      pure (some (← elems.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)))
+      pure (some (← elems.mapM translateExpr))
   | none =>
-      match ← arrayElementTupleElemExprs? fields constDecls immutableDecls params locals rhs with
+      match ← arrayElementTupleElemExprs? fields constDecls immutableDecls params locals rhs translateExpr? with
       | some exprs => pure (some exprs)
       | none =>
           match ← structCtorValueExprs? with
@@ -4159,8 +4356,9 @@ def tupleReturnValueExprs?
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (rhs : Term) : CommandElabM (Option (Array Term)) := do
-  match (← tupleLiteralOrStructValueExprs? fields constDecls immutableDecls params locals rhs) with
+    (rhs : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Option (Array Term)) := do
+  match (← tupleLiteralOrStructValueExprs? fields constDecls immutableDecls params locals rhs translateExpr?) with
   | some exprs => pure (some exprs)
   | none =>
       match stripParens rhs with
@@ -4205,7 +4403,12 @@ def translateInternalHelperCallArgs
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (fn : FunctionDecl)
-    (argTerms : Array Term) : CommandElabM (Array Term) := do
+    (argTerms : Array Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Array Term) := do
+  let translateExpr (arg : Term) : CommandElabM Term :=
+    match translateExpr? with
+    | some translate => translate arg
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals arg
   let mut out : Array Term := #[]
   for idx in [:argTerms.size] do
     let some arg := argTerms[idx]? | pure ()
@@ -4224,7 +4427,7 @@ def translateInternalHelperCallArgs
                 arrayElementDynamicMemberProjection? params arg then
               match fieldTy with
               | .array _ =>
-                  let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                  let indexExpr ← translateExpr index
                   out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                     $(strTerm paramName)
                     $indexExpr
@@ -4239,7 +4442,7 @@ def translateInternalHelperCallArgs
                 localArrayElementDynamicMemberProjection? locals arg then
               match fieldTy with
               | .array _ =>
-                  let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                  let indexExpr ← translateExpr index
                   out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                     $(strTerm paramName)
                     $indexExpr
@@ -4277,10 +4480,10 @@ def translateInternalHelperCallArgs
                 | _ =>
                     out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
               else
-                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                out := out.push (← translateExpr arg)
           | none =>
               if let some (paramName, index, _elemTy) := arrayElementDynamicTupleArg? params arg then
-                let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                let indexExpr ← translateExpr index
                 out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicDataOffset
                   $(strTerm paramName)
                   $indexExpr))
@@ -4288,7 +4491,7 @@ def translateInternalHelperCallArgs
                   arrayElementDynamicMemberProjection? params arg then
                 match fnParam.ty, fieldTy with
                 | .bytes, .bytes | .string, .string =>
-                    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                    let indexExpr ← translateExpr index
                     out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                       $(strTerm paramName)
                       $indexExpr
@@ -4298,12 +4501,12 @@ def translateInternalHelperCallArgs
                       $indexExpr
                       $(natTerm wordOffset)))
                 | _, _ =>
-                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                    out := out.push (← translateExpr arg)
               else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                   localArrayElementDynamicMemberProjection? locals arg then
                 match fnParam.ty, fieldTy with
                 | .bytes, .bytes | .string, .string =>
-                    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                    let indexExpr ← translateExpr index
                     out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                       $(strTerm paramName)
                       $indexExpr
@@ -4313,7 +4516,7 @@ def translateInternalHelperCallArgs
                       $indexExpr
                       $(natTerm wordOffset)))
                 | _, _ =>
-                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                    out := out.push (← translateExpr arg)
               else if let some (paramName, fieldTy, wordOffset) :=
                   paramDynamicMemberProjection? params arg then
                 match fnParam.ty, fieldTy with
@@ -4325,23 +4528,23 @@ def translateInternalHelperCallArgs
                       $(strTerm paramName)
                       $(natTerm wordOffset)))
                 | _, _ =>
-                    out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                    out := out.push (← translateExpr arg)
               else
-                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                out := out.push (← translateExpr arg)
         else
           if isStaticCompositeInternalHelperType fnParam.ty then
             match directParamNameWithType? params arg with
             | some (name, ty) =>
                 let bindingNames := staticInternalHelperBindingNames name ty
                 if bindingNames.isEmpty then
-                  out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                  out := out.push (← translateExpr arg)
                 else
                   for bindingName in bindingNames do
                     out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm bindingName)))
             | none =>
-                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+                out := out.push (← translateExpr arg)
           else
-            out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+            out := out.push (← translateExpr arg)
   pure out
 
 def translateLinkedExternalCallArgs
@@ -4350,9 +4553,20 @@ def translateLinkedExternalCallArgs
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (argTerms : Array Term) : CommandElabM (Array Term) := do
+    (argTerms : Array Term)
+    (expectedTypes : Option (Array ValueType) := none)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Array Term) := do
+  let translateExpr (arg : Term) : CommandElabM Term :=
+    match translateExpr? with
+    | some translate => translate arg
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals arg
   let mut out : Array Term := #[]
-  for arg in argTerms do
+  for (arg, argIdx) in argTerms.zipIdx do
+    let translateScalar : CommandElabM Term := do
+      let raw ← translateExpr arg
+      match expectedTypes >>= (·[argIdx]?) with
+      | some expectedTy => normalizeTranslatedExprForType expectedTy arg raw
+      | none => pure raw
     match ← translateAbiEncodeProjection? fields constDecls immutableDecls params locals arg with
     | some exprs =>
         out := out ++ exprs
@@ -4363,12 +4577,18 @@ def translateLinkedExternalCallArgs
               out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
               out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
             else
-              out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+              out := out.push (← translateScalar)
         | none =>
-            if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
+            if let some (name, _) := localMemoryArray? locals arg then
+              out := out.push (← `(Compiler.CompilationModel.Expr.localVar $(strTerm s!"{name}_data_offset")))
+              out := out.push (← `(Compiler.CompilationModel.Expr.localVar $(strTerm s!"{name}_length")))
+            else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 arrayElementDynamicMemberProjection? params arg then
               if externalCallDynamicArgSupported fieldTy then
-                let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                if syntaxContainsCallExternal index then
+                  throwErrorAt index
+                    "dynamic projection indices cannot contain callExternal because ABI lowering reuses the index for offset and length; bind the external result first"
+                let indexExpr ← translateExpr index
                 out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                   $(strTerm paramName)
                   $indexExpr
@@ -4382,7 +4602,10 @@ def translateLinkedExternalCallArgs
             else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 localArrayElementDynamicMemberProjection? locals arg then
               if externalCallDynamicArgSupported fieldTy then
-                let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                if syntaxContainsCallExternal index then
+                  throwErrorAt index
+                    "dynamic projection indices cannot contain callExternal because ABI lowering reuses the index for offset and length; bind the external result first"
+                let indexExpr ← translateExpr index
                 out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                   $(strTerm paramName)
                   $indexExpr
@@ -4405,8 +4628,48 @@ def translateLinkedExternalCallArgs
               else
                 throwErrorAt arg s!"linked external dynamic-member argument currently supports only Array<wordLike>/bytes/string members, got {renderValueType fieldTy}"
             else
-              out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg)
+              out := out.push (← translateScalar)
   pure out
+
+set_option linter.unusedVariables false in
+partial def translateDeclaredPureExpr
+    (fields : Array StorageFieldDecl)
+    (constDecls : Array ConstantDecl)
+    (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (stx : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM Term := do
+  let translateExpr (arg : Term) : CommandElabM Term :=
+    match translateExpr? with
+    | some translate => translate arg
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals arg
+  let lower : Ident → Array Term → CommandElabM Term := fun name args => do
+    let extName := toString name.getId
+    let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+      | some ext => pure ext
+      | none => throwErrorAt name s!"unknown linked external '{extName}'"
+    validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+      extName ext.params args
+    match ext.returnTys.toList with
+    | [retTy] =>
+        unless isSingleWordStaticValueType retTy do
+          throwErrorAt name s!"callExternal '{extName}' return type cannot be used as a pure single-word expression"
+        let argExprs ← translateLinkedExternalCallArgs
+          fields constDecls immutableDecls params locals args (some ext.params)
+          (some (translateDeclaredPureExpr
+            fields constDecls immutableDecls externalDecls params locals))
+        let callExpr ←
+          `(Compiler.CompilationModel.Expr.externalCall $(strTerm extName) [ $[$argExprs],* ])
+        normalizeTranslatedExprForType retTy stx callExpr
+    | [] => throwErrorAt name s!"callExternal '{extName}' returns no values"
+    | _ => throwErrorAt name s!"callExternal '{extName}' returns multiple values"
+  let lowerer : LinkedExternalLowerer :=
+    { lower := lower
+      inferType := fun expr visiting =>
+        inferPureExprType fields constDecls immutableDecls externalDecls params locals expr visiting }
+  translatePureExprWithTypes fields constDecls immutableDecls params locals stx [] (some lowerer)
 
 def tupleInternalCallAssignStmt?
     (fields : Array StorageFieldDecl)
@@ -4435,6 +4698,8 @@ def tupleInternalCallAssignStmt?
       ensureCallableAsInternalHelper rhs fn
       let argExprs ← translateInternalHelperCallArgs
         fields constDecls immutableDecls params locals fn argTerms
+        (some (translateDeclaredPureExpr
+          fields constDecls immutableDecls externalDecls params locals))
       pure (some (← `(Compiler.CompilationModel.Stmt.internalCallAssign
         [ $[$resultNameTerms],* ]
         $(strTerm (internalHelperSpecNameFor fn))
@@ -4444,7 +4709,8 @@ def tupleInternalCallAssignStmt?
       | some (qualifiedName, argTerms) =>
           let _ ← unsafe qualifiedTupleBindTypedLocals rhs.raw qualifiedName names
           let argExprs ← argTerms.mapM
-            (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+            (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals)
           pure (some (← `(Compiler.CompilationModel.Stmt.internalCallAssign
             [ $[$resultNameTerms],* ]
             $(strTerm (qualifiedInternalHelperName functions qualifiedName))
@@ -4452,12 +4718,11 @@ def tupleInternalCallAssignStmt?
       | none =>
           pure none
 
-/-- Try to translate a tuple‐destructured `tryExternalCall "name" [args]` RHS into
-    a `Stmt.tryExternalCallBind` term.  Returns `none` when the RHS is not a
-    `tryExternalCall` application.  Returns the statement term and the inferred
-    types for each bound name (Bool for success flag, Uint256 for all result
-    vars — precise return types require external decl lookup which happens in
-    the validation pass).  (#1727, Axis 1 Step 5f) -/
+/-- Try to translate a tuple‐destructured `tryExternalCall "name" [args]` RHS.
+    Returns `none` when the RHS is not a `tryExternalCall` application.  Returns
+    the generated statements and inferred types for each bound name.  Narrow result
+    words are normalized immediately after the call bind.  (#1727, Axis 1
+    Step 5f) -/
 def tryExternalCallBindStmt?
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
@@ -4466,14 +4731,23 @@ def tryExternalCallBindStmt?
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (rhs : Term)
-    (names : Array (Option String)) : CommandElabM (Option (Term × Array TypedLocal)) := do
+    (names : Array (Option String)) : CommandElabM (Option (Array Term × Array TypedLocal)) := do
   let rhs := stripParens rhs
   match rhs with
   | `(term| tryExternalCall $name:term $args:term) =>
       let extName := ← expectStringOrIdent name
+      let ext ←
+        match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt rhs s!"unknown external function '{extName}'"
       let argExprs ← match stripParens args with
-        | `(term| [ $[$xs],* ]) =>
+        | `(term| [ $[$xs],* ]) => do
+            validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+              extName ext.params xs
             translateLinkedExternalCallArgs fields constDecls immutableDecls params locals xs
+              (some ext.params)
+              (some (translateDeclaredPureExpr
+                fields constDecls immutableDecls externalDecls params locals))
         | _ => throwErrorAt args "expected list literal [..]"
       -- names[0] is the success flag, names[1..] are result vars
       let initialUsedNames := (params.toList.map (fun p => p.name)) ++ (typedLocalNames locals).toList ++ (names.filterMap id).toList
@@ -4491,33 +4765,49 @@ def tryExternalCallBindStmt?
         | none => "_try_success"
       let resultVars := targetNames.drop 1
       let successVarTerm := strTerm successVar
-      let resultTys ←
-        match externalDecls.find? (fun ext => ext.name == extName) with
-        | some ext =>
-            if ext.returnTys.size != resultVars.length then
-              throwErrorAt rhs s!"tryExternalCall '{extName}' binds {resultVars.length} result value(s), but the external declaration returns {ext.returnTys.size}"
-            pure ext.returnTys
-        | none =>
-            -- Validation reports the unknown external with full context; keep
-            -- translation moving with word-shaped placeholders.
-            pure (Array.replicate resultVars.length .uint256)
+      if ext.returnTys.size != resultVars.length then
+        throwErrorAt rhs s!"tryExternalCall '{extName}' binds {resultVars.length} result value(s), but the external declaration returns {ext.returnTys.size}"
+      let resultTys := ext.returnTys
       let mut flattenedResultVars : Array String := #[]
+      let existingNames := (params.map (fun p => p.name)) ++ typedLocalNames locals
       let mut visibleLocals : Array TypedLocal := #[mkTypedLocal successVar .bool]
+      let mut normalizations : Array Term := #[]
+      if let some normalization ← normalizeBoundValueStmt? .bool rhs successVar then
+        normalizations := normalizations.push normalization
       for (resultVar, resultTy) in resultVars.toArray.zip resultTys do
         let flatNames ← flattenExternalResultNames resultVar resultTy
+        unless flatNames.length == 1 || (staticStructDirectFieldLocals? resultVar resultTy).isSome do
+          throwErrorAt rhs
+            s!"tryExternalCall '{extName}' cannot bind flattened composite return type {renderValueType resultTy} to source variable '{resultVar}'"
+        for flatName in flatNames do
+          if existingNames.contains flatName then
+            throwErrorAt rhs
+              s!"tryExternalCall '{extName}' flattened result variable '{flatName}' conflicts with an existing local"
+          if flatName == successVar || flattenedResultVars.contains flatName ||
+              (flatName != resultVar && resultVars.contains flatName) then
+            throwErrorAt rhs
+              s!"tryExternalCall '{extName}' generates duplicate flattened result variable '{flatName}'"
         flattenedResultVars := flattenedResultVars ++ flatNames.toArray
         let source :=
           match staticStructDirectFieldLocals? resultVar resultTy with
           | some fieldLocals => LocalSource.externalStaticStruct fieldLocals
           | none => LocalSource.value
         visibleLocals := visibleLocals.push { name := resultVar, ty := resultTy, source := source }
+        if let .struct _ fields := resultTy then
+          if let some fieldLocals := staticStructDirectFieldLocals? resultVar resultTy then
+            for ((_, fieldTy), (_, fieldLocal)) in fields.zip fieldLocals do
+              if let some normalization ← normalizeBoundValueStmt? fieldTy rhs fieldLocal then
+                normalizations := normalizations.push normalization
+        else if flatNames.length == 1 then
+          if let some normalization ← normalizeBoundValueStmt? resultTy rhs resultVar then
+            normalizations := normalizations.push normalization
       let resultVarTerms := flattenedResultVars.map strTerm
       let stmt ← `(Compiler.CompilationModel.Stmt.tryExternalCallBind
           $successVarTerm
           [ $[$resultVarTerms],* ]
           $(strTerm extName)
           [ $[$argExprs],* ])
-      pure (some (stmt, visibleLocals))
+      pure (some (#[stmt] ++ normalizations, visibleLocals))
   | _ => pure none
 
 /-- Translate `let r ← callResult "name" [args]` into the existing try-call
@@ -4531,19 +4821,24 @@ def callResultBindStmt?
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (rhs : Term)
-    (resultName : String) : CommandElabM (Option (Term × TypedLocal)) := do
+    (resultName : String) : CommandElabM (Option (Array Term × TypedLocal)) := do
   let rhs := stripParens rhs
   match rhs with
   | `(term| callResult $name:term $args:term) =>
       let extName := ← expectStringOrIdent name
-      let argExprs ← match stripParens args with
-        | `(term| [ $[$xs],* ]) =>
-            translateLinkedExternalCallArgs fields constDecls immutableDecls params locals xs
-        | _ => throwErrorAt args "expected list literal [..]"
       let ext ←
         match externalDecls.find? (fun ext => ext.name == extName) with
         | some ext => pure ext
         | none => throwErrorAt rhs s!"unknown external function '{extName}'"
+      let argExprs ← match stripParens args with
+        | `(term| [ $[$xs],* ]) => do
+            validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+              extName ext.params xs
+            translateLinkedExternalCallArgs fields constDecls immutableDecls params locals xs
+              (some ext.params)
+              (some (translateDeclaredPureExpr
+                fields constDecls immutableDecls externalDecls params locals))
+        | _ => throwErrorAt args "expected list literal [..]"
       for retTy in ext.returnTys do
         unless isSingleWordStaticValueType retTy do
           throwErrorAt rhs
@@ -4552,12 +4847,14 @@ def callResultBindStmt?
       let usedAfterSuccess : Array TypedLocal := locals.push (mkTypedLocal successVar .bool)
       let mut fieldLocals : List (String × String) := [("success", successVar)]
       let mut resultVars : Array String := #[]
+      let mut resultVarTys : Array ValueType := #[]
       let mut resultFields : List (String × ValueType) := [("success", .bool)]
       match ext.returnTys.toList with
       | [] => pure ()
       | [retTy] =>
           let payloadVar := freshSyntheticLocalName s!"{resultName}_returndata" params usedAfterSuccess #[]
           resultVars := resultVars.push payloadVar
+          resultVarTys := resultVarTys.push retTy
           fieldLocals := fieldLocals ++ [("returndata", payloadVar)]
           resultFields := resultFields ++ [("returndata", retTy)]
       | retTys =>
@@ -4567,6 +4864,7 @@ def callResultBindStmt?
             let payloadVar := freshSyntheticLocalName s!"{resultName}_{fieldName}" params indexedLocals #[]
             indexedLocals := indexedLocals.push (mkTypedLocal payloadVar retTy)
             resultVars := resultVars.push payloadVar
+            resultVarTys := resultVarTys.push retTy
             fieldLocals := fieldLocals ++ [(fieldName, payloadVar)]
             resultFields := resultFields ++ [(fieldName, retTy)]
       let resultVarTerms := resultVars.map strTerm
@@ -4575,11 +4873,17 @@ def callResultBindStmt?
           [ $[$resultVarTerms],* ]
           $(strTerm extName)
           [ $[$argExprs],* ])
+      let mut normalizations : Array Term := #[]
+      if let some normalization ← normalizeBoundValueStmt? .bool rhs successVar then
+        normalizations := normalizations.push normalization
+      for (resultVar, resultTy) in resultVars.zip resultVarTys do
+        if let some normalization ← normalizeBoundValueStmt? resultTy rhs resultVar then
+          normalizations := normalizations.push normalization
       let resultLocal : TypedLocal :=
         { name := resultName
           ty := .struct "Call.Result" resultFields
           source := .externalStaticStruct fieldLocals }
-      pure (some (stmt, resultLocal))
+      pure (some (#[stmt] ++ normalizations, resultLocal))
   | _ => pure none
 
 def expectExprList
@@ -4588,14 +4892,19 @@ def expectExprList
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (stx : Term) : CommandElabM (Array Term) := do
+    (stx : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Array Term) := do
+  let translateExpr (x : Term) :=
+    match translateExpr? with
+    | some translate => translate x
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals x
   match stripParens stx with
   | `(term| [ $[$xs],* ]) =>
       let mut out : Array Term := #[]
       for x in xs do
         match ← translateAbiEncodeProjection? fields constDecls immutableDecls params locals x with
         | some exprs => out := out ++ exprs
-        | none => out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+        | none => out := out.push (← translateExpr x)
       pure out
   | _ => throwErrorAt stx "expected list literal [..]"
 
@@ -4605,7 +4914,12 @@ def expectEcmExprList
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (stx : Term) : CommandElabM (Array Term) := do
+    (stx : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Array Term) := do
+  let translateExpr (x : Term) :=
+    match translateExpr? with
+    | some translate => translate x
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals x
   match stripParens stx with
   | `(term| [ $[$xs],* ]) =>
       let mut out : Array Term := #[]
@@ -4618,12 +4932,15 @@ def expectEcmExprList
             else
               match ← translateAbiEncodeProjection? fields constDecls immutableDecls params locals x with
               | some exprs => out := out ++ exprs
-              | none => out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+              | none => out := out.push (← translateExpr x)
         | none =>
             if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 arrayElementDynamicMemberProjection? params x then
               if externalCallDynamicArgSupported fieldTy then
-                  let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                  if syntaxContainsCallExternal index then
+                    throwErrorAt index
+                      "ECM dynamic projection indices cannot contain callExternal because ABI lowering reuses the index for offset and length; bind the external result first"
+                  let indexExpr ← translateExpr index
                   out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                     $(strTerm paramName)
                     $indexExpr
@@ -4633,11 +4950,14 @@ def expectEcmExprList
                     $indexExpr
                     $(natTerm wordOffset)))
               else
-                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+                out := out.push (← translateExpr x)
             else if let some (paramName, index, fieldTy, _elemTy, wordOffset) :=
                 localArrayElementDynamicMemberProjection? locals x then
               if externalCallDynamicArgSupported fieldTy then
-                  let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+                  if syntaxContainsCallExternal index then
+                    throwErrorAt index
+                      "ECM dynamic projection indices cannot contain callExternal because ABI lowering reuses the index for offset and length; bind the external result first"
+                  let indexExpr ← translateExpr index
                   out := out.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberDataOffset
                     $(strTerm paramName)
                     $indexExpr
@@ -4647,7 +4967,7 @@ def expectEcmExprList
                     $indexExpr
                     $(natTerm wordOffset)))
               else
-                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+                out := out.push (← translateExpr x)
             else if let some (paramName, fieldTy, wordOffset) :=
                 paramDynamicMemberProjection? params x then
               if externalCallDynamicArgSupported fieldTy then
@@ -4658,11 +4978,11 @@ def expectEcmExprList
                     $(strTerm paramName)
                     $(natTerm wordOffset)))
               else
-                out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+                out := out.push (← translateExpr x)
             else
               match ← translateAbiEncodeProjection? fields constDecls immutableDecls params locals x with
               | some exprs => out := out ++ exprs
-              | none => out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals x)
+              | none => out := out.push (← translateExpr x)
       pure out
   | _ => throwErrorAt stx "expected list literal [..]"
 
@@ -4672,19 +4992,24 @@ def translateEmitArgExpr
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (stx : Term) : CommandElabM Term := do
+    (stx : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM Term := do
+  let translateExpr (x : Term) :=
+    match translateExpr? with
+    | some translate => translate x
+    | none => translatePureExprWithTypes fields constDecls immutableDecls params locals x
   if let some (name, _) := localMemoryArray? locals stx then
     `(Compiler.CompilationModel.Expr.memoryArrayLength $(strTerm name))
   else if let some (paramName, index, _fieldTy, _elemTy, wordOffset) :=
       localArrayElementDynamicMemberProjection? locals stx then
-    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+    let indexExpr ← translateExpr index
     `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
         $(strTerm paramName)
         $indexExpr
         $(natTerm wordOffset))
   else if let some (paramName, index, _fieldTy, _elemTy, wordOffset) :=
       arrayElementDynamicMemberProjection? params stx then
-    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index
+    let indexExpr ← translateExpr index
     `(Compiler.CompilationModel.Expr.arrayElementDynamicMemberLength
         $(strTerm paramName)
         $indexExpr
@@ -4700,7 +5025,7 @@ def translateEmitArgExpr
         $(strTerm paramName)
         $(natTerm wordOffset))
   else
-    translatePureExprWithTypes fields constDecls immutableDecls params locals stx
+    translateExpr stx
 
 def expectEmitExprList
     (fields : Array StorageFieldDecl)
@@ -4708,10 +5033,12 @@ def expectEmitExprList
     (immutableDecls : Array ImmutableDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
-    (stx : Term) : CommandElabM (Array Term) := do
+    (stx : Term)
+    (translateExpr? : Option (Term → CommandElabM Term) := none) : CommandElabM (Array Term) := do
   match stripParens stx with
   | `(term| [ $[$xs],* ]) =>
-      xs.mapM (translateEmitArgExpr fields constDecls immutableDecls params locals)
+      xs.mapM fun x => translateEmitArgExpr
+        fields constDecls immutableDecls params locals x translateExpr?
   | _ => throwErrorAt stx "expected list literal [..]"
 
 def inferEmitArgExprType
@@ -4737,7 +5064,34 @@ def translateBindSource
     (locals : Array TypedLocal)
     (rhs : Term) : CommandElabM Term := do
   let rhs := stripParens rhs
+  let translateOperand := translateDeclaredPureExpr
+    fields constDecls immutableDecls externalDecls params locals
   match rhs with
+  | `(term| callExternal $name:ident ($[$args:term],*)) =>
+      let extName := toString name.getId
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown linked external '{extName}'"
+      validateLinkedExternalCallArgs fields constDecls immutableDecls externalDecls params locals
+        extName ext.params args
+      match ext.returnTys.toList with
+      | [retTy] =>
+          unless isSingleWordStaticValueType retTy do
+            throwErrorAt name s!"callExternal '{extName}' return type cannot be used as a pure single-word expression"
+          let argExprs ← translateLinkedExternalCallArgs
+            fields constDecls immutableDecls params locals args (some ext.params)
+            (some (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals))
+          let callExpr ←
+            `(Compiler.CompilationModel.Expr.externalCall $(strTerm extName) [ $[$argExprs],* ])
+          normalizeTranslatedExprForType retTy rhs callExpr
+      | [] => throwErrorAt name s!"callExternal '{extName}' returns no values"
+      | _ => throwErrorAt name s!"callExternal '{extName}' returns multiple values"
+  | `(term| memoryLoad($_))
+    | `(term| returnDataSize())
+    | `(term| evmCall($_, $_, $_, $_, $_, $_, $_))
+    | `(term| evmStaticCall($_, $_, $_, $_, $_, $_)) =>
+      translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals rhs
   | `(term| getStorage $field:ident) =>
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with
@@ -4777,15 +5131,15 @@ def translateBindSource
       | .dynamicArray _ | .scalar (.fixedArray (.uintN 128) _) =>
           `(Compiler.CompilationModel.Expr.storageArrayElement
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals index))
+              $(← translateOperand index))
       | _ => throwErrorAt rhs s!"field '{f.name}' is not a storage dynamic array"
   | `(term| getMapping $field:ident $key:term) =>
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with
       | .mappingAddressToUint256 | .mappingAddressToEnum _ _ =>
-          `(Compiler.CompilationModel.Expr.mapping $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key))
+          `(Compiler.CompilationModel.Expr.mapping $(strTerm f.name) $(← translateOperand key))
       | .mappingUintToUint256 | .mappingUintToEnum _ _ =>
-          `(Compiler.CompilationModel.Expr.mappingUint $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key))
+          `(Compiler.CompilationModel.Expr.mappingUint $(strTerm f.name) $(← translateOperand key))
       | .mapping2AddressToAddressToUint256 | .mapping2AddressToAddressToEnum _ _ =>
           throwErrorAt rhs s!"field '{f.name}' is a double mapping; use getMapping2"
       | .mappingChain _ | .mappingChainEnum _ _ _ =>
@@ -4799,7 +5153,7 @@ def translateBindSource
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with
       | .mappingAddressToUint256 =>
-          `(Compiler.CompilationModel.Expr.mapping $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key))
+          `(Compiler.CompilationModel.Expr.mapping $(strTerm f.name) $(← translateOperand key))
       | .mappingUintToUint256 =>
           throwErrorAt rhs s!"field '{f.name}' is Uint256-keyed; use getMappingUintAddr"
       | .mappingAddressToEnum _ _ | .mappingUintToEnum _ _ =>
@@ -4817,7 +5171,7 @@ def translateBindSource
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with
       | .mappingUintToUint256 | .mappingUintToEnum _ _ =>
-          `(Compiler.CompilationModel.Expr.mappingUint $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key))
+          `(Compiler.CompilationModel.Expr.mappingUint $(strTerm f.name) $(← translateOperand key))
       | .mappingAddressToUint256 | .mappingAddressToEnum _ _ =>
           throwErrorAt rhs s!"field '{f.name}' is Address-keyed; use getMapping"
       | .mapping2AddressToAddressToUint256 | .mapping2AddressToAddressToEnum _ _ =>
@@ -4833,7 +5187,7 @@ def translateBindSource
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with
       | .mappingUintToUint256 =>
-          `(Compiler.CompilationModel.Expr.mappingUint $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key))
+          `(Compiler.CompilationModel.Expr.mappingUint $(strTerm f.name) $(← translateOperand key))
       | .mappingAddressToUint256 =>
           throwErrorAt rhs s!"field '{f.name}' is Address-keyed; use getMappingAddr"
       | .mappingAddressToEnum _ _ | .mappingUintToEnum _ _ =>
@@ -4854,7 +5208,7 @@ def translateBindSource
         | .mappingAddressToEnum _ _ | .mappingUintToEnum _ _ =>
           `(Compiler.CompilationModel.Expr.mappingWord
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
+              $(← translateOperand key)
               $wordOffset)
       | .mapping2AddressToAddressToUint256 | .mapping2AddressToAddressToEnum _ _ =>
           throwErrorAt rhs s!"field '{f.name}' is a double mapping; use getMapping2Word"
@@ -4873,8 +5227,8 @@ def translateBindSource
       | .mapping2AddressToAddressToUint256 | .mapping2AddressToAddressToEnum _ _ =>
           `(Compiler.CompilationModel.Expr.mapping2
               $(strTerm f.name)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1)
-              $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2))
+              $(← translateOperand key1)
+              $(← translateOperand key2))
       | .mappingStruct2 _ _ _ =>
           throwErrorAt rhs s!"field '{f.name}' is a nested struct mapping; use structMember2"
       | .mappingStruct _ _ =>
@@ -4887,7 +5241,7 @@ def translateBindSource
       | some keyTypes =>
           if keyTerms.size != keyTypes.length then
             throwErrorAt rhs s!"field '{f.name}' expects {keyTypes.length} mapping keys, but getMappingN received {keyTerms.size}"
-          let keyExprs ← keyTerms.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+          let keyExprs ← keyTerms.mapM translateOperand
           `(Compiler.CompilationModel.Expr.mappingChain
               $(strTerm f.name)
               [ $[$keyExprs],* ])
@@ -4902,7 +5256,7 @@ def translateBindSource
       let _ ← lookupStructMemberDecl fields fieldName memberName false
       `(Compiler.CompilationModel.Expr.structMember
           $(strTerm fieldName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key)
+          $(← translateOperand key)
           $(strTerm memberName))
   | `(term| structMember2 $field:term $key1:term $key2:term $member:term) =>
       let fieldName := ← expectStringOrIdent field
@@ -4910,8 +5264,8 @@ def translateBindSource
       let _ ← lookupStructMemberDecl fields fieldName memberName true
       `(Compiler.CompilationModel.Expr.structMember2
           $(strTerm fieldName)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1)
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2)
+          $(← translateOperand key1)
+          $(← translateOperand key2)
           $(strTerm memberName))
   | `(term| msgSender) | `(term| Verity.msgSender) => `(Compiler.CompilationModel.Expr.caller)
   | `(term| msgValue) | `(term| Verity.msgValue) => `(Compiler.CompilationModel.Expr.msgValue)
@@ -4931,21 +5285,22 @@ def translateBindSource
       `(Compiler.CompilationModel.Expr.chainid)
   | `(term| tload $offset:term) =>
       `(Compiler.CompilationModel.Expr.tload
-          $(← translatePureExprWithTypes fields constDecls immutableDecls params locals offset))
+          $(← translateOperand offset))
   | _ =>
       match ← resolveLocalFunctionApp? fields constDecls immutableDecls externalDecls functions params locals rhs with
       | some (fn, argTerms) =>
           ensureCallableAsInternalHelper rhs fn
           let argExprs ← translateInternalHelperCallArgs
             fields constDecls immutableDecls params locals fn argTerms
+            (some (translateDeclaredPureExpr
+              fields constDecls immutableDecls externalDecls params locals))
           `(Compiler.CompilationModel.Expr.internalCall
               $(strTerm (internalHelperSpecNameFor fn))
               [ $[$argExprs],* ])
       | none =>
           match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
           | some (qualifiedName, argTerms) =>
-              let argExprs ← argTerms.mapM
-                (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+              let argExprs ← argTerms.mapM translateOperand
               `(Compiler.CompilationModel.Expr.internalCall
                   $(strTerm (qualifiedInternalHelperName functions qualifiedName))
                   [ $[$argExprs],* ])
@@ -4957,10 +5312,13 @@ def translateSafeRequireBind
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
     (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
     (params : Array ParamDecl)
     (locals : Array TypedLocal)
     (varName : String)
     (rhs : Term) : CommandElabM (Option (Array Term)) := do
+  let translateOperand :=
+    translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals
   let narrowBitsOf (term : Term) : CommandElabM Nat := do
     match stripParens term with
     | `(term| $name:ident) =>
@@ -4973,22 +5331,25 @@ def translateSafeRequireBind
     | _ => throwErrorAt term "narrow arithmetic currently requires direct UintN operands"
   let translateSafeUintGuardAndValue (optExpr : Term) (label : String) :
       CommandElabM (Term × Term) := do
+    if syntaxContainsCallExternal optExpr then
+      throwErrorAt optExpr
+        s!"{label} operands cannot contain callExternal because safe-arithmetic lowering reuses operands in both the guard and result; bind the external result first"
     match stripParens optExpr with
     | `(term| safeAdd $a:term $b:term) =>
-        let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-        let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+        let aExpr ← translateOperand a
+        let bExpr ← translateOperand b
         let valueExpr : Term ← `(Compiler.CompilationModel.Expr.add $aExpr $bExpr)
         let guardExpr : Term ← `(Compiler.CompilationModel.Expr.ge $valueExpr $aExpr)
         pure (guardExpr, valueExpr)
     | `(term| safeSub $a:term $b:term) =>
-        let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-        let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+        let aExpr ← translateOperand a
+        let bExpr ← translateOperand b
         let valueExpr : Term ← `(Compiler.CompilationModel.Expr.sub $aExpr $bExpr)
         let guardExpr : Term ← `(Compiler.CompilationModel.Expr.ge $aExpr $bExpr)
         pure (guardExpr, valueExpr)
     | `(term| safeMul $a:term $b:term) =>
-        let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-        let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+        let aExpr ← translateOperand a
+        let bExpr ← translateOperand b
         let valueExpr : Term ← `(Compiler.CompilationModel.Expr.mul $aExpr $bExpr)
         let zeroExpr : Term ← `(Compiler.CompilationModel.Expr.literal 0)
         let divisorZeroExpr : Term ← `(Compiler.CompilationModel.Expr.eq $bExpr $zeroExpr)
@@ -4997,8 +5358,8 @@ def translateSafeRequireBind
         let guardExpr : Term ← `(Compiler.CompilationModel.Expr.logicalOr $divisorZeroExpr $noOverflowExpr)
         pure (guardExpr, valueExpr)
     | `(term| safeDiv $a:term $b:term) =>
-        let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-        let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+        let aExpr ← translateOperand a
+        let bExpr ← translateOperand b
         let valueExpr : Term ← `(Compiler.CompilationModel.Expr.div $aExpr $bExpr)
         let zeroExpr : Term ← `(Compiler.CompilationModel.Expr.literal 0)
         let guardExpr : Term ←
@@ -5011,8 +5372,8 @@ def translateSafeRequireBind
   match rhs with
   | `(term| narrowAddPanic $a:term $b:term) =>
       let bits ← narrowBitsOf a
-      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let aExpr ← translateOperand a
+      let bExpr ← translateOperand b
       let valueExpr : Term ← `(Compiler.CompilationModel.Expr.add $aExpr $bExpr)
       let guardExpr : Term ← `(Compiler.CompilationModel.Expr.lt $valueExpr
         (Compiler.CompilationModel.Expr.literal $(natTerm (2 ^ bits))))
@@ -5021,8 +5382,8 @@ def translateSafeRequireBind
         (← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $valueExpr))
       ])
   | `(term| narrowSubPanic $a:term $b:term) =>
-      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let aExpr ← translateOperand a
+      let bExpr ← translateOperand b
       let valueExpr : Term ← `(Compiler.CompilationModel.Expr.sub $aExpr $bExpr)
       let guardExpr : Term ← `(Compiler.CompilationModel.Expr.ge $aExpr $bExpr)
       pure (some #[
@@ -5031,8 +5392,8 @@ def translateSafeRequireBind
       ])
   | `(term| narrowMulPanic $a:term $b:term) =>
       let bits ← narrowBitsOf a
-      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let aExpr ← translateOperand a
+      let bExpr ← translateOperand b
       let valueExpr : Term ← `(Compiler.CompilationModel.Expr.mul $aExpr $bExpr)
       -- Check the mathematical product before evaluating the wrapping EVM `mul`.
       -- Looking only at `valueExpr < 2^bits` is unsound for widths above 128:
@@ -5063,7 +5424,7 @@ def translateSafeRequireBind
   -- error name and argument list.
   | `(term| requireSomeUintError $optExpr:term $errorName:ident($args,*)) =>
       let errorNameLit := strTerm (toString errorName.getId)
-      let argExprs ← args.getElems.mapM (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+      let argExprs ← args.getElems.mapM translateOperand
       let (guardExpr, valueExpr) ← translateSafeUintGuardAndValue optExpr "requireSomeUintError"
       pure (some #[
         (← `(Compiler.CompilationModel.Stmt.requireError $guardExpr $errorNameLit [ $[$argExprs],* ])),
@@ -5077,8 +5438,8 @@ def translateSafeRequireBind
   -- and `Panic(0x12)` (division by zero) opcodes.
   | `(term| addPanic $a:term $b:term) =>
       let msgLit := strTerm "Panic(0x11): arithmetic overflow"
-      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let aExpr ← translateOperand a
+      let bExpr ← translateOperand b
       let valueExpr : Term ← `(Compiler.CompilationModel.Expr.add $aExpr $bExpr)
       let guardExpr : Term ← `(Compiler.CompilationModel.Expr.ge $valueExpr $aExpr)
       pure (some #[
@@ -5087,8 +5448,8 @@ def translateSafeRequireBind
       ])
   | `(term| subPanic $a:term $b:term) =>
       let msgLit := strTerm "Panic(0x11): arithmetic underflow"
-      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let aExpr ← translateOperand a
+      let bExpr ← translateOperand b
       let valueExpr : Term ← `(Compiler.CompilationModel.Expr.sub $aExpr $bExpr)
       let guardExpr : Term ← `(Compiler.CompilationModel.Expr.ge $aExpr $bExpr)
       pure (some #[
@@ -5097,8 +5458,8 @@ def translateSafeRequireBind
       ])
   | `(term| mulPanic $a:term $b:term) =>
       let msgLit := strTerm "Panic(0x11): arithmetic overflow"
-      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let aExpr ← translateOperand a
+      let bExpr ← translateOperand b
       let valueExpr : Term ← `(Compiler.CompilationModel.Expr.mul $aExpr $bExpr)
       let zeroExpr : Term ← `(Compiler.CompilationModel.Expr.literal 0)
       let divisorZeroExpr : Term ← `(Compiler.CompilationModel.Expr.eq $bExpr $zeroExpr)
@@ -5111,8 +5472,8 @@ def translateSafeRequireBind
       ])
   | `(term| divPanic $a:term $b:term) =>
       let msgLit := strTerm "Panic(0x12): division by zero"
-      let aExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals a
-      let bExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals b
+      let aExpr ← translateOperand a
+      let bExpr ← translateOperand b
       let valueExpr : Term ← `(Compiler.CompilationModel.Expr.div $aExpr $bExpr)
       let zeroExpr : Term ← `(Compiler.CompilationModel.Expr.literal 0)
       let guardExpr : Term ←

--- a/artifacts/macro_property_tests/PropertyAdtLinkedPayloadSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyAdtLinkedPayloadSmoke.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyAdtLinkedPayloadSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/ExternalCallInBodySmoke.lean
+ */
+contract PropertyAdtLinkedPayloadSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("AdtLinkedPayloadSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: store has no unexpected revert
+    function testAuto_Store_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("store()"));
+        require(ok, "store reverted unexpectedly");
+    }
+}

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyExternalCallInBodySmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/ExternalCallInBodySmoke.lean
+ */
+contract PropertyExternalCallInBodySmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("ExternalCallInBodySmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `linkedRead` result
+    function testTODO_LinkedRead_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("linkedRead()"));
+        require(ok, "linkedRead reverted unexpectedly");
+        assertEq(ret.length, 32, "linkedRead ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: linkedWrite has no unexpected revert
+    function testAuto_LinkedWrite_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("linkedWrite(uint256,bytes)", uint256(1), hex"CAFE"));
+        require(ok, "linkedWrite reverted unexpectedly");
+    }
+    // Property 3: TODO decode and assert `pureNarrow` result
+    function testTODO_PureNarrow_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureNarrow()"));
+        require(ok, "pureNarrow reverted unexpectedly");
+        assertEq(ret.length, 32, "pureNarrow ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 4: TODO decode and assert `pureDirtyUint` result
+    function testTODO_PureDirtyUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyUint()"));
+        require(ok, "pureDirtyUint reverted unexpectedly");
+        assertEq(ret.length, 32, "pureDirtyUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 5: TODO decode and assert `directDirtyUint` result
+    function testTODO_DirectDirtyUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("directDirtyUint()"));
+        require(ok, "directDirtyUint reverted unexpectedly");
+        assertEq(ret.length, 32, "directDirtyUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 6: TODO decode and assert `nestedDirtyUint` result
+    function testTODO_NestedDirtyUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("nestedDirtyUint()"));
+        require(ok, "nestedDirtyUint reverted unexpectedly");
+        assertEq(ret.length, 32, "nestedDirtyUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 7: TODO decode and assert `nestedExternalArg` result
+    function testTODO_NestedExternalArg_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("nestedExternalArg()"));
+        require(ok, "nestedExternalArg reverted unexpectedly");
+        assertEq(ret.length, 32, "nestedExternalArg ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 8: TODO decode and assert `bindDirtyUint` result
+    function testTODO_BindDirtyUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyUint()"));
+        require(ok, "bindDirtyUint reverted unexpectedly");
+        assertEq(ret.length, 32, "bindDirtyUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 9: TODO decode and assert `tryDirtyUint` result
+    function testTODO_TryDirtyUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryDirtyUint()"));
+        require(ok, "tryDirtyUint reverted unexpectedly");
+        assertEq(ret.length, 32, "tryDirtyUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 10: TODO decode and assert `callResultDirtyUint` result
+    function testTODO_CallResultDirtyUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("callResultDirtyUint()"));
+        require(ok, "callResultDirtyUint reverted unexpectedly");
+        assertEq(ret.length, 32, "callResultDirtyUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 11: TODO decode and assert `tryNotifyBool` result
+    function testTODO_TryNotifyBool_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryNotifyBool(bool)", true));
+        require(ok, "tryNotifyBool reverted unexpectedly");
+        assertEq(ret.length, 32, "tryNotifyBool ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 12: TODO decode and assert `tryDirtyPair` result
+    function testTODO_TryDirtyPair_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryDirtyPair()"));
+        require(ok, "tryDirtyPair reverted unexpectedly");
+        assertEq(ret.length, 32, "tryDirtyPair ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 13: TODO decode and assert `bindDirtyAddress` result
+    function testTODO_BindDirtyAddress_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyAddress()"));
+        require(ok, "bindDirtyAddress reverted unexpectedly");
+        assertEq(ret.length, 32, "bindDirtyAddress ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 14: TODO decode and assert `bindDirtyBool` result
+    function testTODO_BindDirtyBool_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBool()"));
+        require(ok, "bindDirtyBool reverted unexpectedly");
+        assertEq(ret.length, 32, "bindDirtyBool ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 15: TODO decode and assert `leanHelperNestedExternal` result
+    function testTODO_LeanHelperNestedExternal_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("leanHelperNestedExternal()"));
+        require(ok, "leanHelperNestedExternal reverted unexpectedly");
+        assertEq(ret.length, 32, "leanHelperNestedExternal ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 16: TODO decode and assert `bindNestedExternalArg` result
+    function testTODO_BindNestedExternalArg_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindNestedExternalArg()"));
+        require(ok, "bindNestedExternalArg reverted unexpectedly");
+        assertEq(ret.length, 32, "bindNestedExternalArg ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 17: statementNestedExternalArg has no unexpected revert
+    function testAuto_StatementNestedExternalArg_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("statementNestedExternalArg()"));
+        require(ok, "statementNestedExternalArg reverted unexpectedly");
+    }
+    // Property 18: legacyNarrowArgs has no unexpected revert
+    function testAuto_LegacyNarrowArgs_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("legacyNarrowArgs()"));
+        require(ok, "legacyNarrowArgs reverted unexpectedly");
+    }
+    // Property 19: emitNestedExternalArg has no unexpected revert
+    function testAuto_EmitNestedExternalArg_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("emitNestedExternalArg()"));
+        require(ok, "emitNestedExternalArg reverted unexpectedly");
+    }
+    // Property 20: customErrorNestedExternalArg has no unexpected revert
+    function testAuto_CustomErrorNestedExternalArg_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("customErrorNestedExternalArg()"));
+        require(ok, "customErrorNestedExternalArg reverted unexpectedly");
+    }
+    // Property 21: consumeHelper has no unexpected revert
+    function testAuto_ConsumeHelper_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("consumeHelper(uint256)", uint256(1)));
+        require(ok, "consumeHelper reverted unexpectedly");
+    }
+    // Property 22: helperNestedExternalArg has no unexpected revert
+    function testAuto_HelperNestedExternalArg_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("helperNestedExternalArg()"));
+        require(ok, "helperNestedExternalArg reverted unexpectedly");
+    }
+    // Property 23: ecmNestedExternalArg has no unexpected revert
+    function testAuto_EcmNestedExternalArg_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("ecmNestedExternalArg()"));
+        require(ok, "ecmNestedExternalArg reverted unexpectedly");
+    }
+    // Property 24: TODO decode and assert `erc20BalanceNestedExternalArg` result
+    function testTODO_Erc20BalanceNestedExternalArg_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20BalanceNestedExternalArg()"));
+        require(ok, "erc20BalanceNestedExternalArg reverted unexpectedly");
+        assertEq(ret.length, 32, "erc20BalanceNestedExternalArg ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 25: TODO decode and assert `erc20AllowanceNestedExternalArg` result
+    function testTODO_Erc20AllowanceNestedExternalArg_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20AllowanceNestedExternalArg()"));
+        require(ok, "erc20AllowanceNestedExternalArg reverted unexpectedly");
+        assertEq(ret.length, 32, "erc20AllowanceNestedExternalArg ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 26: TODO decode and assert `erc20SupplyNestedExternalArg` result
+    function testTODO_Erc20SupplyNestedExternalArg_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20SupplyNestedExternalArg()"));
+        require(ok, "erc20SupplyNestedExternalArg reverted unexpectedly");
+        assertEq(ret.length, 32, "erc20SupplyNestedExternalArg ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 27: TODO decode and assert `mappingNestedExternalArg` result
+    function testTODO_MappingNestedExternalArg_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("mappingNestedExternalArg()"));
+        require(ok, "mappingNestedExternalArg reverted unexpectedly");
+        assertEq(ret.length, 32, "mappingNestedExternalArg ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 28: TODO decode and assert `tupleNestedExternalResult` result
+    function testTODO_TupleNestedExternalResult_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalResult()"));
+        require(ok, "tupleNestedExternalResult reverted unexpectedly");
+        assertEq(ret.length, 32, "tupleNestedExternalResult ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 29: TODO decode and assert `tupleNestedExternalReturn` result
+    function testTODO_TupleNestedExternalReturn_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalReturn()"));
+        require(ok, "tupleNestedExternalReturn reverted unexpectedly");
+        require(ret.length >= 64, "tupleNestedExternalReturn ABI tuple return payload unexpectedly short");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 30: TODO decode and assert `pureDirtyInt` result
+    function testTODO_PureDirtyInt_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
+        require(ok, "pureDirtyInt reverted unexpectedly");
+        assertEq(ret.length, 32, "pureDirtyInt ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 31: TODO decode and assert `bindDirtyInt` result
+    function testTODO_BindDirtyInt_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
+        require(ok, "bindDirtyInt reverted unexpectedly");
+        assertEq(ret.length, 32, "bindDirtyInt ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 32: TODO decode and assert `pureDirtyBytes` result
+    function testTODO_PureDirtyBytes_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
+        require(ok, "pureDirtyBytes reverted unexpectedly");
+        assertEq(ret.length, 32, "pureDirtyBytes ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 33: TODO decode and assert `bindDirtyBytes` result
+    function testTODO_BindDirtyBytes_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));
+        require(ok, "bindDirtyBytes reverted unexpectedly");
+        assertEq(ret.length, 32, "bindDirtyBytes ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}


### PR DESCRIPTION
Integrates the net patch from merged #2245 onto current `main` as one forward commit.

Scope: declared `callExternal` and low-level calls in contract bodies, including recursive/nested linked external-call lowering in `abiEncode`, with #2247/#2248/#2249 behavior retained during conflict resolution.

Provenance:
- source merge: `d48472c8a0c4d99584ea01bbc914d23e3d9fe2f5` (merged into `feat/uint-narrow-types`)
- base: `c41757164e9e8230536d7af29d81a2961b30e482`
- integration head: `9ea9b4d47d52634bcaf529106095bb84a0676f0f`

Validation:
- targeted `lake build Contracts.Smoke.ExternalCallInBodySmoke Verity.Macro.Translate Verity.Macro.Translate.Expr` submitted to the remote builder for this head
- full `lake build` was blocked before execution by the remote runner disk-reserve policy (83 GiB available; 12 GiB estimate plus 80 GiB emergency floor)
- `make check` invoked; it includes axiom, trust-surface, compiler-boundary and forbidden-escape gates

No trust/axiom/CI boundary files changed; `AUDIT.md`, `TRUST_ASSUMPTIONS.md`, and `AXIOMS.md` remain synchronized.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the contract macro/compiler lowering path for external and low-level calls, where mistaken single- vs multi-evaluation semantics could alter generated bytecode; mitigated by broad smoke coverage but still security-adjacent.
> 
> **Overview**
> Adds first-class **`callExternal`** and low-level EVM surface syntax (`evmCall`, `evmStaticCall`, `memoryLoad`/`memoryStore`, `returnDataSize`, `returnDataCopy`) in `verity_contract` bodies, wired through **`Verity.Macro.Translate`** (and expression lowering) instead of ad-hoc spellings.
> 
> The translator now lowers linked externals in statements and expressions (including **nested** calls in args, emits, ECM/ERC-20 helpers, ADT payloads, tuples, and `arrayElement` indices), applies **post-bind narrowing** for dirty word types, and normalizes **`tryExternalCall` success** flags to booleans. It **rejects** `callExternal` inside expression forms that would duplicate or reuse operands (conditionals, short-circuit `&&`, safe arithmetic, transparent Lean helpers, etc.), with stricter **word-like** checks on memory/returndata ops.
> 
> **`Contracts.Smoke.ExternalCallInBodySmoke`** is a large regression suite (`rfl` on `modelBody`, semantic preservation, and `#guard_msgs` negative cases). Existing **`ExternalCalls`** smoke expectations are updated for the new `_success` assign after `tryExternalCallBind`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea9b4d47d52634bcaf529106095bb84a0676f0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->