### PR TITLE
refactor(proofs): master compileValidatedCore inversion

### DIFF
--- a/Compiler/Proofs/IRGeneration/Contract.lean
+++ b/Compiler/Proofs/IRGeneration/Contract.lean
@@ -122,22 +122,6 @@ theorem filterInternalFunctions_eq_nil_of_all_nonInternal :
         exact hall fn' (by simp [hmem])
       simp [hfn, filterInternalFunctions_eq_nil_of_all_nonInternal rest hrest]
 
-private theorem filterInternalFunctions_eq_nil_of_supported
-    (model : CompilationModel)
-    (selectors : List Nat)
-    (hSupported : SupportedSpec model selectors) :
-    model.functions.filter (·.isInternal) = [] := by
-  exact filterInternalFunctions_eq_nil_of_all_nonInternal model.functions
-    (hSupported.noInternalFunctions)
-
-private theorem filterInternalFunctions_eq_nil_of_supported_except_mapping_writes
-    (model : CompilationModel)
-    (selectors : List Nat)
-    (hSupported : SupportedSpecExceptMappingWrites model selectors) :
-    model.functions.filter (·.isInternal) = [] := by
-  exact filterInternalFunctions_eq_nil_of_all_nonInternal model.functions
-    (hSupported.noInternalFunctions)
-
 private theorem compileValidatedCore_ok_yields_compiled_functions
     (model : CompilationModel)
     (selectors : List Nat)
@@ -149,51 +133,17 @@ private theorem compileValidatedCore_ok_yields_compiled_functions
         compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1 = Except.ok irFn)
       (SourceSemantics.selectorFunctionPairs model selectors)
       ir.functions := by
-  have hfallback :
-      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "fallback" model.functions hSupported.noFallback
-  have hreceive :
-      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "receive" model.functions hSupported.noReceive
-  have hnoInternalFns :
-      model.functions.filter (·.isInternal) = [] :=
-    filterInternalFunctions_eq_nil_of_supported model selectors hSupported
-  unfold compileValidatedCore at hcore
-  rw [hSupported.normalizedFields,
-    hSupported.noAdtTypes, hSupported.noEvents, hSupported.noErrors,
-    hnoInternalFns, hfallback, hreceive, hSupported.surface.noTemplateIntrinsics] at hcore
-  simp only [bind, Except.bind, pure, Except.pure] at hcore
-  rw [ContractShape.guardedFunctionsMapM_eq model.fields [] [] [] [] _
-    (ContractShape.supportedSpec_entries_lock_free hSupported)] at hcore
-  rcases hmap :
-      ((model.functions.filter
-          (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
-        (fun x => compileFunctionSpec model.fields [] [] [] x.2 x.1) with _ | irFns
-  · simp [hmap] at hcore
-  · simp [hmap] at hcore
-    rcases hctor :
-        compileConstructor model.fields [] [] [] model.constructor with _ | deployStmts
-    · simp [hctor] at hcore
-      cases hcore
-    · simp [hctor] at hcore
-      have hfunctions : ir.functions = irFns := by
-        injection hcore with hir
-        cases hir
-        rfl
-      have hcompiled :
-          List.Forall₂
-            (fun (entry : FunctionSpec × Nat) irFn =>
-              compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1 = Except.ok irFn)
-            ((model.functions.filter
-                (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors)
-            irFns :=
-        by
-          simpa [hSupported.noEvents, hSupported.noErrors] using
-            (compiled_functions_forall₂_of_mapM_ok model.fields [] [] _ _ hmap)
-      simpa [SourceSemantics.selectorFunctionPairs, selectorDispatchedFunctions,
-        hfunctions] using hcompiled
+  obtain ⟨irFns, deployStmts, hmap, hctor, hir⟩ :=
+    ContractShape.compileValidatedCore_ok_inv
+      model selectors ir hSupported.noFallback hSupported.noReceive
+      hSupported.noInternalFunctions
+      (ContractShape.supportedSpec_entries_lock_free hSupported)
+      hSupported.surface.noTemplateIntrinsics hcore
+  rw [hSupported.normalizedFields, hSupported.noAdtTypes] at hmap
+  have hcompiled := compiled_functions_forall₂_of_mapM_ok
+    model.fields model.events model.errors _ _ hmap
+  simpa [SourceSemantics.selectorFunctionPairs, selectorDispatchedFunctions,
+    hir] using hcompiled
 
 private theorem compileValidatedCore_ok_yields_compiled_functions_except_mapping_writes
     (model : CompilationModel)
@@ -206,51 +156,17 @@ private theorem compileValidatedCore_ok_yields_compiled_functions_except_mapping
         compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1 = Except.ok irFn)
       (SourceSemantics.selectorFunctionPairs model selectors)
       ir.functions := by
-  have hfallback :
-      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "fallback" model.functions hSupported.noFallback
-  have hreceive :
-      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "receive" model.functions hSupported.noReceive
-  have hnoInternalFns :
-      model.functions.filter (·.isInternal) = [] :=
-    filterInternalFunctions_eq_nil_of_supported_except_mapping_writes model selectors hSupported
-  unfold compileValidatedCore at hcore
-  rw [hSupported.normalizedFields,
-    hSupported.noAdtTypes, hSupported.noEvents, hSupported.noErrors,
-    hnoInternalFns, hfallback, hreceive, hSupported.surface.noTemplateIntrinsics] at hcore
-  simp only [bind, Except.bind, pure, Except.pure] at hcore
-  rw [ContractShape.guardedFunctionsMapM_eq model.fields [] [] [] [] _
-    (ContractShape.supportedSpecExceptMappingWrites_entries_lock_free hSupported)] at hcore
-  rcases hmap :
-      ((model.functions.filter
-          (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
-        (fun x => compileFunctionSpec model.fields [] [] [] x.2 x.1) with _ | irFns
-  · simp [hmap] at hcore
-  · simp [hmap] at hcore
-    rcases hctor :
-        compileConstructor model.fields [] [] [] model.constructor with _ | deployStmts
-    · simp [hctor] at hcore
-      cases hcore
-    · simp [hctor] at hcore
-      have hfunctions : ir.functions = irFns := by
-        injection hcore with hir
-        cases hir
-        rfl
-      have hcompiled :
-          List.Forall₂
-            (fun (entry : FunctionSpec × Nat) irFn =>
-              compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1 = Except.ok irFn)
-            ((model.functions.filter
-                (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors)
-            irFns :=
-        by
-          simpa [hSupported.noEvents, hSupported.noErrors] using
-            (compiled_functions_forall₂_of_mapM_ok model.fields [] [] _ _ hmap)
-      simpa [SourceSemantics.selectorFunctionPairs, selectorDispatchedFunctions,
-        hfunctions] using hcompiled
+  obtain ⟨irFns, deployStmts, hmap, hctor, hir⟩ :=
+    ContractShape.compileValidatedCore_ok_inv
+      model selectors ir hSupported.noFallback hSupported.noReceive
+      hSupported.noInternalFunctions
+      (ContractShape.supportedSpecExceptMappingWrites_entries_lock_free hSupported)
+      hSupported.surface.noTemplateIntrinsics hcore
+  rw [hSupported.normalizedFields, hSupported.noAdtTypes] at hmap
+  have hcompiled := compiled_functions_forall₂_of_mapM_ok
+    model.fields model.events model.errors _ _ hmap
+  simpa [SourceSemantics.selectorFunctionPairs, selectorDispatchedFunctions,
+    hir] using hcompiled
 
 private theorem compileValidatedCore_ok_yields_internalFunctions_nil
     (model : CompilationModel)
@@ -259,48 +175,20 @@ private theorem compileValidatedCore_ok_yields_internalFunctions_nil
     (ir : IRContract)
     (hcore : compileValidatedCore model selectors = Except.ok ir) :
     ir.internalFunctions = [] := by
-  have hfallback :
-      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "fallback" model.functions hSupported.noFallback
-  have hreceive :
-      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "receive" model.functions hSupported.noReceive
-  have hnoInternalFns :
-      model.functions.filter (·.isInternal) = [] :=
-    filterInternalFunctions_eq_nil_of_supported model selectors hSupported
-  have harray : contractUsesArrayElement model = false :=
+  obtain ⟨irFns, deployStmts, hmap, hctor, hir⟩ :=
+    ContractShape.compileValidatedCore_ok_inv
+      model selectors ir hSupported.noFallback hSupported.noReceive
+      hSupported.noInternalFunctions
+      (ContractShape.supportedSpec_entries_lock_free hSupported)
+      hSupported.surface.noTemplateIntrinsics hcore
+  rw [hir]
+  exact ContractShape.coreHelperInternalFunctions_eq_nil model
     hSupported.contractUsesArrayElement_eq_false
-  have hstorageArray : contractUsesStorageArrayElement model = false :=
     hSupported.contractUsesStorageArrayElement_eq_false
-  have hdynamicBytesEq : contractUsesDynamicBytesEq model = false :=
     hSupported.contractUsesDynamicBytesEq_eq_false
-  have hmulDiv512 : contractUsesMulDiv512 model = false :=
     hSupported.contractUsesMulDiv512_eq_false
-  have hparamDyn : contractUsesParamDynamicHeadWord model = false :=
     hSupported.contractUsesParamDynamicHeadWord_eq_false
-  unfold compileValidatedCore at hcore
-  rw [hSupported.normalizedFields, hfallback, hreceive,
-    contractUsesPlainArrayElement, contractUsesArrayElementWord, harray,
-    hstorageArray, hdynamicBytesEq, hmulDiv512, hparamDyn,
-    hSupported.noCheckedArithmetic,
-    hnoInternalFns, hSupported.noAdtTypes, hSupported.surface.noTemplateIntrinsics] at hcore
-  simp only [bind, Except.bind, pure, Except.pure, List.mapM_nil] at hcore
-  rw [ContractShape.guardedFunctionsMapM_eq model.fields model.events model.errors [] [] _
-    (ContractShape.supportedSpec_entries_lock_free hSupported)] at hcore
-  rcases hmap :
-      ((model.functions.filter
-          (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
-        (fun x => compileFunctionSpec model.fields model.events model.errors [] x.2 x.1) with _ | irFns
-  · simp [hmap] at hcore
-  · rcases hctor :
-        compileConstructor model.fields model.events model.errors [] model.constructor with _ | deployStmts
-    · simp [hmap, hctor] at hcore
-      cases hcore
-    · simp [hmap, hctor] at hcore
-      cases hcore
-      rfl
+    hSupported.noCheckedArithmetic
 
 private theorem compileValidatedCore_ok_yields_noFallbackEntrypoint
     (model : CompilationModel)
@@ -309,36 +197,13 @@ private theorem compileValidatedCore_ok_yields_noFallbackEntrypoint
     (ir : IRContract)
     (hcore : compileValidatedCore model selectors = Except.ok ir) :
     ir.fallbackEntrypoint = none := by
-  have hfallback :
-      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "fallback" model.functions hSupported.noFallback
-  have hreceive :
-      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "receive" model.functions hSupported.noReceive
-  have hnoInternalFns :
-      model.functions.filter (·.isInternal) = [] :=
-    filterInternalFunctions_eq_nil_of_supported model selectors hSupported
-  unfold compileValidatedCore at hcore
-  rw [hnoInternalFns, hfallback, hreceive, hSupported.surface.noTemplateIntrinsics] at hcore
-  simp only [bind, Except.bind, Option.mapM_none, pure, Except.pure] at hcore
-  rw [ContractShape.guardedFunctionsMapM_eq (applySlotAliasRanges model.fields model.slotAliasRanges)
-    model.events model.errors model.adtTypes [] _
-    (ContractShape.supportedSpec_entries_lock_free hSupported)] at hcore
-  rcases hmap :
-      ((model.functions.filter
-          (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
-        (fun x => compileFunctionSpec (applySlotAliasRanges model.fields model.slotAliasRanges)
-          model.events model.errors model.adtTypes x.2 x.1) with _ | irFns
-  · simp [hmap] at hcore
-  · rcases hctor :
-        compileConstructor (applySlotAliasRanges model.fields model.slotAliasRanges)
-          model.events model.errors model.adtTypes model.constructor with _ | deployStmts
-    · simp [hmap, hctor, Pure.pure, Except.pure] at hcore
-    · simp [hmap, hctor, Pure.pure, Except.pure] at hcore
-      cases hcore
-      rfl
+  obtain ⟨irFns, deployStmts, hmap, hctor, hir⟩ :=
+    ContractShape.compileValidatedCore_ok_inv
+      model selectors ir hSupported.noFallback hSupported.noReceive
+      hSupported.noInternalFunctions
+      (ContractShape.supportedSpec_entries_lock_free hSupported)
+      hSupported.surface.noTemplateIntrinsics hcore
+  rw [hir]
 
 private theorem compileValidatedCore_ok_yields_noReceiveEntrypoint
     (model : CompilationModel)
@@ -347,36 +212,13 @@ private theorem compileValidatedCore_ok_yields_noReceiveEntrypoint
     (ir : IRContract)
     (hcore : compileValidatedCore model selectors = Except.ok ir) :
     ir.receiveEntrypoint = none := by
-  have hfallback :
-      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "fallback" model.functions hSupported.noFallback
-  have hreceive :
-      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "receive" model.functions hSupported.noReceive
-  have hnoInternalFns :
-      model.functions.filter (·.isInternal) = [] :=
-    filterInternalFunctions_eq_nil_of_supported model selectors hSupported
-  unfold compileValidatedCore at hcore
-  rw [hnoInternalFns, hfallback, hreceive, hSupported.surface.noTemplateIntrinsics] at hcore
-  simp only [bind, Except.bind, Option.mapM_none, pure, Except.pure] at hcore
-  rw [ContractShape.guardedFunctionsMapM_eq (applySlotAliasRanges model.fields model.slotAliasRanges)
-    model.events model.errors model.adtTypes [] _
-    (ContractShape.supportedSpec_entries_lock_free hSupported)] at hcore
-  rcases hmap :
-      ((model.functions.filter
-          (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
-        (fun x => compileFunctionSpec (applySlotAliasRanges model.fields model.slotAliasRanges)
-          model.events model.errors model.adtTypes x.2 x.1) with _ | irFns
-  · simp [hmap] at hcore
-  · rcases hctor :
-        compileConstructor (applySlotAliasRanges model.fields model.slotAliasRanges)
-          model.events model.errors model.adtTypes model.constructor with _ | deployStmts
-    · simp [hmap, hctor, Pure.pure, Except.pure] at hcore
-    · simp [hmap, hctor, Pure.pure, Except.pure] at hcore
-      cases hcore
-      rfl
+  obtain ⟨irFns, deployStmts, hmap, hctor, hir⟩ :=
+    ContractShape.compileValidatedCore_ok_inv
+      model selectors ir hSupported.noFallback hSupported.noReceive
+      hSupported.noInternalFunctions
+      (ContractShape.supportedSpec_entries_lock_free hSupported)
+      hSupported.surface.noTemplateIntrinsics hcore
+  rw [hir]
 
 theorem supported_params_of_supportedSpec
     (model : CompilationModel)
@@ -634,56 +476,21 @@ theorem compile_ok_yields_internalFunctions_nil_except_mapping_writes
     (ir : IRContract)
     (hcompile : CompilationModel.compile model selectors = Except.ok ir) :
     ir.internalFunctions = [] := by
-  have hfallback :
-      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "fallback" model.functions hSupported.noFallback
-  have hreceive :
-      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "receive" model.functions hSupported.noReceive
-  have hnoInternalFns :
-      model.functions.filter (·.isInternal) = [] :=
-    filterInternalFunctions_eq_nil_of_supported_except_mapping_writes model selectors hSupported
-  have harray : contractUsesArrayElement model = false :=
+  have hcore := ContractShape.compile_ok_yields_core model selectors ir hcompile
+  obtain ⟨irFns, deployStmts, hmap, hctor, hir⟩ :=
+    ContractShape.compileValidatedCore_ok_inv
+      model selectors ir hSupported.noFallback hSupported.noReceive
+      hSupported.noInternalFunctions
+      (ContractShape.supportedSpecExceptMappingWrites_entries_lock_free hSupported)
+      hSupported.surface.noTemplateIntrinsics hcore
+  rw [hir]
+  exact ContractShape.coreHelperInternalFunctions_eq_nil model
     hSupported.contractUsesArrayElement_eq_false
-  have hstorageArray : contractUsesStorageArrayElement model = false :=
     hSupported.contractUsesStorageArrayElement_eq_false
-  have hdynamicBytesEq : contractUsesDynamicBytesEq model = false :=
     hSupported.contractUsesDynamicBytesEq_eq_false
-  have hmulDiv512 : contractUsesMulDiv512 model = false :=
     hSupported.contractUsesMulDiv512_eq_false
-  have hparamDyn : contractUsesParamDynamicHeadWord model = false :=
     hSupported.contractUsesParamDynamicHeadWord_eq_false
-  have hcheckedArithmetic : contractUsesCheckedArithmetic model = false :=
     hSupported.noCheckedArithmetic
-  unfold CompilationModel.compile at hcompile
-  simp only [bind, Except.bind] at hcompile
-  rcases hvalidate : validateCompileInputs model selectors with _ | validated
-  · simp [hvalidate] at hcompile
-  · simp [hvalidate] at hcompile
-    unfold compileValidatedCore at hcompile
-    rw [hSupported.normalizedFields, hfallback, hreceive,
-      contractUsesPlainArrayElement, contractUsesArrayElementWord, harray,
-      hstorageArray, hdynamicBytesEq, hmulDiv512, hparamDyn,
-      hcheckedArithmetic,
-      hnoInternalFns, hSupported.noAdtTypes, hSupported.surface.noTemplateIntrinsics] at hcompile
-    simp only [bind, Except.bind, pure, Except.pure, List.mapM_nil] at hcompile
-    rw [ContractShape.guardedFunctionsMapM_eq model.fields model.events model.errors [] [] _
-      (ContractShape.supportedSpecExceptMappingWrites_entries_lock_free hSupported)] at hcompile
-    rcases hmap :
-        ((model.functions.filter
-            (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
-          (fun x => compileFunctionSpec model.fields model.events model.errors [] x.2 x.1) with _ | irFns
-    · simp [hmap] at hcompile
-    · rcases hctor :
-          compileConstructor model.fields model.events model.errors [] model.constructor with _ | deployStmts
-      · simp [hmap, hctor] at hcompile
-        cases hcompile
-      · simp [hmap, hctor] at hcompile
-        injection hcompile with hir
-        cases hir
-        rfl
 
 theorem compile_ok_yields_noFallbackEntrypoint_except_mapping_writes
     (model : CompilationModel)
@@ -692,48 +499,14 @@ theorem compile_ok_yields_noFallbackEntrypoint_except_mapping_writes
     (ir : IRContract)
     (hcompile : CompilationModel.compile model selectors = Except.ok ir) :
     ir.fallbackEntrypoint = none := by
-  have hfallback :
-      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "fallback" model.functions hSupported.noFallback
-  have hreceive :
-      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "receive" model.functions hSupported.noReceive
-  have hnoInternalFns :
-      model.functions.filter (·.isInternal) = [] :=
-    filterInternalFunctions_eq_nil_of_supported_except_mapping_writes model selectors hSupported
-  have harray : contractUsesArrayElement model = false :=
-    hSupported.contractUsesArrayElement_eq_false
-  have hstorageArray : contractUsesStorageArrayElement model = false :=
-    hSupported.contractUsesStorageArrayElement_eq_false
-  have hdynamicBytesEq : contractUsesDynamicBytesEq model = false :=
-    hSupported.contractUsesDynamicBytesEq_eq_false
-  unfold CompilationModel.compile at hcompile
-  simp only [bind, Except.bind] at hcompile
-  rcases hvalidate : validateCompileInputs model selectors with _ | validated
-  · simp [hvalidate] at hcompile
-  · simp [hvalidate] at hcompile
-    unfold compileValidatedCore at hcompile
-    rw [hSupported.normalizedFields, hfallback, hreceive,
-      contractUsesPlainArrayElement, contractUsesArrayElementWord, harray,
-      hstorageArray, hdynamicBytesEq, hnoInternalFns, hSupported.noAdtTypes, hSupported.surface.noTemplateIntrinsics] at hcompile
-    simp only [bind, Except.bind, pure, Except.pure, List.mapM_nil] at hcompile
-    rw [ContractShape.guardedFunctionsMapM_eq model.fields model.events model.errors [] [] _
-      (ContractShape.supportedSpecExceptMappingWrites_entries_lock_free hSupported)] at hcompile
-    rcases hmap :
-        ((model.functions.filter
-            (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
-          (fun x => compileFunctionSpec model.fields model.events model.errors [] x.2 x.1) with _ | irFns
-    · simp [hmap] at hcompile
-    · rcases hctor :
-          compileConstructor model.fields model.events model.errors [] model.constructor with _ | deployStmts
-      · simp [hmap, hctor] at hcompile
-        cases hcompile
-      · simp [hmap, hctor] at hcompile
-        injection hcompile with hir
-        cases hir
-        rfl
+  have hcore := ContractShape.compile_ok_yields_core model selectors ir hcompile
+  obtain ⟨irFns, deployStmts, hmap, hctor, hir⟩ :=
+    ContractShape.compileValidatedCore_ok_inv
+      model selectors ir hSupported.noFallback hSupported.noReceive
+      hSupported.noInternalFunctions
+      (ContractShape.supportedSpecExceptMappingWrites_entries_lock_free hSupported)
+      hSupported.surface.noTemplateIntrinsics hcore
+  rw [hir]
 
 theorem compile_ok_yields_noReceiveEntrypoint_except_mapping_writes
     (model : CompilationModel)
@@ -742,48 +515,14 @@ theorem compile_ok_yields_noReceiveEntrypoint_except_mapping_writes
     (ir : IRContract)
     (hcompile : CompilationModel.compile model selectors = Except.ok ir) :
     ir.receiveEntrypoint = none := by
-  have hfallback :
-      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "fallback" model.functions hSupported.noFallback
-  have hreceive :
-      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "receive" model.functions hSupported.noReceive
-  have hnoInternalFns :
-      model.functions.filter (·.isInternal) = [] :=
-    filterInternalFunctions_eq_nil_of_supported_except_mapping_writes model selectors hSupported
-  have harray : contractUsesArrayElement model = false :=
-    hSupported.contractUsesArrayElement_eq_false
-  have hstorageArray : contractUsesStorageArrayElement model = false :=
-    hSupported.contractUsesStorageArrayElement_eq_false
-  have hdynamicBytesEq : contractUsesDynamicBytesEq model = false :=
-    hSupported.contractUsesDynamicBytesEq_eq_false
-  unfold CompilationModel.compile at hcompile
-  simp only [bind, Except.bind] at hcompile
-  rcases hvalidate : validateCompileInputs model selectors with _ | validated
-  · simp [hvalidate] at hcompile
-  · simp [hvalidate] at hcompile
-    unfold compileValidatedCore at hcompile
-    rw [hSupported.normalizedFields, hfallback, hreceive,
-      contractUsesPlainArrayElement, contractUsesArrayElementWord, harray,
-      hstorageArray, hdynamicBytesEq, hnoInternalFns, hSupported.noAdtTypes, hSupported.surface.noTemplateIntrinsics] at hcompile
-    simp only [bind, Except.bind, pure, Except.pure, List.mapM_nil] at hcompile
-    rw [ContractShape.guardedFunctionsMapM_eq model.fields model.events model.errors [] [] _
-      (ContractShape.supportedSpecExceptMappingWrites_entries_lock_free hSupported)] at hcompile
-    rcases hmap :
-        ((model.functions.filter
-            (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
-          (fun x => compileFunctionSpec model.fields model.events model.errors [] x.2 x.1) with _ | irFns
-    · simp [hmap] at hcompile
-    · rcases hctor :
-          compileConstructor model.fields model.events model.errors [] model.constructor with _ | deployStmts
-      · simp [hmap, hctor] at hcompile
-        cases hcompile
-      · simp [hmap, hctor] at hcompile
-        injection hcompile with hir
-        cases hir
-        rfl
+  have hcore := ContractShape.compile_ok_yields_core model selectors ir hcompile
+  obtain ⟨irFns, deployStmts, hmap, hctor, hir⟩ :=
+    ContractShape.compileValidatedCore_ok_inv
+      model selectors ir hSupported.noFallback hSupported.noReceive
+      hSupported.noInternalFunctions
+      (ContractShape.supportedSpecExceptMappingWrites_entries_lock_free hSupported)
+      hSupported.surface.noTemplateIntrinsics hcore
+  rw [hir]
 
 -- NOTE: compileValidatedCore_ok_yields_supportedRuntimeHelperTableInterface and
 -- compile_ok_yields_supportedRuntimeHelperTableInterface are BLOCKED by missing

--- a/Compiler/Proofs/IRGeneration/ContractShape.lean
+++ b/Compiler/Proofs/IRGeneration/ContractShape.lean
@@ -153,6 +153,159 @@ private theorem filterInternalFunctions_eq_nil_of_supported
   exact filterInternalFunctions_eq_nil_of_all_nonInternal model.functions
     (hSupported.noInternalFunctions)
 
+/-- Closed form of the helper `internalFunctions` emitted by
+`compileValidatedCore` when the model has no source internal functions and
+no template intrinsics: only the usage-gated builtin helper groups remain. -/
+def coreHelperInternalFunctions (model : CompilationModel) :
+    List Compiler.Yul.YulStmt :=
+  ((if contractUsesPlainArrayElement model then
+      [ checkedArrayElementCalldataHelper
+      , checkedArrayElementMemoryHelper
+      ]
+    else
+      []) ++
+    (if contractUsesArrayElementWord model then
+      [ checkedArrayElementWordCalldataHelper
+      , checkedArrayElementWordMemoryHelper
+      , checkedArrayElementDynamicWordCalldataHelper
+      , checkedArrayElementDynamicWordMemoryHelper
+      , checkedArrayElementDynamicDataOffsetCalldataHelper
+      , checkedArrayElementDynamicDataOffsetMemoryHelper
+      , checkedArrayElementDynamicMemberLengthCalldataHelper
+      , checkedArrayElementDynamicMemberLengthMemoryHelper
+      , checkedArrayElementDynamicMemberDataOffsetCalldataHelper
+      , checkedArrayElementDynamicMemberDataOffsetMemoryHelper
+      , checkedArrayElementDynamicMemberElementCalldataHelper
+      , checkedArrayElementDynamicMemberElementMemoryHelper
+      ]
+    else
+      []) ++
+    (if contractUsesParamDynamicHeadWord model then
+      [ checkedParamDynamicHeadWordCalldataHelper
+      , checkedParamDynamicHeadWordMemoryHelper
+      , checkedParamDynamicMemberLengthCalldataHelper
+      , checkedParamDynamicMemberLengthMemoryHelper
+      , checkedParamDynamicMemberDataOffsetCalldataHelper
+      , checkedParamDynamicMemberDataOffsetMemoryHelper
+      , checkedParamDynamicMemberElementCalldataHelper
+      , checkedParamDynamicMemberElementMemoryHelper
+      ]
+    else
+      []) ++
+    (if contractUsesMulDiv512 model then
+      [ fullMulDivHelper
+      , fullMulDivUpHelper
+      ]
+    else
+      [])) ++
+  (if contractUsesStorageArrayElement model then
+    [checkedStorageArrayElementHelper, checkedFixedUint128ArrayElementHelper]
+  else
+    []) ++
+  (if contractUsesDynamicBytesEq model then
+    [dynamicBytesEqCalldataHelper, dynamicBytesEqMemoryHelper]
+  else
+    []) ++
+  (if contractUsesCheckedArithmetic model then
+    [ panicError0x11Helper
+    , panicError0x12Helper
+    , checkedAddUint256Helper
+    , checkedSubUint256Helper
+    , checkedMulUint256Helper
+    , checkedDivUint256Helper
+    ]
+  else
+    [])
+
+/-- The gated helper groups vanish when no gate fires. -/
+theorem coreHelperInternalFunctions_eq_nil
+    (model : CompilationModel)
+    (harray : contractUsesArrayElement model = false)
+    (hstorageArray : contractUsesStorageArrayElement model = false)
+    (hdynamicBytesEq : contractUsesDynamicBytesEq model = false)
+    (hmulDiv512 : contractUsesMulDiv512 model = false)
+    (hparamDyn : contractUsesParamDynamicHeadWord model = false)
+    (hcheckedArith : contractUsesCheckedArithmetic model = false) :
+    coreHelperInternalFunctions model = [] := by
+  unfold coreHelperInternalFunctions contractUsesPlainArrayElement
+    contractUsesArrayElementWord
+  simp [harray, hstorageArray, hdynamicBytesEq, hmulDiv512, hparamDyn,
+    hcheckedArith]
+
+/-- Successful `compile` factors through `compileValidatedCore`. -/
+theorem compile_ok_yields_core
+    (model : CompilationModel) (selectors : List Nat) (ir : IRContract)
+    (hcompile : CompilationModel.compile model selectors = Except.ok ir) :
+    compileValidatedCore model selectors = Except.ok ir := by
+  unfold CompilationModel.compile at hcompile
+  simp only [bind, Except.bind] at hcompile
+  rcases hvalidate : validateCompileInputs model selectors with _ | validated
+  · simp [hvalidate] at hcompile
+  · simpa [hvalidate] using hcompile
+
+/-- Master inversion for `compileValidatedCore` on the lock-free,
+no-internal-function, no-template-intrinsic surface: pins every field of the
+output contract.  All per-projection shape lemmas derive from this. -/
+theorem compileValidatedCore_ok_inv
+    (model : CompilationModel) (selectors : List Nat) (ir : IRContract)
+    (hfallbackAbsent : ∀ fn ∈ model.functions, fn.name != "fallback")
+    (hreceiveAbsent : ∀ fn ∈ model.functions, fn.name != "receive")
+    (hnoInternal : ∀ fn ∈ model.functions, fn.isInternal = false)
+    (hlockfree : ∀ e ∈ (model.functions.filter
+        (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors,
+      (e : FunctionSpec × Nat).1.nonReentrantLock = none)
+    (hnoTemplate : templateIntrinsicItems model = [])
+    (hcore : compileValidatedCore model selectors = Except.ok ir) :
+    ∃ irFns deployStmts,
+      ((model.functions.filter
+          (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
+        (fun x => compileFunctionSpec (applySlotAliasRanges model.fields model.slotAliasRanges)
+          model.events model.errors model.adtTypes x.2 x.1) = Except.ok irFns ∧
+      compileConstructor (applySlotAliasRanges model.fields model.slotAliasRanges)
+        model.events model.errors model.adtTypes model.constructor = Except.ok deployStmts ∧
+      ir = { name := model.name
+             deploy := deployStmts
+             constructorPayable := (model.constructor.map (·.isPayable)).getD false
+             functions := irFns
+             fallbackEntrypoint := none
+             receiveEntrypoint := none
+             usesMapping := usesMapping (applySlotAliasRanges model.fields model.slotAliasRanges)
+             internalFunctions := coreHelperInternalFunctions model } := by
+  have hfallback :
+      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
+    pickUniqueFunctionByName_eq_ok_none_of_absent
+      "fallback" model.functions hfallbackAbsent
+  have hreceive :
+      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
+    pickUniqueFunctionByName_eq_ok_none_of_absent
+      "receive" model.functions hreceiveAbsent
+  have hnoInternalFns :
+      model.functions.filter (·.isInternal) = [] :=
+    filterInternalFunctions_eq_nil_of_all_nonInternal model.functions hnoInternal
+  have hnoTemplateEmpty : (templateIntrinsicItems model).isEmpty = true := by
+    simp [hnoTemplate]
+  unfold compileValidatedCore at hcore
+  rw [hnoInternalFns, hfallback, hreceive] at hcore
+  simp only [bind, Except.bind, Option.mapM_none, pure, Except.pure,
+    List.mapM_nil] at hcore
+  simp only [guardedFunctionsMapM_eq
+    (applySlotAliasRanges model.fields model.slotAliasRanges)
+    model.events model.errors model.adtTypes [] _ hlockfree] at hcore
+  rcases hmap :
+      ((model.functions.filter
+          (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
+        (fun x => compileFunctionSpec (applySlotAliasRanges model.fields model.slotAliasRanges)
+          model.events model.errors model.adtTypes x.2 x.1) with _ | irFns
+  · simp [hmap] at hcore
+  · rcases hctor :
+        compileConstructor (applySlotAliasRanges model.fields model.slotAliasRanges)
+          model.events model.errors model.adtTypes model.constructor with _ | deployStmts
+    · simp [hmap, hctor, hnoTemplateEmpty] at hcore
+    · refine ⟨irFns, deployStmts, hmap, rfl, ?_⟩
+      simp [hmap, hctor, hnoTemplateEmpty] at hcore
+      rw [← hcore]
+      simp [coreHelperInternalFunctions]
+
 private theorem compileValidatedCore_ok_yields_compiled_functions
     (model : CompilationModel)
     (selectors : List Nat)
@@ -164,52 +317,15 @@ private theorem compileValidatedCore_ok_yields_compiled_functions
         compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1 = Except.ok irFn)
       (SourceSemantics.selectorFunctionPairs model selectors)
       ir.functions := by
-  have hfallback :
-      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "fallback" model.functions hSupported.noFallback
-  have hreceive :
-      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "receive" model.functions hSupported.noReceive
-  have hnoInternalFns :
-      model.functions.filter (·.isInternal) = [] :=
-    filterInternalFunctions_eq_nil_of_supported model selectors hSupported
-  unfold compileValidatedCore at hcore
-  rw [hSupported.normalizedFields,
-    hSupported.noAdtTypes, hSupported.noEvents, hSupported.noErrors,
-    hnoInternalFns, hfallback, hreceive] at hcore
-  simp only [bind, Except.bind, pure, Except.pure] at hcore
-  simp only [guardedFunctionsMapM_eq model.fields [] [] [] [] _
-    (supportedSpec_entries_lock_free hSupported)] at hcore
-  rcases hmap :
-      ((model.functions.filter
-          (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
-        (fun x => compileFunctionSpec model.fields [] [] [] x.2 x.1) with _ | irFns
-  · simp [hmap] at hcore
-  · simp [hmap] at hcore
-    simp [hSupported.surface.noTemplateIntrinsics] at hcore
-    rcases hctor :
-        compileConstructor model.fields [] [] [] model.constructor with _ | deployStmts
-    · simp [hctor] at hcore
-      cases hcore
-    · simp [hctor] at hcore
-      have hfunctions : ir.functions = irFns := by
-        injection hcore with hir
-        cases hir
-        rfl
-      have hcompiled :
-          List.Forall₂
-            (fun (entry : FunctionSpec × Nat) irFn =>
-              compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1 = Except.ok irFn)
-            ((model.functions.filter
-                (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors)
-            irFns :=
-        by
-          simpa [hSupported.noEvents, hSupported.noErrors] using
-            (compiled_functions_forall₂_of_mapM_ok model.fields [] [] _ _ hmap)
-      simpa [SourceSemantics.selectorFunctionPairs, selectorDispatchedFunctions,
-        hfunctions] using hcompiled
+  obtain ⟨irFns, deployStmts, hmap, hctor, hir⟩ := compileValidatedCore_ok_inv
+    model selectors ir hSupported.noFallback hSupported.noReceive
+    hSupported.noInternalFunctions (supportedSpec_entries_lock_free hSupported)
+    hSupported.surface.noTemplateIntrinsics hcore
+  rw [hSupported.normalizedFields, hSupported.noAdtTypes] at hmap
+  have hcompiled := compiled_functions_forall₂_of_mapM_ok
+    model.fields model.events model.errors _ _ hmap
+  simpa [SourceSemantics.selectorFunctionPairs, selectorDispatchedFunctions,
+    hir] using hcompiled
 
 private theorem compileValidatedCore_ok_yields_internalFunctions_nil
     (model : CompilationModel)
@@ -218,47 +334,18 @@ private theorem compileValidatedCore_ok_yields_internalFunctions_nil
     (ir : IRContract)
     (hcore : compileValidatedCore model selectors = Except.ok ir) :
     ir.internalFunctions = [] := by
-  have hfallback :
-      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "fallback" model.functions hSupported.noFallback
-  have hreceive :
-      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "receive" model.functions hSupported.noReceive
-  have hnoInternalFns :
-      model.functions.filter (·.isInternal) = [] :=
-    filterInternalFunctions_eq_nil_of_supported model selectors hSupported
-  have harray : contractUsesArrayElement model = false :=
+  obtain ⟨irFns, deployStmts, hmap, hctor, hir⟩ := compileValidatedCore_ok_inv
+    model selectors ir hSupported.noFallback hSupported.noReceive
+    hSupported.noInternalFunctions (supportedSpec_entries_lock_free hSupported)
+    hSupported.surface.noTemplateIntrinsics hcore
+  rw [hir]
+  exact coreHelperInternalFunctions_eq_nil model
     hSupported.contractUsesArrayElement_eq_false
-  have hstorageArray : contractUsesStorageArrayElement model = false :=
     hSupported.contractUsesStorageArrayElement_eq_false
-  have hdynamicBytesEq : contractUsesDynamicBytesEq model = false :=
     hSupported.contractUsesDynamicBytesEq_eq_false
-  have hmulDiv512 : contractUsesMulDiv512 model = false :=
     hSupported.contractUsesMulDiv512_eq_false
-  have hparamDyn : contractUsesParamDynamicHeadWord model = false :=
     hSupported.contractUsesParamDynamicHeadWord_eq_false
-  unfold compileValidatedCore at hcore
-  rw [hSupported.normalizedFields, hfallback, hreceive,
-    contractUsesPlainArrayElement, contractUsesArrayElementWord, harray,
-    hstorageArray, hdynamicBytesEq, hmulDiv512, hparamDyn,
-    hSupported.noCheckedArithmetic,
-    hnoInternalFns, hSupported.noAdtTypes] at hcore
-  simp only [bind, Except.bind, pure, Except.pure, List.mapM_nil] at hcore
-  simp only [guardedFunctionsMapM_eq model.fields model.events model.errors [] [] _
-    (supportedSpec_entries_lock_free hSupported)] at hcore
-  rcases hmap :
-      ((model.functions.filter
-          (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
-        (fun x => compileFunctionSpec model.fields model.events model.errors [] x.2 x.1) with _ | irFns
-  · simp [hmap] at hcore
-  · rcases hctor :
-        compileConstructor model.fields model.events model.errors [] model.constructor with _ | deployStmts
-    · simp [hmap, hctor, hSupported.surface.noTemplateIntrinsics, pure, Except.pure] at hcore
-    · simp [hmap, hctor, hSupported.surface.noTemplateIntrinsics, pure, Except.pure] at hcore
-      cases hcore
-      rfl
+    hSupported.noCheckedArithmetic
 
 private theorem compileValidatedCore_ok_yields_deploy_compileConstructor
     (model : CompilationModel)
@@ -268,38 +355,13 @@ private theorem compileValidatedCore_ok_yields_deploy_compileConstructor
     (hcore : compileValidatedCore model selectors = Except.ok ir) :
     compileConstructor model.fields model.events model.errors [] model.constructor =
       Except.ok ir.deploy := by
-  have hfallback :
-      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "fallback" model.functions hSupported.noFallback
-  have hreceive :
-      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "receive" model.functions hSupported.noReceive
-  have hnoInternalFns :
-      model.functions.filter (·.isInternal) = [] :=
-    filterInternalFunctions_eq_nil_of_supported model selectors hSupported
-  unfold compileValidatedCore at hcore
-  rw [hSupported.normalizedFields,
-    hSupported.noAdtTypes, hSupported.noEvents, hSupported.noErrors,
-    hnoInternalFns, hfallback, hreceive] at hcore
-  simp only [bind, Except.bind, pure, Except.pure] at hcore
-  simp only [guardedFunctionsMapM_eq model.fields [] [] [] [] _
-    (supportedSpec_entries_lock_free hSupported)] at hcore
-  rcases hmap :
-      ((model.functions.filter
-          (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
-        (fun x => compileFunctionSpec model.fields [] [] [] x.2 x.1) with _ | irFns
-  · simp [hmap] at hcore
-  · simp [hmap] at hcore
-    simp [hSupported.surface.noTemplateIntrinsics] at hcore
-    rcases hctor :
-        compileConstructor model.fields [] [] [] model.constructor with _ | deployStmts
-    · simp [hctor] at hcore
-      cases hcore
-    · simp [hctor] at hcore
-      cases hcore
-      simpa [hSupported.noEvents, hSupported.noErrors] using hctor
+  obtain ⟨irFns, deployStmts, hmap, hctor, hir⟩ := compileValidatedCore_ok_inv
+    model selectors ir hSupported.noFallback hSupported.noReceive
+    hSupported.noInternalFunctions (supportedSpec_entries_lock_free hSupported)
+    hSupported.surface.noTemplateIntrinsics hcore
+  rw [hSupported.normalizedFields, hSupported.noAdtTypes] at hctor
+  rw [hir]
+  exact hctor
 
 private theorem compileValidatedCore_ok_yields_noFallbackEntrypoint
     (model : CompilationModel)
@@ -308,36 +370,11 @@ private theorem compileValidatedCore_ok_yields_noFallbackEntrypoint
     (ir : IRContract)
     (hcore : compileValidatedCore model selectors = Except.ok ir) :
     ir.fallbackEntrypoint = none := by
-  have hfallback :
-      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "fallback" model.functions hSupported.noFallback
-  have hreceive :
-      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "receive" model.functions hSupported.noReceive
-  have hnoInternalFns :
-      model.functions.filter (·.isInternal) = [] :=
-    filterInternalFunctions_eq_nil_of_supported model selectors hSupported
-  unfold compileValidatedCore at hcore
-  rw [hnoInternalFns, hfallback, hreceive] at hcore
-  simp only [bind, Except.bind, Option.mapM_none, pure, Except.pure] at hcore
-  simp only [guardedFunctionsMapM_eq (applySlotAliasRanges model.fields model.slotAliasRanges)
-    model.events model.errors model.adtTypes [] _
-    (supportedSpec_entries_lock_free hSupported)] at hcore
-  rcases hmap :
-      ((model.functions.filter
-          (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
-        (fun x => compileFunctionSpec (applySlotAliasRanges model.fields model.slotAliasRanges)
-          model.events model.errors model.adtTypes x.2 x.1) with _ | irFns
-  · simp [hmap] at hcore
-  · rcases hctor :
-        compileConstructor (applySlotAliasRanges model.fields model.slotAliasRanges)
-          model.events model.errors model.adtTypes model.constructor with _ | deployStmts
-    · simp [hmap, hctor, hSupported.surface.noTemplateIntrinsics, Pure.pure, Except.pure] at hcore
-    · simp [hmap, hctor, hSupported.surface.noTemplateIntrinsics, Pure.pure, Except.pure] at hcore
-      cases hcore
-      rfl
+  obtain ⟨irFns, deployStmts, hmap, hctor, hir⟩ := compileValidatedCore_ok_inv
+    model selectors ir hSupported.noFallback hSupported.noReceive
+    hSupported.noInternalFunctions (supportedSpec_entries_lock_free hSupported)
+    hSupported.surface.noTemplateIntrinsics hcore
+  rw [hir]
 
 private theorem compileValidatedCore_ok_yields_noReceiveEntrypoint
     (model : CompilationModel)
@@ -346,36 +383,11 @@ private theorem compileValidatedCore_ok_yields_noReceiveEntrypoint
     (ir : IRContract)
     (hcore : compileValidatedCore model selectors = Except.ok ir) :
     ir.receiveEntrypoint = none := by
-  have hfallback :
-      pickUniqueFunctionByName "fallback" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "fallback" model.functions hSupported.noFallback
-  have hreceive :
-      pickUniqueFunctionByName "receive" model.functions = Except.ok none :=
-    pickUniqueFunctionByName_eq_ok_none_of_absent
-      "receive" model.functions hSupported.noReceive
-  have hnoInternalFns :
-      model.functions.filter (·.isInternal) = [] :=
-    filterInternalFunctions_eq_nil_of_supported model selectors hSupported
-  unfold compileValidatedCore at hcore
-  rw [hnoInternalFns, hfallback, hreceive] at hcore
-  simp only [bind, Except.bind, Option.mapM_none, pure, Except.pure] at hcore
-  simp only [guardedFunctionsMapM_eq (applySlotAliasRanges model.fields model.slotAliasRanges)
-    model.events model.errors model.adtTypes [] _
-    (supportedSpec_entries_lock_free hSupported)] at hcore
-  rcases hmap :
-      ((model.functions.filter
-          (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
-        (fun x => compileFunctionSpec (applySlotAliasRanges model.fields model.slotAliasRanges)
-          model.events model.errors model.adtTypes x.2 x.1) with _ | irFns
-  · simp [hmap] at hcore
-  · rcases hctor :
-        compileConstructor (applySlotAliasRanges model.fields model.slotAliasRanges)
-          model.events model.errors model.adtTypes model.constructor with _ | deployStmts
-    · simp [hmap, hctor, hSupported.surface.noTemplateIntrinsics, Pure.pure, Except.pure] at hcore
-    · simp [hmap, hctor, hSupported.surface.noTemplateIntrinsics, Pure.pure, Except.pure] at hcore
-      cases hcore
-      rfl
+  obtain ⟨irFns, deployStmts, hmap, hctor, hir⟩ := compileValidatedCore_ok_inv
+    model selectors ir hSupported.noFallback hSupported.noReceive
+    hSupported.noInternalFunctions (supportedSpec_entries_lock_free hSupported)
+    hSupported.surface.noTemplateIntrinsics hcore
+  rw [hir]
 
 theorem compile_ok_yields_compiled_functions
     (model : CompilationModel)
@@ -411,39 +423,16 @@ private theorem compileValidatedCore_ok_yields_compiled_functions_with_scalar_ev
         compileFunctionSpec model.fields model.events model.errors [] entry.2 entry.1 = Except.ok irFn)
       (SourceSemantics.selectorFunctionPairs model selectors)
       ir.functions := by
-  have hfallback := pickUniqueFunctionByName_eq_ok_none_of_absent
-    "fallback" model.functions hSupported.surface.noFallback
-  have hreceive := pickUniqueFunctionByName_eq_ok_none_of_absent
-    "receive" model.functions hSupported.surface.noReceive
-  have hnoInternalFns :
-      model.functions.filter (·.isInternal) = [] :=
-    filterInternalFunctions_eq_nil_of_all_nonInternal model.functions
-      hSupported.noInternalFunctions
-  unfold compileValidatedCore at hcore
-  rw [hSupported.normalizedFields, hSupported.noAdtTypes, hSupported.noErrors,
-    hnoInternalFns, hfallback, hreceive] at hcore
-  simp only [bind, Except.bind, pure, Except.pure] at hcore
-  simp only [guardedFunctionsMapM_eq model.fields model.events [] [] [] _
-    (supportedSpecWithScalarEvents_entries_lock_free hSupported)] at hcore
-  rcases hmap : ((model.functions.filter
-      (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)).zip selectors).mapM
-      (fun x => compileFunctionSpec model.fields model.events [] [] x.2 x.1) with _ | irFns
-  · simp [hmap] at hcore
-  · simp [hmap] at hcore
-    simp [hSupported.surface.noTemplateIntrinsics] at hcore
-    rcases hctor :
-        compileConstructor model.fields model.events [] [] model.constructor with _ | deployStmts
-    · simp [hctor] at hcore
-      cases hcore
-    · simp [hctor] at hcore
-      have hfunctions : ir.functions = irFns := by
-        injection hcore with hir
-        cases hir
-        rfl
-      have hcompiled := compiled_functions_forall₂_of_mapM_ok
-        model.fields model.events [] _ _ hmap
-      simpa [SourceSemantics.selectorFunctionPairs, selectorDispatchedFunctions,
-        hfunctions, hSupported.noErrors] using hcompiled
+  obtain ⟨irFns, deployStmts, hmap, hctor, hir⟩ := compileValidatedCore_ok_inv
+    model selectors ir hSupported.surface.noFallback hSupported.surface.noReceive
+    hSupported.noInternalFunctions
+    (supportedSpecWithScalarEvents_entries_lock_free hSupported)
+    hSupported.surface.noTemplateIntrinsics hcore
+  rw [hSupported.normalizedFields, hSupported.noAdtTypes] at hmap
+  have hcompiled := compiled_functions_forall₂_of_mapM_ok
+    model.fields model.events model.errors _ _ hmap
+  simpa [SourceSemantics.selectorFunctionPairs, selectorDispatchedFunctions,
+    hir] using hcompiled
 
 theorem compile_ok_yields_compiled_functions_with_scalar_events
     (model : CompilationModel)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2101,8 +2101,6 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.Contract.compiled_internal_functions_forall₂_of_mapM_ok  -- private
   -- Compiler.Proofs.IRGeneration.Contract.exists_right_of_forall₂_mem_left  -- private
   Compiler.Proofs.IRGeneration.Contract.filterInternalFunctions_eq_nil_of_all_nonInternal
-  -- Compiler.Proofs.IRGeneration.Contract.filterInternalFunctions_eq_nil_of_supported  -- private
-  -- Compiler.Proofs.IRGeneration.Contract.filterInternalFunctions_eq_nil_of_supported_except_mapping_writes  -- private
   -- Compiler.Proofs.IRGeneration.Contract.compileValidatedCore_ok_yields_compiled_functions  -- private
   -- Compiler.Proofs.IRGeneration.Contract.compileValidatedCore_ok_yields_compiled_functions_except_mapping_writes  -- private
   -- Compiler.Proofs.IRGeneration.Contract.compileValidatedCore_ok_yields_internalFunctions_nil  -- private
@@ -2217,6 +2215,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.ContractShape.supportedSpecWithScalarEvents_entries_lock_free
   -- Compiler.Proofs.IRGeneration.ContractShape.filterInternalFunctions_eq_nil_of_all_nonInternal  -- private
   -- Compiler.Proofs.IRGeneration.ContractShape.filterInternalFunctions_eq_nil_of_supported  -- private
+  Compiler.Proofs.IRGeneration.ContractShape.coreHelperInternalFunctions_eq_nil
+  Compiler.Proofs.IRGeneration.ContractShape.compile_ok_yields_core
+  Compiler.Proofs.IRGeneration.ContractShape.compileValidatedCore_ok_inv
   -- Compiler.Proofs.IRGeneration.ContractShape.compileValidatedCore_ok_yields_compiled_functions  -- private
   -- Compiler.Proofs.IRGeneration.ContractShape.compileValidatedCore_ok_yields_internalFunctions_nil  -- private
   -- Compiler.Proofs.IRGeneration.ContractShape.compileValidatedCore_ok_yields_deploy_compileConstructor  -- private
@@ -6782,4 +6783,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6307 theorems/lemmas (4441 public, 1866 private, 0 sorry'd)
+-- Total: 6308 theorems/lemmas (4444 public, 1864 private, 0 sorry'd)

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -404,12 +404,11 @@ ALLOWLIST: set[str] = {
     "supported_function_correct_with_body_interface_except_mapping_writes_stmtSafety",
     # --- Legacy compatibility and dispatch ---
     "interpretContract_correct_of_compiled_functions_except_mapping_writes_and_helper_ir_closed",
-    # Constructor-bearing compile output adds one extra compileConstructor split
-    # to these component extractors; the surrounding Forall₂ proof shape remains
-    # unchanged and does not factor cleanly without duplicating mapM plumbing.
-    "compileValidatedCore_ok_yields_compiled_functions",
-    "compileValidatedCore_ok_yields_compiled_functions_except_mapping_writes",
-    "compile_ok_yields_internalFunctions_nil_except_mapping_writes",
+    # master compileValidatedCore inversion: pins every field of the output
+    # record in one pass (mapM + constructor + record shape); all per-projection
+    # shape lemmas are one-line derivations of it, so splitting it would just
+    # reintroduce the per-projection duplication it removed.
+    "compileValidatedCore_ok_inv",
     "compile_preserves_semantics",
     "compile_preserves_semantics_except_mapping_writes",
     "compile_preserves_semantics_except_mapping_writes_stmtSafety",
@@ -1045,7 +1044,6 @@ ALLOWLIST_REGEXES: tuple[re.Pattern[str], ...] = tuple(
         r"^simpleStorage_denote_endToEnd_native_evmYulLean_of_sourceIR$",
         r"^compileStmt_setStructMember2_singleSlot_nonzero_bridged$",
         r"^compileStmtList_append_eq$",
-        r"^compile_ok_yields_noReceiveEntrypoint_except_mapping_writes$",
     )
 )
 


### PR DESCRIPTION
## Summary
Refactor item 2 (ContractShape/Contract dedup). Fourteen shape lemmas across `ContractShape.lean` and `Contract.lean` each re-inverted `compileValidatedCore` from scratch (fallback/receive lookup, internal-function filter, `guardedFunctionsMapM_eq` rewrite, mapM + constructor case splits) just to extract one field of the compiled contract.

New single source of truth in `ContractShape.lean`:
- `coreHelperInternalFunctions` — closed form of the usage-gated builtin helper groups, with `coreHelperInternalFunctions_eq_nil` under the all-gates-false surface facts.
- `compileValidatedCore_ok_inv` — master inversion on the lock-free / no-internal-function / no-template-intrinsic surface: one pass pins **every** field of the output record (`functions`, `deploy`, `internalFunctions`, `fallback`/`receiveEntrypoint`, `name`, `constructorPayable`, `usesMapping`).
- `compile_ok_yields_core` — `compile` factors through `compileValidatedCore`.

All 6 ContractShape clones + 8 Contract clones/inline proofs are now one-line projections (`obtain` + `rw`). **All public statements byte-identical.** Net -273 lines (271+/544-), ~430 duplicated proof lines removed. Bonus: the master also exposes record fields (`constructorPayable`, `usesMapping`) no projection lemma covered before — free for future consumers.

## Verification
- Full `lake build` green (exit 0)
- `make check` green (PrintAxioms regenerated; proof-length allowlist −3 stale entries, −1 stale regex, +1 master entry)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in IR generation contract shape lemmas; no runtime compiler or public API behavior changes, with statements preserved byte-for-byte.
> 
> **Overview**
> **Centralizes `compileValidatedCore` shape reasoning** in `ContractShape.lean` so duplicated inversion proofs in `Contract.lean` and `ContractShape.lean` collapse to short projections.
> 
> Adds **`coreHelperInternalFunctions`** (closed form of usage-gated builtin helpers on the IR contract) and **`coreHelperInternalFunctions_eq_nil`** when all usage gates are false. Adds **`compile_ok_yields_core`** (`compile` success implies the same `compileValidatedCore` result) and **`compileValidatedCore_ok_inv`**, which in one pass pins the full output record: `functions`/`deploy` mapM equations, `fallback`/`receive` as `none`, and fields including `constructorPayable`, `usesMapping`, and `internalFunctions := coreHelperInternalFunctions model`.
> 
> **~14 lemmas** that each re-unfolded `compileValidatedCore` (fallback/receive, internal filter, `guardedFunctionsMapM_eq`, mapM + constructor splits) now **`obtain` from `compileValidatedCore_ok_inv`** and rewrite a single field. Public theorem statements stay the same; net line count drops sharply.
> 
> **Tooling:** `PrintAxioms.lean` lists the new public lemmas; `check_proof_length.py` drops stale per-lemma allowlist entries and allowlists `compileValidatedCore_ok_inv` instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78cdc4b94d5e6bdc21bd932e7b320e4cf44c208b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->