### PR TITLE
proof(abi): dynamic head-offset round-trip (#2082)

### DIFF
--- a/Verity/Core/Model/DynamicAbiRoundTrip.lean
+++ b/Verity/Core/Model/DynamicAbiRoundTrip.lean
@@ -209,4 +209,21 @@ theorem externalWordAt?_aligned (selector : Nat) (calldata : List Nat)
     omega
   simp [externalWordAt?, hbound, calldataloadWord_aligned selector calldata q hval]
 
+/-- Dynamic head-offset round-trip: with a canonical offset table (the stored
+relative offset points past the table) and an in-bounds element head, the
+head-offset decoder recovers exactly `dataOffset + storedRelOffset`. -/
+theorem arrayElementDynamicHeadOffset?_aligned (selector : Nat)
+    (calldata : List Nat) (q0 length index : Nat)
+    (hidx : index < length) (hq : q0 + index < calldata.length)
+    (hval : calldata.getD (q0 + index) 0 < Compiler.Constants.evmModulus)
+    (htable : length * 32 ≤ calldata.getD (q0 + index) 0)
+    (hhead : 4 + 32 * q0 + calldata.getD (q0 + index) 0 + 32 ≤
+      externalCalldataSize calldata) :
+    arrayElementDynamicHeadOffset? selector calldata (4 + 32 * q0) length index =
+      some (4 + 32 * q0 + calldata.getD (q0 + index) 0) := by
+  have harith : 4 + 32 * q0 + index * 32 = 4 + 32 * (q0 + index) := by omega
+  simp [arrayElementDynamicHeadOffset?, hidx, harith,
+    externalWordAt?_aligned selector calldata (q0 + index) hq hval]
+  exact ⟨by simpa using htable, by simpa using hhead⟩
+
 end Compiler.CompilationModel.DynamicAbi


### PR DESCRIPTION
Extends the round-trip chain (#2263-#2266) to the dynamic head/tail layout: `arrayElementDynamicHeadOffset?_aligned` proves the head-offset decoder recovers exactly `dataOffset + storedRelOffset` for canonical offset tables with in-bounds heads. Next: `arrayElementDynamicWord?`/member-length composition.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proof only; no executable logic, ABI decoder, or runtime behavior changes.
> 
> **Overview**
> Extends the ABI round-trip proof chain with **`arrayElementDynamicHeadOffset?_aligned`**: for a canonical offset table and in-bounds element head, the head-offset decoder recovers exactly `dataOffset + storedRelOffset`.
> 
> Builds on `externalWordAt?_aligned` and is the next step toward composing proofs for `arrayElementDynamicWord?` / member-length decoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4c5f060be25606260602ff759463e0457c604a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->