### PR TITLE
feat(proofs): guarded source semantics + source bridge (final conceptual piece)

### DIFF
--- a/Compiler/Proofs/IRGeneration/GuardedSourceBridge.lean
+++ b/Compiler/Proofs/IRGeneration/GuardedSourceBridge.lean
@@ -1,0 +1,158 @@
+import Compiler.Proofs.IRGeneration.GuardedSpec
+import Verity.Core.Model.NonReentrantGuard
+
+/-!
+# Guarded source semantics and its bridge to the compiled guard
+
+The source semantics of an annotated function, defined via the existing
+`interpretFunction`: a locked entry reverts; a free entry is the plain
+interpretation from the lock-acquired world.  `SourceContractResult` does not
+observe transient storage, so the release is invisible on both sides — the
+free case therefore reuses the whole existing correspondence stack verbatim
+at the acquired world, and only record-commutation glue is new.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+open Compiler.CompilationModel
+open Verity.Core.NonReentrantGuard
+open Compiler.Proofs.IRGeneration.Function
+
+/-- Source semantics of a `nonreentrant`-annotated function. -/
+def interpretGuardedFunction (spec : CompilationModel) (lockSlot : Nat)
+    (fn : FunctionSpec) (tx : IRTransaction)
+    (initialWorld : Verity.ContractState) : SourceSemantics.SourceContractResult :=
+  if (initialWorld.transientStorage lockSlot).val = 1 then
+    SourceSemantics.revertedResult spec
+      (SourceSemantics.withTransactionContext initialWorld tx)
+  else
+    SourceSemantics.interpretFunction spec fn tx
+      (setLock lockSlot 1 initialWorld)
+
+/-- Acquiring the lock commutes with installing the transaction context. -/
+theorem withTransactionContext_setLock (world : Verity.ContractState)
+    (tx : IRTransaction) (slot : Nat) (v : Verity.Uint256) :
+    SourceSemantics.withTransactionContext (setLock slot v world) tx =
+      setLock slot v (SourceSemantics.withTransactionContext world tx) := rfl
+
+/-- The dynamic-array scan never reads transient storage. -/
+theorem findDynamicArrayElementAtSlot_go_setLock
+    (world : Verity.ContractState) (targetSlot lockSlot : Nat)
+    (v : Verity.Uint256) :
+    ∀ (remaining : List Field) (idx : Nat),
+      SourceSemantics.findDynamicArrayElementAtSlot.go
+          (setLock lockSlot v world) targetSlot remaining idx =
+        SourceSemantics.findDynamicArrayElementAtSlot.go
+          world targetSlot remaining idx
+  | [], _ => rfl
+  | field :: rest, idx => by
+      simp only [SourceSemantics.findDynamicArrayElementAtSlot.go]
+      rw [show (setLock lockSlot v world).storageArray = world.storageArray
+        from rfl,
+        findDynamicArrayElementAtSlot_go_setLock world targetSlot lockSlot v
+          rest (idx + 1)]
+
+/-- `encodeStorageAt` never reads transient storage. -/
+theorem encodeStorageAt_setLock (fields : List Field)
+    (world : Verity.ContractState) (lockSlot : Nat) (v : Verity.Uint256)
+    (slot : Nat) :
+    SourceSemantics.encodeStorageAt fields (setLock lockSlot v world) slot =
+      SourceSemantics.encodeStorageAt fields world slot := by
+  unfold SourceSemantics.encodeStorageAt
+  rw [show SourceSemantics.findDynamicArrayElementAtSlot fields
+      (setLock lockSlot v world) slot =
+    SourceSemantics.findDynamicArrayElementAtSlot fields world slot from
+    findDynamicArrayElementAtSlot_go_setLock world slot lockSlot v fields 0]
+  cases SourceSemantics.findResolvedFieldAtSlot fields slot <;> rfl
+
+/-- The initial IR state of the lock-acquired world is the lock overlay of
+the initial IR state. -/
+theorem initialIRStateForTx_setLock (spec : CompilationModel)
+    (tx : IRTransaction) (world : Verity.ContractState) (slot : Nat) :
+    FunctionBody.initialIRStateForTx spec tx (setLock slot 1 world) =
+      { FunctionBody.initialIRStateForTx spec tx world with
+        transientStorage := fun o =>
+          if o = slot then 1 else (world.transientStorage o).val } := by
+  simp only [FunctionBody.initialIRStateForTx]
+  congr 1
+  all_goals first
+    | rfl
+    | (funext o
+       exact congrArg IRStorageWord.ofNat
+         (encodeStorageAt_setLock _ world slot 1 o.toNat))
+    | (funext o
+       by_cases h : o = slot <;> simp [setLock, h])
+
+/-- The revert projection ignores transient storage: overlaying the lock on
+the rollback state does not change it. -/
+theorem execResultToIRResult_lock_overlay (spec : CompilationModel)
+    (tx : IRTransaction) (world : Verity.ContractState) (slot : Nat)
+    (r : IRExecResult) :
+    execResultToIRResult
+        (FunctionBody.initialIRStateForTx spec tx (setLock slot 1 world)) r =
+      execResultToIRResult
+        (FunctionBody.initialIRStateForTx spec tx world) r := by
+  rw [initialIRStateForTx_setLock]
+  cases r <;> rfl
+
+/-- Locked entry: the source revert matches the IR revert projection. -/
+theorem revertedResult_matches_revert_projection (spec : CompilationModel)
+    (tx : IRTransaction) (initialWorld : Verity.ContractState)
+    (s : IRState) :
+    FunctionBody.sourceResultMatchesIRResult
+      (SourceSemantics.revertedResult spec
+        (SourceSemantics.withTransactionContext initialWorld tx))
+      (execResultToIRResult
+        (FunctionBody.initialIRStateForTx spec tx initialWorld) (.revert s)) := by
+  refine ⟨rfl, rfl, ?_, ?_⟩
+  · funext x
+    simp [SourceSemantics.revertedResult, execResultToIRResult,
+      FunctionBody.initialIRStateForTx,
+      SourceSemantics.encodeStorage_withTransactionContext]
+  · simp [SourceSemantics.revertedResult, execResultToIRResult,
+      FunctionBody.initialIRStateForTx,
+      FunctionBody.encodeEvents_withTransactionContext]
+
+/-- The guarded gluing theorem: given the base correspondence at the
+lock-acquired world (exactly what the existing per-function machinery
+produces there) and the compiled guard's dispatch behavior (from the family
+root, at whatever fuel the consumer chose), the guarded source semantics
+matches the compiled guarded function. -/
+theorem interpretGuardedFunction_matches (spec : CompilationModel)
+    (lockSlot : Nat) (fn : FunctionSpec) (tx : IRTransaction)
+    (initialWorld : Verity.ContractState) (guardedFn : IRFunction)
+    (tailIR : IRExecResult)
+    (hlocked_ir :
+      (initialWorld.transientStorage lockSlot).val = 1 →
+      execIRFunction guardedFn tx.args
+          (FunctionBody.initialIRStateForTx spec tx initialWorld) =
+        execResultToIRResult
+          (FunctionBody.initialIRStateForTx spec tx initialWorld)
+          (.revert (FunctionBody.initialIRStateForTx spec tx initialWorld)))
+    (hfree_ir :
+      (initialWorld.transientStorage lockSlot).val ≠ 1 →
+      execIRFunction guardedFn tx.args
+          (FunctionBody.initialIRStateForTx spec tx initialWorld) =
+        execResultToIRResult
+          (FunctionBody.initialIRStateForTx spec tx
+            (setLock lockSlot 1 initialWorld)) tailIR)
+    (hfree_base :
+      (initialWorld.transientStorage lockSlot).val ≠ 1 →
+      FunctionBody.sourceResultMatchesIRResult
+        (SourceSemantics.interpretFunction spec fn tx
+          (setLock lockSlot 1 initialWorld))
+        (execResultToIRResult
+          (FunctionBody.initialIRStateForTx spec tx
+            (setLock lockSlot 1 initialWorld)) tailIR)) :
+    FunctionBody.sourceResultMatchesIRResult
+      (interpretGuardedFunction spec lockSlot fn tx initialWorld)
+      (execIRFunction guardedFn tx.args
+        (FunctionBody.initialIRStateForTx spec tx initialWorld)) := by
+  unfold interpretGuardedFunction
+  by_cases hlock : (initialWorld.transientStorage lockSlot).val = 1
+  · rw [if_pos hlock, hlocked_ir hlock]
+    exact revertedResult_matches_revert_projection spec tx initialWorld _
+  · rw [if_neg hlock, hfree_ir hlock]
+    exact hfree_base hlock
+
+end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -79,6 +79,7 @@ import Compiler.Proofs.IRGeneration.GuardedCompile
 import Compiler.Proofs.IRGeneration.GuardedContractShape
 import Compiler.Proofs.IRGeneration.GuardedDispatch
 import Compiler.Proofs.IRGeneration.GuardedFunction
+import Compiler.Proofs.IRGeneration.GuardedSourceBridge
 import Compiler.Proofs.IRGeneration.GuardedSpec
 import Compiler.Proofs.IRGeneration.HelperBodyBridge
 import Compiler.Proofs.IRGeneration.HelperBodyShape
@@ -3575,6 +3576,15 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.exec_compiledGuardedFunctionIR_of_body_fallthrough
   Compiler.Proofs.IRGeneration.exec_compiledGuardedFunctionIR_of_body_halting
 
+  -- Compiler/Proofs/IRGeneration/GuardedSourceBridge.lean
+  Compiler.Proofs.IRGeneration.withTransactionContext_setLock
+  Compiler.Proofs.IRGeneration.findDynamicArrayElementAtSlot_go_setLock
+  Compiler.Proofs.IRGeneration.encodeStorageAt_setLock
+  Compiler.Proofs.IRGeneration.initialIRStateForTx_setLock
+  Compiler.Proofs.IRGeneration.execResultToIRResult_lock_overlay
+  Compiler.Proofs.IRGeneration.revertedResult_matches_revert_projection
+  Compiler.Proofs.IRGeneration.interpretGuardedFunction_matches
+
   -- Compiler/Proofs/IRGeneration/GuardedSpec.lean
   Compiler.Proofs.IRGeneration.SupportedSpecGuarded.noInternalFunctions
   Compiler.Proofs.IRGeneration.compileValidatedCore_ok_yields_guarded_functions
@@ -6747,4 +6757,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6284 theorems/lemmas (4415 public, 1869 private, 0 sorry'd)
+-- Total: 6291 theorems/lemmas (4422 public, 1869 private, 0 sorry'd)


### PR DESCRIPTION
The last conceptual piece of the `*_guarded` family: `interpretGuardedFunction` (locked ⇒ revert; free ⇒ plain `interpretFunction` from the lock-acquired world — maximally clean since `SourceContractResult` doesn't observe transient storage) with the full invariance/commutation kit (transaction-context/lock commutation, transient-invisibility of storage encoding incl. the dynamic-array scan via let-rec induction, lock-overlay characterization of the acquired initial IR state) and the gluing theorem `interpretGuardedFunction_matches`. Every piece of `compile_preserves_semantics_guarded` now exists; the final theorem is a one-page composition.

Validation: full `lake build` OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions with no runtime or compiler behavior changes; risk is limited to Lean proof maintenance and axiom inventory registration.
> 
> **Overview**
> Introduces **`GuardedSourceBridge.lean`**, defining **`interpretGuardedFunction`**: if the lock slot is already set, the source semantics revert; otherwise they run the usual **`interpretFunction`** from a lock-acquired world (transient lock state is not observable in **`SourceContractResult`**).
> 
> The new lemmas show lock/transaction-context commutation, that storage encoding (including dynamic-array scans) ignores transient storage, how the acquired-world initial IR state overlays the lock, and that revert projections are unchanged by that overlay. **`interpretGuardedFunction_matches`** combines compiled guard dispatch with the existing per-function correspondence at the acquired world.
> 
> **`PrintAxioms.lean`** imports the module and lists the new public theorems (axiom inventory +7).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a7829c281f52d2d37540068c553371fcdedd13d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->