### PR TITLE
proof(ir): attachNonReentrantGuard output shape (lane 2.2)

### DIFF
--- a/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
+++ b/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
@@ -295,4 +295,28 @@ theorem guardedBody_free_runs_suffix (slot : Nat) (rest : List YulStmt)
     (execIRStmts_guardPrologue_free k state slot hslot hlock)]
   rfl
 
+/-! ## attachNonReentrantGuard shape -/
+
+/-- The guarded compilation unit has exactly the param-loads ++ prologue ++
+released-body shape: the split point is the param-load count, the prologue is
+`guardPrologueStmts` at the resolved slot, and the suffix goes through
+`applyLockReleaseOnExits` with the matching release.  This pins the object the
+composed guard laws talk about to the transformation's actual output. -/
+theorem attachNonReentrantGuard_some_shape (fields : List Field)
+    (spec : FunctionSpec) (irFn : IRFunction) (lockField : String)
+    (field : Field) (slot : Nat)
+    (hlock : spec.nonReentrantLock = some lockField)
+    (hfield : findFieldWithResolvedSlot fields lockField = some (field, slot)) :
+    attachNonReentrantGuard fields spec irFn = .ok { irFn with
+      body :=
+        irFn.body.take (genParamLoads spec.params).length ++
+          guardPrologueStmts slot ++
+          applyLockReleaseOnExits (lockReleaseStmt slot)
+            (irFn.body.drop (genParamLoads spec.params).length) } := by
+  simp only [attachNonReentrantGuard, hlock,
+    nonReentrantGuardPrologue_eq fields lockField field slot hfield,
+    hfield, lockReleaseStmt, List.splitAt_eq]
+  simp [pure, Except.pure, List.append_assoc]
+  rfl
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3863,6 +3863,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.applyLockReleaseOnExits_stop
   Compiler.Proofs.IRGeneration.guardedBody_locked_reverts
   Compiler.Proofs.IRGeneration.guardedBody_free_runs_suffix
+  Compiler.Proofs.IRGeneration.attachNonReentrantGuard_some_shape
 
   -- Compiler/Proofs/IRGeneration/ParamLoading.lean
   Compiler.Proofs.IRGeneration.ParamLoading.uint256_modulus_eq_evm
@@ -6618,4 +6619,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6188 theorems/lemmas (4320 public, 1868 private, 0 sorry'd)
+-- Total: 6189 theorems/lemmas (4321 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Pins the guarded compilation unit to its proved pieces: `attachNonReentrantGuard_some_shape` shows the transformation's output is exactly `take paramLoads ++ guardPrologueStmts slot ++ applyLockReleaseOnExits (release slot) (drop paramLoads)` — the precise object of #2262/#2272/#2273/#2274. What remains for the full lift is the param-load prefix semantics + nested-control-flow splice points + threading into compile_preserves_semantics.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only addition with no compiler or runtime behavior change; registers one new theorem and bumps the axiom inventory count.
> 
> **Overview**
> Adds `attachNonReentrantGuard_some_shape`, proving that when a lock is present the transformation yields exactly **param-loads ++ `guardPrologueStmts` ++ `applyLockReleaseOnExits` on the remaining body**.
> 
> This ties the already-proved composed guard laws to the compiler's actual output shape, advancing the lane-2.2 nonreentrant IR correspondence. Also registers the theorem in `PrintAxioms.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6e49006532b2118c10cebc1591ade46f0af3ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->