### PR TITLE
proof(ir): loop-free fuel stability (#2276 resolved for the fragment)

### DIFF
--- a/Compiler/Proofs/IRGeneration/FuelBound.lean
+++ b/Compiler/Proofs/IRGeneration/FuelBound.lean
@@ -88,4 +88,215 @@ theorem stmtFuelBound_le_stmtsFuelBound (s : YulStmt) :
           (Nat.le_of_lt (stmtFuelBound_le_stmtsFuelBound s rest h))
           (Nat.le_max_right _ _))
 
+/-- Case-bound domination by membership. -/
+theorem stmtsFuelBound_le_casesFuelBound :
+    ∀ (cs : List (Nat × List YulStmt)) (c : Nat × List YulStmt),
+      c ∈ cs → stmtsFuelBound c.2 ≤ casesFuelBound cs
+  | [], _, h => by cases h
+  | _ :: rest, c, h => by
+      rcases List.mem_cons.mp h with rfl | h
+      · exact Nat.le_max_left _ _
+      · exact Nat.le_trans (stmtsFuelBound_le_casesFuelBound rest c h)
+          (Nat.le_max_right _ _)
+
+/-- Fragment membership for the branch selected at runtime. -/
+theorem LoopFreeCases.mem :
+    ∀ {cs : List (Nat × List YulStmt)}, LoopFreeCases cs →
+      ∀ {c : Nat × List YulStmt}, c ∈ cs → LoopFreeList c.2 := by
+  intro cs h c hmem
+  induction cs with
+  | nil => cases hmem
+  | cons x rest ih =>
+      obtain ⟨hx, hrest⟩ := h
+      rcases List.mem_cons.mp hmem with rfl | hmem
+      · exact hx
+      · exact ih hrest hmem
+
+mutual
+
+/-- Fuel stability: a loop-free statement executes identically at its bound
+and at any additional fuel. -/
+theorem execIRStmt_stable : ∀ (stmt : YulStmt), LoopFree stmt →
+    ∀ (f : Nat) (state : IRState),
+      execIRStmt (stmtFuelBound stmt + f) state stmt =
+        execIRStmt (stmtFuelBound stmt) state stmt
+  | .comment _, _, f, state => by
+      simp only [stmtFuelBound]
+      rw [Nat.add_comm 1 f]
+      rfl
+  | .let_ _ _, _, f, state => by
+      simp only [stmtFuelBound]
+      rw [Nat.add_comm 1 f]
+      rfl
+  | .letMany _ _, _, f, state => by
+      simp only [stmtFuelBound]
+      rw [Nat.add_comm 1 f]
+      rfl
+  | .assign _ _, _, f, state => by
+      simp only [stmtFuelBound]
+      rw [Nat.add_comm 1 f]
+      rfl
+  | .leave, _, f, state => by
+      simp only [stmtFuelBound]
+      rw [Nat.add_comm 1 f]
+      rfl
+  | .exprStmt _, _, f, state => by
+      simp only [stmtFuelBound]
+      rw [Nat.add_comm 1 f]
+      rfl
+  | .funcDef _ _ _ _, _, f, state => by
+      simp only [stmtFuelBound]
+      rw [Nat.add_comm 1 f]
+      rfl
+  | .for_ _ _ _ _, hLF, _, _ => absurd hLF (by simp [LoopFree])
+  | .if_ cond body, hLF, f, state => by
+      simp only [stmtFuelBound]
+      rw [show stmtsFuelBound body + 1 + f = (stmtsFuelBound body + f) + 1 from by omega]
+      show (match evalIRExpr state cond with
+        | some c => if c ≠ 0 then
+            execIRStmts (stmtsFuelBound body + f) state body
+          else .continue state
+        | none => .revert state) =
+      (match evalIRExpr state cond with
+        | some c => if c ≠ 0 then
+            execIRStmts (stmtsFuelBound body) state body
+          else .continue state
+        | none => .revert state)
+      cases evalIRExpr state cond with
+      | none => rfl
+      | some c =>
+          by_cases hc : c ≠ 0 <;>
+            simp [hc, execIRStmts_stable body (by simpa [LoopFree] using hLF) f state]
+  | .block stmts, hLF, f, state => by
+      simp only [stmtFuelBound]
+      rw [show stmtsFuelBound stmts + 1 + f = (stmtsFuelBound stmts + f) + 1 from by omega]
+      show execIRStmts (stmtsFuelBound stmts + f) state stmts =
+        execIRStmts (stmtsFuelBound stmts) state stmts
+      exact execIRStmts_stable stmts (by simpa [LoopFree] using hLF) f state
+  | .switch e cases dflt, hLF, f, state => by
+      simp only [stmtFuelBound]
+      rw [show Nat.max (casesFuelBound cases) (dfltFuelBound dflt) + 1 + f =
+        (Nat.max (casesFuelBound cases) (dfltFuelBound dflt) + f) + 1 from by omega]
+      obtain ⟨hcases, hdflt⟩ : LoopFreeCases cases ∧ LoopFreeDflt dflt := by
+        simpa [LoopFree] using hLF
+      cases heval : evalIRExpr state e with
+      | none => simp [execIRStmt, heval]
+      | some v =>
+          cases hfind : List.find? (fun (c : Nat × List YulStmt) => c.1 == v) cases with
+          | some c =>
+              obtain ⟨k, body⟩ := c
+              have hmem := List.mem_of_find?_eq_some hfind
+              have hle : stmtsFuelBound body ≤
+                  Nat.max (casesFuelBound cases) (dfltFuelBound dflt) :=
+                Nat.le_trans (stmtsFuelBound_le_casesFuelBound cases (k, body) hmem)
+                  (Nat.le_max_left _ _)
+              have hLFb := LoopFreeCases.mem hcases hmem
+              simp only [execIRStmt, heval, hfind]
+              rw [show Nat.max (casesFuelBound cases) (dfltFuelBound dflt) + f =
+                  stmtsFuelBound body + (Nat.max (casesFuelBound cases)
+                    (dfltFuelBound dflt) - stmtsFuelBound body + f) from by omega,
+                execIRStmts_stable body hLFb _ state,
+                show Nat.max (casesFuelBound cases) (dfltFuelBound dflt) =
+                  stmtsFuelBound body + (Nat.max (casesFuelBound cases)
+                    (dfltFuelBound dflt) - stmtsFuelBound body) from by omega,
+                execIRStmts_stable body hLFb _ state]
+          | none =>
+              cases hdd : dflt with
+              | none => simp [execIRStmt, heval, hfind]
+              | some body =>
+                  have hLFb : LoopFreeList body := by
+                    rw [hdd] at hdflt
+                    simpa [LoopFreeDflt] using hdflt
+                  have hle : stmtsFuelBound body ≤
+                      Nat.max (casesFuelBound cases) (dfltFuelBound (some body)) := by
+                    have hh : stmtsFuelBound body = dfltFuelBound (some body) := rfl
+                    rw [hh]
+                    exact Nat.le_max_right _ _
+                  simp only [execIRStmt, heval, hfind]
+                  rw [show Nat.max (casesFuelBound cases) (dfltFuelBound (some body)) + f =
+                      stmtsFuelBound body + (Nat.max (casesFuelBound cases)
+                        (dfltFuelBound (some body)) - stmtsFuelBound body + f) from by omega,
+                    execIRStmts_stable body hLFb _ state,
+                    show Nat.max (casesFuelBound cases) (dfltFuelBound (some body)) =
+                      stmtsFuelBound body + (Nat.max (casesFuelBound cases)
+                        (dfltFuelBound (some body)) - stmtsFuelBound body) from by omega,
+                    execIRStmts_stable body hLFb _ state]
+
+termination_by stmt _ _ _ => sizeOf stmt
+decreasing_by
+  all_goals simp_wf
+  all_goals try omega
+  all_goals try (have h1 := List.sizeOf_lt_of_mem hmem; simp at h1 ⊢; omega)
+  all_goals (try simp [*, Option.some.sizeOf_spec, Prod.mk.sizeOf_spec]) <;> omega
+
+/-- Fuel stability for statement lists. -/
+theorem execIRStmts_stable : ∀ (xs : List YulStmt), LoopFreeList xs →
+    ∀ (f : Nat) (state : IRState),
+      execIRStmts (stmtsFuelBound xs + f) state xs =
+        execIRStmts (stmtsFuelBound xs) state xs
+  | [], _, f, state => by
+      simp only [stmtsFuelBound]
+      rw [Nat.add_comm 1 f]
+      rfl
+  | x :: rest, hLF, f, state => by
+      simp only [stmtsFuelBound]
+      rw [show Nat.max (stmtFuelBound x) (stmtsFuelBound rest) + 1 + f =
+        (Nat.max (stmtFuelBound x) (stmtsFuelBound rest) + f) + 1 from by omega]
+      obtain ⟨hx, hrest⟩ : LoopFree x ∧ LoopFreeList rest := by
+        simpa [LoopFreeList] using hLF
+      have hax : stmtFuelBound x ≤ Nat.max (stmtFuelBound x) (stmtsFuelBound rest) :=
+        Nat.le_max_left _ _
+      have hbx : stmtsFuelBound rest ≤ Nat.max (stmtFuelBound x) (stmtsFuelBound rest) :=
+        Nat.le_max_right _ _
+      show (match execIRStmt (Nat.max (stmtFuelBound x) (stmtsFuelBound rest) + f)
+          state x with
+        | .continue s₁ => execIRStmts
+            (Nat.max (stmtFuelBound x) (stmtsFuelBound rest) + f) s₁ rest
+        | .return v s => .return v s
+        | .stop s => .stop s
+        | .revert s => .revert s) =
+      (match execIRStmt (Nat.max (stmtFuelBound x) (stmtsFuelBound rest))
+          state x with
+        | .continue s₁ => execIRStmts
+            (Nat.max (stmtFuelBound x) (stmtsFuelBound rest)) s₁ rest
+        | .return v s => .return v s
+        | .stop s => .stop s
+        | .revert s => .revert s)
+      have hhead1 : execIRStmt (Nat.max (stmtFuelBound x) (stmtsFuelBound rest) + f)
+          state x = execIRStmt (stmtFuelBound x) state x := by
+        rw [show Nat.max (stmtFuelBound x) (stmtsFuelBound rest) + f =
+          stmtFuelBound x + (Nat.max (stmtFuelBound x) (stmtsFuelBound rest) -
+            stmtFuelBound x + f) from by omega]
+        exact execIRStmt_stable x hx _ state
+      have hhead2 : execIRStmt (Nat.max (stmtFuelBound x) (stmtsFuelBound rest))
+          state x = execIRStmt (stmtFuelBound x) state x := by
+        rw [show Nat.max (stmtFuelBound x) (stmtsFuelBound rest) =
+          stmtFuelBound x + (Nat.max (stmtFuelBound x) (stmtsFuelBound rest) -
+            stmtFuelBound x) from by omega]
+        exact execIRStmt_stable x hx _ state
+      have htail : ∀ s₁ : IRState,
+          execIRStmts (Nat.max (stmtFuelBound x) (stmtsFuelBound rest) + f) s₁ rest =
+            execIRStmts (Nat.max (stmtFuelBound x) (stmtsFuelBound rest)) s₁ rest := by
+        intro s₁
+        rw [show Nat.max (stmtFuelBound x) (stmtsFuelBound rest) + f =
+          stmtsFuelBound rest + (Nat.max (stmtFuelBound x) (stmtsFuelBound rest) -
+            stmtsFuelBound rest + f) from by omega,
+          execIRStmts_stable rest hrest _ s₁,
+          show Nat.max (stmtFuelBound x) (stmtsFuelBound rest) =
+            stmtsFuelBound rest + (Nat.max (stmtFuelBound x) (stmtsFuelBound rest) -
+              stmtsFuelBound rest) from by omega,
+          execIRStmts_stable rest hrest _ s₁]
+      rw [hhead1, hhead2]
+      cases execIRStmt (stmtFuelBound x) state x with
+      | «continue» s₁ => exact htail s₁
+      | «return» v s => rfl
+      | stop s => rfl
+      | revert s => rfl
+termination_by xs _ _ _ => sizeOf xs
+decreasing_by
+  all_goals simp_wf
+  all_goals omega
+
+end
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2355,6 +2355,10 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.stmtFuelBound_pos
   Compiler.Proofs.IRGeneration.stmtsFuelBound_pos
   Compiler.Proofs.IRGeneration.stmtFuelBound_le_stmtsFuelBound
+  Compiler.Proofs.IRGeneration.stmtsFuelBound_le_casesFuelBound
+  Compiler.Proofs.IRGeneration.LoopFreeCases.mem
+  Compiler.Proofs.IRGeneration.execIRStmt_stable
+  Compiler.Proofs.IRGeneration.execIRStmts_stable
 
   -- Compiler/Proofs/IRGeneration/Function.lean
   -- Compiler.Proofs.IRGeneration.Function.yulStmtList_length_le_sizeOf  -- private
@@ -6653,4 +6657,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6214 theorems/lemmas (4346 public, 1868 private, 0 sorry'd)
+-- Total: 6218 theorems/lemmas (4350 public, 1868 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -36,6 +36,11 @@ HARD_LIMIT = 50
 # before the check was introduced. New proofs must not be added here without a
 # justification comment in the PR explaining why decomposition is not feasible.
 ALLOWLIST: set[str] = {
+    # #2276 fuel stability: mutual well-founded induction mirroring the
+    # interpreter's statement/list recursion; extracting per-case lemmas would
+    # break the shared sizeOf termination measure across the mutual block.
+    "execIRStmt_stable",
+    "execIRStmts_stable",
     # #2083 expression-surface closure: both proofs are mechanical constructor/list
     # traversals kept whole so the denotation and scanner cases remain auditable
     # against the corresponding exhaustive expression definitions.


### PR DESCRIPTION
The capstone of #2276 option (c): `execIRStmt_stable`/`execIRStmts_stable` prove by mutual well-founded induction that loop-free statements execute identically at their computable `stmtFuelBound`/`stmtsFuelBound` and at any additional fuel — covering `if`/`block`/`switch` (found case and default, via find?-membership domination) and all atomics. The fuel-exhaustion-conflated-with-revert obstacle is thereby resolved for the loop-free fragment: simulation proofs (nested splice, Tier 4 transformed bodies) can equate executions at shifted fuel indices. `for` loops remain outside the fragment as designed.

Both theorems are allowlisted for proof length: per-case extraction would break the shared termination measure of the mutual block.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only changes in IR generation fuel bounds; no runtime or auth paths, with explicit allowlisting for long Lean proofs.
> 
> **Overview**
> Adds **fuel stability** for the loop-free IR fragment: `execIRStmt_stable` and `execIRStmts_stable` show that execution at `stmtFuelBound`/`stmtsFuelBound` matches execution with any extra fuel, so simulation proofs can relate shifted fuel indices without conflating fuel exhaustion with revert.
> 
> Supporting lemmas tie **switch** branches to bounds (`stmtsFuelBound_le_casesFuelBound`, `LoopFreeCases.mem`); the main proof is a **mutual** well-founded induction over statements and lists covering atomics, `if`, `block`, and `switch` (matched case via `find?` membership, default branch). `for` stays outside `LoopFree`.
> 
> `PrintAxioms.lean` registers the new public theorems; `check_proof_length.py` allowlists the two large stability proofs because splitting would break the shared termination measure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45715bd416b22302ee32b146780aa9f3bcae3345. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->