### PR TITLE
chore: refresh verification status artifact

### DIFF
--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 1027,
+    "core_lines": 1070,
     "example_contracts": 16
   },
   "proofs": {


### PR DESCRIPTION
core_lines drifted after the call-journal additions in #2317; regenerated so `make check` stays green on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single derived metric refresh in a checked JSON artifact; no runtime, auth, or proof logic changes.
> 
> **Overview**
> Updates **`artifacts/verification_status.json`** so **`codebase.core_lines`** matches the current Lean core after the call-journal work in #2317 (**1027 → 1070**). No other fields in the artifact change.
> 
> This is a **regenerated derived artifact** so **`make check`** / **`generate_verification_status.py --check`** stay green on main.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8732f9fdeedc4de9f93ef9bb15f39763347ff7fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->