### PR TITLE
feat(proofs): guarded whole-contract shape lemmas (additive)

### DIFF
--- a/Compiler/Proofs/IRGeneration/GuardedContractShape.lean
+++ b/Compiler/Proofs/IRGeneration/GuardedContractShape.lean
@@ -1,0 +1,102 @@
+import Compiler.Proofs.IRGeneration.GuardedCompile
+import Compiler.Proofs.IRGeneration.ContractShape
+import Compiler.Proofs.IRGeneration.Function
+
+/-!
+# Shape lemmas for the guarded whole-contract variant (additive)
+
+The existing whole-contract chain erases `compileGuardedFunctionSpec` down to
+`compileFunctionSpec` via the global lock-free rewrite.  The `*_guarded`
+variant instead keeps the guarded pipeline: this module provides the
+erasure-free `Forall₂` decomposition of the compile mapM and the metadata
+preservation facts the dispatcher lookup needs (`attachNonReentrantGuard`
+touches only the body).
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+open Compiler.CompilationModel
+open Verity.Core.Intrinsics (HardFork)
+
+/-- The guard transformation preserves every metadata field. -/
+theorem attachNonReentrantGuard_metadata (fields : List Field)
+    (spec : FunctionSpec) (irFn fn' : IRFunction)
+    (h : attachNonReentrantGuard fields spec irFn = .ok fn') :
+    fn'.name = irFn.name ∧ fn'.selector = irFn.selector ∧
+      fn'.params = irFn.params ∧ fn'.ret = irFn.ret ∧
+      fn'.payable = irFn.payable := by
+  unfold attachNonReentrantGuard at h
+  cases hlock : spec.nonReentrantLock with
+  | none =>
+      rw [hlock] at h
+      obtain rfl := Except.ok.inj h
+      exact ⟨rfl, rfl, rfl, rfl, rfl⟩
+  | some lockField =>
+      rw [hlock] at h
+      simp only [bind, Except.bind] at h
+      cases hpro : nonReentrantGuardPrologue fields lockField with
+      | error e =>
+          rw [hpro] at h
+          cases h
+      | ok guardStmts =>
+          rw [hpro] at h
+          obtain rfl := Except.ok.inj h
+          exact ⟨rfl, rfl, rfl, rfl, rfl⟩
+
+/-- Guarded-pipeline metadata: selector/params/payable come from the spec
+exactly as in the unguarded pipeline. -/
+theorem compileGuardedFunctionSpec_ok_metadata (fields : List Field)
+    (events : List EventDef) (errors : List ErrorDef)
+    (internalFunctions : List FunctionSpec)
+    (sel : Nat) (spec : FunctionSpec) (fn : IRFunction)
+    (h : compileGuardedFunctionSpec fields events errors [] internalFunctions
+      sel spec = .ok fn) :
+    fn.params = spec.params.map Param.toIRParam ∧
+      fn.selector = sel ∧ fn.payable = spec.isPayable := by
+  obtain ⟨irFn, hcompile, hattach⟩ :=
+    compileGuardedFunctionSpec_inv fields events errors [] internalFunctions
+      sel spec .cancun fn h
+  obtain ⟨hparams, hsel, hpay⟩ :=
+    Function.compileFunctionSpec_ok_metadata_with_internals fields events errors
+      sel spec irFn internalFunctions hcompile
+  obtain ⟨_, hsel', hparams', _, hpay'⟩ :=
+    attachNonReentrantGuard_metadata fields spec irFn fn hattach
+  exact ⟨hparams' ▸ hparams, hsel' ▸ hsel, hpay' ▸ hpay⟩
+
+/-- Erasure-free `Forall₂` decomposition of the guarded compile mapM: no
+lock-free hypothesis, each entry is characterized by the guarded pipeline. -/
+theorem guarded_functions_forall₂_of_mapM_ok
+    (fields : List Field) (events : List EventDef) (errors : List ErrorDef)
+    (internalFunctions : List FunctionSpec) :
+    ∀ (entries : List (FunctionSpec × Nat)) irFns,
+      (entries.mapM fun (entry : FunctionSpec × Nat) =>
+        compileGuardedFunctionSpec fields events errors [] internalFunctions
+          entry.2 entry.1) = Except.ok irFns →
+      List.Forall₂
+        (fun (entry : FunctionSpec × Nat) irFn =>
+          compileGuardedFunctionSpec fields events errors [] internalFunctions
+            entry.2 entry.1 = Except.ok irFn)
+        entries irFns := by
+  intro entries
+  induction entries with
+  | nil =>
+      intro irFns hmap
+      cases hmap
+      simp
+  | cons entry entries ih =>
+      intro irFns hmap
+      rcases hstep : compileGuardedFunctionSpec fields events errors []
+          internalFunctions entry.2 entry.1 with _ | irFn
+      · simp only [List.mapM_cons, hstep, bind, Except.bind] at hmap
+        cases hmap
+      · rcases htail : List.mapM
+            (fun (entry : FunctionSpec × Nat) =>
+              compileGuardedFunctionSpec fields events errors []
+                internalFunctions entry.2 entry.1) entries with _ | irFnsTail
+        · simp only [List.mapM_cons, hstep, htail, bind, Except.bind] at hmap
+          cases hmap
+        · simp only [List.mapM_cons, hstep, htail, bind, Except.bind] at hmap
+          cases hmap
+          exact List.Forall₂.cons hstep (ih _ htail)
+
+end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -76,6 +76,7 @@ import Compiler.Proofs.IRGeneration.GenericInduction.Scope
 import Compiler.Proofs.IRGeneration.GenericInduction.Storage
 import Compiler.Proofs.IRGeneration.GenericInduction.StorageWord
 import Compiler.Proofs.IRGeneration.GuardedCompile
+import Compiler.Proofs.IRGeneration.GuardedContractShape
 import Compiler.Proofs.IRGeneration.GuardedFunction
 import Compiler.Proofs.IRGeneration.HelperBodyBridge
 import Compiler.Proofs.IRGeneration.HelperBodyShape
@@ -3554,6 +3555,11 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.compileFunctionSpec_body_shape
   Compiler.Proofs.IRGeneration.compileGuardedFunctionSpec_inv
 
+  -- Compiler/Proofs/IRGeneration/GuardedContractShape.lean
+  Compiler.Proofs.IRGeneration.attachNonReentrantGuard_metadata
+  Compiler.Proofs.IRGeneration.compileGuardedFunctionSpec_ok_metadata
+  Compiler.Proofs.IRGeneration.guarded_functions_forall₂_of_mapM_ok
+
   -- Compiler/Proofs/IRGeneration/GuardedFunction.lean
   Compiler.Proofs.IRGeneration.execResultToIRResult_releasedResult
   Compiler.Proofs.IRGeneration.prebindRawArgs_transient
@@ -6728,4 +6734,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6274 theorems/lemmas (4404 public, 1870 private, 0 sorry'd)
+-- Total: 6277 theorems/lemmas (4407 public, 1870 private, 0 sorry'd)


### PR DESCRIPTION
Pieces 1-3 of the `compile_preserves_semantics_guarded` plan (per the Contract.lean scouting): `attachNonReentrantGuard_metadata`, `compileGuardedFunctionSpec_ok_metadata`, and `guarded_functions_forall₂_of_mapM_ok` — the erasure-free `Forall₂` decomposition of the guarded compile mapM plus the metadata facts the dispatcher lookup needs. Remaining assembly: the Dispatch-level guarded `interpretContract` lemma and the fuel/source bridges to the family root (#2309/#2310) with the decidable checkers (#2312).

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions with no changes to compilation or runtime behavior; risk is limited to proof maintenance and axiom inventory.
> 
> **Overview**
> Adds **`GuardedContractShape.lean`** with three lemmas for the guarded whole-contract proof track, without reducing `compileGuardedFunctionSpec` to the lock-free `compileFunctionSpec` path.
> 
> **`attachNonReentrantGuard_metadata`** shows the non-reentrant guard step only changes the IR body and leaves name, selector, params, return type, and payable unchanged. **`compileGuardedFunctionSpec_ok_metadata`** carries that through so successful guarded compiles still expose params, selector, and payable from the spec. **`guarded_functions_forall₂_of_mapM_ok`** is the standard `mapM`/`Forall₂` split for batched guarded compiles, stated directly on `compileGuardedFunctionSpec` with no lock-free rewrite hypothesis.
> 
> The new theorems are wired into **`PrintAxioms.lean`** (import + public axiom list); theorem count goes from 6274 to 6277.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc5e457fd028940ad2d7c077a4f235eb484b90e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->