### PR TITLE
feat(model): result-aware loops with trace-based transaction rollback (#1963 slice 2)

### DIFF
--- a/Contracts/Examples/CallProgramRollback.lean
+++ b/Contracts/Examples/CallProgramRollback.lean
@@ -108,4 +108,62 @@ example :
     (denoteTransaction commitsThenReverts mutatingAdversary demoState).state.gasRemaining = 90 := by
   decide
 
+/-! ### Result-aware loop, Lido shape
+
+Three deposit-like calls iterate under a policy that aborts once the gas
+budget drops to 85.  Every call succeeds and commits (slot k := 42), the
+first two observations continue, the third aborts — so the enclosing
+transaction reverts and discards three genuinely committed mutations. -/
+
+def third : CallSite :=
+  { siteId := 3, kind := .call, target := 30, gas := 30 }
+
+def depositLoop : CallProgram (TransactionResult Nat) :=
+  forEachCall
+    (fun obs => if obs.state.gasRemaining ≤ 85 then .abort [0xbe, 0xef] else .next)
+    0
+    [first, second, third]
+
+/-- All three planned sites are actually observed before the abort. -/
+example :
+    (CallsIn depositLoop mutatingAdversary demoState).map (·.siteId) = [1, 2, 3] := by
+  decide
+
+/-- Each iteration really committed: the threaded pre-revert world has all
+three slots mutated. -/
+example :
+    (denote depositLoop mutatingAdversary demoState).2.world.storage 1 = 42 ∧
+    (denote depositLoop mutatingAdversary demoState).2.world.storage 2 = 42 ∧
+    (denote depositLoop mutatingAdversary demoState).2.world.storage 3 = 42 := by
+  refine ⟨?_, ?_, ?_⟩ <;> decide
+
+/-- The loop aborts through its policy and the transaction reverts with the
+policy's data, rolling every committed iteration back to the initial world
+while keeping the charged gas. -/
+example :
+    (denoteTransaction depositLoop mutatingAdversary demoState).result =
+        .revert [0xbe, 0xef] ∧
+    (denoteTransaction depositLoop mutatingAdversary demoState).state.world.storage 1 = 0 ∧
+    (denoteTransaction depositLoop mutatingAdversary demoState).state.world.storage 3 = 0 ∧
+    (denoteTransaction depositLoop mutatingAdversary demoState).state.gasRemaining = 85 := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
+
+/-- The generic trace-based law instantiated on the concrete loop: revert
+result, rollback to the initial world, and intermediate world pinned to the
+fold of the observed commits. -/
+example :
+    (denoteTransaction depositLoop mutatingAdversary demoState).state.world =
+        demoState.world ∧
+    (denote depositLoop mutatingAdversary demoState).2.world =
+      commitWorlds mutatingAdversary demoState.world
+        (CallsIn depositLoop mutatingAdversary demoState) := by
+  have h := forEachCall_abort_discards_committed_prefix
+    (fun obs => if obs.state.gasRemaining ≤ 85 then .abort [0xbe, 0xef] else .next)
+    0 [first, second, third] mutatingAdversary demoState [0xbe, 0xef]
+    (by decide)
+    (by intro entry hentry
+        refine ⟨[], ?_⟩
+        rfl)
+  exact ⟨h.2.1, h.2.2⟩
+
 end Contracts.Examples.CallProgramRollback

--- a/Verity/Core/Model/CallProgramRollback.lean
+++ b/Verity/Core/Model/CallProgramRollback.lean
@@ -227,4 +227,115 @@ theorem denoteCallProgram_all_succeed_commits_world
           (CallsIn (next observation) adversary observation.state)
       rw [hcall]
 
+/-! ## Result-aware iteration
+
+A loop whose continuation decides, after observing each call, whether to keep
+iterating, stop with a committed value, or abort the enclosing transaction.
+The laws below relate the *observed trace* — not just the wrapper — to the
+rollback: an aborted run has really committed the fold of its observed sites
+into the threaded state before the transaction discards it. -/
+
+/-- Decision taken by the loop policy after observing one iteration. -/
+inductive LoopStep (α : Type) where
+  | next
+  | stop (value : α)
+  | abort (returndata : List Nat)
+
+/-- Iterate `sites` in order.  After each call the `step` policy inspects the
+observation and chooses to continue, stop with a committed value, or abort the
+enclosing transaction.  Exhausting the sites commits `exhausted`.  A failed or
+reverted inner call does not by itself abort the transaction: the policy sees
+the observation and chooses, which models callers that tolerate individual
+call failures. -/
+def forEachCall (step : CallObservation → LoopStep α) (exhausted : α) :
+    List CallSite → CallProgram (TransactionResult α)
+  | [] => .pure (.commit exhausted)
+  | site :: rest =>
+      .bind site fun obs =>
+        match step obs with
+        | .next => forEachCall step exhausted rest
+        | .stop value => .pure (.commit value)
+        | .abort data => .pure (.revert data)
+
+/-- The loop executes a prefix of its planned sites: iteration order follows
+the site list and stops at the first `stop`/`abort` decision. -/
+theorem forEachCall_callsIn_take (step : CallObservation → LoopStep α)
+    (exhausted : α) (sites : List CallSite) (adversary : AdversaryModel)
+    (state : CallState) :
+    ∃ n, CallsIn (forEachCall step exhausted sites) adversary state =
+      sites.take n := by
+  induction sites generalizing state with
+  | nil => exact ⟨0, rfl⟩
+  | cons site rest ih =>
+      cases hstep : step (denoteCall adversary site state) with
+      | next =>
+          obtain ⟨n, hn⟩ := ih (denoteCall adversary site state).state
+          exact ⟨n + 1, by
+            simp [CallsIn, ObservedCalls, forEachCall, hstep] at hn ⊢
+            exact hn⟩
+      | stop value =>
+          exact ⟨1, by simp [CallsIn, ObservedCalls, forEachCall, hstep]⟩
+      | abort data =>
+          exact ⟨1, by simp [CallsIn, ObservedCalls, forEachCall, hstep]⟩
+
+/-- A transaction-level revert of the loop can only originate from the loop
+policy: some actually produced observation was mapped to `abort` with exactly
+the revert data the transaction reports. -/
+theorem forEachCall_revert_step_abort (step : CallObservation → LoopStep α)
+    (exhausted : α) (sites : List CallSite) (adversary : AdversaryModel)
+    (state : CallState) (data : List Nat)
+    (habort : (denote (forEachCall step exhausted sites) adversary state).1 =
+      .revert data) :
+    ∃ obs : CallObservation, step obs = .abort data := by
+  induction sites generalizing state with
+  | nil => simp [forEachCall, denote] at habort
+  | cons site rest ih =>
+      have hden : (denote (forEachCall step exhausted (site :: rest)) adversary state).1 =
+          (denote
+            (match step (denoteCall adversary site state) with
+              | .next => forEachCall step exhausted rest
+              | .stop value => CallProgram.pure (TransactionResult.commit value)
+              | .abort data => CallProgram.pure (TransactionResult.revert data))
+            adversary (denoteCall adversary site state).state).1 := rfl
+      rw [hden] at habort
+      cases hstep : step (denoteCall adversary site state) with
+      | next =>
+          rw [hstep] at habort
+          exact ih (denoteCall adversary site state).state habort
+      | stop value =>
+          rw [hstep] at habort
+          exact absurd habort (by simp [denote])
+      | abort d =>
+          rw [hstep] at habort
+          have hdd : d = data := by simpa [denote] using habort
+          exact ⟨denoteCall adversary site state, by rw [hstep, hdd]⟩
+
+/-- The Lido-shaped rollback law.  A run of the loop whose observed iterations
+all succeed — and therefore committed their world transitions into the
+threaded state, per the third conjunct — but which ends in a policy abort,
+reverts the whole transaction: the observable result carries the abort data,
+the final world is the initial world, and the discarded intermediate world is
+exactly the fold of the observed sites' commits.  The conclusion is tied to
+`ObservedCalls`/`CallsIn`, so it cannot be satisfied by a wrapper that merely
+overwrites the final state: the same hypotheses pin the intermediate state to
+the committed prefix. -/
+theorem forEachCall_abort_discards_committed_prefix
+    (step : CallObservation → LoopStep α) (exhausted : α)
+    (sites : List CallSite) (adversary : AdversaryModel) (state : CallState)
+    (data : List Nat)
+    (habort : (denote (forEachCall step exhausted sites) adversary state).1 =
+      .revert data)
+    (hsucc : ∀ entry ∈ ObservedCalls (forEachCall step exhausted sites) adversary state,
+      Succeeds adversary entry) :
+    (denoteTransaction (forEachCall step exhausted sites) adversary state).result =
+        .revert data ∧
+    (denoteTransaction (forEachCall step exhausted sites) adversary state).state.world =
+        state.world ∧
+    (denote (forEachCall step exhausted sites) adversary state).2.world =
+      commitWorlds adversary state.world
+        (CallsIn (forEachCall step exhausted sites) adversary state) :=
+  ⟨denoteTransaction_revert_result _ adversary state data habort,
+   denoteTransaction_revert_world _ adversary state data habort,
+   denoteCallProgram_all_succeed_commits_world _ adversary state hsucc⟩
+
 end Compiler.CompilationModel.DenoteExternalCalls


### PR DESCRIPTION
## Summary
Second slice of #1963, building on the transaction boundary merged via #2255: a result-aware iteration primitive whose rollback laws are tied to the observed call trace, addressing the "theorems true only by construction" concern from the OCR review of #2254.

- `LoopStep` / `forEachCall`: iterate call sites; the policy observes each `CallObservation` and chooses **continue**, **stop (commit)**, or **abort (transaction revert)**. An individual call failure does not by itself revert the parent — the program chooses.
- `forEachCall_callsIn_take`: the loop executes a prefix of its planned sites.
- `forEachCall_revert_step_abort`: a transaction-level revert can only originate from an actually produced observation that the policy mapped to `abort`, with the same returndata.
- `forEachCall_abort_discards_committed_prefix` (Lido / P-DEPOSIT-1 shape): iterations 0…k succeed → their mutations are pinned to `commitWorlds` over `CallsIn` in the threaded state → policy abort reverts the whole transaction to the initial world, keeping charged gas. The conclusion quantifies over `ObservedCalls`/`CallsIn`, so a wrapper that merely overwrites the final state cannot satisfy it.

## Examples (kernel `decide`, non-vacuous)
Three-call deposit-like loop under a concrete mutating adversary (site k writes 42 to slot k), gas-based abort policy: all three sites observed, all three slots provably 42 pre-revert, rolled back to 0 post-revert, gas 100→85 retained, plus the generic law instantiated on the concrete loop.

## Not in this slice
Typed ECM interpretation, source/compiler oracle unification (#1963 §1.2/1.3), exceptional-failure taxonomy (§1.4).

## Validation
- `lake build` full: 2464 jobs OK
- `make check`: all checks passed (no `native_decide` in proof files)
- `make test-python`: 658 OK
- No `sorry`/`admit`/new axiom/`unsafe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the formal call/transaction rollback model with new iteration semantics and proofs that encode security-relevant revert behavior. Additive Lean theorems and examples only; no runtime or auth surface changes.
> 
> **Overview**
> Adds a **result-aware call loop** so programs can continue, commit-stop, or abort a transaction after each observed call, with rollback laws pinned to the actual call trace (not just a final-state wrapper).
> 
> Introduces `LoopStep` / `forEachCall` plus theorems that a loop runs a prefix of planned sites, that transaction reverts come only from a policy `abort`, and that an abort after successful iterations rolls back to the initial world while the discarded intermediate world equals `commitWorlds` over `CallsIn`.
> 
> Concrete Lido-shaped deposit-loop examples exercise the law under a mutating adversary: three committed slot writes are observed pre-revert, then discarded post-revert with gas retained.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bda337df71bff9630d1ddf077e69d121cbaf18ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->