### PR TITLE
feat: add top-level call transaction rollback

### DIFF
--- a/Contracts/Examples/CallProgramRollback.lean
+++ b/Contracts/Examples/CallProgramRollback.lean
@@ -11,6 +11,15 @@ def first : CallSite :=
 def second : CallSite :=
   { siteId := 2, kind := .delegatecall, target := 20, gas := 30 }
 
+def commitsThenReverts : CallProgram (TransactionResult Nat) :=
+  .bind first fun _ =>
+    .bind second fun _ =>
+      .pure (.revert [0xde, 0xad])
+
+def commits : CallProgram (TransactionResult Nat) :=
+  .bind first fun _ =>
+    .pure (.commit 7)
+
 example (adversary : AdversaryModel) (state : CallState)
     (h : ∀ entry ∈ ObservedCalls (sequential first second) adversary state,
       RollsBack adversary entry) :
@@ -26,5 +35,29 @@ example (adversary : AdversaryModel) (state : CallState)
         (CallsIn (sequential first second) adversary state) := by
   exact denoteCallProgram_all_succeed_commits_world
     (sequential first second) adversary state h
+
+example (adversary : AdversaryModel) (state : CallState) :
+    (denoteTransaction commitsThenReverts adversary state).state.world = state.world := by
+  exact denoteTransaction_revert_world commitsThenReverts adversary state [0xde, 0xad] rfl
+
+example (adversary : AdversaryModel) (state : CallState) :
+    (denoteTransaction commitsThenReverts adversary state).state.returndata = [0xde, 0xad] := by
+  exact denoteTransaction_revert_returndata commitsThenReverts adversary state [0xde, 0xad] rfl
+
+example (adversary : AdversaryModel) (state : CallState) :
+    (denoteTransaction commitsThenReverts adversary state).result = .revert [0xde, 0xad] := by
+  exact denoteTransaction_revert_result commitsThenReverts adversary state [0xde, 0xad] rfl
+
+example (adversary : AdversaryModel) (state : CallState) :
+    (denoteTransaction commitsThenReverts adversary state).state.gasRemaining =
+      (denote commitsThenReverts adversary state).2.gasRemaining := by
+  exact denoteTransaction_revert_gasRemaining
+    commitsThenReverts adversary state [0xde, 0xad] rfl
+
+example (adversary : AdversaryModel) (state : CallState) :
+    denoteTransaction commits adversary state =
+      let (_, postState) := denote commits adversary state
+      { result := .commit 7, state := postState } := by
+  exact denoteTransaction_commit_eq commits adversary state 7 rfl
 
 end Contracts.Examples.CallProgramRollback

--- a/Contracts/Smoke/EnumFeatureTest.lean
+++ b/Contracts/Smoke/EnumFeatureTest.lean
@@ -69,9 +69,12 @@ def eventAndErrorUseUint8Abi : Bool :=
 
 example : eventAndErrorUseUint8Abi = true := by native_decide
 
-def memberConstantIsOne : Bool := MacroEnumUsage.Status.Active == 1
+def memberConstantsFollowDeclarationOrder : Bool :=
+  MacroEnumUsage.Status.Pending == 0 &&
+    MacroEnumUsage.Status.Active == 1 &&
+    MacroEnumUsage.Status.Closed == 2
 
-example : memberConstantIsOne = true := by native_decide
+example : memberConstantsFollowDeclarationOrder = true := by native_decide
 
 def castAcceptsLastMember : Bool :=
   match MacroEnumUsage.castStatus 2 defaultState with

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -32,6 +32,8 @@ verity_contract ExternalCallInBodySmoke where
     wide : Uint256
   errors
     error Failure(Uint256)
+  event_defs
+    event Seen(value : Uint256)
 
   linked_externals
     external getDepositableEther() -> (Uint256)

--- a/Contracts/Smoke/Helpers.lean
+++ b/Contracts/Smoke/Helpers.lean
@@ -285,7 +285,7 @@ abbrev Amount := Address
 end QualifiedTypeFixture
 
 /--
-error: unsupported type 'QualifiedTypeFixture.Amount'; expected Uint256, Int256, Uint8, Uint16, Address, Bytes32, Bool, String, Bytes, Array <type>, FixedArray <type> <size>, Tuple [...], Unit, a user-defined struct, or a user-defined type from the `types` or `inductive` section
+error: unsupported type 'QualifiedTypeFixture.Amount'; expected a built-in type or a user-defined enum, struct, newtype, or inductive type
 -/
 #guard_msgs in
 verity_contract QualifiedLocalTypeCaptureRejected where

--- a/Verity/Core/Model/CallProgramRollback.lean
+++ b/Verity/Core/Model/CallProgramRollback.lean
@@ -52,6 +52,66 @@ def commitWorlds (adversary : AdversaryModel) (world : Verity.ContractState)
     (sites : List CallSite) : Verity.ContractState :=
   sites.foldl (commitWorld adversary) world
 
+/-! ## Top-level transaction rollback -/
+
+/-- The control result of the enclosing transaction.  Unlike an individual
+external-call result, `revert` rolls back every mutable call already performed
+by the program. -/
+inductive TransactionResult (α : Type) where
+  | commit (value : α)
+  | revert (returndata : List Nat)
+  deriving DecidableEq, Repr
+
+/-- The observable result and final caller state of a transaction. -/
+structure TransactionObservation (α : Type) where
+  result : TransactionResult α
+  state : CallState
+
+/-- Run a call program against a snapshot of the caller world.  A committed
+result keeps the threaded state.  A top-level revert restores the initial
+world after all inner calls have run, while retaining charged gas and exposing
+the transaction's revert data. -/
+def denoteTransaction (prog : CallProgram (TransactionResult α))
+    (adversary : AdversaryModel) (state : CallState) : TransactionObservation α :=
+  let (result, postState) := denote prog adversary state
+  match result with
+  | .commit value => { result := .commit value, state := postState }
+  | .revert data =>
+      { result := .revert data
+        state := { postState with world := state.world, returndata := data } }
+
+theorem denoteTransaction_commit_eq (prog : CallProgram (TransactionResult α))
+    (adversary : AdversaryModel) (state : CallState) (value : α)
+    (h : (denote prog adversary state).1 = .commit value) :
+    denoteTransaction prog adversary state =
+      { result := .commit value, state := (denote prog adversary state).2 } := by
+  simp [denoteTransaction, h]
+
+theorem denoteTransaction_revert_world (prog : CallProgram (TransactionResult α))
+    (adversary : AdversaryModel) (state : CallState) (data : List Nat)
+    (h : (denote prog adversary state).1 = .revert data) :
+    (denoteTransaction prog adversary state).state.world = state.world := by
+  simp [denoteTransaction, h]
+
+theorem denoteTransaction_revert_result (prog : CallProgram (TransactionResult α))
+    (adversary : AdversaryModel) (state : CallState) (data : List Nat)
+    (h : (denote prog adversary state).1 = .revert data) :
+    (denoteTransaction prog adversary state).result = .revert data := by
+  simp [denoteTransaction, h]
+
+theorem denoteTransaction_revert_returndata (prog : CallProgram (TransactionResult α))
+    (adversary : AdversaryModel) (state : CallState) (data : List Nat)
+    (h : (denote prog adversary state).1 = .revert data) :
+    (denoteTransaction prog adversary state).state.returndata = data := by
+  simp [denoteTransaction, h]
+
+theorem denoteTransaction_revert_gasRemaining (prog : CallProgram (TransactionResult α))
+    (adversary : AdversaryModel) (state : CallState) (data : List Nat)
+    (h : (denote prog adversary state).1 = .revert data) :
+    (denoteTransaction prog adversary state).state.gasRemaining =
+      (denote prog adversary state).2.gasRemaining := by
+  simp [denoteTransaction, h]
+
 theorem denote_pure_world (value : α) (adversary : AdversaryModel)
     (state : CallState) :
     (denote (.pure value) adversary state).2.world = state.world := rfl

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -805,7 +805,7 @@ private def translateEffectStmt
       | none =>
           match f.ty with
           | .scalar .uint256 | .scalar .int256 | .scalar .uint16 | .scalar (.uintN _)
-          | .scalar (.newtype _ .uint256) =>
+          | .scalar (.newtype _ .uint256) | .scalar (.enum _ _) =>
               `(Compiler.CompilationModel.Stmt.setStorage $(strTerm f.name) $(← translateDeclaredPureExpr fields constDecls immutableDecls externalDecls params locals value))
           | .scalar (.adt adtName _) =>
               `(Compiler.CompilationModel.Stmt.setStorage
@@ -3541,6 +3541,15 @@ def parseContractSyntax
         match constantDecls with
         | some decls => decls.mapM (parseConstant typeNewtypes)
         | none => pure #[]
+      let enumConstants : Array ConstantDecl := parsedEnums.flatMap fun enumDecl =>
+        enumDecl.members.mapIdx fun ordinal member => {
+          ident := mkIdentFrom member <|
+            Name.str (Name.mkSimple enumDecl.name) (toString member.getId)
+          name := s!"{enumDecl.name}.{toString member.getId}"
+          ty := .enum enumDecl.name enumDecl.members.size
+          body := natTerm ordinal
+        }
+      let parsedConstants := enumConstants ++ parsedConstants
       let parsedImmutables ←
         match immutableDecls with
         | some decls => decls.mapM (parseImmutable typeNewtypes)


### PR DESCRIPTION
## Summary
- add an explicit `TransactionResult` / `TransactionObservation` boundary around stateful `CallProgram` execution
- restore the pre-transaction caller world when the enclosing transaction reverts, even after earlier inner calls committed
- preserve charged gas and expose the top-level revert returndata; keep the threaded post-state on commit
- prove exact commit, rollback-world, revert-result, revert-returndata, and gas-preservation laws

## Dependency
Stacked on #2253 (`fix/external-call-smoke-main`) because that PR is still open. Merge #2253 first; this PR intentionally contains its one-line smoke-event fix in the GitHub comparison against `main`.

## Issue / downstream blocker
Slice 1 of #1963, directly addressing the top-level snapshot rollback gap identified for Lido P-DEPOSIT-1 in #2234 A.1/B.1(c).

This is narrower than all of #1963: it establishes the stateful transaction commit/revert foundation only. It does not add result-aware executable-loop semantics (the remaining P-DEPOSIT-1 blocker from #2234 B.1(d)), typed ECM interpretation, source/compiler oracle unification, or trust-report generation.

## TDD / validation
Tests were written first in `Contracts/Examples/CallProgramRollback.lean`, then the semantic API and laws were implemented.

- `/root/.elan/toolchains/leanprover--lean4---v4.31.0/bin/lake build Verity.Core.Model.CallProgramRollback Contracts.Examples.CallProgramRollback`
- `PATH=/root/.elan/toolchains/leanprover--lean4---v4.31.0/bin:$PATH make check` (658 tests)
- `git diff --check`
- source scan: no `sorry`, `admit`, new `axiom`, or `unsafe`

## Known inherited CI state
At stack creation, #2253 head `387cbe87af66ff57284b548e2043ee5d283baff9` had passing `checks`, `build`, and `build-audits`, but failing `build-compiler-binaries` in `Contracts.Smoke.ExternalCallInBodySmoke` / `Contracts.Smoke.Helpers`. This slice does not repair that unrelated active failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core external-call rollback semantics used for contract verification, but the change is additive with proven laws rather than rewriting existing call denotation.
> 
> **Overview**
> Adds an explicit **transaction boundary** around stateful `CallProgram` execution so a top-level revert can roll back the caller world even after earlier inner calls committed.
> 
> Introduces `TransactionResult` / `TransactionObservation` and `denoteTransaction`, which keeps the threaded post-state on commit, and on revert restores the initial world while preserving charged gas and exposing revert returndata. Proves commit equality plus revert world/result/returndata/gas laws, with examples in `CallProgramRollback`.
> 
> Also wires enum member ordinals as generated constants (declaration order), allows `setStorage` on enum fields, and includes small smoke/error-message cleanups (`events` → `event_defs`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0bef2e59570b1b386abc328b56c856fb30dfb62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->