### PR TITLE
fix(ci): restore the zero-warning Lean baseline

### DIFF
--- a/Compiler/Proofs/IRGeneration/ErrorStringPayloadIR.lean
+++ b/Compiler/Proofs/IRGeneration/ErrorStringPayloadIR.lean
@@ -90,7 +90,7 @@ theorem execIRStmts_mstoreWrites :
           (.exprStmt (.call "mstore" [.lit o, .lit w])) =
         .continue { state with
           memory := fun x => if x = o then w else state.memory x } from by
-        simp [execIRStmt, evalIRExpr, evalIRCall, evalIRExprs]]
+        simp [execIRStmt, evalIRExpr]]
       exact execIRStmts_mstoreWrites htail fuel _
   | _, _, @MstoreWrites.consHex tail wtail o w htail, fuel, state => by
       rw [show (YulStmt.exprStmt (.call "mstore" [.lit o, .hex w]) :: tail).length +
@@ -105,7 +105,7 @@ theorem execIRStmts_mstoreWrites :
           (.exprStmt (.call "mstore" [.lit o, .hex w])) =
         .continue { state with
           memory := fun x => if x = o then w else state.memory x } from by
-        simp [execIRStmt, evalIRExpr, evalIRCall, evalIRExprs]]
+        simp [execIRStmt, evalIRExpr]]
       exact execIRStmts_mstoreWrites htail fuel _
 
 /-- The write list `revertWithMessage` performs: three header words then one
@@ -331,7 +331,7 @@ theorem execIRStmt_log (fuel : Nat) (state next : IRState) (func : String)
     simp [Compiler.Proofs.YulGeneration.isYulLogName] at hlog
     tauto
   rcases hcases with rfl | rfl | rfl | rfl | rfl <;>
-    simp [execIRStmt, evalIRCall, hargs, happly,
+    simp [execIRStmt, hargs, happly,
       Compiler.Proofs.YulGeneration.isYulLogName]
 
 end Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/IRGeneration/FuelBound.lean
+++ b/Compiler/Proofs/IRGeneration/FuelBound.lean
@@ -225,9 +225,8 @@ theorem execIRStmt_stable : ∀ (stmt : YulStmt), LoopFree stmt →
 termination_by stmt _ _ _ => sizeOf stmt
 decreasing_by
   all_goals simp_wf
-  all_goals try omega
   all_goals try (have h1 := List.sizeOf_lt_of_mem hmem; simp at h1 ⊢; omega)
-  all_goals (try simp [*, Option.some.sizeOf_spec, Prod.mk.sizeOf_spec]) <;> omega
+  all_goals (try simp [*, Option.some.sizeOf_spec]); omega
 
 /-- Fuel stability for statement lists. -/
 theorem execIRStmts_stable : ∀ (xs : List YulStmt), LoopFreeList xs →

--- a/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
+++ b/Compiler/Proofs/IRGeneration/NonReentrantGuardIR.lean
@@ -85,7 +85,7 @@ theorem execIRStmt_lockRelease (fuel : Nat) (state : IRState) (slot : Nat)
       .continue { state with
         transientStorage := fun o => if o = slot then 0 else state.transientStorage o } := by
   have hmod : slot % Compiler.Constants.evmModulus = slot := Nat.mod_eq_of_lt hslot
-  simp [lockReleaseStmt, execIRStmt, evalIRExpr, evalIRCall, evalIRExprs, hmod]
+  simp [lockReleaseStmt, execIRStmt, evalIRExpr, hmod]
 
 /-- On the reachable (binary) lock values, the Yul decision `eq(lock, 1)`
 agrees with the source model's `lock ≠ 0` (`NonReentrantGuard.guarded`). -/
@@ -132,7 +132,7 @@ theorem execIRStmts_append_continue (ys : List YulStmt) :
       have hs : s' = state := by
         simpa [execIRStmts] using h.symm
       subst hs
-      simp [execIRStmts]
+      simp
   | x :: xs', fuel, state, s', h => by
       cases fuel with
       | zero => simp [execIRStmts] at h

--- a/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
+++ b/Compiler/Proofs/IRGeneration/SpliceSimulation.lean
@@ -119,7 +119,6 @@ theorem execIRStmt_exprStmt_no_halt (e : YulExpr) (fuel : Nat) (state : IRState)
       | exact absurd rfl (hstop _)
       | exact absurd rfl (hsd _)
       | simp_all
-      | cases hcontra
 
 /-- Atomic non-exit statements: everything the splice leaves untouched and
 whose execution cannot halt the frame. -/
@@ -332,7 +331,7 @@ theorem spliced_cons_return (slot : Nat)
     | .revert s => .revert s) = _
   rw [execIRStmt_lockRelease (F' + 1) state slot hslot]
   by_cases hb : b = 32 <;>
-    simp [execIRStmts, execIRStmt, evalIRExpr, evalIRExprs, releasedResult,
+    simp [execIRStmts, execIRStmt, evalIRExpr, releasedResult,
       releaseState, hb]
 
 /-- Cons step for an `if` head: the condition evaluates identically, the
@@ -729,15 +728,8 @@ theorem execIRStmts_spliced (slot : Nat)
                       IHrest F G state hF hG
 termination_by xs _ _ _ _ _ _ => sizeOf xs
 decreasing_by
-  all_goals try assumption
   all_goals simp_wf
-  all_goals try omega
-  all_goals try (have h1 := List.sizeOf_lt_of_mem hmem; simp at h1 ⊢; omega)
-  all_goals try (have h1 := List.sizeOf_lt_of_mem hmem; obtain ⟨k1, b1⟩ := c; simp at h1 ⊢; omega)
-  all_goals try (subst hbody; simp; omega)
-  all_goals try (injection hbody with hbb; subst hbb; simp; omega)
-  all_goals try (rename _ ∈ _ => hm; have h1 := List.sizeOf_lt_of_mem hm; simp at h1 ⊢; omega)
-  all_goals (try simp [*, Option.some.sizeOf_spec]) <;> omega
+  all_goals (try simp [*, Option.some.sizeOf_spec]); omega
 
 /-- Companion recursion over switch cases: pointwise simulation for every
 member body, with structurally static termination. -/
@@ -759,7 +751,7 @@ theorem execIRStmts_splicedCases (slot : Nat)
 termination_by cs _ _ _ _ _ _ _ _ => sizeOf cs
 decreasing_by
   all_goals simp_wf
-  all_goals (try simp) <;> omega
+  all_goals omega
 
 /-- Companion recursion for the default branch. -/
 theorem execIRStmts_splicedDflt (slot : Nat)
@@ -778,7 +770,6 @@ theorem execIRStmts_splicedDflt (slot : Nat)
 termination_by d _ _ _ _ _ _ _ _ => sizeOf d
 decreasing_by
   all_goals simp_wf
-  all_goals (try simp [Option.some.sizeOf_spec]) <;> omega
 
 end
 
@@ -907,7 +898,7 @@ theorem execIRStmt_modeledHalt_no_continue (h : YulStmt) (hmh : ModeledHalt h)
       | zero => simp [execIRStmt] at hcontra
       | succ f =>
           by_cases hb : b = 32 <;>
-            simp [execIRStmt, evalIRExpr, evalIRExprs, hb] at hcontra
+            simp [execIRStmt, evalIRExpr, hb] at hcontra
   | rev a b => cases fuel <;> simp [execIRStmt] at hcontra
   | inv => cases fuel <;> simp [execIRStmt] at hcontra
 

--- a/Verity/Core/Model/DynamicAbiRoundTrip.lean
+++ b/Verity/Core/Model/DynamicAbiRoundTrip.lean
@@ -90,7 +90,7 @@ theorem decodeSupportedParamWord_canonical :
   | .uintN bits, v, h => by
       obtain ⟨hbits, hmod⟩ := h
       simp [decodeSupportedParamWord, wordNormalize_eq_of_lt v hmod,
-        and_mask_eq_mod, Nat.mod_eq_of_lt hbits]
+        Nat.mod_eq_of_lt hbits]
   | .address, v, h => by
       have hlt : v < Compiler.Constants.evmModulus :=
         Nat.lt_of_lt_of_le h (pow_le_evmModulus 160 (by decide))
@@ -243,7 +243,7 @@ theorem arrayElementDynamicWord?_aligned (selector : Nat)
       some (calldata.getD (q0 + relq + wordOffset) 0) := by
   simp only [arrayElementDynamicWord?,
     arrayElementDynamicHeadOffset?_aligned selector calldata q0 length index
-      hidx hq hval htable hhead, Option.bind]
+      hidx hq hval htable hhead]
   rw [hrel]
   show externalWordAt? selector calldata (4 + 32 * q0 + 32 * relq + wordOffset * 32) =
     some (calldata.getD (q0 + relq + wordOffset) 0)
@@ -272,7 +272,7 @@ theorem arrayElementDynamicMemberLength?_aligned (selector : Nat)
       some (calldata.getD (q0 + relq + mrelq) 0) := by
   simp only [arrayElementDynamicMemberLength?,
     arrayElementDynamicHeadOffset?_aligned selector calldata q0 length index
-      hidx hq hval htable hhead, Option.bind]
+      hidx hq hval htable hhead]
   rw [hrel]
   show (externalWordAt? selector calldata
       (4 + 32 * q0 + 32 * relq + wordOffset * 32)).bind
@@ -311,7 +311,7 @@ theorem arrayElementDynamicMemberDataOffset?_aligned (selector : Nat)
     omega
   simp only [arrayElementDynamicMemberDataOffset?,
     arrayElementDynamicHeadOffset?_aligned selector calldata q0 length index
-      hidx hq hval htable hhead, Option.bind]
+      hidx hq hval htable hhead]
   rw [hrel]
   show (externalWordAt? selector calldata
       (4 + 32 * q0 + 32 * relq + wordOffset * 32)).bind
@@ -360,8 +360,7 @@ theorem arrayElementDynamicMemberElement?_aligned (selector : Nat)
     arrayElementDynamicMemberLength?_aligned selector calldata q0 length index
       wordOffset relq mrelq hidx hq hval hrel htable hhead hq2 hval2 hmrel hq3 hval3,
     arrayElementDynamicMemberDataOffset?_aligned selector calldata q0 length index
-      wordOffset relq mrelq hidx hq hval hrel htable hhead hq2 hval2 hmrel hq3,
-    Option.bind]
+      wordOffset relq mrelq hidx hq hval hrel htable hhead hq2 hval2 hmrel hq3]
   show (if innerIndex < calldata.getD (q0 + relq + mrelq) 0 then
       externalWordAt? selector calldata
         (4 + 32 * (q0 + relq + mrelq) + 32 + innerIndex * 32)


### PR DESCRIPTION
Main's `Verify proofs` run failed on the warning-baseline gate (unused simp args introduced by today's proof modules). Full sweep: unused simp arguments removed, dead decreasing-script branches pruned (they became unreachable after the mutual-companion restructures), dead tactic alternative removed. Zero Lean warnings across the tree.

Validation: full `lake build` OK, `make check` all passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-script and linter-hygiene only; no runtime, compiler output, or verified semantics changes.
> 
> **Overview**
> Restores the **zero-warning Lean baseline** for the `Verify proofs` CI gate by tightening proof scripts only—no interpreter, decoder, or theorem statement changes.
> 
> **IR-generation proofs** (`ErrorStringPayloadIR`, `NonReentrantGuardIR`, `SpliceSimulation`): `simp` lists drop lemmas that `simp` already unfolds (`evalIRCall`, `evalIRExprs`) where `execIRStmt` / `evalIRExpr` suffice; `execIRStmt_log` and similar proofs are adjusted the same way. `execIRStmts_append_continue` uses bare `simp` instead of `simp [execIRStmts]` on the empty-prefix case. In `execIRStmt_exprStmt_no_halt`, a dead `cases hcontra` branch after `simp_all` is removed.
> 
> **Fuel and splice simulation** (`FuelBound`, `SpliceSimulation`): mutual-recursion `decreasing_by` blocks are collapsed—redundant `try omega` / membership / injection branches removed after companion restructures left them unreachable—into shorter `(try simp [*, Option.some.sizeOf_spec]); omega` or `omega`-only scripts.
> 
> **Dynamic ABI round-trip** (`DynamicAbiRoundTrip`): aligned decoder proofs stop passing redundant `Option.bind` / duplicate `and_mask_eq_mod` simp lemmas; `simp only` on composed decoders relies on definitional unfolding from the aligned sub-lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef2329a14e9365bec8674be3cdee4183610b32de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->