### PR TITLE
proof(ir): structural halt-hypothesis discharge (#2276)

### DIFF
--- a/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
+++ b/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
@@ -422,4 +422,48 @@ theorem spliceLockReleaseList_eq_self (release : YulStmt) :
           (fun s hs => hall s (by simp [hs]))]
       rfl
 
+/-- Companion discharge for the fall-through law's halt hypothesis: a
+straight-line statement that is no halting builtin call does not halt the
+frame, and a list of such statements never halts (the analysis only inspects
+the last statement, but the pointwise condition is what shapes provide). -/
+theorem yulFrameHalts_eq_false (stmt : YulStmt)
+    (hs : StraightLineStmt stmt)
+    (hexit : ∀ f args, stmt = YulStmt.exprStmt (.call f args) →
+      f ≠ "return" ∧ f ≠ "stop" ∧ f ≠ "revert" ∧ f ≠ "invalid" ∧
+        f ≠ "selfdestruct") :
+    yulFrameHalts stmt = false := by
+  cases stmt with
+  | exprStmt e =>
+      cases e with
+      | call f args =>
+          obtain ⟨h1, h2, h3, h4, h5⟩ := hexit f args rfl
+          simp [yulFrameHalts, h1, h2, h3, h4, h5]
+      | _ => rfl
+  | comment _ => rfl
+  | let_ _ _ => rfl
+  | letMany _ _ => rfl
+  | assign _ _ => rfl
+  | «leave» => rfl
+  | funcDef _ _ _ _ => rfl
+  | if_ _ _ => rfl
+  | for_ _ _ _ _ => rfl
+  | «switch» _ _ _ => simp [StraightLineStmt] at hs
+  | block _ => simp [StraightLineStmt] at hs
+
+theorem yulFrameHaltsList_eq_false :
+    ∀ (xs : List YulStmt),
+      (∀ s ∈ xs, StraightLineStmt s ∧
+        ∀ f args, s = YulStmt.exprStmt (.call f args) →
+          f ≠ "return" ∧ f ≠ "stop" ∧ f ≠ "revert" ∧ f ≠ "invalid" ∧
+            f ≠ "selfdestruct") →
+      yulFrameHaltsList xs = false
+  | [], _ => rfl
+  | [x], hall => by
+      obtain ⟨hx, hexit⟩ := hall x (by simp)
+      simpa [yulFrameHaltsList] using yulFrameHalts_eq_false x hx hexit
+  | x :: x' :: xs', hall => by
+      simpa [yulFrameHaltsList] using
+        yulFrameHaltsList_eq_false (x' :: xs')
+          (fun s hs => hall s (by simp at hs ⊢; tauto))
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3868,6 +3868,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.execIRStmts_straightline_fuel_insensitive
   Compiler.Proofs.IRGeneration.spliceLockRelease_eq_self
   Compiler.Proofs.IRGeneration.spliceLockReleaseList_eq_self
+  Compiler.Proofs.IRGeneration.yulFrameHalts_eq_false
+  Compiler.Proofs.IRGeneration.yulFrameHaltsList_eq_false
 
   -- Compiler/Proofs/IRGeneration/ParamLoading.lean
   Compiler.Proofs.IRGeneration.ParamLoading.uint256_modulus_eq_evm
@@ -6623,4 +6625,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6193 theorems/lemmas (4325 public, 1868 private, 0 sorry'd)
+-- Total: 6195 theorems/lemmas (4327 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Completes the shape-only hypothesis set for the straight-line guard fragment: `yulFrameHalts_eq_false`/`yulFrameHaltsList_eq_false` discharge the `hnohalt` hypothesis of the fall-through law (#2272) from the body's syntactic shape, matching the splice discharge in #2278.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions with no runtime or semantic changes; registers two new theorems and updates axiom inventory counts.
> 
> **Overview**
> Completes the **shape-only hypothesis set** for straight-line nonreentrant guard bodies by discharging the fall-through law's `hnohalt` premise from syntax alone.
> 
> Adds `yulFrameHalts_eq_false` / `yulFrameHaltsList_eq_false`, which show that straight-line statements (and lists of them) that are not halting builtins (`return`/`stop`/`revert`/`invalid`/`selfdestruct`) never frame-halt. This mirrors the existing `spliceLockRelease*_eq_self` discharge for the no-splice hypothesis.
> 
> Also registers the new theorems in `PrintAxioms.lean` (6193 → 6195).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43f2cf0d50dc97cf15c95a8bfc2c24dfc296665a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->