### PR TITLE
proof(abi): dynamic element word reads round-trip (#2082)

### DIFF
--- a/Verity/Core/Model/DynamicAbiRoundTrip.lean
+++ b/Verity/Core/Model/DynamicAbiRoundTrip.lean
@@ -226,4 +226,29 @@ theorem arrayElementDynamicHeadOffset?_aligned (selector : Nat)
     externalWordAt?_aligned selector calldata (q0 + index) hq hval]
   exact ⟨by simpa using htable, by simpa using hhead⟩
 
+/-- Composition: reading word `wordOffset` of a dynamic element through the
+head-offset indirection recovers exactly the stored word, provided the
+relative offset is word-aligned (as canonical ABI encoding guarantees). -/
+theorem arrayElementDynamicWord?_aligned (selector : Nat)
+    (calldata : List Nat) (q0 length index wordOffset relq : Nat)
+    (hidx : index < length) (hq : q0 + index < calldata.length)
+    (hval : calldata.getD (q0 + index) 0 < Compiler.Constants.evmModulus)
+    (hrel : calldata.getD (q0 + index) 0 = 32 * relq)
+    (htable : length * 32 ≤ calldata.getD (q0 + index) 0)
+    (hhead : 4 + 32 * q0 + calldata.getD (q0 + index) 0 + 32 ≤
+      externalCalldataSize calldata)
+    (hq2 : q0 + relq + wordOffset < calldata.length)
+    (hval2 : calldata.getD (q0 + relq + wordOffset) 0 < Compiler.Constants.evmModulus) :
+    arrayElementDynamicWord? selector calldata (4 + 32 * q0) length index wordOffset =
+      some (calldata.getD (q0 + relq + wordOffset) 0) := by
+  simp only [arrayElementDynamicWord?,
+    arrayElementDynamicHeadOffset?_aligned selector calldata q0 length index
+      hidx hq hval htable hhead, Option.bind]
+  rw [hrel]
+  show externalWordAt? selector calldata (4 + 32 * q0 + 32 * relq + wordOffset * 32) =
+    some (calldata.getD (q0 + relq + wordOffset) 0)
+  rw [show 4 + 32 * q0 + 32 * relq + wordOffset * 32 =
+    4 + 32 * (q0 + relq + wordOffset) from by omega,
+    externalWordAt?_aligned selector calldata (q0 + relq + wordOffset) hq2 hval2]
+
 end Compiler.CompilationModel.DynamicAbi


### PR DESCRIPTION
Composes #2266/#2267: `arrayElementDynamicWord?_aligned` proves that reading word `wordOffset` of a dynamic array element through the head-offset indirection recovers exactly the stored calldata word, for canonical word-aligned offset tables with in-bounds heads. The static+dynamic round-trip chain now covers the full path the generated decoders take for supported dynamic layouts.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a Lean proof only; no executable decoder, runtime, or security-sensitive logic changes.
> 
> **Overview**
> Adds `arrayElementDynamicWord?_aligned`, composing the existing head-offset and aligned-word lemmas so a word read through dynamic-array head-offset indirection recovers exactly the stored calldata word under canonical word-aligned offsets.
> 
> This closes the static+dynamic round-trip path used by generated decoders for supported dynamic layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c43b913aece3643d51cc9e72d1e8194cd06ba8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->