### PR TITLE
feat(model): ECM-induced summary environments (#1963 slice 4)

### DIFF
--- a/Verity/Core/Model/SummaryBridge.lean
+++ b/Verity/Core/Model/SummaryBridge.lean
@@ -147,4 +147,43 @@ theorem denoteCallProgram_all_static_preserves_world
   denoteCallProgram_all_revert_preserves_world prog adversary state
     (fun entry hentry => Or.inl (h entry hentry))
 
+/-! ## ECM-induced summary environments
+
+Typed External Call Modules already carry a derived `externalSummary`.  The
+definitions below interpret an ECM assignment as a `SummaryEnv`, so the same
+conformance notion covers typed ECM calls and raw call sites, and the trust
+report linkage (`assumptionNames = axioms`) is a definitional lemma rather
+than a convention. -/
+
+/-- Summary environment induced by assigning an ECM to every call site. -/
+def SummaryEnv.ofECM (moduleFor : CallSite → Compiler.ECM.ExternalCallModule) :
+    SummaryEnv :=
+  { summaryFor := fun site => (moduleFor site).externalSummary }
+
+/-- The trust assumptions surfaced by the summary environment are exactly the
+module's declared axioms. -/
+theorem SummaryEnv.ofECM_assumptions
+    (moduleFor : CallSite → Compiler.ECM.ExternalCallModule) (site : CallSite) :
+    ((SummaryEnv.ofECM moduleFor).summaryFor site).assumptionNames =
+      (moduleFor site).axioms := rfl
+
+/-- Under conformance, a site handled by a staticcall-mutability ECM must be
+compiled as a staticcall, and a successful response cannot change the external
+world.  For standard modules `summaryMutability` defaults to `.staticcall`
+exactly when `writesState = false`, so read-only ECMs are externally pure by
+construction of the boundary, not by per-module assumption. -/
+theorem Conforms.static_ecm_success_is_externally_pure
+    {moduleFor : CallSite → Compiler.ECM.ExternalCallModule}
+    {adversary : AdversaryModel}
+    (h : Conforms (SummaryEnv.ofECM moduleFor) adversary)
+    (site : CallSite) (world : Verity.ContractState) (data : List Nat)
+    (hstatic : (moduleFor site).summaryMutability = .staticcall)
+    (hres : adversary.result site world = .success data) :
+    site.kind = .staticcall ∧
+      externalWorldOf (adversary.stateTransition site world) =
+        externalWorldOf world := by
+  have hkm := (h site world).1
+  have hkind : site.kind = .staticcall := hkm.mpr hstatic
+  exact ⟨hkind, h.staticcall_preserves_externalWorld site world data hkind hres⟩
+
 end Compiler.CompilationModel.DenoteExternalCalls


### PR DESCRIPTION
Continuation of #2257 (§1.3 of #1963): `SummaryEnv.ofECM` interprets an ECM assignment as a summary environment so typed ECMs and raw call sites share one conformance boundary; `assumptionNames = axioms` becomes a definitional lemma (trust-report linkage); `Conforms.static_ecm_success_is_externally_pure` forces staticcall-mutability ECM sites to compile as staticcall and proves their successful responses externally pure — read-only ECMs cannot mutate the external world by construction.

Validation: full `lake build` (2465 jobs) OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean model/proof definitions only; no runtime, auth, or data-handling changes, and the PR reports a clean full build with no new axioms.
> 
> **Overview**
> Unifies typed ECM calls and raw call sites under one summary-conformance boundary by interpreting an ECM assignment as a `SummaryEnv`.
> 
> Adds `SummaryEnv.ofECM` (via each module's `externalSummary`), a definitional lemma that trust-report `assumptionNames` equal the module's `axioms`, and `Conforms.static_ecm_success_is_externally_pure`, which forces staticcall-mutability ECM sites to compile as `staticcall` and proves successful responses leave the external world unchanged—so read-only ECMs are externally pure by construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2fd434ed51890e4e2cd9ca6e98f885726a7f0ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->