### PR TITLE
proof(ir): fuel-stability consumer API (#2276)

### DIFF
--- a/Compiler/Proofs/IRGeneration/FuelBound.lean
+++ b/Compiler/Proofs/IRGeneration/FuelBound.lean
@@ -299,4 +299,24 @@ decreasing_by
 
 end
 
+/-- Consumer API: any two fuels at or above the bound execute identically. -/
+theorem execIRStmts_stable_of_le (xs : List YulStmt) (hLF : LoopFreeList xs)
+    (F G : Nat) (state : IRState)
+    (hF : stmtsFuelBound xs ≤ F) (hG : stmtsFuelBound xs ≤ G) :
+    execIRStmts F state xs = execIRStmts G state xs := by
+  rw [show F = stmtsFuelBound xs + (F - stmtsFuelBound xs) from by omega,
+    execIRStmts_stable xs hLF _ state,
+    show G = stmtsFuelBound xs + (G - stmtsFuelBound xs) from by omega,
+    execIRStmts_stable xs hLF _ state]
+
+/-- Statement-level consumer API. -/
+theorem execIRStmt_stable_of_le (stmt : YulStmt) (hLF : LoopFree stmt)
+    (F G : Nat) (state : IRState)
+    (hF : stmtFuelBound stmt ≤ F) (hG : stmtFuelBound stmt ≤ G) :
+    execIRStmt F state stmt = execIRStmt G state stmt := by
+  rw [show F = stmtFuelBound stmt + (F - stmtFuelBound stmt) from by omega,
+    execIRStmt_stable stmt hLF _ state,
+    show G = stmtFuelBound stmt + (G - stmtFuelBound stmt) from by omega,
+    execIRStmt_stable stmt hLF _ state]
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2359,6 +2359,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.LoopFreeCases.mem
   Compiler.Proofs.IRGeneration.execIRStmt_stable
   Compiler.Proofs.IRGeneration.execIRStmts_stable
+  Compiler.Proofs.IRGeneration.execIRStmts_stable_of_le
+  Compiler.Proofs.IRGeneration.execIRStmt_stable_of_le
 
   -- Compiler/Proofs/IRGeneration/Function.lean
   -- Compiler.Proofs.IRGeneration.Function.yulStmtList_length_le_sizeOf  -- private
@@ -6657,4 +6659,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6218 theorems/lemmas (4350 public, 1868 private, 0 sorry'd)
+-- Total: 6220 theorems/lemmas (4352 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Packages #2286 for consumers: `execIRStmt_stable_of_le`/`execIRStmts_stable_of_le` — any two fuels at or above the bound execute identically. This is the form the nested-splice simulation and Tier-4 proofs will consume.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Lean proof wrappers with no runtime or interpreter changes; only extends the verified API surface for upcoming simulation proofs.
> 
> **Overview**
> Adds **consumer-facing** fuel-stability lemmas on top of the existing `execIRStmt_stable` / `execIRStmts_stable` results: for loop-free Yul, if both fuels are at least the structural bound, **`execIRStmt` / `execIRStmts` agree at `F` and `G`**.
> 
> The proofs rewrite each fuel as `bound + (fuel - bound)` and apply the existing stability theorems twice. **`PrintAxioms.lean`** lists both new theorems so the public proof inventory stays in sync (+2 public lemmas).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b992ab3d3d365f5353bd9b1cfdb275f726262b99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->