### PR TITLE
proof(ir): guarded-function halting twin (lane 2.2)

### DIFF
--- a/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
+++ b/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
@@ -1092,6 +1092,49 @@ theorem execIRStmts_guardedFunction_fallthrough (slot : Nat)
     (ParamLoading.applyBindingsToIRState state bindings)
     (by rw [htrans]; exact hlock01) hF hG, htrans]
 
+/-- Halting twin of `execIRStmts_guardedFunction_fallthrough`: bodies ending
+in a modeled halt. -/
+theorem execIRStmts_guardedFunction_halting (slot : Nat)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (params : List Param) (bindings : List (String × Nat))
+    (ys : List YulStmt) (h : YulStmt)
+    (hSS : SpliceSimList (ys ++ [h])) (hmh : ModeledHalt h)
+    (extraFuel G : Nat) (state : IRState)
+    (hsupported : ∀ param ∈ params, SupportedExternalParamType param.ty)
+    (hfits : 4 + state.calldata.length * 32 < Compiler.Constants.evmModulus)
+    (hbind : SourceSemantics.bindSupportedParams params state.calldata =
+      some bindings)
+    (hlock01 : state.transientStorage slot = 0 ∨ state.transientStorage slot = 1)
+    (hF : stmtsFuelBound (spliceLockReleaseList (lockReleaseStmt slot)
+      (ys ++ [h])) + 2 ≤
+      (guardPrologueStmts slot ++
+        applyLockReleaseOnExits (lockReleaseStmt slot) (ys ++ [h])).length +
+        extraFuel + 1)
+    (hG : stmtsFuelBound (ys ++ [h]) ≤ G) :
+    execIRStmts ((genParamLoads params).length +
+        (guardPrologueStmts slot ++
+          applyLockReleaseOnExits (lockReleaseStmt slot) (ys ++ [h])).length +
+        extraFuel + 1) state
+      (genParamLoads params ++
+        (guardPrologueStmts slot ++
+          applyLockReleaseOnExits (lockReleaseStmt slot) (ys ++ [h]))) =
+      if state.transientStorage slot = 1 then
+        .revert (ParamLoading.applyBindingsToIRState state bindings)
+      else
+        (match execIRStmts G { ParamLoading.applyBindingsToIRState state bindings with
+            transientStorage := fun o => if o = slot then 1
+              else state.transientStorage o } (ys ++ [h]) with
+          | .continue s => .continue (releaseState slot s)
+          | .return v s => .return v (releaseState slot s)
+          | .stop s => .stop (releaseState slot s)
+          | .revert s => .revert s) := by
+  rw [ParamLoading.exec_genParamLoads_supported_then_extraFuel state params bindings
+    _ extraFuel hsupported hfits hbind]
+  have htrans := applyBindingsToIRState_transient bindings state
+  rw [execIRStmts_guardedUnit_halting slot hslot ys h hSS hmh _ G
+    (ParamLoading.applyBindingsToIRState state bindings)
+    (by rw [htrans]; exact hlock01) hF hG, htrans]
+
 /-- Correctness of the post-compilation guard transformation itself: for an
 annotated function whose compiled body has the standard loads-then-body
 shape, the transformed function's body executes exactly as the guarded

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4189,6 +4189,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.execIRStmts_guardedUnit_halting
   Compiler.Proofs.IRGeneration.applyBindingsToIRState_transient
   Compiler.Proofs.IRGeneration.execIRStmts_guardedFunction_fallthrough
+  Compiler.Proofs.IRGeneration.execIRStmts_guardedFunction_halting
   Compiler.Proofs.IRGeneration.attachNonReentrantGuard_exec
 
   -- Compiler/Proofs/IRGeneration/SupportedFragment.lean
@@ -6697,4 +6698,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6252 theorems/lemmas (4384 public, 1868 private, 0 sorry'd)
+-- Total: 6253 theorems/lemmas (4385 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Mirrors #2296 for modeled-halt endings: `execIRStmts_guardedFunction_halting`. Both exit classes of the guarded function composition are now covered, matching the `guardedUnit` pair (#2294).

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proof only; no compiler runtime, semantics, or axiom changes beyond registering one new public theorem.
> 
> **Overview**
> Adds **`execIRStmts_guardedFunction_halting`**, the halting counterpart to `execIRStmts_guardedFunction_fallthrough`, for guarded function bodies that end in a **modeled halt** (`return`/`stop`/`revert`). The statement matches the fall-through theorem (param loads, lock revert vs acquire + release on success) but uses `ys ++ [h]` and `ModeledHalt h`, and the proof reuses param-load reduction plus `execIRStmts_guardedUnit_halting`.
> 
> The new theorem is listed in **`PrintAxioms.lean`** so the axiom inventory stays complete. Together with the existing fall-through and `guardedUnit` pair, both exit shapes of the guarded-function IR composition are now covered at this layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a7aae58dc00e24eecb847d846979c280b6830b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->