### PR TITLE
proof(ir): memory-insensitive evaluation (event lane brick 3)

### DIFF
--- a/Compiler/Proofs/IRGeneration/EventObservable.lean
+++ b/Compiler/Proofs/IRGeneration/EventObservable.lean
@@ -1,0 +1,67 @@
+import Compiler.Proofs.IRGeneration.ErrorStringPayloadIR
+
+/-!
+# Memory-insensitive expression evaluation (event lane)
+
+Event payload emission interleaves memory writes with value expressions
+(`normalizeEventWord ty argExpr` — masks and sign-extensions over variables).
+To move those evaluations across the payload's `mstore`s, this module proves
+that expressions avoiding the two memory-reading builtins (`mload`,
+`keccak256`) evaluate identically under any memory: every other evaluation
+path reads variables, storage, transient storage, calldata, or the
+environment — never `state.memory`.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+
+mutual
+
+/-- Expressions whose evaluation never reads memory. -/
+def MemInsensitiveExpr : YulExpr → Prop
+  | .lit _ => True
+  | .hex _ => True
+  | .str _ => True
+  | .ident _ => True
+  | .call f args =>
+      f ≠ "mload" ∧ f ≠ "keccak256" ∧ MemInsensitiveExprs args
+
+def MemInsensitiveExprs : List YulExpr → Prop
+  | [] => True
+  | e :: rest => MemInsensitiveExpr e ∧ MemInsensitiveExprs rest
+
+end
+
+mutual
+
+/-- Memory-insensitive expressions evaluate identically under any memory. -/
+theorem evalIRExpr_mem_insensitive :
+    ∀ (e : YulExpr), MemInsensitiveExpr e → ∀ (state : IRState) (m : Nat → Nat),
+      evalIRExpr { state with memory := m } e = evalIRExpr state e
+  | .lit _, _, _, _ => by simp [evalIRExpr]
+  | .hex _, _, _, _ => by simp [evalIRExpr]
+  | .str _, _, _, _ => by simp [evalIRExpr]
+  | .ident _, _, _, _ => by simp [evalIRExpr, IRState.getVar]
+  | .call f args, h, state, m => by
+      obtain ⟨hml, hkec, hargs⟩ := h
+      simp only [evalIRExpr]
+      rw [evalIRCall, evalIRCall,
+        evalIRExprs_mem_insensitive args hargs state m]
+      cases hv : evalIRExprs state args with
+      | none => simp
+      | some argVals => simp [hml, hkec]
+
+theorem evalIRExprs_mem_insensitive :
+    ∀ (es : List YulExpr), MemInsensitiveExprs es →
+      ∀ (state : IRState) (m : Nat → Nat),
+        evalIRExprs { state with memory := m } es = evalIRExprs state es
+  | [], _, _, _ => by simp [evalIRExprs]
+  | e :: rest, h, state, m => by
+      obtain ⟨he, hrest⟩ := h
+      simp only [evalIRExprs]
+      rw [evalIRExpr_mem_insensitive e he state m,
+        evalIRExprs_mem_insensitive rest hrest state m]
+
+end
+
+end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -55,6 +55,7 @@ import Compiler.Proofs.IRGeneration.DenoteFunctionAgreement
 import Compiler.Proofs.IRGeneration.Dispatch
 import Compiler.Proofs.IRGeneration.DynamicAbiRefinement
 import Compiler.Proofs.IRGeneration.ErrorStringPayloadIR
+import Compiler.Proofs.IRGeneration.EventObservable
 import Compiler.Proofs.IRGeneration.FuelBound
 import Compiler.Proofs.IRGeneration.Function
 import Compiler.Proofs.IRGeneration.FunctionBody.Base
@@ -2355,6 +2356,10 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.execIRStmt_mstore_ptr
   Compiler.Proofs.IRGeneration.execIRStmts_mstore_ptr_block
   Compiler.Proofs.IRGeneration.execIRStmt_log
+
+  -- Compiler/Proofs/IRGeneration/EventObservable.lean
+  Compiler.Proofs.IRGeneration.evalIRExpr_mem_insensitive
+  Compiler.Proofs.IRGeneration.evalIRExprs_mem_insensitive
 
   -- Compiler/Proofs/IRGeneration/FuelBound.lean
   Compiler.Proofs.IRGeneration.stmtFuelBound_pos
@@ -6702,4 +6707,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6257 theorems/lemmas (4389 public, 1868 private, 0 sorry'd)
+-- Total: 6259 theorems/lemmas (4391 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Third event-lane brick: `MemInsensitiveExpr`/`MemInsensitiveExprs` with `evalIRExpr_mem_insensitive`/`evalIRExprs_mem_insensitive` — expressions avoiding `mload`/`keccak256` evaluate identically under any memory (all other paths read vars, storage, transient, calldata, or the environment). Lets `normalizeEventWord` values commute with payload `mstore`s; the scalar-event emission observable composing #2301 + #2302 is next.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions with no runtime, compiler output, or axiom changes beyond registering new lemmas in PrintAxioms.
> 
> **Overview**
> Adds **`EventObservable.lean`**, defining `MemInsensitiveExpr` / `MemInsensitiveExprs` (Yul expressions that never call `mload` or `keccak256`) and proving **`evalIRExpr_mem_insensitive`** / **`evalIRExprs_mem_insensitive`**: such expressions evaluate the same when only `IRState.memory` is swapped.
> 
> This is event-lane groundwork so **`normalizeEventWord`**-style value evaluations can be reordered past payload **`mstore`** steps without changing results. **`PrintAxioms.lean`** imports the module and registers the two new theorems (theorem count 6257 → 6259).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c2138dad4489c0511275236f56b9405b6404f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->