### PR TITLE
proof(ir): nonreentrant guard prologue semantics (lane 2.2 step 2)

### DIFF
--- a/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
+++ b/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
@@ -1,0 +1,116 @@
+import Compiler.Proofs.IRGeneration.IRInterpreter
+import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBridgeLemmas
+
+/-!
+# IR semantics of the nonreentrant guard prologue
+
+First machine-checked brick of the `guarded` ↔ emitted-Yul correspondence
+(lane 2.2): the exact statements produced by
+`Compiler.CompilationModel.nonReentrantGuardPrologue` are evaluated under the
+IR interpreter used by the IR-generation proofs.
+
+- lock slot reads `1` → the frame reverts with the state untouched;
+- lock slot reads `0` → execution falls through with the lock set to `1` and
+  nothing else changed;
+- the release statement spliced by `applyLockReleaseOnExits` resets the slot;
+- on the reachable (binary) lock values, the Yul decision `eq(tload(slot), 1)`
+  agrees with the source-model decision `lock ≠ 0` of
+  `Verity.Core.Model.NonReentrantGuard.guarded`.
+
+Still open: pushing these statement-level facts through
+`attachNonReentrantGuard`/`compileGuardedFunctionSpec` and the
+`compile_preserves_semantics` stack to lift the `noNonReentrant`
+supported-fragment obligations.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+open Compiler.CompilationModel
+
+/-- The exact prologue shape emitted for a resolved lock slot. -/
+def guardPrologueStmts (slot : Nat) : List YulStmt :=
+  [ .if_ (.call "eq" [.call "tload" [.lit slot], .lit 1])
+      [.exprStmt (.call "revert" [.lit 0, .lit 0])],
+    .exprStmt (.call "tstore" [.lit slot, .lit 1]) ]
+
+/-- The release statement spliced before every successful exit. -/
+def lockReleaseStmt (slot : Nat) : YulStmt :=
+  .exprStmt (.call "tstore" [.lit slot, .lit 0])
+
+/-- `nonReentrantGuardPrologue` emits exactly `guardPrologueStmts` at the
+resolved slot. -/
+theorem nonReentrantGuardPrologue_eq (fields : List Field) (lockField : String)
+    (field : Field) (slot : Nat)
+    (h : findFieldWithResolvedSlot fields lockField = some (field, slot)) :
+    nonReentrantGuardPrologue fields lockField = .ok (guardPrologueStmts slot) := by
+  simp [nonReentrantGuardPrologue, h, guardPrologueStmts, pure, Except.pure]
+
+/-- Lock held (`tload = 1`) → the prologue reverts and the state is untouched. -/
+theorem execIRStmts_guardPrologue_locked (fuel : Nat) (state : IRState) (slot : Nat)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (hlock : state.transientStorage slot = 1) :
+    execIRStmts (fuel + 3) state (guardPrologueStmts slot) = .revert state := by
+  have hmod : slot % Compiler.Constants.evmModulus = slot := Nat.mod_eq_of_lt hslot
+  have hone : (1 : Nat) < Compiler.Constants.evmModulus := by
+    simp [Compiler.Constants.evmModulus]
+  cases fuel with
+  | zero =>
+      simp [guardPrologueStmts, execIRStmts, execIRStmt, evalIRExpr, evalIRCall,
+        evalIRExprs, hmod, hlock, Nat.mod_eq_of_lt hone,
+        YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext]
+  | succ n =>
+      simp [guardPrologueStmts, execIRStmts, execIRStmt, evalIRExpr, evalIRCall,
+        evalIRExprs, hmod, hlock, Nat.mod_eq_of_lt hone,
+        YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext]
+
+/-- Lock free (`tload = 0`) → the prologue acquires the lock and changes
+nothing else. -/
+theorem execIRStmts_guardPrologue_free (fuel : Nat) (state : IRState) (slot : Nat)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (hlock : state.transientStorage slot = 0) :
+    execIRStmts (fuel + 3) state (guardPrologueStmts slot) =
+      .continue { state with
+        transientStorage := fun o => if o = slot then 1 else state.transientStorage o } := by
+  have hmod : slot % Compiler.Constants.evmModulus = slot := Nat.mod_eq_of_lt hslot
+  have hone : (1 : Nat) < Compiler.Constants.evmModulus := by
+    simp [Compiler.Constants.evmModulus]
+  simp [guardPrologueStmts, execIRStmts, execIRStmt, evalIRExpr, evalIRCall,
+    evalIRExprs, hmod, hlock, Nat.mod_eq_of_lt hone,
+    YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext]
+
+/-- The spliced release resets the lock slot and changes nothing else. -/
+theorem execIRStmt_lockRelease (fuel : Nat) (state : IRState) (slot : Nat)
+    (hslot : slot < Compiler.Constants.evmModulus) :
+    execIRStmt (fuel + 1) state (lockReleaseStmt slot) =
+      .continue { state with
+        transientStorage := fun o => if o = slot then 0 else state.transientStorage o } := by
+  have hmod : slot % Compiler.Constants.evmModulus = slot := Nat.mod_eq_of_lt hslot
+  simp [lockReleaseStmt, execIRStmt, evalIRExpr, evalIRCall, evalIRExprs, hmod]
+
+/-- On the reachable (binary) lock values, the Yul decision `eq(lock, 1)`
+agrees with the source model's `lock ≠ 0` (`NonReentrantGuard.guarded`). -/
+theorem guard_decision_agrees (v : Nat) (hv : v = 0 ∨ v = 1) :
+    (v = 1) ↔ v ≠ 0 := by
+  rcases hv with h | h <;> simp [h]
+
+/-- Acquire-then-release round-trips the lock slot: the transient storage
+function is extensionally the initial one when the slot started free. -/
+theorem guard_acquire_release_roundtrip (fuel₁ fuel₂ : Nat) (state : IRState)
+    (slot : Nat) (hslot : slot < Compiler.Constants.evmModulus)
+    (hlock : state.transientStorage slot = 0) :
+    ∀ acquired, execIRStmts (fuel₁ + 3) state (guardPrologueStmts slot) =
+        .continue acquired →
+      ∀ released, execIRStmt (fuel₂ + 1) acquired (lockReleaseStmt slot) =
+          .continue released →
+        ∀ k, released.transientStorage k = state.transientStorage k := by
+  intro acquired hacq released hrel k
+  rw [execIRStmts_guardPrologue_free fuel₁ state slot hslot hlock] at hacq
+  injection hacq with hacq
+  rw [execIRStmt_lockRelease fuel₂ acquired slot hslot] at hrel
+  injection hrel with hrel
+  rw [← hrel, ← hacq]
+  by_cases hk : k = slot
+  · simp [hk, hlock]
+  · simp [hk]
+
+end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -79,6 +79,7 @@ import Compiler.Proofs.IRGeneration.IRInterpreter
 import Compiler.Proofs.IRGeneration.IRStorageWord
 import Compiler.Proofs.IRGeneration.InternalHelperBodyCorrespondence
 import Compiler.Proofs.IRGeneration.IntrinsicProofs
+import Compiler.Proofs.IRGeneration.NonReentrantGuardIR
 import Compiler.Proofs.IRGeneration.ParamLoading
 import Compiler.Proofs.IRGeneration.SourceSemantics
 import Compiler.Proofs.IRGeneration.SupportedFragment
@@ -3848,6 +3849,14 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.IntrinsicProofs.compileExpr_intrinsic_verbatim_zero_output_error
   Compiler.Proofs.IRGeneration.IntrinsicProofs.compileExpr_intrinsic_verbatim_wrong_arity_error
 
+  -- Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
+  Compiler.Proofs.IRGeneration.nonReentrantGuardPrologue_eq
+  Compiler.Proofs.IRGeneration.execIRStmts_guardPrologue_locked
+  Compiler.Proofs.IRGeneration.execIRStmts_guardPrologue_free
+  Compiler.Proofs.IRGeneration.execIRStmt_lockRelease
+  Compiler.Proofs.IRGeneration.guard_decision_agrees
+  Compiler.Proofs.IRGeneration.guard_acquire_release_roundtrip
+
   -- Compiler/Proofs/IRGeneration/ParamLoading.lean
   Compiler.Proofs.IRGeneration.ParamLoading.uint256_modulus_eq_evm
   Compiler.Proofs.IRGeneration.ParamLoading.wordNormalize_eq_mod
@@ -6602,4 +6611,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6175 theorems/lemmas (4307 public, 1868 private, 0 sorry'd)
+-- Total: 6181 theorems/lemmas (4313 public, 1868 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -179,11 +179,17 @@ after external calls are permitted within reentrancy-protected entry points.
 set and successful exits release it; lock held ⇒ revert with the pre-call
 state unchanged; and whole reentry schedules of same-lock guarded entrypoints
 collapse to the identity on locked states (`runSeq_guarded_locked_id`) — the
-reentry window is closed at the model level. Still trusted: the
-correspondence between `guarded` and the Yul emitted by
-`attachNonReentrantGuard`, and the supported-fragment `noNonReentrant`
-restriction (guarded functions are not yet inside the generically proved
-compiler fragment).
+reentry window is closed at the model level. On the compiled side,
+`Compiler.Proofs.IRGeneration.NonReentrantGuardIR` proves the emitted
+prologue/release statements under the IR interpreter: locked entry reverts
+untouched, free entry acquires the lock and changes nothing else, the spliced
+release resets it (acquire/release round-trips the transient store), and the
+Yul decision `eq(lock,1)` agrees with the model's `lock ≠ 0` on reachable
+binary lock values. Still trusted: threading these statement-level facts
+through `attachNonReentrantGuard`/`compileGuardedFunctionSpec` and the
+`compile_preserves_semantics` stack, and the supported-fragment
+`noNonReentrant` restriction (guarded functions are not yet inside the
+generically proved compiler fragment).
 **Fork requirement**: the compile driver rejects any contract carrying a
 `nonreentrant(<lock>)` annotation when the targeted EVM fork predates
 Cancun (the `validateNonReentrantForkCompatibility` pre-check in


### PR DESCRIPTION
Machine-checks the compiled side of the guard begun in #2261: the exact prologue `if eq(tload(slot),1) { revert } ; tstore(slot,1)` and the spliced release `tstore(slot,0)` are evaluated under the IR-generation interpreter (`execIRStmts`/`execIRStmt`), proving locked-entry revert (state untouched), free-entry acquire (nothing else changed), release reset with extensional acquire/release round-trip, decision agreement with `NonReentrantGuard.guarded` on reachable binary lock values, and the emitted-shape pin `nonReentrantGuardPrologue_eq`.

Remaining for the full `noNonReentrant` lift (documented in TRUST_ASSUMPTIONS.md): threading through `attachNonReentrantGuard`/`compileGuardedFunctionSpec` and `compile_preserves_semantics` — blocked mainly by `spliceLockRelease`/`yulFrameHalts` being `partial def`.

Validation: full `lake build` (2468 jobs) OK, `make check` all passed, PrintAxioms regenerated, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proofs and trust-doc updates only; no compiler or runtime behavior changes, and no new axioms or sorry.
> 
> **Overview**
> Adds the first machine-checked IR-side brick for the `nonreentrant` guard: the exact prologue/release Yul statements are now evaluated under `execIRStmts`/`execIRStmt`.
> 
> **`NonReentrantGuardIR`** pins the emitted prologue shape and proves locked entry reverts with state untouched, free entry acquires the lock only, the spliced release resets it (acquire/release round-trips transient storage), and Yul `eq(lock,1)` agrees with the source model's `lock ≠ 0` on binary lock values.
> 
> Updates `TRUST_ASSUMPTIONS.md` accordingly: statement-level IR facts are proved; threading through `attachNonReentrantGuard` / `compile_preserves_semantics` and lifting `noNonReentrant` remain trusted. Registers the six new theorems in `PrintAxioms` (+6 public, 0 sorry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3439b077df4d10ae7cd3c57560636ef5a5b08e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->