### PR TITLE
feat(proofs): *_guarded family root, halting twin

### DIFF
--- a/Compiler/Proofs/IRGeneration/GuardedFunction.lean
+++ b/Compiler/Proofs/IRGeneration/GuardedFunction.lean
@@ -155,4 +155,94 @@ theorem exec_compiledGuardedFunctionIR_of_body_fallthrough
     cases tailResult <;>
       simp [releasedResult, execResultToIRResult, releaseState]
 
+/-- Guarded per-function root, modeled-halt bodies. -/
+theorem exec_compiledGuardedFunctionIR_of_body_halting
+    (fields : List Field) (state : IRState) (selector : Nat)
+    (spec : FunctionSpec) (returns : List ParamType)
+    (ys : List YulStmt) (h : YulStmt) (bindings : List (String × Nat))
+    (tailResult : IRExecResult) (guardedFn : IRFunction)
+    (lockField : String) (field : Field) (slot : Nat)
+    (hlock : spec.nonReentrantLock = some lockField)
+    (hfield : findFieldWithResolvedSlot fields lockField = some (field, slot))
+    (hguard : attachNonReentrantGuard fields spec
+      (compiledFunctionIR selector spec returns (ys ++ [h])) = .ok guardedFn)
+    (hslot : slot < Compiler.Constants.evmModulus)
+    (hSS : SpliceSimList (ys ++ [h])) (hmh : ModeledHalt h)
+    (hsupported : ∀ param ∈ spec.params, SupportedExternalParamType param.ty)
+    (hcalldataSizeFits : 4 + state.calldata.length * 32 <
+      Compiler.Constants.evmModulus)
+    (hbind : SourceSemantics.bindSupportedParams spec.params state.calldata =
+      some bindings)
+    (hlock01 : state.transientStorage slot = 0 ∨
+      state.transientStorage slot = 1)
+    (hbody : execIRStmts (stmtsFuelBound (ys ++ [h]))
+        (acquiredBoundState slot state spec.params bindings) (ys ++ [h]) =
+      tailResult) :
+    Compiler.Proofs.YulGeneration.execIRFunctionFuel
+        ((genParamLoads spec.params).length +
+          (guardPrologueStmts slot ++
+            applyLockReleaseOnExits (lockReleaseStmt slot) (ys ++ [h])).length +
+          (stmtsFuelBound (spliceLockReleaseList (lockReleaseStmt slot)
+            (ys ++ [h])) + 2) + 1)
+        guardedFn state.calldata state =
+      if state.transientStorage slot = 1 then
+        execResultToIRResult state (.revert state)
+      else
+        execResultToIRResult state tailResult := by
+  let preboundState := prebindRawArgs state spec.params
+  have hbind' :
+      SourceSemantics.bindSupportedParams spec.params preboundState.calldata =
+        some bindings := by
+    simpa [preboundState] using hbind
+  have hfits' : 4 + preboundState.calldata.length * 32 <
+      Compiler.Constants.evmModulus := by
+    simpa [preboundState] using hcalldataSizeFits
+  have htransPre : preboundState.transientStorage = state.transientStorage :=
+    prebindRawArgs_transient state spec.params
+  have hshape := attachNonReentrantGuard_some_shape fields spec
+    (compiledFunctionIR selector spec returns (ys ++ [h])) lockField field slot
+    hlock hfield
+  rw [hguard] at hshape
+  have hbodyEq : guardedFn.body =
+      genParamLoads spec.params ++
+        (guardPrologueStmts slot ++
+          applyLockReleaseOnExits (lockReleaseStmt slot) (ys ++ [h])) := by
+    have := congrArg IRFunction.body (Except.ok.inj hshape)
+    simpa [compiledFunctionIR, List.take_left, List.drop_left,
+      List.append_assoc] using this
+  have hparamsEq : guardedFn.params = spec.params.map Param.toIRParam := by
+    have := congrArg IRFunction.params (Except.ok.inj hshape)
+    simpa [compiledFunctionIR] using this
+  have hmain := execIRStmts_guardedFunction_halting slot hslot spec.params
+    bindings ys h hSS hmh
+    (stmtsFuelBound (spliceLockReleaseList (lockReleaseStmt slot) (ys ++ [h])) + 2)
+    (stmtsFuelBound (ys ++ [h])) preboundState hsupported hfits' hbind'
+    (by rw [htransPre]; exact hlock01)
+    (by omega) (le_refl _)
+  unfold Compiler.Proofs.YulGeneration.execIRFunctionFuel
+  rw [hbodyEq, hparamsEq]
+  have hprebound :
+      List.foldl (fun s x => s.setVar x.1.name x.2) state
+        ((List.map Param.toIRParam spec.params).zip state.calldata) =
+      preboundState := rfl
+  rw [hprebound]
+  show (match execIRStmts _ preboundState _ with
+    | .continue s => _
+    | .return v s => _
+    | .stop s => _
+    | .revert s => _) = _
+  rw [hmain, htransPre]
+  by_cases hl : state.transientStorage slot = 1
+  · rw [if_pos hl, if_pos hl]
+    rfl
+  · rw [if_neg hl, if_neg hl]
+    rw [show ({ ParamLoading.applyBindingsToIRState preboundState bindings with
+        transientStorage := fun o => if o = slot then 1
+          else state.transientStorage o } : IRState) =
+      acquiredBoundState slot state spec.params bindings from
+      (acquiredBoundState_eq slot state spec.params bindings).symm]
+    rw [hbody]
+    cases tailResult <;>
+      simp [releasedResult, execResultToIRResult, releaseState]
+
 end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3551,6 +3551,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.prebindRawArgs_transient
   Compiler.Proofs.IRGeneration.acquiredBoundState_eq
   Compiler.Proofs.IRGeneration.exec_compiledGuardedFunctionIR_of_body_fallthrough
+  Compiler.Proofs.IRGeneration.exec_compiledGuardedFunctionIR_of_body_halting
 
   -- Compiler/Proofs/IRGeneration/HelperBodyBridge.lean
   Compiler.Proofs.IRGeneration.execIRInternalFunctionWithInternals_obeys_internal_helper_summary
@@ -6719,4 +6720,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6268 theorems/lemmas (4398 public, 1870 private, 0 sorry'd)
+-- Total: 6269 theorems/lemmas (4399 public, 1870 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -55,6 +55,7 @@ ALLOWLIST: set[str] = {
     # ParamLoading prefix, and the guarded-unit laws; fragmenting it would
     # duplicate the fuel bookkeeping across artificial sub-lemmas.
     "exec_compiledGuardedFunctionIR_of_body_fallthrough",
+    "exec_compiledGuardedFunctionIR_of_body_halting",
     # #2083 expression-surface closure: both proofs are mechanical constructor/list
     # traversals kept whole so the denotation and scanner cases remain auditable
     # against the corresponding exhaustive expression definitions.


### PR DESCRIPTION
Mirrors #2309 for modeled-halt bodies: `exec_compiledGuardedFunctionIR_of_body_halting`. The `*_guarded` per-function root now covers both exit classes, symmetric with the unit/function/transformation layers.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proof only; no runtime or auth changes, with CI hygiene updates for axiom inventory and proof length.
> 
> **Overview**
> Adds **`exec_compiledGuardedFunctionIR_of_body_halting`**, the modeled-halt counterpart to the existing fall-through guarded per-function root. For `nonreentrant` functions whose body is `ys ++ [h]` with `ModeledHalt h`, it shows `execIRFunctionFuel` on the guarded compile matches the same observable rule: **locked** entry reverts at the initial state, **free** entry projects the body’s tail `IRExecResult` from the acquired bound state.
> 
> The proof mirrors the fall-through root (shape pin, param-load prefix, lock case split) but delegates the guarded stmt list step to **`execIRStmts_guardedFunction_halting`** with halting-specific fuel bounds.
> 
> Also registers the theorem in **`PrintAxioms.lean`** and allowlists it in **`scripts/check_proof_length.py`** alongside the fall-through guarded root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39aa247e3cdd8948543843c246c445d8fa330212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->