### PR TITLE
proof(ir): full guarded-function composition (lane 2.2)

### DIFF
--- a/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
+++ b/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
@@ -1,5 +1,6 @@
 import Compiler.Proofs.IRGeneration.FuelBound
 import Compiler.Proofs.IRGeneration.NonReentrantGuardIR
+import Compiler.Proofs.IRGeneration.ParamLoading
 
 /-!
 # Splice simulation (fragment slice 1: atomics, `if`, `block`)
@@ -1033,5 +1034,62 @@ theorem execIRStmts_guardedUnit_halting (slot : Nat)
       (F - 2) G _ (by omega) hG
   · rw [if_pos hlocked]
     exact guardedBody_locked_reverts slot _ F state hslot hlocked (by omega)
+
+/-- Parameter binding never touches transient storage. -/
+theorem applyBindingsToIRState_transient :
+    ∀ (bindings : List (String × Nat)) (state : IRState),
+      (ParamLoading.applyBindingsToIRState state bindings).transientStorage =
+        state.transientStorage
+  | [], _ => rfl
+  | (n, v) :: rest, state => by
+      rw [show ParamLoading.applyBindingsToIRState state ((n, v) :: rest) =
+        ParamLoading.applyBindingsToIRState (state.setVar n v) rest from rfl,
+        applyBindingsToIRState_transient rest (state.setVar n v)]
+      rfl
+
+/-- The full guarded function body — parameter loads, prologue, release-wrapped
+body — mirrors `guarded` end to end for fall-through fragment bodies: loads
+bind the arguments, a locked entry then reverts with only the bindings
+applied, and a free entry runs the body from the acquired bound state with
+successful outcomes released. -/
+theorem execIRStmts_guardedFunction_fallthrough (slot : Nat)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (params : List Param) (bindings : List (String × Nat))
+    (xs : List YulStmt) (hSS : SpliceSimList xs)
+    (hH : yulFrameHaltsList xs = false)
+    (extraFuel G : Nat) (state : IRState)
+    (hsupported : ∀ param ∈ params, SupportedExternalParamType param.ty)
+    (hfits : 4 + state.calldata.length * 32 < Compiler.Constants.evmModulus)
+    (hbind : SourceSemantics.bindSupportedParams params state.calldata =
+      some bindings)
+    (hlock01 : state.transientStorage slot = 0 ∨ state.transientStorage slot = 1)
+    (hF : stmtsFuelBound (spliceLockReleaseList (lockReleaseStmt slot) xs) +
+      (spliceLockReleaseList (lockReleaseStmt slot) xs).length + 4 ≤
+      (guardPrologueStmts slot ++
+        applyLockReleaseOnExits (lockReleaseStmt slot) xs).length + extraFuel + 1)
+    (hG : stmtsFuelBound xs ≤ G) :
+    execIRStmts ((genParamLoads params).length +
+        (guardPrologueStmts slot ++
+          applyLockReleaseOnExits (lockReleaseStmt slot) xs).length +
+        extraFuel + 1) state
+      (genParamLoads params ++
+        (guardPrologueStmts slot ++
+          applyLockReleaseOnExits (lockReleaseStmt slot) xs)) =
+      if state.transientStorage slot = 1 then
+        .revert (ParamLoading.applyBindingsToIRState state bindings)
+      else
+        (match execIRStmts G { ParamLoading.applyBindingsToIRState state bindings with
+            transientStorage := fun o => if o = slot then 1
+              else state.transientStorage o } xs with
+          | .continue s => .continue (releaseState slot s)
+          | .return v s => .return v (releaseState slot s)
+          | .stop s => .stop (releaseState slot s)
+          | .revert s => .revert s) := by
+  rw [ParamLoading.exec_genParamLoads_supported_then_extraFuel state params bindings
+    _ extraFuel hsupported hfits hbind]
+  have htrans := applyBindingsToIRState_transient bindings state
+  rw [execIRStmts_guardedUnit_fallthrough slot hslot xs hSS hH _ G
+    (ParamLoading.applyBindingsToIRState state bindings)
+    (by rw [htrans]; exact hlock01) hF hG, htrans]
 
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4182,6 +4182,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.execIRStmts_applyLockReleaseOnExits_halting
   Compiler.Proofs.IRGeneration.execIRStmts_guardedUnit_fallthrough
   Compiler.Proofs.IRGeneration.execIRStmts_guardedUnit_halting
+  Compiler.Proofs.IRGeneration.applyBindingsToIRState_transient
+  Compiler.Proofs.IRGeneration.execIRStmts_guardedFunction_fallthrough
 
   -- Compiler/Proofs/IRGeneration/SupportedFragment.lean
   Compiler.Proofs.IRGeneration.stmtNextScope_requireError_preserves_scope
@@ -6689,4 +6691,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6247 theorems/lemmas (4379 public, 1868 private, 0 sorry'd)
+-- Total: 6249 theorems/lemmas (4381 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Composes the ParamLoading exact-fuel lemmas with the end-to-end guarded unit (#2294/#2295): `execIRStmts_guardedFunction_fallthrough` proves the complete guarded function body — `genParamLoads ++ guardPrologueStmts ++ applyLockReleaseOnExits body` — mirrors `NonReentrantGuard.guarded` end to end (loads bind, locked entry reverts with bindings only, free entry runs from the acquired bound state, successful outcomes released). With the `attachNonReentrantGuard` shape pin (#2275), this is the `compileGuardedFunctionSpec`-level semantic statement; the remaining step for the `noNonReentrant` lift is the `compile_preserves_semantics` threading (ContractShape/SupportedSpec surgery).

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in the IR generation verification layer; no runtime compiler or contract semantics changes.
> 
> **Overview**
> **Adds end-to-end IR semantics for the full guarded function body** (`genParamLoads` ++ guard prologue ++ lock-release-wrapped body) by composing existing ParamLoading fuel lemmas with `execIRStmts_guardedUnit_fallthrough`.
> 
> New lemma **`execIRStmts_guardedFunction_fallthrough`** states that supported calldata binding runs first; if the reentrancy slot is locked the call **reverts with only argument bindings applied**; otherwise the body runs from the post-acquire state and **successful outcomes release the lock**. Supporting lemma **`applyBindingsToIRState_transient`** shows parameter binding does not alter transient storage, which is needed to reuse the guarded-unit lock preconditions after loads.
> 
> **`PrintAxioms.lean`** registers both theorems (count 6247 → 6249).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dab52829e59205982ac9b226e628917da0e54701. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->