### PR TITLE
feat(core): storage-lens API freeze — C5 step 1

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -224,6 +224,22 @@ sibling entrypoint.
 | Intrinsic fork gate | Fail-closed `min_fork` enforcement against `--target-fork` / `YulEmitOptions.targetFork` | `lake build Compiler.CompileDriverTest` |
 | `trust_report.intrinsics[*]` | Planned consumer-declared intrinsic trust surface: name, emission mode, opcode/builtin target, obligation, `min_fork`, and source location | Follow-up hardening; until then, grep consumer trees for `verity_intrinsic` |
 
+## Storage-Lens API Freeze — C5 Step 1 (2026-08)
+
+- `scripts/check_storage_lens_freeze.py` (in `make check`) ratchets raw
+  `ContractState` storage-channel record updates: new
+  `{ s with storageMap := ... }`-style sites fail CI; the 304 existing sites
+  are frozen per file in the script's `BASELINE` and must only shrink.
+  Exactly-lens-shaped helpers (`setLock`, `ReentrancyExample.setStorageSlot`/
+  `setMappingSlot`, adversary transitions in the call-program examples,
+  `TypedIRCompilerCorrectness` typed-IR write helpers) are already migrated
+  to `writeSlot`/`writeMap`/`writeTransient`.
+- This is step 1 of the C5 storage-representation flip (single word-addressed
+  map + Solidity-layout slot derivation under stable lens names); steps 2–4
+  (proofs onto `storage_simps`, representation flip, compiler slot
+  correspondence) are tracked in `docs/ROADMAP.md`. No semantic change: the
+  lenses are definitionally the former raw updates.
+
 ## CI Guards
 
 - `make check` validates generated reports, bridge coverage synchronization,

--- a/Compiler/TypedIRCompilerCorrectness.lean
+++ b/Compiler/TypedIRCompilerCorrectness.lean
@@ -35,7 +35,7 @@ theorem compileStmts_append_from (fields : List Field) (pre post : List Stmt)
 `setStorage fieldName (literal n)` updates the resolved storage slot. -/
 def execSourceSetStorageLiteral (world : Verity.ContractState) (slot : Nat) (n : Verity.Core.Uint256) :
     Verity.ContractState :=
-  { world with storage := fun i => if i == slot then n else world.storage i }
+  world.writeSlot slot n
 
 /-- Compile + execute the same supported subset statement through typed IR. -/
 def execCompiledSetStorageLiteral
@@ -455,9 +455,8 @@ def execSourceRequireCallerEqStorageAddrSetStorageAddStop
     (init : TExecState) (ownerSlot countSlot : Nat) (n : Nat)
     (msg : String) : TExecResult :=
   if decide (init.env.sender = init.world.storageAddr ownerSlot) then
-    .ok { init with world := { init.world with
-      storage := fun i => if i == countSlot then
-        Verity.Core.Uint256.add (init.world.storage countSlot) n else init.world.storage i } }
+    .ok { init with world := (init.world.writeSlot countSlot
+      (Verity.Core.Uint256.add (init.world.storage countSlot) n)) }
   else .revert msg
 
 /-- Compiled semantics for `require (eq caller (storage ownerField)) msg ;
@@ -478,9 +477,8 @@ def execSourceRequireCallerEqStorageAddrSetStorageSubStop
     (init : TExecState) (ownerSlot countSlot : Nat) (n : Nat)
     (msg : String) : TExecResult :=
   if decide (init.env.sender = init.world.storageAddr ownerSlot) then
-    .ok { init with world := { init.world with
-      storage := fun i => if i == countSlot then
-        Verity.Core.Uint256.sub (init.world.storage countSlot) n else init.world.storage i } }
+    .ok { init with world := (init.world.writeSlot countSlot
+      (Verity.Core.Uint256.sub (init.world.storage countSlot) n)) }
   else .revert msg
 
 /-- Compiled semantics for `require (eq caller (storage ownerField)) msg ;

--- a/Contracts/Examples/CallProgramRollback.lean
+++ b/Contracts/Examples/CallProgramRollback.lean
@@ -71,7 +71,7 @@ the initial and the final state. -/
 
 def mutatingAdversary : AdversaryModel where
   stateTransition := fun site w =>
-    { w with storage := fun slot => if slot == site.siteId then 42 else w.storage slot }
+    w.writeSlot site.siteId 42
   result := fun _ _ => .success []
   gasUsed := fun _ _ => 5
 

--- a/Contracts/Examples/SummaryConformance.lean
+++ b/Contracts/Examples/SummaryConformance.lean
@@ -24,7 +24,7 @@ def pingEnv : SummaryEnv where
 its external projection is untouched, as `pingEnv` demands. -/
 def pingAdversary : AdversaryModel where
   stateTransition := fun site w =>
-    { w with storage := fun slot => if slot == site.siteId then 7 else w.storage slot }
+    w.writeSlot site.siteId 7
   result := fun _ _ => .success [1]
   gasUsed := fun _ _ => 3
 

--- a/Contracts/ReentrancyExample/Contract.lean
+++ b/Contracts/ReentrancyExample/Contract.lean
@@ -32,11 +32,11 @@ def supplyInvariant (s : ContractState) (addrs : List Address) : Prop :=
 
 -- Minimal state updates (pure helpers)
 def setStorageSlot (slot : StorageSlot Uint256) (val : Uint256) (s : ContractState) : ContractState :=
-  { s with storage := fun n => if n == slot.slot then val else s.storage n }
+  s.writeSlot slot.slot val
 
 def setMappingSlot (slot : StorageSlot (Address → Uint256)) (addr : Address) (val : Uint256)
   (s : ContractState) : ContractState :=
-  { s with storageMap := fun n a => if n == slot.slot && a == addr then val else s.storageMap n a }
+  s.writeMap slot.slot addr val
 
 @[simp] theorem modulus_sub_max :
   Verity.Core.Uint256.modulus - Verity.EVM.MAX_UINT256 = 1 := by

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ check: ## Run local CI-equivalent checks job (no Lean build, no solc)
 	python3 scripts/lean_lint.py --only axioms
 	python3 scripts/lean_lint.py --only trust_surface_registry
 	python3 scripts/check_benchmark_cases.py
+	python3 scripts/check_storage_lens_freeze.py
 	python3 scripts/generate_verification_status.py --check
 	python3 scripts/generate_layer2_boundary_catalog.py --check
 	python3 scripts/check_verification_status_doc.py

--- a/Verity/Core/Model/NonReentrantGuard.lean
+++ b/Verity/Core/Model/NonReentrantGuard.lean
@@ -32,7 +32,7 @@ open Verity.Core.Invariant (Preserves runSeq)
 
 /-- Write `value` into transient lock slot `slot`. -/
 def setLock (slot : Nat) (value : Uint256) (s : ContractState) : ContractState :=
-  { s with transientStorage := fun k => if k == slot then value else s.transientStorage k }
+  s.writeTransient slot value
 
 @[simp] theorem setLock_reads (slot : Nat) (value : Uint256) (s : ContractState) :
     (setLock slot value s).transientStorage slot = value := by

--- a/scripts/check_storage_lens_freeze.py
+++ b/scripts/check_storage_lens_freeze.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Storage-lens API freeze gate (C5 step 1).
+
+The C5 storage-representation flip (one word-addressed `Nat -> Uint256` map
+with Solidity-layout slot derivation) requires that every read/write of
+`Verity.ContractState`'s storage channels go through the canonical lens API
+(`readSlot`/`writeSlot`/`writeMap`/... in `Verity/Core.lean`) instead of raw
+record updates like `{ s with storageMap := ... }`.
+
+This gate is a RATCHET: raw storage-channel record-update sites are counted
+per file and frozen at the current baseline below.  Any NEW raw site fails
+the check; migrating sites down requires shrinking the baseline (the script
+prints the expected new entry).  The goal is a monotonically shrinking
+baseline until only `Verity/Core.lean` remains, at which point the flip
+(C5 step 3) can swap the representation under stable lens names.
+
+Scope notes:
+- The six channels unique to `ContractState` (`contractStorage`,
+  `storageAddr`, `storageMap`, `storageMapUint`, `storageMap2`,
+  `storageArray`) are checked repo-wide.
+- `storage :=` / `transientStorage :=` are only checked under `Verity/` and
+  `Contracts/`: under `Compiler/` those field names also belong to
+  `IRState`/`DenoteState`-style records, which are proof-side runtime states,
+  not the source `ContractState`.  Raw `ContractState` writes under
+  `Compiler/` on those two fields are therefore NOT caught by this gate
+  (known v1 boundary; they are enumerated in the baseline where they use a
+  unique channel).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+UNIQUE_CHANNELS = (
+    "contractStorage",
+    "storageAddr",
+    "storageMap",
+    "storageMapUint",
+    "storageMap2",
+    "storageArray",
+)
+SHARED_CHANNELS = ("storage", "transientStorage")
+
+UNIQUE_RE = re.compile(
+    r"(?<![\w.])(?:«)?(" + "|".join(UNIQUE_CHANNELS) + r")(?:»)?\s*:=")
+SHARED_RE = re.compile(
+    r"(?<![\w.])(?:«)?(" + "|".join(SHARED_CHANNELS) + r")(?:»)?\s*:=")
+
+SCAN_DIRS = ("Verity", "Contracts", "Compiler")
+SHARED_SCAN_DIRS = ("Verity", "Contracts")
+
+# file (relative to repo root) -> frozen raw-site count.  Burn this down;
+# never grow it.  `Verity/Core.lean` hosts the lens implementations and the
+# canonical `defaultState`/`emitEvent`-style literals; it is the only file
+# meant to keep raw access after the migration completes.
+BASELINE = {
+    # Lens implementations + defaultState (the permanent residue).
+    "Verity/Core.lean": 26,
+    # Denotational bulk writes (multi-slot / packed): need bulk lenses
+    # before they can migrate (C5 step 2).
+    "Verity/Core/Model/Denote.lean": 26,
+    "Verity/Core/Free/TypedIR.lean": 7,
+    # Bridge lemma statements equating monad ops with the raw update form;
+    # restated via lenses when the simp attribute moves to `storage_simps`.
+    "Verity/Proofs/Stdlib/Automation.lean": 3,
+    "Verity/Proofs/Stdlib/MappingAutomation.lean": 3,
+    "Verity/Specs/Common/Sum.lean": 1,
+    # Contract proofs spelling out full post-state record literals, and test
+    # fixtures constructing initial states by raw literal; both migrate in
+    # C5 step 2 (proofs onto `storage_simps`, fixtures onto lens chains).
+    "Contracts/Common.lean": 5,
+    "Contracts/ERC20/Proofs/Basic.lean": 16,
+    "Contracts/Interpreter.lean": 7,
+    "Contracts/Ledger/Proofs/Basic.lean": 32,
+    "Contracts/Owned/Proofs/Basic.lean": 8,
+    "Contracts/OwnedCounter/Proofs/Basic.lean": 24,
+    "Contracts/ReentrancyExample/Contract.lean": 7,
+    "Contracts/SafeCounter/Proofs/Basic.lean": 16,
+    "Contracts/SimpleToken/Proofs/Basic.lean": 16,
+    "Contracts/Smoke/Storage.lean": 5,
+    "Contracts/TypedIRTests.lean": 79,
+    "Compiler/CompilationModelFeatureTest.lean": 3,
+    "Compiler/Proofs/IRGeneration/SourceSemantics.lean": 8,
+    "Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean": 1,
+    "Compiler/Proofs/Storage/StructArrayStorage.lean": 1,
+    "Compiler/Proofs/StorageBounds.lean": 1,
+    "Compiler/TypedIRCompilerCorrectness.lean": 9,
+}
+
+
+def count_sites(path: Path) -> int:
+    rel = path.relative_to(ROOT).as_posix()
+    text = path.read_text(encoding="utf-8")
+    # Strip line comments to avoid counting documentation.
+    text = re.sub(r"--[^\n]*", "", text)
+    count = len(UNIQUE_RE.findall(text))
+    if rel.split("/", 1)[0] in SHARED_SCAN_DIRS:
+        count += len(SHARED_RE.findall(text))
+    return count
+
+
+def main() -> int:
+    if "--print-baseline" in sys.argv:
+        for top in SCAN_DIRS:
+            for path in sorted((ROOT / top).rglob("*.lean")):
+                if ".lake" in path.parts:
+                    continue
+                count = count_sites(path)
+                if count:
+                    print(f'    "{path.relative_to(ROOT).as_posix()}": {count},')
+        return 0
+    failures = []
+    seen = {}
+    for top in SCAN_DIRS:
+        for path in sorted((ROOT / top).rglob("*.lean")):
+            if ".lake" in path.parts:
+                continue
+            rel = path.relative_to(ROOT).as_posix()
+            count = count_sites(path)
+            if count:
+                seen[rel] = count
+            allowed = BASELINE.get(rel, 0)
+            if count > allowed:
+                failures.append((rel, count, allowed))
+    for rel, allowed in BASELINE.items():
+        actual = seen.get(rel, 0)
+        if actual < allowed:
+            failures.append((rel, actual, allowed))
+    if failures:
+        print("storage-lens freeze gate FAILED (C5 step 1):")
+        for rel, count, allowed in failures:
+            if count > allowed:
+                print(f"  {rel}: {count} raw storage-channel update sites "
+                      f"(baseline {allowed}).")
+                print("    New raw `{ s with storage... := ... }` sites are "
+                      "frozen out: use the ContractState lens API "
+                      "(readSlot/writeSlot/writeMap/... in Verity/Core.lean).")
+            else:
+                print(f"  {rel}: {count} sites but baseline says {allowed} — "
+                      f"thanks for migrating! Update BASELINE in "
+                      f"scripts/check_storage_lens_freeze.py to {count} "
+                      f"(or remove the entry if 0).")
+        return 1
+    print("OK: storage-lens freeze holds "
+          f"({sum(seen.values())} baselined raw sites across {len(seen)} files).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Step 1 of the C5 storage-representation flip (single word-addressed `Nat → Uint256` map with Solidity-layout slot derivation, lenses as the only API).

## Measured scope
The flip plan assumed thousands of raw sites; the actual count is **304 raw `ContractState` storage-channel record-update sites across 23 files** (79 of them TypedIRTests fixtures). Step 2 (proofs onto `storage_simps`) is much cheaper than budgeted.

## This PR
- **Migrations** (definitionally equal, `==`-shaped): `NonReentrantGuard.setLock` → `writeTransient`; `ReentrancyExample.setStorageSlot`/`setMappingSlot` → `writeSlot`/`writeMap`; adversary transitions in the call-program examples → `writeSlot`; `TypedIRCompilerCorrectness` typed-IR write helpers → `writeSlot`.
- **Ratchet gate** `scripts/check_storage_lens_freeze.py` wired into `make check`: any NEW raw `{ s with storageMap := … }`-style site fails CI; the 304 existing sites are frozen per file in a `BASELINE` that can only shrink (the script prints the updated entry when you migrate). Scope: the 6 ContractState-unique channels repo-wide; `storage`/`transientStorage` under `Verity/`+`Contracts/` only (name collision with `IRState`/`DenoteState` under `Compiler/` — documented v1 boundary).
- **AUDIT.md** synced.

Deliberately NOT started (per plan sequencing): step 2 (drop `attribute [simp]` from lenses, migrate proofs to `storage_simps`), step 3 (representation flip), step 4 (compiler slot correspondence).

## Evidence
- `lake build` + `lake build Contracts` green
- `make check` passes (including the new gate)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical, definitionally equivalent refactors plus a lint gate; no auth, runtime, or representation change yet.
> 
> **Overview**
> **C5 step 1** locks in the storage-lens migration path: new raw `{ s with storage… := … }` updates on `ContractState` channels are blocked in CI, while **304 existing sites** stay frozen per-file until they are migrated off the baseline.
> 
> A new **`scripts/check_storage_lens_freeze.py`** ratchet (wired into **`make check`**) counts raw storage-channel record updates repo-wide for the six ContractState-unique fields and for `storage` / `transientStorage` under `Verity/` and `Contracts/` only; counts above the per-file **`BASELINE`** fail, and shrinking the baseline is required when sites are removed. **`AUDIT.md`** documents the gate and that later C5 steps (proofs, representation flip, compiler correspondence) are still out of scope.
> 
> Several call sites already use the canonical lenses with **no semantic change** (definitionally the old updates): `NonReentrantGuard.setLock` → `writeTransient`; `ReentrancyExample` slot/mapping helpers → `writeSlot` / `writeMap`; call-program example adversaries → `writeSlot`; `TypedIRCompilerCorrectness` source semantics for literal storage writes → `writeSlot`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5ed614d01382ec650d50455ea7378d0fa02e247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->