### PR TITLE
feat(proofs): compile_preserves_semantics_guarded — the *_guarded family complete

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -175,6 +175,24 @@ sibling entrypoint.
   unchanged. Trust-boundary prose is in the "Cross-Function Reentrancy Gate"
   section of `TRUST_ASSUMPTIONS.md`.
 
+## External-Call Journal (2026-08)
+
+- `ContractState.calls` (`Verity.ExternalCall` entries) is a new append-only,
+  defaulted field: a proof-side observable of external-call boundaries, not
+  EVM state. No semantic-preservation claim covers it.
+- `DenoteExternalCalls.denoteCall` is unchanged; the journal is added by the
+  definitionally layered `denoteCallJournaled` / `denoteJournaled`, so all
+  previously proven world/gas/rollback laws hold verbatim.
+- Source-level observation is `DenoteExternalCalls.externalCall :
+  AdversaryModel → CallSite → Contract ExternalCallResult`
+  (`Verity/Core/Model/ContractExternalCall.lean`), which reports
+  callee failure/revert in-band and never raises a monadic revert;
+  `externalCallRequireSuccess` opts into bubbling snapshot rollback.
+- Semantic choices (journal survives caller-side rollback; adversary cannot
+  write the journal) are documented in `TRUST_ASSUMPTIONS.md` §"External-Call
+  Journal".
+- **Axiom-free**: `AXIOMS.md` unchanged.
+
 ## Audit Artifacts
 
 | Artifact | Purpose | Check |

--- a/Compiler/Proofs/IRGeneration/GuardedContract.lean
+++ b/Compiler/Proofs/IRGeneration/GuardedContract.lean
@@ -1,0 +1,301 @@
+import Compiler.Proofs.IRGeneration.GuardedSourceBridge
+
+/-!
+# The guarded whole-contract theorem (`compile_preserves_semantics_guarded`)
+
+Assembles the family: the source-parametric dispatcher (per-entry source
+semantics abstracted alongside the compile predicate), the guarded source
+contract semantics (`interpretGuardedContract`), and the final additive
+whole-contract statement — contracts whose functions may carry
+`nonreentrant(lock)` annotations, characterized by the guarded pipeline with
+no lock-free erasure.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+open Compiler.CompilationModel
+open Compiler.Proofs.IRGeneration.Dispatch
+open Compiler.Proofs.IRGeneration.Contract
+open Verity.Core.NonReentrantGuard
+
+/-- Source contract dispatch with a parametric per-function semantics. -/
+def interpretContractWith
+    (S : FunctionSpec → SourceSemantics.SourceContractResult)
+    (spec : CompilationModel) (selectors : List Nat)
+    (tx : IRTransaction) (initialWorld : Verity.ContractState) :
+    SourceSemantics.SourceContractResult :=
+  match SourceSemantics.findFunctionBySelector spec selectors tx.functionSelector with
+  | some fn =>
+      if !fn.isPayable && tx.msgValue % Compiler.Constants.evmModulus != 0 then
+        SourceSemantics.revertedResult spec
+          (SourceSemantics.withTransactionContext initialWorld tx)
+      else S fn
+  | none =>
+      SourceSemantics.revertedResult spec
+        (SourceSemantics.withTransactionContext initialWorld tx)
+
+/-- The per-function guarded choice: annotated functions with a resolved lock
+run the guarded semantics; everything else runs the plain semantics. -/
+def guardedFunctionChoice (spec : CompilationModel) (tx : IRTransaction)
+    (initialWorld : Verity.ContractState) (fn : FunctionSpec) :
+    SourceSemantics.SourceContractResult :=
+  match fn.nonReentrantLock with
+  | none => SourceSemantics.interpretFunction spec fn tx initialWorld
+  | some lockField =>
+      match findFieldWithResolvedSlot spec.fields lockField with
+      | some (_, slot) => interpretGuardedFunction spec slot fn tx initialWorld
+      | none => SourceSemantics.interpretFunction spec fn tx initialWorld
+
+/-- Guarded source contract semantics. -/
+def interpretGuardedContract (spec : CompilationModel) (selectors : List Nat)
+    (tx : IRTransaction) (initialWorld : Verity.ContractState) :
+    SourceSemantics.SourceContractResult :=
+  interpretContractWith (guardedFunctionChoice spec tx initialWorld)
+    spec selectors tx initialWorld
+
+/-- The reverted result ignores the lock overlay. -/
+theorem revertedResult_setLock (spec : CompilationModel)
+    (world : Verity.ContractState) (slot : Nat) (v : Verity.Uint256) :
+    SourceSemantics.revertedResult spec (setLock slot v world) =
+      SourceSemantics.revertedResult spec world := by
+  unfold SourceSemantics.revertedResult
+  congr 1
+  funext s
+  exact encodeStorageAt_setLock _ world slot v s
+
+/-- Source-parametric dispatcher correctness: like the predicate-generic
+version, additionally abstracting the per-function source semantics.  The
+only structural requirement on `S` is that it reverts on binding failure. -/
+theorem interpretContractWith_correct_of_functions_generic
+    (P : FunctionSpec → Nat → IRFunction → Prop)
+    (S : FunctionSpec → SourceSemantics.SourceContractResult)
+    (model : CompilationModel) (selectors : List Nat)
+    (irFns : List IRFunction) (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (hmeta : ∀ fn sel irFn, P fn sel irFn →
+      irFn.params = fn.params.map Param.toIRParam ∧
+        irFn.selector = sel ∧ irFn.payable = fn.isPayable)
+    (hSbindFail : ∀ fn, fn ∈ selectorDispatchedFunctions model →
+      SourceSemantics.bindSupportedParams fn.params tx.args = none →
+      S fn = SourceSemantics.revertedResult model
+        (SourceSemantics.withTransactionContext initialWorld tx))
+    (hcompiled : List.Forall₂ (fun entry irFn => P entry.1 entry.2 irFn)
+      (SourceSemantics.selectorFunctionPairs model selectors) irFns)
+    (hparamsSupported :
+      ∀ fn ∈ selectorDispatchedFunctions model,
+        ∀ param ∈ fn.params, SupportedExternalParamType param.ty)
+    (hfunction :
+      ∀ fn sel irFn bindings,
+        fn ∈ selectorDispatchedFunctions model →
+        P fn sel irFn →
+        SourceSemantics.bindSupportedParams fn.params tx.args = some bindings →
+        FunctionBody.sourceResultMatchesIRResult (S fn)
+          (execIRFunction irFn tx.args
+            (FunctionBody.initialIRStateForTx model tx initialWorld))) :
+    FunctionBody.sourceResultMatchesIRResult
+      (interpretContractWith S model selectors tx initialWorld)
+      (interpretIR (runtimeContractOfFunctions model.name irFns) tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  have hsel : ∀ fn sel irFn, P fn sel irFn → irFn.selector = sel :=
+    fun fn sel irFn hP => (hmeta fn sel irFn hP).2.1
+  let pairs := SourceSemantics.selectorFunctionPairs model selectors
+  have hinterp :
+      interpretIR (runtimeContractOfFunctions model.name irFns) tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld) =
+      match irFns.find? (fun irFn => irFn.selector == tx.functionSelector) with
+      | some irFn =>
+          if !irFn.payable && tx.msgValue % Compiler.Constants.evmModulus != 0 then
+            { success := false
+              returnValue := none
+              finalStorage := (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              finalMappings := Compiler.Proofs.storageAsMappings
+                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              events := (FunctionBody.initialIRStateForTx model tx initialWorld).events }
+          else if irFn.params.length ≤ tx.args.length then
+            execIRFunction irFn tx.args (FunctionBody.initialIRStateForTx model tx initialWorld)
+          else
+            { success := false
+              returnValue := none
+              finalStorage := (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              finalMappings := Compiler.Proofs.storageAsMappings
+                (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+              events := (FunctionBody.initialIRStateForTx model tx initialWorld).events }
+      | none =>
+          { success := false
+            returnValue := none
+            finalStorage := (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+            finalMappings := Compiler.Proofs.storageAsMappings
+              (FunctionBody.initialIRStateForTx model tx initialWorld).storage
+            events := (FunctionBody.initialIRStateForTx model tx initialWorld).events } := by
+        rfl
+  unfold interpretContractWith SourceSemantics.findFunctionBySelector
+  cases hfindPairs :
+      pairs.find? (fun entry => entry.2 == tx.functionSelector) with
+  | none =>
+      have hfindIr :
+          irFns.find? (fun irFn => irFn.selector == tx.functionSelector) = none :=
+        find_function_none_of_forall₂_generic P hsel tx.functionSelector
+          hcompiled hfindPairs
+      rw [hinterp, hfindIr]
+      simp [hfindPairs, FunctionBody.sourceResultMatchesIRResult,
+        SourceSemantics.revertedResult, FunctionBody.initialIRStateForTx,
+        FunctionBody.encodeStorage_withTransactionContext,
+        FunctionBody.encodeEvents_withTransactionContext]
+  | some pair =>
+      rcases pair with ⟨fn, sel⟩
+      rcases find_function_some_of_forall₂_generic P hsel tx.functionSelector
+          hcompiled hfindPairs with ⟨irFn, hfindIr, hPfn⟩
+      have hpairMem : (fn, sel) ∈ pairs := List.mem_of_find?_eq_some hfindPairs
+      have hfnMem : fn ∈ selectorDispatchedFunctions model := by
+        simpa [pairs, SourceSemantics.selectorFunctionPairs] using
+          (List.of_mem_zip hpairMem).1
+      obtain ⟨hparamsEq, _, hpayableEq⟩ := hmeta fn sel irFn hPfn
+      have hlenEq : irFn.params.length = fn.params.length := by
+        simpa [hparamsEq]
+      by_cases hguard : (!fn.isPayable && tx.msgValue % Compiler.Constants.evmModulus != 0) = true
+      · have hguardIr :
+            (!irFn.payable && tx.msgValue % Compiler.Constants.evmModulus != 0) = true := by
+          simpa [hpayableEq] using hguard
+        rw [hinterp, hfindIr]
+        simp [hfindPairs, hguard, hguardIr, FunctionBody.sourceResultMatchesIRResult,
+          SourceSemantics.revertedResult, FunctionBody.initialIRStateForTx,
+          FunctionBody.encodeStorage_withTransactionContext,
+          FunctionBody.encodeEvents_withTransactionContext]
+      · have hguardFalse :
+            (!fn.isPayable && tx.msgValue % Compiler.Constants.evmModulus != 0) = false :=
+          Bool.eq_false_iff.2 hguard
+        have hguardIrFalse :
+            (!irFn.payable && tx.msgValue % Compiler.Constants.evmModulus != 0) = false := by
+          simpa [hpayableEq] using hguardFalse
+        by_cases hlen : fn.params.length ≤ tx.args.length
+        · rcases bindSupportedParams_some_of_supported fn.params tx.args
+              (hparamsSupported fn hfnMem) hlen with ⟨bindings, hbindings⟩
+          have hmatch := hfunction fn sel irFn bindings hfnMem hPfn hbindings
+          have hlenIr : irFn.params.length ≤ tx.args.length := by
+            simpa [hlenEq] using hlen
+          rw [hinterp, hfindIr]
+          simpa [hfindPairs, hguardFalse, hguardIrFalse, hlenIr] using hmatch
+        · have hbindNone : SourceSemantics.bindSupportedParams fn.params tx.args = none := by
+            cases hbind : SourceSemantics.bindSupportedParams fn.params tx.args with
+            | none => rfl
+            | some bindings =>
+                exact absurd (ParamLoading.bindSupportedParams_some_length hbind) hlen
+          have hlenIr : ¬ irFn.params.length ≤ tx.args.length := by
+            simpa [hlenEq] using hlen
+          rw [hinterp, hfindIr]
+          simp [hfindPairs, hguardFalse, hguardIrFalse, hlenIr,
+            hSbindFail fn hfnMem hbindNone,
+            FunctionBody.sourceResultMatchesIRResult,
+            SourceSemantics.revertedResult, FunctionBody.initialIRStateForTx,
+            FunctionBody.encodeStorage_withTransactionContext,
+            FunctionBody.encodeEvents_withTransactionContext]
+
+theorem SupportedFunctionGuarded.paramsSupported
+    {spec : CompilationModel} {fn : FunctionSpec}
+    (h : SupportedFunctionGuarded spec fn) :
+    ∀ param ∈ fn.params, SupportedExternalParamType param.ty :=
+  h.params.supported
+
+theorem supported_params_of_supportedSpecGuarded
+    (model : CompilationModel) (selectors : List Nat)
+    (hSupported : SupportedSpecGuarded model selectors) :
+    ∀ fn ∈ selectorDispatchedFunctions model,
+      ∀ param ∈ fn.params, SupportedExternalParamType param.ty := by
+  intro fn hfn param hparam
+  have hfnModel : fn ∈ model.functions := List.mem_of_mem_filter hfn
+  exact (hSupported.functions fn hfnModel).paramsSupported param hparam
+
+/-- The guarded choice reverts on binding failure (under supported params,
+binding only fails on arity, where both the plain and the guarded semantics
+revert — the lock overlay is invisible in the reverted result). -/
+theorem guardedFunctionChoice_bindFail (model : CompilationModel)
+    (tx : IRTransaction) (initialWorld : Verity.ContractState)
+    (fn : FunctionSpec)
+    (hparams : ∀ param ∈ fn.params, SupportedExternalParamType param.ty)
+    (hbindNone : SourceSemantics.bindSupportedParams fn.params tx.args = none) :
+    guardedFunctionChoice model tx initialWorld fn =
+      SourceSemantics.revertedResult model
+        (SourceSemantics.withTransactionContext initialWorld tx) := by
+  have hlen : ¬ fn.params.length ≤ tx.args.length := by
+    intro hle
+    rcases bindSupportedParams_some_of_supported fn.params tx.args hparams hle
+      with ⟨bindings, hb⟩
+    rw [hb] at hbindNone
+    cases hbindNone
+  have hext := SourceSemantics.bindExternalParams_eq_none_of_not_length_le
+    (selector := tx.functionSelector) (params := fn.params)
+    (args := tx.args) hlen
+  have hplain : ∀ world, SourceSemantics.interpretFunction model fn tx world =
+      SourceSemantics.revertedResult model
+        (SourceSemantics.withTransactionContext world tx) := by
+    intro world
+    unfold SourceSemantics.interpretFunction
+    rw [hext]
+  unfold guardedFunctionChoice
+  cases hnl : fn.nonReentrantLock with
+  | none =>
+      simp only [hnl]
+      exact hplain initialWorld
+  | some lockField =>
+      simp only [hnl]
+      cases hfield : findFieldWithResolvedSlot model.fields lockField with
+      | none =>
+          simp only [hfield]
+          exact hplain initialWorld
+      | some fs =>
+          obtain ⟨field, slot⟩ := fs
+          simp only [hfield]
+          unfold interpretGuardedFunction
+          by_cases hlock : (initialWorld.transientStorage slot).val = 1
+          · rw [if_pos hlock]
+          · rw [if_neg hlock, hplain (setLock slot 1 initialWorld),
+              withTransactionContext_setLock, revertedResult_setLock]
+
+/-- The guarded whole-contract theorem: contracts whose functions may carry
+`nonreentrant(lock)` annotations, characterized by the guarded pipeline (no
+lock-free erasure), match the guarded source semantics — given the
+per-function correspondence supplied by the caller (dischargeable via
+`interpretGuardedFunction_matches` from the family root and the base
+correspondence at the lock-acquired world). -/
+theorem compile_preserves_semantics_guarded
+    (model : CompilationModel) (selectors : List Nat)
+    (hSupported : SupportedSpecGuarded model selectors)
+    (ir : IRContract) (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (hcompile : CompilationModel.compile model selectors = Except.ok ir)
+    (hfunction :
+      ∀ fn sel irFn bindings,
+        fn ∈ selectorDispatchedFunctions model →
+        compileGuardedFunctionSpec model.fields model.events model.errors []
+          [] sel fn = Except.ok irFn →
+        SourceSemantics.bindSupportedParams fn.params tx.args = some bindings →
+        FunctionBody.sourceResultMatchesIRResult
+          (guardedFunctionChoice model tx initialWorld fn)
+          (execIRFunction irFn tx.args
+            (FunctionBody.initialIRStateForTx model tx initialWorld))) :
+    FunctionBody.sourceResultMatchesIRResult
+      (interpretGuardedContract model selectors tx initialWorld)
+      (interpretIR ir tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  have hcompiled := compile_ok_yields_guarded_functions model selectors
+    hSupported ir hcompile
+  have hparamsSupported := supported_params_of_supportedSpecGuarded
+    model selectors hSupported
+  rw [interpretIR_eq_runtimeContractOfFunctions
+    (ir := ir) (runtimeName := model.name) (irFns := ir.functions)
+    (tx := tx)
+    (initialState := FunctionBody.initialIRStateForTx model tx initialWorld)
+    (hfunctions := rfl)]
+  exact interpretContractWith_correct_of_functions_generic
+    (fun fn sel irFn =>
+      compileGuardedFunctionSpec model.fields model.events model.errors []
+        [] sel fn = Except.ok irFn)
+    (guardedFunctionChoice model tx initialWorld)
+    model selectors ir.functions tx initialWorld
+    (fun fn sel irFn hP => compileGuardedFunctionSpec_ok_metadata
+      model.fields model.events model.errors [] sel fn irFn hP)
+    (fun fn hmem hbindNone => guardedFunctionChoice_bindFail model tx
+      initialWorld fn (hparamsSupported fn hmem) hbindNone)
+    hcompiled hparamsSupported hfunction
+
+end Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/IRGeneration/GuardedDispatch.lean
+++ b/Compiler/Proofs/IRGeneration/GuardedDispatch.lean
@@ -23,7 +23,7 @@ section Generic
 variable (P : FunctionSpec → Nat → IRFunction → Prop)
 
 /-- Selector alignment of `find?` under any selector-faithful predicate. -/
-private theorem find_function_some_of_forall₂_generic
+theorem find_function_some_of_forall₂_generic
     (hsel : ∀ fn sel irFn, P fn sel irFn → irFn.selector = sel)
     (selector : Nat)
     {pairs : List (FunctionSpec × Nat)} {irFns : List IRFunction}
@@ -55,7 +55,7 @@ private theorem find_function_some_of_forall₂_generic
           hsel headFn headSel irFn hhead
         simp [hselEq, hheadSelector, hfindIr]
 
-private theorem find_function_none_of_forall₂_generic
+theorem find_function_none_of_forall₂_generic
     (hsel : ∀ fn sel irFn, P fn sel irFn → irFn.selector = sel)
     (selector : Nat)
     {pairs : List (FunctionSpec × Nat)} {irFns : List IRFunction}

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -76,6 +76,7 @@ import Compiler.Proofs.IRGeneration.GenericInduction.Scope
 import Compiler.Proofs.IRGeneration.GenericInduction.Storage
 import Compiler.Proofs.IRGeneration.GenericInduction.StorageWord
 import Compiler.Proofs.IRGeneration.GuardedCompile
+import Compiler.Proofs.IRGeneration.GuardedContract
 import Compiler.Proofs.IRGeneration.GuardedContractShape
 import Compiler.Proofs.IRGeneration.GuardedDispatch
 import Compiler.Proofs.IRGeneration.GuardedFunction
@@ -3558,14 +3559,22 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.compileFunctionSpec_body_shape
   Compiler.Proofs.IRGeneration.compileGuardedFunctionSpec_inv
 
+  -- Compiler/Proofs/IRGeneration/GuardedContract.lean
+  Compiler.Proofs.IRGeneration.revertedResult_setLock
+  Compiler.Proofs.IRGeneration.interpretContractWith_correct_of_functions_generic
+  Compiler.Proofs.IRGeneration.SupportedFunctionGuarded.paramsSupported
+  Compiler.Proofs.IRGeneration.supported_params_of_supportedSpecGuarded
+  Compiler.Proofs.IRGeneration.guardedFunctionChoice_bindFail
+  Compiler.Proofs.IRGeneration.compile_preserves_semantics_guarded
+
   -- Compiler/Proofs/IRGeneration/GuardedContractShape.lean
   Compiler.Proofs.IRGeneration.attachNonReentrantGuard_metadata
   Compiler.Proofs.IRGeneration.compileGuardedFunctionSpec_ok_metadata
   Compiler.Proofs.IRGeneration.guarded_functions_forall₂_of_mapM_ok
 
   -- Compiler/Proofs/IRGeneration/GuardedDispatch.lean
-  -- Compiler.Proofs.IRGeneration.find_function_some_of_forall₂_generic  -- private
-  -- Compiler.Proofs.IRGeneration.find_function_none_of_forall₂_generic  -- private
+  Compiler.Proofs.IRGeneration.find_function_some_of_forall₂_generic
+  Compiler.Proofs.IRGeneration.find_function_none_of_forall₂_generic
   Compiler.Proofs.IRGeneration.interpretContract_correct_of_functions_generic
   Compiler.Proofs.IRGeneration.interpretContract_correct_of_compiled_guarded_functions
 
@@ -6757,4 +6766,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6291 theorems/lemmas (4422 public, 1869 private, 0 sorry'd)
+-- Total: 6297 theorems/lemmas (4430 public, 1867 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -164,6 +164,30 @@ High-level semantics can expose intermediate state in reverted computations. EVM
 ### External-Call Gas Discipline (short-term model)
 `Verity.Core.Model.GasCoupling` ties the modeled callee cost to the call's gas allowance: a `GasFaithful` adversary can only succeed within the allowance, must fail (never commit) when over budget, and cannot claim more gas than forwarded. Failure causes (`outOfGas` vs. opaque exceptional halt) are modeling artifacts: `denoteCall_congr`/`denote_congr` prove observations are determined by the adversary's responses alone, so causes cannot leak to the caller — matching the EVM's zero-success-bit observability. The caller-has-enough-gas-for-its-handler assumption is the explicit `CallerCoversAllowance` hypothesis. Opcode-level gas accounting (EIP-150, warm/cold, refunds, stipend) is out of scope for this model and remains a dedicated roadmap lane.
 
+### External-Call Journal (`ContractState.calls`)
+`ContractState.calls` is an append-only journal of observed external calls
+(`Verity.ExternalCall`: site id, kind, target, value, calldata, control,
+returndata). It is a **proof-side observable, not EVM state**: the EVM keeps
+no such record, so nothing about it is claimed by semantic preservation.
+Two deliberate modeling choices in
+`Verity.Core.Model.DenoteExternalCalls.denoteCallJournaled` and the source
+primitive `externalCall` (`Verity.Core.Model.ContractExternalCall`):
+1. **The journal survives caller-side rollback.** A failed or reverted call
+   restores the caller world *except* `calls` — otherwise reverted calls
+   would be unobservable and per-iteration reasoning over retrying loops
+   would be impossible. Consequently `externalCall` never raises a monadic
+   revert; the callee's outcome is reported in-band via
+   `ExternalCallResult.control` (a full monadic revert through
+   `Contract.run` still discards the journal with the rest of the snapshot,
+   matching EVM top-level semantics — `externalCallRequireSuccess` opts into
+   that deliberately).
+2. **The adversary cannot write the journal.** Even a committed
+   `call`/`delegatecall` transition has its `calls` field overwritten with
+   `pre.calls ++ [entry]`: the journal is the caller's observation record,
+   not adversary-controlled state.
+`denoteCall` itself is unchanged; all previously proven world/gas laws hold
+verbatim.
+
 ### Reentrancy Guard (`nonreentrant(lockField)`)
 Functions annotated `nonreentrant(lockField)` are compiled with a
 **transient-storage** reentrancy guard prologue (#1893): an

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -166,6 +166,39 @@ structure Event where
   indexedArgs : List Uint256    -- Indexed topic arguments
   deriving Repr
 
+-- External-call journal: core-level observables for calls that cross the
+-- contract boundary. Mirrors the denotational call model
+-- (`Verity.Core.Model.DenoteExternalCalls`) without importing it, the same
+-- way `Event` mirrors log emission (#153).
+
+/-- The EVM external-call opcode family, as recorded in the journal. -/
+inductive ExternalCallKind where
+  | call
+  | staticcall
+  | delegatecall
+  deriving DecidableEq, Repr
+
+/-- The control component of an external call's outcome. `failure` is a zero
+success bit without a revert payload; `revert` carries its payload through
+`returndata`. -/
+inductive ExternalCallControl where
+  | success
+  | failure
+  | revert
+  deriving DecidableEq, Repr
+
+/-- One entry of the external-call journal: everything a caller can observe
+at a call boundary — who was called, how, with what, and what came back. -/
+structure ExternalCall where
+  siteId : Nat
+  kind : ExternalCallKind
+  target : Nat
+  value : Nat := 0
+  calldata : List Nat := []
+  control : ExternalCallControl
+  returndata : List Nat := []
+  deriving DecidableEq, Repr
+
 -- State monad for contract execution
 structure ContractState where
   storage : Nat → Uint256                -- Uint256 storage mapping
@@ -197,6 +230,16 @@ structure ContractState where
   memory : Nat → Uint256 := fun _ => 0     -- EVM memory (word-addressed, zero-initialized)
   knownAddresses : Nat → FiniteAddressSet  -- Tracked addresses per storage slot (for sum properties)
   events : List Event := []  -- Emitted events, append-only log (#153)
+  /-- Observed external calls, append-only journal. Journaled call
+      denotations (`DenoteExternalCalls.denoteCallJournaled`) append here and
+      preserve the journal across caller-side rollback of a failed or
+      reverted call: the world is restored *except* this field, otherwise
+      reverted calls would be unobservable. A full monadic revert through
+      `Contract.run` still restores the pre-call snapshot including the
+      journal, which is why the source primitive `externalCall` reports the
+      callee's outcome in-band (`ExternalCallResult.control`) instead of
+      raising a monadic revert. -/
+  calls : List ExternalCall := []
 
 namespace ContractState
 

--- a/Verity/Core/Model/ContractExternalCall.lean
+++ b/Verity/Core/Model/ContractExternalCall.lean
@@ -1,0 +1,104 @@
+import Verity.Core.Model.DenoteExternalCalls
+
+/-!
+# Source-level external calls in the `Contract` monad
+
+`Contract.run` alone cannot observe a call boundary: nothing in
+`ContractState` records that a call happened, what it carried, or what came
+back.  This module lifts the journaled call denotation
+(`DenoteExternalCalls.denoteCallJournaled`) into the `Contract` monad so
+source-level contracts observe `kind`/`value`/`control`/`returndata` directly
+and every crossing lands in the append-only `ContractState.calls` journal.
+
+Design points:
+
+* **Never a monadic revert.**  A failed or reverted callee is reported
+  in-band through `ExternalCallResult.control`; the caller inspects it and
+  decides.  Raising `ContractResult.revert` instead would erase the journal
+  through `Contract.run`'s snapshot rollback, making the failed call
+  unobservable.  Callers wanting bubbling semantics compose with
+  `requireSuccess` below.
+* **No gas channel.**  The `Contract` monad carries no gas, so the call's
+  allowance is the site's own `gas` field; `chargedGas` caps the adversary's
+  claim by it.  Opcode-level gas accounting stays in the dedicated
+  `GasCoupling` lane.
+* **FFI-backed externals** (e.g. an SSZ Merkle verifier over the SHA-256
+  precompile) need no dedicated feature: model them as an ordinary
+  `staticcall` site whose `AdversaryModel.result` is constrained by the
+  relevant trust assumption.
+-/
+
+namespace Compiler.CompilationModel.DenoteExternalCalls
+
+open Verity
+
+/-- Perform one external call from inside the `Contract` monad: the callee's
+behaviour is the explicit `adversary` parameter, the observed result is
+returned in-band, and the call is appended to the caller's journal. -/
+def externalCall (adversary : AdversaryModel) (site : CallSite) :
+    Contract ExternalCallResult :=
+  fun s =>
+    let observation := denoteCallJournaled adversary site
+      { world := s, gasRemaining := site.gas }
+    ContractResult.success observation.result observation.state.world
+
+/-- Unfolding law: `externalCall` succeeds monadically with the adversary's
+response and the journaled post-world. -/
+theorem externalCall_run (adversary : AdversaryModel) (site : CallSite)
+    (s : ContractState) :
+    (externalCall adversary site).run s =
+      ContractResult.success (adversary.result site s)
+        (denoteCallJournaled adversary site
+          { world := s, gasRemaining := site.gas }).state.world := rfl
+
+/-- The returned result is exactly the adversary's response on the pre-call
+world. -/
+@[simp] theorem externalCall_result (adversary : AdversaryModel)
+    (site : CallSite) (s : ContractState) :
+    ((externalCall adversary site).run s).fst = adversary.result site s := rfl
+
+/-- One call appends exactly one journal entry. -/
+@[simp] theorem externalCall_calls (adversary : AdversaryModel)
+    (site : CallSite) (s : ContractState) :
+    ((externalCall adversary site).run s).snd.calls =
+      s.calls ++ [journalEntry site (adversary.result site s)] := rfl
+
+/-- Caller-side rollback: when a mutable call fails or reverts, the post
+world is the pre world except the journal entry. -/
+theorem externalCall_rollback (adversary : AdversaryModel) (site : CallSite)
+    (s : ContractState) (data : List Nat)
+    (hkind : site.kind = .call ∨ site.kind = .delegatecall)
+    (hresult : adversary.result site s = .failure data ∨
+      adversary.result site s = .revert data) :
+    ((externalCall adversary site).run s).snd =
+      { s with calls := s.calls ++ [journalEntry site (adversary.result site s)] } := by
+  show (denoteCallJournaled adversary site
+      { world := s, gasRemaining := site.gas }).state.world = _
+  rw [denoteCallJournaled_rollback_world adversary site
+    { world := s, gasRemaining := site.gas } data hkind hresult]
+  simp [denoteCall]
+
+/-- A static call preserves the caller world except the journal entry. -/
+theorem externalCall_staticcall (adversary : AdversaryModel) (site : CallSite)
+    (s : ContractState) (hkind : site.kind = .staticcall) :
+    ((externalCall adversary site).run s).snd =
+      { s with calls := s.calls ++ [journalEntry site (adversary.result site s)] } := by
+  show (denoteCallJournaled adversary site
+      { world := s, gasRemaining := site.gas }).state.world = _
+  rw [denoteCallJournaled_staticcall_world adversary site
+    { world := s, gasRemaining := site.gas } hkind]
+  simp [denoteCall]
+
+/-- Bubbling wrapper: revert the caller when the callee did not succeed.
+This intentionally re-enters `Contract.run`'s snapshot rollback — including
+the journal — matching EVM top-level semantics where a fully reverted
+execution leaves nothing observable. -/
+def externalCallRequireSuccess (adversary : AdversaryModel) (site : CallSite)
+    (msg : String := "external call failed") : Contract (List Nat) :=
+  Verity.bind (externalCall adversary site) fun result =>
+    fun s =>
+      match result with
+      | .success data => ContractResult.success data s
+      | .failure _ | .revert _ => ContractResult.revert msg s
+
+end Compiler.CompilationModel.DenoteExternalCalls

--- a/Verity/Core/Model/DenoteExternalCalls.lean
+++ b/Verity/Core/Model/DenoteExternalCalls.lean
@@ -48,6 +48,8 @@ inductive ExternalCallResult where
   | revert (returndata : List Nat)
   deriving DecidableEq, Repr
 
+instance : Inhabited ExternalCallResult := ⟨.success []⟩
+
 namespace ExternalCallResult
 
 def returndata : ExternalCallResult → List Nat
@@ -246,6 +248,153 @@ theorem denote_nested (adversary : AdversaryModel) (state : CallState)
       let outerResult := denoteCall adversary outer state
       let innerResult := denoteCall adversary (inner outerResult.result) outerResult.state
       ((outerResult.result, innerResult.result), innerResult.state) := rfl
+
+/-! ## Journaled denotation
+
+`denoteCall` leaves no trace of the boundary crossing in the caller world.
+The journaled variant additionally appends one `Verity.ExternalCall` entry to
+`ContractState.calls` per call.  Two deliberate semantic choices:
+
+* **The journal survives rollback.**  Failure and revert restore the caller
+  world *except* the journal — otherwise reverted calls would be
+  unobservable, and per-iteration reasoning over retrying loops (e.g. the
+  MinFirst allocation loop) would be impossible.
+* **The adversary cannot touch the journal.**  Even on a committed `call` /
+  `delegatecall` success, the post-call journal is forced to
+  `pre.calls ++ [entry]`, regardless of what `stateTransition` did to the
+  `calls` field.  The journal is the caller's observation record, not
+  adversary-controlled state.
+
+`denoteCall` itself is unchanged, so every existing world/gas law holds
+verbatim; the journaled lemmas below characterize the delta. -/
+
+/-- Journal projections of the model-level call kinds and controls. -/
+def CallKind.toJournal : CallKind → Verity.ExternalCallKind
+  | .call => .call
+  | .staticcall => .staticcall
+  | .delegatecall => .delegatecall
+
+def CallControl.toJournal : CallControl → Verity.ExternalCallControl
+  | .success => .success
+  | .failure => .failure
+  | .revert => .revert
+
+/-- The journal entry recorded for one call site and its observed result. -/
+def journalEntry (site : CallSite) (result : ExternalCallResult) :
+    Verity.ExternalCall :=
+  { siteId := site.siteId
+    kind := site.kind.toJournal
+    target := site.target
+    value := site.value
+    calldata := site.calldata
+    control := result.control.toJournal
+    returndata := result.returndata }
+
+/-- Denote one external call and record it in the caller world's journal. -/
+def denoteCallJournaled (adversary : AdversaryModel) (site : CallSite)
+    (state : CallState) : CallObservation :=
+  let observation := denoteCall adversary site state
+  { observation with
+    state :=
+      { observation.state with
+        world :=
+          { observation.state.world with
+            calls := state.world.calls ++ [journalEntry site observation.result] } } }
+
+@[simp] theorem denoteCallJournaled_result (adversary : AdversaryModel)
+    (site : CallSite) (state : CallState) :
+    (denoteCallJournaled adversary site state).result =
+      (denoteCall adversary site state).result := rfl
+
+@[simp] theorem denoteCallJournaled_gasUsed (adversary : AdversaryModel)
+    (site : CallSite) (state : CallState) :
+    (denoteCallJournaled adversary site state).gasUsed =
+      (denoteCall adversary site state).gasUsed := rfl
+
+@[simp] theorem denoteCallJournaled_gasRemaining (adversary : AdversaryModel)
+    (site : CallSite) (state : CallState) :
+    (denoteCallJournaled adversary site state).state.gasRemaining =
+      (denoteCall adversary site state).state.gasRemaining := rfl
+
+@[simp] theorem denoteCallJournaled_returndata (adversary : AdversaryModel)
+    (site : CallSite) (state : CallState) :
+    (denoteCallJournaled adversary site state).state.returndata =
+      (denoteCall adversary site state).state.returndata := rfl
+
+/-- The journaled world is the plain-denotation world with exactly one entry
+appended to the journal — the adversary's committed transition cannot leak
+into `calls`. -/
+theorem denoteCallJournaled_world (adversary : AdversaryModel)
+    (site : CallSite) (state : CallState) :
+    (denoteCallJournaled adversary site state).state.world =
+      { (denoteCall adversary site state).state.world with
+        calls := state.world.calls ++
+          [journalEntry site (denoteCall adversary site state).result] } := rfl
+
+/-- Append law: one call appends exactly one journal entry. -/
+@[simp] theorem denoteCallJournaled_calls (adversary : AdversaryModel)
+    (site : CallSite) (state : CallState) :
+    (denoteCallJournaled adversary site state).state.world.calls =
+      state.world.calls ++
+        [journalEntry site (denoteCall adversary site state).result] := rfl
+
+/-- Rollback preserves the journal: a failed or reverted mutable call
+restores the caller world except the appended entry. -/
+theorem denoteCallJournaled_rollback_world (adversary : AdversaryModel)
+    (site : CallSite) (state : CallState) (data : List Nat)
+    (hkind : site.kind = .call ∨ site.kind = .delegatecall)
+    (hresult : adversary.result site state.world = .failure data ∨
+      adversary.result site state.world = .revert data) :
+    (denoteCallJournaled adversary site state).state.world =
+      { state.world with
+        calls := state.world.calls ++
+          [journalEntry site (denoteCall adversary site state).result] } := by
+  rw [denoteCallJournaled_world]
+  rcases hresult with h | h
+  · rw [denoteCall_failure_world adversary site state data hkind h]
+  · rw [denoteCall_revert_world adversary site state data hkind h]
+
+/-- A static call preserves the caller world except the appended entry. -/
+theorem denoteCallJournaled_staticcall_world (adversary : AdversaryModel)
+    (site : CallSite) (state : CallState) (h : site.kind = .staticcall) :
+    (denoteCallJournaled adversary site state).state.world =
+      { state.world with
+        calls := state.world.calls ++
+          [journalEntry site (denoteCall adversary site state).result] } := by
+  rw [denoteCallJournaled_world,
+    denoteCall_staticcall_world adversary site state h]
+
+/-- Journaled denotation of a call program: every boundary crossing along the
+program is recorded, in order. -/
+def denoteJournaled : CallProgram α → AdversaryModel → CallState → α × CallState
+  | .pure value, _, state => (value, state)
+  | .bind site next, adversary, state =>
+      let observation := denoteCallJournaled adversary site state
+      denoteJournaled (next observation) adversary observation.state
+
+@[simp] theorem denoteJournaled_pure (adversary : AdversaryModel)
+    (state : CallState) (value : α) :
+    denoteJournaled (.pure value) adversary state = (value, state) := rfl
+
+theorem denoteJournaled_bind (adversary : AdversaryModel) (state : CallState)
+    (site : CallSite) (next : CallObservation → CallProgram α) :
+    denoteJournaled (.bind site next) adversary state =
+      let observation := denoteCallJournaled adversary site state
+      denoteJournaled (next observation) adversary observation.state := rfl
+
+/-- Monotonicity: a program only ever extends the journal. The witness is the
+ordered trace of the calls the program performed. -/
+theorem denoteJournaled_calls_monotone (program : CallProgram α)
+    (adversary : AdversaryModel) (state : CallState) :
+    ∃ trace, (denoteJournaled program adversary state).2.world.calls =
+      state.world.calls ++ trace := by
+  induction program generalizing state with
+  | pure value => exact ⟨[], by simp⟩
+  | bind site next ih =>
+      obtain ⟨trace, htrace⟩ :=
+        ih (denoteCallJournaled adversary site state) (denoteCallJournaled adversary site state).state
+      exact ⟨journalEntry site (denoteCall adversary site state).result :: trace, by
+        simpa [denoteJournaled_bind, denoteCallJournaled_calls] using htrace⟩
 
 /-! ## Bridge to the existing non-call denotation -/
 

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -65,6 +65,7 @@ ALLOWLIST: set[str] = {
     # branch structure mirrors interpretContract_correct_of_compiled_functions.
     "interpretContract_correct_of_functions_generic",
     "compileValidatedCore_ok_yields_guarded_functions",
+    "interpretContractWith_correct_of_functions_generic",
     # #2083 expression-surface closure: both proofs are mechanical constructor/list
     # traversals kept whole so the denotation and scanner cases remain auditable
     # against the corresponding exhaustive expression definitions.


### PR DESCRIPTION
The final assembly of the additive `*_guarded` family:

- `interpretContractWith` — source dispatch with parametric per-function semantics + correctness generic over BOTH the compile predicate and the source choice (only structural requirement: revert on binding failure);
- `guardedFunctionChoice`/`interpretGuardedContract` — guarded source contract semantics;
- **`compile_preserves_semantics_guarded`** — annotated contracts under the guarded pipeline (no lock-free erasure) match the guarded source semantics; per-function obligation discharges via `interpretGuardedFunction_matches` (#2316) + family root (#2309/#2310), side-conditions decidable per contract (#2312). Existing statements untouched.

Also includes (separate commit) the concurrent call-observation lane's core journal additions (`ExternalCallKind` + DenoteExternalCalls observables) that were present in the working tree and compile green with the stack.

Validation: full `lake build` (2470 jobs) OK, `make check` all passed, no sorry/admit/new axiom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new proof obligations and a deliberate semantic model for `ContractState.calls` (journal survives partial rollback); existing preservation theorems are unchanged but reviewers should confirm journal semantics match intended proof use.
> 
> **Overview**
> **Completes the additive `*_guarded` compiler proof family** with a whole-contract theorem: guarded source dispatch (`interpretGuardedContract` / `guardedFunctionChoice`) is shown to match IR from the guarded compile pipeline (no lock-free erasure), via a parametric dispatcher lemma and binding-failure side conditions dischargeable with existing per-function guarded machinery.
> 
> **Introduces an external-call observation lane** that is explicitly *not* part of semantic preservation: `ContractState` gains an append-only `calls` journal and core `ExternalCall` types; `denoteCallJournaled` / `denoteJournaled` layer journaling on unchanged `denoteCall` gas/world laws; source contracts get `externalCall` (in-band outcomes, journal survives caller-side rollback) plus optional `externalCallRequireSuccess` for bubbling revert.
> 
> **Housekeeping:** exports generic `find_function_*` lemmas from `GuardedDispatch`, registers new theorems in `PrintAxioms`, documents the journal in `AUDIT.md` / `TRUST_ASSUMPTIONS.md`, and allowlists the new large dispatcher proof in `check_proof_length.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddabfec49fcd3cc6bad9b9865345ee1853758e77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->