### PR TITLE
proof(ir): nested conditional-exit splice law (lane 2.2)

### DIFF
--- a/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
+++ b/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
@@ -466,4 +466,64 @@ theorem yulFrameHaltsList_eq_false :
         yulFrameHaltsList_eq_false (x' :: xs')
           (fun s hs => hall s (by simp at hs ⊢; tauto))
 
+/-! ## First nested splice law: conditional frame exit -/
+
+/-- Splicing a conditional stop guards the release inside the branch. -/
+theorem spliceLockRelease_if_stop_shape (slot : Nat) (cond : YulExpr) :
+    spliceLockRelease (lockReleaseStmt slot)
+        (.if_ cond [.exprStmt (.call "stop" [])]) =
+      [.if_ cond [lockReleaseStmt slot, .exprStmt (.call "stop" [])]] := rfl
+
+/-- Semantics of the spliced conditional exit: a true condition releases the
+lock and halts; a false condition falls through with nothing changed. -/
+theorem execIRStmts_spliced_if_stop (slot : Nat) (cond : YulExpr)
+    (fuel : Nat) (state : IRState) (c : Nat)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (hcond : evalIRExpr state cond = some c) :
+    execIRStmts (fuel + 5) state
+        (spliceLockRelease (lockReleaseStmt slot)
+          (.if_ cond [.exprStmt (.call "stop" [])])) =
+      if c ≠ 0 then
+        .stop { state with
+          transientStorage := fun o => if o = slot then 0
+            else state.transientStorage o }
+      else .continue state := by
+  rw [spliceLockRelease_if_stop_shape]
+  show (match execIRStmt (fuel + 4) state
+      (.if_ cond [lockReleaseStmt slot, .exprStmt (.call "stop" [])]) with
+    | .continue s₁ => execIRStmts (fuel + 4) s₁ []
+    | .return v s => .return v s
+    | .stop s => .stop s
+    | .revert s => .revert s) = _
+  rw [show execIRStmt (fuel + 4) state
+      (.if_ cond [lockReleaseStmt slot, .exprStmt (.call "stop" [])]) =
+    (match evalIRExpr state cond with
+      | some c => if c ≠ 0 then
+          execIRStmts (fuel + 3) state
+            [lockReleaseStmt slot, .exprStmt (.call "stop" [])]
+        else .continue state
+      | none => .revert state) from rfl, hcond]
+  show (match (if c ≠ 0 then
+      execIRStmts (fuel + 3) state
+        [lockReleaseStmt slot, .exprStmt (.call "stop" [])]
+    else .continue state) with
+    | .continue s₁ => execIRStmts (fuel + 4) s₁ []
+    | .return v s => .return v s
+    | .stop s => .stop s
+    | .revert s => .revert s) = _
+  by_cases hc : c ≠ 0
+  · rw [if_pos hc, if_pos hc,
+      show execIRStmts (fuel + 3) state
+          [lockReleaseStmt slot, .exprStmt (.call "stop" [])] =
+        (match execIRStmt (fuel + 2) state (lockReleaseStmt slot) with
+          | .continue s₁ => execIRStmts (fuel + 2) s₁
+              [.exprStmt (.call "stop" [])]
+          | .return v s => .return v s
+          | .stop s => .stop s
+          | .revert s => .revert s) from rfl,
+      execIRStmt_lockRelease (fuel + 1) state slot hslot]
+    rfl
+  · rw [if_neg hc, if_neg hc]
+    rfl
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3887,6 +3887,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.spliceLockReleaseList_eq_self
   Compiler.Proofs.IRGeneration.yulFrameHalts_eq_false
   Compiler.Proofs.IRGeneration.yulFrameHaltsList_eq_false
+  Compiler.Proofs.IRGeneration.spliceLockRelease_if_stop_shape
+  Compiler.Proofs.IRGeneration.execIRStmts_spliced_if_stop
 
   -- Compiler/Proofs/IRGeneration/PanicPayloadIR.lean
   Compiler.Proofs.IRGeneration.execIRStmts_solidityPanicPayload
@@ -6645,4 +6647,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6209 theorems/lemmas (4341 public, 1868 private, 0 sorry'd)
+-- Total: 6211 theorems/lemmas (4343 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
First splice law beyond straight-line bodies: `spliceLockRelease_if_stop_shape` (the release is spliced inside the branch) and `execIRStmts_spliced_if_stop` (a taken conditional exit halts with the lock cleared; an untaken one falls through untouched). Demonstrates the mechanism on one nesting level; the general simulation still awaits the #2276 `ExecutesWithin` infrastructure.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions to IR generation lemmas with no runtime, compiler emission, or axiom changes.
> 
> **Overview**
> Extends the non-reentrant guard IR proofs beyond straight-line bodies with the **first nested splice law** for a conditional `stop` exit.
> 
> **`spliceLockRelease_if_stop_shape`** shows that splicing `lockRelease` into `if cond [stop]` places the release **inside the taken branch** (`if cond [release; stop]`), matching how `spliceLockRelease` recurses through `if_` in the compiler.
> 
> **`execIRStmts_spliced_if_stop`** gives the IR semantics: when the condition evaluates to non-zero, execution **stops with the lock slot cleared**; when it is zero, execution **continues with state unchanged**. The two lemmas are registered in `PrintAxioms.lean` (theorem count 6209 → 6211).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d13da78a42a1ceb79faf19a85a44dedacc6c6b7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->