### PR TITLE
feat(proofs): predicate-generic dispatcher + guarded instance

### DIFF
--- a/Compiler/Proofs/IRGeneration/Dispatch.lean
+++ b/Compiler/Proofs/IRGeneration/Dispatch.lean
@@ -49,7 +49,7 @@ private theorem decodeSupportedParamWord_some_of_supported
     ∃ value, SourceSemantics.decodeSupportedParamWord ty word = some value := by
   cases ty <;> simp [SupportedExternalParamType, SourceSemantics.decodeSupportedParamWord] at hsupported ⊢
 
-private theorem bindSupportedParams_some_of_supported
+theorem bindSupportedParams_some_of_supported
     (params : List Param) (args : List Nat)
     (hsupported : ∀ param ∈ params, SupportedExternalParamType param.ty)
     (hlen : params.length ≤ args.length) :

--- a/Compiler/Proofs/IRGeneration/GuardedDispatch.lean
+++ b/Compiler/Proofs/IRGeneration/GuardedDispatch.lean
@@ -1,0 +1,244 @@
+import Compiler.Proofs.IRGeneration.GuardedContractShape
+import Compiler.Proofs.IRGeneration.Dispatch
+
+/-!
+# Predicate-generic dispatcher correctness and its guarded instance
+
+`interpretContract_correct_of_compiled_functions` fixes the per-entry
+characterization to `compileFunctionSpec`.  Its proof only consumes that
+predicate through metadata (selector/params/payable) and the per-function
+callback — so this module states the dispatcher lemma once, generic over the
+compile predicate, and instantiates it for the guarded pipeline with the
+metadata facts from `GuardedContractShape`.  The existing theorem statements
+are untouched.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+open Compiler.CompilationModel
+open Compiler.Proofs.IRGeneration.Dispatch
+
+section Generic
+
+variable (P : FunctionSpec → Nat → IRFunction → Prop)
+
+/-- Selector alignment of `find?` under any selector-faithful predicate. -/
+private theorem find_function_some_of_forall₂_generic
+    (hsel : ∀ fn sel irFn, P fn sel irFn → irFn.selector = sel)
+    (selector : Nat)
+    {pairs : List (FunctionSpec × Nat)} {irFns : List IRFunction}
+    (hcompiled : List.Forall₂ (fun entry irFn => P entry.1 entry.2 irFn)
+      pairs irFns)
+    {fn : FunctionSpec} {sel : Nat}
+    (hfind : pairs.find? (fun entry => entry.2 == selector) = some (fn, sel)) :
+    ∃ irFn,
+      irFns.find? (fun irFn => irFn.selector == selector) = some irFn ∧
+      P fn sel irFn := by
+  induction hcompiled generalizing fn sel with
+  | nil => simp at hfind
+  | @cons entry irFn pairs irFns hhead hrest ih =>
+      rcases entry with ⟨headFn, headSel⟩
+      by_cases hselEq : headSel = selector
+      · simp [hselEq] at hfind
+        rcases hfind with ⟨rfl, rfl⟩
+        refine ⟨irFn, ?_, by simpa [hselEq] using hhead⟩
+        have hselector : irFn.selector = selector := by
+          calc irFn.selector = headSel := hsel headFn headSel irFn hhead
+            _ = selector := hselEq
+        simp [hselector]
+      · have hfindRest :
+            pairs.find? (fun entry => entry.2 == selector) = some (fn, sel) := by
+          simpa [hselEq] using hfind
+        rcases ih hfindRest with ⟨irFn', hfindIr, hP⟩
+        refine ⟨irFn', ?_, hP⟩
+        have hheadSelector : irFn.selector = headSel :=
+          hsel headFn headSel irFn hhead
+        simp [hselEq, hheadSelector, hfindIr]
+
+private theorem find_function_none_of_forall₂_generic
+    (hsel : ∀ fn sel irFn, P fn sel irFn → irFn.selector = sel)
+    (selector : Nat)
+    {pairs : List (FunctionSpec × Nat)} {irFns : List IRFunction}
+    (hcompiled : List.Forall₂ (fun entry irFn => P entry.1 entry.2 irFn)
+      pairs irFns)
+    (hfind : pairs.find? (fun entry => entry.2 == selector) = none) :
+    irFns.find? (fun irFn => irFn.selector == selector) = none := by
+  induction hcompiled with
+  | nil => simp
+  | @cons entry irFn pairs irFns hhead hrest ih =>
+      rcases entry with ⟨headFn, headSel⟩
+      by_cases hselEq : headSel = selector
+      · simp [hselEq] at hfind
+      · have hfindRest :
+            pairs.find? (fun entry => entry.2 == selector) = none := by
+          simpa [hselEq] using hfind
+        have hheadSelector : irFn.selector = headSel :=
+          hsel headFn headSel irFn hhead
+        simp [hselEq, hheadSelector, ih hfindRest]
+
+/-- Dispatcher correctness, generic over the per-entry compile predicate. -/
+theorem interpretContract_correct_of_functions_generic
+    (model : CompilationModel) (selectors : List Nat)
+    (irFns : List IRFunction) (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (hmeta : ∀ fn sel irFn, P fn sel irFn →
+      irFn.params = fn.params.map Param.toIRParam ∧
+        irFn.selector = sel ∧ irFn.payable = fn.isPayable)
+    (hcompiled : List.Forall₂ (fun entry irFn => P entry.1 entry.2 irFn)
+      (SourceSemantics.selectorFunctionPairs model selectors) irFns)
+    (hparamsSupported :
+      ∀ fn ∈ selectorDispatchedFunctions model,
+        ∀ param ∈ fn.params, SupportedExternalParamType param.ty)
+    (hfunction :
+      ∀ fn sel irFn bindings,
+        fn ∈ selectorDispatchedFunctions model →
+        P fn sel irFn →
+        SourceSemantics.bindSupportedParams fn.params tx.args = some bindings →
+        FunctionBody.sourceResultMatchesIRResult
+          (SourceSemantics.interpretFunction model fn tx initialWorld)
+          (execIRFunction irFn tx.args
+            (FunctionBody.initialIRStateForTx model tx initialWorld))) :
+    FunctionBody.sourceResultMatchesIRResult
+      (SourceSemantics.interpretContract model selectors tx initialWorld)
+      (interpretIR (runtimeContractOfFunctions model.name irFns) tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  have hsel : ∀ fn sel irFn, P fn sel irFn → irFn.selector = sel :=
+    fun fn sel irFn hP => (hmeta fn sel irFn hP).2.1
+  let pairs := SourceSemantics.selectorFunctionPairs model selectors
+  have hinterp :
+      interpretIR (runtimeContractOfFunctions model.name irFns) tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld) =
+      match irFns.find? (fun irFn => irFn.selector == tx.functionSelector) with
+      | some irFn =>
+          if !irFn.payable && tx.msgValue % Compiler.Constants.evmModulus != 0 then
+            { success := false
+              returnValue := none
+              finalStorage := (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              finalMappings := Compiler.Proofs.storageAsMappings
+                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              events := (FunctionBody.initialIRStateForTx model tx initialWorld).events }
+          else if irFn.params.length ≤ tx.args.length then
+            execIRFunction irFn tx.args (FunctionBody.initialIRStateForTx model tx initialWorld)
+          else
+            { success := false
+              returnValue := none
+              finalStorage := (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              finalMappings := Compiler.Proofs.storageAsMappings
+                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              events := (FunctionBody.initialIRStateForTx model tx initialWorld).events }
+      | none =>
+          { success := false
+            returnValue := none
+            finalStorage := (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+            finalMappings := Compiler.Proofs.storageAsMappings
+              (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+            events := (FunctionBody.initialIRStateForTx model tx initialWorld).events } := by
+        rfl
+  unfold SourceSemantics.interpretContract SourceSemantics.findFunctionBySelector
+  cases hfindPairs :
+      pairs.find? (fun entry => entry.2 == tx.functionSelector) with
+  | none =>
+      have hfindIr :
+          irFns.find? (fun irFn => irFn.selector == tx.functionSelector) = none :=
+        find_function_none_of_forall₂_generic P hsel tx.functionSelector
+          hcompiled hfindPairs
+      rw [hinterp, hfindIr]
+      simp [hfindPairs, FunctionBody.sourceResultMatchesIRResult,
+        SourceSemantics.revertedResult, FunctionBody.initialIRStateForTx,
+        FunctionBody.encodeStorage_withTransactionContext,
+        FunctionBody.encodeEvents_withTransactionContext]
+  | some pair =>
+      rcases pair with ⟨fn, sel⟩
+      rcases find_function_some_of_forall₂_generic P hsel tx.functionSelector
+          hcompiled hfindPairs with ⟨irFn, hfindIr, hPfn⟩
+      have hpairMem : (fn, sel) ∈ pairs := List.mem_of_find?_eq_some hfindPairs
+      have hfnMem : fn ∈ selectorDispatchedFunctions model := by
+        simpa [pairs, SourceSemantics.selectorFunctionPairs] using
+          (List.of_mem_zip hpairMem).1
+      obtain ⟨hparamsEq, _, hpayableEq⟩ := hmeta fn sel irFn hPfn
+      have hlenEq : irFn.params.length = fn.params.length := by
+        simpa [hparamsEq]
+      by_cases hguard : (!fn.isPayable && tx.msgValue % Compiler.Constants.evmModulus != 0) = true
+      · have hguardIr :
+            (!irFn.payable && tx.msgValue % Compiler.Constants.evmModulus != 0) = true := by
+          simpa [hpayableEq] using hguard
+        rw [hinterp, hfindIr]
+        simp [hfindPairs, hguard, hguardIr, FunctionBody.sourceResultMatchesIRResult,
+          SourceSemantics.revertedResult, FunctionBody.initialIRStateForTx,
+          FunctionBody.encodeStorage_withTransactionContext,
+          FunctionBody.encodeEvents_withTransactionContext]
+      · have hguardFalse :
+            (!fn.isPayable && tx.msgValue % Compiler.Constants.evmModulus != 0) = false :=
+          Bool.eq_false_iff.2 hguard
+        have hguardIrFalse :
+            (!irFn.payable && tx.msgValue % Compiler.Constants.evmModulus != 0) = false := by
+          simpa [hpayableEq] using hguardFalse
+        by_cases hlen : fn.params.length ≤ tx.args.length
+        · rcases bindSupportedParams_some_of_supported fn.params tx.args
+              (hparamsSupported fn hfnMem) hlen with ⟨bindings, hbindings⟩
+          have hmatch := hfunction fn sel irFn bindings hfnMem hPfn hbindings
+          have hlenIr : irFn.params.length ≤ tx.args.length := by
+            simpa [hlenEq] using hlen
+          rw [hinterp, hfindIr]
+          simpa [hfindPairs, hguardFalse, hguardIrFalse, hlenIr] using hmatch
+        · have hbindNone : SourceSemantics.bindSupportedParams fn.params tx.args = none := by
+            cases hbind : SourceSemantics.bindSupportedParams fn.params tx.args with
+            | none => rfl
+            | some bindings =>
+                exact absurd (ParamLoading.bindSupportedParams_some_length hbind) hlen
+          have hlenIr : ¬ irFn.params.length ≤ tx.args.length := by
+            simpa [hlenEq] using hlen
+          have hbindExternalNone :
+              SourceSemantics.bindExternalParams tx.functionSelector fn.params tx.args = none :=
+            SourceSemantics.bindExternalParams_eq_none_of_not_length_le tx.functionSelector hlen
+          rw [hinterp, hfindIr]
+          simp [SourceSemantics.interpretFunction, hbindNone, hbindExternalNone,
+            hfindPairs, hguardFalse, hguardIrFalse, hlenIr,
+            FunctionBody.sourceResultMatchesIRResult,
+            SourceSemantics.revertedResult, FunctionBody.initialIRStateForTx,
+            FunctionBody.encodeStorage_withTransactionContext,
+            FunctionBody.encodeEvents_withTransactionContext]
+
+end Generic
+
+/-- Guarded instance: dispatcher correctness with entries characterized by
+the guarded pipeline. -/
+theorem interpretContract_correct_of_compiled_guarded_functions
+    (model : CompilationModel) (selectors : List Nat)
+    (internalFunctions : List FunctionSpec)
+    (irFns : List IRFunction) (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (hcompiled : List.Forall₂
+      (fun (entry : FunctionSpec × Nat) irFn =>
+        compileGuardedFunctionSpec model.fields model.events model.errors []
+          internalFunctions entry.2 entry.1 = Except.ok irFn)
+      (SourceSemantics.selectorFunctionPairs model selectors) irFns)
+    (hparamsSupported :
+      ∀ fn ∈ selectorDispatchedFunctions model,
+        ∀ param ∈ fn.params, SupportedExternalParamType param.ty)
+    (hfunction :
+      ∀ fn sel irFn bindings,
+        fn ∈ selectorDispatchedFunctions model →
+        compileGuardedFunctionSpec model.fields model.events model.errors []
+          internalFunctions sel fn = Except.ok irFn →
+        SourceSemantics.bindSupportedParams fn.params tx.args = some bindings →
+        FunctionBody.sourceResultMatchesIRResult
+          (SourceSemantics.interpretFunction model fn tx initialWorld)
+          (execIRFunction irFn tx.args
+            (FunctionBody.initialIRStateForTx model tx initialWorld))) :
+    FunctionBody.sourceResultMatchesIRResult
+      (SourceSemantics.interpretContract model selectors tx initialWorld)
+      (interpretIR (runtimeContractOfFunctions model.name irFns) tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
+  interpretContract_correct_of_functions_generic
+    (fun fn sel irFn =>
+      compileGuardedFunctionSpec model.fields model.events model.errors []
+        internalFunctions sel fn = Except.ok irFn)
+    model selectors irFns tx initialWorld
+    (fun fn sel irFn hP => by
+      obtain ⟨hp, hs, hpay⟩ := compileGuardedFunctionSpec_ok_metadata
+        model.fields model.events model.errors internalFunctions sel fn irFn hP
+      exact ⟨hp, hs, hpay⟩)
+    hcompiled hparamsSupported hfunction
+
+end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -77,6 +77,7 @@ import Compiler.Proofs.IRGeneration.GenericInduction.Storage
 import Compiler.Proofs.IRGeneration.GenericInduction.StorageWord
 import Compiler.Proofs.IRGeneration.GuardedCompile
 import Compiler.Proofs.IRGeneration.GuardedContractShape
+import Compiler.Proofs.IRGeneration.GuardedDispatch
 import Compiler.Proofs.IRGeneration.GuardedFunction
 import Compiler.Proofs.IRGeneration.HelperBodyBridge
 import Compiler.Proofs.IRGeneration.HelperBodyShape
@@ -2317,7 +2318,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Dispatch.runtimeContractOfFunctions_legacyCompatible
   Compiler.Proofs.IRGeneration.Dispatch.runtimeContractOfFunctions_disjoint
   -- Compiler.Proofs.IRGeneration.Dispatch.decodeSupportedParamWord_some_of_supported  -- private
-  -- Compiler.Proofs.IRGeneration.Dispatch.bindSupportedParams_some_of_supported  -- private
+  Compiler.Proofs.IRGeneration.Dispatch.bindSupportedParams_some_of_supported
   -- Compiler.Proofs.IRGeneration.Dispatch.find_compiledFunction_some_of_forall₂  -- private
   -- Compiler.Proofs.IRGeneration.Dispatch.find_compiledFunction_none_of_forall₂  -- private
   Compiler.Proofs.IRGeneration.Dispatch.interpretContract_correct_of_compiled_functions
@@ -3559,6 +3560,12 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.attachNonReentrantGuard_metadata
   Compiler.Proofs.IRGeneration.compileGuardedFunctionSpec_ok_metadata
   Compiler.Proofs.IRGeneration.guarded_functions_forall₂_of_mapM_ok
+
+  -- Compiler/Proofs/IRGeneration/GuardedDispatch.lean
+  -- Compiler.Proofs.IRGeneration.find_function_some_of_forall₂_generic  -- private
+  -- Compiler.Proofs.IRGeneration.find_function_none_of_forall₂_generic  -- private
+  Compiler.Proofs.IRGeneration.interpretContract_correct_of_functions_generic
+  Compiler.Proofs.IRGeneration.interpretContract_correct_of_compiled_guarded_functions
 
   -- Compiler/Proofs/IRGeneration/GuardedFunction.lean
   Compiler.Proofs.IRGeneration.execResultToIRResult_releasedResult
@@ -6734,4 +6741,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6277 theorems/lemmas (4407 public, 1870 private, 0 sorry'd)
+-- Total: 6281 theorems/lemmas (4410 public, 1871 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -60,6 +60,10 @@ ALLOWLIST: set[str] = {
     # executable mirror; splitting per constructor would break the mutual
     # recursion with the Cases/Dflt/List companions.
     "spliceSimCheck_sound",
+    # predicate-generic dispatcher correctness: faithful clone of the
+    # dispatcher case analysis with the compile predicate abstracted; the
+    # branch structure mirrors interpretContract_correct_of_compiled_functions.
+    "interpretContract_correct_of_functions_generic",
     # #2083 expression-surface closure: both proofs are mechanical constructor/list
     # traversals kept whole so the denotation and scanner cases remain auditable
     # against the corresponding exhaustive expression definitions.


### PR DESCRIPTION
Piece 4 of the whole-contract `*_guarded` assembly: `interpretContract_correct_of_functions_generic` states the dispatcher correctness once, generic over the per-entry compile predicate (its proof consumed the predicate only through selector/params/payable metadata and the per-function callback — now explicit), with generic `find?`-alignment lemmas; instantiated as `interpretContract_correct_of_compiled_guarded_functions` via #2313's metadata facts. Existing statements untouched; one private Dispatch helper made public.

Remaining assembly: the compile-level wrapper (erasure-free clone of `compile_ok_yields_compiled_functions`) and the per-function callback bridging the family root (#2309/#2310) to `sourceResultMatchesIRResult` — the source-side guarded semantics bridge.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor that adds lemmas without changing existing theorem statements or runtime behavior; risk is limited to proof maintenance and axiom inventory accuracy.
> 
> **Overview**
> Adds **`GuardedDispatch.lean`** with a **predicate-generic** contract-dispatcher correctness lemma (`interpretContract_correct_of_functions_generic`) that abstracts the per-entry compile predicate, plus generic `find?` alignment helpers. **`interpretContract_correct_of_compiled_guarded_functions`** instantiates it for `compileGuardedFunctionSpec` using metadata from `GuardedContractShape`.
> 
> **`bindSupportedParams_some_of_supported`** in `Dispatch.lean` is promoted from **private** to **public** so the generic proof can reuse it. Existing `Dispatch` theorem statements are unchanged.
> 
> `PrintAxioms.lean` registers the new module and public lemmas; **`interpretContract_correct_of_functions_generic`** is added to the proof-length allowlist as a mirror of the legacy dispatcher case analysis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd7fc2f222565553217bd23ae961b481837a9ced. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->