### PR TITLE
feat(edsl): verifiable mixin include for proof reuse

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ FOUNDRY_PROFILE=difftest forge test  # Must pass — runs all Foundry tests
 
 **When adding a new contract**, also update:
 - Author the contract with `verity_contract`; do not add a separate hand-written `Compiler.Specs` body unless the workflow truly requires a special case like external linking.
+- A new reusable facet (Ownable, Pausable, …) is a `verity_mixin` plus named-slot specs, a `Footprint`, and `_meets_spec` / guard theorems. Hosts `include` the mixin; do not copy `Owned.lean` into the host.
 - Add the macro-generated `<Name>.spec` alias/list entry in [`Contracts/Specs.lean`](Contracts/Specs.lean) if the contract should ship through the default compiler manifest.
 - `test/property_manifest.json` — Run `python3 scripts/extract_property_manifest.py`
 - `README.md` — Contracts table (theorem count and description)

--- a/Compiler/TypedIRCompilerCorrectness.lean
+++ b/Compiler/TypedIRCompilerCorrectness.lean
@@ -1127,7 +1127,7 @@ theorem compile_setStorage_literal_semantics
       .ok { init with world := execSourceSetStorageLiteral init.world slot n } := by
   simp [execCompiledSetStorageLiteral, execSourceSetStorageLiteral,
     compileStmts_single_setStorage_literal_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for the supported two-statement subset:
 compiling and running `letVar tmp (literal n); setStorage fieldName (localVar tmp)`
@@ -1144,7 +1144,7 @@ theorem compile_let_setStorage_local_literal_semantics
             vars := init.vars.set { id := 0, ty := Ty.uint256 } (n : Verity.Core.Uint256) }) := by
   simp [execCompiledLetSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for a broader supported three-statement subset:
 compiling and running
@@ -1164,7 +1164,7 @@ theorem compile_let_assign_setStorage_local_literal_semantics
               { id := 1, ty := Ty.uint256 } (m : Verity.Core.Uint256) }) := by
   simp [execCompiledLetAssignSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_assign_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for an arithmetic supported three-statement subset:
 compiling and running
@@ -1186,7 +1186,7 @@ theorem compile_let_assign_add_setStorage_local_literal_semantics
                 ((n : Verity.Core.Uint256).add (m : Verity.Core.Uint256)) }) := by
   simp [execCompiledLetAssignAddSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_assign_add_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for an arithmetic supported three-statement subset:
 compiling and running
@@ -1310,7 +1310,7 @@ theorem compile_return_storage_semantics
   simp [execCompiledReturnStorage, execSourceReturnStorage,
     compileStmts_single_return_storage_run, hfind,
     evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for `return (storage field)` (address). -/
 theorem compile_return_storage_addr_semantics
@@ -1323,7 +1323,7 @@ theorem compile_return_storage_addr_semantics
   simp [execCompiledReturnStorageAddr, execSourceReturnStorageAddr,
     compileStmts_single_return_storage_addr_run, hfind,
     evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation for `return (mapping fieldName caller)`:
 compiled execution matches direct source semantics (no state change). -/
@@ -1336,7 +1336,7 @@ theorem compile_return_mapping_caller_semantics
   simp [execCompiledReturnMappingCaller, execSourceReturnMappingCaller,
     compileStmts_single_return_mapping_caller_run, hSlot,
     evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation for the address storage-read + return pattern. -/
 theorem compile_let_storage_addr_return_local_semantics
@@ -1952,7 +1952,7 @@ theorem compile_return_literal_semantics
     execCompiledReturnLiteral fields init n = execSourceReturnLiteral init n := by
   simp [execCompiledReturnLiteral, execSourceReturnLiteral,
     compileStmts_single_return_literal_run, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for a broader supported subset:
 compiling and running `letVar tmp (literal n); return (localVar tmp)`
@@ -1963,7 +1963,7 @@ theorem compile_let_return_local_literal_semantics
       execSourceLetReturnLocalLiteral init n := by
   simp [execCompiledLetReturnLocalLiteral, execSourceLetReturnLocalLiteral,
     compileStmts_let_return_local_literal_run, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for a broader supported branch subset:
 compiling and running

--- a/Contracts.lean
+++ b/Contracts.lean
@@ -7,7 +7,9 @@ import Contracts.Smoke
 import Contracts.Counter
 import Contracts.SimpleStorage
 import Contracts.Owned
+import Contracts.Ownable
 import Contracts.OwnedCounter
+import Contracts.OwnedCounterComposed
 import Contracts.SafeCounter
 import Contracts.Ledger
 import Contracts.Vault

--- a/Contracts/Ownable.lean
+++ b/Contracts/Ownable.lean
@@ -1,0 +1,4 @@
+import Contracts.Ownable.Ownable
+import Contracts.Ownable.Spec
+import Contracts.Ownable.Invariants
+import Contracts.Ownable.Proofs.Basic

--- a/Contracts/Ownable/Invariants.lean
+++ b/Contracts/Ownable/Invariants.lean
@@ -1,0 +1,30 @@
+import Verity.Specs.Common
+import Verity.Specs.Composition
+import Contracts.Ownable.Ownable
+
+namespace Contracts.Ownable.Invariants
+
+open Verity
+open Verity.Specs.Composition
+open Contracts.Ownable
+
+structure WellFormedState (s : ContractState) : Prop where
+  sender_nonzero : s.sender ≠ 0
+  contract_nonzero : s.thisAddress ≠ 0
+  owner_nonzero : s.storageAddr owner.slot ≠ 0
+
+def Inv (s : ContractState) : Prop :=
+  s.storageAddr owner.slot ≠ 0
+
+theorem inv_depends_only_on_footprint :
+    InvDependsOnlyOn Inv { addrSlots := [owner.slot] } := by
+  intro s s' h
+  constructor
+  · intro hinv
+    have := h.2.1 owner.slot (by simp)
+    simpa [Inv, this] using hinv
+  · intro hinv
+    have := h.2.1 owner.slot (by simp)
+    simpa [Inv, this] using hinv
+
+end Contracts.Ownable.Invariants

--- a/Contracts/Ownable/Ownable.lean
+++ b/Contracts/Ownable/Ownable.lean
@@ -1,0 +1,27 @@
+import Contracts.Common
+
+namespace Contracts
+
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_mixin Ownable where
+  storage
+    owner : Address := slot 0
+
+  constructor (initialOwner : Address) := do
+    setStorageAddr owner initialOwner
+
+  modifier onlyOwner := do
+    let sender ← msgSender
+    let currentOwner ← getStorageAddr owner
+    require (sender == currentOwner) "Caller is not the owner"
+
+  function transferOwnership (newOwner : Address) with onlyOwner modifies(owner) : Unit := do
+    setStorageAddr owner newOwner
+
+  function getOwner () : Address := do
+    let currentOwner ← getStorageAddr owner
+    return currentOwner
+
+end Contracts

--- a/Contracts/Ownable/Proofs/Basic.lean
+++ b/Contracts/Ownable/Proofs/Basic.lean
@@ -1,0 +1,67 @@
+import Contracts.Ownable.Spec
+import Contracts.Ownable.Invariants
+import Verity.Proofs.Stdlib.Automation
+import Verity.Specs.Composition
+
+namespace Contracts.Ownable.Proofs
+
+open Verity
+open Contracts.Ownable
+open Contracts.Ownable.Spec
+open Contracts.Ownable.Invariants
+open Verity.Proofs.Stdlib.Automation (address_beq_false_of_ne)
+open Verity.Specs.Composition
+
+private theorem owner_slot_zero : StorageSlot.slot owner = 0 := rfl
+
+theorem onlyOwner_ok (s : ContractState)
+    (h_owner : s.sender = s.storageAddr (StorageSlot.slot owner)) :
+    onlyOwner.run s = ContractResult.success () s := by
+  simp [onlyOwner, owner, msgSender, getStorageAddr, ContractState.readAddrSlot,
+    Verity.require, Verity.bind, Bind.bind, Contract.run, h_owner]
+
+theorem onlyOwner_reverts (s : ContractState)
+    (h_not_owner : s.sender ≠ s.storageAddr (StorageSlot.slot owner)) :
+    ∃ msg, onlyOwner.run s = ContractResult.revert msg s :=
+  ⟨"Caller is not the owner", by
+    have h : s.sender ≠ s.storageAddr 0 := owner_slot_zero ▸ h_not_owner
+    simp [onlyOwner, owner, msgSender, getStorageAddr, ContractState.readAddrSlot,
+      Verity.require, Verity.bind, Bind.bind, Contract.run,
+      address_beq_false_of_ne s.sender (s.storageAddr 0) h]⟩
+
+theorem transferOwnership_writes_only (s : ContractState) (newOwner : Address)
+    (h_owner : s.sender = s.storageAddr (StorageSlot.slot owner)) :
+    WritesOnly footprint s ((transferOwnership newOwner).run s).snd := by
+  simp [transferOwnership, footprint, WritesOnly, owner,
+    msgSender, getStorageAddr, setStorageAddr, ContractState.readAddrSlot,
+    ContractState.writeAddrSlot, Verity.require, Verity.bind, Bind.bind,
+    Contract.run, ContractResult.snd, h_owner, Specs.sameContext]
+  intro _ hneq heq
+  exact (hneq heq).elim
+
+theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : Address)
+    (h_owner : s.sender = s.storageAddr (StorageSlot.slot owner)) :
+    let s' := ((transferOwnership newOwner).run s).snd
+    transferOwnership_spec newOwner s s' := by
+  simp [transferOwnership, transferOwnership_spec, owner,
+    msgSender, getStorageAddr, setStorageAddr, ContractState.readAddrSlot,
+    ContractState.writeAddrSlot, Verity.require, Verity.bind, Bind.bind,
+    Contract.run, ContractResult.snd, h_owner,
+    Specs.storageAddrUpdateSpec, Specs.storageAddrUnchangedExcept,
+    Specs.sameStorageMapContext, Specs.sameStorage, Specs.sameStorageMap,
+    Specs.sameStorageArray, Specs.sameContext]
+  intro _ hneq heq
+  exact (hneq heq).elim
+
+theorem getOwner_meets_spec (s : ContractState) :
+    getOwner_spec ((getOwner).run s).fst s := by
+  simp [getOwner, getOwner_spec, owner, getStorageAddr, ContractState.readAddrSlot,
+    Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run]
+
+theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
+    ((«constructor» initialOwner).run s).snd.storageAddr (StorageSlot.slot owner)
+      = initialOwner := by
+  simp [«constructor», owner, setStorageAddr, ContractState.writeAddrSlot,
+    Contract.run, ContractResult.snd]
+
+end Contracts.Ownable.Proofs

--- a/Contracts/Ownable/Spec.lean
+++ b/Contracts/Ownable/Spec.lean
@@ -1,0 +1,24 @@
+import Verity.Specs.Common
+import Verity.Specs.Composition
+import Verity.Macro
+import Contracts.Ownable.Ownable
+
+namespace Contracts.Ownable.Spec
+
+open Verity
+open Verity.Specs
+open Verity.Specs.Composition
+open Contracts.Ownable
+
+#gen_spec_addr constructor_spec for (initialOwner : Address)
+  (owner.slot, (fun _ => initialOwner), sameStorageMapContext)
+
+def getOwner_spec (result : Address) (s : ContractState) : Prop :=
+  result = s.storageAddr owner.slot
+
+#gen_spec_addr transferOwnership_spec for (newOwner : Address)
+  (owner.slot, (fun _ => newOwner), sameStorageMapContext)
+
+def footprint : Footprint := { addrSlots := [owner.slot] }
+
+end Contracts.Ownable.Spec

--- a/Contracts/Owned/Invariants.lean
+++ b/Contracts/Owned/Invariants.lean
@@ -5,10 +5,12 @@
 -/
 
 import Verity.Specs.Common
+import Contracts.Owned.Owned
 
 namespace Contracts.Owned.Invariants
 
 open Verity
+open Contracts.Owned
 
 /-! ## State Invariants
 
@@ -23,6 +25,6 @@ Properties that should be maintained by all operations.
 structure WellFormedState (s : ContractState) : Prop where
   sender_nonzero : s.sender ≠ 0
   contract_nonzero : s.thisAddress ≠ 0
-  owner_nonzero : s.storageAddr 0 ≠ 0
+  owner_nonzero : s.storageAddr owner.slot ≠ 0
 
 end Contracts.Owned.Invariants

--- a/Contracts/Owned/Proofs/Basic.lean
+++ b/Contracts/Owned/Proofs/Basic.lean
@@ -27,13 +27,13 @@ These establish fundamental properties of address storage operations.
 theorem setStorageAddr_updates_owner (s : ContractState) (addr : Address) :
   let slotIdx : StorageSlot Address := owner
   let s' := ((setStorageAddr slotIdx addr).run s).snd
-  s'.storageAddr 0 = addr := by
+  s'.storageAddr owner.slot = addr := by
   simp [owner]
 
 theorem getStorageAddr_reads_owner (s : ContractState) :
   let slotIdx : StorageSlot Address := owner
   let result := ((getStorageAddr slotIdx).run s).fst
-  result = s.storageAddr 0 := by
+  result = s.storageAddr owner.slot := by
   simp [owner]
 
 theorem setStorageAddr_preserves_other_slots (s : ContractState) (addr : Address) (slot_num : Nat)
@@ -66,16 +66,16 @@ theorem setStorageAddr_preserves_context (s : ContractState) (addr : Address) :
 theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
   constructor_spec initialOwner s s' := by
-  refine ⟨?_, ?_, ?_⟩
-  · simp [owner]
+  simp [constructor_spec, owner]
+  refine ⟨rfl, ?_, ?_⟩
   · intro slotIdx h_neq
-    simp [owner, h_neq]
-  · simp [owner, Specs.sameStorageMapContext,
+    simp [h_neq]
+  · simp [Specs.sameStorageMapContext,
       Specs.sameStorage, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
-  s'.storageAddr 0 = initialOwner := by
+  s'.storageAddr owner.slot = initialOwner := by
   simp [owner]
 
 /-! ## getOwner Correctness -/
@@ -88,7 +88,7 @@ theorem getOwner_meets_spec (s : ContractState) :
 
 theorem getOwner_returns_owner (s : ContractState) :
   let result := ((getOwner).run s).fst
-  result = s.storageAddr 0 := by
+  result = s.storageAddr owner.slot := by
   simpa [getOwner_spec] using getOwner_meets_spec s
 
 theorem getOwner_preserves_state (s : ContractState) :
@@ -102,12 +102,11 @@ theorem isOwner_meets_spec (s : ContractState) :
   let result := ((isOwner).run s).fst
   isOwner_spec result s := by
   verity_unfold isOwner
-  simp only [isOwner_spec]
-  rfl
+  simp [isOwner_spec, owner]
 
 theorem isOwner_returns_correct_value (s : ContractState) :
   let result := ((isOwner).run s).fst
-  result = (s.sender == s.storageAddr 0) := by
+  result = (s.sender == s.storageAddr owner.slot) := by
   simpa [isOwner_spec] using isOwner_meets_spec s
 
 /-! ## transferOwnership Correctness
@@ -120,7 +119,7 @@ is fully modeled and can be unfolded in proofs.
 
 /-- Helper: unfold transferOwnership when caller is owner -/
 theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
-  (h_owner : s.sender = s.storageAddr 0) :
+  (h_owner : s.sender = s.storageAddr owner.slot) :
   (transferOwnership newOwner).run s = ContractResult.success ()
     { «storage» := s.storage,
       contractStorage := s.contractStorage,
@@ -149,23 +148,23 @@ theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
   exact h_owner
 
 theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : Address)
-  (h_is_owner : s.sender = s.storageAddr 0) :
+  (h_is_owner : s.sender = s.storageAddr owner.slot) :
   let s' := ((transferOwnership newOwner).run s).snd
   transferOwnership_spec newOwner s s' := by
   rw [transferOwnership_unfold s newOwner h_is_owner]
-  refine ⟨?_, ?_, ?_⟩
-  · simp [ContractResult.snd]
+  simp [transferOwnership_spec, owner, ContractResult.snd]
+  refine ⟨rfl, ?_, ?_⟩
   · intro slotIdx h_neq
-    simp [ContractResult.snd, h_neq]
-  · simp [ContractResult.snd, Specs.sameStorageMapContext,
+    simp [h_neq]
+  · simp [Specs.sameStorageMapContext,
       Specs.sameStorage, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem transferOwnership_changes_owner_when_allowed (s : ContractState) (newOwner : Address)
-  (h_is_owner : s.sender = s.storageAddr 0) :
+  (h_is_owner : s.sender = s.storageAddr owner.slot) :
   let s' := ((transferOwnership newOwner).run s).snd
-  s'.storageAddr 0 = newOwner := by
+  s'.storageAddr owner.slot = newOwner := by
   rw [transferOwnership_unfold s newOwner h_is_owner]
-  simp [ContractResult.snd]
+  simp [owner, ContractResult.snd]
 
 /-! ## Composition Properties -/
 

--- a/Contracts/Owned/Proofs/Correctness.lean
+++ b/Contracts/Owned/Proofs/Correctness.lean
@@ -26,20 +26,21 @@ The fundamental access control property: non-owners cannot transfer ownership.
 /-- transferOwnership reverts when the caller is not the owner.
     This is the core security property of the Owned pattern. -/
 theorem transferOwnership_reverts_when_not_owner (s : ContractState) (newOwner : Address)
-  (h_not_owner : s.sender ≠ s.storageAddr 0) :
+  (h_not_owner : s.sender ≠ s.storageAddr owner.slot) :
   ∃ msg, (transferOwnership newOwner).run s = ContractResult.revert msg s := by
+  have h : s.sender ≠ s.storageAddr 0 := by simpa [owner] using h_not_owner
   simp [transferOwnership, owner,
-    msgSender, getStorageAddr,
+    msgSender, getStorageAddr, ContractState.readAddrSlot,
     Verity.require, Verity.bind, Bind.bind,
     Contract.run,
-    address_beq_false_of_ne s.sender (s.storageAddr 0) h_not_owner]
+    address_beq_false_of_ne s.sender (s.storageAddr 0) h]
 
 /-! ## Invariant Preservation -/
 
 /-- transferOwnership preserves WellFormedState when the new owner is non-empty.
     After ownership transfer, all address fields remain non-empty. -/
 theorem transferOwnership_preserves_wellformedness (s : ContractState) (newOwner : Address)
-  (h : WellFormedState s) (h_owner : s.sender = s.storageAddr 0) (h_new : newOwner ≠ 0) :
+  (h : WellFormedState s) (h_owner : s.sender = s.storageAddr owner.slot) (h_new : newOwner ≠ 0) :
   let s' := ((transferOwnership newOwner).run s).snd
   WellFormedState s' := by
   verity_frame (transferOwnership_unfold s newOwner h_owner)
@@ -55,19 +56,21 @@ theorem constructor_transferOwnership_getOwner (s : ContractState) (initialOwner
   let s2 := ((transferOwnership newOwner).run s1).snd
   ((getOwner).run s2).fst = newOwner := by
   simp [setStorageAddr, transferOwnership, owner, getOwner,
-    msgSender, getStorageAddr, setStorageAddr,
+    msgSender, getStorageAddr, ContractState.readAddrSlot, ContractState.writeAddrSlot,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
     Contract.run, ContractResult.snd, ContractResult.fst, h_sender]
 
 /-- After ownership transfer, the previous owner can no longer transfer.
     Proves that ownership is truly transferred, not just copied. -/
 theorem transferred_owner_cannot_act (s : ContractState) (newOwner : Address)
-  (h_owner : s.sender = s.storageAddr 0) (h_ne : s.sender ≠ newOwner) :
+  (h_owner : s.sender = s.storageAddr owner.slot) (h_ne : s.sender ≠ newOwner) :
   let s' := ((transferOwnership newOwner).run s).snd
   ∃ msg, (transferOwnership 42).run s' = ContractResult.revert msg s' := by
   have h_ne' : ((transferOwnership newOwner).run s).snd.sender ≠
-      ((transferOwnership newOwner).run s).snd.storageAddr 0 := by
+      ((transferOwnership newOwner).run s).snd.storageAddr owner.slot := by
     verity_frame (transferOwnership_unfold s newOwner h_owner) with h_ne
+    simp [owner] at *
+    exact h_ne
   exact transferOwnership_reverts_when_not_owner _ _ h_ne'
 
 /-! ## Summary

--- a/Contracts/Owned/Spec.lean
+++ b/Contracts/Owned/Spec.lean
@@ -15,17 +15,17 @@ open Contracts.Owned
 /-! ## Operation Specifications -/
 
 -- Constructor: sets the owner to the provided address.
-#gen_spec_addr constructor_spec for (initialOwner : Address) (0, (fun _ => initialOwner), sameStorageMapContext)
+#gen_spec_addr constructor_spec for (initialOwner : Address) (owner.slot, (fun _ => initialOwner), sameStorageMapContext)
 
 /-- getOwner: returns the current owner address -/
 def getOwner_spec (result : Address) (s : ContractState) : Prop :=
-  result = s.storageAddr 0
+  result = s.storageAddr owner.slot
 
 -- transferOwnership: updates owner to new address (owner only).
-#gen_spec_addr transferOwnership_spec for (newOwner : Address) (0, (fun _ => newOwner), sameStorageMapContext)
+#gen_spec_addr transferOwnership_spec for (newOwner : Address) (owner.slot, (fun _ => newOwner), sameStorageMapContext)
 
 /-- isOwner: returns true if sender equals current owner -/
 def isOwner_spec (result : Bool) (s : ContractState) : Prop :=
-  result = (s.sender == s.storageAddr 0)
+  result = (s.sender == s.storageAddr owner.slot)
 
 end Contracts.Owned.Spec

--- a/Contracts/OwnedCounterComposed.lean
+++ b/Contracts/OwnedCounterComposed.lean
@@ -1,0 +1,3 @@
+import Contracts.OwnedCounterComposed.OwnedCounterComposed
+import Contracts.OwnedCounterComposed.Spec
+import Contracts.OwnedCounterComposed.Proofs.Basic

--- a/Contracts/OwnedCounterComposed/OwnedCounterComposed.lean
+++ b/Contracts/OwnedCounterComposed/OwnedCounterComposed.lean
@@ -1,0 +1,28 @@
+import Contracts.Common
+import Contracts.Ownable.Ownable
+
+namespace Contracts
+
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_contract OwnedCounterComposed include Ownable where
+  storage
+    count : Uint256 := slot 1
+
+  constructor (initialOwner : Address) Ownable(initialOwner) := do
+    setStorage count 0
+
+  function increment () with onlyOwner modifies(count) : Unit := do
+    let current ← getStorage count
+    setStorage count (add current 1)
+
+  function decrement () with onlyOwner modifies(count) : Unit := do
+    let current ← getStorage count
+    setStorage count (sub current 1)
+
+  function getCount () : Uint256 := do
+    let current ← getStorage count
+    return current
+
+end Contracts

--- a/Contracts/OwnedCounterComposed/Proofs/Basic.lean
+++ b/Contracts/OwnedCounterComposed/Proofs/Basic.lean
@@ -1,0 +1,81 @@
+import Contracts.OwnedCounterComposed.Spec
+import Contracts.Ownable.Proofs.Basic
+import Contracts.Ownable.Invariants
+import Verity.Specs.Composition
+import Verity.Proofs.Stdlib.Automation
+
+namespace Contracts.OwnedCounterComposed.Proofs
+
+open Verity
+open Contracts.OwnedCounterComposed
+open Contracts.OwnedCounterComposed.Spec
+open Contracts.Ownable
+open Contracts.Ownable.Proofs
+open Contracts.Ownable.Invariants
+open Verity.Specs.Composition
+
+theorem increment_reverts_when_not_owner (s : ContractState)
+    (h_not_owner : s.sender ≠ s.storageAddr (StorageSlot.slot owner)) :
+    ∃ msg, increment.run s = ContractResult.revert msg s := by
+  rcases onlyOwner_reverts s h_not_owner with ⟨msg, hrev⟩
+  refine ⟨msg, ?_⟩
+  simp only [increment]
+  exact Verity.bind_run_revert onlyOwner _ s msg hrev
+
+theorem increment_meets_spec_when_owner (s : ContractState)
+    (h_owner : s.sender = s.storageAddr (StorageSlot.slot owner)) :
+    let s' := (increment.run s).snd
+    increment_spec s s' := by
+  have hok := onlyOwner_ok s h_owner
+  simp only [increment, Bind.bind]
+  rw [bind_run_success onlyOwner _ s () hok]
+  simp [increment_spec, count, getStorage, setStorage,
+    ContractState.readSlot, ContractState.writeSlot,
+    Verity.bind, Contract.run, ContractResult.snd,
+    Specs.storageUpdateSpec, Specs.storageUnchangedExcept,
+    Specs.sameAddrMapContext, Specs.sameStorageAddr, Specs.sameStorageMap,
+    Specs.sameStorageArray, Specs.sameContext]
+  intro _ hneq heq
+  exact (hneq heq).elim
+
+theorem increment_preserves_owner (s : ContractState)
+    (h_owner : s.sender = s.storageAddr (StorageSlot.slot owner)) :
+    ((increment.run s).snd).storageAddr (StorageSlot.slot owner)
+      = s.storageAddr (StorageSlot.slot owner) := by
+  have hok := onlyOwner_ok s h_owner
+  simp only [increment, Bind.bind]
+  rw [bind_run_success onlyOwner _ s () hok]
+  simp [count, getStorage, setStorage, ContractState.readSlot, ContractState.writeSlot,
+    Verity.bind, Contract.run, ContractResult.snd]
+
+theorem increment_writes_only_count (s : ContractState)
+    (h_owner : s.sender = s.storageAddr (StorageSlot.slot owner)) :
+    WritesOnly countFootprint s (increment.run s).snd := by
+  have hok := onlyOwner_ok s h_owner
+  simp only [increment, Bind.bind]
+  rw [bind_run_success onlyOwner _ s () hok]
+  simp [countFootprint, WritesOnly, count, getStorage, setStorage,
+    ContractState.readSlot, ContractState.writeSlot,
+    Verity.bind, Contract.run, ContractResult.snd, Specs.sameContext]
+  intro _ hneq heq
+  exact (hneq heq).elim
+
+theorem increment_preserves_ownable_inv (s : ContractState)
+    (h_owner : s.sender = s.storageAddr (StorageSlot.slot owner))
+    (hInv : Inv s) :
+    Inv (increment.run s).snd :=
+  writesOnly_preserves_other_inv
+    countFootprint
+    { addrSlots := [StorageSlot.slot owner] }
+    (disjoint_uint_addr (StorageSlot.slot count) (StorageSlot.slot owner))
+    Inv inv_depends_only_on_footprint
+    s (increment.run s).snd
+    (increment_writes_only_count s h_owner)
+    hInv
+
+theorem getCount_meets_spec (s : ContractState) :
+    getCount_spec ((getCount).run s).fst s := by
+  simp [getCount, getCount_spec, count, getStorage, ContractState.readSlot,
+    Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run]
+
+end Contracts.OwnedCounterComposed.Proofs

--- a/Contracts/OwnedCounterComposed/Spec.lean
+++ b/Contracts/OwnedCounterComposed/Spec.lean
@@ -1,0 +1,22 @@
+import Verity.Specs.Common
+import Verity.Specs.Composition
+import Verity.Macro
+import Contracts.OwnedCounterComposed.OwnedCounterComposed
+
+namespace Contracts.OwnedCounterComposed.Spec
+
+open Verity
+open Verity.EVM.Uint256
+open Verity.Specs
+open Verity.Specs.Composition
+open Contracts.OwnedCounterComposed
+
+#gen_spec increment_spec (count.slot, (fun st => add (st.storage count.slot) 1), sameAddrMapContext)
+#gen_spec decrement_spec (count.slot, (fun st => sub (st.storage count.slot) 1), sameAddrMapContext)
+
+def getCount_spec (result : Uint256) (s : ContractState) : Prop :=
+  result = s.storage count.slot
+
+def countFootprint : Footprint := { uintSlots := [count.slot] }
+
+end Contracts.OwnedCounterComposed.Spec

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -1,4 +1,5 @@
 import Contracts.Smoke.Helpers
+import Contracts.Smoke.Include
 import Contracts.Smoke.Intrinsics
 import Contracts.Smoke.Storage
 import Contracts.Smoke.Arithmetic

--- a/Contracts/Smoke/Include.lean
+++ b/Contracts/Smoke/Include.lean
@@ -1,0 +1,95 @@
+import Contracts.Common
+import Compiler.CheckContract
+
+namespace Contracts.Smoke
+
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_mixin IncludeOwnableMixin where
+  storage
+    owner : Address := slot 0
+
+  constructor (initialOwner : Address) := do
+    setStorageAddr owner initialOwner
+
+  modifier onlyOwner := do
+    let sender ← msgSender
+    let currentOwner ← getStorageAddr owner
+    require (sender == currentOwner) "Caller is not the owner"
+
+  function transferOwnership (newOwner : Address) with onlyOwner modifies(owner) : Unit := do
+    setStorageAddr owner newOwner
+
+verity_contract IncludeOwnedCounterHost include IncludeOwnableMixin where
+  storage
+    count : Uint256 := slot 1
+
+  constructor (initialOwner : Address) IncludeOwnableMixin(initialOwner) := do
+    setStorage count 0
+
+  function increment () with onlyOwner modifies(count) : Unit := do
+    let current ← getStorage count
+    setStorage count (add current 1)
+
+#check_contract IncludeOwnedCounterHost
+
+verity_mixin IncludeNsMixinA where
+  storage
+    storage_namespace erc7201 "verity.mixin.A"
+    flagA : Uint256 := slot 0
+
+  constructor () := do
+    setStorage flagA 1
+
+verity_mixin IncludeNsMixinB where
+  storage
+    storage_namespace erc7201 "verity.mixin.B"
+    flagB : Uint256 := slot 0
+
+  constructor () := do
+    setStorage flagB 2
+
+verity_contract IncludeTwoNamespaceHost include IncludeNsMixinA, IncludeNsMixinB where
+  storage
+    extra : Uint256 := slot 1
+
+  constructor IncludeNsMixinA() IncludeNsMixinB() := do
+    setStorage extra 3
+
+#check_contract IncludeTwoNamespaceHost
+
+/--
+error: include clash: slot 0 from mixin 'Contracts.Smoke.IncludeOwnableMixin' field 'owner' overlaps a host or earlier mixin slot
+-/
+#guard_msgs in
+verity_contract IncludeSlotOverlapRejected include IncludeOwnableMixin where
+  storage
+    ownerDup : Address := slot 0
+
+  constructor (initialOwner : Address) IncludeOwnableMixin(initialOwner) := do
+    pure ()
+
+/--
+error: include clash: field 'owner' from mixin 'Contracts.Smoke.IncludeOwnableMixin' duplicates a host or earlier mixin field
+-/
+#guard_msgs in
+verity_contract IncludeNameClashRejected include IncludeOwnableMixin where
+  storage
+    owner : Address := slot 2
+
+  constructor (initialOwner : Address) IncludeOwnableMixin(initialOwner) := do
+    pure ()
+
+/--
+error: missing mixin constructor call for 'IncludeOwnableMixin'; add `IncludeOwnableMixin(...)` to the host constructor
+-/
+#guard_msgs in
+verity_contract IncludeMissingCtorRejected include IncludeOwnableMixin where
+  storage
+    count : Uint256 := slot 1
+
+  constructor (initialOwner : Address) := do
+    setStorage count 0
+
+end Contracts.Smoke

--- a/Contracts/Smoke/Include.lean
+++ b/Contracts/Smoke/Include.lean
@@ -123,4 +123,87 @@ verity_contract IncludeRenamedCtorArgHost include IncludeOwnableMixin where
 
 #check_contract IncludeRenamedCtorArgHost
 
+verity_mixin IncludeErrorMixin where
+  storage
+    owner : Address := slot 0
+
+  errors
+    error NotOwner()
+
+  constructor (initialOwner : Address) := do
+    setStorageAddr owner initialOwner
+
+  modifier onlyOwner := do
+    let sender ← msgSender
+    let currentOwner ← getStorageAddr owner
+    requireError (sender == currentOwner) NotOwner()
+
+  function poke () with onlyOwner : Unit := do
+    pure ()
+
+verity_contract IncludeErrorHost include IncludeErrorMixin where
+  storage
+    count : Uint256 := slot 1
+
+  constructor (initialOwner : Address) IncludeErrorMixin(initialOwner) := do
+    setStorage count 0
+
+  function increment () with onlyOwner modifies(count) : Unit := do
+    let current ← getStorage count
+    setStorage count (add current 1)
+
+#check_contract IncludeErrorHost
+
+verity_mixin IncludeImmutableMixin where
+  storage
+
+  immutables
+    version : Uint256 := seed
+
+  constructor (seed : Uint256) := do
+    let _ := seed
+    pure ()
+
+  function getVersion () : Uint256 := do
+    return version
+
+verity_contract IncludeImmutableHost include IncludeImmutableMixin where
+  storage
+    count : Uint256 := slot 0
+
+  constructor (seed : Uint256) IncludeImmutableMixin(seed) := do
+    setStorage count 0
+
+#check_contract IncludeImmutableHost
+
+verity_mixin IncludeHelperMixinA where
+  storage
+    a : Uint256 := slot 0
+
+  constructor () := do
+    setStorage a 1
+
+  function internal helper (x : Uint256) : Uint256 := do
+    return x
+
+verity_mixin IncludeHelperMixinB where
+  storage
+    b : Uint256 := slot 1
+
+  constructor () := do
+    setStorage b 2
+
+  function internal helper (x : Uint256) : Uint256 := do
+    return x
+
+/--
+error: include clash: function 'helper' from mixin 'Contracts.Smoke.IncludeHelperMixinB' duplicates a host or earlier mixin function
+-/
+#guard_msgs in
+verity_contract IncludeInternalClashRejected include IncludeHelperMixinA, IncludeHelperMixinB where
+  storage
+
+  constructor IncludeHelperMixinA() IncludeHelperMixinB() := do
+    pure ()
+
 end Contracts.Smoke

--- a/Contracts/Smoke/Include.lean
+++ b/Contracts/Smoke/Include.lean
@@ -92,4 +92,35 @@ verity_contract IncludeMissingCtorRejected include IncludeOwnableMixin where
   constructor (initialOwner : Address) := do
     setStorage count 0
 
+/--
+error: duplicate mixin constructor call for 'IncludeOwnableMixin'; each included mixin may be initialized once
+-/
+#guard_msgs in
+verity_contract IncludeDupCtorRejected include IncludeOwnableMixin where
+  storage
+    count : Uint256 := slot 1
+
+  constructor (initialOwner : Address) IncludeOwnableMixin(initialOwner) IncludeOwnableMixin(initialOwner) := do
+    setStorage count 0
+
+/--
+error: mixin constructor 'IncludeOwnableMixin' expects 1 argument(s), got 0
+-/
+#guard_msgs in
+verity_contract IncludeCtorArityRejected include IncludeOwnableMixin where
+  storage
+    count : Uint256 := slot 1
+
+  constructor IncludeOwnableMixin() := do
+    setStorage count 0
+
+verity_contract IncludeRenamedCtorArgHost include IncludeOwnableMixin where
+  storage
+    count : Uint256 := slot 1
+
+  constructor (owner_ : Address) IncludeOwnableMixin(owner_) := do
+    setStorage count 0
+
+#check_contract IncludeRenamedCtorArgHost
+
 end Contracts.Smoke

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -17,11 +17,13 @@ import Contracts.Ledger.Proofs.Conservation
 import Contracts.Ledger.Proofs.Correctness
 import Contracts.LocalObligationMacroSmoke.Proofs.Basic
 import Contracts.LocalObligationMacroSmoke.Proofs.Correctness
+import Contracts.Ownable.Proofs.Basic
 import Contracts.Owned.Proofs.Basic
 import Contracts.Owned.Proofs.Correctness
 import Contracts.OwnedCounter.Proofs.Basic
 import Contracts.OwnedCounter.Proofs.Correctness
 import Contracts.OwnedCounter.Proofs.Isolation
+import Contracts.OwnedCounterComposed.Proofs.Basic
 import Contracts.SafeCounter.Proofs.Basic
 import Contracts.SafeCounter.Proofs.Correctness
 import Contracts.SimpleStorage.Proofs.Basic
@@ -394,6 +396,15 @@ end Verity.AxiomAudit
   -- Contracts/LocalObligationMacroSmoke/Proofs/Correctness.lean
   Contracts.LocalObligationMacroSmoke.Proofs.Correctness.dischargedEdge_roundtrip
 
+  -- Contracts/Ownable/Proofs/Basic.lean
+  -- Contracts.Ownable.Proofs.owner_slot_zero  -- private
+  Contracts.Ownable.Proofs.onlyOwner_ok
+  Contracts.Ownable.Proofs.onlyOwner_reverts
+  Contracts.Ownable.Proofs.transferOwnership_writes_only
+  Contracts.Ownable.Proofs.transferOwnership_meets_spec_when_owner
+  Contracts.Ownable.Proofs.getOwner_meets_spec
+  Contracts.Ownable.Proofs.constructor_sets_owner
+
   -- Contracts/Owned/Proofs/Basic.lean
   Contracts.Owned.Proofs.setStorageAddr_updates_owner
   Contracts.Owned.Proofs.getStorageAddr_reads_owner
@@ -479,6 +490,14 @@ end Verity.AxiomAudit
   Contracts.OwnedCounter.Proofs.Isolation.increment_preserves_map_storage
   Contracts.OwnedCounter.Proofs.Isolation.decrement_preserves_map_storage
   Contracts.OwnedCounter.Proofs.Isolation.transferOwnership_preserves_map_storage
+
+  -- Contracts/OwnedCounterComposed/Proofs/Basic.lean
+  Contracts.OwnedCounterComposed.Proofs.increment_reverts_when_not_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_meets_spec_when_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_preserves_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_writes_only_count
+  Contracts.OwnedCounterComposed.Proofs.increment_preserves_ownable_inv
+  Contracts.OwnedCounterComposed.Proofs.getCount_meets_spec
 
   -- Contracts/SafeCounter/Proofs/Basic.lean
   -- Contracts.SafeCounter.Proofs.getCount_run  -- private
@@ -6809,4 +6828,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6328 theorems/lemmas (4463 public, 1865 private, 0 sorry'd)
+-- Total: 6341 theorems/lemmas (4475 public, 1866 private, 0 sorry'd)

--- a/Verity.lean
+++ b/Verity.lean
@@ -13,5 +13,6 @@ import Verity.EVM.Uint256
 import Verity.Stdlib.Math
 import Verity.Specs.Common
 import Verity.Specs.Common.Sum
+import Verity.Specs.Composition
 import Verity.Proofs.Stdlib.Math
 import Verity.Proofs.Stdlib.ListSum

--- a/Verity/Core/Invariant.lean
+++ b/Verity/Core/Invariant.lean
@@ -34,6 +34,12 @@ theorem comp {σ : Type} {Inv : σ → Prop} {f g : σ → σ}
     Preserves Inv (fun s => f (g s)) :=
   fun s h => hf (g s) (hg s h)
 
+/-- Conjunction of invariants is preserved when each conjunct is. -/
+theorem and {σ : Type} {InvA InvB : σ → Prop} {f : σ → σ}
+    (hA : Preserves InvA f) (hB : Preserves InvB f) :
+    Preserves (fun s => InvA s ∧ InvB s) f :=
+  fun s h => ⟨hA s h.1, hB s h.2⟩
+
 end Preserves
 
 /-- A reentrant adversary as a finite *schedule* of picked entrypoints, applied

--- a/Verity/Core/Model/Types.lean
+++ b/Verity/Core/Model/Types.lean
@@ -1535,6 +1535,50 @@ structure CompilationModel where
   storageNamespace : Option Nat := none
   deriving Repr
 
+/-- Concatenate mixin constructor bodies in include order, then the host body. -/
+def mergeConstructorSpecs (mixins : List (Option ConstructorSpec)) (host : Option ConstructorSpec) :
+    Option ConstructorSpec :=
+  let mixinCtors := mixins.filterMap id
+  match mixinCtors, host with
+  | [], host => host
+  | m :: rest, none =>
+      some {
+        params := m.params
+        isPayable := false
+        body := (m :: rest).flatMap (·.body)
+        localObligations := (m :: rest).flatMap (·.localObligations)
+      }
+  | ms, some h =>
+      some {
+        h with
+        body := ms.flatMap (·.body) ++ h.body
+        localObligations := ms.flatMap (·.localObligations) ++ h.localObligations
+      }
+
+/-- Host CompilationModel is mixin specs (include order) then host fields/functions. -/
+def mergeIncludedSpecs (name : String) (mixins : List CompilationModel) (host : CompilationModel) :
+    CompilationModel :=
+  { host with
+    name := name
+    fields := mixins.flatMap (·.fields) ++ host.fields
+    immutables := mixins.flatMap (·.immutables) ++ host.immutables
+    roles := mixins.flatMap (·.roles) ++ host.roles
+    errors := mixins.flatMap (·.errors) ++ host.errors
+    events := mixins.flatMap (·.events) ++ host.events
+    functions := mixins.flatMap (·.functions) ++ host.functions
+    externals := mixins.flatMap (·.externals) ++ host.externals
+    adtTypes := mixins.flatMap (·.adtTypes) ++ host.adtTypes
+    constructor := mergeConstructorSpecs (mixins.map (·.constructor)) host.constructor
+  }
+
+/-- Public functions that share an ABI name across mixin and host specs. -/
+def selectorCollision? (mixins : List CompilationModel) (host : CompilationModel) : Option String :=
+  let publicName (fn : FunctionSpec) : Option String :=
+    if fn.isInternal then none else some fn.name
+  let mixinNames := mixins.flatMap (fun m => m.functions.filterMap publicName)
+  let hostNames := host.functions.filterMap publicName
+  hostNames.find? (fun n => mixinNames.contains n)
+
 /-!
 ## IR Generation from Spec
 

--- a/Verity/Core/Model/Types.lean
+++ b/Verity/Core/Model/Types.lean
@@ -1535,7 +1535,10 @@ structure CompilationModel where
   storageNamespace : Option Nat := none
   deriving Repr
 
-/-- Concatenate mixin constructor bodies in include order, then the host body. -/
+/-- Concatenate mixin constructor bodies in include order, then the host body.
+    Prefer expanding mixin inits into the host constructor *before* merge so
+    argument substitution is hygienic. This helper remains for callers that
+    already performed that expansion (or have matching parameter names). -/
 def mergeConstructorSpecs (mixins : List (Option ConstructorSpec)) (host : Option ConstructorSpec) :
     Option ConstructorSpec :=
   let mixinCtors := mixins.filterMap id
@@ -1555,7 +1558,10 @@ def mergeConstructorSpecs (mixins : List (Option ConstructorSpec)) (host : Optio
         localObligations := ms.flatMap (·.localObligations) ++ h.localObligations
       }
 
-/-- Host CompilationModel is mixin specs (include order) then host fields/functions. -/
+/-- Host CompilationModel is mixin specs (include order) then host fields/functions.
+    The host constructor is already the full sequence (mixin inits with
+    substituted arguments, then the host body); do not concatenate mixin
+    constructor bodies a second time. -/
 def mergeIncludedSpecs (name : String) (mixins : List CompilationModel) (host : CompilationModel) :
     CompilationModel :=
   { host with
@@ -1568,7 +1574,9 @@ def mergeIncludedSpecs (name : String) (mixins : List CompilationModel) (host : 
     functions := mixins.flatMap (·.functions) ++ host.functions
     externals := mixins.flatMap (·.externals) ++ host.externals
     adtTypes := mixins.flatMap (·.adtTypes) ++ host.adtTypes
-    constructor := mergeConstructorSpecs (mixins.map (·.constructor)) host.constructor
+    reservedSlotRanges := mixins.flatMap (·.reservedSlotRanges) ++ host.reservedSlotRanges
+    slotAliasRanges := mixins.flatMap (·.slotAliasRanges) ++ host.slotAliasRanges
+    constructor := host.constructor
   }
 
 /-- Public functions that share an ABI name across mixin and host specs. -/

--- a/Verity/Core/Model/Types.lean
+++ b/Verity/Core/Model/Types.lean
@@ -1559,9 +1559,10 @@ def mergeConstructorSpecs (mixins : List (Option ConstructorSpec)) (host : Optio
       }
 
 /-- Host CompilationModel is mixin specs (include order) then host fields/functions.
-    The host constructor is already the full sequence (mixin inits with
-    substituted arguments, then the host body); do not concatenate mixin
-    constructor bodies a second time. -/
+    The host constructor is already the full sequence: mixin immutable
+    `setImmutable` statements (with host-substituted initializers), mixin
+    user-ctor bodies with hygienic argument bindings, then the host body.
+    Do not concatenate mixin constructor bodies a second time. -/
 def mergeIncludedSpecs (name : String) (mixins : List CompilationModel) (host : CompilationModel) :
     CompilationModel :=
   { host with

--- a/Verity/Macro/Bridge.lean
+++ b/Verity/Macro/Bridge.lean
@@ -266,7 +266,8 @@ private def mkFieldFrameConjunct (field : StorageFieldDecl) : CommandElabM Term 
     (#1729, Axis 3 Step 1b) -/
 def mkFrameDefCommand
     (fields : Array StorageFieldDecl)
-    (fnDecl : FunctionDecl) : CommandElabM (Array Cmd) := do
+    (fnDecl : FunctionDecl)
+    (generateExecutionFrame : Bool := true) : CommandElabM (Array Cmd) := do
   let frameName ← mkSuffixedIdent fnDecl.ident "_frame"
   let frameRflName ← mkSuffixedIdent fnDecl.ident "_frame_rfl"
   let frameHoldsName ← mkSuffixedIdent fnDecl.ident "_frame_holds"
@@ -290,7 +291,12 @@ def mkFrameDefCommand
       simp [Verity.Specs.sameContext, Verity.Specs.sameStorageSlot,
             Verity.Specs.sameStorageAddrSlot, Verity.Specs.sameStorage])
 
-  if fnDecl.requiresRole.isSome || fnDecl.nonReentrantLock.isSome || fnDecl.initGuard?.isSome then
+  -- Mixin modifiers / include hosts bind a Lean guard that the generated
+  -- `simp` proof cannot case-split. Keep the frame *definition* and skip
+  -- the automatic `_frame_holds` theorem in those cases.
+  if !generateExecutionFrame || !fnDecl.modifiers.isEmpty ||
+      fnDecl.requiresRole.isSome || fnDecl.nonReentrantLock.isSome ||
+      fnDecl.initGuard?.isSome then
     pure #[frameCmd, frameRflCmd]
   else
     let fnApp ← mkFunctionApplication fnDecl

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -91,14 +91,39 @@ private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
   validateExternalDeclsPublic externalDecls
   let mut mixinModifiers : Array ModifierDecl := #[]
   let mut mixinFields : Array StorageFieldDecl := #[]
+  let mut mixinErrorDecls : Array ErrorDecl := #[]
+  let mut mixinEventDecls : Array EventDecl := #[]
+  let mut mixinConstDecls : Array ConstantDecl := #[]
+  let mut mixinImmutableDecls : Array ImmutableDecl := #[]
+  let mut mixinExternalDecls : Array ExternalDecl := #[]
+  let mut mixinFunctions : Array FunctionDecl := #[]
+  let mut mixinRoleDecls : Array RoleDecl := #[]
+  let mut mixinParsed : Array (Name × ParsedContractSyntax) := #[]
   for mixinName in resolvedIncludes do
     match (← lookupContractSyntaxPublic mixinName) with
     | some mixin =>
         mixinModifiers := mixinModifiers ++ mixin.modifiers
         mixinFields := mixinFields ++ mixin.fields
+        mixinErrorDecls := mixinErrorDecls ++ mixin.errorDecls
+        mixinEventDecls := mixinEventDecls ++ mixin.eventDecls
+        mixinConstDecls := mixinConstDecls ++ mixin.constDecls
+        mixinImmutableDecls := mixinImmutableDecls ++ mixin.immutableDecls
+        mixinExternalDecls := mixinExternalDecls ++ mixin.externalDecls
+        mixinFunctions := mixinFunctions ++ mixin.functions
+        mixinRoleDecls := mixinRoleDecls ++ mixin.roleDecls
+        mixinParsed := mixinParsed.push (mixinName, mixin)
     | none => pure ()
-  validateFunctionDeclsPublic (mixinFields ++ fields) errorDecls eventDecls constDecls immutableDecls
-    externalDecls ctor (mixinModifiers ++ modifiers) functions
+  let translationFields := mixinFields ++ fields
+  let translationErrorDecls := mixinErrorDecls ++ errorDecls
+  let translationEventDecls := mixinEventDecls ++ eventDecls
+  let translationConstDecls := mixinConstDecls ++ constDecls
+  let translationImmutableDecls := mixinImmutableDecls ++ immutableDecls
+  let translationExternalDecls := mixinExternalDecls ++ externalDecls
+  let translationFunctions := mixinFunctions ++ functions
+  let translationRoleDecls := mixinRoleDecls ++ roleDecls
+  validateFunctionDeclsPublic translationFields translationErrorDecls translationEventDecls
+    translationConstDecls translationImmutableDecls translationExternalDecls ctor
+    (mixinModifiers ++ modifiers) translationFunctions
 
   let declarationNs ← getCurrNamespace
   elabCommand (← `(namespace $contractName))
@@ -146,11 +171,14 @@ private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
           elabCommand (← mkHostConstructorDefCommandPublic resolvedIncludes ctorDecl)
       | none => pure ()
 
-    -- Translation (not storage-def emission) must see mixin fields so
-    -- inlined mixin-modifier CompilationModel bodies can resolve slots.
-    let translationFields := mixinFields ++ fields
+    -- Translation (not storage-def emission) must see mixin fields/decls so
+    -- inlined mixin-modifier CompilationModel bodies can resolve slots,
+    -- custom errors, constants, and helpers.
     for fn in functions do
-      let fnCmds ← mkFunctionCommandsPublic translationFields roleDecls errorDecls constDecls immutableDecls externalDecls functions fn resolvedIncludes
+      let fnCmds ← mkFunctionCommandsPublic translationFields translationRoleDecls
+        translationErrorDecls translationConstDecls translationImmutableDecls
+        translationExternalDecls translationFunctions fn resolvedIncludes
+        (boundImmutableDecls := immutableDecls)
       for cmd in fnCmds do
         elabCommand cmd
       elabCommand (← mkBridgeCommand fn.ident)
@@ -160,17 +188,15 @@ private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
       else mkIdent (Name.mkSimple "host_spec")
     let mut modelCtor := ctor
     if !resolvedIncludes.isEmpty then
-      let mut mixins : Array (Name × ParsedContractSyntax) := #[]
-      for mixinName in resolvedIncludes do
-        match (← lookupContractSyntaxPublic mixinName) with
-        | some mixin => mixins := mixins.push (mixinName, mixin)
-        | none => pure ()
       match ctor with
       | some ctorDecl =>
           modelCtor := some (← expandMixinConstructorForModelPublic
-            translationFields constDecls immutableDecls externalDecls ctorDecl mixins)
+            translationFields translationConstDecls translationImmutableDecls
+            translationExternalDecls ctorDecl mixinParsed)
       | none => pure ()
-    elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls modelCtor modifiers functions adtDecls storageNamespace specName translationFields)
+    let constructorImmutableDecls :=
+      includedMixinImmutablesForHostPublic ctor mixinParsed ++ immutableDecls
+    elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls modelCtor modifiers functions adtDecls storageNamespace specName translationFields translationErrorDecls translationConstDecls translationImmutableDecls translationExternalDecls translationFunctions constructorImmutableDecls)
     if !resolvedIncludes.isEmpty then
       elabCommand (← mkMergedSpecCommandPublic (toString contractName.getId) resolvedIncludes)
 

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -158,7 +158,19 @@ private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
     let specName : Ident :=
       if resolvedIncludes.isEmpty then mkIdent (Name.mkSimple "spec")
       else mkIdent (Name.mkSimple "host_spec")
-    elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace specName)
+    let mut modelCtor := ctor
+    if !resolvedIncludes.isEmpty then
+      let mut mixins : Array (Name × ParsedContractSyntax) := #[]
+      for mixinName in resolvedIncludes do
+        match (← lookupContractSyntaxPublic mixinName) with
+        | some mixin => mixins := mixins.push (mixinName, mixin)
+        | none => pure ()
+      match ctor with
+      | some ctorDecl =>
+          modelCtor := some (← expandMixinConstructorForModelPublic
+            translationFields constDecls immutableDecls externalDecls ctorDecl mixins)
+      | none => pure ()
+    elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls modelCtor modifiers functions adtDecls storageNamespace specName translationFields)
     if !resolvedIncludes.isEmpty then
       elabCommand (← mkMergedSpecCommandPublic (toString contractName.getId) resolvedIncludes)
 

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -65,8 +65,7 @@ private def parseIntrinsicProofStatus (status : Ident) : CommandElabM String := 
       throwErrorAt status
         "unsupported proof status for verity_intrinsic obligation; expected proved, assumed, or unchecked"
 
-@[command_elab verityContractCmd]
-def elabVerityContract : CommandElab := fun stx => do
+private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
   let parsed ← parseContractSyntax stx
   let contractName := parsed.contractName
   let structDecls := parsed.structDecls
@@ -83,12 +82,23 @@ def elabVerityContract : CommandElab := fun stx => do
   let modifiers := parsed.modifiers
   let functions := parsed.functions
   let storageNamespace := parsed.storageNamespace
+  let isMixin := parsed.isMixin
+  let resolvedIncludes := parsed.resolvedIncludes
 
   validateGeneratedDefNamesPublic fields constDecls immutableDecls functions
   validateConstantDeclsPublic constDecls
   validateImmutableDeclsPublic fields constDecls immutableDecls ctor
   validateExternalDeclsPublic externalDecls
-  validateFunctionDeclsPublic fields errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions
+  let mut mixinModifiers : Array ModifierDecl := #[]
+  let mut mixinFields : Array StorageFieldDecl := #[]
+  for mixinName in resolvedIncludes do
+    match (← lookupContractSyntaxPublic mixinName) with
+    | some mixin =>
+        mixinModifiers := mixinModifiers ++ mixin.modifiers
+        mixinFields := mixinFields ++ mixin.fields
+    | none => pure ()
+  validateFunctionDeclsPublic (mixinFields ++ fields) errorDecls eventDecls constDecls immutableDecls
+    externalDecls ctor (mixinModifiers ++ modifiers) functions
 
   let declarationNs ← getCurrNamespace
   elabCommand (← `(namespace $contractName))
@@ -99,6 +109,10 @@ def elabVerityContract : CommandElab := fun stx => do
     for structDecl in structDecls do
       elabCommand (← mkStructDefCommandPublic structDecl)
       elabCommand (← mkStructEventArgInstanceCommandPublic structDecl)
+
+    let aliasCmds ← mkIncludeAliasCommandsPublic resolvedIncludes
+    for cmd in aliasCmds do
+      elabCommand cmd
 
     for field in fields do
       if field.emitDef then
@@ -118,13 +132,35 @@ def elabVerityContract : CommandElab := fun stx => do
     -- Use the resolved namespace from parseContractSyntax to respect custom keys.
     elabCommand (← mkStorageNamespaceCommand (toString contractName.getId) storageNamespace)
 
+    if isMixin then
+      for modDecl in modifiers do
+        elabCommand (← mkModifierDefCommandPublic modDecl)
+      match ctor with
+      | some ctorDecl =>
+          elabCommand (← mkConstructorDefCommandPublic ctorDecl)
+      | none => pure ()
+
+    if !resolvedIncludes.isEmpty then
+      match ctor with
+      | some ctorDecl =>
+          elabCommand (← mkHostConstructorDefCommandPublic resolvedIncludes ctorDecl)
+      | none => pure ()
+
+    -- Translation (not storage-def emission) must see mixin fields so
+    -- inlined mixin-modifier CompilationModel bodies can resolve slots.
+    let translationFields := mixinFields ++ fields
     for fn in functions do
-      let fnCmds ← mkFunctionCommandsPublic fields roleDecls errorDecls constDecls immutableDecls externalDecls functions fn
+      let fnCmds ← mkFunctionCommandsPublic translationFields roleDecls errorDecls constDecls immutableDecls externalDecls functions fn resolvedIncludes
       for cmd in fnCmds do
         elabCommand cmd
       elabCommand (← mkBridgeCommand fn.ident)
 
-    elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace)
+    let specName : Ident :=
+      if resolvedIncludes.isEmpty then mkIdent (Name.mkSimple "spec")
+      else mkIdent (Name.mkSimple "host_spec")
+    elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace specName)
+    if !resolvedIncludes.isEmpty then
+      elabCommand (← mkMergedSpecCommandPublic (toString contractName.getId) resolvedIncludes)
 
     let findIdxSimpCmds ← mkFindIdxFieldSimpCommandsPublic contractName fields
     for cmd in findIdxSimpCmds do
@@ -159,10 +195,13 @@ def elabVerityContract : CommandElab := fun stx => do
 
     -- Emit per-function _modifies theorem and _frame definition for
     -- functions with modifies(...) annotation (#1729, Axis 3 Step 1b).
+    -- Mixin / include functions keep the frame definition; the automatic
+    -- `_frame_holds` simp proof cannot close over mixin `require` guards.
+    let generateExecutionFrame := !isMixin && resolvedIncludes.isEmpty
     for fn in functions do
       if !fn.modifies.isEmpty then
         elabCommand (← mkModifiesTheoremCommand fn)
-        let frameCmds ← mkFrameDefCommand fields fn
+        let frameCmds ← mkFrameDefCommand translationFields fn generateExecutionFrame
         for cmd in frameCmds do
           elabCommand cmd
 
@@ -211,6 +250,14 @@ def elabVerityContract : CommandElab := fun stx => do
   catch err =>
     elabCommand (← `(end $contractName))
     throw err
+
+@[command_elab verityContractCmd]
+def elabVerityContract : CommandElab := fun stx =>
+  elabVerityContractOrMixin stx
+
+@[command_elab verityMixinCmd]
+def elabVerityMixin : CommandElab := fun stx =>
+  elabVerityContractOrMixin stx
 
 @[command_elab verityIntrinsicCmd]
 def elabVerityIntrinsic : CommandElab := fun stx => do

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -186,8 +186,12 @@ syntax "requireError " term:max ppSpace ident "(" sepBy(term, ",") ")" : doElem
 syntax (name := requireSomeUintErrorTerm) "requireSomeUintError " term:max ppSpace ident "(" sepBy(term, ",") ")" : term
 syntax "ecmBind " term:max ppSpace term:max ppSpace term:max : doElem
 syntax (priority := high) "unsafe " str " do " doSeq : doElem
-syntax "constructor " "(" sepBy(verityParam, ",") ")" (ppSpace ident "(" sepBy(term, ",") ")")? (ppSpace verityLocalObligations)? " := " term : verityConstructor
-syntax "constructor " "(" sepBy(verityParam, ",") ")" " payable" (ppSpace ident "(" sepBy(term, ",") ")")? (ppSpace verityLocalObligations)? " := " term : verityConstructor
+syntax "constructor " "(" sepBy(verityParam, ",") ")" (ppSpace ident "(" sepBy(term, ",") ")")* (ppSpace verityLocalObligations)? " := " term : verityConstructor
+syntax "constructor " "(" sepBy(verityParam, ",") ")" " payable" (ppSpace ident "(" sepBy(term, ",") ")")* (ppSpace verityLocalObligations)? " := " term : verityConstructor
+-- Parameter-less host constructors may start directly with mixin inits:
+-- `constructor Ownable() Other() := do ...`
+syntax "constructor " (ppSpace ident "(" sepBy(term, ",") ")")+ (ppSpace verityLocalObligations)? " := " term : verityConstructor
+syntax "constructor " "payable" (ppSpace ident "(" sepBy(term, ",") ")")+ (ppSpace verityLocalObligations)? " := " term : verityConstructor
 syntax "receive" (ppSpace verityLocalObligations)? " := " term : veritySpecialEntrypoint
 syntax "fallback" (ppSpace verityLocalObligations)? " := " term : veritySpecialEntrypoint
 syntax "modifier " ident " := " term : verityModifier
@@ -225,7 +229,7 @@ syntax (name := verityIntrinsicCmd)
   ident " := " term ";" ident "[" sepBy(verityIntrinsicObligation, ",") "]" : command
 
 syntax (name := verityContractCmd)
-  "verity_contract " ident (" is " ident)? " where "
+  "verity_contract " ident (" is " ident)? (" include " sepBy1(ident, ","))? " where "
   ("types " verityNewtype+)?
   ("enums " verityEnumDecl+)?
   ("inductive " verityAdtDecl+)?
@@ -241,6 +245,25 @@ syntax (name := verityContractCmd)
   ("linked_externals " verityExternal+)?
   (verityConstructor)?
   (veritySpecialEntrypoint)*
+  (verityModifier)*
+  verityFunction* : command
+
+syntax (name := verityMixinCmd)
+  "verity_mixin " ident " where "
+  ("types " verityNewtype+)?
+  ("enums " verityEnumDecl+)?
+  ("inductive " verityAdtDecl+)?
+  (verityNamespaceSpec)?
+  "storage " verityStorageItem*
+  ("roles " verityRoleDecl+)?
+  (verityStructDecl)*
+  ("errors " verityError+)?
+  ("event_defs " verityEvent+)?
+  ("constants " verityConstant+)?
+  ("immutables " verityImmutable+)?
+  ("interfaces " verityInterface+)?
+  ("linked_externals " verityExternal+)?
+  (verityConstructor)?
   (verityModifier)*
   verityFunction* : command
 

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2674,7 +2674,13 @@ private def mkSpecCommand
     (adtDecls : Array AdtDecl)
     (storageNamespace : Option Nat)
     (specIdent : Ident := mkIdent (Name.mkSimple "spec"))
-    (translationFields : Array StorageFieldDecl := fields) : CommandElabM Cmd := do
+    (translationFields : Array StorageFieldDecl := fields)
+    (translationErrorDecls : Array ErrorDecl := errorDecls)
+    (translationConstDecls : Array ConstantDecl := constDecls)
+    (translationImmutableDecls : Array ImmutableDecl := immutableDecls)
+    (translationExternalDecls : Array ExternalDecl := externalDecls)
+    (translationFunctions : Array FunctionDecl := functions)
+    (constructorImmutableDecls : Array ImmutableDecl := immutableDecls) : CommandElabM Cmd := do
   let immutableTerms ← immutableDecls.mapM fun imm => do
     let tyTerm ← modelParamTypeTerm imm.ty
     let initTerm ← translatePureExpr fields constDecls #[] (ctor.map (·.params) |>.getD #[]) #[] imm.body
@@ -2691,15 +2697,18 @@ private def mkSpecCommand
   let eventTerms ← eventDecls.mapM mkModelEventTerm
   let externalTerms ← externalDecls.mapM mkModelExternalTerm
   let constructorTerm ←
-    match ctor, immutableDecls.isEmpty with
+    match ctor, constructorImmutableDecls.isEmpty with
     | none, true => `(none)
     | some ctor, _ =>
         let ctorParams ← mkModelParamsTerm ctor.params
         let ctorPayable ← if ctor.isPayable then `(true) else `(false)
         let ctorLocalObligationTerms ←
-          (constructorLocalObligationsWithArithmetic ctor immutableDecls).mapM mkModelLocalObligationTerm
-        let immutableInitTerms ← immutableInitStmtTerms fields constDecls immutableDecls ctor.params
-        let ctorBodyTerms ← translateConstructorBodyToStmtTerms translationFields errorDecls constDecls immutableDecls externalDecls functions ctor
+          (constructorLocalObligationsWithArithmetic ctor constructorImmutableDecls).mapM mkModelLocalObligationTerm
+        let immutableInitTerms ← immutableInitStmtTerms
+          translationFields translationConstDecls constructorImmutableDecls ctor.params
+        let ctorBodyTerms ← translateConstructorBodyToStmtTerms
+          translationFields translationErrorDecls translationConstDecls
+          translationImmutableDecls translationExternalDecls translationFunctions ctor
         let enumGuardCount := ctor.params.countP fun param =>
           match param.ty with | .enum _ _ => true | _ => false
         let ctorAllTerms := ctorBodyTerms.take enumGuardCount ++ immutableInitTerms ++
@@ -2711,9 +2720,10 @@ private def mkSpecCommand
           body := [ $[$ctorAllTerms],* ]
         })
     | none, false =>
-        let immutableInitTerms ← immutableInitStmtTerms fields constDecls immutableDecls #[]
+        let immutableInitTerms ← immutableInitStmtTerms
+          translationFields translationConstDecls constructorImmutableDecls #[]
         let ctorLocalObligationTerms ←
-          (synthesizedConstructorLocalObligationsWithArithmetic immutableDecls).mapM mkModelLocalObligationTerm
+          (synthesizedConstructorLocalObligationsWithArithmetic constructorImmutableDecls).mapM mkModelLocalObligationTerm
         `(some {
           params := []
           isPayable := false
@@ -2807,7 +2817,9 @@ private def mkSpecCommand
     let bodyTerms ←
       match modDecl.body with
       | `(term| do $[$elems:doElem]*) =>
-          pure (← (translateDoElems fields constDecls immutableDecls externalDecls errorDecls functions .unit #[] #[] #[] elems)).1
+          pure (← (translateDoElems translationFields translationConstDecls
+            translationImmutableDecls translationExternalDecls
+            translationErrorDecls translationFunctions .unit #[] #[] #[] elems)).1
       | _ => throwErrorAt modDecl.body "modifier body must be a do block"
     let bodyTerms := bodyTerms.push (← `(Compiler.CompilationModel.Stmt.stop))
     `( ({
@@ -3524,6 +3536,30 @@ def expandMixinConstructorForModelPublic
     (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM ConstructorDecl :=
   expandMixinConstructorForModel hostFields hostConsts hostImmutables hostExternals host mixins
 
+/-- Mixin immutable initializers, with constructor-parameter references
+    rewritten to the host init expressions. The host CompilationModel must
+    emit `setImmutable` for these; merge keeps `host.constructor` only. -/
+private def includedMixinImmutablesForHost
+    (hostCtor : Option ConstructorDecl)
+    (mixins : Array (Name × ParsedContractSyntax)) : Array ImmutableDecl :=
+  let inits := hostCtor.map (·.mixinInits) |>.getD #[]
+  mixins.flatMap fun (mixinName, mixin) =>
+    let bindings : Array (String × Syntax) :=
+      match mixin.ctor with
+      | none => #[]
+      | some mixinCtor =>
+          match inits.find? (fun (id, _) => namesMixin (toString id.getId) mixinName) with
+          | none => #[]
+          | some (_, args) =>
+              mixinCtor.params.zip args |>.map fun (param, arg) => (param.name, arg.raw)
+    mixin.immutableDecls.map fun imm =>
+      { imm with body := substitutePureInitializerParams bindings imm.body }
+
+def includedMixinImmutablesForHostPublic
+    (hostCtor : Option ConstructorDecl)
+    (mixins : Array (Name × ParsedContractSyntax)) : Array ImmutableDecl :=
+  includedMixinImmutablesForHost hostCtor mixins
+
 private def resolveIncludedMixin (currentNs : Name) (id : Ident) :
     CommandElabM (Name × ParsedContractSyntax) := do
   let candidates := [currentNs ++ id.getId, id.getId]
@@ -3555,6 +3591,15 @@ private def fieldOccupiedSlots (field : StorageFieldDecl) : Array Nat :=
 private def fieldDeclaredNames (field : StorageFieldDecl) : Array String :=
   #[field.name] ++ field.aliases.toArray
 
+private def pushUniqueIncludeName
+    (kind : String) (mixinName : Name) (name : String) (seen : Array String) :
+    CommandElabM (Array String) := do
+  if seen.contains name then
+    throwError
+      ("include clash: " ++ kind ++ " '" ++ name ++ "' from mixin '" ++
+        toString mixinName ++ "' duplicates a host or earlier mixin " ++ kind)
+  pure (seen.push name)
+
 private def checkIncludeClashes
     (host : ParsedContractSyntax)
     (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM Unit := do
@@ -3566,8 +3611,14 @@ private def checkIncludeClashes
     (host.fields.filter (·.isTransient)).flatMap fieldOccupiedSlots
   let mut seenModNames : Array String := host.modifiers.map (·.name)
   let mut seenRoleNames : Array String := host.roleDecls.map (·.name)
-  let mut seenFnNames : Array String :=
-    host.functions.filterMap fun fn => if fn.isInternal then none else some fn.name
+  -- Internal helpers share the Yul/CompilationModel name key with entrypoints.
+  let mut seenFnNames : Array String := host.functions.map (·.name)
+  let mut seenErrorNames : Array String := host.errorDecls.map (·.name)
+  let mut seenEventNames : Array String := host.eventDecls.map (·.name)
+  let mut seenConstNames : Array String := host.constDecls.map (·.name)
+  let mut seenImmutableNames : Array String := host.immutableDecls.map (·.name)
+  let mut seenExternalNames : Array String := host.externalDecls.map (·.name)
+  let mut seenAdtNames : Array String := host.adtDecls.map (·.name)
   for (mixinName, mixin) in mixins do
     for field in mixin.fields do
       for n in fieldDeclaredNames field do
@@ -3586,18 +3637,23 @@ private def checkIncludeClashes
             throwError s!"include clash: slot {sl} from mixin '{mixinName}' field '{field.name}' overlaps a host or earlier mixin slot"
           seenPersistSlots := seenPersistSlots.push sl
     for modDecl in mixin.modifiers do
-      if seenModNames.contains modDecl.name then
-        throwError s!"include clash: modifier '{modDecl.name}' from mixin '{mixinName}' duplicates a host or earlier mixin modifier"
-      seenModNames := seenModNames.push modDecl.name
+      seenModNames ← pushUniqueIncludeName "modifier" mixinName modDecl.name seenModNames
     for role in mixin.roleDecls do
-      if seenRoleNames.contains role.name then
-        throwError s!"include clash: role '{role.name}' from mixin '{mixinName}' duplicates a host or earlier mixin role"
-      seenRoleNames := seenRoleNames.push role.name
+      seenRoleNames ← pushUniqueIncludeName "role" mixinName role.name seenRoleNames
     for fn in mixin.functions do
-      unless fn.isInternal do
-        if seenFnNames.contains fn.name then
-          throwError s!"include clash: function '{fn.name}' from mixin '{mixinName}' duplicates a host or earlier mixin entrypoint"
-        seenFnNames := seenFnNames.push fn.name
+      seenFnNames ← pushUniqueIncludeName "function" mixinName fn.name seenFnNames
+    for err in mixin.errorDecls do
+      seenErrorNames ← pushUniqueIncludeName "error" mixinName err.name seenErrorNames
+    for ev in mixin.eventDecls do
+      seenEventNames ← pushUniqueIncludeName "event" mixinName ev.name seenEventNames
+    for c in mixin.constDecls do
+      seenConstNames ← pushUniqueIncludeName "constant" mixinName c.name seenConstNames
+    for imm in mixin.immutableDecls do
+      seenImmutableNames ← pushUniqueIncludeName "immutable" mixinName imm.name seenImmutableNames
+    for extDecl in mixin.externalDecls do
+      seenExternalNames ← pushUniqueIncludeName "external" mixinName extDecl.name seenExternalNames
+    for adtDecl in mixin.adtDecls do
+      seenAdtNames ← pushUniqueIncludeName "ADT" mixinName adtDecl.name seenAdtNames
 
 private def checkMixinConstructorInits
     (host : ParsedContractSyntax)
@@ -3639,13 +3695,11 @@ private def finishIncludeContract
   let mixins ← includeIdents.mapM (resolveIncludedMixin currentNs)
   checkIncludeClashes own mixins
   checkMixinConstructorInits own mixins
-  let mixinFnNames := mixins.flatMap fun (_, mixin) =>
-    mixin.functions.filterMap fun fn => if fn.isInternal then none else some fn.name
+  let mixinFnNames := mixins.flatMap fun (_, mixin) => mixin.functions.map (·.name)
   for fn in own.functions do
-    unless fn.isInternal do
-      if mixinFnNames.contains fn.name then
-        throwErrorAt fn.ident
-          s!"include clash: function '{fn.name}' collides with an included mixin entrypoint"
+    if mixinFnNames.contains fn.name then
+      throwErrorAt fn.ident
+        s!"include clash: function '{fn.name}' collides with an included mixin function"
   let mixinModNames := mixinModifierNames mixins
   let localModifiers := own.modifiers.filter fun m => !mixinModNames.contains m.name
   -- Inline only host-local modifiers. Mixin modifiers stay on the function
@@ -4369,7 +4423,8 @@ def mkFunctionCommandsPublic
     (externalDecls : Array ExternalDecl)
     (functions : Array FunctionDecl)
     (fn : FunctionDecl)
-    (resolvedIncludes : Array Name := #[]) : CommandElabM (Array Cmd) := do
+    (resolvedIncludes : Array Name := #[])
+    (boundImmutableDecls : Array ImmutableDecl := immutableDecls) : CommandElabM (Array Cmd) := do
   let fnType ← mkContractFnType fn.params fn.returnTy
   -- Mixin modifiers belong after ABI/enum, init, and role guards, matching
   -- `translateBodyToStmtTerms`. Prefix them onto the source body so those
@@ -4379,7 +4434,10 @@ def mkFunctionCommandsPublic
   let fnRoleGuardedBody ← mkRoleGuardedBody fields roleDecls fnWithMixin
   let fnDecl := { fnWithMixin with body := fnRoleGuardedBody }
   let fnGuardedBody ← mkInitGuardedBody fields fnDecl
-  let fnBody ← mkImmutableBoundBody fields immutableDecls fn fnGuardedBody
+  -- Bind only this contract's immutables. Mixin immutables keep the hidden
+  -- slots computed in the mixin namespace; recomputing them against host
+  -- fields would shift those slots.
+  let fnBody ← mkImmutableBoundBody fields boundImmutableDecls fn fnGuardedBody
   let fnExecutableBody ← rewriteForEachExecutableBody fields externalDecls fn.params fnBody
   -- The parsed body already contains guards for the model path. Re-applying
   -- them outside all executable wrappers makes ABI validation happen before
@@ -4468,8 +4526,14 @@ def mkSpecCommandPublic
     (adtDecls : Array AdtDecl)
     (storageNamespace : Option Nat)
     (specIdent : Ident := mkIdent (Name.mkSimple "spec"))
-    (translationFields : Array StorageFieldDecl := fields) : CommandElabM Cmd :=
-  mkSpecCommand contractName fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace specIdent translationFields
+    (translationFields : Array StorageFieldDecl := fields)
+    (translationErrorDecls : Array ErrorDecl := errorDecls)
+    (translationConstDecls : Array ConstantDecl := constDecls)
+    (translationImmutableDecls : Array ImmutableDecl := immutableDecls)
+    (translationExternalDecls : Array ExternalDecl := externalDecls)
+    (translationFunctions : Array FunctionDecl := functions)
+    (constructorImmutableDecls : Array ImmutableDecl := immutableDecls) : CommandElabM Cmd :=
+  mkSpecCommand contractName fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace specIdent translationFields translationErrorDecls translationConstDecls translationImmutableDecls translationExternalDecls translationFunctions constructorImmutableDecls
 
 def mkFindIdxFieldSimpCommandsPublic
     (contractIdent : Ident)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2673,7 +2673,8 @@ private def mkSpecCommand
     (functions : Array FunctionDecl)
     (adtDecls : Array AdtDecl)
     (storageNamespace : Option Nat)
-    (specIdent : Ident := mkIdent (Name.mkSimple "spec")) : CommandElabM Cmd := do
+    (specIdent : Ident := mkIdent (Name.mkSimple "spec"))
+    (translationFields : Array StorageFieldDecl := fields) : CommandElabM Cmd := do
   let immutableTerms ← immutableDecls.mapM fun imm => do
     let tyTerm ← modelParamTypeTerm imm.ty
     let initTerm ← translatePureExpr fields constDecls #[] (ctor.map (·.params) |>.getD #[]) #[] imm.body
@@ -2698,7 +2699,7 @@ private def mkSpecCommand
         let ctorLocalObligationTerms ←
           (constructorLocalObligationsWithArithmetic ctor immutableDecls).mapM mkModelLocalObligationTerm
         let immutableInitTerms ← immutableInitStmtTerms fields constDecls immutableDecls ctor.params
-        let ctorBodyTerms ← translateConstructorBodyToStmtTerms fields errorDecls constDecls immutableDecls externalDecls functions ctor
+        let ctorBodyTerms ← translateConstructorBodyToStmtTerms translationFields errorDecls constDecls immutableDecls externalDecls functions ctor
         let enumGuardCount := ctor.params.countP fun param =>
           match param.ty with | .enum _ _ => true | _ => false
         let ctorAllTerms := ctorBodyTerms.take enumGuardCount ++ immutableInitTerms ++
@@ -3442,6 +3443,87 @@ private def mixinShortName (mixinName : Name) : String :=
 private def namesMixin (n : String) (mixinName : Name) : Bool :=
   n == mixinShortName mixinName || n == toString mixinName
 
+/-- Expand host constructor mixin inits into scoped do-elems so the
+    CompilationModel constructor references host arguments (or expressions),
+    not the mixin's original parameter names. Executable lowering still
+    calls the mixin `constructor` Lean def. -/
+private def expandMixinConstructorForModel
+    (hostFields : Array StorageFieldDecl)
+    (hostConsts : Array ConstantDecl)
+    (hostImmutables : Array ImmutableDecl)
+    (hostExternals : Array ExternalDecl)
+    (host : ConstructorDecl)
+    (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM ConstructorDecl := do
+  if host.mixinInits.isEmpty then
+    return host
+  let mut preludeElems : Array (TSyntax `doElem) := #[]
+  let mut extraObligations : Array LocalObligationDecl := #[]
+  for (mixinIdent, args) in host.mixinInits do
+    let n := toString mixinIdent.getId
+    let some (mixinName, mixin) :=
+        mixins.find? (fun (mixinName, mixin) =>
+          mixin.ctor.isSome && namesMixin n mixinName)
+      | throwErrorAt mixinIdent s!"constructor init '{n}' does not name an included mixin that has a constructor"
+    let some mixinCtor := mixin.ctor
+      | throwErrorAt mixinIdent s!"constructor init '{n}' names a mixin without a constructor"
+    if args.size != mixinCtor.params.size then
+      throwErrorAt mixinIdent
+        s!"mixin constructor '{mixinShortName mixinName}' expects {mixinCtor.params.size} argument(s), got {args.size}"
+    extraObligations := extraObligations ++ mixinCtor.localObligations
+    for (param, arg) in mixinCtor.params.zip args do
+      let argTy ← inferPureExprType
+        (mixin.fields ++ hostFields) (mixin.constDecls ++ hostConsts)
+        (mixin.immutableDecls ++ hostImmutables)
+        (mixin.externalDecls ++ hostExternals)
+        host.params #[] arg
+      unless argumentTypeMatchesParam arg argTy param.ty do
+        throwErrorAt arg
+          s!"mixin constructor parameter '{param.name}' expects {renderValueType param.ty}, got {renderValueType argTy}"
+    let mut mixinBindings : Array (TSyntax `doElem) := #[]
+    let mut dynamicParamBindings : Array (String × Syntax) := #[]
+    for (param, arg) in mixinCtor.params.zip args do
+      let directHostParam? := match stripParens arg with
+        | `(term| $name:ident) =>
+            host.params.find? (fun (hostParam : ParamDecl) =>
+              declaredNameMatches (toString name.getId) hostParam.name)
+        | _ => host.params.find? (fun hostParam =>
+            (stripParens arg).raw.reprint.getD "" == hostParam.name)
+      let isIdentityArg := directHostParam?.any (fun hostParam => hostParam.name == param.name)
+      if !isIdentityArg then
+        if host.params.any (fun hostParam => paramReservesName hostParam param.name) then
+          throwErrorAt arg
+            s!"mixin constructor parameter '{param.name}' conflicts with a host constructor parameter; rename the host parameter"
+        if valueTypeUsesDynamicData param.ty && directHostParam?.isSome then
+          dynamicParamBindings := dynamicParamBindings.push (param.name, arg.raw)
+        else
+          let normalizedArg ← normalizeParentConstructorArg param.ty arg
+          mixinBindings := mixinBindings.push (← `(doElem| let $param.ident := $normalizedArg))
+    let mixinBody := substituteDynamicParentParams dynamicParamBindings mixinCtor.body
+    let mixinElems ← doElems mixinBody
+    let scopedElem ← `(doElem| if true then
+      $[$mixinBindings:doElem]*
+      $[$mixinElems:doElem]*
+      else
+        pure ())
+    preludeElems := preludeElems.push scopedElem
+  let hostElems ← doElems host.body
+  let combined ← `(term| do $[$preludeElems:doElem]* $[$hostElems:doElem]*)
+  pure {
+    host with
+    localObligations := extraObligations ++ host.localObligations
+    mixinInits := #[]
+    body := combined
+  }
+
+def expandMixinConstructorForModelPublic
+    (hostFields : Array StorageFieldDecl)
+    (hostConsts : Array ConstantDecl)
+    (hostImmutables : Array ImmutableDecl)
+    (hostExternals : Array ExternalDecl)
+    (host : ConstructorDecl)
+    (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM ConstructorDecl :=
+  expandMixinConstructorForModel hostFields hostConsts hostImmutables hostExternals host mixins
+
 private def resolveIncludedMixin (currentNs : Name) (id : Ident) :
     CommandElabM (Name × ParsedContractSyntax) := do
   let candidates := [currentNs ++ id.getId, id.getId]
@@ -3460,26 +3542,49 @@ private def resolveIncludedMixin (currentNs : Name) (id : Ident) :
   | none =>
       throwErrorAt id s!"unknown mixin '{id.getId}'; import or declare the mixin before the host"
 
+private def fieldOccupiedSlots (field : StorageFieldDecl) : Array Nat :=
+  let extra :=
+    match field.adtInfo? with
+    | some (_, maxFields) => maxFields
+    | none =>
+        match field.ty with
+        | .scalar (.adt _ maxFields) => maxFields
+        | _ => 0
+  ((List.range (extra + 1)).map (fun i => field.slotNum + i)).toArray
+
+private def fieldDeclaredNames (field : StorageFieldDecl) : Array String :=
+  #[field.name] ++ field.aliases.toArray
+
 private def checkIncludeClashes
     (host : ParsedContractSyntax)
     (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM Unit := do
-  let mut seenFieldNames : Array String := host.fields.map (·.name)
-  let mut seenSlots : Array (Nat × String × String) :=
-    host.fields.map fun f => (f.slotNum, "host", f.name)
+  let mut seenFieldNames : Array String := host.fields.flatMap fieldDeclaredNames
+  -- Persistent and transient storage are distinct EVM spaces.
+  let mut seenPersistSlots : Array Nat :=
+    (host.fields.filter (fun f => !f.isTransient)).flatMap fieldOccupiedSlots
+  let mut seenTransientSlots : Array Nat :=
+    (host.fields.filter (·.isTransient)).flatMap fieldOccupiedSlots
   let mut seenModNames : Array String := host.modifiers.map (·.name)
   let mut seenRoleNames : Array String := host.roleDecls.map (·.name)
   let mut seenFnNames : Array String :=
     host.functions.filterMap fun fn => if fn.isInternal then none else some fn.name
   for (mixinName, mixin) in mixins do
     for field in mixin.fields do
-      if seenFieldNames.contains field.name then
-        throwError s!"include clash: field '{field.name}' from mixin '{mixinName}' duplicates a host or earlier mixin field"
-      seenFieldNames := seenFieldNames.push field.name
-      match seenSlots.find? (fun (n, _, _) => n == field.slotNum) with
-      | some _ =>
-          throwError s!"include clash: slot {field.slotNum} from mixin '{mixinName}' field '{field.name}' overlaps a host or earlier mixin slot"
-      | none =>
-          seenSlots := seenSlots.push (field.slotNum, toString mixinName, field.name)
+      for n in fieldDeclaredNames field do
+        if seenFieldNames.contains n then
+          throwError s!"include clash: field '{n}' from mixin '{mixinName}' duplicates a host or earlier mixin field"
+        seenFieldNames := seenFieldNames.push n
+      let occupied := fieldOccupiedSlots field
+      if field.isTransient then
+        for sl in occupied do
+          if seenTransientSlots.contains sl then
+            throwError s!"include clash: transient slot {sl} from mixin '{mixinName}' field '{field.name}' overlaps a host or earlier mixin slot"
+          seenTransientSlots := seenTransientSlots.push sl
+      else
+        for sl in occupied do
+          if seenPersistSlots.contains sl then
+            throwError s!"include clash: slot {sl} from mixin '{mixinName}' field '{field.name}' overlaps a host or earlier mixin slot"
+          seenPersistSlots := seenPersistSlots.push sl
     for modDecl in mixin.modifiers do
       if seenModNames.contains modDecl.name then
         throwError s!"include clash: modifier '{modDecl.name}' from mixin '{mixinName}' duplicates a host or earlier mixin modifier"
@@ -3501,19 +3606,29 @@ private def checkMixinConstructorInits
     match host.ctor with
     | some ctor => ctor.mixinInits
     | none => #[]
-  let initNames := inits.map fun (id, _) => toString id.getId
+  let mut seenInitMixins : Array Name := #[]
+  for (id, args) in inits do
+    let n := toString id.getId
+    let some (mixinName, mixin) :=
+        mixins.find? (fun (mixinName, mixin) =>
+          mixin.ctor.isSome && namesMixin n mixinName)
+      | throwErrorAt id s!"constructor init '{n}' does not name an included mixin that has a constructor"
+    if seenInitMixins.any (fun prev => namesMixin (mixinShortName prev) mixinName) then
+      throwErrorAt id
+        s!"duplicate mixin constructor call for '{mixinShortName mixinName}'; each included mixin may be initialized once"
+    seenInitMixins := seenInitMixins.push mixinName
+    match mixin.ctor with
+    | some mixinCtor =>
+        if args.size != mixinCtor.params.size then
+          throwErrorAt id
+            s!"mixin constructor '{mixinShortName mixinName}' expects {mixinCtor.params.size} argument(s), got {args.size}"
+    | none => pure ()
   for (mixinName, mixin) in mixins do
     if mixin.ctor.isSome then
       let shortName := mixinShortName mixinName
-      unless initNames.any (fun n => namesMixin n mixinName) do
+      unless inits.any (fun (id, _) => namesMixin (toString id.getId) mixinName) do
         throwError
           s!"missing mixin constructor call for '{shortName}'; add `{shortName}(...)` to the host constructor"
-  for (id, _) in inits do
-    let n := toString id.getId
-    let known := mixins.any fun (mixinName, mixin) =>
-      mixin.ctor.isSome && namesMixin n mixinName
-    unless known do
-      throwErrorAt id s!"constructor init '{n}' does not name an included mixin that has a constructor"
 
 private def mixinModifierNames (mixins : Array (Name × ParsedContractSyntax)) : Array String :=
   mixins.flatMap fun (_, mixin) => mixin.modifiers.map (·.name)
@@ -4256,8 +4371,13 @@ def mkFunctionCommandsPublic
     (fn : FunctionDecl)
     (resolvedIncludes : Array Name := #[]) : CommandElabM (Array Cmd) := do
   let fnType ← mkContractFnType fn.params fn.returnTy
-  let fnRoleGuardedBody ← mkRoleGuardedBody fields roleDecls fn
-  let fnDecl := { fn with body := fnRoleGuardedBody }
+  -- Mixin modifiers belong after ABI/enum, init, and role guards, matching
+  -- `translateBodyToStmtTerms`. Prefix them onto the source body so those
+  -- wrappers stay outside.
+  let fnBodyWithMixin ← prefixMixinModifierExecutableBody resolvedIncludes fn fn.body
+  let fnWithMixin := { fn with body := fnBodyWithMixin }
+  let fnRoleGuardedBody ← mkRoleGuardedBody fields roleDecls fnWithMixin
+  let fnDecl := { fnWithMixin with body := fnRoleGuardedBody }
   let fnGuardedBody ← mkInitGuardedBody fields fnDecl
   let fnBody ← mkImmutableBoundBody fields immutableDecls fn fnGuardedBody
   let fnExecutableBody ← rewriteForEachExecutableBody fields externalDecls fn.params fnBody
@@ -4265,7 +4385,6 @@ def mkFunctionCommandsPublic
   -- them outside all executable wrappers makes ABI validation happen before
   -- initializer, role, and modifier effects (the inner copy is harmless).
   let fnExecutableBody ← prependEnumGuards fn.params fnExecutableBody
-  let fnExecutableBody ← prefixMixinModifierExecutableBody resolvedIncludes fn fnExecutableBody
   let fnValue ← mkContractFnValue fn.params fnExecutableBody
   let modelBodyName ← mkSuffixedIdent fn.ident "_modelBody"
   let modelName ← mkSuffixedIdent fn.ident "_model"
@@ -4348,8 +4467,9 @@ def mkSpecCommandPublic
     (functions : Array FunctionDecl)
     (adtDecls : Array AdtDecl)
     (storageNamespace : Option Nat)
-    (specIdent : Ident := mkIdent (Name.mkSimple "spec")) : CommandElabM Cmd :=
-  mkSpecCommand contractName fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace specIdent
+    (specIdent : Ident := mkIdent (Name.mkSimple "spec"))
+    (translationFields : Array StorageFieldDecl := fields) : CommandElabM Cmd :=
+  mkSpecCommand contractName fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace specIdent translationFields
 
 def mkFindIdxFieldSimpCommandsPublic
     (contractIdent : Ident)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2672,7 +2672,8 @@ private def mkSpecCommand
     (modifiers : Array ModifierDecl)
     (functions : Array FunctionDecl)
     (adtDecls : Array AdtDecl)
-    (storageNamespace : Option Nat) : CommandElabM Cmd := do
+    (storageNamespace : Option Nat)
+    (specIdent : Ident := mkIdent (Name.mkSimple "spec")) : CommandElabM Cmd := do
   let immutableTerms ← immutableDecls.mapM fun imm => do
     let tyTerm ← modelParamTypeTerm imm.ty
     let initTerm ← translatePureExpr fields constDecls #[] (ctor.map (·.params) |>.getD #[]) #[] imm.body
@@ -2841,7 +2842,7 @@ private def mkSpecCommand
   let namespaceTerm ← match storageNamespace with
     | some ns => `(some $(natTerm ns))
     | none => `(none)
-  `(command| def spec : Compiler.CompilationModel.CompilationModel := {
+  `(command| def $specIdent : Compiler.CompilationModel.CompilationModel := {
     name := $(strTerm contractName)
     fields := [ $[$fieldTerms],* ]
     «immutables» := [ $[$immutableTerms],* ]
@@ -3024,6 +3025,9 @@ structure ParsedContractSyntax where
   modifiers : Array ModifierDecl
   functions : Array FunctionDecl
   storageNamespace : Option Nat
+  isMixin : Bool := false
+  includes : Array Ident := #[]
+  resolvedIncludes : Array Name := #[]
 
 abbrev ContractSyntaxRegistry := List (Name × ParsedContractSyntax)
 
@@ -3045,6 +3049,9 @@ def registerContractSyntax (name : Name) (parsed : ParsedContractSyntax) : Comma
 private def lookupContractSyntax (name : Name) : CommandElabM (Option ParsedContractSyntax) := do
   pure (contractSyntaxExt.getState (← getEnv)
     |>.find? (fun entry => entry.1 == name) |>.map (·.2))
+
+def lookupContractSyntaxPublic (name : Name) : CommandElabM (Option ParsedContractSyntax) :=
+  lookupContractSyntax name
 
 private def doElems (body : Term) : CommandElabM (Array (TSyntax `doElem)) := do
   match body with
@@ -3427,11 +3434,146 @@ private def parseRoleDecl
               throwErrorAt fieldName s!"role '{toString roleName.getId}' uses unsupported backing field '{backingName}'; roles require an Address scalar field or Address→Uint256 mapping"
   | _ => throwErrorAt roleStx "invalid role declaration"
 
-def parseContractSyntax
+private def mixinShortName (mixinName : Name) : String :=
+  match mixinName with
+  | .str _ s => s
+  | _ => toString mixinName
+
+private def namesMixin (n : String) (mixinName : Name) : Bool :=
+  n == mixinShortName mixinName || n == toString mixinName
+
+private def resolveIncludedMixin (currentNs : Name) (id : Ident) :
+    CommandElabM (Name × ParsedContractSyntax) := do
+  let candidates := [currentNs ++ id.getId, id.getId]
+  let mut found : Option (Name × ParsedContractSyntax) := none
+  for candidate in candidates do
+    if found.isNone then
+      match (← lookupContractSyntax candidate) with
+      | some parsed =>
+          if parsed.isMixin then
+            found := some (candidate, parsed)
+          else
+            throwErrorAt id s!"include '{id.getId}' names a contract, not a verity_mixin"
+      | none => pure ()
+  match found with
+  | some result => pure result
+  | none =>
+      throwErrorAt id s!"unknown mixin '{id.getId}'; import or declare the mixin before the host"
+
+private def checkIncludeClashes
+    (host : ParsedContractSyntax)
+    (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM Unit := do
+  let mut seenFieldNames : Array String := host.fields.map (·.name)
+  let mut seenSlots : Array (Nat × String × String) :=
+    host.fields.map fun f => (f.slotNum, "host", f.name)
+  let mut seenModNames : Array String := host.modifiers.map (·.name)
+  let mut seenRoleNames : Array String := host.roleDecls.map (·.name)
+  let mut seenFnNames : Array String :=
+    host.functions.filterMap fun fn => if fn.isInternal then none else some fn.name
+  for (mixinName, mixin) in mixins do
+    for field in mixin.fields do
+      if seenFieldNames.contains field.name then
+        throwError s!"include clash: field '{field.name}' from mixin '{mixinName}' duplicates a host or earlier mixin field"
+      seenFieldNames := seenFieldNames.push field.name
+      match seenSlots.find? (fun (n, _, _) => n == field.slotNum) with
+      | some _ =>
+          throwError s!"include clash: slot {field.slotNum} from mixin '{mixinName}' field '{field.name}' overlaps a host or earlier mixin slot"
+      | none =>
+          seenSlots := seenSlots.push (field.slotNum, toString mixinName, field.name)
+    for modDecl in mixin.modifiers do
+      if seenModNames.contains modDecl.name then
+        throwError s!"include clash: modifier '{modDecl.name}' from mixin '{mixinName}' duplicates a host or earlier mixin modifier"
+      seenModNames := seenModNames.push modDecl.name
+    for role in mixin.roleDecls do
+      if seenRoleNames.contains role.name then
+        throwError s!"include clash: role '{role.name}' from mixin '{mixinName}' duplicates a host or earlier mixin role"
+      seenRoleNames := seenRoleNames.push role.name
+    for fn in mixin.functions do
+      unless fn.isInternal do
+        if seenFnNames.contains fn.name then
+          throwError s!"include clash: function '{fn.name}' from mixin '{mixinName}' duplicates a host or earlier mixin entrypoint"
+        seenFnNames := seenFnNames.push fn.name
+
+private def checkMixinConstructorInits
+    (host : ParsedContractSyntax)
+    (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM Unit := do
+  let inits :=
+    match host.ctor with
+    | some ctor => ctor.mixinInits
+    | none => #[]
+  let initNames := inits.map fun (id, _) => toString id.getId
+  for (mixinName, mixin) in mixins do
+    if mixin.ctor.isSome then
+      let shortName := mixinShortName mixinName
+      unless initNames.any (fun n => namesMixin n mixinName) do
+        throwError
+          s!"missing mixin constructor call for '{shortName}'; add `{shortName}(...)` to the host constructor"
+  for (id, _) in inits do
+    let n := toString id.getId
+    let known := mixins.any fun (mixinName, mixin) =>
+      mixin.ctor.isSome && namesMixin n mixinName
+    unless known do
+      throwErrorAt id s!"constructor init '{n}' does not name an included mixin that has a constructor"
+
+private def mixinModifierNames (mixins : Array (Name × ParsedContractSyntax)) : Array String :=
+  mixins.flatMap fun (_, mixin) => mixin.modifiers.map (·.name)
+
+private def finishIncludeContract
+    (currentNs : Name) (includeIdents : Array Ident) (own : ParsedContractSyntax) :
+    CommandElabM ParsedContractSyntax := do
+  let mixins ← includeIdents.mapM (resolveIncludedMixin currentNs)
+  checkIncludeClashes own mixins
+  checkMixinConstructorInits own mixins
+  let mixinFnNames := mixins.flatMap fun (_, mixin) =>
+    mixin.functions.filterMap fun fn => if fn.isInternal then none else some fn.name
+  for fn in own.functions do
+    unless fn.isInternal do
+      if mixinFnNames.contains fn.name then
+        throwErrorAt fn.ident
+          s!"include clash: function '{fn.name}' collides with an included mixin entrypoint"
+  let mixinModNames := mixinModifierNames mixins
+  let localModifiers := own.modifiers.filter fun m => !mixinModNames.contains m.name
+  -- Inline only host-local modifiers. Mixin modifiers stay on the function
+  -- so CompilationModel can emit statements / the elaborator can bind the
+  -- mixin's Lean `def`.
+  let functions ← own.functions.mapM fun fn => do
+    let localUsed := fn.modifiers.filter fun id =>
+      localModifiers.any (fun m => m.name == toString id.getId)
+    let mixinUsed := fn.modifiers.filter fun id =>
+      mixinModNames.contains (toString id.getId)
+    for id in fn.modifiers do
+      let n := toString id.getId
+      unless localModifiers.any (fun m => m.name == n) || mixinModNames.contains n do
+        throwErrorAt id s!"function '{fn.name}' references unknown modifier '{n}'"
+    let inlined ←
+      if localUsed.isEmpty then
+        pure fn
+      else
+        let onlyLocal := { fn with modifiers := localUsed }
+        let arr ← inlineModifierPrefixes localModifiers #[onlyLocal]
+        match arr[0]? with
+        | some inlinedFn => pure { inlinedFn with modifiers := mixinUsed }
+        | none => pure { fn with modifiers := mixinUsed }
+    pure { inlined with modifiers := mixinUsed }
+  pure {
+    own with
+    functions := functions
+    includes := includeIdents
+    resolvedIncludes := mixins.map (·.1)
+  }
+
+partial def parseContractSyntax
     (stx : Syntax)
     : CommandElabM ParsedContractSyntax := do
   match stx with
-  | `(command| verity_contract $contractName:ident $[is $parentName:ident]? where $[types $[$newtypeDecls:verityNewtype]*]? $[enums $[$enumDecls:verityEnumDecl]*]? $[inductive $[$adtDecls:verityAdtDecl]*]? $[$nsSpec:verityNamespaceSpec]? storage $[$storageItems:verityStorageItem]* $[roles $[$roleDecls:verityRoleDecl]*]? $[$structDecls:verityStructDecl]* $[errors $[$errorDecls:verityError]*]? $[event_defs $[$eventDecls:verityEvent]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[interfaces $[$interfaceDecls:verityInterface]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$entrypoints:veritySpecialEntrypoint]* $[$modifierDecls:verityModifier]* $[$functions:verityFunction]*) =>
+  | `(command| verity_contract $contractName:ident $[is $parentName:ident]? $[include $[$includeNames:ident],*]? where $[types $[$newtypeDecls:verityNewtype]*]? $[enums $[$enumDecls:verityEnumDecl]*]? $[inductive $[$adtDecls:verityAdtDecl]*]? $[$nsSpec:verityNamespaceSpec]? storage $[$storageItems:verityStorageItem]* $[roles $[$roleDecls:verityRoleDecl]*]? $[$structDecls:verityStructDecl]* $[errors $[$errorDecls:verityError]*]? $[event_defs $[$eventDecls:verityEvent]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[interfaces $[$interfaceDecls:verityInterface]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$entrypoints:veritySpecialEntrypoint]* $[$modifierDecls:verityModifier]* $[$functions:verityFunction]*) =>
+      let includeIdents : Array Ident :=
+        match includeNames with
+        | some ids => ids
+        | none => #[]
+      if parentName.isSome && !includeIdents.isEmpty then
+        throwErrorAt stx "cannot combine `is` inheritance with `include` mixins"
+
       -- Resolve inheritance before parsing the child: inherited user-defined
       -- types are valid in every child declaration and function signature.
       let currentNs ← getCurrNamespace
@@ -3693,12 +3835,21 @@ def parseContractSyntax
         storageNamespace := firstNamespaceOpt
       }
       match parentName with
-      | none => pure { own with functions := (← inlineModifierPrefixes own.modifiers own.functions) }
       | some parentIdent =>
           let some parent := parent? | unreachable!
           let flattened ← flattenSingleInheritance parentIdent parent own
           pure { flattened with
             functions := (← inlineModifierPrefixes flattened.modifiers flattened.functions) }
+      | none =>
+          if includeIdents.isEmpty then
+            pure { own with functions := (← inlineModifierPrefixes own.modifiers own.functions) }
+          else
+            finishIncludeContract currentNs includeIdents own
+  | `(command| verity_mixin $contractName:ident where $[types $[$newtypeDecls:verityNewtype]*]? $[enums $[$enumDecls:verityEnumDecl]*]? $[inductive $[$adtDecls:verityAdtDecl]*]? $[$nsSpec:verityNamespaceSpec]? storage $[$storageItems:verityStorageItem]* $[roles $[$roleDecls:verityRoleDecl]*]? $[$structDecls:verityStructDecl]* $[errors $[$errorDecls:verityError]*]? $[event_defs $[$eventDecls:verityEvent]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[interfaces $[$interfaceDecls:verityInterface]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$modifierDecls:verityModifier]* $[$functions:verityFunction]*) =>
+      -- Reuse the contract parser by wrapping mixin syntax as a contract with no parent/includes/entrypoints.
+      let wrapped ← `(command| verity_contract $contractName:ident where $[types $[$newtypeDecls:verityNewtype]*]? $[enums $[$enumDecls:verityEnumDecl]*]? $[inductive $[$adtDecls:verityAdtDecl]*]? $[$nsSpec:verityNamespaceSpec]? storage $[$storageItems:verityStorageItem]* $[roles $[$roleDecls:verityRoleDecl]*]? $[$structDecls:verityStructDecl]* $[errors $[$errorDecls:verityError]*]? $[event_defs $[$eventDecls:verityEvent]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[interfaces $[$interfaceDecls:verityInterface]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$modifierDecls:verityModifier]* $[$functions:verityFunction]*)
+      let parsed ← parseContractSyntax wrapped
+      pure { parsed with isMixin := true }
   | _ => throwErrorAt stx "invalid verity_contract declaration"
 
 private def mkConstantDefCommand (constant : ConstantDecl) : CommandElabM Cmd := do
@@ -3996,6 +4147,104 @@ def validateFunctionDeclsPublic
       throwErrorAt fn.ident s!"function '{fn.name}': nonreentrant and cei_safe are mutually exclusive"
     validateFunctionBodyExprTypes fields errorDecls eventDecls constDecls immutableDecls externalDecls functions fn
 
+/-- Prepend calls to included mixin modifier Lean defs. CompilationModel still
+    uses `fn.modifiers` for inlined mixin-modifier statements. -/
+def prefixMixinModifierExecutableBody
+    (resolvedIncludes : Array Name) (fn : FunctionDecl) (body : Term) :
+    CommandElabM Term := do
+  if fn.modifiers.isEmpty || resolvedIncludes.isEmpty then
+    return body
+  let mut preludes : Array (TSyntax `doElem) := #[]
+  for modIdent in fn.modifiers do
+    let modName := toString modIdent.getId
+    let mut qual? : Option Name := none
+    for mixinName in resolvedIncludes do
+      if qual?.isNone then
+        match (← lookupContractSyntax mixinName) with
+        | some mixin =>
+            if mixin.modifiers.any (fun m => m.name == modName) then
+              qual? := some (mixinName ++ modIdent.getId)
+        | none => pure ()
+    let target :=
+      match qual? with
+      | some q => mkIdent q
+      | none => modIdent
+    preludes := preludes.push (← `(doElem| $target:ident))
+  match body with
+  | `(term| do $[$elems:doElem]*) =>
+      `(term| do $[$preludes:doElem]* $[$elems:doElem]*)
+  | _ =>
+      `(term| do $[$preludes:doElem]* $body:term)
+
+def mkModifierDefCommandPublic (modDecl : ModifierDecl) : CommandElabM Cmd := do
+  `(command| def $(modDecl.ident) : Verity.Contract Unit := $(modDecl.body))
+
+def mkConstructorDefCommandPublic (ctor : ConstructorDecl) : CommandElabM Cmd := do
+  let fnType ← mkContractFnType ctor.params .unit
+  let fnValue ← mkContractFnValue ctor.params ctor.body
+  let id : Ident := mkIdent (Name.mkSimple "constructor")
+  `(command| def $id : $fnType := $fnValue)
+
+def mkHostConstructorDefCommandPublic
+    (resolvedIncludes : Array Name) (ctor : ConstructorDecl) : CommandElabM Cmd := do
+  let fnType ← mkContractFnType ctor.params .unit
+  match ctor.body with
+  | `(term| do $[$elems:doElem]*) =>
+      let mut preludes : Array (TSyntax `doElem) := #[]
+      for (mixinIdent, args) in ctor.mixinInits do
+        let mut targetName : Option Name := none
+        for mixinName in resolvedIncludes do
+          if targetName.isNone && namesMixin (toString mixinIdent.getId) mixinName then
+            targetName := some (mixinName ++ Name.mkSimple "constructor")
+        let tgt := mkIdent (targetName.getD (mixinIdent.getId ++ Name.mkSimple "constructor"))
+        if args.isEmpty then
+          preludes := preludes.push (← `(doElem| $tgt:ident))
+        else
+          preludes := preludes.push (← `(doElem| $tgt:ident $args*))
+      let body ← `(term| do $[$preludes:doElem]* $[$elems:doElem]*)
+      let fnValue ← mkContractFnValue ctor.params body
+      let id : Ident := mkIdent (Name.mkSimple "constructor")
+      `(command| def $id : $fnType := $fnValue)
+  | _ =>
+      mkConstructorDefCommandPublic ctor
+
+def mkIncludeAliasCommandsPublic
+    (resolvedIncludes : Array Name) : CommandElabM (Array Cmd) := do
+  let mut cmds : Array Cmd := #[]
+  for mixinName in resolvedIncludes do
+    match (← lookupContractSyntax mixinName) with
+    | none => pure ()
+    | some mixin =>
+        for field in mixin.fields do
+          if field.emitDef then
+            let tgt := mkIdent (mixinName ++ field.ident.getId)
+            cmds := cmds.push (← `(command| abbrev $(field.ident) := $tgt))
+        for fn in mixin.functions do
+          unless fn.isInternal do
+            let tgt := mkIdent (mixinName ++ fn.ident.getId)
+            cmds := cmds.push (← `(command| abbrev $(fn.ident) := $tgt))
+        for modDecl in mixin.modifiers do
+          let tgt := mkIdent (mixinName ++ modDecl.ident.getId)
+          cmds := cmds.push (← `(command| abbrev $(modDecl.ident) := $tgt))
+        if mixin.ctor.isSome then
+          let tgt := mkIdent (mixinName ++ Name.mkSimple "constructor")
+          let id : Ident := mkIdent (Name.mkSimple s!"{mixinShortName mixinName}_constructor")
+          cmds := cmds.push (← `(command| abbrev $id := $tgt))
+  pure cmds
+
+def mkMergedSpecCommandPublic
+    (contractName : String)
+    (resolvedIncludes : Array Name) : CommandElabM Cmd := do
+  let mixinSpecs : Array Term :=
+    resolvedIncludes.map fun mixinName =>
+      mkIdent (mixinName ++ Name.mkSimple "spec")
+  `(command|
+    def spec : Compiler.CompilationModel.CompilationModel :=
+      Compiler.CompilationModel.mergeIncludedSpecs
+        $(strTerm contractName)
+        [ $[$mixinSpecs],* ]
+        host_spec)
+
 def mkFunctionCommandsPublic
     (fields : Array StorageFieldDecl)
     (roleDecls : Array RoleDecl)
@@ -4004,7 +4253,8 @@ def mkFunctionCommandsPublic
     (immutableDecls : Array ImmutableDecl)
     (externalDecls : Array ExternalDecl)
     (functions : Array FunctionDecl)
-    (fn : FunctionDecl) : CommandElabM (Array Cmd) := do
+    (fn : FunctionDecl)
+    (resolvedIncludes : Array Name := #[]) : CommandElabM (Array Cmd) := do
   let fnType ← mkContractFnType fn.params fn.returnTy
   let fnRoleGuardedBody ← mkRoleGuardedBody fields roleDecls fn
   let fnDecl := { fn with body := fnRoleGuardedBody }
@@ -4015,10 +4265,27 @@ def mkFunctionCommandsPublic
   -- them outside all executable wrappers makes ABI validation happen before
   -- initializer, role, and modifier effects (the inner copy is harmless).
   let fnExecutableBody ← prependEnumGuards fn.params fnExecutableBody
+  let fnExecutableBody ← prefixMixinModifierExecutableBody resolvedIncludes fn fnExecutableBody
   let fnValue ← mkContractFnValue fn.params fnExecutableBody
   let modelBodyName ← mkSuffixedIdent fn.ident "_modelBody"
   let modelName ← mkSuffixedIdent fn.ident "_model"
-  let stmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls immutableDecls externalDecls functions fn
+  -- CompilationModel inlines mixin modifier statements so `modifies(...)`
+  -- can see the write set. The executable path above still binds the
+  -- mixin's Lean `def` (import, not copy).
+  let mut mixinModifiers : Array ModifierDecl := #[]
+  for mixinName in resolvedIncludes do
+    match (← lookupContractSyntax mixinName) with
+    | some mixin => mixinModifiers := mixinModifiers ++ mixin.modifiers
+    | none => pure ()
+  let modelFn ←
+    if mixinModifiers.isEmpty then
+      pure fn
+    else
+      let arr ← inlineModifierPrefixes mixinModifiers #[fn]
+      match arr[0]? with
+      | some inlined => pure inlined
+      | none => pure fn
+  let stmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls immutableDecls externalDecls functions modelFn
   let modelParams ← mkModelParamsTerm fn.params
   let localObligationTerms ← (functionLocalObligationsWithArithmetic fn).mapM mkModelLocalObligationTerm
   let payableTerm ← if fn.isPayable then `(true) else `(false)
@@ -4080,8 +4347,9 @@ def mkSpecCommandPublic
     (modifiers : Array ModifierDecl)
     (functions : Array FunctionDecl)
     (adtDecls : Array AdtDecl)
-    (storageNamespace : Option Nat) : CommandElabM Cmd :=
-  mkSpecCommand contractName fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace
+    (storageNamespace : Option Nat)
+    (specIdent : Ident := mkIdent (Name.mkSimple "spec")) : CommandElabM Cmd :=
+  mkSpecCommand contractName fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace specIdent
 
 def mkFindIdxFieldSimpCommandsPublic
     (contractIdent : Ident)

--- a/Verity/Macro/Translate/Parsing.lean
+++ b/Verity/Macro/Translate/Parsing.lean
@@ -609,62 +609,104 @@ def parseFunction (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl
       }
   | _ => throwErrorAt stx "invalid function declaration"
 
+private def constructorInits (parents : Array Ident) (argsArr : Array (Array Term)) :
+    Array (Ident × Array Term) :=
+  parents.zip argsArr
+
+private def firstInit (inits : Array (Ident × Array Term)) :
+    Option Ident × Array Term :=
+  match inits[0]? with
+  | some (name, args) => (some name, args)
+  | none => (none, #[])
+
 def parseConstructor (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl := #[]) (adtDecls : Array AdtDecl := #[]) (stx : Syntax) : CommandElabM ConstructorDecl := do
   match stx with
-  | `(verityConstructor| constructor ($[$params:verityParam],*) payable $parent:ident($[$args:term],*) local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+  | `(verityConstructor| constructor ($[$params:verityParam],*) payable $[$parent:ident($[$args:term],*)]* local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
         params := ← params.mapM (parseParam newtypes structDecls adtDecls)
         isPayable := true
         localObligations := ← obligations.mapM parseLocalObligation
-        parentName? := some parent
-        parentArgs := args
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
-  | `(verityConstructor| constructor ($[$params:verityParam],*) payable $parent:ident($[$args:term],*) := $body:term) =>
+  | `(verityConstructor| constructor ($[$params:verityParam],*) payable $[$parent:ident($[$args:term],*)]* := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
         params := ← params.mapM (parseParam newtypes structDecls adtDecls)
         isPayable := true
-        parentName? := some parent
-        parentArgs := args
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
-  | `(verityConstructor| constructor ($[$params:verityParam],*) $parent:ident($[$args:term],*) local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+  | `(verityConstructor| constructor ($[$params:verityParam],*) $[$parent:ident($[$args:term],*)]* local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
         params := ← params.mapM (parseParam newtypes structDecls adtDecls)
         localObligations := ← obligations.mapM parseLocalObligation
-        parentName? := some parent
-        parentArgs := args
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
-  | `(verityConstructor| constructor ($[$params:verityParam],*) $parent:ident($[$args:term],*) := $body:term) =>
+  | `(verityConstructor| constructor ($[$params:verityParam],*) $[$parent:ident($[$args:term],*)]* := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
         params := ← params.mapM (parseParam newtypes structDecls adtDecls)
-        parentName? := some parent
-        parentArgs := args
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
-  | `(verityConstructor| constructor ($[$params:verityParam],*) payable local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+  | `(verityConstructor| constructor payable $[$parent:ident($[$args:term],*)]* local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
-        params := ← params.mapM (parseParam newtypes structDecls adtDecls)
+        params := #[]
         isPayable := true
         localObligations := ← obligations.mapM parseLocalObligation
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
-  | `(verityConstructor| constructor ($[$params:verityParam],*) payable := $body:term) =>
+  | `(verityConstructor| constructor payable $[$parent:ident($[$args:term],*)]* := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
-        params := ← params.mapM (parseParam newtypes structDecls adtDecls)
+        params := #[]
         isPayable := true
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
-  | `(verityConstructor| constructor ($[$params:verityParam],*) local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+  | `(verityConstructor| constructor $[$parent:ident($[$args:term],*)]* local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
-        params := ← params.mapM (parseParam newtypes structDecls adtDecls)
+        params := #[]
         localObligations := ← obligations.mapM parseLocalObligation
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
-  | `(verityConstructor| constructor ($[$params:verityParam],*) := $body:term) =>
+  | `(verityConstructor| constructor $[$parent:ident($[$args:term],*)]* := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
-        params := ← params.mapM (parseParam newtypes structDecls adtDecls)
+        params := #[]
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
   | _ => throwErrorAt stx "invalid constructor declaration"

--- a/Verity/Macro/Types.lean
+++ b/Verity/Macro/Types.lean
@@ -280,6 +280,9 @@ structure ConstructorDecl where
   boundParentParamNames : Array String := #[]
   parentName? : Option Ident := none
   parentArgs : Array Term := #[]
+  /-- Mixin constructor inits from `constructor (...) M1(args) M2(args)`.
+      For `is Parent`, the first init is also recorded in `parentName?`/`parentArgs`. -/
+  mixinInits : Array (Ident × Array Term) := #[]
   body : Term
 
 def strTerm (s : String) : Term := ⟨Syntax.mkStrLit s⟩

--- a/Verity/Specs/Composition.lean
+++ b/Verity/Specs/Composition.lean
@@ -1,0 +1,128 @@
+/-
+  Mixin composition helpers.
+
+  A mixin owns a storage footprint. Host proofs reuse mixin theorems by
+  showing the host function writes only its own footprint, which is
+  disjoint from the mixin's, so mixin invariants are preserved.
+-/
+
+import Verity.Core
+import Verity.Core.Invariant
+import Verity.Specs.Common
+
+namespace Verity.Specs.Composition
+
+open Verity
+open Verity.Core.Invariant
+
+/-- Named storage channels a mixin (or host function) is allowed to write. -/
+structure Footprint where
+  uintSlots : List Nat := []
+  addrSlots : List Nat := []
+  mapSlots : List Nat := []
+  mapUintSlots : List Nat := []
+  map2Slots : List Nat := []
+  arraySlots : List Nat := []
+  transientSlots : List Nat := []
+  deriving Repr, DecidableEq
+
+/-- Two footprints own disjoint slot sets on every channel. -/
+def Disjoint (a b : Footprint) : Prop :=
+  (∀ s, s ∈ a.uintSlots → s ∉ b.uintSlots) ∧
+  (∀ s, s ∈ a.addrSlots → s ∉ b.addrSlots) ∧
+  (∀ s, s ∈ a.mapSlots → s ∉ b.mapSlots) ∧
+  (∀ s, s ∈ a.mapUintSlots → s ∉ b.mapUintSlots) ∧
+  (∀ s, s ∈ a.map2Slots → s ∉ b.map2Slots) ∧
+  (∀ s, s ∈ a.arraySlots → s ∉ b.arraySlots) ∧
+  (∀ s, s ∈ a.transientSlots → s ∉ b.transientSlots)
+
+theorem Disjoint.symm {a b : Footprint} (h : Disjoint a b) : Disjoint b a :=
+  ⟨fun s hb ha => h.1 s ha hb,
+    fun s hb ha => h.2.1 s ha hb,
+    fun s hb ha => h.2.2.1 s ha hb,
+    fun s hb ha => h.2.2.2.1 s ha hb,
+    fun s hb ha => h.2.2.2.2.1 s ha hb,
+    fun s hb ha => h.2.2.2.2.2.1 s ha hb,
+    fun s hb ha => h.2.2.2.2.2.2 s ha hb⟩
+
+/-- `s'` differs from `s` only inside `fp`. Context is unchanged. -/
+def WritesOnly (fp : Footprint) (s s' : ContractState) : Prop :=
+  (∀ slot, slot ∉ fp.uintSlots → s'.storage slot = s.storage slot) ∧
+  (∀ slot, slot ∉ fp.addrSlots → s'.storageAddr slot = s.storageAddr slot) ∧
+  (∀ slot, slot ∉ fp.mapSlots → ∀ k, s'.storageMap slot k = s.storageMap slot k) ∧
+  (∀ slot, slot ∉ fp.mapUintSlots → ∀ k, s'.storageMapUint slot k = s.storageMapUint slot k) ∧
+  (∀ slot, slot ∉ fp.map2Slots → ∀ k1 k2, s'.storageMap2 slot k1 k2 = s.storageMap2 slot k1 k2) ∧
+  (∀ slot, slot ∉ fp.arraySlots → s'.storageArray slot = s.storageArray slot) ∧
+  (∀ slot, slot ∉ fp.transientSlots → s'.transientStorage slot = s.transientStorage slot) ∧
+  Specs.sameContext s s'
+
+/-- `s` and `s'` agree on every slot owned by `fp`. -/
+def AgreesOn (fp : Footprint) (s s' : ContractState) : Prop :=
+  (∀ slot, slot ∈ fp.uintSlots → s'.storage slot = s.storage slot) ∧
+  (∀ slot, slot ∈ fp.addrSlots → s'.storageAddr slot = s.storageAddr slot) ∧
+  (∀ slot, slot ∈ fp.mapSlots → ∀ k, s'.storageMap slot k = s.storageMap slot k) ∧
+  (∀ slot, slot ∈ fp.mapUintSlots → ∀ k, s'.storageMapUint slot k = s.storageMapUint slot k) ∧
+  (∀ slot, slot ∈ fp.map2Slots → ∀ k1 k2, s'.storageMap2 slot k1 k2 = s.storageMap2 slot k1 k2) ∧
+  (∀ slot, slot ∈ fp.arraySlots → s'.storageArray slot = s.storageArray slot) ∧
+  (∀ slot, slot ∈ fp.transientSlots → s'.transientStorage slot = s.transientStorage slot)
+
+/-- An invariant that only inspects `fp` is unchanged when `fp` is unchanged. -/
+def InvDependsOnlyOn (Inv : ContractState → Prop) (fp : Footprint) : Prop :=
+  ∀ s s', AgreesOn fp s s' → (Inv s ↔ Inv s')
+
+theorem writesOnly_agrees_on_disjoint
+    (hostFp mixinFp : Footprint)
+    (hDisjoint : Disjoint hostFp mixinFp)
+    (s s' : ContractState)
+    (hWrite : WritesOnly hostFp s s') :
+    AgreesOn mixinFp s s' := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · intro slot hslot
+    have : slot ∉ hostFp.uintSlots := fun hin => hDisjoint.1 slot hin hslot
+    exact hWrite.1 slot this
+  · intro slot hslot
+    have : slot ∉ hostFp.addrSlots := fun hin => hDisjoint.2.1 slot hin hslot
+    exact hWrite.2.1 slot this
+  · intro slot hslot
+    have : slot ∉ hostFp.mapSlots := fun hin => hDisjoint.2.2.1 slot hin hslot
+    exact hWrite.2.2.1 slot this
+  · intro slot hslot
+    have : slot ∉ hostFp.mapUintSlots := fun hin => hDisjoint.2.2.2.1 slot hin hslot
+    exact hWrite.2.2.2.1 slot this
+  · intro slot hslot
+    have : slot ∉ hostFp.map2Slots := fun hin => hDisjoint.2.2.2.2.1 slot hin hslot
+    exact hWrite.2.2.2.2.1 slot this
+  · intro slot hslot
+    have : slot ∉ hostFp.arraySlots := fun hin => hDisjoint.2.2.2.2.2.1 slot hin hslot
+    exact hWrite.2.2.2.2.2.1 slot this
+  · intro slot hslot
+    have : slot ∉ hostFp.transientSlots := fun hin => hDisjoint.2.2.2.2.2.2 slot hin hslot
+    exact hWrite.2.2.2.2.2.2.1 slot this
+
+theorem writesOnly_preserves_other_inv
+    (hostFp mixinFp : Footprint)
+    (hDisjoint : Disjoint hostFp mixinFp)
+    (Inv : ContractState → Prop)
+    (hInv : InvDependsOnlyOn Inv mixinFp)
+    (s s' : ContractState)
+    (hWrite : WritesOnly hostFp s s')
+    (hInvS : Inv s) : Inv s' :=
+  (hInv s s' (writesOnly_agrees_on_disjoint hostFp mixinFp hDisjoint s s' hWrite)).mp hInvS
+
+/-- Address-channel and uint-channel footprints are always disjoint. -/
+theorem disjoint_addr_uint (addrSlot uintSlot : Nat) :
+    Disjoint { addrSlots := [addrSlot] } { uintSlots := [uintSlot] } := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · intro s hs; cases hs
+  · intro s _ h; cases h
+  · intro s hs; cases hs
+  · intro s hs; cases hs
+  · intro s hs; cases hs
+  · intro s hs; cases hs
+  · intro s hs; cases hs
+
+theorem disjoint_uint_addr (uintSlot addrSlot : Nat) :
+    Disjoint { uintSlots := [uintSlot] } { addrSlots := [addrSlot] } :=
+  (disjoint_addr_uint addrSlot uintSlot).symm
+
+end Verity.Specs.Composition

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -169,7 +169,7 @@
   "mechanisms": {
     "@[implemented_by": 1,
     "native_decide": 477,
-    "partial def": 170
+    "partial def": 171
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",
   "schema_version": 1

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,7 +1,7 @@
 {
   "codebase": {
     "core_lines": 1098,
-    "example_contracts": 16
+    "example_contracts": 18
   },
   "proofs": {
     "axioms": 0,
@@ -15,19 +15,21 @@
     "suites": 52
   },
   "theorems": {
-    "categories": 13,
-    "coverage_percent": 84,
+    "categories": 15,
+    "coverage_percent": 81,
     "covered": 255,
-    "excluded": 47,
-    "non_stdlib_total": 302,
+    "excluded": 59,
+    "non_stdlib_total": 314,
     "per_contract": {
       "Counter": 31,
       "ERC20": 22,
       "ERC721": 11,
       "Ledger": 33,
       "LocalObligationMacroSmoke": 4,
+      "Ownable": 6,
       "Owned": 23,
       "OwnedCounter": 48,
+      "OwnedCounterComposed": 6,
       "ReentrancyExample": 5,
       "ReentrancyRelyGuarantee": 10,
       "SafeCounter": 25,
@@ -35,9 +37,9 @@
       "SimpleToken": 61,
       "Vault": 9
     },
-    "proven": 302,
+    "proven": 314,
     "stdlib": 0,
-    "total": 302
+    "total": 314
   },
   "toolchain": {
     "lean": "leanprover/lean4:v4.31.0",

--- a/docs-site/content/edsl/functions.mdx
+++ b/docs-site/content/edsl/functions.mdx
@@ -177,6 +177,37 @@ wrappers**, **storage namespaces** (`storage_namespace erc7201 "myapp.storage.X"
 and **mapping-of-struct** sugar (`MappingStruct`, `MappingStruct2`). Concrete
 usage shapes are in the [production patterns guide](/guides/production-solidity-patterns).
 
+## Mixins and `include`
+
+Reusable facets are `verity_mixin` modules. A host imports them with
+`include` — this is **not** `is` flatten:
+
+```verity
+verity_mixin Ownable where
+  storage
+    owner : Address := slot 0
+  modifier onlyOwner := do
+    let sender ← msgSender
+    require (sender == (← getStorageAddr owner)) "not owner"
+  function transferOwnership (newOwner : Address) with onlyOwner : Unit := do
+    setStorageAddr owner newOwner
+
+verity_contract Host include Ownable where
+  storage
+    count : Uint256 := slot 1
+  constructor (initialOwner : Address) Ownable(initialOwner) := do
+    setStorage count 0
+  function increment () with onlyOwner : Unit := do
+    setStorage count (add (← getStorage count) 1)
+```
+
+`with onlyOwner` on the host binds the mixin's Lean `onlyOwner` definition
+(same `StorageSlot`). Mixin proofs import into the host. `is Parent` still
+exists and re-elaborates a copied tree; use `include` when proofs must reuse.
+
+Name, slot, role, and modifier clashes fail closed. Mixin slots are not
+remapped. See [Modifiers and inheritance](https://github.com/lfglabs-dev/verity/blob/main/docs/MODIFIERS_AND_INHERITANCE.md).
+
 ## See also
 
 - [Storage & Data](/edsl/storage) — field declarations, immutables seeded in the constructor.

--- a/docs-site/content/guides/production-solidity-patterns.mdx
+++ b/docs-site/content/guides/production-solidity-patterns.mdx
@@ -19,7 +19,7 @@ surfaces.
 
 | Solidity pattern | Prefer this Verity surface | Notes |
 |---|---|---|
-| `onlyOwner`, role gates | `requires(ownerSlot)` or a named `modifier` | Use a mapping-backed modifier for role sets such as relayers. |
+| `onlyOwner`, role gates | `verity_mixin Ownable` + `include Ownable`, or `requires(ownerSlot)` / a named `modifier` | Prefer include so host proofs reuse mixin `onlyOwner_*` theorems. Flatten (`is`) does not reuse proofs. |
 | `nonReentrant` | `nonreentrant(reentrancyLockSlot)` | Keep the external entrypoint guard instead of sprinkling manual lock writes. |
 | `initializer` | `initializer(initializedSlot)` | Mirrors upgradeable-contract bootstrap guards. |
 | `immutable` values | `immutables` block | Constructor-visible values become read-only bindings in functions. |

--- a/docs-site/content/guides/solidity-to-verity.mdx
+++ b/docs-site/content/guides/solidity-to-verity.mdx
@@ -59,13 +59,17 @@ Use this table as your first-pass conversion checklist.
 
 Some Solidity features are not 1:1 in the current EDSL/compiler pipeline.
 
-### Inheritance -> Explicit Composition
+### Inheritance -> Mixin include (preferred) or flatten
 
 - Solidity: `contract Child is Ownable, ERC20 { ... }`
-- Verity: compose the inherited storage roots, guards, and helpers explicitly.
-- Use `storage_namespace erc7201 "..."` for each inherited ERC-7201 root when
-  the source uses namespaced storage.
-- Put shared checks in reusable EDSL helpers (for example `onlyOwner`).
+- Verity, proof reuse: declare `verity_mixin Ownable` and
+  `verity_contract Child include Ownable where` plus the host's own storage.
+  Host `with onlyOwner` calls the mixin's Lean `onlyOwner`; mixin proofs
+  import into the host. Mixin slots stay as written (put ERC-7201 on the
+  mixin itself).
+- Verity, source flatten only: `verity_contract Child is Parent where`
+  re-elaborates a copied tree. Parent proofs do not apply. One parent, no C3.
+- Do not copy Ownable storage and re-prove `onlyOwner` by hand for new ports.
 
 ### Modifiers -> Guard Helpers
 

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -17,7 +17,9 @@ Counts are theorems in each module. Read the actual statements in [`Contracts/<N
 | Counter | 19 | 9 |, |, |, | 28 |
 | SafeCounter | 20 | 8 |, |, |, | 28 |
 | Owned | 19 | 4 |, |, |, | 23 |
+| Ownable (mixin) | 6 | — |, |, |, | 6 |
 | OwnedCounter | 33 | 6 |, | 14 |, | 53 |
+| OwnedCounterComposed | 6 | — |, |, |, | 6 |
 | Ledger | 24 | 6 | 7 (conservation) |, |, | 37 |
 | SimpleToken | 40 | 10 | 6 (supply) | 12 |, | 68 |
 | ERC20 | 15 | 7 |, |, | 3 | 25 |

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -31,9 +31,9 @@ Every transition inside the proof envelope is either fully verified or recorded 
 
 <!-- BEGIN GENERATED QUICK FACTS -->
 - **Language**: Lean 4.31.0
-- **Core Size**: 1027 lines
-- **Verified Contracts**: 13 (Counter, ERC20, ERC721, Ledger, LocalObligationMacroSmoke, Owned, OwnedCounter, ReentrancyExample, ReentrancyRelyGuarantee, SafeCounter, SimpleStorage, SimpleToken, Vault)
-- **Theorems**: 302 across 13 categories, 302 fully proven
+- **Core Size**: 1098 lines
+- **Verified Contracts**: 15 (Counter, ERC20, ERC721, Ledger, LocalObligationMacroSmoke, Ownable, Owned, OwnedCounter, OwnedCounterComposed, ReentrancyExample, ReentrancyRelyGuarantee, SafeCounter, SimpleStorage, SimpleToken, Vault)
+- **Theorems**: 314 across 15 categories, 314 fully proven
 - **Axioms**: 0 documented Lean axioms (see AXIOMS.md)
 - **Tests**: 528 Foundry tests, 239 property tests
 - **Build**: `lake build` verifies all proofs

--- a/docs/MODIFIERS_AND_INHERITANCE.md
+++ b/docs/MODIFIERS_AND_INHERITANCE.md
@@ -44,7 +44,10 @@ definition; it does not copy the modifier body. Constructor inits
 `M1(args) M2(args)` run the mixin `constructor` values in include order,
 then the host body.
 
-Name, role, modifier, function, and slot clashes fail closed at elaboration.
+Name, role, modifier, function (including internal helpers), error, event,
+constant, immutable, external, type, and slot clashes fail closed at
+elaboration. Mixin modifiers validate against mixin errors/constants; mixin
+immutables are initialized in the host constructor model.
 Mixin slots are absolute as written (including mixin-owned ERC-7201 roots).
 The host does not remap mixin slots. v1 has no `exclude` and no `override`
 on the include path.

--- a/docs/MODIFIERS_AND_INHERITANCE.md
+++ b/docs/MODIFIERS_AND_INHERITANCE.md
@@ -1,8 +1,10 @@
-# Modifiers and inheritance
+# Modifiers, inheritance, and mixins
 
 `verity_contract` supports precondition-only user-defined modifiers, flattened
-single inheritance, direct parent-constructor calls, and compile-time
-`virtual`/`override` specialization.
+single inheritance, mixin include (import, not flatten), direct parent/mixin
+constructor calls, and compile-time `virtual`/`override` specialization.
+
+## Modifiers
 
 Modifiers are declared with `modifier name := do ...` and attached with
 `with name`. Their statements are inserted, in declaration order, before the
@@ -10,9 +12,12 @@ function body in both executable semantics and the compilation model. The
 current stage is intended for checks such as `onlyOwner`; Solidity-style `_`
 placement and postcondition code are not supported.
 
-A child uses `verity_contract Child is Parent where`. The parent must be
-declared earlier in the same module. Storage, declarations, modifiers, and
-functions are flattened into the child. A child constructor calls its direct
+## Single-parent flatten (`is`)
+
+A child uses `verity_contract Child is Parent where`. The parent must already
+be elaborated (same module or imported `.olean`). Storage, declarations,
+modifiers, and functions are **flattened** into the child: new `StorageSlot`
+and function definitions are generated. A child constructor calls its direct
 parent with `constructor (...) Parent(args...) := do ...`; parent initialization
 runs before the child body.
 
@@ -22,5 +27,27 @@ overrides of non-virtual functions, and accidental signature collisions are
 compile-time errors. Dispatch is specialized during elaboration, so no runtime
 dispatch table or additional proof axiom is introduced.
 
-Multiple inheritance/C3 linearization, abstract body-less functions,
+Because `is` re-elaborates a copied syntax tree, parent proofs do **not**
+apply to the child. Use mixin `include` when you need proof reuse.
+
+## Mixin include (import, not flatten)
+
+`verity_mixin Name where ...` is the reusable facet form. It emits the same
+executable Lean definitions and `CompilationModel` as a contract, plus Lean
+`def`s for modifiers and the constructor. Mixins cannot use `is`, `include`,
+`receive`, or `fallback`.
+
+A host writes `verity_contract Host include M1, M2 where ...`. Include
+**imports** the mixin's existing Lean names (same `StorageSlot` values) and
+merges CompilationModels. `with onlyOwner` binds the mixin's `onlyOwner`
+definition; it does not copy the modifier body. Constructor inits
+`M1(args) M2(args)` run the mixin `constructor` values in include order,
+then the host body.
+
+Name, role, modifier, function, and slot clashes fail closed at elaboration.
+Mixin slots are absolute as written (including mixin-owned ERC-7201 roots).
+The host does not remap mixin slots. v1 has no `exclude` and no `override`
+on the include path.
+
+Multiple `is` parents / C3 linearization, abstract body-less functions,
 parameterized modifiers, and modifier postludes remain out of scope.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -30,7 +30,9 @@ EVM Bytecode
 | Counter | 31 | Complete | `Contracts/Counter/Proofs/` |
 | SafeCounter | 25 | Complete | `Contracts/SafeCounter/Proofs/` |
 | Owned | 23 | Complete | `Contracts/Owned/Proofs/` |
+| Ownable | 6 | Complete | `Contracts/Ownable/Proofs/` |
 | OwnedCounter | 48 | Complete | `Contracts/OwnedCounter/Proofs/` |
+| OwnedCounterComposed | 6 | Complete | `Contracts/OwnedCounterComposed/Proofs/` |
 | Ledger | 33 | Complete | `Contracts/Ledger/Proofs/` |
 | LocalObligationMacroSmoke | 4 | Baseline | `Contracts/LocalObligationMacroSmoke/Proofs/` |
 | SimpleToken | 61 | Complete | `Contracts/SimpleToken/Proofs/` |
@@ -40,9 +42,9 @@ EVM Bytecode
 | ReentrancyExample | 5 | Complete | `Contracts/ReentrancyExample/Contract.lean` |
 | ReentrancyRelyGuarantee | 10 | Semantic | `Contracts/ReentrancyRelyGuarantee/Contract.lean` |
 | CryptoHash | 0 | No specs | `Contracts/CryptoHash/Contract.lean` |
-| **Total** | **302** | **✅ 100%** | — |
+| **Total** | **314** | **✅ 100%** | — |
 
-> **Note**: Stdlib (0 internal proof-automation properties) is excluded from the contract-spec theorem table above but included in overall coverage statistics (302 total properties).
+> **Note**: Stdlib (0 internal proof-automation properties) is excluded from the contract-spec theorem table above but included in overall coverage statistics (314 total properties).
 
 Layer 1 uses macro-generated EDSL-to-`CompilationModel` bridge theorems backed by a generic typed-IR compilation-correctness theorem ([`TypedIRCompilerCorrectness.lean`](../Compiler/TypedIRCompilerCorrectness.lean)). Tuple/bytes/fixed-array/dynamic-array/string parameters now stay inside that proof path when they are carried as ABI head words/offsets. Advanced constructs beyond that typed-IR head-word surface (linked libraries, ECMs, fully custom ABI behavior) are still expressed directly in `CompilationModel` and trusted at that boundary. Higher-order internal helpers (function-pointer parameters, [#1747](https://github.com/lfglabs-dev/verity/issues/1747)) are eliminated by a compile-time monomorphization pre-pass that runs before any lowering, so the `CompilationModel` only ever contains first-order helpers: these calls are covered by the existing first-order proof path and introduce no new boundary trust.
 
@@ -198,17 +200,19 @@ Also note that the macro-generated `*_semantic_preservation` theorems are not co
 | SimpleStorage | 95% (19/20) | 1 proof-only |
 | OwnedCounter | 92% (44/48) | 4 proof-only |
 | Owned | 87% (20/23) | 3 proof-only |
+| Ownable | 0% (0/6) | 6 proof-only |
+| OwnedCounterComposed | 0% (0/6) | 6 proof-only |
 | SimpleToken | 85% (52/61) | 9 proof-only |
 | Counter | 74% (23/31) | 8 proof-only |
 | Stdlib | 0% (0/0) | 0 proof-only |
 
-**Status**: 84% coverage (255/302), 47 remaining exclusions all proof-only
+**Status**: 81% coverage (255/314), 59 remaining exclusions all proof-only
 
-- **Total Properties**: 302
+- **Total Properties**: 314
 - **Covered**: 255
-- **Excluded**: 47 (all proof-only)
+- **Excluded**: 59 (all proof-only)
 
-**Proof-Only Properties (47 exclusions)**: Internal proof machinery that cannot be tested in Foundry.
+**Proof-Only Properties (59 exclusions)**: Internal proof machinery that cannot be tested in Foundry.
 
 0 `sorry` remaining across `Compiler/**/*.lean` and `Verity/**/*.lean` proof modules.
 5266 theorems/lemmas (3645 public, 1621 private) verified by `lake build PrintAxioms`.

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -16,6 +16,7 @@ lean_lib «Verity» where
     .andSubmodules `Verity.Macro,
     .submodules `Verity.Stdlib,
     .andSubmodules `Verity.Specs.Common,
+    .one `Verity.Specs.Composition,
     .submodules `Verity.Proofs.Stdlib,
     .one `Verity.Proofs.LoopSimulation,
     .one `Verity.Proofs.LoopSimulationResultAware
@@ -32,7 +33,9 @@ lean_lib «Contracts» where
     .andSubmodules `Contracts.Counter,
     .andSubmodules `Contracts.SimpleStorage,
     .andSubmodules `Contracts.Owned,
+    .andSubmodules `Contracts.Ownable,
     .andSubmodules `Contracts.OwnedCounter,
+    .andSubmodules `Contracts.OwnedCounterComposed,
     .andSubmodules `Contracts.SafeCounter,
     .andSubmodules `Contracts.Ledger,
     .andSubmodules `Contracts.Vault,

--- a/packages/verity-edsl/lakefile.lean
+++ b/packages/verity-edsl/lakefile.lean
@@ -26,6 +26,7 @@ lean_lib «Verity» where
     .one `Verity.Stdlib.Math,
     .one `Verity.Specs.Common,
     .one `Verity.Specs.Common.Sum,
+    .one `Verity.Specs.Composition,
     .one `Verity.Proofs.Stdlib.Math,
     .one `Verity.Proofs.Stdlib.ListSum,
     .one `Verity.Proofs.Stdlib.Automation

--- a/scripts/check_contract_structure.py
+++ b/scripts/check_contract_structure.py
@@ -19,6 +19,8 @@ EXCLUDED_CONTRACTS = {
     "ReentrancyExample",        # Inline proofs in Examples/, no separate Proofs/ dir
     "CryptoHash",               # Axiom-based, no separate proof structure
     "ReentrancyRelyGuarantee",  # Proof-only rely-guarantee framework example, inline proofs
+    "Ownable",                  # Mixin facet: named-slot proofs + footprint, no Foundry/Yul twin
+    "OwnedCounterComposed",     # Include-host acceptance example; OwnedCounter keeps Yul/difftest
 }
 
 # Contracts excluded from property test check
@@ -26,6 +28,8 @@ EXCLUDED_FROM_PROPERTY_TESTS = {
     "CryptoHash",               # External-library contract, no property tests
     "Vault",                    # Minimal scaffolding landed before proof/property suite completion
     "ReentrancyRelyGuarantee",  # Abstract state-transformer proofs, no compiled contract to property-test
+    "Ownable",                  # Mixin proofs are reused by hosts; no compiled property harness
+    "OwnedCounterComposed",     # Proof-composition host; OwnedCounter remains the Foundry target
 }
 
 # Contracts excluded from differential test check
@@ -34,6 +38,8 @@ EXCLUDED_FROM_DIFFERENTIAL_TESTS = {
     "ReentrancyExample",        # Reentrancy model requires dedicated external-call harnessing
     "Vault",                    # Minimal scaffolding landed before differential harness completion
     "ReentrancyRelyGuarantee",  # No compiled bytecode (abstract proofs), nothing to differential-test
+    "Ownable",                  # Mixin facet; no dedicated Yul/Foundry twin
+    "OwnedCounterComposed",     # Selectors/layout stay on OwnedCounter until bit-identical
 }
 
 # Expected files for each contract (relative to ROOT)

--- a/test/property_exclusions.json
+++ b/test/property_exclusions.json
@@ -50,6 +50,22 @@
   "setStorage_updates_supply",
   "transfer_sum_preserved_unique"
  ],
+ "Ownable": [
+  "constructor_sets_owner",
+  "getOwner_meets_spec",
+  "onlyOwner_ok",
+  "onlyOwner_reverts",
+  "transferOwnership_meets_spec_when_owner",
+  "transferOwnership_writes_only"
+ ],
+ "OwnedCounterComposed": [
+  "getCount_meets_spec",
+  "increment_meets_spec_when_owner",
+  "increment_preserves_ownable_inv",
+  "increment_preserves_owner",
+  "increment_reverts_when_not_owner",
+  "increment_writes_only_count"
+ ],
  "ReentrancyRelyGuarantee": [
   "any_cross_contract_schedule_preserves_I",
   "any_reentry_schedule_preserves_I",

--- a/test/property_manifest.json
+++ b/test/property_manifest.json
@@ -110,6 +110,14 @@
     "dischargedEdge_roundtrip",
     "unsafeEdge_preserves_state"
   ],
+  "Ownable": [
+    "constructor_sets_owner",
+    "getOwner_meets_spec",
+    "onlyOwner_ok",
+    "onlyOwner_reverts",
+    "transferOwnership_meets_spec_when_owner",
+    "transferOwnership_writes_only"
+  ],
   "Owned": [
     "constructor_getOwner_correct",
     "constructor_meets_spec",
@@ -184,6 +192,14 @@
     "transfer_then_decrement_reverts",
     "transfer_then_increment_reverts",
     "transfer_then_transfer_reverts"
+  ],
+  "OwnedCounterComposed": [
+    "getCount_meets_spec",
+    "increment_meets_spec_when_owner",
+    "increment_preserves_ownable_inv",
+    "increment_preserves_owner",
+    "increment_reverts_when_not_owner",
+    "increment_writes_only_count"
   ],
   "ReentrancyExample": [
     "deposit_maintains_supply",


### PR DESCRIPTION
## Summary

Adds `verity_mixin` and `verity_contract Host include M1, M2` so a host **imports** mixin Lean definitions and proofs instead of flattening a copied tree (`is Parent`).

- Mixin slots stay as written (including ERC-7201 roots).
- `with onlyOwner` binds the mixin’s `onlyOwner` (same `StorageSlot`).
- Constructor inits `M1(args) M2(args)` run mixin `constructor` values, then the host body.
- Slot / name / role / modifier / function clashes fail closed.
- `is Parent` flatten is unchanged.

Acceptance example: `Contracts.Ownable` + `Contracts.OwnedCounterComposed`. Host `increment_reverts_when_not_owner` reuses `onlyOwner_reverts`; `increment_preserves_owner` is `WritesOnly` + disjoint footprints.

`Owned` specs now use `owner.slot`. `OwnedCounter` remains the Yul / Foundry twin.

## Test plan

- [x] `lake build Contracts.Owned`
- [x] `lake build Contracts.Smoke` (`#check_contract` + `#guard_msgs` for slot/name/missing-ctor)
- [x] `lake build Contracts.OwnedCounterComposed`
- [x] `Contract.run` eval: owner increment writes count, not-owner reverts, owner slot unchanged
- [x] `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large macro and elaboration surface (include merge, constructors, modifiers) affects how every host contract compiles, though clash checks and smoke tests constrain regressions.
> 
> **Overview**
> Adds **`verity_mixin`** and **`verity_contract Host include M1, M2`** so hosts import mixin Lean defs and proofs instead of flattening with **`is Parent`**. Elaboration merges **`CompilationModel`** via **`mergeIncludedSpecs`**, emits **`host_spec`** plus merged **`spec`**, binds **`with onlyOwner`** to the mixin modifier, runs **`Mixin(args)`** constructor inits, and **fails closed** on slot/name/role/modifier/function clashes. Mixin slots are not remapped.
> 
> Introduces **`Verity.Specs.Composition`** (**`Footprint`**, **`WritesOnly`**, **`writesOnly_preserves_other_inv`**) so host proofs reuse mixin guard and invariant theorems when footprints are disjoint.
> 
> Ships **`Contracts.Ownable`** and **`OwnedCounterComposed`** as the acceptance path; **`Owned`** specs/proofs switch from literal slot **`0`** to **`owner.slot`**. Docs, CONTRIBUTING mixin guidance, **`PrintAxioms`**, and verification manifests are updated. Compiler correctness proofs drop redundant storage **`simp`** lemmas; smoke **`Include.lean`** adds **`#guard_msgs`** for include errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afd650164cef5ab907b5e0d0831e2b3d3ba8954a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->