### PR TITLE
proof(abi): nested member-length round-trip (#2082)

### DIFF
--- a/Verity/Core/Model/DynamicAbiRoundTrip.lean
+++ b/Verity/Core/Model/DynamicAbiRoundTrip.lean
@@ -251,4 +251,42 @@ theorem arrayElementDynamicWord?_aligned (selector : Nat)
     4 + 32 * (q0 + relq + wordOffset) from by omega,
     externalWordAt?_aligned selector calldata (q0 + relq + wordOffset) hq2 hval2]
 
+/-- Nested composition: the member-length decoder — head indirection, then a
+member offset word, then the length word at the member's data position —
+recovers exactly the stored length word under canonical word alignment. -/
+theorem arrayElementDynamicMemberLength?_aligned (selector : Nat)
+    (calldata : List Nat) (q0 length index wordOffset relq mrelq : Nat)
+    (hidx : index < length) (hq : q0 + index < calldata.length)
+    (hval : calldata.getD (q0 + index) 0 < Compiler.Constants.evmModulus)
+    (hrel : calldata.getD (q0 + index) 0 = 32 * relq)
+    (htable : length * 32 ≤ calldata.getD (q0 + index) 0)
+    (hhead : 4 + 32 * q0 + calldata.getD (q0 + index) 0 + 32 ≤
+      externalCalldataSize calldata)
+    (hq2 : q0 + relq + wordOffset < calldata.length)
+    (hval2 : calldata.getD (q0 + relq + wordOffset) 0 < Compiler.Constants.evmModulus)
+    (hmrel : calldata.getD (q0 + relq + wordOffset) 0 = 32 * mrelq)
+    (hq3 : q0 + relq + mrelq < calldata.length)
+    (hval3 : calldata.getD (q0 + relq + mrelq) 0 < Compiler.Constants.evmModulus) :
+    arrayElementDynamicMemberLength? selector calldata (4 + 32 * q0)
+        length index wordOffset =
+      some (calldata.getD (q0 + relq + mrelq) 0) := by
+  simp only [arrayElementDynamicMemberLength?,
+    arrayElementDynamicHeadOffset?_aligned selector calldata q0 length index
+      hidx hq hval htable hhead, Option.bind]
+  rw [hrel]
+  show (externalWordAt? selector calldata
+      (4 + 32 * q0 + 32 * relq + wordOffset * 32)).bind
+    (fun memberRelOffset => externalWordAt? selector calldata
+      (4 + 32 * q0 + 32 * relq + memberRelOffset)) =
+    some (calldata.getD (q0 + relq + mrelq) 0)
+  rw [show 4 + 32 * q0 + 32 * relq + wordOffset * 32 =
+      4 + 32 * (q0 + relq + wordOffset) from by omega,
+    externalWordAt?_aligned selector calldata (q0 + relq + wordOffset) hq2 hval2]
+  show externalWordAt? selector calldata
+      (4 + 32 * q0 + 32 * relq + calldata.getD (q0 + relq + wordOffset) 0) =
+    some (calldata.getD (q0 + relq + mrelq) 0)
+  rw [hmrel, show 4 + 32 * q0 + 32 * relq + 32 * mrelq =
+      4 + 32 * (q0 + relq + mrelq) from by omega,
+    externalWordAt?_aligned selector calldata (q0 + relq + mrelq) hq3 hval3]
+
 end Compiler.CompilationModel.DynamicAbi


### PR DESCRIPTION
Completes the current dynamic round-trip chain (#2265-#2268): `arrayElementDynamicMemberLength?_aligned` proves the two-level indirection — element head offset, member offset word, then the length word at the member's data position — recovers exactly the stored length word under canonical word alignment. With #2263/#2264 (static types) this covers encoder-inversion for every decoder shape currently in `DynamicAbi`.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only Lean addition with no runtime or semantic code changes; risk is limited to theorem correctness.
> 
> **Overview**
> Completes the dynamic ABI round-trip chain with **`arrayElementDynamicMemberLength?_aligned`**: under canonical word alignment, the two-level decoder (element head offset → member offset word → length word) recovers exactly the stored length.
> 
> This covers encoder-inversion for the remaining nested dynamic decoder shape in `DynamicAbi`, alongside the existing head-offset and dynamic-word round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dfc03b783b13ab3587f0fccdfec37b52ad5ab80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->