### PR TITLE
proof(ir): expression-valued pointer-store blocks (event lane brick 4)

### DIFF
--- a/Compiler/Proofs/IRGeneration/EventObservable.lean
+++ b/Compiler/Proofs/IRGeneration/EventObservable.lean
@@ -64,4 +64,72 @@ theorem evalIRExprs_mem_insensitive :
 
 end
 
+/-- Pointer-offset stores with memory-insensitive expression values: the block
+executes to its evaluated writes applied at the pointer, evaluations taken in
+the initial state (the values commute with the block's own writes). -/
+theorem execIRStmts_mstore_ptr_expr_block (ptrName : String) (p : Nat) :
+    ∀ (stores : List (Nat × YulExpr)) (vals : List Nat) (fuel : Nat)
+      (state : IRState),
+      state.getVar ptrName = some p →
+      MemInsensitiveExprs (stores.map (·.2)) →
+      evalIRExprs state (stores.map (·.2)) = some vals →
+      execIRStmts (stores.length + fuel + 1) state
+          (stores.map fun ov =>
+            YulStmt.exprStmt (.call "mstore"
+              [.call "add" [.ident ptrName, .lit ov.1], ov.2])) =
+        .continue { state with
+          memory := applyWrites state.memory
+            ((stores.map (fun ov => (p + ov.1) % Compiler.Constants.evmModulus)).zip vals) }
+  | [], vals, fuel, state, _, _, hvals => by
+      have hnil : vals = [] := by
+        simpa [evalIRExprs] using hvals.symm
+      subst hnil
+      simp [execIRStmts, applyWrites]
+  | (o, v) :: rest, vals, fuel, state, hptr, hmi, hvals => by
+      obtain ⟨hv, hrest⟩ : MemInsensitiveExpr v ∧
+          MemInsensitiveExprs (rest.map (fun (x : Nat × YulExpr) => x.2)) := hmi
+      simp only [List.map, evalIRExprs] at hvals
+      cases hev : evalIRExpr state v with
+      | none => rw [hev] at hvals; cases hvals
+      | some w =>
+          rw [hev] at hvals
+          cases hevs : evalIRExprs state (rest.map (·.2)) with
+          | none => rw [hevs] at hvals; cases hvals
+          | some ws =>
+              rw [hevs] at hvals
+              obtain rfl : w :: ws = vals := by simpa using hvals
+              rw [show ((o, v) :: rest).length + fuel + 1 =
+                (rest.length + fuel + 1) + 1 from by simp [List.length]; omega]
+              show (match execIRStmt (rest.length + fuel + 1) state
+                  (.exprStmt (.call "mstore"
+                    [.call "add" [.ident ptrName, .lit o], v])) with
+                | .continue s₁ => execIRStmts (rest.length + fuel + 1) s₁
+                    (rest.map fun (ov : Nat × YulExpr) =>
+                      YulStmt.exprStmt (.call "mstore"
+                        [.call "add" [.ident ptrName, .lit ov.1], ov.2]))
+                | .return v' s => .return v' s
+                | .stop s => .stop s
+                | .revert s => .revert s) = _
+              rw [show execIRStmt (rest.length + fuel + 1) state
+                  (.exprStmt (.call "mstore"
+                    [.call "add" [.ident ptrName, .lit o], v])) =
+                .continue { state with
+                  memory := fun x =>
+                    if x = (p + o) % Compiler.Constants.evmModulus then w
+                    else state.memory x } from by
+                simp [execIRStmt, evalIRExpr, evalIRCall, evalIRExprs, hptr, hev,
+                  YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext]]
+              have hptr' : ({ state with
+                  memory := fun x =>
+                    if x = (p + o) % Compiler.Constants.evmModulus then w
+                    else state.memory x } : IRState).getVar ptrName = some p := hptr
+              have hevs' : evalIRExprs { state with
+                  memory := fun x =>
+                    if x = (p + o) % Compiler.Constants.evmModulus then w
+                    else state.memory x } (rest.map (·.2)) = some ws := by
+                rw [evalIRExprs_mem_insensitive (rest.map (·.2)) hrest state _]
+                exact hevs
+              exact execIRStmts_mstore_ptr_expr_block ptrName p rest ws fuel _
+                hptr' hrest hevs'
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2360,6 +2360,7 @@ end Verity.AxiomAudit
   -- Compiler/Proofs/IRGeneration/EventObservable.lean
   Compiler.Proofs.IRGeneration.evalIRExpr_mem_insensitive
   Compiler.Proofs.IRGeneration.evalIRExprs_mem_insensitive
+  Compiler.Proofs.IRGeneration.execIRStmts_mstore_ptr_expr_block
 
   -- Compiler/Proofs/IRGeneration/FuelBound.lean
   Compiler.Proofs.IRGeneration.stmtFuelBound_pos
@@ -6707,4 +6708,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6259 theorems/lemmas (4391 public, 1868 private, 0 sorry'd)
+-- Total: 6260 theorems/lemmas (4392 public, 1868 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -50,6 +50,7 @@ ALLOWLIST: set[str] = {
     "spliced_cons_atomic",
     "execIRStmts_applyLockReleaseOnExits_fallthrough",
     "spliced_cons_switch",
+    "execIRStmts_mstore_ptr_expr_block",
     # #2083 expression-surface closure: both proofs are mechanical constructor/list
     # traversals kept whole so the denotation and scanner cases remain auditable
     # against the corresponding exhaustive expression definitions.


### PR DESCRIPTION
Composes #2301 (pointer stores) with #2303 (memory insensitivity): `execIRStmts_mstore_ptr_expr_block` — a payload block of `mstore(add(ptr, off), expr)` with memory-insensitive value expressions executes to its evaluated writes at the pointer, evaluations pinned to the initial state. This is exactly the `scalarEventUnindexedStores` shape; the full scalar-event emission observable (payload + `execIRStmt_log`) is now a mechanical composition.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal verification only (new Lean theorem and hygiene list updates); no runtime compiler or execution behavior changes.
> 
> **Overview**
> Adds **`execIRStmts_mstore_ptr_expr_block`** in `EventObservable.lean`: a block of `mstore(add(ptr, off), expr)` steps is shown to end in **continue** with memory equal to those offsets at `ptr`, using values from **`evalIRExprs` in the starting state**, when every value expression is **memory-insensitive** (no `mload` / `keccak256`). The proof is list induction—one store step, then **`evalIRExprs_mem_insensitive`** so later expression evaluations are unchanged by earlier writes in the block.
> 
> This matches the **`scalarEventUnindexedStores`** IR shape and sets up composing payload stores with the existing **`execIRStmt_log`** observable.
> 
> **`PrintAxioms.lean`** registers the new theorem (count 6260). **`check_proof_length.py`** allowlists the proof as a long mechanical induction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7be2d3343139efc91aea00f483b879b3e32f7ff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->