### PR TITLE
proof(ir): Panic(uint256) revert observable (#1999)

### DIFF
--- a/Compiler/Proofs/IRGeneration/PanicPayloadIR.lean
+++ b/Compiler/Proofs/IRGeneration/PanicPayloadIR.lean
@@ -1,0 +1,44 @@
+import Compiler.Proofs.IRGeneration.IRInterpreter
+import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBridgeLemmas
+
+/-!
+# Proof-side observable for the built-in Panic(uint256) payload (#1999)
+
+The compiler owns panic emission (`solidityPanicPayload` in
+`Compiler/CompilationModel/DynamicData.lean`); this module supplies the
+matching proof-side revert observable: under the IR interpreter, the emitted
+statements deterministically revert with the exact Solidity ABI panic payload
+laid out in memory — selector word `0x4e487b71 << 224` at offset 0 and the
+panic code at offset 4 — for every code and every starting state.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+open Compiler.CompilationModel
+
+/-- The 32-byte word holding the left-aligned `Panic(uint256)` selector. -/
+def panicSelectorWord : Nat := 0x4e487b71 * 2 ^ 224
+
+/-- The emitted panic sequence reverts with the canonical payload in memory:
+selector word at offset 0, code at offset 4, nothing else changed. -/
+theorem execIRStmts_solidityPanicPayload (fuel : Nat) (state : IRState)
+    (code : Nat) (hcode : code < Compiler.Constants.evmModulus) :
+    execIRStmts (fuel + 4) state (solidityPanicPayload code) =
+      .revert { state with
+        memory := fun o =>
+          if o = 4 then code
+          else if o = 0 then panicSelectorWord
+          else state.memory o } := by
+  simp [solidityPanicPayload, solidityPanicPayloadExpr, execIRStmts, execIRStmt,
+    evalIRExpr, evalIRCall, evalIRExprs,
+    YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
+    panicSelectorWord, Nat.mod_eq_of_lt hcode]
+  funext o
+  by_cases h4 : o = 4
+  · simp [h4]
+  · by_cases h0 : o = 0
+    · have h224 : (224 : Nat) % Compiler.Constants.evmModulus = 224 := by decide
+      simp [h4, h0, h224]
+    · simp [h4, h0]
+
+end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -80,6 +80,7 @@ import Compiler.Proofs.IRGeneration.IRStorageWord
 import Compiler.Proofs.IRGeneration.InternalHelperBodyCorrespondence
 import Compiler.Proofs.IRGeneration.IntrinsicProofs
 import Compiler.Proofs.IRGeneration.NonReentrantGuardIR
+import Compiler.Proofs.IRGeneration.PanicPayloadIR
 import Compiler.Proofs.IRGeneration.ParamLoading
 import Compiler.Proofs.IRGeneration.SourceSemantics
 import Compiler.Proofs.IRGeneration.SupportedFragment
@@ -3871,6 +3872,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.yulFrameHalts_eq_false
   Compiler.Proofs.IRGeneration.yulFrameHaltsList_eq_false
 
+  -- Compiler/Proofs/IRGeneration/PanicPayloadIR.lean
+  Compiler.Proofs.IRGeneration.execIRStmts_solidityPanicPayload
+
   -- Compiler/Proofs/IRGeneration/ParamLoading.lean
   Compiler.Proofs.IRGeneration.ParamLoading.uint256_modulus_eq_evm
   Compiler.Proofs.IRGeneration.ParamLoading.wordNormalize_eq_mod
@@ -6625,4 +6629,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6195 theorems/lemmas (4327 public, 1868 private, 0 sorry'd)
+-- Total: 6196 theorems/lemmas (4328 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
The compiler already owns panic emission (`solidityPanicPayload`); this adds the missing proof-side observable: `execIRStmts_solidityPanicPayload` proves the emitted statements deterministically revert with the canonical ABI payload in memory (selector word `0x4e487b71 << 224` at offset 0, code at offset 4, nothing else changed) for every code and starting state. Downstream consumers (e.g. the Morpho `solidityPanicModule` ECM) can consume this instead of assuming the payload shape; bundling with #1993 checked-arithmetic paths can build on it.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only addition with no changes to compilation or runtime behavior; only extends the verified IR interpreter story for panic emission.
> 
> **Overview**
> Adds a proof-side guarantee that compiler-emitted **`solidityPanicPayload`** IR always reverts under the IR interpreter with the canonical Solidity **`Panic(uint256)`** ABI layout in memory.
> 
> New module **`PanicPayloadIR.lean`** defines **`panicSelectorWord`** and proves **`execIRStmts_solidityPanicPayload`**: for any starting state and panic code below the EVM modulus, executing the payload updates only memory offsets **0** (selector `0x4e487b71 << 224`) and **4** (the code), then reverts. **`PrintAxioms.lean`** imports the module and lists the theorem (public theorem count **6195 → 6196**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e450a3998b0c58c4870c83a4b736a550cf20618a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->