### PR TITLE
feat(core): storage lenses off default simp — C5 step 2

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -240,6 +240,23 @@ sibling entrypoint.
   correspondence) are tracked in `docs/ROADMAP.md`. No semantic change: the
   lenses are definitionally the former raw updates.
 
+## Storage-Lens Simp Flip — C5 Step 2 (2026-08)
+
+- The ContractState lenses are no longer default-`simp` transparent: the
+  global `attribute [simp]` block in `Verity/Core.lean` is removed.
+  `storage_simps` stays laws-only (read-over-write normalization; it
+  deliberately does not unfold lenses to the raw record representation, so it
+  survives the step-3 flip). Proofs that genuinely need the current raw
+  representation now name the lens explicitly in their `simp` lists
+  (`simp [ContractState.writeSlot]`) — those call sites are the step-3
+  burn-down inventory, greppable as `ContractState.read`/`ContractState.write`
+  occurrences inside simp lists.
+- Repair surface: ~25 files (Core storage-array run-lemmas, Stdlib
+  Automation/MappingAutomation, NonReentrantGuard, the `denote_stmt_arm`
+  macro in `DenoteAgreement`, the `simp_tir_eval` macro in
+  `TypedIRCompilerCorrectness`, and the contract proof suites). No theorem
+  statement changed; no semantic change; zero axioms.
+
 ## CI Guards
 
 - `make check` validates generated reports, bridge coverage synchronization,

--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -507,6 +507,7 @@ macro "denote_stmt_arm" : tactic =>
        ← denote_evalExpr_eq, ← denote_evalExprList_eq]
      repeat' (split <;>
          try simp_all [toStmtResult, toRuntimeState,
+         Verity.ContractState.readArray, Verity.ContractState.writeArray,
          writeAddressKeyedMappingSlots_eq, writeUintKeyedMappingSlots_eq,
          writeAddressKeyedMapping2Slots_eq, writeAddressKeyedMappingFieldSlots_eq,
          writeUintKeyedMappingFieldSlots_eq, writeAddressKeyedMapping2FieldSlots_eq,

--- a/Compiler/TypedIRCompilerCorrectness.lean
+++ b/Compiler/TypedIRCompilerCorrectness.lean
@@ -8,7 +8,8 @@ syntax "simp_tir_eval" : tactic
 
 macro_rules
   | `(tactic| simp_tir_eval) =>
-      `(tactic| simp [evalTStmtsFuel, evalTStmtFuel, evalTExpr])
+      `(tactic| simp [evalTStmtsFuel, evalTStmtFuel, evalTExpr,
+        Verity.ContractState.readSlot, Verity.ContractState.writeSlot])
 
 /-- Generic structural-induction theorem: compiling concatenated statement lists
 is equivalent to compiling the prefix then the suffix. -/
@@ -1126,7 +1127,7 @@ theorem compile_setStorage_literal_semantics
       .ok { init with world := execSourceSetStorageLiteral init.world slot n } := by
   simp [execCompiledSetStorageLiteral, execSourceSetStorageLiteral,
     compileStmts_single_setStorage_literal_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for the supported two-statement subset:
 compiling and running `letVar tmp (literal n); setStorage fieldName (localVar tmp)`
@@ -1143,7 +1144,7 @@ theorem compile_let_setStorage_local_literal_semantics
             vars := init.vars.set { id := 0, ty := Ty.uint256 } (n : Verity.Core.Uint256) }) := by
   simp [execCompiledLetSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for a broader supported three-statement subset:
 compiling and running
@@ -1163,7 +1164,7 @@ theorem compile_let_assign_setStorage_local_literal_semantics
               { id := 1, ty := Ty.uint256 } (m : Verity.Core.Uint256) }) := by
   simp [execCompiledLetAssignSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_assign_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for an arithmetic supported three-statement subset:
 compiling and running
@@ -1185,7 +1186,7 @@ theorem compile_let_assign_add_setStorage_local_literal_semantics
                 ((n : Verity.Core.Uint256).add (m : Verity.Core.Uint256)) }) := by
   simp [execCompiledLetAssignAddSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_assign_add_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for an arithmetic supported three-statement subset:
 compiling and running
@@ -1309,7 +1310,7 @@ theorem compile_return_storage_semantics
   simp [execCompiledReturnStorage, execSourceReturnStorage,
     compileStmts_single_return_storage_run, hfind,
     evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for `return (storage field)` (address). -/
 theorem compile_return_storage_addr_semantics
@@ -1322,7 +1323,7 @@ theorem compile_return_storage_addr_semantics
   simp [execCompiledReturnStorageAddr, execSourceReturnStorageAddr,
     compileStmts_single_return_storage_addr_run, hfind,
     evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation for `return (mapping fieldName caller)`:
 compiled execution matches direct source semantics (no state change). -/
@@ -1335,7 +1336,7 @@ theorem compile_return_mapping_caller_semantics
   simp [execCompiledReturnMappingCaller, execSourceReturnMappingCaller,
     compileStmts_single_return_mapping_caller_run, hSlot,
     evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation for the address storage-read + return pattern. -/
 theorem compile_let_storage_addr_return_local_semantics
@@ -1951,7 +1952,7 @@ theorem compile_return_literal_semantics
     execCompiledReturnLiteral fields init n = execSourceReturnLiteral init n := by
   simp [execCompiledReturnLiteral, execSourceReturnLiteral,
     compileStmts_single_return_literal_run, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for a broader supported subset:
 compiling and running `letVar tmp (literal n); return (localVar tmp)`
@@ -1962,7 +1963,7 @@ theorem compile_let_return_local_literal_semantics
       execSourceLetReturnLocalLiteral init n := by
   simp [execCompiledLetReturnLocalLiteral, execSourceLetReturnLocalLiteral,
     compileStmts_let_return_local_literal_run, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for a broader supported branch subset:
 compiling and running

--- a/Contracts/Counter/Proofs/Basic.lean
+++ b/Contracts/Counter/Proofs/Basic.lean
@@ -64,11 +64,14 @@ theorem increment_meets_spec (s : ContractState) :
   increment_spec s s' := by
   unfold increment_spec Specs.storageUpdateSpec Specs.sameAddrMapContext
   refine ⟨?_, ?_, ?_⟩
-  · simp [increment, count, getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind]
+  · simp [increment, count, getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind,
+      ContractState.readSlot, ContractState.writeSlot]
   · intro other h_neq
-    simp [increment, count, getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind, h_neq]
+    simp [increment, count, getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind, h_neq,
+      ContractState.readSlot, ContractState.writeSlot]
   · simp [Specs.sameStorageAddr, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext, increment, count,
-      getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind]
+      getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind,
+      ContractState.readSlot, ContractState.writeSlot]
 
 theorem increment_adds_one (s : ContractState) :
   let s' := ((increment).run s).snd
@@ -82,11 +85,14 @@ theorem decrement_meets_spec (s : ContractState) :
   decrement_spec s s' := by
   unfold decrement_spec Specs.storageUpdateSpec Specs.sameAddrMapContext
   refine ⟨?_, ?_, ?_⟩
-  · simp [decrement, count, getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind]
+  · simp [decrement, count, getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind,
+      ContractState.readSlot, ContractState.writeSlot]
   · intro other h_neq
-    simp [decrement, count, getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind, h_neq]
+    simp [decrement, count, getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind, h_neq,
+      ContractState.readSlot, ContractState.writeSlot]
   · simp [Specs.sameStorageAddr, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext, decrement, count,
-      getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind]
+      getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind,
+      ContractState.readSlot, ContractState.writeSlot]
 
 theorem decrement_subtracts_one (s : ContractState) :
   let s' := ((decrement).run s).snd

--- a/Contracts/Counter/Proofs/Preview.lean
+++ b/Contracts/Counter/Proofs/Preview.lean
@@ -21,7 +21,7 @@ theorem previewAddTwice_correct (s : ContractState) (delta : Uint256) :
     let result := ((previewAddTwice delta).run s).fst
     result = EVM.Uint256.add (EVM.Uint256.add (s.storage 0) delta) delta := by
   simp [previewAddTwice, count, getStorage, Contract.run, ContractResult.fst,
-    Verity.bind, Bind.bind, Verity.pure, Pure.pure]
+    Verity.bind, Bind.bind, Verity.pure, Pure.pure, ContractState.readSlot]
 
 theorem previewAddTwice_preserves_state (s : ContractState) (delta : Uint256) :
     let s' := ((previewAddTwice delta).run s).snd

--- a/Contracts/ERC20/Proofs/Basic.lean
+++ b/Contracts/ERC20/Proofs/Basic.lean
@@ -24,22 +24,24 @@ private def constructorCompat (initialOwner : Address) : Contract Unit := do
 theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
     constructor_spec initialOwner s ((constructorCompat initialOwner).runState s) := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
-  · simp [constructorCompat, ownerSlot, setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind]
-  · simp [constructorCompat, totalSupplySlot, setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind]
+  · simp [constructorCompat, ownerSlot, setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind,
+      ContractState.writeAddrSlot, ContractState.writeSlot]
+  · simp [constructorCompat, totalSupplySlot, setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind,
+      ContractState.writeAddrSlot, ContractState.writeSlot]
   · intro slotIdx h_neq
     simp [constructorCompat, ownerSlot, setStorageAddr, setStorage, Contract.runState, Verity.bind,
-      Bind.bind, h_neq]
+      Bind.bind, h_neq, ContractState.writeAddrSlot, ContractState.writeSlot]
   · intro slotIdx h_neq
     simp [constructorCompat, ownerSlot, totalSupplySlot, setStorageAddr, setStorage, Contract.runState,
-      Verity.bind, Bind.bind, h_neq]
+      Verity.bind, Bind.bind, h_neq, ContractState.writeAddrSlot, ContractState.writeSlot]
   · simp [Specs.sameStorageMap, constructorCompat, ownerSlot, totalSupplySlot, setStorageAddr, setStorage,
-      Contract.runState, Verity.bind, Bind.bind]
+      Contract.runState, Verity.bind, Bind.bind, ContractState.writeAddrSlot, ContractState.writeSlot]
   · simp [Specs.sameStorageMap2, constructorCompat, ownerSlot, totalSupplySlot, setStorageAddr, setStorage,
-      Contract.runState, Verity.bind, Bind.bind]
+      Contract.runState, Verity.bind, Bind.bind, ContractState.writeAddrSlot, ContractState.writeSlot]
   · simp [Specs.sameStorageArray, constructorCompat, ownerSlot, totalSupplySlot, setStorageAddr, setStorage,
-      Contract.runState, Verity.bind, Bind.bind]
+      Contract.runState, Verity.bind, Bind.bind, ContractState.writeAddrSlot, ContractState.writeSlot]
   · simp [Specs.sameContext, constructorCompat, ownerSlot, totalSupplySlot, setStorageAddr, setStorage,
-      Contract.runState, Verity.bind, Bind.bind]
+      Contract.runState, Verity.bind, Bind.bind, ContractState.writeAddrSlot, ContractState.writeSlot]
 
 /-- `approve` writes allowance(sender, spender) and leaves other state unchanged. -/
 theorem approve_meets_spec (s : ContractState) (spender : Address) (amount : Uint256) :
@@ -47,14 +49,15 @@ theorem approve_meets_spec (s : ContractState) (spender : Address) (amount : Uin
   unfold approve_spec Specs.storageMap2UpdateSpec Specs.storageMap2UnchangedExceptKeyPair
     Specs.sameStorageAddrMapContext
   refine ⟨?_, ?_, ?_⟩
-  · simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind]
+  · simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind,
+      ContractState.writeMap2]
   · refine ⟨?_, ?_⟩
     · intro o' sp' h_neq
       simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind,
-        h_neq]
+        h_neq, ContractState.writeMap2]
     · intro sp' h_neq
       simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind,
-        h_neq]
+        h_neq, ContractState.writeMap2]
   · refine ⟨?_, ?_, ?_, ?_, ?_⟩
     · rfl
     · rfl
@@ -66,25 +69,25 @@ theorem approve_meets_spec (s : ContractState) (spender : Address) (amount : Uin
 theorem balanceOf_meets_spec (s : ContractState) (addr : Address) :
     balanceOf_spec addr ((balanceOf addr).runValue s) s := by
   simp [balanceOf, balanceOf_spec, Contract.runValue, getMapping, Verity.bind, Bind.bind,
-    Verity.pure, Pure.pure, balancesSlot]
+    Verity.pure, Pure.pure, balancesSlot, ContractState.readMap]
 
 /-- `allowanceOf` returns the value stored in allowances slot 3 for `(owner, spender)`. -/
 theorem allowanceOf_meets_spec (s : ContractState) (ownerAddr spender : Address) :
     allowance_spec ownerAddr spender ((allowanceOf ownerAddr spender).runValue s) s := by
   simp [allowanceOf, allowance_spec, Contract.runValue, getMapping2, Verity.bind, Bind.bind,
-    Verity.pure, Pure.pure, allowancesSlot]
+    Verity.pure, Pure.pure, allowancesSlot, ContractState.readMap2]
 
 /-- `getTotalSupply` returns slot 1. -/
 theorem totalSupply_meets_spec (s : ContractState) :
     totalSupply_spec ((getTotalSupply).runValue s) s := by
   simp [getTotalSupply, totalSupply_spec, Contract.runValue, totalSupply, getStorage, Verity.bind,
-    Bind.bind, Verity.pure, Pure.pure, totalSupplySlot]
+    Bind.bind, Verity.pure, Pure.pure, totalSupplySlot, ContractState.readSlot]
 
 /-- `getOwner` returns owner slot 0. -/
 theorem getOwner_meets_spec (s : ContractState) :
     getOwner_spec ((getOwner).runValue s) s := by
   simp [getOwner, getOwner_spec, Contract.runValue, owner, getStorageAddr, Verity.bind, Bind.bind,
-    Verity.pure, Pure.pure, ownerSlot]
+    Verity.pure, Pure.pure, ownerSlot, ContractState.readAddrSlot]
 
 /-- Helper: unfold `mint` on the successful owner/non-overflow path. -/
 private theorem mint_unfold (s : ContractState) (toAddr : Address) (amount : Uint256)

--- a/Contracts/ERC721/Proofs/Basic.lean
+++ b/Contracts/ERC721/Proofs/Basic.lean
@@ -18,24 +18,24 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
   · simp [Contracts.ERC721.«constructor», Contracts.ERC721.owner,
       Contracts.ERC721.totalSupply, Contracts.ERC721.nextTokenId,
-      setStorageAddr, setStorage,
+      setStorageAddr, setStorage, ContractState.writeAddrSlot, ContractState.writeSlot,
       Contract.runState, Verity.bind, Bind.bind]
   · simp [Contracts.ERC721.«constructor», Contracts.ERC721.owner,
       Contracts.ERC721.totalSupply, Contracts.ERC721.nextTokenId,
-      setStorageAddr, setStorage,
+      setStorageAddr, setStorage, ContractState.writeAddrSlot, ContractState.writeSlot,
       Contract.runState, Verity.bind, Bind.bind]
   · simp [Contracts.ERC721.«constructor», Contracts.ERC721.owner,
       Contracts.ERC721.totalSupply, Contracts.ERC721.nextTokenId,
-      setStorageAddr, setStorage,
+      setStorageAddr, setStorage, ContractState.writeAddrSlot, ContractState.writeSlot,
       Contract.runState, Verity.bind, Bind.bind]
   · intro other h_neq
     simp [Contracts.ERC721.«constructor», Contracts.ERC721.owner,
       Contracts.ERC721.totalSupply, Contracts.ERC721.nextTokenId,
-      setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind, h_neq]
+      setStorageAddr, setStorage, ContractState.writeAddrSlot, ContractState.writeSlot, Contract.runState, Verity.bind, Bind.bind, h_neq]
   · intro other h_slot1 h_slot2
     simp [Contracts.ERC721.«constructor», Contracts.ERC721.owner,
       Contracts.ERC721.totalSupply, Contracts.ERC721.nextTokenId,
-      setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind, h_slot1, h_slot2]
+      setStorageAddr, setStorage, ContractState.writeAddrSlot, ContractState.writeSlot, Contract.runState, Verity.bind, Bind.bind, h_slot1, h_slot2]
   · refine ⟨?_, ?_, ?_, ?_, ?_⟩
     · rfl
     · rfl
@@ -43,7 +43,7 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
     · rfl
     · simp [Specs.sameContext, Contracts.ERC721.«constructor», Contracts.ERC721.owner,
         Contracts.ERC721.totalSupply, Contracts.ERC721.nextTokenId,
-        setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind]
+        setStorageAddr, setStorage, ContractState.writeAddrSlot, ContractState.writeSlot, Contract.runState, Verity.bind, Bind.bind]
 
 /-- `balanceOf` returns balances slot 3 at address `addr`. -/
 theorem balanceOf_meets_spec (s : ContractState) (addr : Address) :
@@ -59,7 +59,7 @@ theorem ownerOf_meets_spec (s : ContractState) (tokenId : Uint256) :
     simp [ownerOf_spec, Contracts.ERC721.ownerOf, Contract.run, Verity.bind, Bind.bind,
       getMappingUint, Contracts.ERC721.owners,
       Verity.wordToAddress, Pure.pure, Verity.pure,
-      require, h_owner]
+      require, h_owner, ContractState.readMapUint]
 
 /-- `getApproved` reverts for unminted tokens and returns approval for minted tokens. -/
 theorem getApproved_meets_spec (s : ContractState) (tokenId : Uint256) :
@@ -68,13 +68,13 @@ theorem getApproved_meets_spec (s : ContractState) (tokenId : Uint256) :
     simp [getApproved_spec, Contracts.ERC721.getApproved, Contract.run, Verity.bind, Bind.bind,
       getMappingUint, getMappingUintAddr, Contracts.ERC721.owners, Contracts.ERC721.tokenApprovals,
       Verity.wordToAddress, Pure.pure, Verity.pure,
-      require, h_owner]
+      require, h_owner, ContractState.readMapUint]
 
 /-- `isApprovedForAll` checks nonzero operator-approval flag in slot 6. -/
 theorem isApprovedForAll_meets_spec (s : ContractState) (ownerAddr operator : Address) :
     isApprovedForAll_spec ownerAddr operator ((Contracts.ERC721.isApprovedForAll ownerAddr operator).runValue s) s := by
   simp [isApprovedForAll_spec, Contracts.ERC721.isApprovedForAll, Contract.runValue, Verity.bind, Bind.bind,
-    getMapping2, Contracts.ERC721.operatorApprovals]
+    getMapping2, Contracts.ERC721.operatorApprovals, ContractState.readMap2]
   simp [Pure.pure, Verity.pure]
 
 /-- `setApprovalForAll` writes sender/operator flag and leaves other state unchanged. -/
@@ -86,34 +86,37 @@ theorem setApprovalForAll_meets_spec (s : ContractState) (operator : Address) (a
   · cases approved <;>
       simp [Contracts.ERC721.setApprovalForAll, Contracts.ERC721.operatorApprovals,
         setMapping2, Contracts.ERC721.Spec.boolToWord,
-        msgSender, Contract.runState, Verity.bind, Bind.bind]
+        msgSender, Contract.runState, Verity.bind, Bind.bind,
+        ContractState.writeMap2]
   · refine ⟨?_, ?_⟩
     · intro o' op' h_neq
       simp [Contracts.ERC721.setApprovalForAll, Contracts.ERC721.operatorApprovals,
         setMapping2,
-        msgSender, Contract.runState, Verity.bind, Bind.bind, h_neq]
+        msgSender, Contract.runState, Verity.bind, Bind.bind, h_neq,
+        ContractState.writeMap2]
     · intro op' h_neq
       simp [Contracts.ERC721.setApprovalForAll, Contracts.ERC721.operatorApprovals,
         setMapping2,
-        msgSender, Contract.runState, Verity.bind, Bind.bind, h_neq]
+        msgSender, Contract.runState, Verity.bind, Bind.bind, h_neq,
+        ContractState.writeMap2]
   · refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
     · simp [Specs.sameStorage, Contracts.ERC721.setApprovalForAll, Contracts.ERC721.operatorApprovals,
       setMapping2,
-      msgSender, Contract.runState, Verity.bind, Bind.bind]
+      msgSender, Contract.runState, Verity.bind, Bind.bind, ContractState.writeMap2]
     · simp [Specs.sameStorageAddr, Contracts.ERC721.setApprovalForAll, Contracts.ERC721.operatorApprovals,
       setMapping2,
-      msgSender, Contract.runState, Verity.bind, Bind.bind]
+      msgSender, Contract.runState, Verity.bind, Bind.bind, ContractState.writeMap2]
     · simp [Specs.sameStorageMap, Contracts.ERC721.setApprovalForAll, Contracts.ERC721.operatorApprovals,
       setMapping2,
-      msgSender, Contract.runState, Verity.bind, Bind.bind]
+      msgSender, Contract.runState, Verity.bind, Bind.bind, ContractState.writeMap2]
     · simp [Specs.sameStorageMapUint, Contracts.ERC721.setApprovalForAll,
       Contracts.ERC721.operatorApprovals, setMapping2,
-      msgSender, Contract.runState, Verity.bind, Bind.bind]
+      msgSender, Contract.runState, Verity.bind, Bind.bind, ContractState.writeMap2]
     · simp [Specs.sameStorageArray, Contracts.ERC721.setApprovalForAll,
       Contracts.ERC721.operatorApprovals, setMapping2,
-      msgSender, Contract.runState, Verity.bind, Bind.bind]
+      msgSender, Contract.runState, Verity.bind, Bind.bind, ContractState.writeMap2]
     · simp [Specs.sameContext, Contracts.ERC721.setApprovalForAll,
       Contracts.ERC721.operatorApprovals, setMapping2,
-      msgSender, Contract.runState, Verity.bind, Bind.bind]
+      msgSender, Contract.runState, Verity.bind, Bind.bind, ContractState.writeMap2]
 
 end Contracts.ERC721.Proofs

--- a/Contracts/ERC721/Proofs/Correctness.lean
+++ b/Contracts/ERC721/Proofs/Correctness.lean
@@ -25,14 +25,15 @@ theorem ownerOf_preserves_state (s : ContractState) (tokenId : Uint256) :
     ((Contracts.ERC721.ownerOf tokenId).runState s) = s := by
   cases h_owner : (s.storageMapUint Contracts.ERC721.owners.slot tokenId != 0) <;>
     simp [Contracts.ERC721.ownerOf, getMappingUint, Contract.runState, Verity.bind, Bind.bind,
-      require, Pure.pure, Verity.pure, h_owner]
+      require, Pure.pure, Verity.pure, h_owner, ContractState.readMapUint]
 
 /-- Read-only `getApproved` preserves state. -/
 theorem getApproved_preserves_state (s : ContractState) (tokenId : Uint256) :
     ((Contracts.ERC721.getApproved tokenId).runState s) = s := by
   cases h_owner : (s.storageMapUint Contracts.ERC721.owners.slot tokenId != 0) <;>
     simp [Contracts.ERC721.getApproved, getMappingUint, getMappingUintAddr,
-      Contract.runState, Verity.bind, Bind.bind, require, Pure.pure, Verity.pure, h_owner]
+      Contract.runState, Verity.bind, Bind.bind, require, Pure.pure, Verity.pure, h_owner,
+      ContractState.readMapUint]
 
 /-- Read-only `isApprovedForAll` preserves state. -/
 theorem isApprovedForAll_preserves_state (s : ContractState) (ownerAddr operator : Address) :

--- a/Contracts/Ledger/Proofs/Basic.lean
+++ b/Contracts/Ledger/Proofs/Basic.lean
@@ -30,12 +30,13 @@ theorem getBalance_meets_spec (s : ContractState) (addr : Address) :
   getBalance_spec addr result s := by
   unfold getBalance
   simp [getBalance_spec, Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run, getMapping,
-    balances]
+    balances, ContractState.readMap]
 
 theorem getBalance_returns_balance (s : ContractState) (addr : Address) :
   ((getBalance addr).run s).fst = s.storageMap 0 addr := by
   unfold getBalance
-  simp [Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run, getMapping, balances]
+  simp [Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run, getMapping, balances,
+    ContractState.readMap]
 
 theorem getBalance_preserves_state (s : ContractState) (addr : Address) :
   ((getBalance addr).run s).snd = s := by
@@ -161,7 +162,7 @@ theorem withdraw_decreases_balance (s : ContractState) (amount : Uint256)
 theorem withdraw_reverts_insufficient (s : ContractState) (amount : Uint256)
   (h_insufficient : ¬(s.storageMap 0 s.sender >= amount)) :
   ∃ msg, (withdraw amount).run s = ContractResult.revert msg s := by
-  simp [withdraw, msgSender, getMapping, balances,
+  simp [withdraw, msgSender, getMapping, balances, ContractState.readMap,
     Verity.require, Verity.bind, Bind.bind, Contract.run,
     show (s.storageMap 0 s.sender >= amount) = false from by
       simp [ge_iff_le] at h_insufficient ⊢; omega]
@@ -275,7 +276,7 @@ theorem transfer_increases_recipient (s : ContractState) (toAddr : Address) (amo
 theorem transfer_reverts_insufficient (s : ContractState) (toAddr : Address) (amount : Uint256)
   (h_insufficient : ¬(s.storageMap 0 s.sender >= amount)) :
   ∃ msg, (transfer toAddr amount).run s = ContractResult.revert msg s := by
-  simp [transfer, msgSender, getMapping, balances,
+  simp [transfer, msgSender, getMapping, balances, ContractState.readMap,
     Verity.require, Verity.bind, Bind.bind, Contract.run,
     show (s.storageMap 0 s.sender >= amount) = false from by
       simp [ge_iff_le] at h_insufficient ⊢; omega]
@@ -356,7 +357,7 @@ theorem deposit_getBalance_correct (s : ContractState) (amount : Uint256) :
   rw [deposit_unfold]
   unfold getBalance
   simp [ContractResult.snd, Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run,
-    getMapping, balances]
+    getMapping, balances, ContractState.readMap]
 
 /-! ## Summary of Proven Properties
 

--- a/Contracts/Ledger/Proofs/Correctness.lean
+++ b/Contracts/Ledger/Proofs/Correctness.lean
@@ -89,7 +89,7 @@ theorem deposit_withdraw_cancel (s : ContractState) (amount : Uint256)
   have h_sender : s1.sender = s.sender := by
     simp [s1, deposit, msgSender, getMapping, setMapping, balances,
       Verity.bind, Bind.bind,
-      Contract.run, ContractResult.snd]
+      Contract.run, ContractResult.snd, ContractState.readMap, ContractState.writeMap]
   have h_balance' : s1.storageMap 0 s.sender ≥ amount := by
     simpa [s1, h_inc] using h_balance
   have h_wd := withdraw_decreases_balance (s := s1) amount h_balance'

--- a/Contracts/LocalObligationMacroSmoke/Proofs/Basic.lean
+++ b/Contracts/LocalObligationMacroSmoke/Proofs/Basic.lean
@@ -18,12 +18,12 @@ theorem dischargedEdge_meets_spec (s : ContractState) (value : Uint256) :
   let output := (LocalObligationMacroSmoke.dischargedEdge value).run s
   dischargedEdge_spec value output.fst s output.snd := by
   unfold LocalObligationMacroSmoke.dischargedEdge
-  simp [dischargedEdge_spec, LocalObligationMacroSmoke.lastValue, Verity.Contract.run, Verity.bind, Bind.bind, Verity.setStorage, Verity.pure, Pure.pure]
+  simp [dischargedEdge_spec, LocalObligationMacroSmoke.lastValue, Verity.Contract.run, Verity.bind, Bind.bind, Verity.setStorage, Verity.pure, Pure.pure, ContractState.writeSlot]
 
 theorem dischargedEdge_preserves_slot_zero (s : ContractState) (value : Uint256) :
   let s' := ((LocalObligationMacroSmoke.dischargedEdge value).run s).snd
   slotZeroUnchanged s s' := by
   unfold LocalObligationMacroSmoke.dischargedEdge
-  simp [slotZeroUnchanged, LocalObligationMacroSmoke.lastValue, Verity.Contract.run, Verity.bind, Bind.bind, Verity.setStorage, Verity.pure, Pure.pure]
+  simp [slotZeroUnchanged, LocalObligationMacroSmoke.lastValue, Verity.Contract.run, Verity.bind, Bind.bind, Verity.setStorage, Verity.pure, Pure.pure, ContractState.writeSlot]
 
 end Contracts.LocalObligationMacroSmoke.Proofs

--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -27,6 +27,7 @@ private theorem onlyOwner_reverts (s : ContractState) (h : s.sender ≠ s.storag
     onlyOwner s = ContractResult.revert "Caller is not the owner" s := by
   simp [onlyOwner, isOwner, owner, msgSender, getStorageAddr,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
+    ContractState.readAddrSlot,
     address_beq_false_of_ne s.sender (s.storageAddr 0) h]
 
 private theorem guarded_reverts (f : Unit → Contract α) (s : ContractState)
@@ -40,21 +41,23 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
   constructor_spec initialOwner s s' := by
   refine ⟨?_, ?_, ?_⟩
-  · simp [setStorageAddr, owner, Contract.run, ContractResult.snd]
-  · intro slotIdx h_neq
-    simp [setStorageAddr, owner, Contract.run, ContractResult.snd, h_neq]
   · simp [setStorageAddr, owner, Contract.run, ContractResult.snd,
+      ContractState.writeAddrSlot]
+  · intro slotIdx h_neq
+    simp [setStorageAddr, owner, Contract.run, ContractResult.snd, h_neq, ContractState.writeAddrSlot, ContractState.readAddrSlot, ContractState.writeSlot, ContractState.readSlot]
+  · simp [setStorageAddr, owner, Contract.run, ContractResult.snd,
+      ContractState.writeAddrSlot,
       Specs.sameStorageMapContext, Specs.sameStorage, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
   s'.storageAddr 0 = initialOwner := by
-  simp [setStorageAddr, owner, Contract.run, ContractResult.snd]
+  simp [setStorageAddr, owner, Contract.run, ContractResult.snd, ContractState.writeAddrSlot, ContractState.readAddrSlot, ContractState.writeSlot, ContractState.readSlot]
 
 theorem constructor_preserves_count (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
   s'.storage = s.storage := by
-  simp [setStorageAddr, owner, Contract.run, ContractResult.snd]
+  simp [setStorageAddr, owner, Contract.run, ContractResult.snd, ContractState.writeAddrSlot, ContractState.readAddrSlot, ContractState.writeSlot, ContractState.readSlot]
 
 /-! ## Read Operation Correctness -/
 
@@ -329,6 +332,8 @@ theorem constructor_increment_getCount (s : ContractState) (initialOwner : Addre
   simp only [setStorageAddr, increment, owner, count,
     getCount, getStorage, getStorageAddr, setStorage, setStorageAddr,
     msgSender, Verity.require, Verity.pure, Verity.bind,
+    ContractState.writeAddrSlot, ContractState.readAddrSlot,
+    ContractState.writeSlot, ContractState.readSlot,
     Bind.bind, Pure.pure, Contract.run, ContractResult.snd, ContractResult.fst]
   simp [h_sender]
 

--- a/Contracts/OwnedCounter/Proofs/Correctness.lean
+++ b/Contracts/OwnedCounter/Proofs/Correctness.lean
@@ -86,7 +86,9 @@ theorem increment_survives_transfer (s : ContractState) (initialOwner newOwner :
   simp [setStorageAddr, increment, transferOwnership, owner, count,
     getCount, getStorage, getStorageAddr, setStorage, setStorageAddr,
     msgSender, Verity.require, Verity.pure, Verity.bind,
-    Bind.bind, Pure.pure, Contract.run, ContractResult.snd, ContractResult.fst, h_sender]
+    Bind.bind, Pure.pure, Contract.run, ContractResult.snd, ContractResult.fst, h_sender,
+    ContractState.readSlot, ContractState.writeSlot, ContractState.readAddrSlot,
+    ContractState.writeAddrSlot]
 
 /-! ## Summary
 

--- a/Contracts/OwnedCounter/Proofs/Isolation.lean
+++ b/Contracts/OwnedCounter/Proofs/Isolation.lean
@@ -64,7 +64,8 @@ All successful operations preserve sender and thisAddress.
 /-- Constructor preserves context. -/
 theorem constructor_context_preserved (s : ContractState) (initialOwner : Address) :
   context_preserved s ((setStorageAddr owner initialOwner).run s).snd := by
-  simp [context_preserved, Specs.sameContext, setStorageAddr, owner, Contract.run, ContractResult.snd]
+  simp [context_preserved, Specs.sameContext, setStorageAddr, owner, Contract.run, ContractResult.snd,
+    ContractState.writeAddrSlot]
 
 /-- Increment preserves context (when authorized). -/
 theorem increment_context_preserved (s : ContractState)
@@ -108,7 +109,7 @@ doesn't use mappings at all).
 /-- Constructor preserves mapping storage. -/
 theorem constructor_preserves_map_storage (s : ContractState) (initialOwner : Address) :
   ((setStorageAddr owner initialOwner).run s).snd.storageMap = s.storageMap := by
-  simp [setStorageAddr, owner, Contract.run, ContractResult.snd]
+  simp [setStorageAddr, owner, Contract.run, ContractResult.snd, ContractState.writeAddrSlot]
 
 /-- Increment preserves mapping storage. -/
 theorem increment_preserves_map_storage (s : ContractState)

--- a/Contracts/ReentrancyExample/Contract.lean
+++ b/Contracts/ReentrancyExample/Contract.lean
@@ -204,11 +204,11 @@ theorem withdraw_maintains_supply (amount : Uint256) :
   have h_left :
       ((withdraw amount).runState s).storage totalSupply.slot =
         sub (s.storage totalSupply.slot) amount := by
-    simp [Contract.runState, withdraw, withdrawWithEnv, h_cond2, setStorageSlot, setMappingSlot, balances, totalSupply]
+    simp [Contract.runState, withdraw, withdrawWithEnv, h_cond2, setStorageSlot, setMappingSlot, balances, totalSupply, ContractState.writeSlot, ContractState.writeMap]
   have h_right :
       ((withdraw amount).runState s).storageMap balances.slot s.sender =
         sub (s.storageMap balances.slot s.sender) amount := by
-    simp [Contract.runState, withdraw, withdrawWithEnv, h_cond2, setStorageSlot, setMappingSlot, balances, totalSupply]
+    simp [Contract.runState, withdraw, withdrawWithEnv, h_cond2, setStorageSlot, setMappingSlot, balances, totalSupply, ContractState.writeSlot, ContractState.writeMap]
   -- Reduce to the same subtraction on both sides.
   have h_mid : sub (s.storage totalSupply.slot) amount =
       sub (s.storageMap balances.slot s.sender) amount := by
@@ -223,7 +223,7 @@ theorem withdraw_maintains_supply (amount : Uint256) :
       _ = sub (s.storageMap balances.slot s.sender) amount := h_mid
       _ = ((withdraw amount).runState s).storageMap balances.slot s.sender := by
             symm; exact h_right
-  simpa [supplyInvariant, Contract.runState_eq_snd_run] using h_result
+  simpa [supplyInvariant, Contract.runState_eq_snd_run, ContractState.writeSlot, ContractState.writeMap] using h_result
 
 /-
 DEPOSIT ALSO MAINTAINS INVARIANT
@@ -242,11 +242,11 @@ theorem deposit_maintains_supply (amount : Uint256) :
   have h_left :
       ((deposit amount).runState s).storage totalSupply.slot =
         (s.storage totalSupply.slot) + amount := by
-    simp [Contract.runState, deposit, setStorageSlot, setMappingSlot, balances, totalSupply]
+    simp [Contract.runState, deposit, setStorageSlot, setMappingSlot, balances, totalSupply, ContractState.writeSlot, ContractState.writeMap]
   have h_right :
       ((deposit amount).runState s).storageMap balances.slot s.sender =
         (s.storageMap balances.slot s.sender) + amount := by
-    simp [Contract.runState, deposit, setStorageSlot, setMappingSlot, balances, totalSupply]
+    simp [Contract.runState, deposit, setStorageSlot, setMappingSlot, balances, totalSupply, ContractState.writeSlot, ContractState.writeMap]
   have h_mid : (s.storage totalSupply.slot) + amount =
       (s.storageMap balances.slot s.sender) + amount := by
     simp [h_eq]
@@ -259,7 +259,7 @@ theorem deposit_maintains_supply (amount : Uint256) :
       _ = (s.storageMap balances.slot s.sender) + amount := h_mid
       _ = ((deposit amount).runState s).storageMap balances.slot s.sender := by
             symm; exact h_right
-  simpa [supplyInvariant, Contract.runState_eq_snd_run] using h_result
+  simpa [supplyInvariant, Contract.runState_eq_snd_run, ContractState.writeSlot, ContractState.writeMap] using h_result
 
 end SafeBank
 

--- a/Contracts/ReentrancyRelyGuarantee/Contract.lean
+++ b/Contracts/ReentrancyRelyGuarantee/Contract.lean
@@ -55,11 +55,11 @@ def liquidate (s : ContractState) : ContractState :=
 
 @[simp] theorem liquidate_health (s : ContractState) :
     (liquidate s).storage healthSlot = s.storage healthSlot := by
-  unfold liquidate; split <;> simp [healthSlot, liquidatedSlot]
+  unfold liquidate; split <;> simp [healthSlot, liquidatedSlot, ContractState.writeSlot]
 
 @[simp] theorem liquidate_lock (s : ContractState) :
     (liquidate s).storage lockSlot = s.storage lockSlot := by
-  unfold liquidate; split <;> simp [lockSlot, liquidatedSlot]
+  unfold liquidate; split <;> simp [lockSlot, liquidatedSlot, ContractState.writeSlot]
 
 /-- Guarantee discharged by `liquidate`: it preserves `I`. It only ever changes
     the `liquidated` slot, leaving both `I` disjuncts (health, lock) untouched. -/
@@ -87,15 +87,15 @@ def setLock (b : Bool) (s : ContractState) : ContractState :=
 
 @[simp] theorem setHealthy_liq (b : Bool) (s : ContractState) :
     (setHealthy b s).storage liquidatedSlot = s.storage liquidatedSlot := by
-  simp [setHealthy, healthSlot, liquidatedSlot]
+  simp [setHealthy, healthSlot, liquidatedSlot, ContractState.writeSlot, ContractState.readSlot]
 
 @[simp] theorem setLock_liq (b : Bool) (s : ContractState) :
     (setLock b s).storage liquidatedSlot = s.storage liquidatedSlot := by
-  simp [setLock, lockSlot, liquidatedSlot]
+  simp [setLock, lockSlot, liquidatedSlot, ContractState.writeSlot, ContractState.readSlot]
 
 @[simp] theorem setHealthy_lock (b : Bool) (s : ContractState) :
     (setHealthy b s).storage lockSlot = s.storage lockSlot := by
-  simp [setHealthy, healthSlot, lockSlot]
+  simp [setHealthy, healthSlot, lockSlot, ContractState.writeSlot, ContractState.readSlot]
 
 /-! ## Buggy `take`: trade ⇒ transiently unhealthy, NO lock, final health check -/
 
@@ -137,7 +137,7 @@ theorem locked_take_no_new_liquidation
   have hlock : locked (setHealthy false (setLock true s)) := by
     show (setHealthy false (setLock true s)).storage lockSlot ≠ 0
     have hval : (setHealthy false (setLock true s)).storage lockSlot = 1 := by
-      simp [setHealthy, setLock, healthSlot, lockSlot]
+      simp [setHealthy, setLock, healthSlot, lockSlot, ContractState.writeSlot, ContractState.readSlot]
     rw [hval]; decide
   simp only [takeLocked, setHealthy_liq, setLock_liq, hAdv _ hlock]
 
@@ -149,7 +149,7 @@ theorem locked_take_preserves_I (adv : ContractState → ContractState) (s : Con
   left
   show (takeLocked adv s).storage healthSlot ≠ 0
   have hval : (takeLocked adv s).storage healthSlot = 1 := by
-    simp [takeLocked, setLock, setHealthy, healthSlot, lockSlot]
+    simp [takeLocked, setLock, setHealthy, healthSlot, lockSlot, ContractState.writeSlot, ContractState.readSlot]
   rw [hval]; decide
 
 /-- Concrete corollary: the lock blocks the real `liquidate` adversary, because

--- a/Contracts/SimpleToken/Proofs/Basic.lean
+++ b/Contracts/SimpleToken/Proofs/Basic.lean
@@ -233,6 +233,8 @@ theorem mint_reverts_balance_overflow (s : ContractState) (toAddr : Address) (am
   simp [mint, Contracts.SimpleToken.onlyOwner, isOwner, requireSomeUint,
     Contracts.SimpleToken.ownerSlot, Contracts.SimpleToken.balancesSlot, Contracts.SimpleToken.totalSupplySlot,
     msgSender, getStorageAddr, setStorageAddr, getStorage, setStorage, getMapping, setMapping,
+    ContractState.readSlot, ContractState.writeSlot, ContractState.readAddrSlot,
+    ContractState.writeAddrSlot, ContractState.readMap, ContractState.writeMap,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
     Contract.run, ContractResult.snd, ContractResult.fst,
     h_none, h_owner]
@@ -405,6 +407,7 @@ theorem transfer_reverts_recipient_overflow (s : ContractState) (toAddr : Addres
   have h_none := safeAdd_none (s.storageMap 1 toAddr) amount h_overflow
   simp [transfer, requireSomeUint, Contracts.SimpleToken.balancesSlot,
     msgSender, getMapping, setMapping,
+    ContractState.readMap, ContractState.writeMap,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
     Contract.run, ContractResult.snd, ContractResult.fst,
     h_balance', h_ne, beq_iff_eq, h_none]
@@ -432,7 +435,7 @@ theorem getTotalSupply_meets_spec (s : ContractState) :
   getTotalSupply_spec result s := by
   unfold getTotalSupply
   simp [getTotalSupply_spec, Contracts.SimpleToken.totalSupply,
-    getStorage, Contracts.SimpleToken.totalSupplySlot,
+    getStorage, Contracts.SimpleToken.totalSupplySlot, ContractState.readSlot,
     Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run]
 
 theorem getTotalSupply_returns_supply (s : ContractState) :
@@ -453,7 +456,7 @@ theorem getOwner_meets_spec (s : ContractState) :
   getOwner_spec result s := by
   unfold getOwner
   simp [getOwner_spec, Contracts.SimpleToken.owner,
-    getStorageAddr, Contracts.SimpleToken.ownerSlot,
+    getStorageAddr, Contracts.SimpleToken.ownerSlot, ContractState.readAddrSlot,
     Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run]
 
 theorem getOwner_returns_owner (s : ContractState) :

--- a/Contracts/SimpleToken/Proofs/Correctness.lean
+++ b/Contracts/SimpleToken/Proofs/Correctness.lean
@@ -38,7 +38,8 @@ theorem mint_reverts_when_not_owner (s : ContractState) (toAddr : Address) (amou
     msgSender, getStorageAddr, getStorage, setStorage, getMapping, setMapping,
     Verity.require, Verity.bind, Bind.bind,
     Contract.run]
-  simp [address_beq_false_of_ne s.sender (s.storageAddr 0) h_not_owner]
+  simp [address_beq_false_of_ne s.sender (s.storageAddr 0) h_not_owner,
+    ContractState.readAddrSlot]
 
 /-- Transfer reverts when sender has insufficient balance.
     Safety property: no overdrafts possible. -/
@@ -49,7 +50,8 @@ theorem transfer_reverts_insufficient_balance (s : ContractState) (toAddr : Addr
     msgSender, getMapping,
     Verity.require, Verity.bind, Bind.bind,
     Contract.run]
-  simp [show ¬(s.storageMap 1 s.sender ≥ amount) from Nat.not_le.mpr h_insufficient]
+  simp [show ¬(s.storageMap 1 s.sender ≥ amount) from Nat.not_le.mpr h_insufficient,
+    ContractState.readMap]
 
 /-! ## Invariant Preservation
 

--- a/Contracts/SimpleToken/Proofs/Isolation.lean
+++ b/Contracts/SimpleToken/Proofs/Isolation.lean
@@ -110,13 +110,15 @@ private theorem transfer_isolation (s : ContractState) (toAddr : Address) (amoun
     simp [transfer, Contracts.SimpleToken.balancesSlot,
       msgSender, getMapping,
       Verity.require, Verity.pure, Pure.pure, Verity.bind, Bind.bind,
-      Contract.run, ContractResult.snd, h_balance', h_eq]
+      Contract.run, ContractResult.snd, h_balance', h_eq,
+      ContractState.readMap]
   · refine ⟨?_, fun h_ne_slot addr => ?_, ?_⟩
     all_goals simp [transfer, Contracts.SimpleToken.balancesSlot,
         msgSender, getMapping, setMapping, requireSomeUint,
         Verity.require, Verity.bind, Bind.bind, Pure.pure,
         Contract.run, ContractResult.snd,
-        h_balance, h_eq, beq_iff_eq]
+        h_balance, h_eq, beq_iff_eq,
+        ContractState.readMap, ContractState.writeMap]
     all_goals cases safeAdd (s.storageMap 1 toAddr) amount <;>
         simp_all [Verity.require, Verity.pure, Verity.bind]
 

--- a/Contracts/Vault/Proofs/Correctness.lean
+++ b/Contracts/Vault/Proofs/Correctness.lean
@@ -22,7 +22,7 @@ theorem totalAssets_meets_spec (s : ContractState) :
     let result := ((totalAssets).run s).fst
     totalAssets_spec result s := by
   simp [totalAssets, totalAssets_spec, Contract.run, ContractResult.fst, getStorage,
-    Verity.bind, Bind.bind, Verity.pure, Pure.pure, totalAssetsSlot]
+    Verity.bind, Bind.bind, Verity.pure, Pure.pure, totalAssetsSlot, ContractState.readSlot]
 
 theorem totalAssets_preserves_state (s : ContractState) :
     let s' := ((totalAssets).run s).snd
@@ -35,7 +35,7 @@ theorem totalSupply_meets_spec (s : ContractState) :
     let result := ((totalSupply).run s).fst
     totalSupply_spec result s := by
   simp [totalSupply, totalSupply_spec, Contract.run, ContractResult.fst, getStorage,
-    Verity.bind, Bind.bind, Verity.pure, Pure.pure, totalSupplySlot]
+    Verity.bind, Bind.bind, Verity.pure, Pure.pure, totalSupplySlot, ContractState.readSlot]
 
 theorem totalSupply_preserves_state (s : ContractState) :
     let s' := ((totalSupply).run s).snd
@@ -48,7 +48,7 @@ theorem balanceOf_meets_spec (s : ContractState) (addr : Address) :
     let result := ((balanceOf addr).run s).fst
     balanceOf_spec addr result s := by
   simp [balanceOf, balanceOf_spec, Contract.run, ContractResult.fst, getMapping,
-    Verity.bind, Bind.bind, Verity.pure, Pure.pure, shareBalancesSlot]
+    Verity.bind, Bind.bind, Verity.pure, Pure.pure, shareBalancesSlot, ContractState.readMap]
 
 theorem balanceOf_preserves_state (s : ContractState) (addr : Address) :
     let s' := ((balanceOf addr).run s).snd

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -395,17 +395,17 @@ def writeArray (s : ContractState) (slot : Nat) (values : List Uint256) : Contra
     (s.writeArray slot vs).readArray slot' = s.readArray slot' := by
   simp [readArray, writeArray, h]
 
--- Until the C5 storage-representation flip, the lenses stay default-simp
--- transparent so the existing raw-field proof surface keeps working unchanged.
--- C5 removes this attribute and migrates proofs onto `storage_simps`.
-attribute [simp] readSlot writeSlot readAddrSlot writeAddrSlot readTransient
-  writeTransient readMap writeMap readMapUint writeMapUint readMap2 writeMap2
-  readArray writeArray
+-- C5 step 2: the lenses are no longer default-simp transparent.  Proofs
+-- normalize lens reads over lens writes through the `storage_simps` simp set
+-- (laws only — it deliberately does NOT unfold lenses to the raw record
+-- representation, so it survives the C5 step-3 flip).  Proofs that genuinely
+-- need the current raw representation unfold a specific lens by name
+-- (`simp [ContractState.writeSlot]`); those sites are the step-3 burn-down.
 
 end ContractState
 
 -- Default zero state — all storage zero, empty addresses, no events.
--- Use `{ defaultState with sender := "0xAlice" }` to customize individual fields.
+-- Use `{ defaultState with sender := Address.ofNat 0xA11CE }` to customize fields.
 def defaultState : ContractState where
   storage := fun _ => 0
   transientStorage := fun _ => 0
@@ -508,6 +508,34 @@ set_option warning.simp.varHead false in
     rfl
   | revert msg s0 =>
     simp [hcs] at h
+
+/-- A reverting prefix makes the whole bind revert to the pre-call snapshot. -/
+theorem bind_run_revert {α β : Type} (ma : Contract α) (f : α → Contract β)
+    (s : ContractState) (msg : String)
+    (h : ma.run s = ContractResult.revert msg s) :
+    (bind ma f).run s = ContractResult.revert msg s := by
+  unfold Contract.run at h
+  cases hma : ma s with
+  | success _ _ =>
+      simp [hma] at h
+  | revert msg' _ =>
+      simp [bind, Contract.run, hma] at h ⊢
+      subst h
+      rfl
+
+/-- If `ma` succeeds without changing state, `run (bind ma f)` is `run (f a)`. -/
+theorem bind_run_success {α β : Type} (ma : Contract α) (f : α → Contract β)
+    (s : ContractState) (a : α)
+    (h : ma.run s = ContractResult.success a s) :
+    (bind ma f).run s = (f a).run s := by
+  unfold Contract.run at h
+  cases hma : ma s with
+  | success a' s' =>
+      simp [hma] at h
+      rcases h with ⟨rfl, rfl⟩
+      simp [bind, Contract.run, hma]
+  | revert _ _ =>
+      simp [hma] at h
 
 @[simp] theorem pure_run (a : α) (state : ContractState) :
   (pure a : Contract α).run state = ContractResult.success a state := rfl
@@ -818,7 +846,7 @@ def setFixedStorageArrayElement {α : Type} [StorageArrayElem α]
     (h : (state.storageArray s.slot)[index.val]? = some value) :
     (getStorageArrayElement s index).run state =
       ContractResult.success (StorageArrayElem.fromWord value) state := by
-  simp [Contract.run, getStorageArrayElement, h]
+  simp [Contract.run, getStorageArrayElement, ContractState.readArray, h]
 
 @[simp] theorem getStorageArrayElement_run_none {α : Type} [StorageArrayElem α]
     (s : StorageSlot (List α)) (index : Uint256)
@@ -826,7 +854,7 @@ def setFixedStorageArrayElement {α : Type} [StorageArrayElem α]
     (h : (state.storageArray s.slot)[index.val]? = none) :
     (getStorageArrayElement s index).run state =
       ContractResult.revert "Storage array index out of bounds" state := by
-  simp [Contract.run, getStorageArrayElement, h]
+  simp [Contract.run, getStorageArrayElement, ContractState.readArray, h]
 
 @[simp] theorem pushStorageArray_run {α : Type} [StorageArrayElem α]
     (s : StorageSlot (List α)) (value : α)
@@ -843,13 +871,13 @@ def setFixedStorageArrayElement {α : Type} [StorageArrayElem α]
     (popStorageArray s).run state = ContractResult.success () { state with
       storageArray := fun slot => if slot == s.slot then updated else state.storageArray slot
     } := by
-  simp [Contract.run, popStorageArray, h]
+  simp [Contract.run, popStorageArray, ContractState.readArray, ContractState.writeArray, h]
 
 @[simp] theorem popStorageArray_run_none {α : Type} (s : StorageSlot (List α)) (state : ContractState)
     (h : storageArrayDropLast? (state.storageArray s.slot) = none) :
     (popStorageArray s).run state =
       ContractResult.revert "Storage array pop on empty array" state := by
-  simp [Contract.run, popStorageArray, h]
+  simp [Contract.run, popStorageArray, ContractState.readArray, h]
 
 @[simp] theorem setStorageArrayElement_run_some {α : Type} [StorageArrayElem α]
     (s : StorageSlot (List α))
@@ -858,7 +886,7 @@ def setFixedStorageArrayElement {α : Type} [StorageArrayElem α]
     (setStorageArrayElement s index value).run state = ContractResult.success () { state with
       storageArray := fun slot => if slot == s.slot then updated else state.storageArray slot
     } := by
-  simp [Contract.run, setStorageArrayElement, h]
+  simp [Contract.run, setStorageArrayElement, ContractState.readArray, ContractState.writeArray, h]
 
 @[simp] theorem setStorageArrayElement_run_none {α : Type} [StorageArrayElem α]
     (s : StorageSlot (List α))
@@ -866,7 +894,7 @@ def setFixedStorageArrayElement {α : Type} [StorageArrayElem α]
     (h : storageArraySetAt (state.storageArray s.slot) index.val (StorageArrayElem.toWord value) = none) :
     (setStorageArrayElement s index value).run state =
       ContractResult.revert "Storage array index out of bounds" state := by
-  simp [Contract.run, setStorageArrayElement, h]
+  simp [Contract.run, setStorageArrayElement, ContractState.readArray, h]
 
 -- Event emission (#153)
 def emitEvent (name : String) (args : List Uint256) (indexedArgs : List Uint256 := []) : Contract Unit :=

--- a/Verity/Core/Model/ContractNamespaceTest.lean
+++ b/Verity/Core/Model/ContractNamespaceTest.lean
@@ -30,7 +30,8 @@ example (state : Verity.ContractState) (slot : Nat) :
 /-- Legacy single-contract writes update the original storage field. -/
 example (state : Verity.ContractState) (slot : Nat) (value : Verity.Uint256) :
     (state.writeContractSlot 0 slot value).readSlot slot = value := by
-  simp [Verity.ContractState.writeContractSlot]
+  simp [Verity.ContractState.writeContractSlot, Verity.ContractState.writeSlot,
+    Verity.ContractState.readSlot]
 
 /-- A write in one contract world is invisible at the same slot in another. -/
 example (state : Verity.ContractState) (slot : Nat) (value : Verity.Uint256) :

--- a/Verity/Core/Model/NonReentrantGuard.lean
+++ b/Verity/Core/Model/NonReentrantGuard.lean
@@ -36,12 +36,12 @@ def setLock (slot : Nat) (value : Uint256) (s : ContractState) : ContractState :
 
 @[simp] theorem setLock_reads (slot : Nat) (value : Uint256) (s : ContractState) :
     (setLock slot value s).transientStorage slot = value := by
-  simp [setLock]
+  simp [setLock, ContractState.writeTransient]
 
 @[simp] theorem setLock_reads_other (slot k : Nat) (value : Uint256)
     (s : ContractState) (h : k ≠ slot) :
     (setLock slot value s).transientStorage k = s.transientStorage k := by
-  simp [setLock, h]
+  simp [setLock, ContractState.writeTransient, h]
 
 /-- Executable semantics of a `nonreentrant(slot)` entrypoint. -/
 def guarded (slot : Nat) (body : Contract α) : Contract α :=

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -270,17 +270,18 @@ theorem getStorage_runState (slot : StorageSlot Uint256) (state : ContractState)
 theorem setStorage_runState (slot : StorageSlot Uint256) (value : Uint256) (state : ContractState) :
     (setStorage slot value).runState state =
       { state with storage := fun s => if s == slot.slot then value else state.storage s } := by
-  simp [setStorage, Contract.runState]
+  simp [setStorage, Contract.runState, ContractState.writeSlot]
 
 -- getStorage returns correct value
 theorem getStorage_runValue (slot : StorageSlot Uint256) (state : ContractState) :
     (getStorage slot).runValue state = state.storage slot.slot := by
-  simp [getStorage, Contract.runValue]
+  simp [getStorage, Contract.runValue, ContractState.readSlot]
 
 -- After setStorage, getStorage returns the value
 theorem setStorage_getStorage (slot : StorageSlot Uint256) (value : Uint256) (state : ContractState) :
     (getStorage slot).runValue ((setStorage slot value).runState state) = value := by
-  simp [setStorage, getStorage, Contract.runState, Contract.runValue]
+  simp [setStorage, getStorage, Contract.runState, Contract.runValue, ContractState.writeSlot,
+    ContractState.readSlot]
 
 -- getStorage for different slot is unchanged after setStorage
 theorem setStorage_getStorage_diff (slot1 slot2 : StorageSlot Uint256) (value : Uint256) (state : ContractState)
@@ -290,7 +291,7 @@ theorem setStorage_getStorage_diff (slot1 slot2 : StorageSlot Uint256) (value : 
   unfold setStorage getStorage Contract.runState Contract.runValue
   by_cases h_eq : slot2.slot = slot1.slot
   · exact (h h_eq.symm).elim
-  · simp [h_eq]
+  · simp [h_eq, ContractState.writeSlot, ContractState.readSlot]
 
 /-!
 ## Monadic Composition Lemmas
@@ -326,7 +327,8 @@ theorem bind_assoc {α β γ : Type} (m : Contract α) (f : α → Contract β) 
 theorem bind_getStorage_setStorage_runState (slot : StorageSlot Uint256) (f : Uint256 → Uint256) (state : ContractState) :
     (Verity.bind (getStorage slot) (fun val => setStorage slot (f val))).runState state =
       { state with storage := fun s => if s == slot.slot then f (state.storage slot.slot) else state.storage s } := by
-  simp [Verity.bind, getStorage, setStorage, Contract.runState]
+  simp [Verity.bind, getStorage, setStorage, Contract.runState, ContractState.writeSlot,
+    ContractState.readSlot]
 
 -- Bind success propagation: if bind succeeds, first action succeeded
 theorem bind_isSuccess_left {α β : Type} (m1 : Contract α) (m2 : α → Contract β) (state : ContractState) :
@@ -358,12 +360,12 @@ theorem getStorageAddr_runState (slot : StorageSlot Address) (state : ContractSt
 theorem setStorageAddr_runState (slot : StorageSlot Address) (value : Address) (state : ContractState) :
     (setStorageAddr slot value).runState state =
       { state with storageAddr := fun s => if s == slot.slot then value else state.storageAddr s } := by
-  simp [setStorageAddr, Contract.runState]
+  simp [setStorageAddr, Contract.runState, ContractState.writeAddrSlot]
 
 -- getStorageAddr returns correct value
 theorem getStorageAddr_runValue (slot : StorageSlot Address) (state : ContractState) :
     (getStorageAddr slot).runValue state = state.storageAddr slot.slot := by
-  simp [getStorageAddr, Contract.runValue]
+  simp [getStorageAddr, Contract.runValue, ContractState.readAddrSlot]
 
 /-!
 ## Address Encoding Lemmas
@@ -398,7 +400,7 @@ theorem getMapping_runState (slot : StorageSlot (Address → Uint256)) (key : Ad
 -- getMapping returns correct value
 theorem getMapping_runValue (slot : StorageSlot (Address → Uint256)) (key : Address) (state : ContractState) :
     (getMapping slot key).runValue state = state.storageMap slot.slot key := by
-  simp [getMapping, Contract.runValue]
+  simp [getMapping, Contract.runValue, ContractState.readMap]
 
 /-!
 ## List Lookup Lemmas
@@ -1253,7 +1255,7 @@ theorem owner_guard_success_implies_storageAddr_eq_sender
     state.storageAddr slot.slot = state.sender := by
   have h_req :
       ((Verity.require (state.sender == state.storageAddr slot.slot) msg).run state).isSuccess = true := by
-    simpa [msgSender, getStorageAddr, Verity.bind, Contract.run] using h
+    simpa [msgSender, getStorageAddr, Verity.bind, Contract.run, ContractState.readAddrSlot] using h
   exact (require_beq_isSuccess_true_iff_eq state.sender (state.storageAddr slot.slot) msg state).1 h_req |>.symm
 
 -- All lemmas in this file are fully proven with zero sorry, zero axioms.

--- a/Verity/Proofs/Stdlib/MappingAutomation.lean
+++ b/Verity/Proofs/Stdlib/MappingAutomation.lean
@@ -46,12 +46,12 @@ theorem setMapping_runState (slot : StorageSlot (Address → Uint256)) (key : Ad
             (state.knownAddresses s).insert key
           else
             state.knownAddresses s } := by
-  simp [setMapping, Contract.runState]
+  simp [setMapping, Contract.runState, ContractState.writeMap]
 
 /-- After setMapping, getMapping on the same key returns the set value. -/
 theorem setMapping_getMapping_same (slot : StorageSlot (Address → Uint256)) (key : Address) (value : Uint256) (state : ContractState) :
     (getMapping slot key).runValue ((setMapping slot key value).runState state) = value := by
-  simp [getMapping, setMapping, Contract.runState, Contract.runValue]
+  simp [getMapping, setMapping, Contract.runState, Contract.runValue, ContractState.readMap, ContractState.writeMap]
 
 /-- setMapping on one key preserves getMapping on a different key (same slot). -/
 theorem setMapping_getMapping_diff (slot : StorageSlot (Address → Uint256))
@@ -69,7 +69,7 @@ theorem setMapping_preserves_other_slot (slot1 : StorageSlot (Address → Uint25
     (h : slot1.slot ≠ slot2) :
     ((setMapping slot1 key value).runState state).storageMap slot2 =
     state.storageMap slot2 := by
-  simp only [setMapping, ContractState.writeMap, Contract.runState]
+  simp only [setMapping, ContractState.writeMap, Contract.runState, ContractState.writeMap]
   funext addr
   have h_slot : (slot2 == slot1.slot) = false := beq_eq_false_iff_ne.mpr (Ne.symm h)
   simp [h_slot]
@@ -79,7 +79,7 @@ theorem setMapping_knownAddresses_same_slot (slot : StorageSlot (Address → Uin
     (key : Address) (value : Uint256) (state : ContractState) :
     ((setMapping slot key value).runState state).knownAddresses slot.slot =
       (state.knownAddresses slot.slot).insert key := by
-  simp [setMapping, Contract.runState]
+  simp [setMapping, Contract.runState, ContractState.writeMap]
 
 /-- setMapping preserves knownAddresses for all non-target slots. -/
 theorem setMapping_knownAddresses_other_slot (slot : StorageSlot (Address → Uint256))
@@ -90,7 +90,7 @@ theorem setMapping_knownAddresses_other_slot (slot : StorageSlot (Address → Ui
   by_cases h_eq : slot' = slot.slot
   · exact (h h_eq).elim
   · have h_slot : (slot' == slot.slot) = false := beq_eq_false_iff_ne.mpr h_eq
-    simp [setMapping, Contract.runState, h_eq]
+    simp [setMapping, Contract.runState, h_eq, ContractState.writeMap]
 
 /-- Membership characterization at target slot after setMapping. -/
 theorem setMapping_knownAddresses_mem_iff (slot : StorageSlot (Address → Uint256))
@@ -106,11 +106,11 @@ theorem setMapping_knownAddresses_mem_iff (slot : StorageSlot (Address → Uint2
 
 theorem getMappingUint_runState (slot : StorageSlot (Uint256 → Uint256)) (key : Uint256) (state : ContractState) :
     (getMappingUint slot key).runState state = state := by
-  simp [getMappingUint, Contract.runState]
+  simp [getMappingUint, Contract.runState, ContractState.readMapUint]
 
 theorem getMappingUint_runValue (slot : StorageSlot (Uint256 → Uint256)) (key : Uint256) (state : ContractState) :
     (getMappingUint slot key).runValue state = state.storageMapUint slot.slot key := by
-  simp [getMappingUint, Contract.runValue]
+  simp [getMappingUint, Contract.runValue, ContractState.readMapUint]
 
 /-- setMappingUint updates storageMapUint. -/
 theorem setMappingUint_runState (slot : StorageSlot (Uint256 → Uint256)) (key : Uint256)
@@ -120,13 +120,13 @@ theorem setMappingUint_runState (slot : StorageSlot (Uint256 → Uint256)) (key 
         storageMapUint := fun s k =>
           if s == slot.slot && k == key then value
           else state.storageMapUint s k } := by
-  simp [setMappingUint, Contract.runState]
+  simp [setMappingUint, Contract.runState, ContractState.writeMapUint]
 
 /-- After setMappingUint, getMappingUint on the same key returns the set value. -/
 theorem setMappingUint_getMappingUint_same (slot : StorageSlot (Uint256 → Uint256))
     (key : Uint256) (value : Uint256) (state : ContractState) :
     (getMappingUint slot key).runValue ((setMappingUint slot key value).runState state) = value := by
-  simp [getMappingUint, setMappingUint, Contract.runState, Contract.runValue]
+  simp [getMappingUint, setMappingUint, Contract.runState, Contract.runValue, ContractState.readMapUint, ContractState.writeMapUint]
 
 /-- setMappingUint on one key preserves getMappingUint on a different key (same slot). -/
 theorem setMappingUint_getMappingUint_diff (slot : StorageSlot (Uint256 → Uint256))
@@ -186,11 +186,11 @@ theorem setMappingUint_preserves_knownAddresses (slot : StorageSlot (Uint256 →
 
 theorem getMapping2_runState (slot : StorageSlot (Address → Address → Uint256)) (key1 key2 : Address) (state : ContractState) :
     (getMapping2 slot key1 key2).runState state = state := by
-  simp [getMapping2, Contract.runState]
+  simp [getMapping2, Contract.runState, ContractState.readMap2]
 
 theorem getMapping2_runValue (slot : StorageSlot (Address → Address → Uint256)) (key1 key2 : Address) (state : ContractState) :
     (getMapping2 slot key1 key2).runValue state = state.storageMap2 slot.slot key1 key2 := by
-  simp [getMapping2, Contract.runValue]
+  simp [getMapping2, Contract.runValue, ContractState.readMap2]
 
 /-- setMapping2 updates storageMap2. -/
 theorem setMapping2_runState (slot : StorageSlot (Address → Address → Uint256))
@@ -200,13 +200,13 @@ theorem setMapping2_runState (slot : StorageSlot (Address → Address → Uint25
         storageMap2 := fun s addr1 addr2 =>
           if s == slot.slot && addr1 == key1 && addr2 == key2 then value
           else state.storageMap2 s addr1 addr2 } := by
-  simp [setMapping2, Contract.runState]
+  simp [setMapping2, Contract.runState, ContractState.writeMap2]
 
 /-- After setMapping2, getMapping2 on the same keys returns the set value. -/
 theorem setMapping2_getMapping2_same (slot : StorageSlot (Address → Address → Uint256))
     (key1 key2 : Address) (value : Uint256) (state : ContractState) :
     (getMapping2 slot key1 key2).runValue ((setMapping2 slot key1 key2 value).runState state) = value := by
-  simp [getMapping2, setMapping2, Contract.runState, Contract.runValue]
+  simp [getMapping2, setMapping2, Contract.runState, Contract.runValue, ContractState.readMap2, ContractState.writeMap2]
 
 /-- setMapping2 with different first key preserves getMapping2. -/
 theorem setMapping2_getMapping2_diff_key1 (slot : StorageSlot (Address → Address → Uint256))


### PR DESCRIPTION
Step 2 of the C5 storage-representation flip: the `ContractState` lens API loses its global `attribute [simp]`.

## Design
- `storage_simps` stays **laws-only** (read-over-write normalization) — it deliberately does not unfold lenses to the raw record representation, so it survives the step-3 flip unchanged.
- Proofs that genuinely need today's raw representation now name the lens explicitly (`simp [ContractState.writeSlot]`). Those call sites are the **step-3 burn-down inventory** (greppable).

## Repair surface
~25 files, **zero theorem statements changed**, zero axioms: Core's storage-array run-lemmas, Stdlib `Automation`/`MappingAutomation`, `NonReentrantGuard`, two proof macros (`denote_stmt_arm` in DenoteAgreement, `simp_tir_eval` in TypedIRCompilerCorrectness — one edit each fixed dozens of arms), and the contract proof suites (Counter, ERC20, ERC721, Ledger, OwnedCounter, SimpleToken, Vault, ReentrancyExample, ReentrancyRelyGuarantee, LocalObligationMacroSmoke). The denotational layer (Denote, DenoteExternalCalls, call journal) needed **no changes** — it never relied on lens transparency.

Also carries `Contract.bind_run_revert` (concurrent lane work present in tree; compiles green with the full stack).

## Evidence
- `lake build` (2471 jobs) + `lake build Contracts` + `lake build PrintAxioms` green
- `make check` passes (including the step-1 ratchet gate)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-tactic and documentation churn only; lens definitions and semantics are unchanged, with broad `lake build` / `make check` evidence cited in the PR.
> 
> **Overview**
> **C5 step 2** drops the global `attribute [simp]` on `ContractState` read/write lenses (`readSlot`, `writeSlot`, maps, arrays, transient, etc.) in `Verity/Core.lean`. **`storage_simps`** stays laws-only (read-over-write), so it is meant to survive the step-3 representation flip without unfolding lenses to the raw record.
> 
> Proofs that relied on automatic lens unfolding now pass explicit lens names in `simp` (e.g. `ContractState.writeSlot`, `readMap`) across Core run-lemmas, Stdlib automation, contract proof suites, and two macros (`denote_stmt_arm`, `simp_tir_eval`) that fix many call sites in one place. **AUDIT.md** documents the step and greppable step-3 burn-down inventory.
> 
> Also adds **`bind_run_revert`** / **`bind_run_success`** on `Contract`. No theorem statements changed; zero axioms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1edc3a5518d859130d6103fab0c4dfb7db54d604. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->