### PR TITLE
feat(proofs): SupportedSpecGuarded + erasure-free compile decomposition

### DIFF
--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -11,7 +11,7 @@ open Compiler.Yul
 
 namespace Contract
 
-private theorem pickUniqueFunctionByName_eq_ok_none_of_absent
+theorem pickUniqueFunctionByName_eq_ok_none_of_absent
     (name : String) (funcs : List FunctionSpec)
     (habsent : ∀ fn ∈ funcs, fn.name != name) :
     pickUniqueFunctionByName name funcs = Except.ok none := by
@@ -110,7 +110,7 @@ private theorem exists_right_of_forall₂_mem_left
       · rcases ih hmemTail with ⟨y, hy, hRy⟩
         exact ⟨y, by simp [hy], hRy⟩
 
-private theorem filterInternalFunctions_eq_nil_of_all_nonInternal :
+theorem filterInternalFunctions_eq_nil_of_all_nonInternal :
     ∀ (fns : List FunctionSpec),
       (∀ fn ∈ fns, fn.isInternal = false) →
         fns.filter (·.isInternal) = []

--- a/Compiler/Proofs/IRGeneration/GuardedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/GuardedSpec.lean
@@ -1,0 +1,151 @@
+import Compiler.Proofs.IRGeneration.GuardedDispatch
+import Compiler.Proofs.IRGeneration.Contract
+
+/-!
+# `SupportedSpecGuarded` and the erasure-free compile decomposition
+
+The guarded counterpart of `SupportedSpec`: identical global invariants,
+surface gates, and constructor support, but per-function support drops the
+`noNonReentrant` boundary in favor of lock resolvability (vacuous for
+unannotated functions, so every `SupportedSpec` embeds).  The compile
+decomposition then characterizes `ir.functions` by the *guarded* pipeline —
+no lock-free rewrite — feeding the generic dispatcher instance (#2314).
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+open Compiler.CompilationModel
+open Compiler.Proofs.IRGeneration.Contract
+
+/-- Per-function support for the guarded family: `SupportedFunction` minus
+the `noNonReentrant` boundary, plus lock resolvability (vacuously true for
+unannotated functions). -/
+structure SupportedFunctionGuarded (spec : CompilationModel)
+    (fn : FunctionSpec) where
+  nonInternal : fn.isInternal = false
+  nonSpecialEntrypoint : isInteropEntrypointName fn.name = false
+  lockResolved : ∀ lockField, fn.nonReentrantLock = some lockField →
+    ∃ field slot,
+      findFieldWithResolvedSlot spec.fields lockField = some (field, slot) ∧
+        slot < Compiler.Constants.evmModulus
+  params : SupportedParamProfile fn.params
+  returns : SupportedReturnProfile fn
+  body : SupportedBodyInterface spec fn
+
+/-- Whole-contract guarded support inventory. -/
+structure SupportedSpecGuarded (spec : CompilationModel)
+    (selectors : List Nat) where
+  invariants : SupportedSpecInvariants spec selectors
+  surface : SupportedSpecSurface spec
+  constructor :
+    ∀ ctor, spec.constructor = some ctor → SupportedConstructor spec ctor
+  functions :
+    ∀ fn, fn ∈ spec.functions → SupportedFunctionGuarded spec fn
+
+/-- Every lock-free supported function is guarded-supported. -/
+def SupportedFunction.toGuarded {spec : CompilationModel} {fn : FunctionSpec}
+    (h : SupportedFunction spec fn) : SupportedFunctionGuarded spec fn where
+  nonInternal := h.nonInternal
+  nonSpecialEntrypoint := h.nonSpecialEntrypoint
+  lockResolved := fun lockField hlock => by
+    rw [h.noNonReentrant] at hlock
+    cases hlock
+  params := h.params
+  returns := h.returns
+  body := h.body
+
+/-- Every supported spec is guarded-supported. -/
+def SupportedSpec.toGuarded {spec : CompilationModel} {selectors : List Nat}
+    (h : SupportedSpec spec selectors) : SupportedSpecGuarded spec selectors where
+  invariants := h.invariants
+  surface := h.surface
+  constructor := h.constructor
+  functions := fun fn hmem => (h.functions fn hmem).toGuarded
+
+theorem SupportedSpecGuarded.noInternalFunctions
+    {spec : CompilationModel} {selectors : List Nat}
+    (h : SupportedSpecGuarded spec selectors) :
+    ∀ fn ∈ spec.functions, fn.isInternal = false :=
+  fun fn hmem => (h.functions fn hmem).nonInternal
+
+/-- Erasure-free compile decomposition: `ir.functions` characterized by the
+guarded pipeline. -/
+theorem compileValidatedCore_ok_yields_guarded_functions
+    (model : CompilationModel) (selectors : List Nat)
+    (hSupported : SupportedSpecGuarded model selectors)
+    (ir : IRContract)
+    (hcore : compileValidatedCore model selectors = Except.ok ir) :
+    List.Forall₂
+      (fun (entry : FunctionSpec × Nat) irFn =>
+        compileGuardedFunctionSpec model.fields model.events model.errors []
+          [] entry.2 entry.1 = Except.ok irFn)
+      (SourceSemantics.selectorFunctionPairs model selectors)
+      ir.functions := by
+  have hfallback :
+      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
+    pickUniqueFunctionByName_eq_ok_none_of_absent
+      "fallback" model.functions hSupported.surface.noFallback
+  have hreceive :
+      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
+    pickUniqueFunctionByName_eq_ok_none_of_absent
+      "receive" model.functions hSupported.surface.noReceive
+  have hnoInternalFns :
+      model.functions.filter (·.isInternal) = [] :=
+    filterInternalFunctions_eq_nil_of_all_nonInternal model.functions
+      hSupported.noInternalFunctions
+  unfold compileValidatedCore at hcore
+  rw [hSupported.invariants.normalizedFields,
+    hSupported.surface.noAdtTypes, hSupported.surface.noEvents,
+    hSupported.surface.noErrors,
+    hnoInternalFns, hfallback, hreceive,
+    hSupported.surface.noTemplateIntrinsics] at hcore
+  simp only [bind, Except.bind, pure, Except.pure] at hcore
+  rcases hmap :
+      ((model.functions.filter
+          (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
+        (fun x => compileGuardedFunctionSpec model.fields [] [] [] [] x.2 x.1) with _ | irFns
+  · simp [hmap] at hcore
+  · simp [hmap] at hcore
+    rcases hctor :
+        compileConstructor model.fields [] [] [] model.constructor with _ | deployStmts
+    · simp [hctor] at hcore
+      cases hcore
+    · simp [hctor] at hcore
+      have hfunctions : ir.functions = irFns := by
+        injection hcore with hir
+        cases hir
+        rfl
+      have hcompiled :
+          List.Forall₂
+            (fun (entry : FunctionSpec × Nat) irFn =>
+              compileGuardedFunctionSpec model.fields model.events model.errors []
+                [] entry.2 entry.1 = Except.ok irFn)
+            ((model.functions.filter
+                (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors)
+            irFns := by
+        simpa [hSupported.surface.noEvents, hSupported.surface.noErrors] using
+          (guarded_functions_forall₂_of_mapM_ok model.fields [] [] [] _ _ hmap)
+      simpa [SourceSemantics.selectorFunctionPairs, selectorDispatchedFunctions,
+        hfunctions] using hcompiled
+
+/-- Compile-level wrapper. -/
+theorem compile_ok_yields_guarded_functions
+    (model : CompilationModel) (selectors : List Nat)
+    (hSupported : SupportedSpecGuarded model selectors)
+    (ir : IRContract)
+    (hcompile : CompilationModel.compile model selectors = Except.ok ir) :
+    List.Forall₂
+      (fun (entry : FunctionSpec × Nat) irFn =>
+        compileGuardedFunctionSpec model.fields model.events model.errors []
+          [] entry.2 entry.1 = Except.ok irFn)
+      (SourceSemantics.selectorFunctionPairs model selectors)
+      ir.functions := by
+  unfold CompilationModel.compile at hcompile
+  simp only [bind, Except.bind] at hcompile
+  rcases hvalidate : validateCompileInputs model selectors with _ | validated
+  · simp [hvalidate] at hcompile
+  · simp [hvalidate] at hcompile
+    exact compileValidatedCore_ok_yields_guarded_functions
+      model selectors hSupported ir hcompile
+
+end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -79,6 +79,7 @@ import Compiler.Proofs.IRGeneration.GuardedCompile
 import Compiler.Proofs.IRGeneration.GuardedContractShape
 import Compiler.Proofs.IRGeneration.GuardedDispatch
 import Compiler.Proofs.IRGeneration.GuardedFunction
+import Compiler.Proofs.IRGeneration.GuardedSpec
 import Compiler.Proofs.IRGeneration.HelperBodyBridge
 import Compiler.Proofs.IRGeneration.HelperBodyShape
 import Compiler.Proofs.IRGeneration.HelperSummaryEvidence
@@ -2091,11 +2092,11 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.ceiProofBackedExecution_checked_empty_body
 
   -- Compiler/Proofs/IRGeneration/Contract.lean
-  -- Compiler.Proofs.IRGeneration.Contract.pickUniqueFunctionByName_eq_ok_none_of_absent  -- private
+  Compiler.Proofs.IRGeneration.Contract.pickUniqueFunctionByName_eq_ok_none_of_absent
   -- Compiler.Proofs.IRGeneration.Contract.compiled_functions_forall₂_of_mapM_ok  -- private
   -- Compiler.Proofs.IRGeneration.Contract.compiled_internal_functions_forall₂_of_mapM_ok  -- private
   -- Compiler.Proofs.IRGeneration.Contract.exists_right_of_forall₂_mem_left  -- private
-  -- Compiler.Proofs.IRGeneration.Contract.filterInternalFunctions_eq_nil_of_all_nonInternal  -- private
+  Compiler.Proofs.IRGeneration.Contract.filterInternalFunctions_eq_nil_of_all_nonInternal
   -- Compiler.Proofs.IRGeneration.Contract.filterInternalFunctions_eq_nil_of_supported  -- private
   -- Compiler.Proofs.IRGeneration.Contract.filterInternalFunctions_eq_nil_of_supported_except_mapping_writes  -- private
   -- Compiler.Proofs.IRGeneration.Contract.compileValidatedCore_ok_yields_compiled_functions  -- private
@@ -3573,6 +3574,11 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.acquiredBoundState_eq
   Compiler.Proofs.IRGeneration.exec_compiledGuardedFunctionIR_of_body_fallthrough
   Compiler.Proofs.IRGeneration.exec_compiledGuardedFunctionIR_of_body_halting
+
+  -- Compiler/Proofs/IRGeneration/GuardedSpec.lean
+  Compiler.Proofs.IRGeneration.SupportedSpecGuarded.noInternalFunctions
+  Compiler.Proofs.IRGeneration.compileValidatedCore_ok_yields_guarded_functions
+  Compiler.Proofs.IRGeneration.compile_ok_yields_guarded_functions
 
   -- Compiler/Proofs/IRGeneration/HelperBodyBridge.lean
   Compiler.Proofs.IRGeneration.execIRInternalFunctionWithInternals_obeys_internal_helper_summary
@@ -6741,4 +6747,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6281 theorems/lemmas (4410 public, 1871 private, 0 sorry'd)
+-- Total: 6284 theorems/lemmas (4415 public, 1869 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -64,6 +64,7 @@ ALLOWLIST: set[str] = {
     # dispatcher case analysis with the compile predicate abstracted; the
     # branch structure mirrors interpretContract_correct_of_compiled_functions.
     "interpretContract_correct_of_functions_generic",
+    "compileValidatedCore_ok_yields_guarded_functions",
     # #2083 expression-surface closure: both proofs are mechanical constructor/list
     # traversals kept whole so the denotation and scanner cases remain auditable
     # against the corresponding exhaustive expression definitions.


### PR DESCRIPTION
Piece 6a of the whole-contract `*_guarded` assembly: the guarded support structures (`SupportedFunctionGuarded`/`SupportedSpecGuarded`, with the `SupportedSpec.toGuarded` embedding — lock resolvability is vacuous for unannotated functions) and the erasure-free compile decomposition (`compile(ValidatedCore)_ok_yields_guarded_functions`), the mirror of the existing chain minus the `guardedFunctionsMapM_eq` rewrite. Composes with #2313/#2314; the sole remaining piece is the per-function source-bridge callback (guarded source semantics vs the family root).

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only Lean additions with no runtime or compiler behavior changes; risk is limited to formal proof maintenance and axiom/print surface updates.
> 
> **Overview**
> Introduces **`SupportedSpecGuarded`** / **`SupportedFunctionGuarded`** as the guarded analogue of supported-spec inventory: same contract invariants and surface gates, but per-function support swaps the **`noNonReentrant`** boundary for **lock resolvability**, with **`SupportedSpec.toGuarded`** showing ordinary **`SupportedSpec`** still embeds.
> 
> Adds **`compileValidatedCore_ok_yields_guarded_functions`** and **`compile_ok_yields_guarded_functions`**, which relate successful compile output to **`compileGuardedFunctionSpec`** on selector-dispatched pairs—**without** the lock-free **`guardedFunctionsMapM_eq`** rewrite used on the standard path.
> 
> **`Contract.lean`** exports **`pickUniqueFunctionByName_eq_ok_none_of_absent`** and **`filterInternalFunctions_eq_nil_of_all_nonInternal`** for the new proof. **`PrintAxioms.lean`** and **`check_proof_length.py`** register the new module and allowlist the long decomposition theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8415f46d5286cc3a1198f0a5062b7287579b3030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->