### PR TITLE
feat(api): Uint256.checkedAdd/addNoWrap + ExternalCallResult.control

### DIFF
--- a/Verity/Core/Model/DenoteExternalCalls.lean
+++ b/Verity/Core/Model/DenoteExternalCalls.lean
@@ -59,6 +59,55 @@ def succeeded : ExternalCallResult → Bool
 
 end ExternalCallResult
 
+/-- The control component of an external-call result, with the returndata
+projected away — what branching logic in callers actually inspects. -/
+inductive CallControl where
+  | success
+  | failure
+  | revert
+  deriving DecidableEq, Repr
+
+namespace ExternalCallResult
+
+/-- Project the control component. -/
+def control : ExternalCallResult → CallControl
+  | .success _ => .success
+  | .failure _ => .failure
+  | .revert _ => .revert
+
+/-- A result is exactly its control paired with its returndata. -/
+theorem control_returndata_eta : ∀ (r : ExternalCallResult),
+    r = match r.control with
+      | .success => .success r.returndata
+      | .failure => .failure r.returndata
+      | .revert => .revert r.returndata
+  | .success _ => rfl
+  | .failure _ => rfl
+  | .revert _ => rfl
+
+/-- Two results agree iff their controls and returndata agree. -/
+theorem ext_iff (r₁ r₂ : ExternalCallResult) :
+    r₁ = r₂ ↔ r₁.control = r₂.control ∧ r₁.returndata = r₂.returndata := by
+  constructor
+  · rintro rfl; exact ⟨rfl, rfl⟩
+  · rintro ⟨hc, hd⟩
+    cases r₁ <;> cases r₂ <;>
+      simp_all [control, returndata]
+
+@[simp] theorem control_success (data : List Nat) :
+    (ExternalCallResult.success data).control = .success := rfl
+@[simp] theorem control_failure (data : List Nat) :
+    (ExternalCallResult.failure data).control = .failure := rfl
+@[simp] theorem control_revert (data : List Nat) :
+    (ExternalCallResult.revert data).control = .revert := rfl
+
+/-- `succeeded` is a control fact. -/
+theorem succeeded_iff_control (r : ExternalCallResult) :
+    r.succeeded = true ↔ r.control = .success := by
+  cases r <;> simp [succeeded, control]
+
+end ExternalCallResult
+
 /-- The caller state threaded between call sites. -/
 structure CallState where
   world : Verity.ContractState

--- a/Verity/Core/Uint256.lean
+++ b/Verity/Core/Uint256.lean
@@ -164,6 +164,39 @@ def signextend (byteIdx value : Uint256) : Uint256 :=
     else
       ofNat (value.val &&& mask)
 
+/-- Checked addition: `some` of the exact sum when it fits, `none` on
+overflow — the semantic counterpart of solc-0.8 checked `+` (#1993). -/
+def checkedAdd (a b : Uint256) : Option Uint256 :=
+  if h : a.val + b.val < modulus then some ⟨a.val + b.val, h⟩ else none
+
+/-- A successful checked addition is the wrapping addition, and its value is
+the exact Nat sum — no wrap occurred. -/
+theorem checkedAdd_eq_some {a b c : Uint256}
+    (h : checkedAdd a b = some c) :
+    c = add a b ∧ c.val = a.val + b.val := by
+  unfold checkedAdd at h
+  split at h
+  · rename_i hlt
+    obtain rfl := Option.some.inj h
+    exact ⟨by simp [add, ofNat, Nat.mod_eq_of_lt hlt], rfl⟩
+  · cases h
+
+/-- Checked addition fails exactly on overflow. -/
+theorem checkedAdd_eq_none_iff (a b : Uint256) :
+    checkedAdd a b = none ↔ modulus ≤ a.val + b.val := by
+  unfold checkedAdd
+  split <;> rename_i hlt
+  · simp
+    omega
+  · simp
+    omega
+
+/-- Non-overflowing addition is exact: the wrapped sum's value is the Nat
+sum. -/
+theorem addNoWrap {a b : Uint256} (h : a.val + b.val < modulus) :
+    (add a b).val = a.val + b.val := by
+  simp [add, ofNat, Nat.mod_eq_of_lt h]
+
 -- Overflow detection predicates for safety proofs (on raw Nat values)
 def willAddOverflow (a b : Uint256) : Bool :=
   a.val + b.val ≥ modulus


### PR DESCRIPTION
The two requested upstream API additions:

**Checked arithmetic (#1993 foundation)** — `Uint256.checkedAdd` (`Option`-returning exact addition; `none` exactly on overflow) with `checkedAdd_eq_some` (a successful check is the wrapping add and its value is the exact Nat sum) and `checkedAdd_eq_none_iff`; plus `addNoWrap` (non-overflowing wrapped addition is exact).

**Call observation** — `CallControl` and `ExternalCallResult.control` with `control_returndata_eta` (a result is exactly its control paired with its returndata), `ext_iff`, per-constructor simp lemmas, and `succeeded_iff_control`.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and proofs only; no changes to existing denotation or arithmetic runtime behavior.
> 
> **Overview**
> Adds two **upstream API surfaces** for formal verification: checked `uint256` addition and a control-only view of external call results.
> 
> **`Uint256`:** Introduces `checkedAdd` returning `some` only when `a.val + b.val` fits below the modulus (aligned with Solidity 0.8 checked `+`), plus lemmas `checkedAdd_eq_some`, `checkedAdd_eq_none_iff`, and `addNoWrap` linking non-overflowing wraps to exact Nat sums.
> 
> **External calls:** Adds `CallControl` and `ExternalCallResult.control` so callers can reason about success/failure/revert without returndata. Includes `control_returndata_eta`, `ext_iff`, `@[simp]` control projections, and `succeeded_iff_control` tying `succeeded` to `.success` control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b2266162a5bbc18d764009564371e8e5ac947e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->