### PR TITLE
feat(proofs): fuel stability for literal-bound forEach loops

### DIFF
--- a/Compiler/Proofs/IRGeneration/BoundedLoopCheck.lean
+++ b/Compiler/Proofs/IRGeneration/BoundedLoopCheck.lean
@@ -1,0 +1,313 @@
+import Compiler.Proofs.IRGeneration.BoundedLoopFuel
+
+/-!
+# Decidable counter-preservation checker for the bounded-loop fragment
+
+`execIRStmt_boundedFor_stable` takes the loop-counter preservation of the
+body as a semantic hypothesis.  This module provides the executable mirror:
+`varUntouchedCheck v` scans a statement for any binding or assignment of
+`v` (loops excluded, matching `LoopFree`), and the soundness theorem
+discharges the semantic hypothesis for any checked body — so fragment
+membership for a concrete compiled `forEach` body is a `decide` obligation,
+in the same style as `spliceSimCheck`.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+
+/-- The state carried by an execution result. -/
+def IRExecResult.state : IRExecResult → IRState
+  | .continue s => s
+  | .return _ s => s
+  | .stop s => s
+  | .revert s => s
+
+mutual
+
+/-- Executable check: the statement never binds or assigns `v` (loops are
+outside the fragment, mirroring `LoopFree`). -/
+def varUntouchedCheck (v : String) : YulStmt → Bool
+  | .let_ n _ => n != v
+  | .letMany ns _ => !(ns.contains v)
+  | .assign n _ => n != v
+  | .if_ _ body => varUntouchedCheckList v body
+  | .block stmts => varUntouchedCheckList v stmts
+  | .switch _ cases dflt =>
+      varUntouchedCheckCases v cases && varUntouchedCheckDflt v dflt
+  | .for_ _ _ _ _ => false
+  | _ => true
+
+def varUntouchedCheckCases (v : String) : List (Nat × List YulStmt) → Bool
+  | [] => true
+  | c :: rest => varUntouchedCheckList v c.2 && varUntouchedCheckCases v rest
+
+def varUntouchedCheckDflt (v : String) : Option (List YulStmt) → Bool
+  | none => true
+  | some stmts => varUntouchedCheckList v stmts
+
+def varUntouchedCheckList (v : String) : List YulStmt → Bool
+  | [] => true
+  | s :: rest => varUntouchedCheck v s && varUntouchedCheckList v rest
+
+end
+
+/-- Yul log emission never touches variables. -/
+theorem applyYulLogCall?_vars (state next : IRState) (func : String)
+    (argVals : List Nat) (h : applyYulLogCall? state func argVals = some next) :
+    next.vars = state.vars := by
+  unfold applyYulLogCall? at h
+  repeat' split at h
+  all_goals ((cases h) <;> rfl)
+
+/-- Expression statements never touch variables: every branch of the
+interpreter's `exprStmt` case updates storage, memory, transient storage,
+or the event log — never the variable environment. -/
+theorem execIRStmt_exprStmt_state_vars (fuel : Nat) (state : IRState)
+    (e : YulExpr) :
+    ((execIRStmt fuel state (.exprStmt e)).state).vars = state.vars := by
+  cases fuel with
+  | zero => rfl
+  | succ fuel =>
+      rw [execIRStmt.eq_def]
+      repeat' split
+      all_goals try subst_vars
+      all_goals first
+        | rfl
+        | exact applyYulLogCall?_vars _ _ _ _ (by assumption)
+        | simp_all
+
+/-- `getVar` only depends on `vars`. -/
+theorem IRState.getVar_congr_vars (s s' : IRState) (v : String)
+    (h : s'.vars = s.vars) : s'.getVar v = s.getVar v := by
+  simp [IRState.getVar, h]
+
+/-- Case-branch membership for the checker. -/
+theorem varUntouchedCheckCases_mem
+    {v : String} {cs : List (Nat × List YulStmt)}
+    (h : varUntouchedCheckCases v cs = true)
+    {c : Nat × List YulStmt} (hmem : c ∈ cs) :
+    varUntouchedCheckList v c.2 = true := by
+  induction cs with
+  | nil => cases hmem
+  | cons x rest ih =>
+      obtain ⟨hx, hrest⟩ : varUntouchedCheckList v x.2 = true ∧
+          varUntouchedCheckCases v rest = true := by
+        simpa [varUntouchedCheckCases, Bool.and_eq_true] using h
+      rcases List.mem_cons.mp hmem with rfl | hmem
+      · exact hx
+      · exact ih hrest hmem
+
+variable {v : String}
+
+mutual
+
+/-- Soundness: a checked, loop-free statement preserves `getVar v` in every
+outcome. -/
+theorem execIRStmt_getVar_of_checked :
+    ∀ (s : YulStmt), LoopFree s → varUntouchedCheck v s = true →
+    ∀ (fuel : Nat) (state : IRState),
+      ((execIRStmt fuel state s).state).getVar v = state.getVar v
+  | .comment _, _, _, fuel, state => by
+      cases fuel <;> rfl
+  | .leave, _, _, fuel, state => by
+      cases fuel <;> rfl
+  | .funcDef _ _ _ _, _, _, fuel, state => by
+      cases fuel <;> rfl
+  | .letMany _ _, _, _, fuel, state => by
+      cases fuel <;> rfl
+  | .let_ n value, _, hchk, fuel, state => by
+      cases fuel with
+      | zero => rfl
+      | succ fuel =>
+          have hne : n ≠ v := by simpa [varUntouchedCheck] using hchk
+          show ((match evalIRExpr state value with
+            | some w => IRExecResult.continue (state.setVar n w)
+            | none => IRExecResult.revert state).state).getVar v =
+            state.getVar v
+          cases evalIRExpr state value with
+          | none => rfl
+          | some w =>
+              simp only [IRExecResult.state]
+              exact IRState.getVar_setVar_ne state n v w (Ne.symm hne)
+  | .assign n value, _, hchk, fuel, state => by
+      cases fuel with
+      | zero => rfl
+      | succ fuel =>
+          have hne : n ≠ v := by simpa [varUntouchedCheck] using hchk
+          show ((match evalIRExpr state value with
+            | some w => IRExecResult.continue (state.setVar n w)
+            | none => IRExecResult.revert state).state).getVar v =
+            state.getVar v
+          cases evalIRExpr state value with
+          | none => rfl
+          | some w =>
+              simp only [IRExecResult.state]
+              exact IRState.getVar_setVar_ne state n v w (Ne.symm hne)
+  | .exprStmt e, _, _, fuel, state =>
+      IRState.getVar_congr_vars state _ v
+        (execIRStmt_exprStmt_state_vars fuel state e)
+  | .for_ _ _ _ _, hLF, _, _, _ => absurd hLF (by simp [LoopFree])
+  | .if_ cond body, hLF, hchk, fuel, state => by
+      cases fuel with
+      | zero => rfl
+      | succ fuel =>
+          have hLFb : LoopFreeList body := by simpa [LoopFree] using hLF
+          have hchkb : varUntouchedCheckList v body = true := by
+            simpa [varUntouchedCheck] using hchk
+          show ((match evalIRExpr state cond with
+            | some c => if c ≠ 0 then execIRStmts fuel state body
+                else IRExecResult.continue state
+            | none => IRExecResult.revert state).state).getVar v =
+            state.getVar v
+          cases evalIRExpr state cond with
+          | none => rfl
+          | some c =>
+              simp only []
+              by_cases hc : c ≠ 0
+              · rw [if_pos hc]
+                exact execIRStmts_getVar_of_checked body hLFb hchkb fuel state
+              · rw [if_neg hc]
+                rfl
+  | .block stmts, hLF, hchk, fuel, state => by
+      cases fuel with
+      | zero => rfl
+      | succ fuel =>
+          have hLFb : LoopFreeList stmts := by simpa [LoopFree] using hLF
+          have hchkb : varUntouchedCheckList v stmts = true := by
+            simpa [varUntouchedCheck] using hchk
+          show ((execIRStmts fuel state stmts).state).getVar v = state.getVar v
+          exact execIRStmts_getVar_of_checked stmts hLFb hchkb fuel state
+  | .switch e cases dflt, hLF, hchk, fuel, state => by
+      cases fuel with
+      | zero => rfl
+      | succ fuel =>
+          obtain ⟨hLFc, hLFd⟩ : LoopFreeCases cases ∧ LoopFreeDflt dflt := by
+            simpa [LoopFree] using hLF
+          obtain ⟨hchkc, hchkd⟩ : varUntouchedCheckCases v cases = true ∧
+              varUntouchedCheckDflt v dflt = true := by
+            simpa [varUntouchedCheck, Bool.and_eq_true] using hchk
+          cases heval : evalIRExpr state e with
+          | none => simp [execIRStmt, heval, IRExecResult.state]
+          | some w =>
+              cases hfind : List.find?
+                  (fun (c : Nat × List YulStmt) => c.1 == w) cases with
+              | some c =>
+                  obtain ⟨k, body⟩ := c
+                  have hmem := List.mem_of_find?_eq_some hfind
+                  simp only [execIRStmt, heval, hfind]
+                  exact execIRStmts_getVar_of_checked body
+                    (LoopFreeCases.mem hLFc hmem)
+                    (varUntouchedCheckCases_mem hchkc hmem) fuel state
+              | none =>
+                  cases hdd : dflt with
+                  | none => simp [execIRStmt, heval, hfind, IRExecResult.state]
+                  | some body =>
+                      have hLFb : LoopFreeList body := by
+                        rw [hdd] at hLFd
+                        simpa [LoopFreeDflt] using hLFd
+                      have hchkb : varUntouchedCheckList v body = true := by
+                        rw [hdd] at hchkd
+                        simpa [varUntouchedCheckDflt] using hchkd
+                      simp only [execIRStmt, heval, hfind]
+                      exact execIRStmts_getVar_of_checked body hLFb hchkb
+                        fuel state
+
+/-- List soundness. -/
+theorem execIRStmts_getVar_of_checked :
+    ∀ (xs : List YulStmt), LoopFreeList xs → varUntouchedCheckList v xs = true →
+    ∀ (fuel : Nat) (state : IRState),
+      ((execIRStmts fuel state xs).state).getVar v = state.getVar v
+  | [], _, _, fuel, state => by
+      simp [execIRStmts, IRExecResult.state]
+  | x :: rest, hLF, hchk, fuel, state => by
+      obtain ⟨hx, hrest⟩ : LoopFree x ∧ LoopFreeList rest := by
+        simpa [LoopFreeList] using hLF
+      obtain ⟨hchkx, hchkrest⟩ : varUntouchedCheck v x = true ∧
+          varUntouchedCheckList v rest = true := by
+        simpa [varUntouchedCheckList, Bool.and_eq_true] using hchk
+      cases fuel with
+      | zero => rfl
+      | succ fuel =>
+          show ((match execIRStmt fuel state x with
+            | .continue s' => execIRStmts fuel s' rest
+            | .return w s => IRExecResult.return w s
+            | .stop s => IRExecResult.stop s
+            | .revert s => IRExecResult.revert s).state).getVar v =
+            state.getVar v
+          have hhead := execIRStmt_getVar_of_checked x hx hchkx fuel state
+          cases hres : execIRStmt fuel state x with
+          | «continue» s' =>
+              rw [hres] at hhead
+              simp only [IRExecResult.state] at hhead
+              rw [execIRStmts_getVar_of_checked rest hrest hchkrest fuel s']
+              exact hhead
+          | «return» w s =>
+              rw [hres] at hhead
+              exact hhead
+          | stop s =>
+              rw [hres] at hhead
+              exact hhead
+          | revert s =>
+              rw [hres] at hhead
+              exact hhead
+
+end
+
+/-- The bridge to `execIRStmt_boundedFor_stable`'s semantic hypothesis: a
+checked body preserves both counters across any `.continue` execution. -/
+theorem counter_preservation_of_checked
+    (idxN cntN : String) (body : List YulStmt)
+    (hLF : LoopFreeList body)
+    (hidx : varUntouchedCheckList idxN body = true)
+    (hcnt : varUntouchedCheckList cntN body = true) :
+    ∀ (g : Nat) (s s' : IRState),
+      execIRStmts g s body = .continue s' →
+      s'.getVar idxN = s.getVar idxN ∧ s'.getVar cntN = s.getVar cntN := by
+  intro g s s' hrun
+  constructor
+  · have h := execIRStmts_getVar_of_checked (v := idxN) body hLF hidx g s
+    rw [hrun] at h
+    exact h
+  · have h := execIRStmts_getVar_of_checked (v := cntN) body hLF hcnt g s
+    rw [hrun] at h
+    exact h
+
+
+/-! ### End-to-end demonstration
+
+A concrete `forEach`-shaped loop body (store the element variable to a
+fixed slot) passes both decidable checks, so the stability theorem applies
+with every side-condition discharged by `decide` — the per-contract
+consumption pattern. -/
+
+example (state : IRState)
+    (hidx : state.getVar "__forEach_idx" = some 0)
+    (hcnt : state.getVar "__forEach_count" = some 3)
+    (F G : Nat)
+    (hF : boundedForFuel
+      [.assign "v" (.ident "__forEach_idx"),
+       .exprStmt (.call "sstore" [.lit 7, .ident "v"])] 3 0 ≤ F)
+    (hG : boundedForFuel
+      [.assign "v" (.ident "__forEach_idx"),
+       .exprStmt (.call "sstore" [.lit 7, .ident "v"])] 3 0 ≤ G) :
+    execIRStmt F state
+        (.for_ [] (.call "lt" [.ident "__forEach_idx", .ident "__forEach_count"])
+          [.assign "__forEach_idx" (.call "add" [.ident "__forEach_idx", .lit 1])]
+          [.assign "v" (.ident "__forEach_idx"),
+           .exprStmt (.call "sstore" [.lit 7, .ident "v"])]) =
+      execIRStmt G state
+        (.for_ [] (.call "lt" [.ident "__forEach_idx", .ident "__forEach_count"])
+          [.assign "__forEach_idx" (.call "add" [.ident "__forEach_idx", .lit 1])]
+          [.assign "v" (.ident "__forEach_idx"),
+           .exprStmt (.call "sstore" [.lit 7, .ident "v"])]) :=
+  execIRStmt_boundedFor_stable_of_le "__forEach_idx" "__forEach_count"
+    (by decide)
+    [.assign "v" (.ident "__forEach_idx"),
+     .exprStmt (.call "sstore" [.lit 7, .ident "v"])]
+    (by constructor <;> trivial)
+    (counter_preservation_of_checked "__forEach_idx" "__forEach_count" _
+      (by constructor <;> trivial) (by decide) (by decide))
+    0 3 state hidx hcnt (by omega) (by decide)
+    F G hF hG
+
+end Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/IRGeneration/BoundedLoopFuel.lean
+++ b/Compiler/Proofs/IRGeneration/BoundedLoopFuel.lean
@@ -1,0 +1,375 @@
+import Compiler.Proofs.IRGeneration.FuelBound
+import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBridgeLemmas
+import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanPureBuiltinLemmas
+
+/-!
+# Fuel stability for literal-bound `forEach` loops (#2276 follow-up)
+
+`FuelBound.lean` gives fuel stability for the loop-free fragment.  This
+module extends it to the steady-state loop emitted by the `forEach`
+lowering — `for_ [] lt(idx, cnt) [idx := add(idx, 1)] body` — under the
+loop invariant that drives it: `idx` holds `k`, `cnt` holds `C`, and the
+body preserves both counters (a semantic hypothesis here; the syntactic
+discharge via a decidable body checker lands with the fragment admission).
+
+Fuel accounting: each iteration of the interpreter's `for_` case peels one
+`succ` (the recursive `for_ []` re-entry), while `body`/`post` run at the
+current (decreasing) fuel.  So `C - k` iterations plus headroom for the
+deepest subterm bound the whole loop:
+`boundedForFuel body C k = (C - k) + max(bodyBound, postBound) + 1`.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.Yul
+
+/-- Variable lookup after `setVar` at the same name. -/
+theorem IRState.getVar_setVar_self (s : IRState) (name : String) (v : Nat) :
+    (s.setVar name v).getVar name = some v := by
+  simp [IRState.getVar, IRState.setVar]
+
+/-- `find?` skips entries removed by a name filter that cannot match. -/
+private theorem find?_filter_ne_name (other name : String) (h : other ≠ name) :
+    ∀ (l : List (String × Nat)),
+      (l.filter (·.1 != name)).find? (·.1 == other) =
+        l.find? (·.1 == other)
+  | [] => rfl
+  | (n', v') :: rest => by
+      by_cases hn : n' = name
+      · subst hn
+        rw [List.filter_cons_of_neg (by simp),
+          List.find?_cons_of_neg (by simp [Ne.symm h]),
+          find?_filter_ne_name other _ h rest]
+      · rw [List.filter_cons_of_pos (by simp [hn])]
+        by_cases ho : n' = other
+        · subst ho
+          rw [List.find?_cons_of_pos (by simp),
+            List.find?_cons_of_pos (by simp)]
+        · rw [List.find?_cons_of_neg (by simp [ho]),
+            List.find?_cons_of_neg (by simp [ho]),
+            find?_filter_ne_name other name h rest]
+
+/-- Variable lookup after `setVar` at a different name. -/
+theorem IRState.getVar_setVar_ne (s : IRState) (name other : String)
+    (v : Nat) (h : other ≠ name) :
+    (s.setVar name v).getVar other = s.getVar other := by
+  simp only [IRState.getVar, IRState.setVar, List.find?_cons]
+  have hbeq : ((name, v).1 == other) = false := by
+    simp [Ne.symm h]
+  rw [hbeq]
+  rw [find?_filter_ne_name other name h s.vars]
+
+/-- The post statement of the `forEach` lowering: increment the counter. -/
+theorem execIRStmts_forEach_post (idxN : String) (fuel : Nat)
+    (state : IRState) (k : Nat)
+    (hidx : state.getVar idxN = some k)
+    (hk : k + 1 < Compiler.Constants.evmModulus)
+    (hfuel : 2 ≤ fuel) :
+    execIRStmts fuel state
+        [.assign idxN (.call "add" [.ident idxN, .lit 1])] =
+      .continue (state.setVar idxN (k + 1)) := by
+  rcases Nat.exists_eq_add_of_le hfuel with ⟨extra, rfl⟩
+  rw [Nat.add_comm]
+  have hkM : k < Compiler.Constants.evmModulus := by omega
+  simp only [execIRStmts, execIRStmt]
+  simp only [evalIRExpr, evalIRCall, evalIRExprs, hidx]
+  simp [Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
+    Nat.mod_eq_of_lt hk]
+
+/-- The loop condition of the `forEach` lowering evaluates to the comparison
+of the two counters. -/
+theorem evalIRExpr_forEach_cond (idxN cntN : String) (state : IRState)
+    (k C : Nat)
+    (hidx : state.getVar idxN = some k)
+    (hcnt : state.getVar cntN = some C)
+    (hkM : k < Compiler.Constants.evmModulus)
+    (hCM : C < Compiler.Constants.evmModulus) :
+    evalIRExpr state (.call "lt" [.ident idxN, .ident cntN]) =
+      some (if k < C then 1 else 0) := by
+  simp only [evalIRExpr, evalIRCall, evalIRExprs, hidx, hcnt]
+  simp [Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
+    Nat.mod_eq_of_lt hkM, Nat.mod_eq_of_lt hCM]
+
+/-- Fuel bound for the steady-state `forEach` loop with `C - k` iterations
+remaining. -/
+def boundedForFuel (body : List YulStmt) (C k : Nat) : Nat :=
+  (C - k) + Nat.max (stmtsFuelBound body)
+    (stmtsFuelBound [.assign "i" (.call "add" [.ident "i", .lit 1])]) + 1
+
+/-- The post bound is name-independent (structural). -/
+theorem stmtsFuelBound_post_eq (idxN : String) :
+    stmtsFuelBound [.assign idxN (.call "add" [.ident idxN, .lit 1])] =
+      stmtsFuelBound [.assign "i" (.call "add" [.ident "i", .lit 1])] := rfl
+
+/-- Fuel stability for the steady-state literal-bound loop: with the counter
+invariant in hand, execution at the structural bound and at any larger fuel
+agree.  The body's counter preservation is a semantic hypothesis; the
+decidable syntactic discharge ships with the fragment admission. -/
+theorem execIRStmt_boundedFor_stable
+    (idxN cntN : String) (hne : idxN ≠ cntN)
+    (body : List YulStmt) (hLF : LoopFreeList body)
+    (hpres : ∀ (g : Nat) (s s' : IRState),
+      execIRStmts g s body = .continue s' →
+      s'.getVar idxN = s.getVar idxN ∧ s'.getVar cntN = s.getVar cntN) :
+    ∀ (gas k C : Nat), gas = C - k →
+      ∀ (state : IRState) (f : Nat),
+      state.getVar idxN = some k →
+      state.getVar cntN = some C →
+      k ≤ C → C < Compiler.Constants.evmModulus →
+      execIRStmt (boundedForFuel body C k + f) state
+          (.for_ [] (.call "lt" [.ident idxN, .ident cntN])
+            [.assign idxN (.call "add" [.ident idxN, .lit 1])] body) =
+        execIRStmt (boundedForFuel body C k) state
+          (.for_ [] (.call "lt" [.ident idxN, .ident cntN])
+            [.assign idxN (.call "add" [.ident idxN, .lit 1])] body) := by
+  intro gas
+  induction gas with
+  | zero =>
+      intro k C hgas state f hidx hcnt hkC hCM
+      have hkeqC : k = C := by omega
+      subst hkeqC
+      have hcond := evalIRExpr_forEach_cond idxN cntN state k k hidx hcnt
+        (by omega) hCM
+      rw [if_neg (by omega)] at hcond
+      have hnil : ∀ (F : Nat), execIRStmts F state [] = .continue state :=
+        fun F => by simp [execIRStmts]
+      rw [show boundedForFuel body k k + f =
+            Nat.succ (boundedForFuel body k k - 1 + f) from by
+          unfold boundedForFuel; omega,
+        show boundedForFuel body k k =
+            Nat.succ (boundedForFuel body k k - 1) from by
+          unfold boundedForFuel; omega,
+        execIRStmt_for_init_cond_zero _ state state []
+          [.assign idxN (.call "add" [.ident idxN, .lit 1])] body
+          (.call "lt" [.ident idxN, .ident cntN]) (hnil _) hcond,
+        execIRStmt_for_init_cond_zero _ state state []
+          [.assign idxN (.call "add" [.ident idxN, .lit 1])] body
+          (.call "lt" [.ident idxN, .ident cntN]) (hnil _) hcond]
+  | succ gas ih =>
+      intro k C hgas state f hidx hcnt hkC hCM
+      have hkltC : k < C := by omega
+      have hcond := evalIRExpr_forEach_cond idxN cntN state k C hidx hcnt
+        (by omega) hCM
+      rw [if_pos hkltC] at hcond
+      have hnil : ∀ (F : Nat), execIRStmts F state [] = .continue state :=
+        fun F => by simp [execIRStmts]
+      have hone : (1 : Nat) ≠ 0 := by omega
+      set F := boundedForFuel body C (k + 1) with hF
+      have hpost2 : 2 ≤ stmtsFuelBound
+          [.assign "i" (.call "add" [.ident "i", .lit 1])] := by
+        simp [stmtsFuelBound, stmtFuelBound]
+      have hFbody : stmtsFuelBound body ≤ F := by
+        rw [hF]
+        calc stmtsFuelBound body
+            ≤ Nat.max (stmtsFuelBound body)
+                (stmtsFuelBound [.assign "i" (.call "add" [.ident "i", .lit 1])]) :=
+              Nat.le_max_left _ _
+          _ ≤ boundedForFuel body C (k + 1) := by
+              unfold boundedForFuel; omega
+      have hF2 : 2 ≤ F := by
+        rw [hF]
+        calc (2 : Nat)
+            ≤ stmtsFuelBound [.assign "i" (.call "add" [.ident "i", .lit 1])] :=
+              hpost2
+          _ ≤ Nat.max (stmtsFuelBound body)
+                (stmtsFuelBound [.assign "i" (.call "add" [.ident "i", .lit 1])]) :=
+              Nat.le_max_right _ _
+          _ ≤ boundedForFuel body C (k + 1) := by
+              unfold boundedForFuel; omega
+      rw [show boundedForFuel body C k + f = Nat.succ (F + f) from by
+          rw [hF]; unfold boundedForFuel; omega,
+        show boundedForFuel body C k = Nat.succ F from by
+          rw [hF]; unfold boundedForFuel; omega]
+      have hbodyEq : execIRStmts (F + f) state body =
+          execIRStmts F state body :=
+        execIRStmts_stable_of_le body hLF _ _ state (by omega) hFbody
+      cases hbody : execIRStmts F state body with
+      | «return» v st =>
+          rw [execIRStmt_for_body_noncontinue (F + f) state state []
+              [.assign idxN (.call "add" [.ident idxN, .lit 1])] body
+              (.call "lt" [.ident idxN, .ident cntN]) 1 (.return v st)
+              (hnil _) hcond hone (hbodyEq.trans hbody)
+              (fun s hh => by cases hh),
+            execIRStmt_for_body_noncontinue F state state []
+              [.assign idxN (.call "add" [.ident idxN, .lit 1])] body
+              (.call "lt" [.ident idxN, .ident cntN]) 1 (.return v st)
+              (hnil _) hcond hone hbody (fun s hh => by cases hh)]
+      | stop st =>
+          rw [execIRStmt_for_body_noncontinue (F + f) state state []
+              [.assign idxN (.call "add" [.ident idxN, .lit 1])] body
+              (.call "lt" [.ident idxN, .ident cntN]) 1 (.stop st)
+              (hnil _) hcond hone (hbodyEq.trans hbody)
+              (fun s hh => by cases hh),
+            execIRStmt_for_body_noncontinue F state state []
+              [.assign idxN (.call "add" [.ident idxN, .lit 1])] body
+              (.call "lt" [.ident idxN, .ident cntN]) 1 (.stop st)
+              (hnil _) hcond hone hbody (fun s hh => by cases hh)]
+      | revert st =>
+          rw [execIRStmt_for_body_noncontinue (F + f) state state []
+              [.assign idxN (.call "add" [.ident idxN, .lit 1])] body
+              (.call "lt" [.ident idxN, .ident cntN]) 1 (.revert st)
+              (hnil _) hcond hone (hbodyEq.trans hbody)
+              (fun s hh => by cases hh),
+            execIRStmt_for_body_noncontinue F state state []
+              [.assign idxN (.call "add" [.ident idxN, .lit 1])] body
+              (.call "lt" [.ident idxN, .ident cntN]) 1 (.revert st)
+              (hnil _) hcond hone hbody (fun s hh => by cases hh)]
+      | «continue» s'' =>
+          obtain ⟨hidx'', hcnt''⟩ := hpres _ state s'' hbody
+          rw [hidx] at hidx''
+          rw [hcnt] at hcnt''
+          have hpost1 : execIRStmts (F + f) s''
+              [.assign idxN (.call "add" [.ident idxN, .lit 1])] =
+              .continue (s''.setVar idxN (k + 1)) :=
+            execIRStmts_forEach_post idxN _ s'' k hidx'' (by omega) (by omega)
+          have hpost2 : execIRStmts F s''
+              [.assign idxN (.call "add" [.ident idxN, .lit 1])] =
+              .continue (s''.setVar idxN (k + 1)) :=
+            execIRStmts_forEach_post idxN _ s'' k hidx'' (by omega) hF2
+          rw [execIRStmt_for_one_continue (F + f) state state s''
+              (s''.setVar idxN (k + 1)) []
+              [.assign idxN (.call "add" [.ident idxN, .lit 1])] body
+              (.call "lt" [.ident idxN, .ident cntN]) 1
+              (hnil _) hcond hone (hbodyEq.trans hbody) hpost1,
+            execIRStmt_for_one_continue F state state s''
+              (s''.setVar idxN (k + 1)) []
+              [.assign idxN (.call "add" [.ident idxN, .lit 1])] body
+              (.call "lt" [.ident idxN, .ident cntN]) 1
+              (hnil _) hcond hone hbody hpost2]
+          have hidx3 : (s''.setVar idxN (k + 1)).getVar idxN = some (k + 1) :=
+            IRState.getVar_setVar_self s'' idxN (k + 1)
+          have hcnt3 : (s''.setVar idxN (k + 1)).getVar cntN = some C := by
+            rw [IRState.getVar_setVar_ne s'' idxN cntN (k + 1) (Ne.symm hne)]
+            exact hcnt''
+          exact ih (k + 1) C (by omega) (s''.setVar idxN (k + 1)) f
+            hidx3 hcnt3 (by omega) hCM
+
+/-- Consumer API: any two fuels at or above the bound execute the
+steady-state loop identically. -/
+theorem execIRStmt_boundedFor_stable_of_le
+    (idxN cntN : String) (hne : idxN ≠ cntN)
+    (body : List YulStmt) (hLF : LoopFreeList body)
+    (hpres : ∀ (g : Nat) (s s' : IRState),
+      execIRStmts g s body = .continue s' →
+      s'.getVar idxN = s.getVar idxN ∧ s'.getVar cntN = s.getVar cntN)
+    (k C : Nat) (state : IRState)
+    (hidx : state.getVar idxN = some k)
+    (hcnt : state.getVar cntN = some C)
+    (hkC : k ≤ C) (hCM : C < Compiler.Constants.evmModulus)
+    (F G : Nat)
+    (hF : boundedForFuel body C k ≤ F) (hG : boundedForFuel body C k ≤ G) :
+    execIRStmt F state
+        (.for_ [] (.call "lt" [.ident idxN, .ident cntN])
+          [.assign idxN (.call "add" [.ident idxN, .lit 1])] body) =
+      execIRStmt G state
+        (.for_ [] (.call "lt" [.ident idxN, .ident cntN])
+          [.assign idxN (.call "add" [.ident idxN, .lit 1])] body) := by
+  rw [show F = boundedForFuel body C k + (F - boundedForFuel body C k) from by
+      omega,
+    execIRStmt_boundedFor_stable idxN cntN hne body hLF hpres (C - k) k C rfl
+      state _ hidx hcnt hkC hCM,
+    show G = boundedForFuel body C k + (G - boundedForFuel body C k) from by
+      omega,
+    execIRStmt_boundedFor_stable idxN cntN hne body hLF hpres (C - k) k C rfl
+      state _ hidx hcnt hkC hCM]
+
+/-! ### Fuel bound vs. term size
+
+`execIRFunction` budgets fuel at `sizeOf fn.body + 1`; these lemmas show the
+structural fuel bound is always within that budget — the seam the upcoming
+`forEach` fragment admission threads through (the literal bound `N` is part
+of the compiled loop's `sizeOf` via its `let cnt := lit N` initializer). -/
+
+theorem yulStmt_sizeOf_pos (s : YulStmt) : 0 < sizeOf s := by
+  cases s <;> simp
+
+mutual
+
+/-- The structural fuel bound is dominated by term size: the `sizeOf`-based
+fuel budget of `execIRFunction` always covers the loop-free bound. -/
+theorem stmtFuelBound_le_sizeOf : ∀ (s : YulStmt), stmtFuelBound s ≤ sizeOf s
+  | .if_ cond body => by
+      have h := stmtsFuelBound_le_sizeOf body
+      simp only [stmtFuelBound]
+      simp
+      omega
+  | .block stmts => by
+      have h := stmtsFuelBound_le_sizeOf stmts
+      simp only [stmtFuelBound]
+      simp
+      omega
+  | .switch e cases dflt => by
+      have hc := casesFuelBound_le_sizeOf cases
+      have hd := dfltFuelBound_le_sizeOf dflt
+      have hmax : Nat.max (casesFuelBound cases) (dfltFuelBound dflt) ≤
+          sizeOf cases + sizeOf dflt :=
+        Nat.max_le.mpr ⟨Nat.le_trans hc (Nat.le_add_right _ _),
+          Nat.le_trans hd (Nat.le_add_left _ _)⟩
+      simp only [stmtFuelBound]
+      simp
+      omega
+  | .comment _ => by
+      simp only [stmtFuelBound]
+      exact yulStmt_sizeOf_pos _
+  | .let_ _ e => by
+      simp only [stmtFuelBound]
+      exact yulStmt_sizeOf_pos _
+  | .letMany _ _ => by
+      simp only [stmtFuelBound]
+      exact yulStmt_sizeOf_pos _
+  | .assign _ _ => by
+      simp only [stmtFuelBound]
+      exact yulStmt_sizeOf_pos _
+  | .leave => by
+      simp only [stmtFuelBound]
+      exact yulStmt_sizeOf_pos _
+  | .exprStmt _ => by
+      simp only [stmtFuelBound]
+      exact yulStmt_sizeOf_pos _
+  | .funcDef _ _ _ _ => by
+      simp only [stmtFuelBound]
+      exact yulStmt_sizeOf_pos _
+  | .for_ _ _ _ _ => by
+      simp only [stmtFuelBound]
+      exact yulStmt_sizeOf_pos _
+
+theorem casesFuelBound_le_sizeOf :
+    ∀ (cs : List (Nat × List YulStmt)), casesFuelBound cs ≤ sizeOf cs
+  | [] => by simp [casesFuelBound]
+  | (k, body) :: rest => by
+      have h1 := stmtsFuelBound_le_sizeOf body
+      have h2 := casesFuelBound_le_sizeOf rest
+      have hmax : Nat.max (stmtsFuelBound body) (casesFuelBound rest) ≤
+          sizeOf body + sizeOf rest :=
+        Nat.max_le.mpr ⟨Nat.le_trans h1 (Nat.le_add_right _ _),
+          Nat.le_trans h2 (Nat.le_add_left _ _)⟩
+      simp only [casesFuelBound]
+      simp
+      omega
+
+theorem dfltFuelBound_le_sizeOf :
+    ∀ (d : Option (List YulStmt)), dfltFuelBound d ≤ sizeOf d
+  | none => by simp [dfltFuelBound]
+  | some stmts => by
+      have h := stmtsFuelBound_le_sizeOf stmts
+      simp only [dfltFuelBound]
+      simp
+      omega
+
+theorem stmtsFuelBound_le_sizeOf :
+    ∀ (xs : List YulStmt), stmtsFuelBound xs ≤ sizeOf xs
+  | [] => by simp [stmtsFuelBound]
+  | x :: rest => by
+      have h1 := stmtFuelBound_le_sizeOf x
+      have h2 := stmtsFuelBound_le_sizeOf rest
+      have h3 := yulStmt_sizeOf_pos x
+      have hmax : Nat.max (stmtFuelBound x) (stmtsFuelBound rest) ≤
+          sizeOf x + sizeOf rest :=
+        Nat.max_le.mpr ⟨Nat.le_trans h1 (Nat.le_add_right _ _),
+          Nat.le_trans h2 (Nat.le_add_left _ _)⟩
+      simp only [stmtsFuelBound]
+      simp
+      omega
+
+end
+
+end Compiler.Proofs.IRGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -45,6 +45,8 @@ import Compiler.Proofs.EventSemantics
 import Compiler.Proofs.ExecutionSummary
 import Compiler.Proofs.Frames
 import Compiler.Proofs.HelperStepProofs
+import Compiler.Proofs.IRGeneration.BoundedLoopCheck
+import Compiler.Proofs.IRGeneration.BoundedLoopFuel
 import Compiler.Proofs.IRGeneration.CEISafety
 import Compiler.Proofs.IRGeneration.Contract
 import Compiler.Proofs.IRGeneration.ContractFeatureTest
@@ -2086,6 +2088,30 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.fullHelperAwareListWitness_of_allInterfaces_disjoint
   Compiler.Proofs.HelperStepProofs.helperFreeContractWitness
   Compiler.Proofs.HelperStepProofs.helperFreeContractWitness_disjoint
+
+  -- Compiler/Proofs/IRGeneration/BoundedLoopCheck.lean
+  Compiler.Proofs.IRGeneration.applyYulLogCall?_vars
+  Compiler.Proofs.IRGeneration.execIRStmt_exprStmt_state_vars
+  Compiler.Proofs.IRGeneration.IRState.getVar_congr_vars
+  Compiler.Proofs.IRGeneration.varUntouchedCheckCases_mem
+  Compiler.Proofs.IRGeneration.execIRStmt_getVar_of_checked
+  Compiler.Proofs.IRGeneration.execIRStmts_getVar_of_checked
+  Compiler.Proofs.IRGeneration.counter_preservation_of_checked
+
+  -- Compiler/Proofs/IRGeneration/BoundedLoopFuel.lean
+  Compiler.Proofs.IRGeneration.IRState.getVar_setVar_self
+  -- Compiler.Proofs.IRGeneration.find?_filter_ne_name  -- private
+  Compiler.Proofs.IRGeneration.IRState.getVar_setVar_ne
+  Compiler.Proofs.IRGeneration.execIRStmts_forEach_post
+  Compiler.Proofs.IRGeneration.evalIRExpr_forEach_cond
+  Compiler.Proofs.IRGeneration.stmtsFuelBound_post_eq
+  Compiler.Proofs.IRGeneration.execIRStmt_boundedFor_stable
+  Compiler.Proofs.IRGeneration.execIRStmt_boundedFor_stable_of_le
+  Compiler.Proofs.IRGeneration.yulStmt_sizeOf_pos
+  Compiler.Proofs.IRGeneration.stmtFuelBound_le_sizeOf
+  Compiler.Proofs.IRGeneration.casesFuelBound_le_sizeOf
+  Compiler.Proofs.IRGeneration.dfltFuelBound_le_sizeOf
+  Compiler.Proofs.IRGeneration.stmtsFuelBound_le_sizeOf
 
   -- Compiler/Proofs/IRGeneration/CEISafety.lean
   Compiler.Proofs.IRGeneration.CEIProofBackedExecution.execution_safe
@@ -6783,4 +6809,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6308 theorems/lemmas (4444 public, 1864 private, 0 sorry'd)
+-- Total: 6328 theorems/lemmas (4463 public, 1865 private, 0 sorry'd)

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -169,7 +169,7 @@
   "mechanisms": {
     "@[implemented_by": 1,
     "native_decide": 477,
-    "partial def": 169
+    "partial def": 170
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",
   "schema_version": 1

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 1070,
+    "core_lines": 1098,
     "example_contracts": 16
   },
   "proofs": {

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -404,6 +404,15 @@ ALLOWLIST: set[str] = {
     "supported_function_correct_with_body_interface_except_mapping_writes_stmtSafety",
     # --- Legacy compatibility and dispatch ---
     "interpretContract_correct_of_compiled_functions_except_mapping_writes_and_helper_ir_closed",
+    # bounded-loop fuel stability: the induction on remaining iterations must
+    # thread the counter invariant through the three body outcomes and the
+    # post-increment in one pass; splitting per-outcome would duplicate the
+    # loop-unfold plumbing at both fuel indices.
+    "execIRStmt_boundedFor_stable",
+    # counter-preservation soundness: mutual structural recursion over the
+    # statement grammar (mirrors execIRStmt_stable); per-constructor splits
+    # would break the mutual recursion with the list companion.
+    "execIRStmt_getVar_of_checked",
     # master compileValidatedCore inversion: pins every field of the output
     # record in one pass (mapM + constructor + record shape); all per-projection
     # shape lemmas are one-line derivations of it, so splitting it would just


### PR DESCRIPTION
## Summary
Refactor item 4 (bounded-loop fragment), foundation PR: fuel stability for the steady-state loop emitted by the `forEach` lowering — `for_ [] lt(idx,cnt) [idx := add(idx,1)] body` — extending the `FuelBound.lean` loop-free stability story (#2276 option (c)) to literal-bound loops.

### `BoundedLoopFuel.lean`
- `boundedForFuel body C k = (C − k) + max(bodyBound, postBound) + 1` — each interpreter iteration peels exactly one `succ` (the `for_ []` re-entry), body/post run at the current decreasing fuel.
- `execIRStmt_boundedFor_stable` (+ `_of_le` consumer API): under the counter invariant (`idx ↦ k`, `cnt ↦ C`, `k ≤ C < 2²⁵⁶`, body loop-free and counter-preserving), execution at the bound and at any larger fuel agree. Induction on `C − k`; the recursive `for_` call at fuel `B−1` is *exactly* `boundedForFuel body C (k+1)`, so the IH applies with no fuel juggling.
- Supporting: `lt`/`add` condition/post evaluation lemmas (via the existing `evalPureBuiltinViaEvmYulLean` simp set), `IRState.getVar_setVar_{self,ne}`.

### `BoundedLoopCheck.lean`
- `varUntouchedCheck v` — executable mirror of "body never binds or assigns `v`" (loops excluded, mirroring `LoopFree`), in the `spliceSimCheck` per-contract-`decide` style.
- Soundness `execIRStmt(s)_getVar_of_checked`: mutual structural recursion; the `exprStmt` case proves every interpreter branch (sstore/mstore/tstore/logs/halts/generic calls) preserves the variable environment.
- `counter_preservation_of_checked`: bridges the checker to the stability theorem's semantic hypothesis.
- End-to-end `example`: a concrete loop body discharges every side-condition by `decide`/`trivial`.

### Not in this PR (next lane, design recorded)
Fragment admission of non-empty literal `forEach` (source↔IR per-iteration correspondence + `requiredFuel` threading into the function-level slack + generic freshness discharge from `pickFreshName`). This PR is the fuel-side foundation it consumes.

## Verification
- Both modules `lake env lean` clean (no errors, no warnings); full `lake build` + `make check` green on the rebased head.
- Proof-length allowlist: +2 entries (`execIRStmt_boundedFor_stable`, `execIRStmt_getVar_of_checked`) with justifications.
- PrintAxioms regenerated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions to the IR generation verification layer; no runtime compiler or execution behavior changes.
> 
> **Overview**
> Adds Lean proof infrastructure for **literal-bound `forEach` loops** (#2276), extending loop-free fuel stability to the steady-state Yul shape `for_ [] lt(idx,cnt) [idx := add(idx,1)] body`.
> 
> **`BoundedLoopFuel.lean`** introduces `boundedForFuel` and proves `execIRStmt_boundedFor_stable` / `_of_le`: under counter invariants and a semantic “body preserves idx/cnt” hypothesis, execution at the structural fuel bound matches any extra fuel. Supporting lemmas cover `lt`/`add` evaluation, `IRState` variable updates, and `stmtsFuelBound ≤ sizeOf` for future `execIRFunction` budgeting.
> 
> **`BoundedLoopCheck.lean`** adds `varUntouchedCheck` (decidable scan that idx/cnt are never bound or assigned in the body) with soundness theorems bridging to `counter_preservation_of_checked`, plus an end-to-end `example` discharging side conditions via `decide`.
> 
> Wiring: new imports in `PrintAxioms.lean`, proof-length allowlist entries for the two large mutual/inductive proofs, and minor artifact counter bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b286ae6f20c9bdc813768d195342aec98e29e347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->