### PR TITLE
feat(model): gas coupling and failure-cause opacity (#1963 slice 5)

### DIFF
--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -161,6 +161,9 @@ High-level semantics can expose intermediate state in reverted computations. EVM
 ### Top-Level Transaction Rollback (`denoteTransaction`)
 `Verity.Core.Model.CallProgramRollback.denoteTransaction` restores the pre-transaction caller world on a top-level `.revert` *by construction*: the `denoteTransaction_revert_*` theorems characterize this wrapper's behavior, they do not derive rollback from lower-level EVM semantics. That the EVM's actual transaction-revert behavior matches this model (full world restoration, gas remains charged, returndata exposed) is a trusted modeling assumption, on par with §6 (EVM/Yul Semantics).
 
+### External-Call Gas Discipline (short-term model)
+`Verity.Core.Model.GasCoupling` ties the modeled callee cost to the call's gas allowance: a `GasFaithful` adversary can only succeed within the allowance, must fail (never commit) when over budget, and cannot claim more gas than forwarded. Failure causes (`outOfGas` vs. opaque exceptional halt) are modeling artifacts: `denoteCall_congr`/`denote_congr` prove observations are determined by the adversary's responses alone, so causes cannot leak to the caller — matching the EVM's zero-success-bit observability. The caller-has-enough-gas-for-its-handler assumption is the explicit `CallerCoversAllowance` hypothesis. Opcode-level gas accounting (EIP-150, warm/cold, refunds, stipend) is out of scope for this model and remains a dedicated roadmap lane.
+
 ### Reentrancy Guard (`nonreentrant(lockField)`)
 Functions annotated `nonreentrant(lockField)` are compiled with a
 **transient-storage** reentrancy guard prologue (#1893): an

--- a/Verity/Core/Model/GasCoupling.lean
+++ b/Verity/Core/Model/GasCoupling.lean
@@ -1,0 +1,133 @@
+import Verity.Core.Model.CallProgramRollback
+
+/-!
+# Gas-faithful adversaries and non-observable failure causes
+
+Short-term gas semantics for the external-call boundary (#1963 §1.4): tie the
+modeled cost of serving a request to the call's gas allowance and its result,
+without committing to opcode-level accounting (a dedicated roadmap lane).
+
+- A `GasFaithful` adversary can only succeed within the site's allowance, and
+  must fail — never commit — when the modeled cost exceeds it (the callee runs
+  out of gas).
+- `FailureCause`/`CauseModel` give failures an internal taxonomy (out-of-gas
+  vs. opaque exceptional halt).  The cause is a modeling artifact only: it is
+  not a field of `AdversaryModel`, and `denoteCall_congr` makes precise that
+  observations are determined by the three adversary fields alone, so no
+  theorem can leak a cause to the caller — matching the EVM, where the caller
+  sees only the zero success bit and returndata.
+- The caller-side assumption that the enclosing function has enough gas to
+  run its own handler is explicit (`CallerCoversAllowance`), not implicit.
+-/
+namespace Compiler.CompilationModel.DenoteExternalCalls
+
+/-- Modeled cost discipline.  `requires site world` is the gas the callee
+needs to serve the request from `world`. -/
+structure GasFaithful (requires : CallSite → Verity.ContractState → Nat)
+    (adversary : AdversaryModel) : Prop where
+  /-- Success is only possible within the requested allowance. -/
+  success_within_allowance : ∀ site world data,
+    adversary.result site world = .success data → requires site world ≤ site.gas
+  /-- An over-budget request fails: the callee runs out of gas.  It cannot
+  succeed, revert with chosen data, or commit. -/
+  overBudget_fails : ∀ site world,
+    site.gas < requires site world → ∃ data, adversary.result site world = .failure data
+  /-- The callee cannot claim more gas than the allowance it was given. -/
+  gasUsed_le_allowance : ∀ site world, adversary.gasUsed site world ≤ site.gas
+
+/-- Contrapositive of `success_within_allowance`: an over-budget call has no
+successful response. -/
+theorem GasFaithful.overBudget_no_success
+    {requires : CallSite → Verity.ContractState → Nat}
+    {adversary : AdversaryModel} (h : GasFaithful requires adversary)
+    (site : CallSite) (world : Verity.ContractState)
+    (hover : site.gas < requires site world) (data : List Nat) :
+    adversary.result site world ≠ .success data := by
+  intro hres
+  exact absurd (h.success_within_allowance site world data hres)
+    (Nat.not_le.mpr hover)
+
+/-- The out-of-gas callee never commits: an over-budget call preserves the
+caller world for every call kind. -/
+theorem GasFaithful.overBudget_preserves_world
+    {requires : CallSite → Verity.ContractState → Nat}
+    {adversary : AdversaryModel} (h : GasFaithful requires adversary)
+    (site : CallSite) (state : CallState)
+    (hover : site.gas < requires site state.world) :
+    (denoteCall adversary site state).state.world = state.world := by
+  obtain ⟨data, hfail⟩ := h.overBudget_fails site state.world hover
+  cases hkind : site.kind with
+  | staticcall => exact denoteCall_staticcall_world adversary site state hkind
+  | call =>
+      exact denoteCall_failure_world adversary site state data (Or.inl hkind) hfail
+  | delegatecall =>
+      exact denoteCall_failure_world adversary site state data (Or.inr hkind) hfail
+
+/-- Explicit caller-side assumption: the caller's remaining gas covers the
+allowance it forwards, so the call cannot silently starve the caller's own
+continuation in the model. -/
+def CallerCoversAllowance (state : CallState) (site : CallSite) : Prop :=
+  site.gas ≤ state.gasRemaining
+
+/-- Under the caller-cover assumption and gas-faithfulness, the charged gas is
+exactly what the callee claims: neither the availability cap nor the
+allowance cap bites. -/
+theorem chargedGas_eq_claimed_of_faithful
+    {requires : CallSite → Verity.ContractState → Nat}
+    {adversary : AdversaryModel} (h : GasFaithful requires adversary)
+    (site : CallSite) (state : CallState)
+    (hcover : CallerCoversAllowance state site) :
+    chargedGas state.gasRemaining site.gas (adversary.gasUsed site state.world) =
+      adversary.gasUsed site state.world := by
+  have hclaim := h.gasUsed_le_allowance site state.world
+  have h1 : Nat.min site.gas (adversary.gasUsed site state.world) =
+      adversary.gasUsed site state.world := Nat.min_eq_right hclaim
+  have h2 : Nat.min state.gasRemaining (adversary.gasUsed site state.world) =
+      adversary.gasUsed site state.world :=
+    Nat.min_eq_right (Nat.le_trans hclaim hcover)
+  unfold chargedGas
+  rw [h1, h2]
+
+/-! ## Non-observable failure causes -/
+
+/-- Internal cause of a zero-success-bit call. -/
+inductive FailureCause where
+  | outOfGas
+  | exceptional
+  deriving DecidableEq, Repr
+
+/-- A cause assignment for an adversary's failures.  Deliberately *not* part
+of `AdversaryModel`: causes exist for the modeler, not for the caller. -/
+structure CauseModel where
+  causeOf : CallSite → Verity.ContractState → FailureCause
+
+/-- Observations are determined by the adversary's three fields alone: two
+adversaries with equal responses, transitions, and gas claims are
+observationally identical, whatever cause narrative accompanies them.  This is
+the formal sense in which `FailureCause` cannot leak to the caller. -/
+theorem denoteCall_congr (a b : AdversaryModel)
+    (hres : a.result = b.result)
+    (htrans : a.stateTransition = b.stateTransition)
+    (hgas : a.gasUsed = b.gasUsed) :
+    denoteCall a = denoteCall b := by
+  cases a; cases b
+  cases hres; cases htrans; cases hgas
+  rfl
+
+/-- The same cause-erasure at the program level. -/
+theorem denote_congr (a b : AdversaryModel)
+    (hres : a.result = b.result)
+    (htrans : a.stateTransition = b.stateTransition)
+    (hgas : a.gasUsed = b.gasUsed)
+    (prog : CallProgram α) (state : CallState) :
+    denote prog a state = denote prog b state := by
+  have hcall := denoteCall_congr a b hres htrans hgas
+  induction prog generalizing state with
+  | pure value => rfl
+  | bind site next ih =>
+      show denote (next (denoteCall a site state)) a (denoteCall a site state).state =
+        denote (next (denoteCall b site state)) b (denoteCall b site state).state
+      rw [hcall]
+      exact ih (denoteCall b site state) (denoteCall b site state).state
+
+end Compiler.CompilationModel.DenoteExternalCalls


### PR DESCRIPTION
§1.4 of #1963: `GasFaithful` (success only within allowance; over-budget ⇒ failure without commit for every call kind; claims capped by allowance; `chargedGas` = claim under explicit `CallerCoversAllowance`), plus `FailureCause`/`CauseModel` kept outside `AdversaryModel` with `denoteCall_congr`/`denote_congr` proving cause-erasure — the caller observes only the success bit and returndata, as in the EVM. Opcode-level accounting explicitly deferred (TRUST_ASSUMPTIONS.md caveat added).

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the external-call semantic model and trust boundary around gas discipline, which downstream proofs will rely on, but is additive modeling with no compiler/runtime or axiom changes.
> 
> **Overview**
> Adds short-term **gas coupling** for the external-call boundary: a `GasFaithful` adversary may succeed only within the call allowance, must fail without committing when over budget, and cannot claim more gas than forwarded. Under the explicit `CallerCoversAllowance` hypothesis, charged gas equals the callee's claim.
> 
> Separately introduces `FailureCause`/`CauseModel` *outside* `AdversaryModel`, with `denoteCall_congr`/`denote_congr` proving observations depend only on result, transition, and gas — so failure causes cannot leak to the caller (EVM zero-success-bit behavior).
> 
> Documents this discipline and the deferred opcode-level accounting (EIP-150, warm/cold, refunds, stipend) in `TRUST_ASSUMPTIONS.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 757024bf006909ed33ffe3e8fc598790be9a69b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->