### PR TITLE
proof(ir): applyLockReleaseOnExits fall-through composition (lane 2.2)

### DIFF
--- a/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
+++ b/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
@@ -505,4 +505,106 @@ theorem execIRStmts_spliced (slot : Nat)
                     (by simp [AtomicNonExit, hret, hstop]) (by simp [LoopFree])
                     IHrest F G state hF hG
 
+/-- A halted prefix short-circuits an appended suffix. -/
+theorem execIRStmts_append_halt (ys : List YulStmt) :
+    ∀ (xs : List YulStmt) (fuel : Nat) (state : IRState) (r : IRExecResult),
+      execIRStmts fuel state xs = r →
+      (∀ s, r ≠ .continue s) →
+      execIRStmts fuel state (xs ++ ys) = r
+  | [], fuel, state, r, hr, hnc => by
+      have hcs : r = .continue state := by
+        cases fuel <;> simpa [execIRStmts] using hr.symm
+      exact absurd hcs (hnc state)
+  | x :: xs', fuel, state, r, hr, hnc => by
+      cases fuel with
+      | zero =>
+          simp [execIRStmts] at hr ⊢
+          exact hr
+      | succ f =>
+          rw [show (x :: xs') ++ ys = x :: (xs' ++ ys) from rfl]
+          rw [show execIRStmts (f + 1) state (x :: (xs' ++ ys)) =
+            (match execIRStmt f state x with
+              | .continue s₁ => execIRStmts f s₁ (xs' ++ ys)
+              | .return v s => .return v s
+              | .stop s => .stop s
+              | .revert s => .revert s) from rfl]
+          rw [show execIRStmts (f + 1) state (x :: xs') =
+            (match execIRStmt f state x with
+              | .continue s₁ => execIRStmts f s₁ xs'
+              | .return v s => .return v s
+              | .stop s => .stop s
+              | .revert s => .revert s) from rfl] at hr
+          cases hstep : execIRStmt f state x with
+          | «continue» s₁ =>
+              rw [hstep] at hr
+              exact execIRStmts_append_halt ys xs' f s₁ r hr hnc
+          | «return» v s => rw [hstep] at hr; rw [← hr]
+          | stop s => rw [hstep] at hr; rw [← hr]
+          | revert s => rw [hstep] at hr; rw [← hr]
+
+/-- Wrapper composition, fall-through analysis branch: when the halt analysis
+reports the body can fall through, `applyLockReleaseOnExits` appends a
+trailing release, and the wrapped execution equals the original with every
+successful outcome carrying the released state — halts released by the
+splice, the fall-through by the trailing statement, reverts rolling back the
+acquire untouched. -/
+theorem execIRStmts_applyLockReleaseOnExits_fallthrough (slot : Nat)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (xs : List YulStmt) (hSS : SpliceSimList xs)
+    (hH : yulFrameHaltsList xs = false)
+    (F G : Nat) (state : IRState)
+    (hF : stmtsFuelBound (spliceLockReleaseList (lockReleaseStmt slot) xs) +
+      (spliceLockReleaseList (lockReleaseStmt slot) xs).length + 2 ≤ F)
+    (hG : stmtsFuelBound xs ≤ G) :
+    execIRStmts F state (applyLockReleaseOnExits (lockReleaseStmt slot) xs) =
+      (match execIRStmts G state xs with
+        | .continue s => .continue (releaseState slot s)
+        | .return v s => .return v (releaseState slot s)
+        | .stop s => .stop (releaseState slot s)
+        | .revert s => .revert s) := by
+  have hboundlist : 1 ≤ stmtsFuelBound (spliceLockReleaseList (lockReleaseStmt slot) xs) :=
+    stmtsFuelBound_pos _
+  unfold applyLockReleaseOnExits
+  rw [hH]
+  simp only [Bool.false_eq_true, if_false]
+  have hsim := execIRStmts_spliced slot hslot xs hSS F G state (by omega) hG
+  cases hres : execIRStmts G state xs with
+  | «continue» s =>
+      have hpre : execIRStmts F state
+          (spliceLockReleaseList (lockReleaseStmt slot) xs) = .continue s := by
+        rw [hsim, hres]; rfl
+      rw [execIRStmts_append_continue [lockReleaseStmt slot] _ F state s hpre]
+      obtain ⟨k, hk⟩ : ∃ k, F -
+          (spliceLockReleaseList (lockReleaseStmt slot) xs).length = k + 2 :=
+        ⟨F - (spliceLockReleaseList (lockReleaseStmt slot) xs).length - 2, by omega⟩
+      rw [hk]
+      rw [show execIRStmts (k + 2) s [lockReleaseStmt slot] =
+        (match execIRStmt (k + 1) s (lockReleaseStmt slot) with
+          | .continue s₁ => execIRStmts (k + 1) s₁ []
+          | .return v s' => .return v s'
+          | .stop s' => .stop s'
+          | .revert s' => .revert s') from rfl,
+        execIRStmt_lockRelease k s slot hslot]
+      rfl
+  | «return» v s =>
+      have hpre : execIRStmts F state
+          (spliceLockReleaseList (lockReleaseStmt slot) xs) =
+          .return v (releaseState slot s) := by
+        rw [hsim, hres]; rfl
+      rw [execIRStmts_append_halt [lockReleaseStmt slot] _ F state _ hpre
+        (by intro s' h; cases h)]
+  | stop s =>
+      have hpre : execIRStmts F state
+          (spliceLockReleaseList (lockReleaseStmt slot) xs) =
+          .stop (releaseState slot s) := by
+        rw [hsim, hres]; rfl
+      rw [execIRStmts_append_halt [lockReleaseStmt slot] _ F state _ hpre
+        (by intro s' h; cases h)]
+  | revert s =>
+      have hpre : execIRStmts F state
+          (spliceLockReleaseList (lockReleaseStmt slot) xs) = .revert s := by
+        rw [hsim, hres]; rfl
+      rw [execIRStmts_append_halt [lockReleaseStmt slot] _ F state _ hpre
+        (by intro s' h; cases h)]
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4166,6 +4166,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.spliced_cons_if
   Compiler.Proofs.IRGeneration.spliced_cons_block
   Compiler.Proofs.IRGeneration.execIRStmts_spliced
+  Compiler.Proofs.IRGeneration.execIRStmts_append_halt
+  Compiler.Proofs.IRGeneration.execIRStmts_applyLockReleaseOnExits_fallthrough
 
   -- Compiler/Proofs/IRGeneration/SupportedFragment.lean
   Compiler.Proofs.IRGeneration.stmtNextScope_requireError_preserves_scope
@@ -6673,4 +6675,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6231 theorems/lemmas (4363 public, 1868 private, 0 sorry'd)
+-- Total: 6233 theorems/lemmas (4365 public, 1868 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -48,6 +48,7 @@ ALLOWLIST: set[str] = {
     "spliced_cons_block",
     "spliced_cons_if",
     "spliced_cons_atomic",
+    "execIRStmts_applyLockReleaseOnExits_fallthrough",
     # #2083 expression-surface closure: both proofs are mechanical constructor/list
     # traversals kept whole so the denotation and scanner cases remain auditable
     # against the corresponding exhaustive expression definitions.


### PR DESCRIPTION
Composes #2291 into the wrapper: `execIRStmts_append_halt` + `execIRStmts_applyLockReleaseOnExits_fallthrough` — over the `SpliceSim` fragment with `yulFrameHaltsList = false`, the wrapped body equals the original with every successful outcome carrying the released state (splice-released halts, trailing-released fall-through, reverts untouched). The halting-analysis-true branch needs a halt-soundness lemma (the analysis marks `invalid`/`selfdestruct` as halting but the interpreter continues them — a modeling gap to resolve there) and is the next step, followed by prologue composition and the `compile_preserves_semantics` threading.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal verification only (new Lean theorems and CI allowlist); no runtime compiler or interpreter behavior changes.
> 
> **Overview**
> Adds IR execution lemmas for the **non-halting** branch of `applyLockReleaseOnExits`: when `yulFrameHaltsList xs = false`, the wrapper is the spliced body plus a trailing `lockReleaseStmt`, and execution matches the unspliced body with **continue / return / stop** outcomes carrying `releaseState` while **revert** is unchanged.
> 
> New supporting lemma **`execIRStmts_append_halt`** shows that once a statement list finishes in a non-`continue` result, appending more statements does not change that result (used so trailing release does not run after splice-released halts).
> 
> Proof hygiene: both lemmas are registered in `PrintAxioms.lean`; **`execIRStmts_applyLockReleaseOnExits_fallthrough`** is added to the proof-length allowlist in `scripts/check_proof_length.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bc8e63f284738ca4f3d8d751f56bc6a87e6ecda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->