### PR TITLE
chore(drain): remove unused simp arguments in DynamicAbiRoundTrip.lean

### DIFF
--- a/Verity/Core/Model/DynamicAbiRoundTrip.lean
+++ b/Verity/Core/Model/DynamicAbiRoundTrip.lean
@@ -90,7 +90,7 @@ theorem decodeSupportedParamWord_canonical :
   | .uintN bits, v, h => by
       obtain ⟨hbits, hmod⟩ := h
       simp [decodeSupportedParamWord, wordNormalize_eq_of_lt v hmod,
-        and_mask_eq_mod, Nat.mod_eq_of_lt hbits]
+        Nat.mod_eq_of_lt hbits]
   | .address, v, h => by
       have hlt : v < Compiler.Constants.evmModulus :=
         Nat.lt_of_lt_of_le h (pow_le_evmModulus 160 (by decide))
@@ -243,7 +243,7 @@ theorem arrayElementDynamicWord?_aligned (selector : Nat)
       some (calldata.getD (q0 + relq + wordOffset) 0) := by
   simp only [arrayElementDynamicWord?,
     arrayElementDynamicHeadOffset?_aligned selector calldata q0 length index
-      hidx hq hval htable hhead, Option.bind]
+      hidx hq hval htable hhead]
   rw [hrel]
   show externalWordAt? selector calldata (4 + 32 * q0 + 32 * relq + wordOffset * 32) =
     some (calldata.getD (q0 + relq + wordOffset) 0)
@@ -272,7 +272,7 @@ theorem arrayElementDynamicMemberLength?_aligned (selector : Nat)
       some (calldata.getD (q0 + relq + mrelq) 0) := by
   simp only [arrayElementDynamicMemberLength?,
     arrayElementDynamicHeadOffset?_aligned selector calldata q0 length index
-      hidx hq hval htable hhead, Option.bind]
+      hidx hq hval htable hhead]
   rw [hrel]
   show (externalWordAt? selector calldata
       (4 + 32 * q0 + 32 * relq + wordOffset * 32)).bind
@@ -311,7 +311,7 @@ theorem arrayElementDynamicMemberDataOffset?_aligned (selector : Nat)
     omega
   simp only [arrayElementDynamicMemberDataOffset?,
     arrayElementDynamicHeadOffset?_aligned selector calldata q0 length index
-      hidx hq hval htable hhead, Option.bind]
+      hidx hq hval htable hhead]
   rw [hrel]
   show (externalWordAt? selector calldata
       (4 + 32 * q0 + 32 * relq + wordOffset * 32)).bind
@@ -360,8 +360,7 @@ theorem arrayElementDynamicMemberElement?_aligned (selector : Nat)
     arrayElementDynamicMemberLength?_aligned selector calldata q0 length index
       wordOffset relq mrelq hidx hq hval hrel htable hhead hq2 hval2 hmrel hq3 hval3,
     arrayElementDynamicMemberDataOffset?_aligned selector calldata q0 length index
-      wordOffset relq mrelq hidx hq hval hrel htable hhead hq2 hval2 hmrel hq3,
-    Option.bind]
+      wordOffset relq mrelq hidx hq hval hrel htable hhead hq2 hval2 hmrel hq3]
   show (if innerIndex < calldata.getD (q0 + relq + mrelq) 0 then
       externalWordAt? selector calldata
         (4 + 32 * (q0 + relq + mrelq) + 32 + innerIndex * 32)


### PR DESCRIPTION
## Summary

Drain stabilization for the unused-simp warning regression seen in [Verify proofs run 31624126381](https://github.com/lfglabs-dev/verity/actions/runs/31624126381).

Removes exactly five unused simp arguments from `Verity/Core/Model/DynamicAbiRoundTrip.lean` without changing proof structure or semantics:

- line 93: `and_mask_eq_mod`
- line 246: `Option.bind`
- line 275: `Option.bind`
- line 314: `Option.bind`
- line 364: `Option.bind`

(Line numbers refer to the pre-change `origin/main` file.)

## Validation

Before:

- `lean-slot lake build Verity.Core.Model.DynamicAbiRoundTrip` — exit 0, exactly five unused-simp warnings.
- `python3 scripts/check_lean_warning_regression.py --log /tmp/dynamicabi-before.log` — exit 1: observed 5 warnings, baseline 0.

After:

- `lean-slot lake build Verity.Core.Model.DynamicAbiRoundTrip` — exit 0, no warnings.
- `python3 scripts/check_lean_warning_regression.py --log /tmp/dynamicabi-after.log` — exit 0: observed 0 warnings; baseline check passed.
- `lean-slot lake env lean Verity/Core/Model/DynamicAbiRoundTrip.lean` — exit 0, no output.
- `git grep -nE 'sorry|admit|axiom|unsafe' -- Verity/Core/Model/DynamicAbiRoundTrip.lean` — exit 1 with no matches (expected).
- `git diff --check` — exit 0.

Only `Verity/Core/Model/DynamicAbiRoundTrip.lean` is changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only cleanup with no logic or API changes; risk is limited to accidental proof breakage, which validation already rules out.
> 
> **Overview**
> **Drain fix** for Lean **unused-simp** warnings on `Verity/Core/Model/DynamicAbiRoundTrip.lean` (CI warning regression).
> 
> Strips five arguments that `simp` no longer needs: `and_mask_eq_mod` in the `uintN` branch of `decodeSupportedParamWord_canonical`, and four redundant `Option.bind` entries on `simp only` lines in the dynamic ABI alignment lemmas (`arrayElementDynamicWord?_aligned`, `arrayElementDynamicMemberLength?_aligned`, `arrayElementDynamicMemberDataOffset?_aligned`, `arrayElementDynamicMemberElement?_aligned`). Proof scripts and theorem statements are unchanged; only the tactic argument lists are tightened so the module builds clean under the warning checker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e96ead212c75157fd488d3efafbfaf7a0def76e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->