### PR TITLE
feat(proofs): *_guarded family root — guarded functions at the IRResult observable

### DIFF
--- a/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Calls.lean
@@ -1959,6 +1959,28 @@ private theorem internalFunctionYulName_ne_stop
     CompilationModel.internalFunctionYulName calleeName ≠ "stop" := by
   exact internalFunctionYulName_ne_of_head calleeName "stop" 's' (by decide) (by decide)
 
+private theorem internalFunctionYulName_ne_selfdestruct
+    (calleeName : String) :
+    CompilationModel.internalFunctionYulName calleeName ≠ "selfdestruct" := by
+  exact internalFunctionYulName_ne_of_head calleeName "selfdestruct" 's'
+    (by decide) (by decide)
+
+private theorem internalFunctionYulName_ne_invalid
+    (calleeName : String) :
+    CompilationModel.internalFunctionYulName calleeName ≠ "invalid" := by
+  intro hEq
+  have hLen := congrArg String.length hEq
+  have hMe : (CompilationModel.internalFunctionYulName calleeName).length =
+      9 + calleeName.length := by
+    show (toString "internal_" ++ toString calleeName).length =
+      9 + calleeName.length
+    rw [String.length_append]
+    simp [toString]
+    decide
+  rw [hMe] at hLen
+  have h7 : ("invalid" : String).length = 7 := by decide
+  omega
+
 private theorem internalFunctionYulName_ne_sstore
     (calleeName : String) :
     CompilationModel.internalFunctionYulName calleeName ≠ "sstore" := by
@@ -2239,6 +2261,8 @@ theorem execIRStmtsWithInternals_of_internalCall_compiledHelperWitness_with_inte
           exact nomatch hHead)
         (internalFunctionYulName_ne_revert calleeName)
         (internalFunctionYulName_ne_return calleeName)
+        (internalFunctionYulName_ne_invalid calleeName)
+        (internalFunctionYulName_ne_selfdestruct calleeName)
         (internalFunctionYulName_isYulLogName_false calleeName)
 
 end Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/IRGeneration/GuardedFunction.lean
+++ b/Compiler/Proofs/IRGeneration/GuardedFunction.lean
@@ -1,0 +1,158 @@
+import Compiler.Proofs.IRGeneration.GuardedCompile
+import Compiler.Proofs.IRGeneration.Function
+import Compiler.Proofs.YulGeneration.IRFuel
+
+/-!
+# The `*_guarded` theorem family (per-function root)
+
+Additive counterparts of `exec_compiledFunctionIR_of_body` for functions
+annotated `nonreentrant(lock)`: the guarded compilation unit executes, at the
+`IRResult` observable, exactly as the guard's source semantics dictates —
+a locked entry reverts (observable rollback to the initial storage/events),
+and a free entry behaves as the body executed from the acquired bound state.
+Because `IRResult` does not observe transient storage, the lock release is
+observably invisible, so the free case's right-hand side is the *plain*
+projection of the body's tail result — existing source-correspondence
+consumers compose with it unchanged.
+
+Existing theorem statements are untouched (per the additive-family design
+decision); this module only adds.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+open Compiler.CompilationModel
+open Compiler.Proofs.IRGeneration.Function
+
+/-- The release is observably invisible: `IRResult` ignores transient
+storage. -/
+theorem execResultToIRResult_releasedResult (init : IRState) (slot : Nat)
+    (r : IRExecResult) :
+    execResultToIRResult init (releasedResult slot r) =
+      execResultToIRResult init r := by
+  cases r <;> rfl
+
+/-- Raw-argument prebinding never touches transient storage. -/
+theorem prebindRawArgs_transient (state : IRState) (params : List Param) :
+    (prebindRawArgs state params).transientStorage = state.transientStorage := by
+  unfold prebindRawArgs
+  generalize (params.map Param.toIRParam).zip state.calldata = l
+  induction l generalizing state with
+  | nil => rfl
+  | cons p rest ih => exact ih (state.setVar p.1.name p.2)
+
+/-- The state a free guarded entry hands to its body: arguments bound, lock
+acquired. -/
+def acquiredBoundState (slot : Nat) (state : IRState) (params : List Param)
+    (bindings : List (String × Nat)) : IRState :=
+  { ParamLoading.applyBindingsToIRState (prebindRawArgs state params) bindings with
+    transientStorage := fun o =>
+      if o = slot then 1
+      else (prebindRawArgs state params).transientStorage o }
+
+/-- Consumer-facing form: the lock overlay reads the ORIGINAL transient
+store. -/
+theorem acquiredBoundState_eq (slot : Nat) (state : IRState)
+    (params : List Param) (bindings : List (String × Nat)) :
+    acquiredBoundState slot state params bindings =
+      { ParamLoading.applyBindingsToIRState (prebindRawArgs state params)
+          bindings with
+        transientStorage := fun o =>
+          if o = slot then 1 else state.transientStorage o } := by
+  simp [acquiredBoundState, prebindRawArgs_transient]
+
+/-- Guarded per-function root, fall-through bodies: a locked entry reverts
+(observable rollback), a free entry projects the body's tail result from the
+acquired bound state. -/
+theorem exec_compiledGuardedFunctionIR_of_body_fallthrough
+    (fields : List Field) (state : IRState) (selector : Nat)
+    (spec : FunctionSpec) (returns : List ParamType)
+    (bodyStmts : List YulStmt) (bindings : List (String × Nat))
+    (tailResult : IRExecResult) (guardedFn : IRFunction)
+    (lockField : String) (field : Field) (slot : Nat)
+    (hlock : spec.nonReentrantLock = some lockField)
+    (hfield : findFieldWithResolvedSlot fields lockField = some (field, slot))
+    (hguard : attachNonReentrantGuard fields spec
+      (compiledFunctionIR selector spec returns bodyStmts) = .ok guardedFn)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (hSS : SpliceSimList bodyStmts)
+    (hH : yulFrameHaltsList bodyStmts = false)
+    (hsupported : ∀ param ∈ spec.params, SupportedExternalParamType param.ty)
+    (hcalldataSizeFits : 4 + state.calldata.length * 32 <
+      Compiler.Constants.evmModulus)
+    (hbind : SourceSemantics.bindSupportedParams spec.params state.calldata =
+      some bindings)
+    (hlock01 : state.transientStorage slot = 0 ∨
+      state.transientStorage slot = 1)
+    (hbody : execIRStmts (stmtsFuelBound bodyStmts)
+        (acquiredBoundState slot state spec.params bindings) bodyStmts =
+      tailResult) :
+    Compiler.Proofs.YulGeneration.execIRFunctionFuel
+        ((genParamLoads spec.params).length +
+          (guardPrologueStmts slot ++
+            applyLockReleaseOnExits (lockReleaseStmt slot) bodyStmts).length +
+          (stmtsFuelBound (spliceLockReleaseList (lockReleaseStmt slot) bodyStmts) +
+            (spliceLockReleaseList (lockReleaseStmt slot) bodyStmts).length + 4) + 1)
+        guardedFn state.calldata state =
+      if state.transientStorage slot = 1 then
+        execResultToIRResult state (.revert state)
+      else
+        execResultToIRResult state tailResult := by
+  let preboundState := prebindRawArgs state spec.params
+  have hbind' :
+      SourceSemantics.bindSupportedParams spec.params preboundState.calldata =
+        some bindings := by
+    simpa [preboundState] using hbind
+  have hfits' : 4 + preboundState.calldata.length * 32 <
+      Compiler.Constants.evmModulus := by
+    simpa [preboundState] using hcalldataSizeFits
+  have htransPre : preboundState.transientStorage = state.transientStorage :=
+    prebindRawArgs_transient state spec.params
+  have hshape := attachNonReentrantGuard_some_shape fields spec
+    (compiledFunctionIR selector spec returns bodyStmts) lockField field slot
+    hlock hfield
+  rw [hguard] at hshape
+  have hbodyEq : guardedFn.body =
+      genParamLoads spec.params ++
+        (guardPrologueStmts slot ++
+          applyLockReleaseOnExits (lockReleaseStmt slot) bodyStmts) := by
+    have := congrArg IRFunction.body (Except.ok.inj hshape)
+    simpa [compiledFunctionIR, List.take_left, List.drop_left,
+      List.append_assoc] using this
+  have hparamsEq : guardedFn.params = spec.params.map Param.toIRParam := by
+    have := congrArg IRFunction.params (Except.ok.inj hshape)
+    simpa [compiledFunctionIR] using this
+  have hmain := execIRStmts_guardedFunction_fallthrough slot hslot spec.params
+    bindings bodyStmts hSS hH
+    (stmtsFuelBound (spliceLockReleaseList (lockReleaseStmt slot) bodyStmts) +
+      (spliceLockReleaseList (lockReleaseStmt slot) bodyStmts).length + 4)
+    (stmtsFuelBound bodyStmts) preboundState hsupported hfits' hbind'
+    (by rw [htransPre]; exact hlock01)
+    (by omega) (le_refl _)
+  unfold Compiler.Proofs.YulGeneration.execIRFunctionFuel
+  rw [hbodyEq, hparamsEq]
+  have hprebound :
+      List.foldl (fun s x => s.setVar x.1.name x.2) state
+        ((List.map Param.toIRParam spec.params).zip state.calldata) =
+      preboundState := rfl
+  rw [hprebound]
+  show (match execIRStmts _ preboundState _ with
+    | .continue s => _
+    | .return v s => _
+    | .stop s => _
+    | .revert s => _) = _
+  rw [hmain, htransPre]
+  by_cases hl : state.transientStorage slot = 1
+  · rw [if_pos hl, if_pos hl]
+    rfl
+  · rw [if_neg hl, if_neg hl]
+    rw [show ({ ParamLoading.applyBindingsToIRState preboundState bindings with
+        transientStorage := fun o => if o = slot then 1
+          else state.transientStorage o } : IRState) =
+      acquiredBoundState slot state spec.params bindings from
+      (acquiredBoundState_eq slot state spec.params bindings).symm]
+    rw [hbody]
+    cases tailResult <;>
+      simp [releasedResult, execResultToIRResult, releaseState]
+
+end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -75,6 +75,7 @@ import Compiler.Proofs.IRGeneration.GenericInduction.Scope
 import Compiler.Proofs.IRGeneration.GenericInduction.Storage
 import Compiler.Proofs.IRGeneration.GenericInduction.StorageWord
 import Compiler.Proofs.IRGeneration.GuardedCompile
+import Compiler.Proofs.IRGeneration.GuardedFunction
 import Compiler.Proofs.IRGeneration.HelperBodyBridge
 import Compiler.Proofs.IRGeneration.HelperBodyShape
 import Compiler.Proofs.IRGeneration.HelperSummaryEvidence
@@ -2985,6 +2986,8 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_head  -- private
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_of_head  -- private
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_stop  -- private
+  -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_selfdestruct  -- private
+  -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_invalid  -- private
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_sstore  -- private
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_mstore  -- private
   -- Compiler.Proofs.IRGeneration.internalFunctionYulName_ne_revert  -- private
@@ -3542,6 +3545,12 @@ end Verity.AxiomAudit
   -- Compiler/Proofs/IRGeneration/GuardedCompile.lean
   Compiler.Proofs.IRGeneration.compileFunctionSpec_body_shape
   Compiler.Proofs.IRGeneration.compileGuardedFunctionSpec_inv
+
+  -- Compiler/Proofs/IRGeneration/GuardedFunction.lean
+  Compiler.Proofs.IRGeneration.execResultToIRResult_releasedResult
+  Compiler.Proofs.IRGeneration.prebindRawArgs_transient
+  Compiler.Proofs.IRGeneration.acquiredBoundState_eq
+  Compiler.Proofs.IRGeneration.exec_compiledGuardedFunctionIR_of_body_fallthrough
 
   -- Compiler/Proofs/IRGeneration/HelperBodyBridge.lean
   Compiler.Proofs.IRGeneration.execIRInternalFunctionWithInternals_obeys_internal_helper_summary
@@ -6710,4 +6719,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6262 theorems/lemmas (4394 public, 1868 private, 0 sorry'd)
+-- Total: 6268 theorems/lemmas (4398 public, 1870 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -51,6 +51,10 @@ ALLOWLIST: set[str] = {
     "execIRStmts_applyLockReleaseOnExits_fallthrough",
     "spliced_cons_switch",
     "execIRStmts_mstore_ptr_expr_block",
+    # guarded-family root: one coherent composition of the shape pin, the
+    # ParamLoading prefix, and the guarded-unit laws; fragmenting it would
+    # duplicate the fuel bookkeeping across artificial sub-lemmas.
+    "exec_compiledGuardedFunctionIR_of_body_fallthrough",
     # #2083 expression-surface closure: both proofs are mechanical constructor/list
     # traversals kept whole so the denotation and scanner cases remain auditable
     # against the corresponding exhaustive expression definitions.


### PR DESCRIPTION
The additive `*_guarded` family begins: `exec_compiledGuardedFunctionIR_of_body_fallthrough` proves the `attachNonReentrantGuard` output executes, at the `IRResult` observable every whole-contract theorem uses, as: locked entry ⇒ revert projection (observable rollback); free entry ⇒ the **plain** projection of the body's tail result from the acquired bound state. The key simplification: `IRResult` doesn't observe transient storage, so the lock release is observably invisible (`execResultToIRResult_releasedResult`) — existing source-correspondence consumers compose with the free case verbatim. No existing statement modified.

Also: `prebindRawArgs_transient`, `acquiredBoundState`(+eq), and the `invalid`/`selfdestruct` freshness threading in `GenericInduction/Calls` (follow-up to #2307).

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions to the IR generation/guarded theorem stack; no runtime compiler or auth changes, with existing theorems left unchanged.
> 
> **Overview**
> Introduces the additive **`*_guarded`** per-function proof layer in `GuardedFunction.lean`, without changing existing unguarded statements.
> 
> **`exec_compiledGuardedFunctionIR_of_body_fallthrough`** is the main result: for `attachNonReentrantGuard` output, `execIRFunctionFuel` at the **`IRResult`** observable matches guard semantics—**locked** entry (`transientStorage slot = 1`) projects to **revert** on the initial state; **free** entry runs the body from **`acquiredBoundState`** and projects the body's tail result. Supporting lemmas show lock **release** is invisible to **`IRResult`** (`execResultToIRResult_releasedResult`), argument prebind does not touch transient storage (`prebindRawArgs_transient`), and **`acquiredBoundState_eq`** for consumers.
> 
> In **`GenericInduction/Calls.lean`**, **`internalFunctionYulName_ne_invalid`** and **`internalFunctionYulName_ne_selfdestruct`** are wired into the `with_internals` internal-call dispatch so helper Yul names stay distinct from those builtins (follow-up to #2307).
> 
> **`PrintAxioms.lean`** imports the new module and registers the public theorems; **`check_proof_length.py`** allowlists the guarded root proof as one coherent fuel/shape composition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac18bb74eae5daebb292edaa76245bdaaa3bade1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->