### PR TITLE
proof(ir): loop-free fuel bounds (#2276 option (c) foundation)

### DIFF
--- a/Compiler/Proofs/IRGeneration/FuelBound.lean
+++ b/Compiler/Proofs/IRGeneration/FuelBound.lean
@@ -1,0 +1,91 @@
+import Compiler.Proofs.IRGeneration.IRInterpreter
+
+/-!
+# Computable fuel bounds for the loop-free fragment (#2276 option (c))
+
+The IR interpreter conflates fuel exhaustion with `.revert`, so naive fuel
+monotonicity is false.  For the loop-free fragment, however, a structural
+bound suffices: execution at any fuel at or above the bound never hits the
+exhaustion branch, so results agree at all such fuels.  This gives the
+simulation proofs (nested splice, Tier 4) a way to equate executions at
+shifted fuel indices without an interpreter refactor.
+
+Fuel flows non-additively: a statement list at fuel `f+1` runs both its head
+and its tail at fuel `f`, so the list bound is the max of its members' bounds
+plus one per cons step; `if`/`block`/`switch` add one step above their body
+bound.  `for` loops are outside the fragment (`LoopFree` excludes them), and
+`funcDef` bodies are skipped by the interpreter.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+
+mutual
+
+/-- Structural fuel bound: executing at this fuel or above never exhausts. -/
+def stmtFuelBound : YulStmt → Nat
+  | .if_ _ body => stmtsFuelBound body + 1
+  | .block stmts => stmtsFuelBound stmts + 1
+  | .switch _ cases dflt =>
+      Nat.max (casesFuelBound cases) (dfltFuelBound dflt) + 1
+  | _ => 1
+
+def casesFuelBound : List (Nat × List YulStmt) → Nat
+  | [] => 0
+  | c :: rest => Nat.max (stmtsFuelBound c.2) (casesFuelBound rest)
+
+def dfltFuelBound : Option (List YulStmt) → Nat
+  | none => 0
+  | some stmts => stmtsFuelBound stmts
+
+def stmtsFuelBound : List YulStmt → Nat
+  | [] => 1
+  | s :: rest => Nat.max (stmtFuelBound s) (stmtsFuelBound rest) + 1
+
+end
+
+mutual
+
+/-- The fragment: no `for_` anywhere (interpreted positions only — `funcDef`
+bodies are never executed by `execIRStmt`). -/
+def LoopFree : YulStmt → Prop
+  | .if_ _ body => LoopFreeList body
+  | .block stmts => LoopFreeList stmts
+  | .switch _ cases dflt => LoopFreeCases cases ∧ LoopFreeDflt dflt
+  | .for_ _ _ _ _ => False
+  | _ => True
+
+def LoopFreeCases : List (Nat × List YulStmt) → Prop
+  | [] => True
+  | c :: rest => LoopFreeList c.2 ∧ LoopFreeCases rest
+
+def LoopFreeDflt : Option (List YulStmt) → Prop
+  | none => True
+  | some stmts => LoopFreeList stmts
+
+def LoopFreeList : List YulStmt → Prop
+  | [] => True
+  | s :: rest => LoopFree s ∧ LoopFreeList rest
+
+end
+
+/-- Bounds are positive: a bound of `stmtFuelBound` always survives the
+`succ` pattern of the interpreter. -/
+theorem stmtFuelBound_pos (stmt : YulStmt) : 0 < stmtFuelBound stmt := by
+  cases stmt <;> simp [stmtFuelBound]
+
+theorem stmtsFuelBound_pos (stmts : List YulStmt) : 0 < stmtsFuelBound stmts := by
+  cases stmts <;> simp [stmtsFuelBound]
+
+/-- Member bounds are dominated by the list bound. -/
+theorem stmtFuelBound_le_stmtsFuelBound (s : YulStmt) :
+    ∀ (xs : List YulStmt), s ∈ xs → stmtFuelBound s < stmtsFuelBound xs
+  | [], h => by cases h
+  | x :: rest, h => by
+      rcases List.mem_cons.mp h with rfl | h
+      · exact Nat.lt_succ_of_le (Nat.le_max_left _ _)
+      · exact Nat.lt_succ_of_le (Nat.le_trans
+          (Nat.le_of_lt (stmtFuelBound_le_stmtsFuelBound s rest h))
+          (Nat.le_max_right _ _))
+
+end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -55,6 +55,7 @@ import Compiler.Proofs.IRGeneration.DenoteFunctionAgreement
 import Compiler.Proofs.IRGeneration.Dispatch
 import Compiler.Proofs.IRGeneration.DynamicAbiRefinement
 import Compiler.Proofs.IRGeneration.ErrorStringPayloadIR
+import Compiler.Proofs.IRGeneration.FuelBound
 import Compiler.Proofs.IRGeneration.Function
 import Compiler.Proofs.IRGeneration.FunctionBody.Base
 import Compiler.Proofs.IRGeneration.FunctionBody.Stmt
@@ -2349,6 +2350,11 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.errorStringWrites_mem4
   Compiler.Proofs.IRGeneration.errorStringWrites_mem36
   Compiler.Proofs.IRGeneration.execIRStmts_revertWithMessage
+
+  -- Compiler/Proofs/IRGeneration/FuelBound.lean
+  Compiler.Proofs.IRGeneration.stmtFuelBound_pos
+  Compiler.Proofs.IRGeneration.stmtsFuelBound_pos
+  Compiler.Proofs.IRGeneration.stmtFuelBound_le_stmtsFuelBound
 
   -- Compiler/Proofs/IRGeneration/Function.lean
   -- Compiler.Proofs.IRGeneration.Function.yulStmtList_length_le_sizeOf  -- private
@@ -6647,4 +6653,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6211 theorems/lemmas (4343 public, 1868 private, 0 sorry'd)
+-- Total: 6214 theorems/lemmas (4346 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Implements the definitional layer of #2276 option (c): `stmtFuelBound`/`stmtsFuelBound` with explicit cases/default helpers (mirroring the #2271 totalization pattern), the `LoopFree` fragment predicate, positivity, and member-domination lemmas. The follow-up fuel-stability theorem (execution at any fuel ≥ bound agrees with execution at the bound, by mutual structural induction) is what unlocks the nested-splice simulation and Tier-4 shifted-fuel reasoning.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions with no runtime or interpreter changes; low risk aside from maintaining the PrintAxioms registry.
> 
> **Overview**
> Adds **`Compiler/Proofs/IRGeneration/FuelBound.lean`** as the definitional foundation for #2276 option (c): structural **`stmtFuelBound` / `stmtsFuelBound`** (with **`casesFuelBound` / `dfltFuelBound`** helpers), the **`LoopFree`** predicate (no `for_` in interpreted positions), and three lemmas—**positivity** of bounds and **`stmtFuelBound < stmtsFuelBound`** for list members.
> 
> **`PrintAxioms.lean`** imports the module and lists the new public theorems so the axiom inventory stays complete (6214 total lemmas).
> 
> This layer does **not** yet prove fuel-stability (execution agrees for all fuel ≥ bound); that is intended for a follow-up to support nested-splice / Tier-4 shifted-fuel simulation without changing the IR interpreter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7e9cc731f0880c076f0199f22098d73a9de6f82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->