### PR TITLE
feat(proofs): guarded whole-contract event preservation + checked arithmetic completion

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -193,6 +193,24 @@ sibling entrypoint.
   Journal".
 - **Axiom-free**: `AXIOMS.md` unchanged.
 
+## Guarded Event Preservation + Checked Arithmetic Completion (2026-08)
+
+- `Compiler/Proofs/IRGeneration/GuardedScalarEvents.lean`:
+  `compile_preserves_semantics_guarded_with_scalar_events` closes final-result
+  event preservation (`encodeEvents source.events = ir.events`) for the
+  guarded whole-contract pipeline on the scalar-event fragment, by proving
+  the guarded source semantics collapses to the plain one when every
+  dispatched function is lock-free (which `SupportedSpecWithScalarEvents`
+  forces). Pure composition of the #2000 event lane and the #2314–#2317
+  guarded family; no new semantic assumption, no axiom.
+- The `notModeledEventEmission` trust slice and `--deny-event-emission` gate
+  are **kept**: they flag `rawLog`, which remains unmodeled. Known limit
+  (documented in `TRUST_ASSUMPTIONS.md` §Event Emission): the slice does not
+  enumerate declared `Stmt.emit` sites outside the scalar fragment; that
+  boundary is enforced at the theorem support witness instead.
+- `Verity/Core/Uint256.lean`: `checkedSub`/`checkedMul` + `subNoWrap`/`mulNoWrap`
+  complete the checked-arithmetic lane (#1993) alongside `checkedAdd`.
+
 ## Audit Artifacts
 
 | Artifact | Purpose | Check |

--- a/Compiler/Proofs/IRGeneration/GuardedScalarEvents.lean
+++ b/Compiler/Proofs/IRGeneration/GuardedScalarEvents.lean
@@ -1,0 +1,135 @@
+import Compiler.Proofs.IRGeneration.GuardedContract
+
+/-!
+# Guarded whole-contract event preservation (`compile_preserves_semantics_guarded_with_scalar_events`)
+
+The guarded whole-contract theorem (#2314–#2317) concludes
+`sourceResultMatchesIRResult`, whose fourth conjunct is the final observable
+event equality `encodeEvents source.events = ir.events` — but its support
+witness (`SupportedSpecGuarded`) uses the event-excluding
+`SupportedBodyInterface`, so no event-carrying instance of the guarded family
+existed.  Conversely, the scalar-event whole-contract theorem
+(`compile_preserves_semantics_with_scalar_events`, #2000 lane) closes that
+equality end-to-end but speaks about the plain, unguarded source semantics.
+
+This module composes the two merged bricks: on the scalar-event fragment
+every supported function is lock-free (`noNonReentrant`), so the guarded
+source semantics collapses to the plain one and the scalar-event theorem
+transports to the guarded pipeline's characterization.  The result is the
+final-result event-preservation statement for `interpretGuardedContract` —
+no intermediate-state detour, no new semantic assumption.
+
+Scope boundary (unchanged): functions that carry a `nonreentrant(lock)`
+annotation *and* emit events remain outside the proven fragment; admitting
+them needs the event bridge inside the guarded per-function pipeline, a
+fragment widening rather than a composition.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+open Compiler.CompilationModel
+open Compiler.Proofs.IRGeneration.Contract
+
+/-- The guarded per-function choice is the plain semantics on lock-free
+functions. -/
+theorem guardedFunctionChoice_eq_of_none (model : CompilationModel)
+    (tx : IRTransaction) (initialWorld : Verity.ContractState)
+    (fn : FunctionSpec) (h : fn.nonReentrantLock = none) :
+    guardedFunctionChoice model tx initialWorld fn =
+      SourceSemantics.interpretFunction model fn tx initialWorld := by
+  unfold guardedFunctionChoice
+  rw [h]
+
+/-- On a contract whose selector-dispatched functions are all lock-free, the
+guarded source contract semantics is the plain source contract semantics. -/
+theorem interpretGuardedContract_eq_of_lock_free (model : CompilationModel)
+    (selectors : List Nat) (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (hlockfree : ∀ fn ∈ selectorDispatchedFunctions model,
+      fn.nonReentrantLock = none) :
+    interpretGuardedContract model selectors tx initialWorld =
+      sourceContractSemantics model selectors tx initialWorld := by
+  unfold interpretGuardedContract interpretContractWith
+    sourceContractSemantics SourceSemantics.interpretContract
+  cases hfind : SourceSemantics.findFunctionBySelector model selectors
+      tx.functionSelector with
+  | none => rfl
+  | some fn =>
+      have hfn : fn ∈ selectorDispatchedFunctions model :=
+        SourceSemantics.findFunctionBySelector_mem_selectorDispatchedFunctions
+          hfind
+      simp only [guardedFunctionChoice, hlockfree fn hfn]
+
+/-- Every scalar-event-supported dispatch target is lock-free. -/
+theorem lock_free_of_supportedSpecWithScalarEvents
+    (model : CompilationModel) (selectors : List Nat)
+    (hSupported : SupportedSpecWithScalarEvents model selectors) :
+    ∀ fn ∈ selectorDispatchedFunctions model, fn.nonReentrantLock = none :=
+  fun _fn hfn =>
+    (hSupported.supportedFunctionOfSelectorDispatched hfn).noNonReentrant
+
+/-- Guarded whole-contract event preservation on the scalar-event fragment:
+the guarded source semantics of a scalar-event-supported contract matches the
+compiled IR's final result — including the observable event equality
+`encodeEvents source.events = ir.events` — end to end. -/
+theorem compile_preserves_semantics_guarded_with_scalar_events
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpecWithScalarEvents model selectors)
+    (ir : IRContract)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (htxNormalized : Function.TxContextNormalized tx)
+    (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
+    (hcompile : CompilationModel.compile model selectors = Except.ok ir)
+    (hfuelPos : 0 < hSupported.helperFuel)
+    (hhelperFree :
+      ∀ fn, fn ∈ selectorDispatchedFunctions model →
+        StmtListHelperFreeNonEventStepInterface
+          (SourceSemantics.effectiveFields model) (fn.params.map (·.name)) fn.body)
+    (hstmtDisjoint :
+      ∀ fn, fn ∈ selectorDispatchedFunctions model →
+        StmtListHelperFreeCompiledCallsDisjoint { ir with internalFunctions := [] }
+          (SourceSemantics.effectiveFields model) (fn.params.map (·.name)) fn.body) :
+    FunctionBody.sourceResultMatchesIRResult
+      (interpretGuardedContract model selectors tx initialWorld)
+      (interpretIR ir tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) := by
+  rw [interpretGuardedContract_eq_of_lock_free model selectors tx initialWorld
+    (lock_free_of_supportedSpecWithScalarEvents model selectors hSupported)]
+  have hcontract := compile_preserves_semantics_with_scalar_events
+    model selectors hSupported ir tx initialWorld htxNormalized
+    hcalldataSizeFits hcompile hfuelPos hhelperFree hstmtDisjoint
+  simpa [supportedSourceContractSemanticsWithScalarEvents_eq_sourceContractSemantics
+    (hSupported := hSupported) tx initialWorld] using hcontract
+
+/-- The final-result event equality, projected out of the guarded theorem:
+the compiled contract's emitted event words are exactly the encoding of the
+guarded source semantics' events. -/
+theorem guarded_scalar_events_final_events_eq
+    (model : CompilationModel)
+    (selectors : List Nat)
+    (hSupported : SupportedSpecWithScalarEvents model selectors)
+    (ir : IRContract)
+    (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (htxNormalized : Function.TxContextNormalized tx)
+    (hcalldataSizeFits : Function.TxCalldataSizeFitsEvm tx)
+    (hcompile : CompilationModel.compile model selectors = Except.ok ir)
+    (hfuelPos : 0 < hSupported.helperFuel)
+    (hhelperFree :
+      ∀ fn, fn ∈ selectorDispatchedFunctions model →
+        StmtListHelperFreeNonEventStepInterface
+          (SourceSemantics.effectiveFields model) (fn.params.map (·.name)) fn.body)
+    (hstmtDisjoint :
+      ∀ fn, fn ∈ selectorDispatchedFunctions model →
+        StmtListHelperFreeCompiledCallsDisjoint { ir with internalFunctions := [] }
+          (SourceSemantics.effectiveFields model) (fn.params.map (·.name)) fn.body) :
+    (interpretGuardedContract model selectors tx initialWorld).events =
+      (interpretIR ir tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)).events :=
+  (compile_preserves_semantics_guarded_with_scalar_events model selectors
+    hSupported ir tx initialWorld htxNormalized hcalldataSizeFits hcompile
+    hfuelPos hhelperFree hstmtDisjoint).2.2.2
+
+end Compiler.Proofs.IRGeneration

--- a/Contracts/ERC20/Proofs/Basic.lean
+++ b/Contracts/ERC20/Proofs/Basic.lean
@@ -117,7 +117,7 @@ private theorem mint_unfold (s : ContractState) (toAddr : Address) (amount : Uin
         memory := s.memory,
         knownAddresses := fun slotIdx =>
           if slotIdx == 2 then (s.knownAddresses slotIdx).insert toAddr else s.knownAddresses slotIdx,
-         events := s.events } := by
+         events := s.events, calls := s.calls } := by
   have h_safe_bal := safeAdd_some (s.storageMap 2 toAddr) amount h_no_bal_overflow
   have h_safe_sup := safeAdd_some (s.storage 1) amount h_no_sup_overflow
   have h_tx0 : s.txOrigin = 0 := h_owner.2
@@ -216,7 +216,7 @@ private theorem transfer_unfold_other (s : ContractState) (toAddr : Address) (am
         knownAddresses := fun slotIdx =>
           if slotIdx == 2 then ((s.knownAddresses slotIdx).insert s.sender).insert toAddr
           else s.knownAddresses slotIdx,
-        events := s.events } := by
+        events := s.events, calls := s.calls } := by
   have h_balance' := uint256_ge_val_le h_balance
   have h_safe := safeAdd_some (s.storageMap 2 toAddr) amount h_no_overflow
   simp only [transfer, balancesSlot, msgSender, getMapping, setMapping,

--- a/Contracts/Ledger/Proofs/Basic.lean
+++ b/Contracts/Ledger/Proofs/Basic.lean
@@ -72,7 +72,7 @@ private theorem deposit_unfold (s : ContractState) (amount : Uint256) :
       knownAddresses := fun slotIdx =>
         if slotIdx == 0 then (s.knownAddresses slotIdx).insert s.sender
         else s.knownAddresses slotIdx,
-      events := s.events } := by
+      events := s.events, calls := s.calls } := by
   verity_unfold deposit
   simp only [balances]
   rfl
@@ -133,7 +133,7 @@ private theorem withdraw_unfold (s : ContractState) (amount : Uint256)
       knownAddresses := fun slotIdx =>
         if slotIdx == 0 then (s.knownAddresses slotIdx).insert s.sender
         else s.knownAddresses slotIdx,
-      events := s.events } := by
+      events := s.events, calls := s.calls } := by
   verity_unfold withdraw
   simp [balances, h_balance]
 
@@ -207,7 +207,7 @@ private theorem transfer_unfold_other (s : ContractState) (toAddr : Address) (am
       knownAddresses := fun slotIdx =>
         if slotIdx == 0 then ((s.knownAddresses slotIdx).insert s.sender).insert toAddr
         else s.knownAddresses slotIdx,
-      events := s.events } := by
+      events := s.events, calls := s.calls } := by
   simp only [transfer, Contracts.Ledger.balances,
     msgSender, getMapping, setMapping,
     ContractState.readMap, ContractState.writeMap,
@@ -313,7 +313,7 @@ theorem transfer_succeeds_recipient_overflow (s : ContractState) (toAddr : Addre
       knownAddresses := fun slotIdx =>
         if slotIdx == 0 then ((s.knownAddresses slotIdx).insert s.sender).insert toAddr
         else s.knownAddresses slotIdx,
-      events := s.events }
+      events := s.events, calls := s.calls }
   refine ⟨s', ?_⟩
   simpa [s'] using transfer_unfold_other s toAddr amount h_balance h_ne
 

--- a/Contracts/Owned/Proofs/Basic.lean
+++ b/Contracts/Owned/Proofs/Basic.lean
@@ -143,7 +143,7 @@ theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
       calldata := s.calldata,
       memory := s.memory,
       knownAddresses := s.knownAddresses,
-      events := s.events } := by
+      events := s.events, calls := s.calls } := by
   verity_unfold transferOwnership with h_owner
   simp [owner]
   exact h_owner

--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -132,7 +132,7 @@ theorem increment_unfold (s : ContractState)
       calldata := s.calldata,
       memory := s.memory,
       knownAddresses := s.knownAddresses,
-      events := s.events } := by
+      events := s.events, calls := s.calls } := by
   verity_unfold increment
   simp [owner, count, h_owner]
 
@@ -187,7 +187,7 @@ theorem decrement_unfold (s : ContractState)
       calldata := s.calldata,
       memory := s.memory,
       knownAddresses := s.knownAddresses,
-      events := s.events } := by
+      events := s.events, calls := s.calls } := by
   verity_unfold decrement
   simp [owner, count, h_owner]
 
@@ -241,7 +241,7 @@ theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
        calldata := s.calldata,
        memory := s.memory,
        knownAddresses := s.knownAddresses,
-       events := s.events } := by
+       events := s.events, calls := s.calls } := by
   verity_unfold transferOwnership
   simp [owner, h_owner]
 

--- a/Contracts/SafeCounter/Proofs/Basic.lean
+++ b/Contracts/SafeCounter/Proofs/Basic.lean
@@ -77,7 +77,7 @@ private theorem increment_unfold (s : ContractState)
       calldata := s.calldata,
       memory := s.memory,
       knownAddresses := s.knownAddresses,
-      events := s.events } := by
+      events := s.events, calls := s.calls } := by
   verity_unfold increment
   simp [count, requireSomeUint, Verity.pure, Pure.pure,
     safeAdd_some (s.storage 0) 1 h_no_overflow]
@@ -145,7 +145,7 @@ private theorem decrement_unfold (s : ContractState)
       calldata := s.calldata,
       memory := s.memory,
       knownAddresses := s.knownAddresses,
-      events := s.events } := by
+      events := s.events, calls := s.calls } := by
   verity_unfold decrement
   simp [count, requireSomeUint, Verity.pure, Pure.pure,
     safeSub_some (s.storage 0) 1 h_no_underflow]

--- a/Contracts/SimpleToken/Proofs/Basic.lean
+++ b/Contracts/SimpleToken/Proofs/Basic.lean
@@ -166,7 +166,7 @@ private theorem mint_unfold (s : ContractState) (toAddr : Address) (amount : Uin
       knownAddresses := fun slotIdx =>
         if slotIdx == 1 then (s.knownAddresses slotIdx).insert toAddr
         else s.knownAddresses slotIdx,
-      events := s.events } := by
+      events := s.events, calls := s.calls } := by
   have h_safe_bal := safeAdd_some (s.storageMap 1 toAddr) amount h_no_bal_overflow
   have h_safe_sup := safeAdd_some (s.storage 2) amount h_no_sup_overflow
   verity_unfold mint
@@ -309,7 +309,7 @@ private theorem transfer_unfold_other (s : ContractState) (toAddr : Address) (am
       knownAddresses := fun slotIdx =>
         if slotIdx == 1 then ((s.knownAddresses slotIdx).insert s.sender).insert toAddr
         else s.knownAddresses slotIdx,
-      events := s.events } := by
+      events := s.events, calls := s.calls } := by
   have h_balance' := uint256_ge_val_le h_balance
   have h_safe := safeAdd_some (s.storageMap 1 toAddr) amount h_no_overflow
   simp only [transfer, Contracts.SimpleToken.balancesSlot,

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -53,6 +53,7 @@ import Compiler.Proofs.IRGeneration.DenoteAgreement
 import Compiler.Proofs.IRGeneration.DenoteEquivalence
 import Compiler.Proofs.IRGeneration.DenoteFunctionAgreement
 import Compiler.Proofs.IRGeneration.Dispatch
+import Compiler.Proofs.IRGeneration.DispatchGeneric
 import Compiler.Proofs.IRGeneration.DynamicAbiRefinement
 import Compiler.Proofs.IRGeneration.ErrorStringPayloadIR
 import Compiler.Proofs.IRGeneration.EventObservable
@@ -80,6 +81,7 @@ import Compiler.Proofs.IRGeneration.GuardedContract
 import Compiler.Proofs.IRGeneration.GuardedContractShape
 import Compiler.Proofs.IRGeneration.GuardedDispatch
 import Compiler.Proofs.IRGeneration.GuardedFunction
+import Compiler.Proofs.IRGeneration.GuardedScalarEvents
 import Compiler.Proofs.IRGeneration.GuardedSourceBridge
 import Compiler.Proofs.IRGeneration.GuardedSpec
 import Compiler.Proofs.IRGeneration.HelperBodyBridge
@@ -2317,13 +2319,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.DenoteAgreement.denoteFunction_eq
 
   -- Compiler/Proofs/IRGeneration/Dispatch.lean
-  Compiler.Proofs.IRGeneration.Dispatch.runtimeContractOfFunctions_internalFunctions
   Compiler.Proofs.IRGeneration.Dispatch.runtimeContractOfFunctions_legacyCompatible
   Compiler.Proofs.IRGeneration.Dispatch.runtimeContractOfFunctions_disjoint
-  -- Compiler.Proofs.IRGeneration.Dispatch.decodeSupportedParamWord_some_of_supported  -- private
-  Compiler.Proofs.IRGeneration.Dispatch.bindSupportedParams_some_of_supported
-  -- Compiler.Proofs.IRGeneration.Dispatch.find_compiledFunction_some_of_forall₂  -- private
-  -- Compiler.Proofs.IRGeneration.Dispatch.find_compiledFunction_none_of_forall₂  -- private
   Compiler.Proofs.IRGeneration.Dispatch.interpretContract_correct_of_compiled_functions
   Compiler.Proofs.IRGeneration.Dispatch.interpretContractWithInternals_correct_of_compiled_functions
   Compiler.Proofs.IRGeneration.Dispatch.interpretContractWithHelpersWithInternals_correct_of_compiled_functions
@@ -2339,6 +2336,21 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Dispatch.interpretContract_correct_of_compiled_functions_with_helper_proofs_and_helper_ir_goal
   Compiler.Proofs.IRGeneration.Dispatch.interpretContract_correct_of_compiled_functions_with_helper_proofs_and_helper_ir_of_disjointRuntimeContract
   Compiler.Proofs.IRGeneration.Dispatch.interpretContract_correct_of_compiled_functions_with_helper_proofs_and_helper_ir_closed
+
+  -- Compiler/Proofs/IRGeneration/DispatchGeneric.lean
+  Compiler.Proofs.IRGeneration.Dispatch.runtimeContractOfFunctions_internalFunctions
+  -- Compiler.Proofs.IRGeneration.Dispatch.decodeSupportedParamWord_some_of_supported  -- private
+  Compiler.Proofs.IRGeneration.Dispatch.bindSupportedParams_some_of_supported
+  Compiler.Proofs.IRGeneration.Dispatch.not_length_le_of_bindSupportedParams_none
+  Compiler.Proofs.IRGeneration.interpretFunction_eq_reverted_of_bind_none
+  Compiler.Proofs.IRGeneration.interpretFunctionWithHelpers_eq_reverted_of_bind_none
+  Compiler.Proofs.IRGeneration.interpretContract_eq_interpretContractWith
+  Compiler.Proofs.IRGeneration.interpretContractWithHelpers_eq_interpretContractWith
+  Compiler.Proofs.IRGeneration.find_function_some_of_forall₂_generic
+  Compiler.Proofs.IRGeneration.find_function_none_of_forall₂_generic
+  Compiler.Proofs.IRGeneration.interpretContractWith_correct_generic
+  Compiler.Proofs.IRGeneration.interpretContractWith_correct_of_functions_generic
+  Compiler.Proofs.IRGeneration.interpretContract_correct_of_functions_generic
 
   -- Compiler/Proofs/IRGeneration/DynamicAbiRefinement.lean
   Compiler.Proofs.IRGeneration.DynamicAbiRefinement.arrayElementDynamicHeadOffset?_index_oob
@@ -3561,7 +3573,6 @@ end Verity.AxiomAudit
 
   -- Compiler/Proofs/IRGeneration/GuardedContract.lean
   Compiler.Proofs.IRGeneration.revertedResult_setLock
-  Compiler.Proofs.IRGeneration.interpretContractWith_correct_of_functions_generic
   Compiler.Proofs.IRGeneration.SupportedFunctionGuarded.paramsSupported
   Compiler.Proofs.IRGeneration.supported_params_of_supportedSpecGuarded
   Compiler.Proofs.IRGeneration.guardedFunctionChoice_bindFail
@@ -3573,9 +3584,6 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.guarded_functions_forall₂_of_mapM_ok
 
   -- Compiler/Proofs/IRGeneration/GuardedDispatch.lean
-  Compiler.Proofs.IRGeneration.find_function_some_of_forall₂_generic
-  Compiler.Proofs.IRGeneration.find_function_none_of_forall₂_generic
-  Compiler.Proofs.IRGeneration.interpretContract_correct_of_functions_generic
   Compiler.Proofs.IRGeneration.interpretContract_correct_of_compiled_guarded_functions
 
   -- Compiler/Proofs/IRGeneration/GuardedFunction.lean
@@ -3584,6 +3592,13 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.acquiredBoundState_eq
   Compiler.Proofs.IRGeneration.exec_compiledGuardedFunctionIR_of_body_fallthrough
   Compiler.Proofs.IRGeneration.exec_compiledGuardedFunctionIR_of_body_halting
+
+  -- Compiler/Proofs/IRGeneration/GuardedScalarEvents.lean
+  Compiler.Proofs.IRGeneration.guardedFunctionChoice_eq_of_none
+  Compiler.Proofs.IRGeneration.interpretGuardedContract_eq_of_lock_free
+  Compiler.Proofs.IRGeneration.lock_free_of_supportedSpecWithScalarEvents
+  Compiler.Proofs.IRGeneration.compile_preserves_semantics_guarded_with_scalar_events
+  Compiler.Proofs.IRGeneration.guarded_scalar_events_final_events_eq
 
   -- Compiler/Proofs/IRGeneration/GuardedSourceBridge.lean
   Compiler.Proofs.IRGeneration.withTransactionContext_setLock
@@ -3603,6 +3618,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.execIRInternalFunctionWithInternals_obeys_internal_helper_summary
   -- Compiler.Proofs.IRGeneration.helperBridge_internalFunctionYulName_head  -- private
   -- Compiler.Proofs.IRGeneration.helperBridge_internalFunctionYulName_ne_of_head  -- private
+  -- Compiler.Proofs.IRGeneration.helperBridge_internalFunctionYulName_ne_invalid  -- private
   -- Compiler.Proofs.IRGeneration.helperBridge_internalFunctionYulName_isYulLogName_false  -- private
   -- Compiler.Proofs.IRGeneration.execIRStmtsWithInternals_singleton_expr_internalFunctionYulName_call_internal  -- private
   Compiler.Proofs.IRGeneration.execIRStmtsWithInternals_internalCallAssign_obeys_internal_helper_summary
@@ -6766,4 +6782,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6297 theorems/lemmas (4430 public, 1867 private, 0 sorry'd)
+-- Total: 6307 theorems/lemmas (4441 public, 1866 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -164,6 +164,27 @@ High-level semantics can expose intermediate state in reverted computations. EVM
 ### External-Call Gas Discipline (short-term model)
 `Verity.Core.Model.GasCoupling` ties the modeled callee cost to the call's gas allowance: a `GasFaithful` adversary can only succeed within the allowance, must fail (never commit) when over budget, and cannot claim more gas than forwarded. Failure causes (`outOfGas` vs. opaque exceptional halt) are modeling artifacts: `denoteCall_congr`/`denote_congr` prove observations are determined by the adversary's responses alone, so causes cannot leak to the caller — matching the EVM's zero-success-bit observability. The caller-has-enough-gas-for-its-handler assumption is the explicit `CallerCoversAllowance` hypothesis. Opcode-level gas accounting (EIP-150, warm/cold, refunds, stipend) is out of scope for this model and remains a dedicated roadmap lane.
 
+### Event Emission (preserved observable, scalar fragment)
+Final-result event preservation — `encodeEvents source.events = ir.events` in
+the transaction's observable result, not merely an intermediate state — is
+**proven** for the scalar fragment by
+`Compiler.Proofs.IRGeneration.Contract.compile_preserves_semantics_with_scalar_events`
+and, for the guarded (`nonreentrant`-aware) pipeline, by
+`Compiler.Proofs.IRGeneration.compile_preserves_semantics_guarded_with_scalar_events`
+(`Compiler/Proofs/IRGeneration/GuardedScalarEvents.lean`; on the scalar
+fragment every supported function is lock-free, so the guarded source
+semantics provably collapses to the plain one). Outside the proven fragment:
+- `Stmt.rawLog` emission is not modeled — this is what the machine-readable
+  trust-report slice `notModeledEventEmission` and the `--deny-event-emission`
+  gate flag.
+- Declared `Stmt.emit` outside the scalar fragment (nested under
+  `ite`/`forEach`, non-scalar or more than 3 indexed params, non-atomic
+  args, or inside a function that carries a `nonreentrant` lock) is
+  excluded by the support witness (`SupportedBodyInterfaceWithScalarEvents`)
+  rather than reported in `notModeledEventEmission`: the boundary is
+  machine-checked at the theorem surface, but the trust-report slice does
+  **not** enumerate it — the slice only ever names `rawLog`.
+
 ### External-Call Journal (`ContractState.calls`)
 `ContractState.calls` is an append-only journal of observed external calls
 (`Verity.ExternalCall`: site id, kind, target, value, calldata, control,

--- a/Verity/Core/Uint256.lean
+++ b/Verity/Core/Uint256.lean
@@ -197,6 +197,70 @@ theorem addNoWrap {a b : Uint256} (h : a.val + b.val < modulus) :
     (add a b).val = a.val + b.val := by
   simp [add, ofNat, Nat.mod_eq_of_lt h]
 
+/-- Checked subtraction: `some` of the exact difference when `b ≤ a`, `none`
+on underflow — the semantic counterpart of solc-0.8 checked `-` (#1993). -/
+def checkedSub (a b : Uint256) : Option Uint256 :=
+  if b.val ≤ a.val then
+    some ⟨a.val - b.val, Nat.lt_of_le_of_lt (Nat.sub_le _ _) a.isLt⟩
+  else none
+
+/-- A successful checked subtraction is the wrapping subtraction, and its
+value is the exact Nat difference — no wrap occurred. -/
+theorem checkedSub_eq_some {a b c : Uint256}
+    (h : checkedSub a b = some c) :
+    c = sub a b ∧ c.val = a.val - b.val := by
+  unfold checkedSub at h
+  split at h
+  · rename_i hle
+    obtain rfl := Option.some.inj h
+    have hlt : a.val - b.val < modulus :=
+      Nat.lt_of_le_of_lt (Nat.sub_le _ _) a.isLt
+    exact ⟨by simp [sub, hle, ofNat, Nat.mod_eq_of_lt hlt], rfl⟩
+  · cases h
+
+/-- Checked subtraction fails exactly on underflow. -/
+theorem checkedSub_eq_none_iff (a b : Uint256) :
+    checkedSub a b = none ↔ a.val < b.val := by
+  unfold checkedSub
+  split <;> rename_i hle <;> simp <;> omega
+
+/-- Non-underflowing subtraction is exact: the wrapped difference's value is
+the Nat difference. -/
+theorem subNoWrap {a b : Uint256} (h : b.val ≤ a.val) :
+    (sub a b).val = a.val - b.val := by
+  have hlt : a.val - b.val < modulus :=
+    Nat.lt_of_le_of_lt (Nat.sub_le _ _) a.isLt
+  simp [sub, h, ofNat, Nat.mod_eq_of_lt hlt]
+
+/-- Checked multiplication: `some` of the exact product when it fits, `none`
+on overflow — the semantic counterpart of solc-0.8 checked `*` (#1993). -/
+def checkedMul (a b : Uint256) : Option Uint256 :=
+  if h : a.val * b.val < modulus then some ⟨a.val * b.val, h⟩ else none
+
+/-- A successful checked multiplication is the wrapping multiplication, and
+its value is the exact Nat product — no wrap occurred. -/
+theorem checkedMul_eq_some {a b c : Uint256}
+    (h : checkedMul a b = some c) :
+    c = mul a b ∧ c.val = a.val * b.val := by
+  unfold checkedMul at h
+  split at h
+  · rename_i hlt
+    obtain rfl := Option.some.inj h
+    exact ⟨by simp [mul, ofNat, Nat.mod_eq_of_lt hlt], rfl⟩
+  · cases h
+
+/-- Checked multiplication fails exactly on overflow. -/
+theorem checkedMul_eq_none_iff (a b : Uint256) :
+    checkedMul a b = none ↔ modulus ≤ a.val * b.val := by
+  unfold checkedMul
+  split <;> rename_i hlt <;> simp <;> omega
+
+/-- Non-overflowing multiplication is exact: the wrapped product's value is
+the Nat product. -/
+theorem mulNoWrap {a b : Uint256} (h : a.val * b.val < modulus) :
+    (mul a b).val = a.val * b.val := by
+  simp [mul, ofNat, Nat.mod_eq_of_lt h]
+
 -- Overflow detection predicates for safety proofs (on raw Nat values)
 def willAddOverflow (a b : Uint256) : Bool :=
   a.val + b.val ≥ modulus


### PR DESCRIPTION
Closes the guarded-family gap in the #2000 event lane and completes the #1993 checked-arithmetic lane.

## Event preservation (guarded pipeline)
`compile_preserves_semantics_guarded_with_scalar_events` (new `Compiler/Proofs/IRGeneration/GuardedScalarEvents.lean`): final-result event preservation — `encodeEvents source.events = ir.events` in the transaction's observable result — for `interpretGuardedContract`, on the scalar-event fragment. Proven by showing the guarded source semantics collapses to the plain one when every dispatched function is lock-free (forced by `SupportedSpecWithScalarEvents`), then transporting `compile_preserves_semantics_with_scalar_events`. Pure composition of merged bricks; no new assumption, no axiom. Also ships the projected `guarded_scalar_events_final_events_eq`.

Deliberately **kept** `notModeledEventEmission` / `--deny-event-emission`: they flag `rawLog`, which remains unmodeled. The fragment boundary (nested emit, non-scalar params, non-atomic args, events in locked functions) is machine-checked at the support witness, not enumerated by the slice — documented in TRUST_ASSUMPTIONS §Event Emission.

## Checked arithmetic
`Uint256.checkedSub`/`checkedMul` + `subNoWrap`/`mulNoWrap`, same pattern and lemma set as `checkedAdd`.

## Repair
`Contracts/*/Proofs/Basic.lean`: explicit `ContractState` record literals now thread the new `calls` field (the `Contracts` lib sits outside the default build target, so this had broken silently with the call-journal addition).

## Evidence
- `lake build` + `lake build Contracts` + `lake build PrintAxioms` green (0 axioms)
- `make check` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive Lean proofs, core arithmetic helpers, and mechanical contract-proof updates with no runtime, auth, or compiler-output behavior changes.
> 
> **Overview**
> Adds **`compile_preserves_semantics_guarded_with_scalar_events`** in `GuardedScalarEvents.lean`, proving final-result **`encodeEvents source.events = ir.events`** for the **`nonreentrant`-aware** whole-contract pipeline on the scalar-event fragment by showing guarded semantics equals plain semantics when every dispatch target is lock-free (`SupportedSpecWithScalarEvents`), then reusing the existing scalar-events theorem. **`rawLog`** / **`--deny-event-emission`** stay; trust docs now spell out the scalar-fragment boundary.
> 
> **`Uint256`** gains **`checkedSub`** / **`checkedMul`** and matching **`subNoWrap`** / **`mulNoWrap`** lemmas (#1993), mirroring **`checkedAdd`**.
> 
> **`Contracts/*/Proofs/Basic.lean`** record literals now include **`calls := s.calls`** so proofs compile after the external-call journal field. **`PrintAxioms.lean`** registers the new module and shuffles some dispatch generic theorem listings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 184dccb7493949e04341a46eb8c9a2f5da857d5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->