### PR TITLE
feat(model): callback-bounded adversaries — reentrancy specs at the call boundary (#1963 slice 6)

### DIFF
--- a/Contracts/ReentrancyRelyGuarantee/Contract.lean
+++ b/Contracts/ReentrancyRelyGuarantee/Contract.lean
@@ -21,6 +21,7 @@
 import Verity.Core
 import Verity.Core.Semantics
 import Verity.Core.Reentrancy
+import Verity.Core.Model.CallbackBridge
 
 namespace Contracts.ReentrancyRelyGuarantee
 
@@ -191,5 +192,29 @@ theorem any_cross_contract_schedule_preserves_I (inScope : List Address)
     (hsteps : ∀ p, p ∈ steps → p.2 ∈ spec.entrypoints) :
     Preserves (Isys I inScope) (runSeq (steps.map (fun p => lift p.1 p.2))) :=
   cross_contract_schedule_preserves spec inScope steps hsteps
+
+/-! ## Call-boundary payoff: invariant safety through whole call programs
+
+The same single `liquidate` obligation now covers the external-call boundary:
+any adversary whose committed transitions are reentry schedules drawn from
+this contract's registry preserves `I` at every externally opened window of
+any `CallProgram`, and through the transaction commit/revert boundary. -/
+
+open Compiler.CompilationModel.DenoteExternalCalls in
+theorem callback_bounded_program_preserves_I
+    {adversary : AdversaryModel}
+    (hbound : CallbackBounded spec.entrypoints adversary)
+    (prog : CallProgram α) (state : CallState) (hInv : I state.world) :
+    I (denote prog adversary state).2.world :=
+  hbound.denote_preserves spec prog state hInv
+
+open Compiler.CompilationModel.DenoteExternalCalls in
+theorem callback_bounded_transaction_preserves_I
+    {adversary : AdversaryModel} {α : Type}
+    (hbound : CallbackBounded spec.entrypoints adversary)
+    (prog : CallProgram (TransactionResult α)) (state : CallState)
+    (hInv : I state.world) :
+    I (denoteTransaction prog adversary state).state.world :=
+  hbound.transaction_preserves spec prog state hInv
 
 end Contracts.ReentrancyRelyGuarantee

--- a/Verity/Core/Model/CallbackBridge.lean
+++ b/Verity/Core/Model/CallbackBridge.lean
@@ -1,0 +1,109 @@
+import Verity.Core.Model.SummaryBridge
+import Verity.Core.Reentrancy
+
+/-!
+# Callback-bounded adversaries
+
+Connects the external-call boundary (`AdversaryModel`) to the reentrancy
+rely-guarantee framework (`ReentrancySpec`): instead of treating the callee as
+an arbitrary world transformer, a *callback-bounded* adversary's committed
+transitions are exactly finite reentry schedules drawn from the caller's
+registered entrypoints — the callee may call back into the caller, choose any
+entrypoints in any order, observe intermediate state, and reenter before the
+first call's continuation runs, but it cannot perform caller-state magic that
+no entrypoint could.
+
+The payoff mirrors `ReentrancySpec.schedule_preserves`: one invariant proof
+per entrypoint extends to every call site of every `CallProgram`, at every
+externally opened window, and through the transaction commit/revert boundary.
+-/
+namespace Compiler.CompilationModel.DenoteExternalCalls
+
+open Verity.Core.Invariant (Preserves runSeq)
+open Verity.Core.Reentrancy (ReentrancySpec)
+
+/-- Each mutable transition is some finite reentry schedule drawn from the
+registry.  Static sites are unrestricted: `denoteCall` never commits their
+transitions, and `Conforms` separately pins them externally. -/
+def CallbackBounded
+    (entrypoints : List (Verity.ContractState → Verity.ContractState))
+    (adversary : AdversaryModel) : Prop :=
+  ∀ site world, site.kind ≠ .staticcall →
+    ∃ sched : List (Verity.ContractState → Verity.ContractState),
+      (∀ f ∈ sched, f ∈ entrypoints) ∧
+        adversary.stateTransition site world = runSeq sched world
+
+/-- One external call under a callback-bounded adversary preserves the spec
+invariant: rollback outcomes keep the pre-call world, and committed outcomes
+are reentry schedules, covered by the per-entrypoint obligations. -/
+theorem CallbackBounded.denoteCall_preserves (spec : ReentrancySpec)
+    {adversary : AdversaryModel}
+    (h : CallbackBounded spec.entrypoints adversary)
+    (site : CallSite) (state : CallState)
+    (hInv : spec.Inv state.world) :
+    spec.Inv (denoteCall adversary site state).state.world := by
+  cases hkind : site.kind with
+  | staticcall =>
+      rw [denoteCall_staticcall_world adversary site state hkind]
+      exact hInv
+  | call =>
+      cases hres : adversary.result site state.world with
+      | success data =>
+          rw [denoteCall_call_success_world adversary site state data hkind hres]
+          obtain ⟨sched, hmem, htrans⟩ := h site state.world (by simp [hkind])
+          rw [htrans]
+          exact spec.schedule_preserves sched hmem state.world hInv
+      | failure data =>
+          rw [denoteCall_failure_world adversary site state data (Or.inl hkind) hres]
+          exact hInv
+      | revert data =>
+          rw [denoteCall_revert_world adversary site state data (Or.inl hkind) hres]
+          exact hInv
+  | delegatecall =>
+      cases hres : adversary.result site state.world with
+      | success data =>
+          rw [denoteCall_delegatecall_success_world adversary site state data hkind hres]
+          obtain ⟨sched, hmem, htrans⟩ := h site state.world (by simp [hkind])
+          rw [htrans]
+          exact spec.schedule_preserves sched hmem state.world hInv
+      | failure data =>
+          rw [denoteCall_failure_world adversary site state data (Or.inr hkind) hres]
+          exact hInv
+      | revert data =>
+          rw [denoteCall_revert_world adversary site state data (Or.inr hkind) hres]
+          exact hInv
+
+/-- The invariant threads through every call of any program: no finite
+sequence of externally opened windows — each free to reenter through any
+registered schedule — can break it. -/
+theorem CallbackBounded.denote_preserves (spec : ReentrancySpec)
+    {adversary : AdversaryModel}
+    (h : CallbackBounded spec.entrypoints adversary)
+    (prog : CallProgram α) (state : CallState)
+    (hInv : spec.Inv state.world) :
+    spec.Inv (denote prog adversary state).2.world := by
+  induction prog generalizing state with
+  | pure value => exact hInv
+  | bind site next ih =>
+      exact ih (denoteCall adversary site state)
+        (denoteCall adversary site state).state
+        (h.denoteCall_preserves spec site state hInv)
+
+/-- Through the transaction boundary: a committed transaction ends in an
+invariant state by the program law, and a reverted one by rollback to the
+initial state. -/
+theorem CallbackBounded.transaction_preserves (spec : ReentrancySpec)
+    {adversary : AdversaryModel}
+    (h : CallbackBounded spec.entrypoints adversary)
+    (prog : CallProgram (TransactionResult α)) (state : CallState)
+    (hInv : spec.Inv state.world) :
+    spec.Inv (denoteTransaction prog adversary state).state.world := by
+  cases hres : (denote prog adversary state).1 with
+  | commit value =>
+      rw [denoteTransaction_commit_eq prog adversary state value hres]
+      exact h.denote_preserves spec prog state hInv
+  | revert data =>
+      rw [denoteTransaction_revert_world prog adversary state data hres]
+      exact hInv
+
+end Compiler.CompilationModel.DenoteExternalCalls

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -16,10 +16,10 @@
   },
   "theorems": {
     "categories": 13,
-    "coverage_percent": 85,
+    "coverage_percent": 84,
     "covered": 255,
-    "excluded": 45,
-    "non_stdlib_total": 300,
+    "excluded": 47,
+    "non_stdlib_total": 302,
     "per_contract": {
       "Counter": 31,
       "ERC20": 22,
@@ -29,15 +29,15 @@
       "Owned": 23,
       "OwnedCounter": 48,
       "ReentrancyExample": 5,
-      "ReentrancyRelyGuarantee": 8,
+      "ReentrancyRelyGuarantee": 10,
       "SafeCounter": 25,
       "SimpleStorage": 20,
       "SimpleToken": 61,
       "Vault": 9
     },
-    "proven": 300,
+    "proven": 302,
     "stdlib": 0,
-    "total": 300
+    "total": 302
   },
   "toolchain": {
     "lean": "leanprover/lean4:v4.31.0",

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -30,12 +30,12 @@ Every transition inside the proof envelope is either fully verified or recorded 
 ## Quick facts
 
 <!-- BEGIN GENERATED QUICK FACTS -->
-- **Language**: Lean 4.22.0
-- **Core Size**: 830 lines
+- **Language**: Lean 4.31.0
+- **Core Size**: 1027 lines
 - **Verified Contracts**: 13 (Counter, ERC20, ERC721, Ledger, LocalObligationMacroSmoke, Owned, OwnedCounter, ReentrancyExample, ReentrancyRelyGuarantee, SafeCounter, SimpleStorage, SimpleToken, Vault)
-- **Theorems**: 300 across 13 categories, 300 fully proven
+- **Theorems**: 302 across 13 categories, 302 fully proven
 - **Axioms**: 0 documented Lean axioms (see AXIOMS.md)
-- **Tests**: 522 Foundry tests, 239 property tests
+- **Tests**: 528 Foundry tests, 239 property tests
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/lfglabs-dev/verity
 <!-- END GENERATED QUICK FACTS -->

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -38,11 +38,11 @@ EVM Bytecode
 | ERC721 | 11 | Baseline | `Contracts/ERC721/Proofs/` |
 | Vault | 9 | Baseline | `Contracts/Vault/Proofs/` |
 | ReentrancyExample | 5 | Complete | `Contracts/ReentrancyExample/Contract.lean` |
-| ReentrancyRelyGuarantee | 8 | Semantic | `Contracts/ReentrancyRelyGuarantee/Contract.lean` |
+| ReentrancyRelyGuarantee | 10 | Semantic | `Contracts/ReentrancyRelyGuarantee/Contract.lean` |
 | CryptoHash | 0 | No specs | `Contracts/CryptoHash/Contract.lean` |
-| **Total** | **300** | **✅ 100%** | — |
+| **Total** | **302** | **✅ 100%** | — |
 
-> **Note**: Stdlib (0 internal proof-automation properties) is excluded from the contract-spec theorem table above but included in overall coverage statistics (300 total properties).
+> **Note**: Stdlib (0 internal proof-automation properties) is excluded from the contract-spec theorem table above but included in overall coverage statistics (302 total properties).
 
 Layer 1 uses macro-generated EDSL-to-`CompilationModel` bridge theorems backed by a generic typed-IR compilation-correctness theorem ([`TypedIRCompilerCorrectness.lean`](../Compiler/TypedIRCompilerCorrectness.lean)). Tuple/bytes/fixed-array/dynamic-array/string parameters now stay inside that proof path when they are carried as ABI head words/offsets. Advanced constructs beyond that typed-IR head-word surface (linked libraries, ECMs, fully custom ABI behavior) are still expressed directly in `CompilationModel` and trusted at that boundary. Higher-order internal helpers (function-pointer parameters, [#1747](https://github.com/lfglabs-dev/verity/issues/1747)) are eliminated by a compile-time monomorphization pre-pass that runs before any lowering, so the `CompilationModel` only ever contains first-order helpers: these calls are covered by the existing first-order proof path and introduce no new boundary trust.
 
@@ -192,7 +192,7 @@ Also note that the macro-generated `*_semantic_preservation` theorems are not co
 | ERC721 | 100% (11/11) | 0 |
 | SafeCounter | 100% (25/25) | 0 |
 | ReentrancyExample | 100% (5/5) | 0 |
-| ReentrancyRelyGuarantee | 0% (0/8) | 8 proof-only |
+| ReentrancyRelyGuarantee | 0% (0/10) | 10 proof-only |
 | Ledger | 100% (33/33) | 0 |
 | LocalObligationMacroSmoke | 100% (4/4) | 0 |
 | SimpleStorage | 95% (19/20) | 1 proof-only |
@@ -202,13 +202,13 @@ Also note that the macro-generated `*_semantic_preservation` theorems are not co
 | Counter | 74% (23/31) | 8 proof-only |
 | Stdlib | 0% (0/0) | 0 proof-only |
 
-**Status**: 85% coverage (255/300), 45 remaining exclusions all proof-only
+**Status**: 84% coverage (255/302), 47 remaining exclusions all proof-only
 
-- **Total Properties**: 300
+- **Total Properties**: 302
 - **Covered**: 255
-- **Excluded**: 45 (all proof-only)
+- **Excluded**: 47 (all proof-only)
 
-**Proof-Only Properties (45 exclusions)**: Internal proof machinery that cannot be tested in Foundry.
+**Proof-Only Properties (47 exclusions)**: Internal proof machinery that cannot be tested in Foundry.
 
 0 `sorry` remaining across `Compiler/**/*.lean` and `Verity/**/*.lean` proof modules.
 5266 theorems/lemmas (3645 public, 1621 private) verified by `lake build PrintAxioms`.

--- a/test/property_exclusions.json
+++ b/test/property_exclusions.json
@@ -1,63 +1,65 @@
 {
-  "ERC20": [
-    "erc20Minimal_functions_bridged",
-    "erc20Minimal_runtime_lowers_native",
-    "erc20Minimal_totalSupply_nativeResultsMatchOn_revert_of_nonzero_value"
-  ],
-  "Vault": [
-    "balanceOf_meets_spec",
-    "balanceOf_preserves_state",
-    "totalAssets_meets_spec",
-    "totalAssets_preserves_state",
-    "totalSupply_meets_spec",
-    "totalSupply_preserves_state",
-    "vaultMinimal_functions_bridged",
-    "vaultMinimal_runtime_lowers_native",
-    "vaultMinimal_totalAssets_nativeResultsMatchOn_revert_of_nonzero_value"
-  ],
-  "Counter": [
-    "getStorage_reads_count",
-    "previewAddTwice_correct",
-    "previewAddTwice_preserves_state",
-    "previewOps_preserves_state",
-    "setStorage_preserves_addr_storage",
-    "setStorage_preserves_context",
-    "setStorage_preserves_map_storage",
-    "setStorage_updates_count"
-  ],
-  "Owned": [
-    "isOwner_meets_spec",
-    "isOwner_returns_correct_value",
-    "transferOwnership_unfold"
-  ],
-  "OwnedCounter": [
-    "decrement_unfold",
-    "increment_unfold",
-    "isOwner_correct",
-    "transferOwnership_unfold"
-  ],
-  "SimpleStorage": [
-    "store_preserves_wellformedness"
-  ],
-  "SimpleToken": [
-    "getMapping_reads_balance",
-    "getStorageAddr_reads_owner",
-    "getStorage_reads_supply",
-    "mint_sum_singleton_to",
-    "setMapping_preserves_other_addresses",
-    "setMapping_updates_balance",
-    "setStorageAddr_updates_owner",
-    "setStorage_updates_supply",
-    "transfer_sum_preserved_unique"
-  ],
-  "ReentrancyRelyGuarantee": [
-    "any_cross_contract_schedule_preserves_I",
-    "any_reentry_schedule_preserves_I",
-    "buggy_admits_permanent_bad_debt",
-    "liquidate_preserves_I",
-    "liquidate_respects_lock",
-    "locked_blocks_concrete_liquidation",
-    "locked_take_no_new_liquidation",
-    "locked_take_preserves_I"
-  ]
+ "ERC20": [
+  "erc20Minimal_functions_bridged",
+  "erc20Minimal_runtime_lowers_native",
+  "erc20Minimal_totalSupply_nativeResultsMatchOn_revert_of_nonzero_value"
+ ],
+ "Vault": [
+  "balanceOf_meets_spec",
+  "balanceOf_preserves_state",
+  "totalAssets_meets_spec",
+  "totalAssets_preserves_state",
+  "totalSupply_meets_spec",
+  "totalSupply_preserves_state",
+  "vaultMinimal_functions_bridged",
+  "vaultMinimal_runtime_lowers_native",
+  "vaultMinimal_totalAssets_nativeResultsMatchOn_revert_of_nonzero_value"
+ ],
+ "Counter": [
+  "getStorage_reads_count",
+  "previewAddTwice_correct",
+  "previewAddTwice_preserves_state",
+  "previewOps_preserves_state",
+  "setStorage_preserves_addr_storage",
+  "setStorage_preserves_context",
+  "setStorage_preserves_map_storage",
+  "setStorage_updates_count"
+ ],
+ "Owned": [
+  "isOwner_meets_spec",
+  "isOwner_returns_correct_value",
+  "transferOwnership_unfold"
+ ],
+ "OwnedCounter": [
+  "decrement_unfold",
+  "increment_unfold",
+  "isOwner_correct",
+  "transferOwnership_unfold"
+ ],
+ "SimpleStorage": [
+  "store_preserves_wellformedness"
+ ],
+ "SimpleToken": [
+  "getMapping_reads_balance",
+  "getStorageAddr_reads_owner",
+  "getStorage_reads_supply",
+  "mint_sum_singleton_to",
+  "setMapping_preserves_other_addresses",
+  "setMapping_updates_balance",
+  "setStorageAddr_updates_owner",
+  "setStorage_updates_supply",
+  "transfer_sum_preserved_unique"
+ ],
+ "ReentrancyRelyGuarantee": [
+  "any_cross_contract_schedule_preserves_I",
+  "any_reentry_schedule_preserves_I",
+  "buggy_admits_permanent_bad_debt",
+  "callback_bounded_program_preserves_I",
+  "callback_bounded_transaction_preserves_I",
+  "liquidate_preserves_I",
+  "liquidate_respects_lock",
+  "locked_blocks_concrete_liquidation",
+  "locked_take_no_new_liquidation",
+  "locked_take_preserves_I"
+ ]
 }

--- a/test/property_manifest.json
+++ b/test/property_manifest.json
@@ -196,6 +196,8 @@
     "any_cross_contract_schedule_preserves_I",
     "any_reentry_schedule_preserves_I",
     "buggy_admits_permanent_bad_debt",
+    "callback_bounded_program_preserves_I",
+    "callback_bounded_transaction_preserves_I",
     "liquidate_preserves_I",
     "liquidate_respects_lock",
     "locked_blocks_concrete_liquidation",


### PR DESCRIPTION
Lane 2.1 of the roadmap: `CallbackBounded` restricts an `AdversaryModel`'s committed transitions to finite reentry schedules drawn from the contract's registered entrypoints (`ReentrancySpec`), formalizing "the callee can call back into the caller, pick entrypoints, observe intermediate state, and reenter before the continuation" — while excluding caller-state magic no entrypoint could perform.

- `CallbackBounded.denoteCall_preserves` / `denote_preserves` / `transaction_preserves`: one invariant obligation per entrypoint covers every externally opened window of any `CallProgram` and the transaction commit/revert boundary.
- Consumer corollaries on the Midnight `take`/`liquidate` example (`callback_bounded_program_preserves_I`, `callback_bounded_transaction_preserves_I`).
- Property manifest/exclusions and VERIFICATION_STATUS/llms.txt counters updated (300 → 302).

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-critical reentrancy and external-call adversary modeling, but is additive Lean proof infrastructure with no new axioms or runtime behavior changes.
> 
> **Overview**
> Extends reentrancy rely-guarantee proofs to the **external-call boundary**: a `CallbackBounded` adversary may only commit finite reentry schedules drawn from the caller's registered entrypoints, not arbitrary caller-state updates.
> 
> Adds `CallbackBridge` with `denoteCall_preserves` / `denote_preserves` / `transaction_preserves`, so one per-entrypoint invariant obligation covers every externally opened window of any `CallProgram` and the transaction commit/revert path.
> 
> Wires the Midnight `take`/`liquidate` example with `callback_bounded_program_preserves_I` and `callback_bounded_transaction_preserves_I`, and bumps theorem counters **300 → 302**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3f6924cb06f8d87b3700fef7a6801d4c9cea331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->