### PR TITLE
proof(ir): end-to-end guarded unit (lane 2.2 milestone)

### DIFF
--- a/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
+++ b/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
@@ -703,4 +703,67 @@ theorem execIRStmts_applyLockReleaseOnExits_halting (slot : Nat)
   | stop s => rfl
   | revert s => rfl
 
+/-- End-to-end guarded unit, fall-through bodies: the compiled prologue plus
+release-wrapped body mirrors `NonReentrantGuard.guarded` exactly — locked
+entry reverts untouched; free entry runs the body from the acquired state
+with every successful outcome carrying the released state. -/
+theorem execIRStmts_guardedUnit_fallthrough (slot : Nat)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (xs : List YulStmt) (hSS : SpliceSimList xs)
+    (hH : yulFrameHaltsList xs = false)
+    (F G : Nat) (state : IRState)
+    (hlock01 : state.transientStorage slot = 0 ∨ state.transientStorage slot = 1)
+    (hF : stmtsFuelBound (spliceLockReleaseList (lockReleaseStmt slot) xs) +
+      (spliceLockReleaseList (lockReleaseStmt slot) xs).length + 4 ≤ F)
+    (hG : stmtsFuelBound xs ≤ G) :
+    execIRStmts F state (guardPrologueStmts slot ++
+        applyLockReleaseOnExits (lockReleaseStmt slot) xs) =
+      if state.transientStorage slot = 1 then .revert state
+      else
+        (match execIRStmts G { state with
+            transientStorage := fun o => if o = slot then 1
+              else state.transientStorage o } xs with
+          | .continue s => .continue (releaseState slot s)
+          | .return v s => .return v (releaseState slot s)
+          | .stop s => .stop (releaseState slot s)
+          | .revert s => .revert s) := by
+  rcases hlock01 with hfree | hlocked
+  · rw [if_neg (by rw [hfree]; decide)]
+    rw [guardedBody_free_runs_suffix slot _ F state hslot hfree (by omega)]
+    exact execIRStmts_applyLockReleaseOnExits_fallthrough slot hslot xs hSS hH
+      (F - 2) G _ (by omega) hG
+  · rw [if_pos hlocked]
+    exact guardedBody_locked_reverts slot _ F state hslot hlocked (by omega)
+
+/-- End-to-end guarded unit, modeled-halt endings. -/
+theorem execIRStmts_guardedUnit_halting (slot : Nat)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (ys : List YulStmt) (h : YulStmt)
+    (hSS : SpliceSimList (ys ++ [h])) (hmh : ModeledHalt h)
+    (F G : Nat) (state : IRState)
+    (hlock01 : state.transientStorage slot = 0 ∨ state.transientStorage slot = 1)
+    (hF : stmtsFuelBound (spliceLockReleaseList (lockReleaseStmt slot)
+      (ys ++ [h])) + 2 ≤ F)
+    (hG : stmtsFuelBound (ys ++ [h]) ≤ G) :
+    execIRStmts F state (guardPrologueStmts slot ++
+        applyLockReleaseOnExits (lockReleaseStmt slot) (ys ++ [h])) =
+      if state.transientStorage slot = 1 then .revert state
+      else
+        (match execIRStmts G { state with
+            transientStorage := fun o => if o = slot then 1
+              else state.transientStorage o } (ys ++ [h]) with
+          | .continue s => .continue (releaseState slot s)
+          | .return v s => .return v (releaseState slot s)
+          | .stop s => .stop (releaseState slot s)
+          | .revert s => .revert s) := by
+  have hpos := stmtsFuelBound_pos
+    (spliceLockReleaseList (lockReleaseStmt slot) (ys ++ [h]))
+  rcases hlock01 with hfree | hlocked
+  · rw [if_neg (by rw [hfree]; decide)]
+    rw [guardedBody_free_runs_suffix slot _ F state hslot hfree (by omega)]
+    exact execIRStmts_applyLockReleaseOnExits_halting slot hslot ys h hSS hmh
+      (F - 2) G _ (by omega) hG
+  · rw [if_pos hlocked]
+    exact guardedBody_locked_reverts slot _ F state hslot hlocked (by omega)
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4172,6 +4172,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.execIRStmts_last_halt_no_continue
   Compiler.Proofs.IRGeneration.ModeledHalt.frameHalts
   Compiler.Proofs.IRGeneration.execIRStmts_applyLockReleaseOnExits_halting
+  Compiler.Proofs.IRGeneration.execIRStmts_guardedUnit_fallthrough
+  Compiler.Proofs.IRGeneration.execIRStmts_guardedUnit_halting
 
   -- Compiler/Proofs/IRGeneration/SupportedFragment.lean
   Compiler.Proofs.IRGeneration.stmtNextScope_requireError_preserves_scope
@@ -6679,4 +6681,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6237 theorems/lemmas (4369 public, 1868 private, 0 sorry'd)
+-- Total: 6239 theorems/lemmas (4371 public, 1868 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -185,11 +185,18 @@ prologue/release statements under the IR interpreter: locked entry reverts
 untouched, free entry acquires the lock and changes nothing else, the spliced
 release resets it (acquire/release round-trips the transient store), and the
 Yul decision `eq(lock,1)` agrees with the model's `lock ≠ 0` on reachable
-binary lock values. Still trusted: threading these statement-level facts
-through `attachNonReentrantGuard`/`compileGuardedFunctionSpec` and the
-`compile_preserves_semantics` stack, and the supported-fragment
-`noNonReentrant` restriction (guarded functions are not yet inside the
-generically proved compiler fragment).
+binary lock values. `Compiler.Proofs.IRGeneration.SpliceSimulation` now proves the full guarded
+unit end to end for the loop/switch-free fragment with compiler-emitted
+exits: the general splice simulation (`execIRStmts_spliced`), both
+`applyLockReleaseOnExits` branches, and
+`execIRStmts_guardedUnit_fallthrough`/`_halting` — the compiled
+prologue + release-wrapped body mirrors `guarded` exactly (locked entry
+reverts untouched; free entry runs from the acquired state with successful
+outcomes released). Still trusted: `switch` bodies and loops in guarded
+functions, the `invalid`/`selfdestruct` analysis-vs-interpreter halt gap
+(scoped out via `ModeledHalt`), and the `compile_preserves_semantics`
+threading that would lift the supported-fragment `noNonReentrant`
+restriction.
 **Fork requirement**: the compile driver rejects any contract carrying a
 `nonreentrant(<lock>)` annotation when the targeted EVM fork predates
 Cancun (the `validateNonReentrantForkCompatibility` pre-check in


### PR DESCRIPTION
The lane's IR-side capstone: `execIRStmts_guardedUnit_fallthrough`/`_halting` compose the prologue laws (#2274/#2275) with both wrapper branches (#2292/#2293), proving the compiled guarded unit mirrors `Verity.Core.Model.NonReentrantGuard.guarded` exactly over the `SpliceSim` fragment: locked entry ⇒ revert untouched; free entry ⇒ body runs from the acquired state, successful outcomes released, reverts roll back the acquire.

TRUST_ASSUMPTIONS.md updated — remaining trusted: `switch`/loop guarded bodies, the `invalid`/`selfdestruct` halt-analysis gap, and the `compile_preserves_semantics` threading for the `noNonReentrant` lift.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions and documentation; no runtime compiler or auth changes.
> 
> **Overview**
> Adds **`execIRStmts_guardedUnit_fallthrough`** and **`execIRStmts_guardedUnit_halting`** in `SpliceSimulation.lean`, showing that `guardPrologueStmts` plus `applyLockReleaseOnExits` on the IR interpreter matches **`NonReentrantGuard.guarded`**: lock held ⇒ revert with unchanged state; lock free ⇒ body runs after acquire and successful exits release the lock.
> 
> Each proof is a short case split on lock 0/1, wiring **`guardedBody_locked_reverts`** / **`guardedBody_free_runs_suffix`** to the existing **`applyLockReleaseOnExits`** fall-through and modeled-halt lemmas.
> 
> **`PrintAxioms.lean`** registers the two new theorems (6237 → 6239 total). **`TRUST_ASSUMPTIONS.md`** records that the loop/switch-free guarded unit is now proved end-to-end and narrows what remains trusted (`switch`/loops, `ModeledHalt` gap, `compile_preserves_semantics` / `noNonReentrant` lift).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e38d1d965c22369d5a0f94bc6ad58707e5e4560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->