### PR TITLE
proof(ir): pointer-based mstore blocks (event-observable foundation, #2000)

### DIFF
--- a/Compiler/Proofs/IRGeneration/ErrorStringPayloadIR.lean
+++ b/Compiler/Proofs/IRGeneration/ErrorStringPayloadIR.lean
@@ -264,4 +264,57 @@ theorem execIRStmts_revertWithMessage (message : String) (fuel : Nat)
     | .revert s => .revert s) = _
   simp [execIRStmt]
 
+/-! ## Pointer-based stores
+
+Event payloads and ABI tails write through a base pointer
+(`mstore(add(ptr, off), value)`).  The lemmas below extend the block
+machinery to that shape: a pointer-offset store with a bound base variable
+executes to exactly the offset write, and blocks of them apply their write
+lists relative to the pointer. -/
+
+/-- One pointer-offset store executes to the offset write. -/
+theorem execIRStmt_mstore_ptr (fuel : Nat) (state : IRState)
+    (ptrName : String) (p off w : Nat)
+    (hptr : state.getVar ptrName = some p) :
+    execIRStmt (fuel + 1) state
+        (.exprStmt (.call "mstore"
+          [.call "add" [.ident ptrName, .lit off], .hex w])) =
+      .continue { state with
+        memory := fun x => if x = (p + off) % Compiler.Constants.evmModulus then w
+          else state.memory x } := by
+  simp [execIRStmt, evalIRExpr, evalIRCall, evalIRExprs, hptr,
+    YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext]
+
+/-- A block of pointer-offset stores applies its writes at the pointer. -/
+theorem execIRStmts_mstore_ptr_block (ptrName : String) (p : Nat) :
+    ∀ (writes : List (Nat × Nat)) (fuel : Nat) (state : IRState),
+      state.getVar ptrName = some p →
+      execIRStmts (writes.length + fuel + 1) state
+          (writes.map fun ow =>
+            YulStmt.exprStmt (.call "mstore"
+              [.call "add" [.ident ptrName, .lit ow.1], .hex ow.2])) =
+        .continue { state with
+          memory := applyWrites state.memory
+            (writes.map fun ow =>
+              ((p + ow.1) % Compiler.Constants.evmModulus, ow.2)) }
+  | [], _, state, _ => by simp [execIRStmts, applyWrites]
+  | (o, w) :: rest, fuel, state, hptr => by
+      rw [show ((o, w) :: rest).length + fuel + 1 =
+        (rest.length + fuel + 1) + 1 from by simp [List.length]; omega]
+      show (match execIRStmt (rest.length + fuel + 1) state
+          (.exprStmt (.call "mstore"
+            [.call "add" [.ident ptrName, .lit o], .hex w])) with
+        | .continue s₁ => execIRStmts (rest.length + fuel + 1) s₁
+            (rest.map fun (ow : Nat × Nat) =>
+              YulStmt.exprStmt (.call "mstore"
+                [.call "add" [.ident ptrName, .lit ow.1], .hex ow.2]))
+        | .return v s => .return v s
+        | .stop s => .stop s
+        | .revert s => .revert s) = _
+      rw [execIRStmt_mstore_ptr (rest.length + fuel) state ptrName p o w hptr]
+      have hptr' : ({ state with
+          memory := fun x => if x = (p + o) % Compiler.Constants.evmModulus then w
+            else state.memory x } : IRState).getVar ptrName = some p := hptr
+      exact execIRStmts_mstore_ptr_block ptrName p rest fuel _ hptr' 
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2352,6 +2352,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.errorStringWrites_mem4
   Compiler.Proofs.IRGeneration.errorStringWrites_mem36
   Compiler.Proofs.IRGeneration.execIRStmts_revertWithMessage
+  Compiler.Proofs.IRGeneration.execIRStmt_mstore_ptr
+  Compiler.Proofs.IRGeneration.execIRStmts_mstore_ptr_block
 
   -- Compiler/Proofs/IRGeneration/FuelBound.lean
   Compiler.Proofs.IRGeneration.stmtFuelBound_pos
@@ -6699,4 +6701,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6254 theorems/lemmas (4386 public, 1868 private, 0 sorry'd)
+-- Total: 6256 theorems/lemmas (4388 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Extends #2282's mstore-block machinery to the base-pointer shape event payload emission uses (`mstore(add(__evt_ptr, off), value)`): `execIRStmt_mstore_ptr` (single pointer-offset store with a bound base variable) and `execIRStmts_mstore_ptr_block` (blocks apply their write lists relative to the pointer). First brick of the event-emission observables toward #2000/Tier 3.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions alongside existing mstore lemmas; no runtime or compiler behavior changes.
> 
> **Overview**
> Extends the existing literal-address **`mstore`** block machinery in `ErrorStringPayloadIR.lean` to the **base-pointer** shape used for event payloads and ABI tails: `mstore(add(ptr, off), value)`.
> 
> Adds **`execIRStmt_mstore_ptr`** (one such store, with the base variable bound in `IRState`, writes at `(p + off) % evmModulus`) and **`execIRStmts_mstore_ptr_block`** (a list of pointer-offset stores applies the corresponding offset write list via `applyWrites`). **`PrintAxioms.lean`** lists both lemmas; the global theorem count comment bumps by two.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2a209665583301f3e658f6a286c6e9fb5f43015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->