### PR TITLE
proof(ir): atomic splice-simulation helpers (lane 2.2)

### DIFF
--- a/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
+++ b/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
@@ -37,6 +37,8 @@ def SpliceSim : YulStmt → Prop
   | .block stmts => SpliceSimList stmts
   | .for_ _ _ _ _ => False
   | .switch _ _ _ => False
+  | .exprStmt (.call "return" args) => ∃ a b, args = [YulExpr.lit a, YulExpr.lit b]
+  | .exprStmt (.call "stop" args) => args = []
   | _ => True
 
 def SpliceSimList : List YulStmt → Prop
@@ -88,5 +90,68 @@ theorem execIRStmt_exprStmt_no_halt (e : YulExpr) (fuel : Nat) (state : IRState)
       | exact absurd rfl (hstop _)
       | simp_all
       | cases hcontra
+
+/-- Atomic non-exit statements: everything the splice leaves untouched and
+whose execution cannot halt the frame. -/
+def AtomicNonExit : YulStmt → Prop
+  | .comment _ => True
+  | .let_ _ _ => True
+  | .letMany _ _ => True
+  | .assign _ _ => True
+  | .leave => True
+  | .funcDef _ _ _ _ => True
+  | .exprStmt (.call "return" _) => False
+  | .exprStmt (.call "stop" _) => False
+  | .exprStmt _ => True
+  | _ => False
+
+/-- The splice leaves atomic non-exit statements untouched. -/
+theorem spliceLockRelease_atomic (release : YulStmt) :
+    ∀ (x : YulStmt), AtomicNonExit x →
+      spliceLockRelease release x = [x]
+  | .comment _, _ => rfl
+  | .let_ _ _, _ => rfl
+  | .letMany _ _, _ => rfl
+  | .assign _ _, _ => rfl
+  | .leave, _ => rfl
+  | .funcDef _ _ _ _, _ => rfl
+  | .exprStmt (.lit _), _ => rfl
+  | .exprStmt (.hex _), _ => rfl
+  | .exprStmt (.ident _), _ => rfl
+  | .exprStmt (.str _), _ => rfl
+  | .exprStmt (.call f args), h => by
+      have hret : f ≠ "return" := by
+        intro hf; subst hf; simp [AtomicNonExit] at h
+      have hstop : f ≠ "stop" := by
+        intro hf; subst hf; simp [AtomicNonExit] at h
+      simp [spliceLockRelease, hret, hstop]
+  | .if_ _ _, h => by simp [AtomicNonExit] at h
+  | .for_ _ _ _ _, h => by simp [AtomicNonExit] at h
+  | .switch _ _ _, h => by simp [AtomicNonExit] at h
+  | .block _, h => by simp [AtomicNonExit] at h
+
+/-- Atomic non-exit statements never halt the frame. -/
+theorem execIRStmt_atomic_no_halt (x : YulStmt) (hx : AtomicNonExit x)
+    (fuel : Nat) (state : IRState) :
+    (∀ v s, execIRStmt (fuel + 1) state x ≠ .return v s) ∧
+      (∀ s, execIRStmt (fuel + 1) state x ≠ .stop s) := by
+  cases x with
+  | exprStmt e =>
+      refine execIRStmt_exprStmt_no_halt e fuel state ?_ ?_ <;>
+        (intro args hcontra; subst hcontra; simp [AtomicNonExit] at hx)
+  | comment _ => exact ⟨(fun v s h => nomatch h), (fun s h => nomatch h)⟩
+  | «leave» => exact ⟨(fun v s h => nomatch h), (fun s h => nomatch h)⟩
+  | funcDef _ _ _ _ => exact ⟨(fun v s h => nomatch h), (fun s h => nomatch h)⟩
+  | letMany _ _ => exact ⟨(fun v s h => nomatch h), (fun s h => nomatch h)⟩
+  | let_ n v =>
+      refine ⟨fun v' s' hcontra => ?_, fun s' hcontra => ?_⟩ <;>
+        (cases heval : evalIRExpr state v <;> simp [execIRStmt, heval] at hcontra)
+  | assign n v =>
+      refine ⟨fun v' s' hcontra => ?_, fun s' hcontra => ?_⟩ <;>
+        (cases heval : evalIRExpr state v <;> simp [execIRStmt, heval] at hcontra)
+  | if_ _ _ => simp [AtomicNonExit] at hx
+  | for_ _ _ _ _ => simp [AtomicNonExit] at hx
+  | «switch» _ _ _ => simp [AtomicNonExit] at hx
+  | block _ => simp [AtomicNonExit] at hx
 
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4158,6 +4158,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.SpliceSim.loopFree
   Compiler.Proofs.IRGeneration.SpliceSimList.loopFree
   Compiler.Proofs.IRGeneration.execIRStmt_exprStmt_no_halt
+  Compiler.Proofs.IRGeneration.spliceLockRelease_atomic
+  Compiler.Proofs.IRGeneration.execIRStmt_atomic_no_halt
 
   -- Compiler/Proofs/IRGeneration/SupportedFragment.lean
   Compiler.Proofs.IRGeneration.stmtNextScope_requireError_preserves_scope
@@ -6665,4 +6667,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6223 theorems/lemmas (4355 public, 1868 private, 0 sorry'd)
+-- Total: 6225 theorems/lemmas (4357 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Builds on #2288/#2289: the `SpliceSim` fragment now pins exits to the compiler-emitted forms, `AtomicNonExit` classifies the statements the splice leaves untouched, `spliceLockRelease_atomic` proves it does, and `execIRStmt_atomic_no_halt` proves they never halt the frame — every case fact the main simulation induction needs for its atomic heads.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in IR generation splice simulation; no runtime or compiler behavior changes.
> 
> **Overview**
> **Tightens the `SpliceSim` fragment** so frame exits must match the compiler’s lowered shapes: `return` with two literal args and `stop` with no args.
> 
> **Adds atomic-case lemmas** for the main splice simulation induction: `AtomicNonExit` names statements `spliceLockRelease` leaves as a singleton `[x]`; `spliceLockRelease_atomic` proves that, and `execIRStmt_atomic_no_halt` shows those statements never produce frame `return`/`stop`. `execIRStmt_exprStmt_no_halt` is reused for expression-statement cases.
> 
> **`PrintAxioms.lean`** lists the two new public theorems (theorem count 6223 → 6225).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15536034635916e472effc0108a919bed97f9ba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->