### PR TITLE
proof(ir): splice-simulation relation and fragment (lane 2.2)

### DIFF
--- a/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
+++ b/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
@@ -1,0 +1,75 @@
+import Compiler.Proofs.IRGeneration.FuelBound
+import Compiler.Proofs.IRGeneration.NonReentrantGuardIR
+
+/-!
+# Splice simulation (fragment slice 1: atomics, `if`, `block`)
+
+Relates the execution of a lock-release-spliced body to the original body:
+results agree exactly, except that frame halts (`return`/`stop`) carry the
+lock-released state — which is the intended semantics of
+`applyLockReleaseOnExits`.  Built on the fuel-stability API (#2286/#2287).
+
+This slice covers the fragment without `switch` and `for`; `switch` follows
+the same shape and is the next extension.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+open Compiler.CompilationModel
+
+/-- Clear the lock slot. -/
+def releaseState (slot : Nat) (s : IRState) : IRState :=
+  { s with transientStorage := fun o => if o = slot then 0 else s.transientStorage o }
+
+/-- The simulation relation: frame halts carry the released state, everything
+else is unchanged. -/
+def releasedResult (slot : Nat) : IRExecResult → IRExecResult
+  | .return v s => .return v (releaseState slot s)
+  | .stop s => .stop (releaseState slot s)
+  | .continue s => .continue s
+  | .revert s => .revert s
+
+mutual
+
+/-- Fragment for this slice: loop- and switch-free. -/
+def SpliceSim : YulStmt → Prop
+  | .if_ _ body => SpliceSimList body
+  | .block stmts => SpliceSimList stmts
+  | .for_ _ _ _ _ => False
+  | .switch _ _ _ => False
+  | _ => True
+
+def SpliceSimList : List YulStmt → Prop
+  | [] => True
+  | s :: rest => SpliceSim s ∧ SpliceSimList rest
+
+end
+
+mutual
+
+theorem SpliceSim.loopFree : ∀ (s : YulStmt), SpliceSim s → LoopFree s
+  | .if_ _ body, h => by
+      simpa [LoopFree] using SpliceSimList.loopFree body (by simpa [SpliceSim] using h)
+  | .block stmts, h => by
+      simpa [LoopFree] using SpliceSimList.loopFree stmts (by simpa [SpliceSim] using h)
+  | .for_ _ _ _ _, h => by simp [SpliceSim] at h
+  | .switch _ _ _, h => by simp [SpliceSim] at h
+  | .comment _, _ => by simp [LoopFree]
+  | .let_ _ _, _ => by simp [LoopFree]
+  | .letMany _ _, _ => by simp [LoopFree]
+  | .assign _ _, _ => by simp [LoopFree]
+  | .leave, _ => by simp [LoopFree]
+  | .exprStmt _, _ => by simp [LoopFree]
+  | .funcDef _ _ _ _, _ => by simp [LoopFree]
+
+theorem SpliceSimList.loopFree : ∀ (xs : List YulStmt), SpliceSimList xs →
+    LoopFreeList xs
+  | [], _ => by simp [LoopFreeList]
+  | x :: rest, h => by
+      obtain ⟨hx, hrest⟩ : SpliceSim x ∧ SpliceSimList rest := by
+        simpa [SpliceSimList] using h
+      exact ⟨SpliceSim.loopFree x hx, SpliceSimList.loopFree rest hrest⟩
+
+end
+
+end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -85,6 +85,7 @@ import Compiler.Proofs.IRGeneration.NonReentrantGuardIR
 import Compiler.Proofs.IRGeneration.PanicPayloadIR
 import Compiler.Proofs.IRGeneration.ParamLoading
 import Compiler.Proofs.IRGeneration.SourceSemantics
+import Compiler.Proofs.IRGeneration.SpliceSimulation
 import Compiler.Proofs.IRGeneration.SupportedFragment
 import Compiler.Proofs.IRGeneration.SupportedSpec
 import Compiler.Proofs.KeccakBound
@@ -4153,6 +4154,10 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.supportedSourceContractSemanticsWithScalarEvents_eq_sourceContractSemantics
   Compiler.Proofs.IRGeneration.supportedSourceContractSemanticsExceptMappingWrites_eq_sourceContractSemantics
 
+  -- Compiler/Proofs/IRGeneration/SpliceSimulation.lean
+  Compiler.Proofs.IRGeneration.SpliceSim.loopFree
+  Compiler.Proofs.IRGeneration.SpliceSimList.loopFree
+
   -- Compiler/Proofs/IRGeneration/SupportedFragment.lean
   Compiler.Proofs.IRGeneration.stmtNextScope_requireError_preserves_scope
 
@@ -6659,4 +6664,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6220 theorems/lemmas (4352 public, 1868 private, 0 sorry'd)
+-- Total: 6222 theorems/lemmas (4354 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Foundation for the general nested-splice simulation, consuming #2286/#2287: `releasedResult` (frame halts carry the lock-released state — the intended semantics of `applyLockReleaseOnExits`), the `SpliceSim` fragment (loop- and switch-free), and its bridge to `LoopFree` so the fuel-stability API applies. The simulation theorem itself follows; its exit statements will be restricted to the compiler-emitted forms (`stop()`, `return(lit, lit)`) since a hypothetical `return(tload(lock), …)` would genuinely observe the release.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions with no runtime or compiler behavior changes; only new Lean definitions/theorems and axiom inventory updates.
> 
> **Overview**
> Adds **`Compiler/Proofs/IRGeneration/SpliceSimulation.lean`** as the first slice of a formal splice-simulation story for lock-release on exits: **`releaseState`** clears the transient lock slot, **`releasedResult`** maps `return`/`stop` outcomes to that released state (matching **`applyLockReleaseOnExits`** intent), and **`SpliceSim`** restricts Yul to atomics/`if`/`block` (no `for`/`switch` yet).
> 
> Proves **`SpliceSim.loopFree`** and **`SpliceSimList.loopFree`** so this fragment plugs into the existing fuel-stability API from **`FuelBound`**. The main simulation theorem is explicitly left for a follow-up; **`PrintAxioms.lean`** imports the module and lists the two new public lemmas (theorem count +2).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6658576dc4c652513ce462a7f9fcd2b43af150fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->