### PR TITLE
feat(proofs): decidable SpliceSim/ModeledHalt membership checkers

### DIFF
--- a/Compiler/Proofs/IRGeneration/FragmentCheck.lean
+++ b/Compiler/Proofs/IRGeneration/FragmentCheck.lean
@@ -1,0 +1,186 @@
+import Compiler.Proofs.IRGeneration.SpliceSimulation
+
+/-!
+# Decidable membership checker for the splice-simulation fragment
+
+`SpliceSim` is a `Prop` fragment; consumers of the `*_guarded` family need to
+discharge membership per concrete compiled body.  This module provides the
+executable mirror `spliceSimCheck` with a soundness theorem, so fragment
+membership for any concrete compilation output is a `decide`/`native_decide`
+obligation — the same per-contract discharge style the rest of the proof
+stack uses — with no induction over the source grammar required.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+
+mutual
+
+/-- Executable mirror of `SpliceSim`. -/
+def spliceSimCheck : YulStmt → Bool
+  | .if_ _ body => spliceSimCheckList body
+  | .block stmts => spliceSimCheckList stmts
+  | .for_ _ _ _ _ => false
+  | .switch _ cases dflt =>
+      spliceSimCheckCases cases && spliceSimCheckDflt dflt
+  | .exprStmt (.call "return" args) =>
+      match args with
+      | [.lit _, .lit _] => true
+      | _ => false
+  | .exprStmt (.call "stop" args) => args.isEmpty
+  | .exprStmt (.call "selfdestruct" _) => false
+  | _ => true
+
+def spliceSimCheckCases : List (Nat × List YulStmt) → Bool
+  | [] => true
+  | c :: rest => spliceSimCheckList c.2 && spliceSimCheckCases rest
+
+def spliceSimCheckDflt : Option (List YulStmt) → Bool
+  | none => true
+  | some stmts => spliceSimCheckList stmts
+
+def spliceSimCheckList : List YulStmt → Bool
+  | [] => true
+  | s :: rest => spliceSimCheck s && spliceSimCheckList rest
+
+end
+
+mutual
+
+/-- Soundness: a checked statement is in the fragment. -/
+theorem spliceSimCheck_sound : ∀ (s : YulStmt), spliceSimCheck s = true →
+    SpliceSim s
+  | .if_ _ body, h => by
+      simp only [SpliceSim]
+      exact spliceSimCheckList_sound body (by simpa [spliceSimCheck] using h)
+  | .block stmts, h => by
+      simp only [SpliceSim]
+      exact spliceSimCheckList_sound stmts (by simpa [spliceSimCheck] using h)
+  | .for_ _ _ _ _, h => by simp [spliceSimCheck] at h
+  | .switch _ cases dflt, h => by
+      obtain ⟨hc, hd⟩ : spliceSimCheckCases cases = true ∧
+          spliceSimCheckDflt dflt = true := by
+        simpa [spliceSimCheck, Bool.and_eq_true] using h
+      exact ⟨spliceSimCheckCases_sound cases hc, spliceSimCheckDflt_sound dflt hd⟩
+  | .comment _, _ => trivial
+  | .let_ _ _, _ => trivial
+  | .letMany _ _, _ => trivial
+  | .assign _ _, _ => trivial
+  | .leave, _ => trivial
+  | .funcDef _ _ _ _, _ => trivial
+  | .exprStmt e, h => by
+      cases e with
+      | call f args =>
+          by_cases hret : f = "return"
+          · subst hret
+            simp only [SpliceSim]
+            cases args with
+            | nil => simp [spliceSimCheck] at h
+            | cons a rest =>
+                cases rest with
+                | nil => cases a <;> simp [spliceSimCheck] at h
+                | cons b rest' =>
+                    cases rest' with
+                    | cons _ _ => cases a <;> cases b <;> simp [spliceSimCheck] at h
+                    | nil =>
+                        cases a <;> cases b <;>
+                          first
+                            | exact ⟨_, _, rfl⟩
+                            | simp [spliceSimCheck] at h
+          · by_cases hstop : f = "stop"
+            · subst hstop
+              simp only [SpliceSim]
+              cases args with
+              | nil => rfl
+              | cons _ _ => simp [spliceSimCheck] at h
+            · by_cases hsd : f = "selfdestruct"
+              · subst hsd
+                simp [spliceSimCheck] at h
+              · rw [SpliceSim.eq_def]
+                split <;> simp_all
+      | lit _ => trivial
+      | hex _ => trivial
+      | ident _ => trivial
+      | str _ => trivial
+
+theorem spliceSimCheckCases_sound :
+    ∀ (cs : List (Nat × List YulStmt)), spliceSimCheckCases cs = true →
+      SpliceSimCases cs
+  | [], _ => trivial
+  | c :: rest, h => by
+      obtain ⟨hc, hrest⟩ : spliceSimCheckList c.2 = true ∧
+          spliceSimCheckCases rest = true := by
+        simpa [spliceSimCheckCases, Bool.and_eq_true] using h
+      exact ⟨spliceSimCheckList_sound c.2 hc, spliceSimCheckCases_sound rest hrest⟩
+
+theorem spliceSimCheckDflt_sound :
+    ∀ (d : Option (List YulStmt)), spliceSimCheckDflt d = true →
+      SpliceSimDflt d
+  | none, _ => trivial
+  | some stmts, h =>
+      spliceSimCheckList_sound stmts (by simpa [spliceSimCheckDflt] using h)
+
+theorem spliceSimCheckList_sound :
+    ∀ (xs : List YulStmt), spliceSimCheckList xs = true → SpliceSimList xs
+  | [], _ => trivial
+  | s :: rest, h => by
+      obtain ⟨hs, hrest⟩ : spliceSimCheck s = true ∧
+          spliceSimCheckList rest = true := by
+        simpa [spliceSimCheckList, Bool.and_eq_true] using h
+      exact ⟨spliceSimCheck_sound s hs, spliceSimCheckList_sound rest hrest⟩
+
+end
+
+/-- Executable mirror of `ModeledHalt`. -/
+def modeledHaltCheck : YulStmt → Bool
+  | .exprStmt (.call "stop" args) => args.isEmpty
+  | .exprStmt (.call "return" args) =>
+      match args with
+      | [.lit _, .lit _] => true
+      | _ => false
+  | .exprStmt (.call "revert" args) => args.length == 2
+  | .exprStmt (.call "invalid" args) => args.isEmpty
+  | _ => false
+
+theorem modeledHaltCheck_sound : ∀ (s : YulStmt), modeledHaltCheck s = true →
+    ModeledHalt s
+  | .exprStmt (.call f args), h => by
+      by_cases hstop : f = "stop"
+      · subst hstop
+        obtain rfl : args = [] := by
+          simpa [modeledHaltCheck, List.isEmpty_iff] using h
+        exact .stop
+      · by_cases hret : f = "return"
+        · subst hret
+          cases args with
+          | nil => simp [modeledHaltCheck] at h
+          | cons a rest =>
+              cases rest with
+              | nil => cases a <;> simp [modeledHaltCheck] at h
+              | cons b rest' =>
+                  cases rest' with
+                  | cons _ _ => cases a <;> cases b <;> simp [modeledHaltCheck] at h
+                  | nil =>
+                      cases a <;> cases b <;>
+                        first
+                          | exact ModeledHalt.ret _ _
+                          | simp [modeledHaltCheck] at h
+        · by_cases hrev : f = "revert"
+          · subst hrev
+            cases args with
+            | nil => simp [modeledHaltCheck] at h
+            | cons a rest =>
+                cases rest with
+                | nil => simp [modeledHaltCheck] at h
+                | cons b rest' =>
+                    cases rest' with
+                    | nil => exact .rev a b
+                    | cons _ _ => simp [modeledHaltCheck] at h
+          · by_cases hinv : f = "invalid"
+            · subst hinv
+              obtain rfl : args = [] := by
+                simpa [modeledHaltCheck, List.isEmpty_iff] using h
+              exact .inv
+            · simp [modeledHaltCheck, hstop, hret, hrev, hinv] at h
+
+end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -56,6 +56,7 @@ import Compiler.Proofs.IRGeneration.Dispatch
 import Compiler.Proofs.IRGeneration.DynamicAbiRefinement
 import Compiler.Proofs.IRGeneration.ErrorStringPayloadIR
 import Compiler.Proofs.IRGeneration.EventObservable
+import Compiler.Proofs.IRGeneration.FragmentCheck
 import Compiler.Proofs.IRGeneration.FuelBound
 import Compiler.Proofs.IRGeneration.Function
 import Compiler.Proofs.IRGeneration.FunctionBody.Base
@@ -2364,6 +2365,13 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.execIRStmts_mstore_ptr_expr_block
   Compiler.Proofs.IRGeneration.normalizeEventWord_memInsensitive
   Compiler.Proofs.IRGeneration.scalarEventUnindexedStoresFrom_shape
+
+  -- Compiler/Proofs/IRGeneration/FragmentCheck.lean
+  Compiler.Proofs.IRGeneration.spliceSimCheck_sound
+  Compiler.Proofs.IRGeneration.spliceSimCheckCases_sound
+  Compiler.Proofs.IRGeneration.spliceSimCheckDflt_sound
+  Compiler.Proofs.IRGeneration.spliceSimCheckList_sound
+  Compiler.Proofs.IRGeneration.modeledHaltCheck_sound
 
   -- Compiler/Proofs/IRGeneration/FuelBound.lean
   Compiler.Proofs.IRGeneration.stmtFuelBound_pos
@@ -6720,4 +6728,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6269 theorems/lemmas (4399 public, 1870 private, 0 sorry'd)
+-- Total: 6274 theorems/lemmas (4404 public, 1870 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -56,6 +56,10 @@ ALLOWLIST: set[str] = {
     # duplicate the fuel bookkeeping across artificial sub-lemmas.
     "exec_compiledGuardedFunctionIR_of_body_fallthrough",
     "exec_compiledGuardedFunctionIR_of_body_halting",
+    # decidable-checker soundness: exhaustive constructor sweep of the
+    # executable mirror; splitting per constructor would break the mutual
+    # recursion with the Cases/Dflt/List companions.
+    "spliceSimCheck_sound",
     # #2083 expression-surface closure: both proofs are mechanical constructor/list
     # traversals kept whole so the denotation and scanner cases remain auditable
     # against the corresponding exhaustive expression definitions.


### PR DESCRIPTION
Completes the consumable `*_guarded` story: `spliceSimCheck`/`modeledHaltCheck` executable mirrors with soundness theorems — fragment hypotheses discharge per concrete compiled body via `decide`/`native_decide`, no source-grammar induction. Exploration confirms supported-fragment output (minus the two degenerate `forEach` constructors) always passes.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions (new checker definitions and soundness lemmas) with no runtime, auth, or compilation pipeline behavior changes.
> 
> **Overview**
> Adds **`FragmentCheck.lean`** with executable **`spliceSimCheck`** / **`modeledHaltCheck`** that mirror the existing **`SpliceSim`** and **`ModeledHalt`** predicates on Yul IR, plus mutual soundness lemmas so `true` implies the corresponding `Prop`.
> 
> This lets `*_guarded` consumers discharge fragment membership on concrete compiled bodies with **`decide`** / **`native_decide`** instead of manual proof or source-grammar induction. **`PrintAxioms.lean`** imports the module and lists the five new theorems; **`check_proof_length.py`** allowlists **`spliceSimCheck_sound`** because splitting would break the mutual recursion with the list/cases/dflt companions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9ee24489632abcbec91bc47a990352de4228a9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->