### PR TITLE
proof(ir): log-call observable (event lane, #2000)

### DIFF
--- a/Compiler/Proofs/IRGeneration/ErrorStringPayloadIR.lean
+++ b/Compiler/Proofs/IRGeneration/ErrorStringPayloadIR.lean
@@ -317,4 +317,21 @@ theorem execIRStmts_mstore_ptr_block (ptrName : String) (p : Nat) :
             else state.memory x } : IRState).getVar ptrName = some p := hptr
       exact execIRStmts_mstore_ptr_block ptrName p rest fuel _ hptr' 
 
+/-- The log observable: a log builtin whose arguments evaluate appends
+exactly the encoded event and changes nothing else. -/
+theorem execIRStmt_log (fuel : Nat) (state next : IRState) (func : String)
+    (args : List YulExpr) (argVals : List Nat)
+    (hlog : Compiler.Proofs.YulGeneration.isYulLogName func = true)
+    (hargs : evalIRExprs state args = some argVals)
+    (happly : applyYulLogCall? state func argVals = some next) :
+    execIRStmt (fuel + 1) state (.exprStmt (.call func args)) =
+      .continue next := by
+  have hcases : func = "log0" ∨ func = "log1" ∨ func = "log2" ∨
+      func = "log3" ∨ func = "log4" := by
+    simp [Compiler.Proofs.YulGeneration.isYulLogName] at hlog
+    tauto
+  rcases hcases with rfl | rfl | rfl | rfl | rfl <;>
+    simp [execIRStmt, evalIRCall, hargs, happly,
+      Compiler.Proofs.YulGeneration.isYulLogName]
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2354,6 +2354,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.execIRStmts_revertWithMessage
   Compiler.Proofs.IRGeneration.execIRStmt_mstore_ptr
   Compiler.Proofs.IRGeneration.execIRStmts_mstore_ptr_block
+  Compiler.Proofs.IRGeneration.execIRStmt_log
 
   -- Compiler/Proofs/IRGeneration/FuelBound.lean
   Compiler.Proofs.IRGeneration.stmtFuelBound_pos
@@ -6701,4 +6702,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6256 theorems/lemmas (4388 public, 1868 private, 0 sorry'd)
+-- Total: 6257 theorems/lemmas (4389 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Second brick of the event lane: `execIRStmt_log` — any `log0..log4` builtin with evaluating arguments appends exactly `encodeYulLogEvent` (topics ++ data words from memory) and changes nothing else. Composes with #2301's pointer store blocks: payload writes then log emission = fully characterized event observable for scalar layouts (`scalarEventUnindexedStores` composition is the next step).

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only addition with no runtime or compiler behavior changes; only extends the formal IR observable story for logs.
> 
> **Overview**
> Adds **`execIRStmt_log`**, a small IR execution lemma in `ErrorStringPayloadIR.lean` for the event lane: when a statement is a **`log0`–`log4`** call, arguments evaluate to `argVals`, and **`applyYulLogCall?`** yields `next`, then **`execIRStmt`** continues in exactly that `next` state (the encoded log event; other state unchanged per that helper).
> 
> The proof case-splits on the five log names via **`isYulLogName`** and closes with **`simp`** on **`evalIRCall`** / **`happly`**. **`PrintAxioms.lean`** lists the new theorem; the tracked axiom/theorem count goes up by one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f6b3fb8f54e2be4334ce6d48563c665995e94bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->