### PR TITLE
proof(ir): composed guard laws — IR mirror of guarded (lane 2.2)

### DIFF
--- a/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
+++ b/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
@@ -249,4 +249,50 @@ theorem applyLockReleaseOnExits_stop (slot : Nat) (xs : List YulStmt)
   rw [execIRStmt_lockRelease (k + 1) s' slot hslot]
   rfl
 
+/-! ## Composed guard correspondence (straight-line bodies)
+
+The IR-level mirror of `Verity.Core.Model.NonReentrantGuard.guarded` for
+straight-line bodies: locked entry reverts untouched; free entry runs the body
+under the acquired lock and releases it on fall-through. -/
+
+/-- Locked entry: the whole guarded compilation unit — prologue followed by
+anything — reverts untouched; the revert short-circuits the rest. -/
+theorem guardedBody_locked_reverts (slot : Nat) (rest : List YulStmt)
+    (fuel : Nat) (state : IRState)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (hlock : state.transientStorage slot = 1)
+    (hfuel : 3 ≤ fuel) :
+    execIRStmts fuel state (guardPrologueStmts slot ++ rest) = .revert state := by
+  obtain ⟨k, hk⟩ : ∃ k, fuel = k + 3 := ⟨fuel - 3, by omega⟩
+  subst hk
+  have hmod : slot % Compiler.Constants.evmModulus = slot := Nat.mod_eq_of_lt hslot
+  have hone : (1 : Nat) < Compiler.Constants.evmModulus := by
+    simp [Compiler.Constants.evmModulus]
+  cases k with
+  | zero =>
+      simp [guardPrologueStmts, execIRStmts, execIRStmt, evalIRExpr, evalIRCall,
+        evalIRExprs, hmod, hlock, Nat.mod_eq_of_lt hone,
+        YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext]
+  | succ n =>
+      simp [guardPrologueStmts, execIRStmts, execIRStmt, evalIRExpr, evalIRCall,
+        evalIRExprs, hmod, hlock, Nat.mod_eq_of_lt hone,
+        YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext]
+
+/-- Free entry: the guarded unit runs its suffix from the acquired state.
+Composes the prologue-acquire lemma with fuel sequencing. -/
+theorem guardedBody_free_runs_suffix (slot : Nat) (rest : List YulStmt)
+    (fuel : Nat) (state : IRState)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (hlock : state.transientStorage slot = 0)
+    (hfuel : 3 ≤ fuel) :
+    execIRStmts fuel state (guardPrologueStmts slot ++ rest) =
+      execIRStmts (fuel - 2) { state with
+        transientStorage := fun o => if o = slot then 1 else state.transientStorage o }
+        rest := by
+  obtain ⟨k, hk⟩ : ∃ k, fuel = k + 3 := ⟨fuel - 3, by omega⟩
+  subst hk
+  rw [execIRStmts_append_continue rest (guardPrologueStmts slot) (k + 3) state _
+    (execIRStmts_guardPrologue_free k state slot hslot hlock)]
+  rfl
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3861,6 +3861,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.spliceLockReleaseList_append
   Compiler.Proofs.IRGeneration.yulFrameHaltsList_append_halting
   Compiler.Proofs.IRGeneration.applyLockReleaseOnExits_stop
+  Compiler.Proofs.IRGeneration.guardedBody_locked_reverts
+  Compiler.Proofs.IRGeneration.guardedBody_free_runs_suffix
 
   -- Compiler/Proofs/IRGeneration/ParamLoading.lean
   Compiler.Proofs.IRGeneration.ParamLoading.uint256_modulus_eq_evm
@@ -6616,4 +6618,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6186 theorems/lemmas (4318 public, 1868 private, 0 sorry'd)
+-- Total: 6188 theorems/lemmas (4320 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Caps the straight-line slice of the `guarded` ↔ emitted-Yul correspondence: `guardedBody_locked_reverts` (locked entry ⇒ revert untouched, body short-circuited) and `guardedBody_free_runs_suffix` (free entry ⇒ suffix runs from the acquired state). Combined with #2272/#2273 the compiled guard's entry and both exit classes now mirror `Verity.Core.Model.NonReentrantGuard.guarded` at the IR level for straight-line bodies. Remaining: nested control-flow splice points and the `attachNonReentrantGuard`-level statement over `compileFunctionSpec` output.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only Lean additions with no runtime or compiler behavior changes; validated with no sorry/admit or new axioms.
> 
> **Overview**
> Adds the IR-level mirror of `NonReentrantGuard.guarded` for **straight-line** bodies, composing prologue behavior with an arbitrary suffix.
> 
> **`guardedBody_locked_reverts`**: locked entry makes `guardPrologueStmts ++ rest` revert with the state untouched (body short-circuited).
> 
> **`guardedBody_free_runs_suffix`**: free entry runs `rest` from the acquired lock state via the existing prologue-acquire and fuel-sequencing lemmas.
> 
> Together with prior prologue/release laws, entry and both exit classes now match source `guarded` at IR for straight-line bodies. Registers the new theorems in `PrintAxioms.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c707ef1f01d3457c51bbab5829221c6290d71053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->