### PR TITLE
proof(ir): non-exit exprStmts never halt (splice-simulation key lemma)

### DIFF
--- a/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
+++ b/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
@@ -72,4 +72,21 @@ theorem SpliceSimList.loopFree : ∀ (xs : List YulStmt), SpliceSimList xs →
 
 end
 
+/-- A non-exit expression statement never halts the frame: every interpreter
+branch other than the `return`/`stop` builtins produces `continue` or
+`revert`. -/
+theorem execIRStmt_exprStmt_no_halt (e : YulExpr) (fuel : Nat) (state : IRState)
+    (hret : ∀ args, e ≠ .call "return" args)
+    (hstop : ∀ args, e ≠ .call "stop" args) :
+    (∀ v s, execIRStmt (fuel + 1) state (.exprStmt e) ≠ .return v s) ∧
+      (∀ s, execIRStmt (fuel + 1) state (.exprStmt e) ≠ .stop s) := by
+  refine ⟨fun v s hcontra => ?_, fun s hcontra => ?_⟩ <;>
+  · rw [execIRStmt.eq_def] at hcontra
+    repeat' split at hcontra
+    all_goals first
+      | exact absurd rfl (hret _)
+      | exact absurd rfl (hstop _)
+      | simp_all
+      | cases hcontra
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4157,6 +4157,7 @@ end Verity.AxiomAudit
   -- Compiler/Proofs/IRGeneration/SpliceSimulation.lean
   Compiler.Proofs.IRGeneration.SpliceSim.loopFree
   Compiler.Proofs.IRGeneration.SpliceSimList.loopFree
+  Compiler.Proofs.IRGeneration.execIRStmt_exprStmt_no_halt
 
   -- Compiler/Proofs/IRGeneration/SupportedFragment.lean
   Compiler.Proofs.IRGeneration.stmtNextScope_requireError_preserves_scope
@@ -6664,4 +6665,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6222 theorems/lemmas (4354 public, 1868 private, 0 sorry'd)
+-- Total: 6223 theorems/lemmas (4355 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Follow-up to #2288: `execIRStmt_exprStmt_no_halt` proves by exhaustive match-splitting over the interpreter (`eq_def` + `repeat' split`) that a non-`return`/`stop` expression statement can only `continue` or `revert` — the case fact the splice simulation needs to relate spliced and original heads for atomic statements.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only addition to the IR generation verification layer; no interpreter or compiler behavior changes.
> 
> **Overview**
> Adds **`execIRStmt_exprStmt_no_halt`** in `SpliceSimulation.lean`: for any expression statement that is not a `return` or `stop` call, `execIRStmt` cannot produce `.return` or `.stop` (only `continue` or `revert`). The proof unfolds `execIRStmt.eq_def` and closes every branch with `split` plus the non-exit hypotheses.
> 
> Registers the new theorem in **`PrintAxioms.lean`** and bumps the public theorem count by one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c998759cb6b74c6507629b1b85d73bfb30d5e934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->