### PR TITLE
proof(abi): bounds-checked aligned reads round-trip (#2082)

### DIFF
--- a/Verity/Core/Model/DynamicAbiRoundTrip.lean
+++ b/Verity/Core/Model/DynamicAbiRoundTrip.lean
@@ -195,4 +195,18 @@ theorem arrayElements_aligned_roundtrip (selector : Nat) (calldata : List Nat)
     (by rw [hstored i hi]; exact hcanon i hi)]
   rw [hstored i hi]
 
+/-- Bounds-checked aligned reads round-trip: an in-range word index passes the
+calldata-size check and recovers exactly the stored word.  This is the base
+fact for the dynamic head-offset/length decoders, which are all built from
+`externalWordAt?`. -/
+theorem externalWordAt?_aligned (selector : Nat) (calldata : List Nat)
+    (q : Nat) (hq : q < calldata.length)
+    (hval : calldata.getD q 0 < Compiler.Constants.evmModulus) :
+    externalWordAt? selector calldata (4 + 32 * q) = some (calldata.getD q 0) := by
+  have hbound : 4 ≤ 4 + 32 * q ∧
+      4 + 32 * q + 32 ≤ externalCalldataSize calldata := by
+    unfold externalCalldataSize
+    omega
+  simp [externalWordAt?, hbound, calldataloadWord_aligned selector calldata q hval]
+
 end Compiler.CompilationModel.DynamicAbi


### PR DESCRIPTION
Adds `externalWordAt?_aligned`: an in-range word index passes the calldata-size guard and recovers exactly the stored word — the base fact for the dynamic head-offset/length decoders (`arrayElementDynamicHeadOffset?` etc.), which are all built from `externalWordAt?`. Follows #2265.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a pure Lean proof lemma with no runtime, auth, or data-handling changes.
> 
> **Overview**
> Adds **`externalWordAt?_aligned`**: for an in-range word index, the bounds-checked `externalWordAt?` read succeeds and recovers exactly the stored calldata word.
> 
> This is the base fact for dynamic head-offset/length decoders built on `externalWordAt?`, extending the existing aligned `calldataload` / `arrayElement?` round-trip lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2754e7cb3fd8b224a9dc7bd276fc9359ebcf11ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->