### PR TITLE
proof(ir): event store shape + normalize insensitivity (event toolkit complete, #2000)

### DIFF
--- a/Compiler/Proofs/IRGeneration/EventObservable.lean
+++ b/Compiler/Proofs/IRGeneration/EventObservable.lean
@@ -14,6 +14,7 @@ environment — never `state.memory`.
 namespace Compiler.Proofs.IRGeneration
 
 open Compiler.Yul
+open Compiler.CompilationModel
 
 mutual
 
@@ -131,5 +132,60 @@ theorem execIRStmts_mstore_ptr_expr_block (ptrName : String) (p : Nat) :
                 exact hevs
               exact execIRStmts_mstore_ptr_expr_block ptrName p rest ws fuel _
                 hptr' hrest hevs'
+
+/-- `normalizeEventWord` preserves memory insensitivity: every wrapper it
+emits (`and`/`signextend`/`iszero∘iszero`) is a non-memory builtin over the
+argument. -/
+theorem normalizeEventWord_memInsensitive :
+    ∀ (ty : ParamType) (e : YulExpr), MemInsensitiveExpr e →
+      MemInsensitiveExpr (normalizeEventWord ty e)
+  | .uint8, e, he => ⟨by decide, by decide, he, trivial, trivial⟩
+  | .uint16, e, he => ⟨by decide, by decide, he, trivial, trivial⟩
+  | .uintN _, e, he => ⟨by decide, by decide, he, trivial, trivial⟩
+  | .intN _, e, he => ⟨by decide, by decide, trivial, he, trivial⟩
+  | .bytesN _, e, he => ⟨by decide, by decide, he, trivial, trivial⟩
+  | .address, e, he => ⟨by decide, by decide, he, trivial, trivial⟩
+  | .bool, e, he =>
+      ⟨by decide, by decide, ⟨by decide, by decide, he, trivial⟩, trivial⟩
+  | .newtypeOf _ baseType, e, he =>
+      normalizeEventWord_memInsensitive baseType e he
+  | .uint256, e, he => he
+  | .int256, e, he => he
+  | .bytes32, e, he => he
+  | .string, e, he => he
+  | .tuple _, e, he => he
+  | .array _, e, he => he
+  | .fixedArray _ _, e, he => he
+  | .bytes, e, he => he
+  | .adt _ _, e, he => he
+
+/-- The write list of the scalar unindexed-store block: offsets accumulate by
+head word size, values are the normalized argument expressions. -/
+def scalarEventWrites :
+    List (EventParam × Expr × YulExpr) → Nat → List (Nat × YulExpr)
+  | [], _ => []
+  | (p, _, argExpr) :: rest, headOffset =>
+      (headOffset, normalizeEventWord p.ty argExpr) ::
+        scalarEventWrites rest (headOffset + eventHeadWordSize p.ty)
+
+/-- The emitted store block is exactly the pointer-store map of its write
+list — so `execIRStmts_mstore_ptr_expr_block` applies directly. -/
+theorem scalarEventUnindexedStoresFrom_shape :
+    ∀ (unindexed : List (EventParam × Expr × YulExpr)) (headOffset : Nat),
+      scalarEventUnindexedStoresFrom unindexed headOffset =
+        (scalarEventWrites unindexed headOffset).map fun ov =>
+          YulStmt.exprStmt (.call "mstore"
+            [.call "add" [.ident "__evt_ptr", .lit ov.1], ov.2])
+  | [], _ => rfl
+  | (p, e, argExpr) :: rest, headOffset => by
+      rw [show scalarEventUnindexedStoresFrom ((p, e, argExpr) :: rest) headOffset =
+        YulStmt.exprStmt (YulExpr.call "mstore" [
+          YulExpr.call "add" [YulExpr.ident "__evt_ptr", YulExpr.lit headOffset],
+          normalizeEventWord p.ty argExpr
+        ]) :: scalarEventUnindexedStoresFrom rest
+          (headOffset + eventHeadWordSize p.ty) from rfl,
+        scalarEventUnindexedStoresFrom_shape rest
+          (headOffset + eventHeadWordSize p.ty)]
+      rfl
 
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2361,6 +2361,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.evalIRExpr_mem_insensitive
   Compiler.Proofs.IRGeneration.evalIRExprs_mem_insensitive
   Compiler.Proofs.IRGeneration.execIRStmts_mstore_ptr_expr_block
+  Compiler.Proofs.IRGeneration.normalizeEventWord_memInsensitive
+  Compiler.Proofs.IRGeneration.scalarEventUnindexedStoresFrom_shape
 
   -- Compiler/Proofs/IRGeneration/FuelBound.lean
   Compiler.Proofs.IRGeneration.stmtFuelBound_pos
@@ -6708,4 +6710,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6260 theorems/lemmas (4392 public, 1868 private, 0 sorry'd)
+-- Total: 6262 theorems/lemmas (4394 public, 1868 private, 0 sorry'd)


### PR DESCRIPTION
Final connection bricks: `scalarEventUnindexedStoresFrom_shape` (the emitted payload block is exactly the pointer-store map of its `scalarEventWrites` list) and `normalizeEventWord_memInsensitive` (every emitted wrapper preserves memory insensitivity, through newtypes). With #2302 (log observable), #2303 (insensitivity), and #2304 (expression store blocks), the scalar-event emission observable is now a direct application chain: shape → block execution → log append.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in the IR generation event lane with no runtime or compiler emission changes.
> 
> **Overview**
> **Completes the scalar-event IR proof toolkit** by linking emitted unindexed payload stores to the existing pointer-store execution lemma.
> 
> Adds **`normalizeEventWord_memInsensitive`**, showing each type wrapper (`and` / `signextend` / bool `iszero`, including newtypes) keeps expressions out of `mload` / `keccak256`. Introduces **`scalarEventWrites`** and proves **`scalarEventUnindexedStoresFrom_shape`**: `scalarEventUnindexedStoresFrom` is exactly the `mstore` block built from offset + normalized-value pairs, so **`execIRStmts_mstore_ptr_expr_block`** applies directly. Opens **`Compiler.CompilationModel`** in the proof module for those definitions; **`PrintAxioms.lean`** lists both new theorems (6262 total).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5698756b85548d18664cb0adc2a397b87c43caf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->