### PR TITLE
fix(proofs): unbreak main — HelperBodyBridge vs invalid/selfdestruct halts

### DIFF
--- a/Compiler/Proofs/IRGeneration/HelperBodyBridge.lean
+++ b/Compiler/Proofs/IRGeneration/HelperBodyBridge.lean
@@ -94,6 +94,24 @@ private theorem helperBridge_internalFunctionYulName_ne_of_head
   rw [helperBridge_internalFunctionYulName_head calleeName] at hHead
   exact hhead hHead.symm
 
+/-- `internal_<name>` is at least 9 characters, `"invalid"` is 7 — a length
+discriminator, since both start with `'i'`. -/
+private theorem helperBridge_internalFunctionYulName_ne_invalid
+    (calleeName : String) :
+    CompilationModel.internalFunctionYulName calleeName ≠ "invalid" := by
+  intro hEq
+  have hLen := congrArg String.length hEq
+  have hMe : (CompilationModel.internalFunctionYulName calleeName).length =
+      9 + calleeName.length := by
+    show (toString "internal_" ++ toString calleeName).length =
+      9 + calleeName.length
+    rw [String.length_append]
+    simp [toString]
+    decide
+  rw [hMe] at hLen
+  have h7 : ("invalid" : String).length = 7 := by decide
+  omega
+
 private theorem helperBridge_internalFunctionYulName_isYulLogName_false (calleeName : String) :
     isYulLogName (CompilationModel.internalFunctionYulName calleeName) = false := by
   simp [isYulLogName,
@@ -161,6 +179,8 @@ private theorem execIRStmtsWithInternals_singleton_expr_internalFunctionYulName_
     (helperBridge_internalFunctionYulName_ne_of_head calleeName "tstore" (by decide))
     (helperBridge_internalFunctionYulName_ne_of_head calleeName "revert" (by decide))
     (helperBridge_internalFunctionYulName_ne_of_head calleeName "return" (by decide))
+    (helperBridge_internalFunctionYulName_ne_invalid calleeName)
+    (helperBridge_internalFunctionYulName_ne_of_head calleeName "selfdestruct" (by decide))
     (helperBridge_internalFunctionYulName_isYulLogName_false calleeName)
 
 /-- N2/N3 assignment-call instantiation of the N1a helper-summary bridge.


### PR DESCRIPTION
aa5e4632 (#2317 lane: invalid/selfdestruct modeled as interpreter halts) added two freshness hypotheses to `execIRStmtsWithInternals_singleton_expr_call_internal`; `HelperBodyBridge.lean:164` still passed the old argument list, breaking `lake build` on main.

Fix: add `helperBridge_internalFunctionYulName_ne_invalid` (length discriminator — `internal_<name>` is ≥9 chars, `"invalid"` is 7; both start with 'i' so the head-char lemma can't apply) and pass the `≠ "invalid"` / `≠ "selfdestruct"` hypotheses.

Authored by the concurrent session in this worktree; shipped to unbreak main. `lake build` green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only call-site and lemma wiring in IR generation; no runtime or security behavior changes.
> 
> **Overview**
> Repairs **HelperBodyBridge** after `execIRStmtsWithInternals_singleton_expr_call_internal` gained freshness obligations for **`"invalid"`** and **`"selfdestruct"`** (interpreter halt modeling).
> 
> Adds **`helperBridge_internalFunctionYulName_ne_invalid`**, showing `internal_<callee>` cannot equal `"invalid"` via **string length** (`9 + calleeName.length` vs `7`), because the existing first-character lemma cannot separate two names that both start with `'i'`.
> 
> The singleton internal-call bridge theorem now supplies **`≠ "invalid"`** and **`≠ "selfdestruct"`** when invoking that lemma, restoring **`lake build`** on main.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8714c537f1ae2f18c928bcc6252e79666d93e10e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->