### PR TITLE
proof(ir): straight-line fuel insensitivity (#2276)

### DIFF
--- a/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
+++ b/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
@@ -319,4 +319,64 @@ theorem attachNonReentrantGuard_some_shape (fields : List Field)
   simp [pure, Except.pure, List.append_assoc]
   rfl
 
+/-! ## Straight-line fuel insensitivity (#2276 option (a), first fragment)
+
+A straight-line statement — no `if`/`for`/`switch`/`block` — executes in one
+fuel step and never recurses, so its result is the same at every positive
+fuel.  This removes exact-fuel bookkeeping from the guard laws' consumers and
+is the first brick of the `ExecutesWithin` plan in #2276. -/
+
+/-- Statements whose execution never recurses into a sub-list. -/
+def StraightLineStmt : YulStmt → Prop
+  | .comment _ => True
+  | .let_ _ _ => True
+  | .letMany _ _ => True
+  | .assign _ _ => True
+  | .leave => True
+  | .exprStmt _ => True
+  | .funcDef _ _ _ _ => True
+  | _ => False
+
+/-- A straight-line statement's execution is fuel-insensitive at positive
+fuel. -/
+theorem execIRStmt_straightline_fuel_insensitive (stmt : YulStmt)
+    (hs : StraightLineStmt stmt) (f g : Nat) (state : IRState) :
+    execIRStmt (f + 1) state stmt = execIRStmt (g + 1) state stmt := by
+  cases stmt <;> simp [StraightLineStmt] at hs <;> rfl
+
+/-- A straight-line list's execution is the same at every fuel strictly above
+its length. -/
+theorem execIRStmts_straightline_fuel_insensitive :
+    ∀ (xs : List YulStmt), (∀ s ∈ xs, StraightLineStmt s) →
+      ∀ (f g : Nat) (state : IRState),
+        execIRStmts (xs.length + f + 1) state xs =
+          execIRStmts (xs.length + g + 1) state xs
+  | [], _, f, g, state => rfl
+  | x :: xs', hall, f, g, state => by
+      have hx : StraightLineStmt x := hall x (by simp)
+      have htail : ∀ s ∈ xs', StraightLineStmt s := fun s hs =>
+        hall s (by simp [hs])
+      rw [show (x :: xs').length + f + 1 = (xs'.length + f + 1) + 1 from by
+            simp [List.length]; omega,
+          show (x :: xs').length + g + 1 = (xs'.length + g + 1) + 1 from by
+            simp [List.length]; omega]
+      show (match execIRStmt (xs'.length + f + 1) state x with
+          | .continue s₁ => execIRStmts (xs'.length + f + 1) s₁ xs'
+          | .return v s => .return v s
+          | .stop s => .stop s
+          | .revert s => .revert s) =
+        (match execIRStmt (xs'.length + g + 1) state x with
+          | .continue s₁ => execIRStmts (xs'.length + g + 1) s₁ xs'
+          | .return v s => .return v s
+          | .stop s => .stop s
+          | .revert s => .revert s)
+      rw [execIRStmt_straightline_fuel_insensitive x hx
+        (xs'.length + f) (xs'.length + g) state]
+      cases execIRStmt (xs'.length + g + 1) state x with
+      | «continue» s₁ =>
+          exact execIRStmts_straightline_fuel_insensitive xs' htail f g s₁
+      | «return» v s => rfl
+      | stop s => rfl
+      | revert s => rfl
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3864,6 +3864,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.guardedBody_locked_reverts
   Compiler.Proofs.IRGeneration.guardedBody_free_runs_suffix
   Compiler.Proofs.IRGeneration.attachNonReentrantGuard_some_shape
+  Compiler.Proofs.IRGeneration.execIRStmt_straightline_fuel_insensitive
+  Compiler.Proofs.IRGeneration.execIRStmts_straightline_fuel_insensitive
 
   -- Compiler/Proofs/IRGeneration/ParamLoading.lean
   Compiler.Proofs.IRGeneration.ParamLoading.uint256_modulus_eq_evm
@@ -6619,4 +6621,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6189 theorems/lemmas (4321 public, 1868 private, 0 sorry'd)
+-- Total: 6191 theorems/lemmas (4323 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
First fragment of the `ExecutesWithin` plan from #2276: `StraightLineStmt` and the two fuel-insensitivity theorems — a non-recursing statement executes identically at every positive fuel, and a straight-line list at every fuel strictly above its length. This is the enabling infrastructure for the nested-splice simulation without exact-fuel bookkeeping.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proof lemmas only; no compiler, runtime, or semantic changes beyond registering two new theorems.
> 
> **Overview**
> Adds the first `#2276` `ExecutesWithin` building block: **`StraightLineStmt`** and fuel-insensitivity laws so non-branching IR statements (and lists of them) execute identically at every sufficient fuel.
> 
> `execIRStmt_straightline_fuel_insensitive` shows a non-recursing statement is stable at any positive fuel; `execIRStmts_straightline_fuel_insensitive` lifts that to lists above their length. This lets later guard/splice proofs avoid exact-fuel bookkeeping. Also registers the new theorems in `PrintAxioms.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4751597975d081bf729d0170c4db638b47972e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->