### PR TITLE
proof(ir): attachNonReentrantGuard halting twin (lane 2.2 pair complete)

### DIFF
--- a/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
+++ b/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
@@ -1192,4 +1192,53 @@ theorem attachNonReentrantGuard_exec (fields : List Field)
   exact execIRStmts_guardedFunction_fallthrough slot hslot spec.params bindings
     bodyStmts hSS hH extraFuel G state hsupported hfits hbind hlock01 hF hG
 
+/-- Halting twin of `attachNonReentrantGuard_exec`. -/
+theorem attachNonReentrantGuard_exec_halting (fields : List Field)
+    (spec : FunctionSpec) (irFn guardedFn : IRFunction) (lockField : String)
+    (field : Field) (slot : Nat) (ys : List YulStmt) (h : YulStmt)
+    (bindings : List (String × Nat)) (extraFuel G : Nat) (state : IRState)
+    (hlock : spec.nonReentrantLock = some lockField)
+    (hfield : findFieldWithResolvedSlot fields lockField = some (field, slot))
+    (hguard : attachNonReentrantGuard fields spec irFn = .ok guardedFn)
+    (hbody : irFn.body = genParamLoads spec.params ++ (ys ++ [h]))
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (hSS : SpliceSimList (ys ++ [h])) (hmh : ModeledHalt h)
+    (hsupported : ∀ param ∈ spec.params, SupportedExternalParamType param.ty)
+    (hfits : 4 + state.calldata.length * 32 < Compiler.Constants.evmModulus)
+    (hbind : SourceSemantics.bindSupportedParams spec.params state.calldata =
+      some bindings)
+    (hlock01 : state.transientStorage slot = 0 ∨ state.transientStorage slot = 1)
+    (hF : stmtsFuelBound (spliceLockReleaseList (lockReleaseStmt slot)
+      (ys ++ [h])) + 2 ≤
+      (guardPrologueStmts slot ++
+        applyLockReleaseOnExits (lockReleaseStmt slot) (ys ++ [h])).length +
+        extraFuel + 1)
+    (hG : stmtsFuelBound (ys ++ [h]) ≤ G) :
+    execIRStmts ((genParamLoads spec.params).length +
+        (guardPrologueStmts slot ++
+          applyLockReleaseOnExits (lockReleaseStmt slot) (ys ++ [h])).length +
+        extraFuel + 1) state guardedFn.body =
+      if state.transientStorage slot = 1 then
+        .revert (ParamLoading.applyBindingsToIRState state bindings)
+      else
+        (match execIRStmts G { ParamLoading.applyBindingsToIRState state bindings with
+            transientStorage := fun o => if o = slot then 1
+              else state.transientStorage o } (ys ++ [h]) with
+          | .continue s => .continue (releaseState slot s)
+          | .return v s => .return v (releaseState slot s)
+          | .stop s => .stop (releaseState slot s)
+          | .revert s => .revert s) := by
+  have hshape := attachNonReentrantGuard_some_shape fields spec irFn lockField
+    field slot hlock hfield
+  rw [hguard] at hshape
+  have hbodyEq : guardedFn.body =
+      genParamLoads spec.params ++
+        (guardPrologueStmts slot ++
+          applyLockReleaseOnExits (lockReleaseStmt slot) (ys ++ [h])) := by
+    have := congrArg IRFunction.body (Except.ok.inj hshape)
+    simpa [hbody, List.take_left, List.drop_left, List.append_assoc] using this
+  rw [hbodyEq]
+  exact execIRStmts_guardedFunction_halting slot hslot spec.params bindings
+    ys h hSS hmh extraFuel G state hsupported hfits hbind hlock01 hF hG
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4191,6 +4191,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.execIRStmts_guardedFunction_fallthrough
   Compiler.Proofs.IRGeneration.execIRStmts_guardedFunction_halting
   Compiler.Proofs.IRGeneration.attachNonReentrantGuard_exec
+  Compiler.Proofs.IRGeneration.attachNonReentrantGuard_exec_halting
 
   -- Compiler/Proofs/IRGeneration/SupportedFragment.lean
   Compiler.Proofs.IRGeneration.stmtNextScope_requireError_preserves_scope
@@ -6698,4 +6699,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6253 theorems/lemmas (4385 public, 1868 private, 0 sorry'd)
+-- Total: 6254 theorems/lemmas (4386 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Completes the symmetric pair for #2297: `attachNonReentrantGuard_exec_halting` covers modeled-halt bodies at the transformation level. Every statement in the guarded chain — unit, function, transformation — now exists in both exit classes.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only addition in IR generation simulation; no runtime or compiler behavior changes.
> 
> **Overview**
> Adds **`attachNonReentrantGuard_exec_halting`**, the halting counterpart to `attachNonReentrantGuard_exec`. It states that after `attachNonReentrantGuard`, executing the guarded IR body matches the guarded semantics when the compiled body is `genParamLoads` plus a splice-sim fragment ending in a **modeled halt** (`return`/`stop`/`revert`), not a fall-through body.
> 
> The proof reuses `attachNonReentrantGuard_some_shape` to relate `guardedFn.body` to the guarded prologue plus lock-release-wrapped `(ys ++ [h])`, then delegates to `execIRStmts_guardedFunction_halting`. **`PrintAxioms.lean`** lists the new theorem so the axiom inventory stays complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb00e8aa896bce1952eb26475d0512dff9624e1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->