### PR TITLE
proof(ir): stop-exit lock release law (lane 2.2)

### DIFF
--- a/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
+++ b/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
@@ -189,4 +189,64 @@ theorem applyLockReleaseOnExits_fallthrough (slot : Nat) (body : List YulStmt)
   rw [execIRStmt_lockRelease k s' slot hslot]
   simp [execIRStmts]
 
+/-! ## Splice-point release semantics
+
+The other exit class: bodies that halt the frame with `stop`/`return` get the
+release spliced immediately before the halt, and no trailing release. -/
+
+/-- Splicing distributes over concatenation. -/
+theorem spliceLockReleaseList_append (release : YulStmt) :
+    ∀ (xs ys : List YulStmt),
+      spliceLockReleaseList release (xs ++ ys) =
+        spliceLockReleaseList release xs ++ spliceLockReleaseList release ys
+  | [], _ => rfl
+  | x :: xs', ys => by
+      simp [spliceLockReleaseList, spliceLockReleaseList_append release xs' ys]
+
+/-- `yulFrameHaltsList` looks only at the last statement: appending a halting
+statement makes the list halt. -/
+theorem yulFrameHaltsList_append_halting (s : YulStmt)
+    (hs : yulFrameHalts s = true) :
+    ∀ (xs : List YulStmt), yulFrameHaltsList (xs ++ [s]) = true
+  | [] => by simpa [yulFrameHaltsList] using hs
+  | [_] => by
+      simpa [yulFrameHaltsList] using
+        yulFrameHaltsList_append_halting s hs []
+  | _ :: x' :: xs' => by
+      simpa [yulFrameHaltsList] using
+        yulFrameHaltsList_append_halting s hs (x' :: xs')
+
+/-- Stop-exit law: a straight-line body ending in `stop` releases the lock
+immediately before halting, and gets no trailing (dead) release. -/
+theorem applyLockReleaseOnExits_stop (slot : Nat) (xs : List YulStmt)
+    (fuel : Nat) (state s' : IRState)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (hnosplice : spliceLockReleaseList (lockReleaseStmt slot) xs = xs)
+    (hxs : execIRStmts fuel state xs = .continue s')
+    (hfuel : xs.length + 3 ≤ fuel) :
+    execIRStmts fuel state
+        (applyLockReleaseOnExits (lockReleaseStmt slot)
+          (xs ++ [YulStmt.exprStmt (.call "stop" [])])) =
+      .stop { s' with
+        transientStorage := fun o => if o = slot then 0 else s'.transientStorage o } := by
+  unfold applyLockReleaseOnExits
+  rw [yulFrameHaltsList_append_halting _ (by rfl) xs, if_pos rfl,
+    spliceLockReleaseList_append, hnosplice,
+    show spliceLockReleaseList (lockReleaseStmt slot)
+        [YulStmt.exprStmt (.call "stop" [])] =
+      [lockReleaseStmt slot, YulStmt.exprStmt (.call "stop" [])] from rfl,
+    execIRStmts_append_continue _ xs fuel state s' hxs]
+  obtain ⟨k, hk⟩ : ∃ k, fuel - xs.length = k + 3 :=
+    ⟨fuel - xs.length - 3, by omega⟩
+  rw [hk]
+  rw [show execIRStmts (k + 3) s'
+      [lockReleaseStmt slot, YulStmt.exprStmt (.call "stop" [])] =
+    (match execIRStmt (k + 2) s' (lockReleaseStmt slot) with
+      | .continue s₁ => execIRStmts (k + 2) s₁ [YulStmt.exprStmt (.call "stop" [])]
+      | .return v s => .return v s
+      | .stop s => .stop s
+      | .revert s => .revert s) from rfl]
+  rw [execIRStmt_lockRelease (k + 1) s' slot hslot]
+  rfl
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3858,6 +3858,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.guard_acquire_release_roundtrip
   Compiler.Proofs.IRGeneration.execIRStmts_append_continue
   Compiler.Proofs.IRGeneration.applyLockReleaseOnExits_fallthrough
+  Compiler.Proofs.IRGeneration.spliceLockReleaseList_append
+  Compiler.Proofs.IRGeneration.yulFrameHaltsList_append_halting
+  Compiler.Proofs.IRGeneration.applyLockReleaseOnExits_stop
 
   -- Compiler/Proofs/IRGeneration/ParamLoading.lean
   Compiler.Proofs.IRGeneration.ParamLoading.uint256_modulus_eq_evm
@@ -6613,4 +6616,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6183 theorems/lemmas (4315 public, 1868 private, 0 sorry'd)
+-- Total: 6186 theorems/lemmas (4318 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Companion to #2272: `spliceLockReleaseList_append`, `yulFrameHaltsList_append_halting`, and `applyLockReleaseOnExits_stop` — a straight-line body ending in `stop` releases the lock immediately before halting, and gets no trailing dead release (the #2075 semantics, now machine-checked). Together with the fall-through law both exit classes of the guard epilogue are covered for straight-line bodies; nested control flow and the composed `guarded` correspondence are next.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only Lean additions with no runtime or compiler behavior changes; no new axioms or sorry.
> 
> **Overview**
> Completes the second straight-line exit class for nonreentrant guard epilogue semantics: bodies ending in `stop` now have a machine-checked release law matching the fall-through case.
> 
> Adds `applyLockReleaseOnExits_stop`, plus helpers `spliceLockReleaseList_append` and `yulFrameHaltsList_append_halting`, proving that a continuing prefix followed by `stop` splices the lock release immediately before the halt and omits any trailing dead release. Registers the new theorems in `PrintAxioms.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42af9908a57a6c234a5bd2568ed574915fe2daba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->