### PR TITLE
proof(ir): attachNonReentrantGuard correctness (lane 2.2 semantic closure)

### DIFF
--- a/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
+++ b/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
@@ -1092,4 +1092,61 @@ theorem execIRStmts_guardedFunction_fallthrough (slot : Nat)
     (ParamLoading.applyBindingsToIRState state bindings)
     (by rw [htrans]; exact hlock01) hF hG, htrans]
 
+/-- Correctness of the post-compilation guard transformation itself: for an
+annotated function whose compiled body has the standard loads-then-body
+shape, the transformed function's body executes exactly as the guarded
+composition — locked entry reverts after binding, free entry runs the body
+from the acquired bound state with successful outcomes released.  This is the
+`compileGuardedFunctionSpec`-level correctness statement; consuming it from
+the whole-contract preservation theorems is the remaining (additive)
+integration step. -/
+theorem attachNonReentrantGuard_exec (fields : List Field)
+    (spec : FunctionSpec) (irFn guardedFn : IRFunction) (lockField : String)
+    (field : Field) (slot : Nat) (bodyStmts : List YulStmt)
+    (bindings : List (String × Nat)) (extraFuel G : Nat) (state : IRState)
+    (hlock : spec.nonReentrantLock = some lockField)
+    (hfield : findFieldWithResolvedSlot fields lockField = some (field, slot))
+    (hguard : attachNonReentrantGuard fields spec irFn = .ok guardedFn)
+    (hbody : irFn.body = genParamLoads spec.params ++ bodyStmts)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (hSS : SpliceSimList bodyStmts)
+    (hH : yulFrameHaltsList bodyStmts = false)
+    (hsupported : ∀ param ∈ spec.params, SupportedExternalParamType param.ty)
+    (hfits : 4 + state.calldata.length * 32 < Compiler.Constants.evmModulus)
+    (hbind : SourceSemantics.bindSupportedParams spec.params state.calldata =
+      some bindings)
+    (hlock01 : state.transientStorage slot = 0 ∨ state.transientStorage slot = 1)
+    (hF : stmtsFuelBound (spliceLockReleaseList (lockReleaseStmt slot) bodyStmts) +
+      (spliceLockReleaseList (lockReleaseStmt slot) bodyStmts).length + 4 ≤
+      (guardPrologueStmts slot ++
+        applyLockReleaseOnExits (lockReleaseStmt slot) bodyStmts).length +
+        extraFuel + 1)
+    (hG : stmtsFuelBound bodyStmts ≤ G) :
+    execIRStmts ((genParamLoads spec.params).length +
+        (guardPrologueStmts slot ++
+          applyLockReleaseOnExits (lockReleaseStmt slot) bodyStmts).length +
+        extraFuel + 1) state guardedFn.body =
+      if state.transientStorage slot = 1 then
+        .revert (ParamLoading.applyBindingsToIRState state bindings)
+      else
+        (match execIRStmts G { ParamLoading.applyBindingsToIRState state bindings with
+            transientStorage := fun o => if o = slot then 1
+              else state.transientStorage o } bodyStmts with
+          | .continue s => .continue (releaseState slot s)
+          | .return v s => .return v (releaseState slot s)
+          | .stop s => .stop (releaseState slot s)
+          | .revert s => .revert s) := by
+  have hshape := attachNonReentrantGuard_some_shape fields spec irFn lockField
+    field slot hlock hfield
+  rw [hguard] at hshape
+  have hbodyEq : guardedFn.body =
+      genParamLoads spec.params ++
+        (guardPrologueStmts slot ++
+          applyLockReleaseOnExits (lockReleaseStmt slot) bodyStmts) := by
+    have := congrArg IRFunction.body (Except.ok.inj hshape)
+    simpa [hbody, List.take_left, List.drop_left, List.append_assoc] using this
+  rw [hbodyEq]
+  exact execIRStmts_guardedFunction_fallthrough slot hslot spec.params bindings
+    bodyStmts hSS hH extraFuel G state hsupported hfits hbind hlock01 hF hG
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4184,6 +4184,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.execIRStmts_guardedUnit_halting
   Compiler.Proofs.IRGeneration.applyBindingsToIRState_transient
   Compiler.Proofs.IRGeneration.execIRStmts_guardedFunction_fallthrough
+  Compiler.Proofs.IRGeneration.attachNonReentrantGuard_exec
 
   -- Compiler/Proofs/IRGeneration/SupportedFragment.lean
   Compiler.Proofs.IRGeneration.stmtNextScope_requireError_preserves_scope
@@ -6691,4 +6692,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6249 theorems/lemmas (4381 public, 1868 private, 0 sorry'd)
+-- Total: 6250 theorems/lemmas (4382 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
The transformation-level correctness statement: `attachNonReentrantGuard_exec` composes the output-shape pin (#2275) with the full guarded-function composition (#2296) — for any annotated function with the standard `genParamLoads ++ body` compiled shape, the transformed body provably executes as `guarded`: bind, check, acquire, run, release. This closes the *semantic* content of the `noNonReentrant` lift; what remains is integration plumbing (consuming this from the whole-contract preservation theorems), which is additive engineering with no new proof obstacles.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only change in Lean formal verification; no runtime compiler or contract behavior is modified.
> 
> **Overview**
> Adds **`attachNonReentrantGuard_exec`**, a formal correctness theorem for the post-compilation non-reentrant guard transform: when `attachNonReentrantGuard` succeeds on a function whose IR body is `genParamLoads ++ bodyStmts`, executing the guarded body matches the intended **guarded** semantics (bind params, revert if lock held, else acquire lock, run body, release on success).
> 
> The proof is a thin composition: **`attachNonReentrantGuard_some_shape`** pins the transformed body shape, then **`execIRStmts_guardedFunction_fallthrough`** supplies the execution equivalence. The theorem is registered in **`PrintAxioms.lean`** (theorem count 6249 → 6250).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 641ad7e6709e0b94bf2b7346cccb38914291ad1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->