### PR TITLE
proof(ir): applyLockReleaseOnExits halting branch — wrapper fully characterized (lane 2.2)

### DIFF
--- a/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
+++ b/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
@@ -607,4 +607,100 @@ theorem execIRStmts_applyLockReleaseOnExits_fallthrough (slot : Nat)
       rw [execIRStmts_append_halt [lockReleaseStmt slot] _ F state _ hpre
         (by intro s' h; cases h)]
 
+/-- Frame halts whose interpreter semantics actually halt (the analysis also
+marks `invalid`/`selfdestruct`, which the interpreter continues — those are
+excluded here). -/
+inductive ModeledHalt : YulStmt → Prop
+  | stop : ModeledHalt (.exprStmt (.call "stop" []))
+  | ret (a b : Nat) :
+      ModeledHalt (.exprStmt (.call "return" [.lit a, .lit b]))
+  | rev (a b : YulExpr) :
+      ModeledHalt (.exprStmt (.call "revert" [a, b]))
+
+/-- A modeled halt never continues, at any fuel (out of fuel reverts). -/
+theorem execIRStmt_modeledHalt_no_continue (h : YulStmt) (hmh : ModeledHalt h)
+    (fuel : Nat) (state : IRState) :
+    ∀ s, execIRStmt fuel state h ≠ .continue s := by
+  intro s hcontra
+  cases hmh with
+  | stop => cases fuel <;> simp [execIRStmt] at hcontra
+  | ret a b =>
+      cases fuel with
+      | zero => simp [execIRStmt] at hcontra
+      | succ f =>
+          by_cases hb : b = 32 <;>
+            simp [execIRStmt, evalIRExpr, evalIRExprs, hb] at hcontra
+  | rev a b => cases fuel <;> simp [execIRStmt] at hcontra
+
+/-- A body ending in a modeled halt never continues. -/
+theorem execIRStmts_last_halt_no_continue (h : YulStmt) (hmh : ModeledHalt h) :
+    ∀ (ys : List YulStmt) (fuel : Nat) (state : IRState) (s : IRState),
+      execIRStmts fuel state (ys ++ [h]) ≠ .continue s := by
+  intro ys fuel state s hcontra
+  cases hpre : execIRStmts fuel state ys with
+  | «continue» s₁ =>
+      rw [execIRStmts_append_continue [h] ys fuel state s₁ hpre] at hcontra
+      cases hfl : fuel - ys.length with
+      | zero => rw [hfl] at hcontra; simp [execIRStmts] at hcontra
+      | succ k =>
+          rw [hfl] at hcontra
+          rw [show execIRStmts (k + 1) s₁ [h] =
+            (match execIRStmt k s₁ h with
+              | .continue s₂ => execIRStmts k s₂ []
+              | .return v s' => .return v s'
+              | .stop s' => .stop s'
+              | .revert s' => .revert s') from rfl] at hcontra
+          cases hstep : execIRStmt k s₁ h with
+          | «continue» s₂ =>
+              exact execIRStmt_modeledHalt_no_continue h hmh k s₁ s₂ hstep
+          | «return» v s' => rw [hstep] at hcontra; cases hcontra
+          | stop s' => rw [hstep] at hcontra; cases hcontra
+          | revert s' => rw [hstep] at hcontra; cases hcontra
+  | «return» v s₁ =>
+      rw [execIRStmts_append_halt [h] ys fuel state _ hpre
+        (by intro _ hc; cases hc)] at hcontra
+      cases hcontra
+  | stop s₁ =>
+      rw [execIRStmts_append_halt [h] ys fuel state _ hpre
+        (by intro _ hc; cases hc)] at hcontra
+      cases hcontra
+  | revert s₁ =>
+      rw [execIRStmts_append_halt [h] ys fuel state _ hpre
+        (by intro _ hc; cases hc)] at hcontra
+      cases hcontra
+
+/-- Modeled halts are halting for the frame analysis. -/
+theorem ModeledHalt.frameHalts {h : YulStmt} (hmh : ModeledHalt h) :
+    yulFrameHalts h = true := by
+  cases hmh <;> rfl
+
+/-- Wrapper composition, halting-analysis branch: a fragment body ending in a
+modeled halt gets no trailing release, and the wrapped execution equals the
+original with halts carrying the released state — the fall-through arm being
+unreachable. -/
+theorem execIRStmts_applyLockReleaseOnExits_halting (slot : Nat)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (ys : List YulStmt) (h : YulStmt)
+    (hSS : SpliceSimList (ys ++ [h])) (hmh : ModeledHalt h)
+    (F G : Nat) (state : IRState)
+    (hF : stmtsFuelBound (spliceLockReleaseList (lockReleaseStmt slot)
+      (ys ++ [h])) ≤ F)
+    (hG : stmtsFuelBound (ys ++ [h]) ≤ G) :
+    execIRStmts F state
+        (applyLockReleaseOnExits (lockReleaseStmt slot) (ys ++ [h])) =
+      (match execIRStmts G state (ys ++ [h]) with
+        | .continue s => .continue (releaseState slot s)
+        | .return v s => .return v (releaseState slot s)
+        | .stop s => .stop (releaseState slot s)
+        | .revert s => .revert s) := by
+  unfold applyLockReleaseOnExits
+  rw [yulFrameHaltsList_append_halting h hmh.frameHalts ys, if_pos rfl]
+  rw [execIRStmts_spliced slot hslot (ys ++ [h]) hSS F G state hF hG]
+  cases hres : execIRStmts G state (ys ++ [h]) with
+  | «continue» s =>
+      exact absurd hres (execIRStmts_last_halt_no_continue h hmh ys G state s)
+  | «return» v s => rfl
+  | stop s => rfl
+  | revert s => rfl
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4168,6 +4168,10 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.execIRStmts_spliced
   Compiler.Proofs.IRGeneration.execIRStmts_append_halt
   Compiler.Proofs.IRGeneration.execIRStmts_applyLockReleaseOnExits_fallthrough
+  Compiler.Proofs.IRGeneration.execIRStmt_modeledHalt_no_continue
+  Compiler.Proofs.IRGeneration.execIRStmts_last_halt_no_continue
+  Compiler.Proofs.IRGeneration.ModeledHalt.frameHalts
+  Compiler.Proofs.IRGeneration.execIRStmts_applyLockReleaseOnExits_halting
 
   -- Compiler/Proofs/IRGeneration/SupportedFragment.lean
   Compiler.Proofs.IRGeneration.stmtNextScope_requireError_preserves_scope
@@ -6675,4 +6679,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6233 theorems/lemmas (4365 public, 1868 private, 0 sorry'd)
+-- Total: 6237 theorems/lemmas (4369 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Completes the wrapper: `ModeledHalt` + no-continue soundness (`execIRStmt_modeledHalt_no_continue`, `execIRStmts_last_halt_no_continue`) and `execIRStmts_applyLockReleaseOnExits_halting` — with #2292's fall-through branch, `applyLockReleaseOnExits` is now fully characterized over the fragment: every outcome of the wrapped body equals the original with successful exits carrying the released state. The `invalid`/`selfdestruct` analysis-vs-interpreter gap is scoped out explicitly in `ModeledHalt`. Next: compose with the prologue laws (#2274/#2275) into the guarded-unit end-to-end statement.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in Lean with no runtime or compiler behavior changes; risk is limited to proof maintenance and axiom inventory accuracy.
> 
> **Overview**
> Adds the **halting-analysis branch** of `applyLockReleaseOnExits` to the IR splice simulation proofs, pairing with the existing fall-through theorem so the wrapper is characterized on the supported fragment.
> 
> Introduces **`ModeledHalt`** for interpreter-real halts (`stop`, literal `return`, `revert`) and deliberately omits `invalid`/`selfdestruct`, where static halt analysis and execution disagree. New lemmas show modeled halts never yield `.continue` (single stmt and `ys ++ [h]`), and that **`ModeledHalt.frameHalts`** aligns them with `yulFrameHalts`.
> 
> **`execIRStmts_applyLockReleaseOnExits_halting`** proves that when a `SpliceSimList` body ends in a modeled halt, the wrapper takes the splice-only path (no trailing release) and wrapped execution matches the original with successful exits carrying **`releaseState`**, ruling out the impossible `.continue` case. **`PrintAxioms.lean`** registers the four new public theorems (6237 total).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af350cbb76b381b2a73afe60fce9303b9aee0e99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->