### PR TITLE
feat(ir): model invalid/selfdestruct halts — analysis/interpreter gap closed

### DIFF
--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -657,6 +657,13 @@ def execIRStmtWithInternals
               | .stop state' => .stop state'
               | .return value' state' => .return value' state'
               | .revert state' => .revert state'
+          | .call "invalid" [] => .revert state
+          | .call "selfdestruct" [addrExpr] =>
+              match evalIRExprsWithInternals contract fuel state [addrExpr] with
+              | .values _ state' => .stop state'
+              | .stop state' => .stop state'
+              | .return value' state' => .return value' state'
+              | .revert state' => .revert state'
           | .call func args =>
               if isYulLogName func then
                 match evalIRExprsWithInternals contract fuel state args with
@@ -940,6 +947,11 @@ def execIRStmt : Nat → IRState → YulStmt → IRExecResult
                 else
                   .return 0 state
               | _, _ => .revert state
+          | .call "invalid" [] => .revert state
+          | .call "selfdestruct" [addrExpr] =>
+              match evalIRExpr state addrExpr with
+              | some _ => .stop state
+              | none => .revert state
           | .call func args =>
               if isYulLogName func then
                 match evalIRExprs state args with
@@ -1759,6 +1771,8 @@ theorem IRStmtPreservesObsAt_of_expr_call_opaque
     (hNotStop : ¬(func = "stop" ∧ args = []))
     (hNotRevert : func ≠ "revert")
     (hNotReturn : func ≠ "return")
+    (hNotInvalid : func ≠ "invalid")
+    (hNotSelfdestruct : func ≠ "selfdestruct")
     (hNotLog : Compiler.Proofs.YulGeneration.isYulLogName func = false)
     (hEval : ∃ v, evalIRExpr state (.call func args) = some v) :
     IRStmtPreservesObsAt state (.exprStmt (.call func args)) := by
@@ -1767,11 +1781,11 @@ theorem IRStmtPreservesObsAt_of_expr_call_opaque
   cases args with
   | nil =>
       have hStopFalse : func ≠ "stop" := fun h => hNotStop ⟨h, rfl⟩
-      simp [execIRStmt, hStopFalse, hNotLog, hv]
+      simp [execIRStmt, hStopFalse, hNotInvalid, hNotLog, hv]
   | cons a rest =>
       cases rest with
       | nil =>
-          simp [execIRStmt, hNotLog, hv]
+          simp [execIRStmt, hNotSelfdestruct, hNotLog, hv]
       | cons b rest' =>
           cases rest' with
           | nil =>
@@ -2898,31 +2912,41 @@ theorem execIRStmtWithInternals_eq_execIRStmt_expr_of_callsDisjoint
                 by_cases hstop : func = "stop"
                 · subst hstop
                   simp only [execIRStmtWithInternals, execIRStmt]
-                · by_cases hlog : isYulLogName func = true
-                  · simpa [execIRStmtWithInternals, execIRStmt, hstop, hlog] using
-                      yulLogStmtResult_eq_of_evalIRExprsWithInternals_eq contract fuel
-                        state func []
-                        (evalIRExprsWithInternals_eq_evalIRExprs_of_callsDisjoint
-                          contract fuel state [] hargs_d)
-                  · cases hcall : evalIRExpr state (.call func []) <;>
-                      simp [execIRStmtWithInternals, execIRStmt,
-                        evalIRCallWithInternals_stmt_eq_of_callsDisjoint contract fuel state
-                          func [] hdisjoint,
-                        hstop, hlog, hcall]
+                · by_cases hinv : func = "invalid"
+                  · subst hinv
+                    simp only [execIRStmtWithInternals, execIRStmt]
+                  · by_cases hlog : isYulLogName func = true
+                    · simpa [execIRStmtWithInternals, execIRStmt, hstop, hinv, hlog] using
+                        yulLogStmtResult_eq_of_evalIRExprsWithInternals_eq contract fuel
+                          state func []
+                          (evalIRExprsWithInternals_eq_evalIRExprs_of_callsDisjoint
+                            contract fuel state [] hargs_d)
+                    · cases hcall : evalIRExpr state (.call func []) <;>
+                        simp [execIRStmtWithInternals, execIRStmt,
+                          evalIRCallWithInternals_stmt_eq_of_callsDisjoint contract fuel state
+                            func [] hdisjoint,
+                          hstop, hinv, hlog, hcall]
             | cons arg rest =>
                 cases rest with
                 | nil =>
-                    by_cases hlog : isYulLogName func = true
-                    · simpa [execIRStmtWithInternals, execIRStmt, hlog] using
-                        yulLogStmtResult_eq_of_evalIRExprsWithInternals_eq contract fuel
-                          state func [arg]
-                          (evalIRExprsWithInternals_eq_evalIRExprs_of_callsDisjoint
-                            contract fuel state [arg] hargs_d)
-                    · cases hcall : evalIRExpr state (.call func [arg]) <;>
-                        simp [execIRStmtWithInternals, execIRStmt,
-                          evalIRCallWithInternals_stmt_eq_of_callsDisjoint contract fuel state
-                            func [arg] hdisjoint,
-                          hlog, hcall]
+                    by_cases hsd : func = "selfdestruct"
+                    · subst hsd
+                      simp only [execIRStmtWithInternals,
+                        evalIRExprsWithInternals_eq_evalIRExprs_of_callsDisjoint
+                          contract fuel state [arg] hargs_d]
+                      cases harg : evalIRExpr state arg <;>
+                        simp [execIRStmt, evalIRExprs, harg]
+                    · by_cases hlog : isYulLogName func = true
+                      · simpa [execIRStmtWithInternals, execIRStmt, hsd, hlog] using
+                          yulLogStmtResult_eq_of_evalIRExprsWithInternals_eq contract fuel
+                            state func [arg]
+                            (evalIRExprsWithInternals_eq_evalIRExprs_of_callsDisjoint
+                              contract fuel state [arg] hargs_d)
+                      · cases hcall : evalIRExpr state (.call func [arg]) <;>
+                          simp [execIRStmtWithInternals, execIRStmt,
+                            evalIRCallWithInternals_stmt_eq_of_callsDisjoint contract fuel state
+                              func [arg] hdisjoint,
+                            hsd, hlog, hcall]
                 | cons arg2 rest =>
                     cases rest with
                     | nil =>
@@ -3737,31 +3761,41 @@ theorem execIRStmtWithInternals_eq_execIRStmt_expr_of_no_internal
                   · subst hstop
                     simpa using execIRStmtWithInternals_eq_execIRStmt_stop_of_no_internal
                       contract hinternal (Nat.succ fuel) state
-                  · by_cases hlog : isYulLogName func = true
-                    · simpa [execIRStmtWithInternals, execIRStmt, hstop, hlog] using
-                        yulLogStmtResult_eq_of_evalIRExprsWithInternals_eq contract fuel
-                          state func []
-                          (evalIRExprsWithInternals_eq_evalIRExprs_of_no_internal
-                            contract hinternal fuel state [])
-                    · cases hcall : evalIRExpr state (.call func []) <;>
-                        simp [execIRStmtWithInternals, execIRStmt,
-                          evalIRCallWithInternals_stmt_eq_of_no_internal contract hinternal
-                            fuel state func [],
-                          hstop, hlog, hcall]
+                  · by_cases hinv : func = "invalid"
+                    · subst hinv
+                      simp only [execIRStmtWithInternals, execIRStmt]
+                    · by_cases hlog : isYulLogName func = true
+                      · simpa [execIRStmtWithInternals, execIRStmt, hstop, hinv, hlog] using
+                          yulLogStmtResult_eq_of_evalIRExprsWithInternals_eq contract fuel
+                            state func []
+                            (evalIRExprsWithInternals_eq_evalIRExprs_of_no_internal
+                              contract hinternal fuel state [])
+                      · cases hcall : evalIRExpr state (.call func []) <;>
+                          simp [execIRStmtWithInternals, execIRStmt,
+                            evalIRCallWithInternals_stmt_eq_of_no_internal contract hinternal
+                              fuel state func [],
+                            hstop, hinv, hlog, hcall]
               | cons arg rest =>
                   cases rest with
                   | nil =>
-                      by_cases hlog : isYulLogName func = true
-                      · simpa [execIRStmtWithInternals, execIRStmt, hlog] using
-                          yulLogStmtResult_eq_of_evalIRExprsWithInternals_eq contract fuel
-                            state func [arg]
-                            (evalIRExprsWithInternals_eq_evalIRExprs_of_no_internal
-                              contract hinternal fuel state [arg])
-                      · cases hcall : evalIRExpr state (.call func [arg]) <;>
-                          simp [execIRStmtWithInternals, execIRStmt,
-                            evalIRCallWithInternals_stmt_eq_of_no_internal contract hinternal
-                              fuel state func [arg],
-                            hlog, hcall]
+                      by_cases hsd : func = "selfdestruct"
+                      · subst hsd
+                        simp only [execIRStmtWithInternals,
+                          evalIRExprsWithInternals_eq_evalIRExprs_of_no_internal
+                            contract hinternal fuel state [arg]]
+                        cases harg : evalIRExpr state arg <;>
+                          simp [execIRStmt, evalIRExprs, harg]
+                      · by_cases hlog : isYulLogName func = true
+                        · simpa [execIRStmtWithInternals, execIRStmt, hsd, hlog] using
+                            yulLogStmtResult_eq_of_evalIRExprsWithInternals_eq contract fuel
+                              state func [arg]
+                              (evalIRExprsWithInternals_eq_evalIRExprs_of_no_internal
+                                contract hinternal fuel state [arg])
+                        · cases hcall : evalIRExpr state (.call func [arg]) <;>
+                            simp [execIRStmtWithInternals, execIRStmt,
+                              evalIRCallWithInternals_stmt_eq_of_no_internal contract hinternal
+                                fuel state func [arg],
+                              hsd, hlog, hcall]
                   | cons arg2 rest =>
                       cases rest with
                       | nil =>
@@ -5624,6 +5658,8 @@ theorem execIRStmtWithInternals_expr_call_internal
     (hmstore : func ≠ "mstore") (htstore : func ≠ "tstore")
     (hrevert : func ≠ "revert")
     (hreturn : func ≠ "return")
+    (hinvalid : func ≠ "invalid")
+    (hselfdestruct : func ≠ "selfdestruct")
     (hlog : isYulLogName func = false) :
     execIRStmtWithInternals contract (fuel + 2) state (.exprStmt (.call func args)) =
       match execIRInternalFunctionWithInternals contract fuel state' helper argVals with
@@ -5637,12 +5673,12 @@ theorem execIRStmtWithInternals_expr_call_internal
   rw [show fuel + 2 = (fuel + 1) + 1 from by omega]
   cases args with
   | nil =>
-    simp [execIRStmtWithInternals, evalIRCallWithInternals, hstop, hlog, hfind]
+    simp [execIRStmtWithInternals, evalIRCallWithInternals, hstop, hinvalid, hlog, hfind]
     rw [hargs]
   | cons arg rest =>
     cases rest with
     | nil =>
-      simp [execIRStmtWithInternals, evalIRCallWithInternals, hargs, hlog, hfind]
+      simp [execIRStmtWithInternals, evalIRCallWithInternals, hargs, hselfdestruct, hlog, hfind]
     | cons arg2 rest =>
       cases rest with
       | nil =>
@@ -5666,6 +5702,8 @@ theorem execIRStmtsWithInternals_singleton_expr_call_internal
     (hmstore : func ≠ "mstore") (htstore : func ≠ "tstore")
     (hrevert : func ≠ "revert")
     (hreturn : func ≠ "return")
+    (hinvalid : func ≠ "invalid")
+    (hselfdestruct : func ≠ "selfdestruct")
     (hlog : isYulLogName func = false) :
     execIRStmtsWithInternals contract (fuel + 3) state
       [YulStmt.exprStmt (YulExpr.call func args)] =
@@ -5678,7 +5716,7 @@ theorem execIRStmtsWithInternals_singleton_expr_call_internal
   rw [execIRStmtsWithInternals_singleton]
   exact execIRStmtWithInternals_expr_call_internal
     contract fuel state func args helper argVals state' hargs hfind
-    hstop hsstore hmstore htstore hrevert hreturn hlog
+    hstop hsstore hmstore htstore hrevert hreturn hinvalid hselfdestruct hlog
 
 /-! ## Compilation output shape theorems
 
@@ -5961,6 +5999,27 @@ theorem execIRStmtsWithInternals_of_internalCall_compile
         rw [internalFunctionYulName_head functionName, hT] at hHead
         exact nomatch hHead)
       hrevert hreturn
+      (by
+        intro hEq
+        have hLen := congrArg String.length hEq
+        have hMe : (CompilationModel.internalFunctionYulName functionName).length =
+            9 + functionName.length := by
+          show (toString "internal_" ++ toString functionName).length =
+            9 + functionName.length
+          rw [String.length_append]
+          simp [toString]
+          decide
+        rw [hMe] at hLen
+        have h7 : ("invalid" : String).length = 7 := by decide
+        omega)
+      (by
+        intro hEq
+        have hHead := congrArg (fun s => s.toList.head?) hEq
+        have hT : ("selfdestruct" : String).toList.head? = some 's' := by decide
+        change (CompilationModel.internalFunctionYulName functionName).toList.head? =
+          ("selfdestruct" : String).toList.head? at hHead
+        rw [internalFunctionYulName_head functionName, hT] at hHead
+        exact nomatch hHead)
       (internalFunctionYulName_isYulLogName_false functionName)⟩
 
 @[simp] theorem applyIRTransactionContext_sender

--- a/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
+++ b/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
@@ -40,6 +40,7 @@ def SpliceSim : YulStmt → Prop
   | .switch _ cases dflt => SpliceSimCases cases ∧ SpliceSimDflt dflt
   | .exprStmt (.call "return" args) => ∃ a b, args = [YulExpr.lit a, YulExpr.lit b]
   | .exprStmt (.call "stop" args) => args = []
+  | .exprStmt (.call "selfdestruct" _) => False
   | _ => True
 
 def SpliceSimCases : List (Nat × List YulStmt) → Prop
@@ -100,12 +101,14 @@ theorem SpliceSimList.loopFree : ∀ (xs : List YulStmt), SpliceSimList xs →
 
 end
 
+set_option maxHeartbeats 1600000 in
 /-- A non-exit expression statement never halts the frame: every interpreter
 branch other than the `return`/`stop` builtins produces `continue` or
 `revert`. -/
 theorem execIRStmt_exprStmt_no_halt (e : YulExpr) (fuel : Nat) (state : IRState)
     (hret : ∀ args, e ≠ .call "return" args)
-    (hstop : ∀ args, e ≠ .call "stop" args) :
+    (hstop : ∀ args, e ≠ .call "stop" args)
+    (hsd : ∀ args, e ≠ .call "selfdestruct" args) :
     (∀ v s, execIRStmt (fuel + 1) state (.exprStmt e) ≠ .return v s) ∧
       (∀ s, execIRStmt (fuel + 1) state (.exprStmt e) ≠ .stop s) := by
   refine ⟨fun v s hcontra => ?_, fun s hcontra => ?_⟩ <;>
@@ -114,6 +117,7 @@ theorem execIRStmt_exprStmt_no_halt (e : YulExpr) (fuel : Nat) (state : IRState)
     all_goals first
       | exact absurd rfl (hret _)
       | exact absurd rfl (hstop _)
+      | exact absurd rfl (hsd _)
       | simp_all
       | cases hcontra
 
@@ -128,6 +132,7 @@ def AtomicNonExit : YulStmt → Prop
   | .funcDef _ _ _ _ => True
   | .exprStmt (.call "return" _) => False
   | .exprStmt (.call "stop" _) => False
+  | .exprStmt (.call "selfdestruct" _) => False
   | .exprStmt _ => True
   | _ => False
 
@@ -163,7 +168,7 @@ theorem execIRStmt_atomic_no_halt (x : YulStmt) (hx : AtomicNonExit x)
       (∀ s, execIRStmt (fuel + 1) state x ≠ .stop s) := by
   cases x with
   | exprStmt e =>
-      refine execIRStmt_exprStmt_no_halt e fuel state ?_ ?_ <;>
+      refine execIRStmt_exprStmt_no_halt e fuel state ?_ ?_ ?_ <;>
         (intro args hcontra; subst hcontra; simp [AtomicNonExit] at hx)
   | comment _ => exact ⟨(fun v s h => nomatch h), (fun s h => nomatch h)⟩
   | «leave» => exact ⟨(fun v s h => nomatch h), (fun s h => nomatch h)⟩
@@ -716,9 +721,12 @@ theorem execIRStmts_spliced (slot : Nat)
                 · subst hstop
                   obtain rfl : args = [] := by simpa [SpliceSim] using hx
                   exact spliced_cons_stop slot hslot rest F G state hF hG
-                · exact spliced_cons_atomic slot _ rest
-                    (by simp [AtomicNonExit, hret, hstop]) (by simp [LoopFree])
-                    IHrest F G state hF hG
+                · by_cases hsd : f = "selfdestruct"
+                  · subst hsd
+                    exact absurd hx (by simp [SpliceSim])
+                  · exact spliced_cons_atomic slot _ rest
+                      (by simp [AtomicNonExit, hret, hstop, hsd]) (by simp [LoopFree])
+                      IHrest F G state hF hG
 termination_by xs _ _ _ _ _ _ => sizeOf xs
 decreasing_by
   all_goals try assumption
@@ -885,6 +893,7 @@ inductive ModeledHalt : YulStmt → Prop
       ModeledHalt (.exprStmt (.call "return" [.lit a, .lit b]))
   | rev (a b : YulExpr) :
       ModeledHalt (.exprStmt (.call "revert" [a, b]))
+  | inv : ModeledHalt (.exprStmt (.call "invalid" []))
 
 /-- A modeled halt never continues, at any fuel (out of fuel reverts). -/
 theorem execIRStmt_modeledHalt_no_continue (h : YulStmt) (hmh : ModeledHalt h)
@@ -900,6 +909,7 @@ theorem execIRStmt_modeledHalt_no_continue (h : YulStmt) (hmh : ModeledHalt h)
           by_cases hb : b = 32 <;>
             simp [execIRStmt, evalIRExpr, evalIRExprs, hb] at hcontra
   | rev a b => cases fuel <;> simp [execIRStmt] at hcontra
+  | inv => cases fuel <;> simp [execIRStmt] at hcontra
 
 /-- A body ending in a modeled halt never continues. -/
 theorem execIRStmts_last_halt_no_continue (h : YulStmt) (hmh : ModeledHalt h) :

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -193,8 +193,10 @@ exits: the general splice simulation (`execIRStmts_spliced`), both
 prologue + release-wrapped body mirrors `guarded` exactly (locked entry
 reverts untouched; free entry runs from the acquired state with successful
 outcomes released). Still trusted: `switch` bodies and loops in guarded
-functions, the `invalid`/`selfdestruct` analysis-vs-interpreter halt gap
-(scoped out via `ModeledHalt`), and the `compile_preserves_semantics`
+functions, `selfdestruct` in guarded bodies (excluded from the simulation fragment: the
+splice inserts no release before it, and a self-destructed contract's lock is
+moot — `invalid` is now modeled as a frame halt and covered by `ModeledHalt`),
+and the `compile_preserves_semantics`
 threading that would lift the supported-fragment `noNonReentrant`
 restriction.
 **Fork requirement**: the compile driver rejects any contract carrying a


### PR DESCRIPTION
Per the decision to favor the long-term-clean fix over scoping: the IR interpreter now halts on `invalid` (revert-like) and `selfdestruct` (stop-like), so `yulFrameHalts` and execution agree on every builtin the analysis marks halting (the gap found in #2292). Both interpreter variants updated with their equivalence proofs; opaque-call/internal-dispatch lemmas gain freshness hypotheses discharged by name-shape facts; `invalid` joins `ModeledHalt`; `selfdestruct` is excluded from the simulation fragment by design (no release is spliced before it, and a destroyed contract's lock is moot) — documented in TRUST_ASSUMPTIONS.

Validation: full `lake build` (2469 jobs) OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formal execution semantics and a large proof surface for non-reentrant guard correctness; scope is proof/interpreter alignment rather than production compiler output, but mistakes could weaken verified properties.
> 
> **Overview**
> Closes the **analysis vs interpreter gap** (#2292): `yulFrameHalts` already treated `invalid` and `selfdestruct` as frame halts, but execution used to fall through like opaque calls. **`execIRStmt` / internals** now handle **`invalid`** as **revert** and **`selfdestruct`** (after evaluating the address) as **stop**, in both the fuel-indexed and plain eval paths.
> 
> Proof work in **`IRInterpreter.lean`** threads the new builtins through equivalence lemmas, opaque-call preservation, and internal-function dispatch (including name-shape proofs that compiled internal names cannot collide with `"invalid"` / `"selfdestruct"`). **`SpliceSimulation.lean`** adds **`invalid`** to **`ModeledHalt`**, treats **`selfdestruct`** as non-simulable in **`SpliceSim`** / **`AtomicNonExit`**, and extends no-halt lemmas accordingly. **`TRUST_ASSUMPTIONS.md`** notes **`invalid`** is now modeled; **`selfdestruct`** stays out of the guarded splice fragment by design.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa5e4632b75649d4dd81ce07e88ea5c100cd5bf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->