### PR TITLE
proof(ir): structural no-splice-point discharge (#2276)

### DIFF
--- a/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
+++ b/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
@@ -379,4 +379,47 @@ theorem execIRStmts_straightline_fuel_insensitive :
       | stop s => rfl
       | revert s => rfl
 
+/-- A straight-line statement that is not a frame exit splices to itself. -/
+theorem spliceLockRelease_eq_self (release : YulStmt) (stmt : YulStmt)
+    (hs : StraightLineStmt stmt)
+    (hexit : ∀ f args, stmt = .exprStmt (.call f args) →
+      f ≠ "return" ∧ f ≠ "stop") :
+    spliceLockRelease release stmt = [stmt] := by
+  cases stmt with
+  | exprStmt e =>
+      cases e with
+      | call f args =>
+          obtain ⟨hret, hstop⟩ := hexit f args rfl
+          simp [spliceLockRelease, hret, hstop]
+      | _ => rfl
+  | comment _ => rfl
+  | let_ _ _ => rfl
+  | letMany _ _ => rfl
+  | assign _ _ => rfl
+  | «leave» => rfl
+  | funcDef _ _ _ _ => rfl
+  | if_ _ _ => simp [StraightLineStmt] at hs
+  | for_ _ _ _ _ => simp [StraightLineStmt] at hs
+  | «switch» _ _ _ => simp [StraightLineStmt] at hs
+  | block _ => simp [StraightLineStmt] at hs
+
+/-- Discharge the no-splice-point hypothesis of the straight-line guard laws
+structurally: a list of straight-line non-exit statements splices to
+itself. -/
+theorem spliceLockReleaseList_eq_self (release : YulStmt) :
+    ∀ (xs : List YulStmt),
+      (∀ s ∈ xs, StraightLineStmt s ∧
+        ∀ f args, s = YulStmt.exprStmt (.call f args) →
+          f ≠ "return" ∧ f ≠ "stop") →
+      spliceLockReleaseList release xs = xs
+  | [], _ => rfl
+  | x :: xs', hall => by
+      obtain ⟨hx, hexit⟩ := hall x (by simp)
+      rw [show spliceLockReleaseList release (x :: xs') =
+        spliceLockRelease release x ++ spliceLockReleaseList release xs' from rfl,
+        spliceLockRelease_eq_self release x hx hexit,
+        spliceLockReleaseList_eq_self release xs'
+          (fun s hs => hall s (by simp [hs]))]
+      rfl
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3866,6 +3866,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.attachNonReentrantGuard_some_shape
   Compiler.Proofs.IRGeneration.execIRStmt_straightline_fuel_insensitive
   Compiler.Proofs.IRGeneration.execIRStmts_straightline_fuel_insensitive
+  Compiler.Proofs.IRGeneration.spliceLockRelease_eq_self
+  Compiler.Proofs.IRGeneration.spliceLockReleaseList_eq_self
 
   -- Compiler/Proofs/IRGeneration/ParamLoading.lean
   Compiler.Proofs.IRGeneration.ParamLoading.uint256_modulus_eq_evm
@@ -6621,4 +6623,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6191 theorems/lemmas (4323 public, 1868 private, 0 sorry'd)
+-- Total: 6193 theorems/lemmas (4325 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
`spliceLockRelease_eq_self`/`spliceLockReleaseList_eq_self`: straight-line non-frame-exit statements splice to themselves, so the `hnosplice` hypotheses of #2272/#2273 follow from the body's syntactic shape. Together with #2277 the straight-line guard fragment needs no per-body assumptions beyond its shape.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only Lean lemmas with no runtime or compiler behavior changes; axiom count increases by two public theorems with no sorry.
> 
> **Overview**
> Adds **`spliceLockRelease_eq_self`** and **`spliceLockReleaseList_eq_self`**: straight-line statements that are not frame exits (`return`/`stop`) are fixed points of `spliceLockRelease` / `spliceLockReleaseList`.
> 
> This **structurally discharges** the `hnosplice` hypotheses on the existing straight-line guard laws (`applyLockReleaseOnExits_fallthrough`, `applyLockReleaseOnExits_stop`), so those obligations follow from body shape rather than per-body assumptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a647f3e60d8337e1c24d8230c4c91c136247935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->