### PR TITLE
refactor(proofs): setLock invariance via storageArray congruence

### DIFF
--- a/Compiler/Proofs/IRGeneration/GuardedSourceBridge.lean
+++ b/Compiler/Proofs/IRGeneration/GuardedSourceBridge.lean
@@ -35,22 +35,17 @@ theorem withTransactionContext_setLock (world : Verity.ContractState)
     SourceSemantics.withTransactionContext (setLock slot v world) tx =
       setLock slot v (SourceSemantics.withTransactionContext world tx) := rfl
 
-/-- The dynamic-array scan never reads transient storage. -/
-theorem findDynamicArrayElementAtSlot_go_setLock
-    (world : Verity.ContractState) (targetSlot lockSlot : Nat)
-    (v : Verity.Uint256) :
-    ∀ (remaining : List Field) (idx : Nat),
-      SourceSemantics.findDynamicArrayElementAtSlot.go
-          (setLock lockSlot v world) targetSlot remaining idx =
-        SourceSemantics.findDynamicArrayElementAtSlot.go
-          world targetSlot remaining idx
-  | [], _ => rfl
-  | field :: rest, idx => by
-      simp only [SourceSemantics.findDynamicArrayElementAtSlot.go]
-      rw [show (setLock lockSlot v world).storageArray = world.storageArray
-        from rfl,
-        findDynamicArrayElementAtSlot_go_setLock world targetSlot lockSlot v
-          rest (idx + 1)]
+/-- The dynamic-array scan never reads transient storage: the lock overlay
+preserves `storageArray` definitionally, so this is the general
+`storageArray` congruence at `rfl`. -/
+theorem findDynamicArrayElementAtSlot_setLock (fields : List Field)
+    (world : Verity.ContractState) (lockSlot : Nat) (v : Verity.Uint256)
+    (slot : Nat) :
+    SourceSemantics.findDynamicArrayElementAtSlot fields
+        (setLock lockSlot v world) slot =
+      SourceSemantics.findDynamicArrayElementAtSlot fields world slot :=
+  SourceSemantics.findDynamicArrayElementAtSlot_congr_storageArray
+    fields _ world slot rfl
 
 /-- `encodeStorageAt` never reads transient storage. -/
 theorem encodeStorageAt_setLock (fields : List Field)
@@ -59,10 +54,7 @@ theorem encodeStorageAt_setLock (fields : List Field)
     SourceSemantics.encodeStorageAt fields (setLock lockSlot v world) slot =
       SourceSemantics.encodeStorageAt fields world slot := by
   unfold SourceSemantics.encodeStorageAt
-  rw [show SourceSemantics.findDynamicArrayElementAtSlot fields
-      (setLock lockSlot v world) slot =
-    SourceSemantics.findDynamicArrayElementAtSlot fields world slot from
-    findDynamicArrayElementAtSlot_go_setLock world slot lockSlot v fields 0]
+  rw [findDynamicArrayElementAtSlot_setLock fields world lockSlot v slot]
   cases SourceSemantics.findResolvedFieldAtSlot fields slot <;> rfl
 
 /-- The initial IR state of the lock-acquired world is the lock overlay of

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3603,7 +3603,7 @@ end Verity.AxiomAudit
 
   -- Compiler/Proofs/IRGeneration/GuardedSourceBridge.lean
   Compiler.Proofs.IRGeneration.withTransactionContext_setLock
-  Compiler.Proofs.IRGeneration.findDynamicArrayElementAtSlot_go_setLock
+  Compiler.Proofs.IRGeneration.findDynamicArrayElementAtSlot_setLock
   Compiler.Proofs.IRGeneration.encodeStorageAt_setLock
   Compiler.Proofs.IRGeneration.initialIRStateForTx_setLock
   Compiler.Proofs.IRGeneration.execResultToIRResult_lock_overlay


### PR DESCRIPTION
Refactor item 6: `findDynamicArrayElementAtSlot_go_setLock` (25-line let-rec induction in GuardedSourceBridge) becomes `findDynamicArrayElementAtSlot_setLock`, a one-line instance of the existing `findDynamicArrayElementAtSlot_congr_storageArray` at `rfl` — `setLock` preserves `storageArray` definitionally (still true after #2323's `writeTransient` redefinition).

The originally-envisioned signature change (take the `storageArray` projection instead of the world) was evaluated and **rejected**: 82 use sites, several naming the `.go`/`.scanElements` let-rec internals across GenericInduction, for no gain over the congruence lemma.

Verification: full `lake build` green, `make check` green (PrintAxioms regenerated for the rename).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof refactor only; behavior and downstream theorems are preserved via the same mathematical fact with a simpler proof path.
> 
> **Overview**
> Replaces the hand-written **`findDynamicArrayElementAtSlot_go_setLock`** induction (on the internal `.go` let-rec) with **`findDynamicArrayElementAtSlot_setLock`**, proved in one step via **`findDynamicArrayElementAtSlot_congr_storageArray`** because **`setLock`** leaves **`storageArray`** unchanged definitionally.
> 
> **`encodeStorageAt_setLock`** now rewrites through the renamed lemma; **`PrintAxioms.lean`** is updated for the axiom/theorem name swap. No change to runtime semantics or proof obligations beyond simplification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c4b5b7894a33ac4b14ce071b6bc0e82a2772410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->