### PR TITLE
feat(core): storage-lens burn-down — C5 step 2.5 (pre-flip)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ FOUNDRY_PROFILE=difftest forge test  # Must pass — runs all Foundry tests
 
 **When adding a new contract**, also update:
 - Author the contract with `verity_contract`; do not add a separate hand-written `Compiler.Specs` body unless the workflow truly requires a special case like external linking.
+- A new reusable facet (Ownable, Pausable, …) is a `verity_mixin` plus named-slot specs, a `Footprint`, and `_meets_spec` / guard theorems. Hosts `include` the mixin; do not copy `Owned.lean` into the host.
 - Add the macro-generated `<Name>.spec` alias/list entry in [`Contracts/Specs.lean`](Contracts/Specs.lean) if the contract should ship through the default compiler manifest.
 - `test/property_manifest.json` — Run `python3 scripts/extract_property_manifest.py`
 - `README.md` — Contracts table (theorem count and description)

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -2364,9 +2364,7 @@ example : storageDynamicArrayPopUsesStorageStmt = true := by native_decide
 
 def storageDynamicArrayExecutableReadsHead : Bool :=
   let seededState : Verity.ContractState :=
-    { Verity.defaultState with
-      storageArray := fun idx =>
-        if idx == (MacroStorageDynamicArray.queue).slot then [11, 17] else [] }
+    Verity.defaultState.writeArray (MacroStorageDynamicArray.queue).slot [11, 17]
   match MacroStorageDynamicArray.firstValue seededState with
   | .success value state =>
       value == 11 && state.storageArray (MacroStorageDynamicArray.queue).slot == [11, 17]
@@ -2385,9 +2383,7 @@ example : storageDynamicArrayExecutableReadRevertsOutOfBounds = true := by nativ
 
 def storageDynamicArrayExecutableSetUpdatesHead : Bool :=
   let seededState : Verity.ContractState :=
-    { Verity.defaultState with
-      storageArray := fun idx =>
-        if idx == (MacroStorageDynamicArray.queue).slot then [11, 17] else [] }
+    Verity.defaultState.writeArray (MacroStorageDynamicArray.queue).slot [11, 17]
   match MacroStorageDynamicArray.setValue0 29 seededState with
   | .success () state =>
       state.storageArray (MacroStorageDynamicArray.queue).slot == [29, 17]
@@ -2406,9 +2402,7 @@ example : storageDynamicArrayExecutableSetRevertsOutOfBounds = true := by native
 
 def storageDynamicArrayExecutablePopShrinksLength : Bool :=
   let seededState : Verity.ContractState :=
-    { Verity.defaultState with
-      storageArray := fun idx =>
-        if idx == (MacroStorageDynamicArray.queue).slot then [11, 17] else [] }
+    Verity.defaultState.writeArray (MacroStorageDynamicArray.queue).slot [11, 17]
   match MacroStorageDynamicArray.popValue seededState with
   | .success () state =>
       state.storageArray (MacroStorageDynamicArray.queue).slot == [11]

--- a/Compiler/Proofs/Frames.lean
+++ b/Compiler/Proofs/Frames.lean
@@ -913,7 +913,7 @@ theorem writeUintSlots_preserves_storage_except
     (writeUintSlots world slots value).storage slot = world.storage slot := by
   have hcontains : (slots.map wordNormalize).contains slot = false := by
     simpa [List.elem_eq_contains] using hslot
-  simp only [writeUintSlots]
+  simp only [writeUintSlots, Verity.ContractState.writeSlots]
   rw [hcontains]
   simp
 
@@ -946,7 +946,7 @@ theorem writeAddressSlots_preserves_address_except
     (writeAddressSlots world slots value).storageAddr slot = world.storageAddr slot := by
   have hcontains : (slots.map wordNormalize).contains slot = false := by
     simpa [List.elem_eq_contains] using hslot
-  simp only [writeAddressSlots]
+  simp only [writeAddressSlots, Verity.ContractState.writeAddrSlots]
   rw [hcontains]
   simp
 
@@ -980,7 +980,7 @@ theorem writeUintFieldSlots_preserves_address
       world.storageAddr slot := by
   generalize hfind : Compiler.CompilationModel.findFieldWithResolvedSlot fields fieldName = found
   cases found with
-  | none => simp [writeUintFieldSlots, hfind, writeUintSlots]
+  | none => simp [writeUintFieldSlots, hfind, writeUintSlots, Verity.ContractState.writeSlots]
   | some result =>
       rcases result with ⟨field, resolvedSlot⟩
       generalize hpacked : field.packedBits = packed
@@ -994,7 +994,7 @@ theorem writeUintFieldSlots_preserves_arrays
       world.storageArray slot := by
   generalize hfind : Compiler.CompilationModel.findFieldWithResolvedSlot fields fieldName = found
   cases found with
-  | none => simp [writeUintFieldSlots, hfind, writeUintSlots]
+  | none => simp [writeUintFieldSlots, hfind, writeUintSlots, Verity.ContractState.writeSlots]
   | some result =>
       rcases result with ⟨field, resolvedSlot⟩
       generalize hpacked : field.packedBits = packed
@@ -1007,7 +1007,7 @@ theorem writeUintFieldSlots_preserves_calldata
     (writeUintFieldSlots fields fieldName world slots value).calldata = world.calldata := by
   generalize hfind : Compiler.CompilationModel.findFieldWithResolvedSlot fields fieldName = found
   cases found with
-  | none => simp [writeUintFieldSlots, hfind, writeUintSlots]
+  | none => simp [writeUintFieldSlots, hfind, writeUintSlots, Verity.ContractState.writeSlots]
   | some result =>
       rcases result with ⟨field, resolvedSlot⟩
       generalize hpacked : field.packedBits = packed
@@ -1022,7 +1022,7 @@ theorem writeAddressFieldSlots_preserves_address_except
       world.storageAddr slot := by
   simp only [writeAddressFieldSlots]
   split
-  · simp [writeTransientTargets]
+  · simp [writeTransientTargets, Verity.ContractState.writeTransientSlots]
   · exact writeAddressSlots_preserves_address_except world slots value slot hslot
 
 theorem writeAddressFieldSlots_preserves_storage
@@ -1030,7 +1030,8 @@ theorem writeAddressFieldSlots_preserves_storage
     (world : Verity.ContractState) (slots : List Nat) (value slot : Nat) :
     (writeAddressFieldSlots fields fieldName world slots value).storage slot = world.storage slot := by
   simp only [writeAddressFieldSlots]
-  split <;> simp [writeTransientTargets, writeAddressSlots]
+  split <;> simp [writeTransientTargets, writeAddressSlots,
+    Verity.ContractState.writeTransientSlots, Verity.ContractState.writeAddrSlots]
 
 theorem writeAddressFieldSlots_preserves_arrays
     (fields : List Compiler.CompilationModel.Field) (fieldName : String)
@@ -1038,14 +1039,16 @@ theorem writeAddressFieldSlots_preserves_arrays
     (writeAddressFieldSlots fields fieldName world slots value).storageArray slot =
       world.storageArray slot := by
   simp only [writeAddressFieldSlots]
-  split <;> simp [writeTransientTargets, writeAddressSlots]
+  split <;> simp [writeTransientTargets, writeAddressSlots,
+    Verity.ContractState.writeTransientSlots, Verity.ContractState.writeAddrSlots]
 
 theorem writeAddressFieldSlots_preserves_calldata
     (fields : List Compiler.CompilationModel.Field) (fieldName : String)
     (world : Verity.ContractState) (slots : List Nat) (value : Nat) :
     (writeAddressFieldSlots fields fieldName world slots value).calldata = world.calldata := by
   simp only [writeAddressFieldSlots]
-  split <;> simp [writeTransientTargets, writeAddressSlots]
+  split <;> simp [writeTransientTargets, writeAddressSlots,
+    Verity.ContractState.writeTransientSlots, Verity.ContractState.writeAddrSlots]
 
 theorem writeStorageArray_preserves_arrays_except
     (world : Verity.ContractState) (arraySlot slot : Nat) (values : List Verity.Core.Uint256)

--- a/Compiler/Proofs/IRGeneration/CompiledNameDiscipline.lean
+++ b/Compiler/Proofs/IRGeneration/CompiledNameDiscipline.lean
@@ -1,0 +1,146 @@
+import Compiler.Proofs.IRGeneration.BoundedLoopCheck
+import Compiler.Proofs.IRGeneration.SupportedFragment
+
+/-!
+# Name discipline of compiled fragment output
+
+The `forEach` loop coupling needs: the compiled body never binds or assigns
+the loop's synthetic counters.  The compiler guarantees this by scope
+threading — `forEachBodyScope` places the counters in `inScopeNames`, so
+every `pickFreshName`-generated scratch name avoids them, and every other
+emitted target is a source name.  This module packages that discipline:
+
+- a prefix-discrimination toolkit (`pickFreshName_startsWith`,
+  `ne_of_startsWith_of_not_startsWith`) in the kernel-friendly
+  `String.startsWith` style of `ReservedScratchNames.lean`;
+- (next step) `supportedStmtList_compiled_varUntouched`, by induction over
+  `SupportedStmtList`: each fragment constructor's compiled shape is
+  explicit, its targets are source names or `__compat_*`/`__evt_*` scratch,
+  and `varUntouchedCheck` never inspects expression innards.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.CompilationModel
+
+/-- `pickFreshName` output always extends its base. -/
+theorem pickFreshName_startsWith (base : String) (usedNames : List String) :
+    (pickFreshName base usedNames).startsWith base = true := by
+  unfold pickFreshName
+  by_cases h : usedNames.contains base
+  · simp only [h, Bool.not_true, Bool.false_eq_true, if_false]
+    rw [String.startsWith_string_iff]
+    exact ⟨_, by simp [String.toList_append, List.append_assoc]; rfl⟩
+  · have hnot : base ∉ usedNames := by simpa using h
+    simp [List.contains_eq_mem, hnot]
+
+/-- Prefix discrimination: a name extending `p` is distinct from any name
+that does not extend `p`. -/
+theorem ne_of_startsWith_of_not_startsWith
+    {v s p : String}
+    (hv : v.startsWith p = true) (hs : s.startsWith p = false) :
+    v ≠ s := by
+  intro hEq
+  rw [hEq, hs] at hv
+  cases hv
+
+open Compiler.Yul
+
+mutual
+
+/-- Executable mirror of `LoopFree`. -/
+def loopFreeCheck : YulStmt → Bool
+  | .if_ _ body => loopFreeCheckList body
+  | .block stmts => loopFreeCheckList stmts
+  | .switch _ cases dflt => loopFreeCheckCases cases && loopFreeCheckDflt dflt
+  | .for_ _ _ _ _ => false
+  | _ => true
+
+def loopFreeCheckCases : List (Nat × List YulStmt) → Bool
+  | [] => true
+  | c :: rest => loopFreeCheckList c.2 && loopFreeCheckCases rest
+
+def loopFreeCheckDflt : Option (List YulStmt) → Bool
+  | none => true
+  | some stmts => loopFreeCheckList stmts
+
+def loopFreeCheckList : List YulStmt → Bool
+  | [] => true
+  | s :: rest => loopFreeCheck s && loopFreeCheckList rest
+
+end
+
+mutual
+
+/-- Soundness: a checked statement is loop-free. -/
+theorem loopFreeCheck_sound : ∀ (s : YulStmt), loopFreeCheck s = true → LoopFree s
+  | .if_ _ body, h => by
+      simp only [LoopFree]
+      exact loopFreeCheckList_sound body (by simpa [loopFreeCheck] using h)
+  | .block stmts, h => by
+      simp only [LoopFree]
+      exact loopFreeCheckList_sound stmts (by simpa [loopFreeCheck] using h)
+  | .switch _ cases dflt, h => by
+      obtain ⟨hc, hd⟩ : loopFreeCheckCases cases = true ∧
+          loopFreeCheckDflt dflt = true := by
+        simpa [loopFreeCheck, Bool.and_eq_true] using h
+      exact ⟨loopFreeCheckCases_sound cases hc, loopFreeCheckDflt_sound dflt hd⟩
+  | .for_ _ _ _ _, h => by simp [loopFreeCheck] at h
+  | .comment _, _ => trivial
+  | .let_ _ _, _ => trivial
+  | .letMany _ _, _ => trivial
+  | .assign _ _, _ => trivial
+  | .leave, _ => trivial
+  | .funcDef _ _ _ _, _ => trivial
+  | .exprStmt _, _ => trivial
+
+theorem loopFreeCheckCases_sound :
+    ∀ (cs : List (Nat × List YulStmt)), loopFreeCheckCases cs = true →
+      LoopFreeCases cs
+  | [], _ => trivial
+  | c :: rest, h => by
+      obtain ⟨hc, hrest⟩ : loopFreeCheckList c.2 = true ∧
+          loopFreeCheckCases rest = true := by
+        simpa [loopFreeCheckCases, Bool.and_eq_true] using h
+      exact ⟨loopFreeCheckList_sound c.2 hc, loopFreeCheckCases_sound rest hrest⟩
+
+theorem loopFreeCheckDflt_sound :
+    ∀ (d : Option (List YulStmt)), loopFreeCheckDflt d = true → LoopFreeDflt d
+  | none, _ => trivial
+  | some stmts, h =>
+      loopFreeCheckList_sound stmts (by simpa [loopFreeCheckDflt] using h)
+
+theorem loopFreeCheckList_sound :
+    ∀ (xs : List YulStmt), loopFreeCheckList xs = true → LoopFreeList xs
+  | [], _ => trivial
+  | s :: rest, h => by
+      obtain ⟨hs, hrest⟩ : loopFreeCheck s = true ∧
+          loopFreeCheckList rest = true := by
+        simpa [loopFreeCheckList, Bool.and_eq_true] using h
+      exact ⟨loopFreeCheck_sound s hs, loopFreeCheckList_sound rest hrest⟩
+
+end
+
+/-- Per-contract decidable gate for admitting a literal-bound `forEach` body:
+the compiled body must be loop-free and must never touch the loop's synthetic
+counters.  Discharged by `decide` on concrete contracts; a generic
+name-discipline theorem can later eliminate the counter checks. -/
+def forEachCompiledBodyChecks
+    (fields : List Compiler.CompilationModel.Field)
+    (scope : List String) (varName : String)
+    (count : Compiler.CompilationModel.Expr)
+    (body : List Compiler.CompilationModel.Stmt) : Bool :=
+  let forUsedNames := varName :: (scope ++
+    Compiler.CompilationModel.collectExprNames count ++
+    Compiler.CompilationModel.collectStmtListNames body)
+  let idxName := Compiler.CompilationModel.pickFreshName "__forEach_idx" forUsedNames
+  let countName := Compiler.CompilationModel.pickFreshName "__forEach_count"
+    (idxName :: forUsedNames)
+  match Compiler.CompilationModel.compileStmtList fields [] [] .calldata [] false
+      (Compiler.CompilationModel.forEachBodyScope scope varName count body) [] body with
+  | .ok ir =>
+      loopFreeCheckList ir &&
+        varUntouchedCheckList idxName ir &&
+        varUntouchedCheckList countName ir
+  | .error _ => false
+
+end Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -237,7 +237,8 @@ theorem writeAddressKeyedMappingSlots_eq
   | cons slot rest =>
       have h := storageRel_foldl k v id (slot :: rest) (storageRel_base w)
       simp only [Denote.writeAddressKeyedMappingSlots,
-        SourceSemantics.writeAddressKeyedMappingSlots]
+        SourceSemantics.writeAddressKeyedMappingSlots,
+        Verity.ContractState.withStorageChannel, Verity.ContractState.writeMap]
       congr 1
       exact storage_field_eq_of_rel h
 
@@ -250,7 +251,8 @@ theorem writeUintKeyedMappingSlots_eq
   | cons slot rest =>
       have h := storageRel_foldl k v id (slot :: rest) (storageRel_base w)
       simp only [Denote.writeUintKeyedMappingSlots,
-        SourceSemantics.writeUintKeyedMappingSlots]
+        SourceSemantics.writeUintKeyedMappingSlots,
+        Verity.ContractState.withStorageChannel, Verity.ContractState.writeMapUint]
       congr 1
       exact storage_field_eq_of_rel h
 
@@ -264,7 +266,8 @@ theorem writeAddressKeyedMapping2Slots_eq
       have h := storageRel_foldl k2 v (fun slot => Compiler.Proofs.abstractMappingSlot slot k1)
         (slot :: rest) (storageRel_base w)
       simp only [Denote.writeAddressKeyedMapping2Slots,
-        SourceSemantics.writeAddressKeyedMapping2Slots]
+        SourceSemantics.writeAddressKeyedMapping2Slots,
+        Verity.ContractState.withStorageChannel, Verity.ContractState.writeMap2]
       congr 1
       exact storage_field_eq_of_rel h
 

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
@@ -39,9 +39,9 @@ private theorem encodeStorageAt_writeUintSlots_singleton_other
   apply SourceSemantics.encodeStorageAt_congr
   · have hneq' : query ≠ slot % Compiler.Constants.evmModulus := by
       simpa [SourceSemantics.wordNormalize] using hneq
-    simp [SourceSemantics.writeUintSlots, SourceSemantics.wordNormalize, hneq']
-  · simp [SourceSemantics.writeUintSlots]
-  · simp [SourceSemantics.writeUintSlots]
+    simp [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots, SourceSemantics.wordNormalize, hneq']
+  · simp [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots]
+  · simp [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots]
 
 private theorem encodeStorageAt_writeUintSlots_other
     {fields : List Field}
@@ -54,12 +54,12 @@ private theorem encodeStorageAt_writeUintSlots_other
       query =
       SourceSemantics.encodeStorageAt fields world query := by
   apply SourceSemantics.encodeStorageAt_congr
-  · simp only [SourceSemantics.writeUintSlots]
+  · simp only [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots]
     rw [show (slots.map SourceSemantics.wordNormalize).contains query = false from by
       simpa using hnotMem]
     simp
-  · simp [SourceSemantics.writeUintSlots]
-  · simp [SourceSemantics.writeUintSlots]
+  · simp [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots]
+  · simp [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots]
 
 set_option maxHeartbeats 800000 in
 private theorem encodeStorageAt_writeUintKeyedMappingSlots_singleton_other
@@ -1392,7 +1392,7 @@ private theorem runtimeStateMatchesIR_writeUintSlot
           (show findResolvedFieldAtSlotCopy fields (SourceSemantics.wordNormalize slot) = some f from
             by rw [findResolvedFieldAtSlotCopy_wordNormalize]; exact hresolved)
       rw [encodeStorageAt_eq_storage_of_resolvedSlot hresolved' hnotAddr hnotDyn]
-      simp [SourceSemantics.writeUintSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
+      simp [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
         SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
         Verity.Core.UINT256_MODULUS, Verity.Core.Uint256.val_ofNat]
       exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
@@ -1482,7 +1482,7 @@ private theorem runtimeStateMatchesIR_writeAddressSlot
           (show findResolvedFieldAtSlotCopy fields (SourceSemantics.wordNormalize slot) = some f from
             by rw [findResolvedFieldAtSlotCopy_wordNormalize]; exact hresolved)
       rw [encodeStorageAt_eq_storageAddr_of_resolvedSlot hresolved' haddr hnotDyn]
-      simp [SourceSemantics.writeAddressSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
+      simp [SourceSemantics.writeAddressSlots, Verity.ContractState.writeAddrSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
         SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
         Verity.Core.UINT256_MODULUS,
         Verity.wordToAddress, Verity.Core.Address.ofNat, Verity.Core.Uint256.val_ofNat,
@@ -1501,9 +1501,9 @@ private theorem runtimeStateMatchesIR_writeAddressSlot
       have hneqNat' : query.toNat ≠ slot % Compiler.Constants.evmModulus := by
         simpa [SourceSemantics.wordNormalize] using hneqNat
       apply SourceSemantics.encodeStorageAt_congr
-      · simp [SourceSemantics.writeAddressSlots]
-      · simp [SourceSemantics.writeAddressSlots, SourceSemantics.wordNormalize, hneqNat']
-      · simp [SourceSemantics.writeAddressSlots]
+      · simp [SourceSemantics.writeAddressSlots, Verity.ContractState.writeAddrSlots]
+      · simp [SourceSemantics.writeAddressSlots, Verity.ContractState.writeAddrSlots, SourceSemantics.wordNormalize, hneqNat']
+      · simp [SourceSemantics.writeAddressSlots, Verity.ContractState.writeAddrSlots]
 
 private theorem runtimeStateMatchesIR_writeUintSlots
     {fields : List Field}
@@ -1547,7 +1547,7 @@ private theorem runtimeStateMatchesIR_writeUintSlots
                 (slot % Verity.Core.Uint256.modulus) = true := by
             simpa [SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
               Verity.Core.UINT256_MODULUS, Verity.Core.Uint256.modulus] using hcontains
-        simp only [SourceSemantics.writeUintSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
+        simp only [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
             SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
             Verity.Core.UINT256_MODULUS, hcontains',
             ↓reduceIte, Verity.Core.Uint256.val_ofNat]
@@ -1623,17 +1623,17 @@ private theorem runtimeStateMatchesIR_writeTransientTarget
   · funext query
     rw [hstorage]
     exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-      (SourceSemantics.encodeStorageAt_congr (by simp [SourceSemantics.writeTransientTargets])
-        (by simp [SourceSemantics.writeTransientTargets])
-        (by simp [SourceSemantics.writeTransientTargets]))
+      (SourceSemantics.encodeStorageAt_congr (by simp [SourceSemantics.writeTransientTargets, Verity.ContractState.writeTransientSlots])
+        (by simp [SourceSemantics.writeTransientTargets, Verity.ContractState.writeTransientSlots])
+        (by simp [SourceSemantics.writeTransientTargets, Verity.ContractState.writeTransientSlots]))
   · funext slot
     by_cases hslot : slot = SourceSemantics.wordNormalize target
     · subst hslot
-      simp [SourceSemantics.writeTransientTargets]
+      simp [SourceSemantics.writeTransientTargets, Verity.ContractState.writeTransientSlots]
       exact (Nat.mod_eq_of_lt (by
         simpa [Compiler.Constants.evmModulus, Verity.Core.UINT256_MODULUS,
           Verity.Core.Uint256.modulus] using hvalue)).symm
-    · simp [SourceSemantics.writeTransientTargets, hslot]
+    · simp [SourceSemantics.writeTransientTargets, Verity.ContractState.writeTransientSlots, hslot]
       have hslot' : slot ≠ target % Compiler.Constants.evmModulus := by
         simpa [SourceSemantics.wordNormalize] using hslot
       simp [hslot', congrFun htransient slot]

--- a/Compiler/Proofs/IRGeneration/GuardedSourceBridge.lean
+++ b/Compiler/Proofs/IRGeneration/GuardedSourceBridge.lean
@@ -73,7 +73,10 @@ theorem initialIRStateForTx_setLock (spec : CompilationModel)
        exact congrArg IRStorageWord.ofNat
          (encodeStorageAt_setLock _ world slot 1 o.toNat))
     | (funext o
-       by_cases h : o = slot <;> simp [setLock, h])
+       by_cases h : o = slot
+       · subst o
+         simp
+       · simp [h])
 
 /-- The revert projection ignores transient storage: overlaying the lock on
 the rollback state does not change it. -/

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -380,9 +380,7 @@ def writeUintSlots (world : Verity.ContractState) (slots : List Nat) (value : Na
     Verity.ContractState :=
   let word : Verity.Core.Uint256 := value
   let targets := slots.map wordNormalize
-  { world with
-    storage := fun slot =>
-      if targets.contains slot then word else world.storage slot }
+  world.writeSlots targets word
 
 def writeStorageWordSlot (world : Verity.ContractState) (slot wordOffset value : Nat) :
     Verity.ContractState :=
@@ -410,9 +408,7 @@ def writeAddressSlots (world : Verity.ContractState) (slots : List Nat) (value :
     Verity.ContractState :=
   let addr := Verity.wordToAddress (value : Verity.Core.Uint256)
   let targets := slots.map wordNormalize
-  { world with
-    storageAddr := fun slot =>
-      if targets.contains slot then addr else world.storageAddr slot }
+  world.writeAddrSlots targets addr
 
 def fieldIsTransient (fields : List Field) (name : String) : Bool :=
   match findFieldWithResolvedSlot fields name with
@@ -430,9 +426,7 @@ def writeTransientTargets (world : Verity.ContractState) (targets : List Nat) (v
     Verity.ContractState :=
   let word : Verity.Core.Uint256 := value
   let targets := targets.map wordNormalize
-  { world with
-    transientStorage := fun slot =>
-      if targets.contains slot then word else world.transientStorage slot }
+  world.writeTransientSlots targets word
 
 def packedWordWrite (current value : Nat) (packed : PackedBits) : Nat :=
   let maskNat := packedMaskNat packed

--- a/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
@@ -33,7 +33,7 @@ private def storageArraySourceSpec : CompilationModel :=
           body := [Stmt.storageArrayPop "queue", .stop] } ] }
 
 private def storageArrayInitialWorld : Verity.ContractState :=
-  { Verity.defaultState with storageArray := fun slot => if slot = 7 then [11, 17] else [] }
+  Verity.defaultState.writeArray 7 [11, 17]
 
 private def signedScalarSourceSpec : CompilationModel :=
   { name := "SignedScalarSource"

--- a/Compiler/Proofs/Storage/SolidityStorage.lean
+++ b/Compiler/Proofs/Storage/SolidityStorage.lean
@@ -77,7 +77,8 @@ def mappingSlotBridgeField (baseSlot : Nat) : Compiler.CompilationModel.Field :=
 
 /-- A slot-reflecting world makes a source read return its actual storage slot. -/
 def mappingSlotBridgeState : SourceSemantics.RuntimeState :=
-  { world := { Verity.defaultState with storage := fun slot => slot }, bindings := [] }
+  { world := Verity.defaultState.withStorageChannel (fun _ => fun slot => slot),
+    bindings := [] }
 
 /-- A source mapping expression evaluated in a slot-reflecting world exposes
     the exact slot passed to `readFieldWord`. -/
@@ -107,7 +108,7 @@ theorem compiledMappingSlotPointer_eq_sourceMappingSlotRead
   simp only [SourceSemantics.evalExpr]
   rw [hfield]
   simp [mappingSlotBridgeField, mappingSlotBridgeState, SourceSemantics.readFieldWord,
-    SourceSemantics.wordNormalize]
+    Verity.ContractState.withStorageChannel, SourceSemantics.wordNormalize]
   change Compiler.Proofs.solidityMappingSlot baseSlot key =
     Compiler.Proofs.solidityMappingSlot baseSlot
       (key % Compiler.Constants.evmModulus) % Compiler.Constants.evmModulus
@@ -234,8 +235,8 @@ def isSourcePackedRead (fields : List Compiler.CompilationModel.Field)
 /-- A runtime state holding `word` in every storage slot, so the bridge observes
     the packed extraction itself rather than slot arithmetic. -/
 def packedReadBridgeState (word : Word) : SourceSemantics.RuntimeState :=
-  { world := { Verity.defaultState with
-                storage := fun _ => Verity.Core.Uint256.ofNat word.toNat },
+  { world := Verity.defaultState.withStorageChannel
+      (fun _ => fun _ => Verity.Core.Uint256.ofNat word.toNat),
     bindings := [] }
 
 /-- The packed read performed by the executable source evaluator. -/
@@ -339,6 +340,7 @@ theorem compiledPackedRead_eq_sourceEvalPackedRead (word : Word) (offset width :
     unfold packedReadBridgeSourceExpr
     rw [SourceSemantics.evalExpr, hfield]
     simp [packedReadBridgeField, packedReadBridgeState,
+      Verity.ContractState.withStorageChannel,
       SourceSemantics.readFieldWord, SourceSemantics.wordNormalize]
   have hextract := uint256_packed_extract (word.toNat % Verity.Core.Uint256.modulus)
     { offset := offset, width := width } hraw hoffset

--- a/Compiler/Proofs/Storage/StructArrayStorage.lean
+++ b/Compiler/Proofs/Storage/StructArrayStorage.lean
@@ -177,7 +177,7 @@ theorem compiledStructMemberSlot_eq_sourceStructMemberSlotRead
     simp only [SourceSemantics.evalExpr, hfield, hmembers, structBridgeMember,
       structMemberBridgeState, Verity.ContractState.withStorageChannel,
       SourceSemantics.wordNormalize_eq_mod, Nat.mod_eq_of_lt hkey]
-    simp only [structBridgeField, structMemberBridgeState, SourceSemantics.readFieldWord,
+    simp only [structBridgeField, SourceSemantics.readFieldWord,
       SourceSemantics.wordNormalize]
     simp [findStructMember]
   rw [hsource]
@@ -742,7 +742,7 @@ theorem storageArrayLength_eq_storageArrayLength (slot : Nat)
     have hfield : findFieldWithResolvedSlot [arrayBridgeField slot] "__array_bridge" =
         some (arrayBridgeField slot, slot) := rfl
     rw [SourceSemantics.evalExpr, hfield]
-    simp [arrayBridgeState, Verity.ContractState.writeArray,
+    simp [arrayBridgeField, arrayBridgeState, Verity.ContractState.writeArray,
       Verity.ContractState.writeSlot]
   rw [hsource, compiledStorageArrayLength_eq]
   simp only [Except.toOption, Option.bind_some, interpretSloadLit, arrayBridgeState,
@@ -750,7 +750,7 @@ theorem storageArrayLength_eq_storageArrayLength (slot : Nat)
     SourceSemantics.wordNormalize]
   simp only [Option.some.injEq]
   simp [Verity.Core.Uint256.ofNat]
-  exact Nat.mod_eq_of_lt hlen
+  exact hlen
 
 /-- The real compiler output for a checked storage-array element read. -/
 def compiledStorageArrayElement (slot index : Nat) : Except String YulExpr :=
@@ -832,7 +832,7 @@ theorem storageArrayElement_eq_sourceEval (storage : SolidityStorage)
         (.storageArrayElement "__array_bridge" (.literal index)) := by
   have hcanonical : index < (storage id (slotPointer slot)).toNat := by
     have hlength := hcoherent.1
-    simp [arrayBridgeState] at hlength
+    simp [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] at hlength
     rw [hlength]
     exact hindex
   rw [storageArrayElement_eq_storageArrayElement storage id slot index hcanonical]
@@ -848,9 +848,9 @@ theorem storageArrayElement_eq_sourceEval (storage : SolidityStorage)
     rw [SourceSemantics.evalExpr]
     simp only [SourceSemantics.evalExpr, SourceSemantics.wordNormalize_eq_mod,
       Nat.mod_eq_of_lt hword, hfield]
-    simp [arrayBridgeField, arrayBridgeState, hvalue]
+    simp [arrayBridgeField, arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot, hvalue]
   rw [hsource]
-  exact congrArg some (hcoherent.2 index value (by simpa [arrayBridgeState] using hvalue))
+  exact congrArg some (hcoherent.2 index value (by simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using hvalue))
 
 /-- A checked read rejects an index at or beyond the length loaded from the
     canonical array slot. -/
@@ -1311,7 +1311,7 @@ theorem setStorageArrayElement_exec_preserved
     rw [SourceSemantics.execStmt, hfield]
     simp only [arrayBridgeField]
     simp [SourceSemantics.evalExpr, SourceSemantics.wordNormalize_eq_mod,
-      Nat.mod_eq_of_lt hindex, Nat.mod_eq_of_lt hvalue, arrayBridgeState, hset]
+      Nat.mod_eq_of_lt hindex, Nat.mod_eq_of_lt hvalue, arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot, hset]
   · simp [applyStateRewrite, storageArrayElementWrite]
 
 /-- Executable push appends at the source length, while the interpreted Yul
@@ -1340,7 +1340,7 @@ theorem pushStorageArray_exec_preserved
     rw [SourceSemantics.execStmt, hfield]
     simp only [arrayBridgeField]
     simp [SourceSemantics.evalExpr, SourceSemantics.wordNormalize_eq_mod,
-      Nat.mod_eq_of_lt hvalue, arrayBridgeState]
+      Nat.mod_eq_of_lt hvalue, arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot]
   · dsimp
     constructor
     · simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite, hdistinct]
@@ -1360,7 +1360,7 @@ theorem popStorageArray_exec_empty (storage : SolidityStorage)
   · have hfield : findFieldWithResolvedSlot [arrayBridgeField slot] "__array_bridge" =
         some (arrayBridgeField slot, slot) := rfl
     rw [SourceSemantics.execStmt, hfield]
-    simp [arrayBridgeField, arrayBridgeState, SourceSemantics.storageArrayDropLast?]
+    simp [arrayBridgeField, arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot, SourceSemantics.storageArrayDropLast?]
   · exact popStorageArray_empty storage currentContract slot hempty
 
 /-- For a nonempty executable pop, the source removes the last value and the
@@ -1387,7 +1387,7 @@ theorem popStorageArray_exec_preserved
   · have hfield : findFieldWithResolvedSlot [arrayBridgeField slot] "__array_bridge" =
         some (arrayBridgeField slot, slot) := rfl
     rw [SourceSemantics.execStmt, hfield]
-    simp [arrayBridgeField, arrayBridgeState, hdrop]
+    simp [arrayBridgeField, arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot, hdrop]
   · dsimp
     constructor
     · simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite, hdistinct]
@@ -1418,7 +1418,7 @@ theorem setStorageArrayElement_compiled_exec_coherent
       (IRStorageWord.ofNat value)] storage) currentContract slot
       (SourceSemantics.writeStorageArray (arrayBridgeState slot values).world slot updated) := by
   have hcanonical : index < (storage currentContract (slotPointer slot)).toNat := by
-    rw [hcoherent.1]; simpa [arrayBridgeState] using hindex
+    rw [hcoherent.1]; simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using hindex
   constructor
   · have hind : index % uint256Modulus = index := Nat.mod_eq_of_lt hword
     have hvaluemod : value % uint256Modulus = value := Nat.mod_eq_of_lt hvalue
@@ -1433,7 +1433,7 @@ theorem setStorageArrayElement_compiled_exec_coherent
       · simp [applyStateRewrite, storageArrayElementWrite,
           Ne.symm hlengthSlot, SourceSemantics.writeStorageArray,
           sourceStorageArraySetAt_length values updated index value hset]
-        simpa [arrayBridgeState] using hcoherent.1
+        simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using hcoherent.1
       · intro j x hj
         simp [SourceSemantics.writeStorageArray] at hj
         by_cases hji : j = index
@@ -1446,7 +1446,7 @@ theorem setStorageArrayElement_compiled_exec_coherent
         · have hsep := helementSlots j (List.getElem?_eq_some_iff.mp hj).1 hji
           simp [applyStateRewrite, storageArrayElementWrite, hsep]
           apply hcoherent.2 j x
-          simpa [arrayBridgeState] using sourceStorageArraySetAt_getElem?_of_ne
+          simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using sourceStorageArraySetAt_getElem?_of_ne
             values updated index j value x hset hji hj
 
 /-- Push derives its index from the canonical length word; coherence identifies
@@ -1467,7 +1467,7 @@ theorem pushStorageArray_compiled_exec_coherent
     StorageArrayCoherent (applyStateRewrite [storageArrayElementWrite currentContract slot values.length (IRStorageWord.ofNat value),
           storageArrayLengthWrite currentContract slot (values.length + 1)] storage)
       currentContract slot (SourceSemantics.writeStorageArray (arrayBridgeState slot values).world slot (values ++ [(value : Verity.Core.Uint256)])) := by
-  have hlength : (storage currentContract (slotPointer slot)).toNat = values.length := by simpa [arrayBridgeState] using hcoherent.1
+  have hlength : (storage currentContract (slotPointer slot)).toNat = values.length := by simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using hcoherent.1
   have hvaluemod : value % uint256Modulus = value := Nat.mod_eq_of_lt hvalue
   constructor
   · simpa [hlength, hvaluemod] using pushStorageArray_eq_compiledStorageArrayPush
@@ -1495,7 +1495,7 @@ theorem pushStorageArray_compiled_exec_coherent
           apply hcoherent.2 j x
           have hx : values[j] = x := by simpa [List.getElem?_append, hjlt] using hj
           have hold : values[j]? = some x := by rw [List.getElem?_eq_getElem hjlt, hx]
-          simpa [arrayBridgeState] using hold
+          simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using hold
 
 /-- Pop's empty guard and decremented index are both derived from the same
     canonical length word that coherence relates to the source array. -/
@@ -1516,7 +1516,7 @@ theorem popStorageArray_compiled_exec_coherent
           storageArrayLengthWrite currentContract slot updated.length] storage)
       currentContract slot
       (SourceSemantics.writeStorageArray (arrayBridgeState slot values).world slot updated) := by
-  have hlength : (storage currentContract (slotPointer slot)).toNat = values.length := by simpa [arrayBridgeState] using hcoherent.1
+  have hlength : (storage currentContract (slotPointer slot)).toNat = values.length := by simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using hcoherent.1
   have hlen : updated.length + 1 = values.length := sourceStorageArrayDropLast_length values updated hdrop
   have hnonempty : 0 < (storage currentContract (slotPointer slot)).toNat := by
     rw [hlength, ← hlen]; omega
@@ -1541,7 +1541,7 @@ theorem popStorageArray_compiled_exec_coherent
         have hsep := helementSlots j hjlt; have hlengthSep := hlengthElements j hjlt
         simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite,
           hsep, hlengthSep]
-        apply hcoherent.2 j x; simpa [arrayBridgeState] using
+        apply hcoherent.2 j x; simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using
           sourceStorageArrayDropLast_getElem? values updated j x hdrop hj
 
 /-- Empty pop is coherent end-to-end: both executable source semantics and the
@@ -1555,6 +1555,6 @@ theorem popStorageArray_compiled_exec_empty_coherent
     Option.bind (compiledStorageArrayPop slot).toOption
         (interpretCompiledStorageArrayPop storage currentContract) = none := by
   apply popStorageArray_exec_empty
-  simpa [arrayBridgeState] using hcoherent.1
+  simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using hcoherent.1
 
 end Compiler.Proofs.Storage

--- a/Compiler/Proofs/Storage/StructArrayStorage.lean
+++ b/Compiler/Proofs/Storage/StructArrayStorage.lean
@@ -128,7 +128,8 @@ def compiledStructMemberSlot (helper : YulStmt) (scratchBase : Nat) :
 /-- A slot-reflecting world makes a source struct-member read return the exact
     slot it consumed. -/
 def structMemberBridgeState : SourceSemantics.RuntimeState :=
-  { world := { Verity.defaultState with storage := fun slot => slot }, bindings := [] }
+  { world := Verity.defaultState.withStorageChannel (fun _ => fun slot => slot),
+    bindings := [] }
 
 /-- The slot the executable source evaluator reads for a struct member. -/
 def sourceStructMemberSlotRead (baseSlot key wordOffset : Nat) : Option Nat :=
@@ -174,6 +175,7 @@ theorem compiledStructMemberSlot_eq_sourceStructMemberSlotRead
     unfold sourceStructMemberSlotRead
     rw [SourceSemantics.evalExpr]
     simp only [SourceSemantics.evalExpr, hfield, hmembers, structBridgeMember,
+      structMemberBridgeState, Verity.ContractState.withStorageChannel,
       SourceSemantics.wordNormalize_eq_mod, Nat.mod_eq_of_lt hkey]
     simp only [structBridgeField, structMemberBridgeState, SourceSemantics.readFieldWord,
       SourceSemantics.wordNormalize]
@@ -686,11 +688,8 @@ def arrayBridgeField (slot : Nat) : Field :=
     itself holding the array length exactly as the EVM layout requires. -/
 def arrayBridgeState (slot : Nat) (values : List Verity.Core.Uint256) :
     SourceSemantics.RuntimeState :=
-  { world := { Verity.defaultState with
-                storageArray := fun s => if s = slot then values else [],
-                storage := fun s =>
-                  if s = SourceSemantics.wordNormalize slot then (values.length : Verity.Core.Uint256)
-                  else 0 },
+  { world := (Verity.defaultState.writeArray slot values).writeSlot
+      (SourceSemantics.wordNormalize slot) (values.length : Verity.Core.Uint256),
     bindings := [] }
 
 theorem sourceStorageArrayDropLast_length (values updated : List Verity.Core.Uint256)
@@ -740,13 +739,17 @@ theorem storageArrayLength_eq_storageArrayLength (slot : Nat)
         (.storageArrayLength "__array_bridge") := by
   have hsource : SourceSemantics.evalExpr [arrayBridgeField slot] (arrayBridgeState slot values)
       (.storageArrayLength "__array_bridge") = some values.length := by
-    rw [SourceSemantics.evalExpr]
-    show some (if slot = slot then values else []).length = some values.length
-    simp
+    have hfield : findFieldWithResolvedSlot [arrayBridgeField slot] "__array_bridge" =
+        some (arrayBridgeField slot, slot) := rfl
+    rw [SourceSemantics.evalExpr, hfield]
+    simp [arrayBridgeState, Verity.ContractState.writeArray,
+      Verity.ContractState.writeSlot]
   rw [hsource, compiledStorageArrayLength_eq]
-  simp only [Except.toOption, Option.bind_some, interpretSloadLit, arrayBridgeState]
+  simp only [Except.toOption, Option.bind_some, interpretSloadLit, arrayBridgeState,
+    Verity.ContractState.writeArray, Verity.ContractState.writeSlot,
+    SourceSemantics.wordNormalize]
   simp only [Option.some.injEq]
-  show (values.length : Verity.Core.Uint256).val = values.length
+  simp [Verity.Core.Uint256.ofNat]
   exact Nat.mod_eq_of_lt hlen
 
 /-- The real compiler output for a checked storage-array element read. -/

--- a/Compiler/Proofs/StorageBounds.lean
+++ b/Compiler/Proofs/StorageBounds.lean
@@ -91,19 +91,18 @@ theorem storageArrayDropLast_length (arr : List Uint256) (arr' : List Uint256)
 /-- Mirrors the private definition in `SourceSemantics.lean`. -/
 def writeStorageArray (world : Verity.ContractState) (slot : Nat)
     (values : List Uint256) : Verity.ContractState :=
-  { world with
-    storageArray := fun s => if s == slot then values else world.storageArray s }
+  world.writeArray slot values
 
 theorem writeStorageArray_same_slot (world : Verity.ContractState) (slot : Nat)
     (values : List Uint256) :
     (writeStorageArray world slot values).storageArray slot = values := by
-  simp [writeStorageArray, BEq.beq]
+  simp [writeStorageArray, Verity.ContractState.writeArray, BEq.beq]
 
 theorem writeStorageArray_other_slot (world : Verity.ContractState) (slot slot' : Nat)
     (values : List Uint256) (h : slot' ≠ slot) :
     (writeStorageArray world slot values).storageArray slot' = world.storageArray slot' := by
   unfold writeStorageArray
-  simp
+  simp [Verity.ContractState.writeArray]
   omega
 
 theorem writeStorageArray_storage_unchanged (world : Verity.ContractState) (slot : Nat)

--- a/Compiler/TypedIRCompilerCorrectness.lean
+++ b/Compiler/TypedIRCompilerCorrectness.lean
@@ -375,11 +375,8 @@ def execSourceLetCallerSetMapping2Stop
     (init : TExecState) (slot : Nat) : TExecResult :=
   .ok { init with
     vars := TVars.set init.vars { id := 2, ty := Ty.address } init.env.sender,
-    world := { init.world with
-      storageMap2 := fun i a1 a2 =>
-        if i == slot && a1 == init.env.sender && a2 == init.vars.address 0
-        then init.vars.uint256 1
-        else init.world.storageMap2 i a1 a2 } }
+    world := init.world.writeMap2 slot init.env.sender (init.vars.address 0)
+      (init.vars.uint256 1) }
 
 /-- Compile + execute the approve pattern from a pre-populated 2-param state
 (spender: address, amount: uint256). -/
@@ -427,11 +424,8 @@ def execCompiledLetMappingUintParamReturnLocal
 Sets a Uint256-keyed mapping at slot: mapping[p1] = p2. -/
 def execSourceSetMappingUintParamsStop
     (init : TExecState) (slot : Nat) : TExecResult :=
-  .ok { init with world := { init.world with
-    storageMapUint := fun i key' =>
-      if i == slot && key' == init.vars.uint256 0
-      then init.vars.uint256 1
-      else init.world.storageMapUint i key' } }
+  .ok { init with world :=
+    init.world.writeMapUint slot (init.vars.uint256 0) (init.vars.uint256 1) }
 
 /-- Compile + execute the setMappingUint(param1, param2) + stop pattern,
 from a pre-populated 2-Uint256-param CompileState. -/
@@ -1390,7 +1384,8 @@ theorem compile_let_caller_setMapping2_stop_semantics
     compileStmts_let_caller_setMapping2_stop_run, hSlot,
     h1, h2, h3, h4, h5, h6,
     evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, evalTExpr, TVars.get, TVars.set]
+  simp [evalTStmtsFuel, evalTStmtFuel, evalTExpr, TVars.get, TVars.set,
+    Verity.ContractState.writeMap2]
 
 /-- Semantic-preservation for the mappingUint(param) read + return pattern. -/
 theorem compile_let_mappingUint_param_return_local_semantics
@@ -1415,7 +1410,8 @@ theorem compile_setMappingUint_params_stop_semantics
   simp [execCompiledSetMappingUintParamsStop, execSourceSetMappingUintParamsStop,
     compileStmts_setMappingUint_params_stop_run, hSlot, hp,
     evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, evalTExpr, TVars.get]
+  simp [evalTStmtsFuel, evalTStmtFuel, evalTExpr, TVars.get,
+    Verity.ContractState.writeMapUint]
 
 -- ============================================================================
 -- Morpho Blue admin function base semantics definitions
@@ -1435,8 +1431,7 @@ def execSourceLetCallerLetStorageAddrReqEqReqNeqSetStorageAddrParamStop
         vars := TVars.set (TVars.set init.vars
           { id := 1, ty := Ty.address } sender)
           { id := 2, ty := Ty.address } owner,
-        world := { init.world with
-          storageAddr := fun i => if i == ownerSlot then param else init.world.storageAddr i } }
+        world := init.world.writeAddrSlot ownerSlot param }
     else .revert msg2
   else .revert msg1
 
@@ -1476,8 +1471,7 @@ def execSourceLetCallerLetStorageAddrReqEqLetStorageAddrReqNeqSetStorageAddrPara
           { id := 1, ty := Ty.address } sender)
           { id := 2, ty := Ty.address } owner)
           { id := 3, ty := Ty.address } targetVal,
-        world := { init.world with
-          storageAddr := fun i => if i == targetSlot then param else init.world.storageAddr i } }
+        world := init.world.writeAddrSlot targetSlot param }
     else .revert msg2
   else .revert msg1
 
@@ -1513,10 +1507,7 @@ def execSourceLetCallerLetStorageAddrReqEqLetMappingReqEqLitSetMappingStop
           { id := 1, ty := Ty.address } sender)
           { id := 2, ty := Ty.address } owner)
           { id := 3, ty := Ty.uint256 } currentVal,
-        world := { init.world with
-          storageMap := fun i a => if i == mappingSlot && a == key
-            then (writeVal : Verity.Core.Uint256)
-            else init.world.storageMap i a } }
+        world := init.world.writeMap mappingSlot key (writeVal : Verity.Core.Uint256) }
     else .revert msg2
   else .revert msg1
 
@@ -1559,10 +1550,8 @@ def execSourceLetCallerLetStorageAddrReqEqLetMappingUintReqEqLitReqLtSetMappingU
             { id := 1, ty := Ty.address } sender)
             { id := 2, ty := Ty.address } owner)
             { id := 3, ty := Ty.uint256 } currentVal,
-          world := { init.world with
-            storageMapUint := fun i k => if i == mappingSlot && k == key
-              then (writeVal : Verity.Core.Uint256)
-              else init.world.storageMapUint i k } }
+          world := init.world.writeMapUint mappingSlot key
+            (writeVal : Verity.Core.Uint256) }
       else .revert msg3
     else .revert msg2
   else .revert msg1
@@ -1612,13 +1601,8 @@ def execSourceLetCallerLetStorageAddrReqEqLetMappingLetStorageSetMappingAddParam
               { id := 3, ty := Ty.address } owner)
             { id := 4, ty := Ty.uint256 } currentBalance)
           { id := 5, ty := Ty.uint256 } currentSupply
-      world := { init.world with
-        storageMap := fun i a =>
-          if i == mappingSlot && a == recipient
-          then currentBalance + amount
-          else init.world.storageMap i a
-        storage := fun i =>
-          if i == supplySlot then currentSupply + amount else init.world.storage i } }
+      world := (init.world.writeMap mappingSlot recipient
+        (currentBalance + amount)).writeSlot supplySlot (currentSupply + amount) }
   else
     .revert msg
 
@@ -1662,10 +1646,8 @@ def execSourceLetCallerLetMapping2IteParamReqSetMapping2Stop
         vars := TVars.set (TVars.set init.vars
           { id := 2, ty := Ty.address } sender)
           { id := 3, ty := Ty.uint256 } currentVal,
-        world := { init.world with
-          storageMap2 := fun i a1 a2 => if i == mappingSlot && a1 == sender && a2 == authAddr
-            then (1 : Verity.Core.Uint256)
-            else init.world.storageMap2 i a1 a2 } }
+        world := init.world.writeMap2 mappingSlot sender authAddr
+          (1 : Verity.Core.Uint256) }
     else .revert msg1
   else
     if decide (¬ ((currentVal : Verity.Core.Uint256) = (0 : Verity.Core.Uint256))) then
@@ -1673,10 +1655,8 @@ def execSourceLetCallerLetMapping2IteParamReqSetMapping2Stop
         vars := TVars.set (TVars.set init.vars
           { id := 2, ty := Ty.address } sender)
           { id := 3, ty := Ty.uint256 } currentVal,
-        world := { init.world with
-          storageMap2 := fun i a1 a2 => if i == mappingSlot && a1 == sender && a2 == authAddr
-            then (0 : Verity.Core.Uint256)
-            else init.world.storageMap2 i a1 a2 } }
+        world := init.world.writeMap2 mappingSlot sender authAddr
+          (0 : Verity.Core.Uint256) }
     else .revert msg2
 
 /-- Compiled semantics for the Morpho setAuthorization pattern.
@@ -1798,7 +1778,8 @@ theorem compile_letCaller_letStorageAddr_reqEq_letMapping_letStorage_setMapping_
     hOwner, hMapping, hSupply, hne_ap_tp, hne_sv_tp, hne_sv_ap, hne_ov_tp, hne_ov_ap, hne_ov_sv,
     hne_bv_tp, hne_bv_ap, hne_sp_tp, hne_sp_ap, hne_sp_bv, evalTStmts, defaultEvalFuel]
   by_cases hEq : init.env.sender = init.world.storageAddr ownerSlot
-  · simp [evalTStmtsFuel, evalTStmtFuel, evalTExpr, hEq, TVars.set, TVars.get]
+  · simp [evalTStmtsFuel, evalTStmtFuel, evalTExpr, hEq, TVars.set, TVars.get,
+      Verity.ContractState.writeMap, Verity.ContractState.writeSlot]
     constructor
     · funext i
       by_cases hi : i = supplySlot

--- a/Compiler/TypedIRCompilerCorrectness.lean
+++ b/Compiler/TypedIRCompilerCorrectness.lean
@@ -1127,7 +1127,7 @@ theorem compile_setStorage_literal_semantics
       .ok { init with world := execSourceSetStorageLiteral init.world slot n } := by
   simp [execCompiledSetStorageLiteral, execSourceSetStorageLiteral,
     compileStmts_single_setStorage_literal_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for the supported two-statement subset:
 compiling and running `letVar tmp (literal n); setStorage fieldName (localVar tmp)`
@@ -1144,7 +1144,7 @@ theorem compile_let_setStorage_local_literal_semantics
             vars := init.vars.set { id := 0, ty := Ty.uint256 } (n : Verity.Core.Uint256) }) := by
   simp [execCompiledLetSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for a broader supported three-statement subset:
 compiling and running
@@ -1164,7 +1164,7 @@ theorem compile_let_assign_setStorage_local_literal_semantics
               { id := 1, ty := Ty.uint256 } (m : Verity.Core.Uint256) }) := by
   simp [execCompiledLetAssignSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_assign_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for an arithmetic supported three-statement subset:
 compiling and running
@@ -1186,7 +1186,7 @@ theorem compile_let_assign_add_setStorage_local_literal_semantics
                 ((n : Verity.Core.Uint256).add (m : Verity.Core.Uint256)) }) := by
   simp [execCompiledLetAssignAddSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_assign_add_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for an arithmetic supported three-statement subset:
 compiling and running

--- a/Compiler/TypedIRCompilerCorrectness.lean
+++ b/Compiler/TypedIRCompilerCorrectness.lean
@@ -1127,7 +1127,7 @@ theorem compile_setStorage_literal_semantics
       .ok { init with world := execSourceSetStorageLiteral init.world slot n } := by
   simp [execCompiledSetStorageLiteral, execSourceSetStorageLiteral,
     compileStmts_single_setStorage_literal_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for the supported two-statement subset:
 compiling and running `letVar tmp (literal n); setStorage fieldName (localVar tmp)`
@@ -1144,7 +1144,7 @@ theorem compile_let_setStorage_local_literal_semantics
             vars := init.vars.set { id := 0, ty := Ty.uint256 } (n : Verity.Core.Uint256) }) := by
   simp [execCompiledLetSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for a broader supported three-statement subset:
 compiling and running
@@ -1164,7 +1164,7 @@ theorem compile_let_assign_setStorage_local_literal_semantics
               { id := 1, ty := Ty.uint256 } (m : Verity.Core.Uint256) }) := by
   simp [execCompiledLetAssignSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_assign_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for an arithmetic supported three-statement subset:
 compiling and running
@@ -1186,7 +1186,7 @@ theorem compile_let_assign_add_setStorage_local_literal_semantics
                 ((n : Verity.Core.Uint256).add (m : Verity.Core.Uint256)) }) := by
   simp [execCompiledLetAssignAddSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_assign_add_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for an arithmetic supported three-statement subset:
 compiling and running
@@ -1310,7 +1310,7 @@ theorem compile_return_storage_semantics
   simp [execCompiledReturnStorage, execSourceReturnStorage,
     compileStmts_single_return_storage_run, hfind,
     evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for `return (storage field)` (address). -/
 theorem compile_return_storage_addr_semantics
@@ -1323,7 +1323,7 @@ theorem compile_return_storage_addr_semantics
   simp [execCompiledReturnStorageAddr, execSourceReturnStorageAddr,
     compileStmts_single_return_storage_addr_run, hfind,
     evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation for `return (mapping fieldName caller)`:
 compiled execution matches direct source semantics (no state change). -/
@@ -1336,7 +1336,7 @@ theorem compile_return_mapping_caller_semantics
   simp [execCompiledReturnMappingCaller, execSourceReturnMappingCaller,
     compileStmts_single_return_mapping_caller_run, hSlot,
     evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation for the address storage-read + return pattern. -/
 theorem compile_let_storage_addr_return_local_semantics
@@ -1952,7 +1952,7 @@ theorem compile_return_literal_semantics
     execCompiledReturnLiteral fields init n = execSourceReturnLiteral init n := by
   simp [execCompiledReturnLiteral, execSourceReturnLiteral,
     compileStmts_single_return_literal_run, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for a broader supported subset:
 compiling and running `letVar tmp (literal n); return (localVar tmp)`
@@ -1963,7 +1963,7 @@ theorem compile_let_return_local_literal_semantics
       execSourceLetReturnLocalLiteral init n := by
   simp [execCompiledLetReturnLocalLiteral, execSourceLetReturnLocalLiteral,
     compileStmts_let_return_local_literal_run, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.readSlot, Verity.ContractState.writeSlot]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for a broader supported branch subset:
 compiling and running

--- a/Contracts.lean
+++ b/Contracts.lean
@@ -7,7 +7,9 @@ import Contracts.Smoke
 import Contracts.Counter
 import Contracts.SimpleStorage
 import Contracts.Owned
+import Contracts.Ownable
 import Contracts.OwnedCounter
+import Contracts.OwnedCounterComposed
 import Contracts.SafeCounter
 import Contracts.Ledger
 import Contracts.Vault

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -480,11 +480,8 @@ def emit (name : String) (args : List EventArg) : Contract Unit := do
 def setPackedStorage {α : Type} (rootSlot : StorageSlot α) (wordOffset : Nat)
     (word : Uint256) : Contract Unit := fun state =>
   let targetSlot := (rootSlot.slot + wordOffset) % Compiler.Constants.evmModulus
-  ContractResult.success () { state with
-    «storage» := fun target => if target == targetSlot then word else state.storage target,
-    storageAddr := fun target =>
-      if target == targetSlot then wordToAddress word else state.storageAddr target
-  }
+  ContractResult.success ()
+    ((state.writeSlot targetSlot word).writeAddrSlot targetSlot (wordToAddress word))
 def rawLog (topics : List Uint256) (dataOffset dataSize : Uint256) : Contract Unit := fun state =>
   if topics.length > 4 then
     ContractResult.revert s!"rawLog supports at most 4 topics, got {topics.length}" state
@@ -495,9 +492,7 @@ def rawLog (topics : List Uint256) (dataOffset dataSize : Uint256) : Contract Un
     }
 def mstore (_offset _value : Uint256) : Contract Unit := pure ()
 def tstore (offset value : Uint256) : Contract Unit := fun state =>
-  ContractResult.success () { state with
-    transientStorage := fun i => if i == (offset : Nat) then value else state.transientStorage i
-  }
+  ContractResult.success () (state.writeTransient (offset : Nat) value)
 class ExternalArg (α : Type) where
   toWord : α → Uint256
 class ExternalResult (α : Type) where
@@ -715,10 +710,7 @@ def setStructMemberAt {κ α : Type} [StorageKey κ] [StorageWord α]
       match packed with
       | none => word
       | some (offset, width) => encodePackedWord (state.storage targetSlot) word offset width
-    let updatedStorage := fun target => if target == targetSlot then stored else state.storage target
-    ContractResult.success () { state with
-      «storage» := updatedStorage
-    }
+    ContractResult.success () (state.writeSlot targetSlot stored)
 
 def setStructMember2At {κ₁ κ₂ α : Type} [StorageKey κ₁] [StorageKey κ₂] [StorageWord α]
     (baseSlot : Nat) (wordOffset : Nat) (packed : Option (Nat × Nat)) (key1 : κ₁) (key2 : κ₂)
@@ -730,10 +722,7 @@ def setStructMember2At {κ₁ κ₂ α : Type} [StorageKey κ₁] [StorageKey κ
       match packed with
       | none => word
       | some (offset, width) => encodePackedWord (state.storage targetSlot) word offset width
-    let updatedStorage := fun target => if target == targetSlot then stored else state.storage target
-    ContractResult.success () { state with
-      «storage» := updatedStorage
-    }
+    ContractResult.success () (state.writeSlot targetSlot stored)
 
 
 end Contracts

--- a/Contracts/ERC20/Proofs/Basic.lean
+++ b/Contracts/ERC20/Proofs/Basic.lean
@@ -95,32 +95,11 @@ private theorem mint_unfold (s : ContractState) (toAddr : Address) (amount : Uin
     (h_no_bal_overflow : (s.storageMap 2 toAddr : Nat) + (amount : Nat) ≤ MAX_UINT256)
     (h_no_sup_overflow : (s.storage 1 : Nat) + (amount : Nat) ≤ MAX_UINT256) :
     (mint toAddr amount).run s = ContractResult.success ()
-      { «storage» := fun slotIdx =>
-          if slotIdx == 1 then EVM.Uint256.add (s.storage 1) amount else s.storage slotIdx,
-        contractStorage := s.contractStorage,
-        transientStorage := s.transientStorage,
-        storageAddr := s.storageAddr,
-        storageMap := fun slotIdx addr =>
-          if (slotIdx == 2 && addr == toAddr) = true then EVM.Uint256.add (s.storageMap 2 toAddr) amount
-        else s.storageMap slotIdx addr,
-        storageMapUint := s.storageMapUint,
-        storageMap2 := s.storageMap2,
-        storageArray := s.storageArray,
-        sender := s.sender,
-        thisAddress := s.thisAddress,
-        txOrigin := s.txOrigin,
-        msgValue := s.msgValue,
-        selfBalance := s.selfBalance,
-        blockTimestamp := s.blockTimestamp,
-        blockNumber := s.blockNumber,
-        chainId := s.chainId,
-        blobBaseFee := s.blobBaseFee,
-        calldataSize := s.calldataSize,
-        calldata := s.calldata,
-        memory := s.memory,
+      { (s.writeMap 2 toAddr (EVM.Uint256.add (s.storageMap 2 toAddr) amount)).writeSlot
+          1 (EVM.Uint256.add (s.storage 1) amount) with
         knownAddresses := fun slotIdx =>
-          if slotIdx == 2 then (s.knownAddresses slotIdx).insert toAddr else s.knownAddresses slotIdx,
-         events := s.events, calls := s.calls } := by
+          if slotIdx == 2 then (s.knownAddresses slotIdx).insert toAddr
+          else s.knownAddresses slotIdx } := by
   have h_safe_bal := safeAdd_some (s.storageMap 2 toAddr) amount h_no_bal_overflow
   have h_safe_sup := safeAdd_some (s.storage 1) amount h_no_sup_overflow
   have h_tx0 : s.txOrigin = 0 := h_owner.2
@@ -146,15 +125,15 @@ theorem mint_meets_spec_when_owner (s : ContractState) (toAddr : Address) (amoun
   simp only [Contract.runState, mint_spec]
   rw [h_unfold_apply]
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
-  · simp
-  · simp
+  · simp [ContractState.writeSlot, ContractState.writeMap]
+  · simp [ContractState.writeSlot, ContractState.writeMap]
   · refine ⟨?_, ?_⟩
     · intro addr h_ne
-      simp [h_ne]
+      simp [ContractState.writeSlot, ContractState.writeMap, h_ne]
     · intro slotIdx h_ne addr
-      simp [h_ne]
+      simp [ContractState.writeSlot, ContractState.writeMap, h_ne]
   · intro slotIdx h_ne
-    simp [h_ne]
+    simp [ContractState.writeSlot, ContractState.writeMap, h_ne]
   · rfl
   · rfl
   · rfl
@@ -193,33 +172,11 @@ private theorem transfer_unfold_other (s : ContractState) (toAddr : Address) (am
     (h_ne : s.sender ≠ toAddr)
     (h_no_overflow : (s.storageMap 2 toAddr : Nat) + (amount : Nat) ≤ MAX_UINT256) :
     (transfer toAddr amount).run s = ContractResult.success ()
-      { «storage» := s.storage,
-        contractStorage := s.contractStorage,
-        transientStorage := s.transientStorage,
-        storageAddr := s.storageAddr,
-        storageMap := fun slotIdx addr =>
-          if (slotIdx == 2 && addr == toAddr) = true then EVM.Uint256.add (s.storageMap 2 toAddr) amount
-          else if (slotIdx == 2 && addr == s.sender) = true then EVM.Uint256.sub (s.storageMap 2 s.sender) amount
-        else s.storageMap slotIdx addr,
-        storageMapUint := s.storageMapUint,
-        storageMap2 := s.storageMap2,
-        storageArray := s.storageArray,
-        sender := s.sender,
-        thisAddress := s.thisAddress,
-        txOrigin := s.txOrigin,
-        msgValue := s.msgValue,
-        selfBalance := s.selfBalance,
-        blockTimestamp := s.blockTimestamp,
-        blockNumber := s.blockNumber,
-        chainId := s.chainId,
-        blobBaseFee := s.blobBaseFee,
-        calldataSize := s.calldataSize,
-        memory := s.memory,
-        calldata := s.calldata,
+      { (s.writeMap 2 s.sender (EVM.Uint256.sub (s.storageMap 2 s.sender) amount)).writeMap
+          2 toAddr (EVM.Uint256.add (s.storageMap 2 toAddr) amount) with
         knownAddresses := fun slotIdx =>
           if slotIdx == 2 then ((s.knownAddresses slotIdx).insert s.sender).insert toAddr
-          else s.knownAddresses slotIdx,
-        events := s.events, calls := s.calls } := by
+          else s.knownAddresses slotIdx } := by
   have h_balance' := uint256_ge_val_le h_balance
   have h_safe := safeAdd_some (s.storageMap 2 toAddr) amount h_no_overflow
   simp only [transfer, balancesSlot, msgSender, getMapping, setMapping,
@@ -258,9 +215,9 @@ theorem transfer_meets_spec_when_sufficient (s : ContractState) (toAddr : Addres
     rw [h_unfold_apply]
     have h_ne' := address_beq_false_of_ne s.sender toAddr h_eq
     refine ⟨h_balance, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
-    · simp [h_ne']
-    · simp [h_ne']
-    · simp [h_ne']
+    · simp [ContractState.writeMap, h_ne', h_eq]
+    · simp [ContractState.writeMap, h_ne']
+    · simp [ContractState.writeMap, h_ne']
       refine ⟨?_, ?_⟩
       · intro addr h_ne_sender h_ne_to
         simp [h_ne_sender, h_ne_to]

--- a/Contracts/Interpreter.lean
+++ b/Contracts/Interpreter.lean
@@ -933,21 +933,16 @@ def main (args : List String) : IO Unit := do
       | some s => parseStorageMap2 s
       | none => fun _ _ _ => 0 -- Default: empty 2-key mapping storage
 
-    let initialState : ContractState := {
-      «storage» := storageState
-      transientStorage := fun _ => 0
-      storageAddr := storageAddrState
-      storageMap := storageMapState
-      storageMapUint := storageMapUintState
-      storageMap2 := storageMap2State
-      storageArray := fun _ => []
-      sender := senderAddress
-      thisAddress := Verity.Core.Address.ofNat 0xC0437AC7
-      msgValue := valueOpt.getD 0
-      blockTimestamp := timestampOpt.getD 0
-      knownAddresses := fun _ => Verity.Core.FiniteAddressSet.empty
-      events := []
-    }
+    let initialState : ContractState :=
+      ContractState.ofChannels storageState
+        (addrChannel := storageAddrState)
+        (mapChannel := storageMapState)
+        (mapUintChannel := storageMapUintState)
+        (map2Channel := storageMap2State)
+        (sender := senderAddress)
+        (thisAddress := Verity.Core.Address.ofNat 0xC0437AC7)
+        (msgValue := valueOpt.getD 0)
+        (blockTimestamp := timestampOpt.getD 0)
     let contractTypeEnum? : Option ContractType := match contractType with
       | "SimpleStorage" => some ContractType.simpleStorage
       | "LocalObligationMacroSmoke" => some ContractType.localObligationMacroSmoke

--- a/Contracts/Ledger/Proofs/Basic.lean
+++ b/Contracts/Ledger/Proofs/Basic.lean
@@ -48,32 +48,10 @@ theorem getBalance_preserves_state (s : ContractState) (addr : Address) :
 /-- Helper: unfold deposit computation -/
 private theorem deposit_unfold (s : ContractState) (amount : Uint256) :
     (deposit amount).run s = ContractResult.success ()
-    { «storage» := s.storage,
-      contractStorage := s.contractStorage,
-      transientStorage := s.transientStorage,
-      storageAddr := s.storageAddr,
-      storageMap := fun slotIdx addr =>
-        if (slotIdx == 0 && addr == s.sender) = true then EVM.Uint256.add (s.storageMap 0 s.sender) amount
-        else s.storageMap slotIdx addr,
-      storageMapUint := s.storageMapUint,
-      storageMap2 := s.storageMap2,
-      storageArray := s.storageArray,
-      sender := s.sender,
-      thisAddress := s.thisAddress,
-      txOrigin := s.txOrigin,
-      msgValue := s.msgValue,
-      selfBalance := s.selfBalance,
-      blockTimestamp := s.blockTimestamp,
-      blockNumber := s.blockNumber,
-      chainId := s.chainId,
-      blobBaseFee := s.blobBaseFee,
-      calldataSize := s.calldataSize,
-      calldata := s.calldata,
-      memory := s.memory,
+    { s.writeMap 0 s.sender (EVM.Uint256.add (s.storageMap 0 s.sender) amount) with
       knownAddresses := fun slotIdx =>
         if slotIdx == 0 then (s.knownAddresses slotIdx).insert s.sender
-        else s.knownAddresses slotIdx,
-      events := s.events, calls := s.calls } := by
+        else s.knownAddresses slotIdx } := by
   verity_unfold deposit
   simp only [balances]
   rfl
@@ -84,24 +62,25 @@ theorem deposit_meets_spec (s : ContractState) (amount : Uint256) :
   rw [deposit_unfold]
   unfold deposit_spec Specs.storageMapUpdateSpec
   refine ⟨?_, ?_, ?_⟩
-  · simp [ContractResult.snd, beq_iff_eq]
+  · simp [ContractResult.snd, ContractState.writeMap, beq_iff_eq]
   · refine ⟨?_, ?_⟩
     · intro addr h_ne
-      simp [ContractResult.snd, beq_iff_eq, h_ne]
+      simp [ContractResult.snd, ContractState.writeMap, beq_iff_eq, h_ne]
     · intro slotIdx h_ne addr
-      simp [ContractResult.snd, beq_iff_eq, h_ne]
+      simp [ContractResult.snd, ContractState.writeMap, beq_iff_eq, h_ne]
   · exact ⟨rfl, rfl, rfl, Specs.sameContext_rfl _⟩
 
 theorem deposit_increases_balance (s : ContractState) (amount : Uint256) :
   let s' := ((deposit amount).run s).snd
   s'.storageMap 0 s.sender = EVM.Uint256.add (s.storageMap 0 s.sender) amount := by
-  verity_frame deposit_unfold
+  verity_frame deposit_unfold with ContractState.writeMap
 
 theorem deposit_preserves_other_balances (s : ContractState) (amount : Uint256)
   (addr : Address) (h_ne : addr ≠ s.sender) :
   let s' := ((deposit amount).run s).snd
   s'.storageMap 0 addr = s.storageMap 0 addr := by
-  verity_frame deposit_unfold with h_ne
+  rw [deposit_unfold]
+  simp [ContractResult.snd, ContractState.writeMap, h_ne]
 
 /-! ## Withdraw Correctness -/
 
@@ -109,32 +88,10 @@ theorem deposit_preserves_other_balances (s : ContractState) (amount : Uint256)
 private theorem withdraw_unfold (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :
   (withdraw amount).run s = ContractResult.success ()
-    { «storage» := s.storage,
-      contractStorage := s.contractStorage,
-      transientStorage := s.transientStorage,
-      storageAddr := s.storageAddr,
-      storageMap := fun slotIdx addr =>
-        if (slotIdx == 0 && addr == s.sender) = true then EVM.Uint256.sub (s.storageMap 0 s.sender) amount
-        else s.storageMap slotIdx addr,
-      storageMapUint := s.storageMapUint,
-      storageMap2 := s.storageMap2,
-      storageArray := s.storageArray,
-      sender := s.sender,
-      thisAddress := s.thisAddress,
-      txOrigin := s.txOrigin,
-      msgValue := s.msgValue,
-      selfBalance := s.selfBalance,
-      blockTimestamp := s.blockTimestamp,
-      blockNumber := s.blockNumber,
-      chainId := s.chainId,
-      blobBaseFee := s.blobBaseFee,
-      calldataSize := s.calldataSize,
-      calldata := s.calldata,
-      memory := s.memory,
+    { s.writeMap 0 s.sender (EVM.Uint256.sub (s.storageMap 0 s.sender) amount) with
       knownAddresses := fun slotIdx =>
         if slotIdx == 0 then (s.knownAddresses slotIdx).insert s.sender
-        else s.knownAddresses slotIdx,
-      events := s.events, calls := s.calls } := by
+        else s.knownAddresses slotIdx } := by
   verity_unfold withdraw
   simp [balances, h_balance]
 
@@ -145,19 +102,19 @@ theorem withdraw_meets_spec (s : ContractState) (amount : Uint256)
   rw [withdraw_unfold s amount h_balance]
   unfold withdraw_spec Specs.storageMapUpdateSpec
   refine ⟨?_, ?_, ?_⟩
-  · simp [ContractResult.snd, beq_iff_eq]
+  · simp [ContractResult.snd, ContractState.writeMap, beq_iff_eq]
   · refine ⟨?_, ?_⟩
     · intro addr h_ne
-      simp [ContractResult.snd, beq_iff_eq, h_ne]
+      simp [ContractResult.snd, ContractState.writeMap, beq_iff_eq, h_ne]
     · intro slotIdx h_ne addr
-      simp [ContractResult.snd, beq_iff_eq, h_ne]
+      simp [ContractResult.snd, ContractState.writeMap, beq_iff_eq, h_ne]
   · exact ⟨rfl, rfl, rfl, Specs.sameContext_rfl _⟩
 
 theorem withdraw_decreases_balance (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :
   let s' := ((withdraw amount).run s).snd
   s'.storageMap 0 s.sender = EVM.Uint256.sub (s.storageMap 0 s.sender) amount := by
-  verity_frame (withdraw_unfold s amount h_balance)
+  verity_frame (withdraw_unfold s amount h_balance) with ContractState.writeMap
 
 theorem withdraw_reverts_insufficient (s : ContractState) (amount : Uint256)
   (h_insufficient : ¬(s.storageMap 0 s.sender >= amount)) :
@@ -182,33 +139,11 @@ private theorem transfer_unfold_other (s : ContractState) (toAddr : Address) (am
   (h_balance : s.storageMap 0 s.sender >= amount)
   (h_ne : s.sender ≠ toAddr) :
   (transfer toAddr amount).run s = ContractResult.success ()
-    { «storage» := s.storage,
-      contractStorage := s.contractStorage,
-      transientStorage := s.transientStorage,
-      storageAddr := s.storageAddr,
-      storageMap := fun slotIdx addr =>
-        if (slotIdx == 0 && addr == toAddr) = true then EVM.Uint256.add (s.storageMap 0 toAddr) amount
-        else if (slotIdx == 0 && addr == s.sender) = true then EVM.Uint256.sub (s.storageMap 0 s.sender) amount
-        else s.storageMap slotIdx addr,
-      storageMapUint := s.storageMapUint,
-      storageMap2 := s.storageMap2,
-      storageArray := s.storageArray,
-      sender := s.sender,
-      thisAddress := s.thisAddress,
-      txOrigin := s.txOrigin,
-      msgValue := s.msgValue,
-      selfBalance := s.selfBalance,
-      blockTimestamp := s.blockTimestamp,
-      blockNumber := s.blockNumber,
-      chainId := s.chainId,
-      blobBaseFee := s.blobBaseFee,
-      calldataSize := s.calldataSize,
-      calldata := s.calldata,
-      memory := s.memory,
+    { (s.writeMap 0 s.sender (EVM.Uint256.sub (s.storageMap 0 s.sender) amount)).writeMap
+        0 toAddr (EVM.Uint256.add (s.storageMap 0 toAddr) amount) with
       knownAddresses := fun slotIdx =>
         if slotIdx == 0 then ((s.knownAddresses slotIdx).insert s.sender).insert toAddr
-        else s.knownAddresses slotIdx,
-      events := s.events, calls := s.calls } := by
+        else s.knownAddresses slotIdx } := by
   simp only [transfer, Contracts.Ledger.balances,
     msgSender, getMapping, setMapping,
     ContractState.readMap, ContractState.writeMap,
@@ -237,15 +172,15 @@ theorem transfer_meets_spec (s : ContractState) (toAddr : Address) (amount : Uin
     simp only [ContractResult.snd, transfer_spec]
     have h_ne' := address_beq_false_of_ne s.sender toAddr h_eq
     refine ⟨?_, ?_, ?_, ?_⟩
-    · simp [h_ne']
-    · simp [h_ne']
-    · simp [h_ne']
+    · simp [ContractState.writeMap, h_ne', h_eq]
+    · simp [ContractState.writeMap, h_ne']
+    · simp [ContractState.writeMap, h_ne']
       refine ⟨?_, ?_⟩
       · intro addr h_ne_sender h_ne_to
         simp [h_ne_sender, h_ne_to]
       · intro slotIdx h_slot addr
         simp [h_slot]
-    · simp [Specs.sameStorageAddrContext, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameStorageArray, Specs.sameContext]
+    · simp [ContractState.writeMap, Specs.sameStorageAddrContext, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameStorageArray, Specs.sameContext]
 
 theorem transfer_self_preserves_balance (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :
@@ -288,33 +223,11 @@ theorem transfer_succeeds_recipient_overflow (s : ContractState) (toAddr : Addre
   (_h_overflow : (s.storageMap 0 toAddr : Nat) + (amount : Nat) > MAX_UINT256) :
   ∃ s', (transfer toAddr amount).run s = ContractResult.success () s' := by
   let s' : ContractState :=
-    { «storage» := s.storage,
-      contractStorage := s.contractStorage,
-      transientStorage := s.transientStorage,
-      storageAddr := s.storageAddr,
-      storageMap := fun slotIdx addr =>
-        if (slotIdx == 0 && addr == toAddr) = true then EVM.Uint256.add (s.storageMap 0 toAddr) amount
-        else if (slotIdx == 0 && addr == s.sender) = true then EVM.Uint256.sub (s.storageMap 0 s.sender) amount
-        else s.storageMap slotIdx addr,
-      storageMapUint := s.storageMapUint,
-      storageMap2 := s.storageMap2,
-      storageArray := s.storageArray,
-      sender := s.sender,
-      thisAddress := s.thisAddress,
-      txOrigin := s.txOrigin,
-      msgValue := s.msgValue,
-      selfBalance := s.selfBalance,
-      blockTimestamp := s.blockTimestamp,
-      blockNumber := s.blockNumber,
-      chainId := s.chainId,
-      blobBaseFee := s.blobBaseFee,
-      calldataSize := s.calldataSize,
-      calldata := s.calldata,
-      memory := s.memory,
+    { (s.writeMap 0 s.sender (EVM.Uint256.sub (s.storageMap 0 s.sender) amount)).writeMap
+        0 toAddr (EVM.Uint256.add (s.storageMap 0 toAddr) amount) with
       knownAddresses := fun slotIdx =>
         if slotIdx == 0 then ((s.knownAddresses slotIdx).insert s.sender).insert toAddr
-        else s.knownAddresses slotIdx,
-      events := s.events, calls := s.calls }
+        else s.knownAddresses slotIdx }
   refine ⟨s', ?_⟩
   simpa [s'] using transfer_unfold_other s toAddr amount h_balance h_ne
 
@@ -324,21 +237,21 @@ theorem deposit_preserves_non_mapping (s : ContractState) (amount : Uint256) :
   let s' := ((deposit amount).run s).snd
   non_mapping_storage_unchanged s s' := by
   rw [deposit_unfold]
-  simp [ContractResult.snd, non_mapping_storage_unchanged, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameStorageArray]
+  simp [ContractResult.snd, ContractState.writeMap, non_mapping_storage_unchanged, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameStorageArray]
 
 theorem withdraw_preserves_non_mapping (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :
   let s' := ((withdraw amount).run s).snd
   non_mapping_storage_unchanged s s' := by
   rw [withdraw_unfold s amount h_balance]
-  simp [ContractResult.snd, non_mapping_storage_unchanged, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameStorageArray]
+  simp [ContractResult.snd, ContractState.writeMap, non_mapping_storage_unchanged, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameStorageArray]
 
 theorem deposit_preserves_wellformedness (s : ContractState) (amount : Uint256)
   (h : WellFormedState s) :
   let s' := ((deposit amount).run s).snd
   WellFormedState s' := by
   rw [deposit_unfold]
-  simp [ContractResult.snd]
+  simp [ContractResult.snd, ContractState.writeMap]
   exact ⟨h.sender_nonzero, h.contract_nonzero⟩
 
 theorem withdraw_preserves_wellformedness (s : ContractState) (amount : Uint256)
@@ -346,7 +259,7 @@ theorem withdraw_preserves_wellformedness (s : ContractState) (amount : Uint256)
   let s' := ((withdraw amount).run s).snd
   WellFormedState s' := by
   rw [withdraw_unfold s amount h_balance]
-  simp [ContractResult.snd]
+  simp [ContractResult.snd, ContractState.writeMap]
   exact ⟨h.sender_nonzero, h.contract_nonzero⟩
 
 /-! ## Composition: deposit → getBalance -/
@@ -356,7 +269,7 @@ theorem deposit_getBalance_correct (s : ContractState) (amount : Uint256) :
   ((getBalance s.sender).run s').fst = EVM.Uint256.add (s.storageMap 0 s.sender) amount := by
   rw [deposit_unfold]
   unfold getBalance
-  simp [ContractResult.snd, Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run,
+  simp [ContractResult.snd, ContractState.writeMap, Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run,
     getMapping, balances, ContractState.readMap]
 
 /-! ## Summary of Proven Properties

--- a/Contracts/Ownable.lean
+++ b/Contracts/Ownable.lean
@@ -1,0 +1,4 @@
+import Contracts.Ownable.Ownable
+import Contracts.Ownable.Spec
+import Contracts.Ownable.Invariants
+import Contracts.Ownable.Proofs.Basic

--- a/Contracts/Ownable/Invariants.lean
+++ b/Contracts/Ownable/Invariants.lean
@@ -1,0 +1,30 @@
+import Verity.Specs.Common
+import Verity.Specs.Composition
+import Contracts.Ownable.Ownable
+
+namespace Contracts.Ownable.Invariants
+
+open Verity
+open Verity.Specs.Composition
+open Contracts.Ownable
+
+structure WellFormedState (s : ContractState) : Prop where
+  sender_nonzero : s.sender ≠ 0
+  contract_nonzero : s.thisAddress ≠ 0
+  owner_nonzero : s.storageAddr owner.slot ≠ 0
+
+def Inv (s : ContractState) : Prop :=
+  s.storageAddr owner.slot ≠ 0
+
+theorem inv_depends_only_on_footprint :
+    InvDependsOnlyOn Inv { addrSlots := [owner.slot] } := by
+  intro s s' h
+  constructor
+  · intro hinv
+    have := h.2.1 owner.slot (by simp)
+    simpa [Inv, this] using hinv
+  · intro hinv
+    have := h.2.1 owner.slot (by simp)
+    simpa [Inv, this] using hinv
+
+end Contracts.Ownable.Invariants

--- a/Contracts/Ownable/Ownable.lean
+++ b/Contracts/Ownable/Ownable.lean
@@ -1,0 +1,27 @@
+import Contracts.Common
+
+namespace Contracts
+
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_mixin Ownable where
+  storage
+    owner : Address := slot 0
+
+  constructor (initialOwner : Address) := do
+    setStorageAddr owner initialOwner
+
+  modifier onlyOwner := do
+    let sender ← msgSender
+    let currentOwner ← getStorageAddr owner
+    require (sender == currentOwner) "Caller is not the owner"
+
+  function transferOwnership (newOwner : Address) with onlyOwner modifies(owner) : Unit := do
+    setStorageAddr owner newOwner
+
+  function getOwner () : Address := do
+    let currentOwner ← getStorageAddr owner
+    return currentOwner
+
+end Contracts

--- a/Contracts/Ownable/Proofs/Basic.lean
+++ b/Contracts/Ownable/Proofs/Basic.lean
@@ -1,0 +1,67 @@
+import Contracts.Ownable.Spec
+import Contracts.Ownable.Invariants
+import Verity.Proofs.Stdlib.Automation
+import Verity.Specs.Composition
+
+namespace Contracts.Ownable.Proofs
+
+open Verity
+open Contracts.Ownable
+open Contracts.Ownable.Spec
+open Contracts.Ownable.Invariants
+open Verity.Proofs.Stdlib.Automation (address_beq_false_of_ne)
+open Verity.Specs.Composition
+
+private theorem owner_slot_zero : StorageSlot.slot owner = 0 := rfl
+
+theorem onlyOwner_ok (s : ContractState)
+    (h_owner : s.sender = s.storageAddr (StorageSlot.slot owner)) :
+    onlyOwner.run s = ContractResult.success () s := by
+  simp [onlyOwner, owner, msgSender, getStorageAddr, ContractState.readAddrSlot,
+    Verity.require, Verity.bind, Bind.bind, Contract.run, h_owner]
+
+theorem onlyOwner_reverts (s : ContractState)
+    (h_not_owner : s.sender ≠ s.storageAddr (StorageSlot.slot owner)) :
+    ∃ msg, onlyOwner.run s = ContractResult.revert msg s :=
+  ⟨"Caller is not the owner", by
+    have h : s.sender ≠ s.storageAddr 0 := owner_slot_zero ▸ h_not_owner
+    simp [onlyOwner, owner, msgSender, getStorageAddr, ContractState.readAddrSlot,
+      Verity.require, Verity.bind, Bind.bind, Contract.run,
+      address_beq_false_of_ne s.sender (s.storageAddr 0) h]⟩
+
+theorem transferOwnership_writes_only (s : ContractState) (newOwner : Address)
+    (h_owner : s.sender = s.storageAddr (StorageSlot.slot owner)) :
+    WritesOnly footprint s ((transferOwnership newOwner).run s).snd := by
+  simp [transferOwnership, footprint, WritesOnly, owner,
+    msgSender, getStorageAddr, setStorageAddr, ContractState.readAddrSlot,
+    ContractState.writeAddrSlot, Verity.require, Verity.bind, Bind.bind,
+    Contract.run, ContractResult.snd, h_owner, Specs.sameContext]
+  intro _ hneq heq
+  exact (hneq heq).elim
+
+theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : Address)
+    (h_owner : s.sender = s.storageAddr (StorageSlot.slot owner)) :
+    let s' := ((transferOwnership newOwner).run s).snd
+    transferOwnership_spec newOwner s s' := by
+  simp [transferOwnership, transferOwnership_spec, owner,
+    msgSender, getStorageAddr, setStorageAddr, ContractState.readAddrSlot,
+    ContractState.writeAddrSlot, Verity.require, Verity.bind, Bind.bind,
+    Contract.run, ContractResult.snd, h_owner,
+    Specs.storageAddrUpdateSpec, Specs.storageAddrUnchangedExcept,
+    Specs.sameStorageMapContext, Specs.sameStorage, Specs.sameStorageMap,
+    Specs.sameStorageArray, Specs.sameContext]
+  intro _ hneq heq
+  exact (hneq heq).elim
+
+theorem getOwner_meets_spec (s : ContractState) :
+    getOwner_spec ((getOwner).run s).fst s := by
+  simp [getOwner, getOwner_spec, owner, getStorageAddr, ContractState.readAddrSlot,
+    Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run]
+
+theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
+    ((«constructor» initialOwner).run s).snd.storageAddr (StorageSlot.slot owner)
+      = initialOwner := by
+  simp [«constructor», owner, setStorageAddr, ContractState.writeAddrSlot,
+    Contract.run, ContractResult.snd]
+
+end Contracts.Ownable.Proofs

--- a/Contracts/Ownable/Spec.lean
+++ b/Contracts/Ownable/Spec.lean
@@ -1,0 +1,24 @@
+import Verity.Specs.Common
+import Verity.Specs.Composition
+import Verity.Macro
+import Contracts.Ownable.Ownable
+
+namespace Contracts.Ownable.Spec
+
+open Verity
+open Verity.Specs
+open Verity.Specs.Composition
+open Contracts.Ownable
+
+#gen_spec_addr constructor_spec for (initialOwner : Address)
+  (owner.slot, (fun _ => initialOwner), sameStorageMapContext)
+
+def getOwner_spec (result : Address) (s : ContractState) : Prop :=
+  result = s.storageAddr owner.slot
+
+#gen_spec_addr transferOwnership_spec for (newOwner : Address)
+  (owner.slot, (fun _ => newOwner), sameStorageMapContext)
+
+def footprint : Footprint := { addrSlots := [owner.slot] }
+
+end Contracts.Ownable.Spec

--- a/Contracts/Owned/Invariants.lean
+++ b/Contracts/Owned/Invariants.lean
@@ -5,10 +5,12 @@
 -/
 
 import Verity.Specs.Common
+import Contracts.Owned.Owned
 
 namespace Contracts.Owned.Invariants
 
 open Verity
+open Contracts.Owned
 
 /-! ## State Invariants
 
@@ -23,6 +25,6 @@ Properties that should be maintained by all operations.
 structure WellFormedState (s : ContractState) : Prop where
   sender_nonzero : s.sender ≠ 0
   contract_nonzero : s.thisAddress ≠ 0
-  owner_nonzero : s.storageAddr 0 ≠ 0
+  owner_nonzero : s.storageAddr owner.slot ≠ 0
 
 end Contracts.Owned.Invariants

--- a/Contracts/Owned/Proofs/Basic.lean
+++ b/Contracts/Owned/Proofs/Basic.lean
@@ -27,13 +27,13 @@ These establish fundamental properties of address storage operations.
 theorem setStorageAddr_updates_owner (s : ContractState) (addr : Address) :
   let slotIdx : StorageSlot Address := owner
   let s' := ((setStorageAddr slotIdx addr).run s).snd
-  s'.storageAddr 0 = addr := by
+  s'.storageAddr owner.slot = addr := by
   simp [owner]
 
 theorem getStorageAddr_reads_owner (s : ContractState) :
   let slotIdx : StorageSlot Address := owner
   let result := ((getStorageAddr slotIdx).run s).fst
-  result = s.storageAddr 0 := by
+  result = s.storageAddr owner.slot := by
   simp [owner]
 
 theorem setStorageAddr_preserves_other_slots (s : ContractState) (addr : Address) (slot_num : Nat)
@@ -66,16 +66,16 @@ theorem setStorageAddr_preserves_context (s : ContractState) (addr : Address) :
 theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
   constructor_spec initialOwner s s' := by
-  refine ⟨?_, ?_, ?_⟩
-  · simp [owner]
+  simp [constructor_spec, owner]
+  refine ⟨rfl, ?_, ?_⟩
   · intro slotIdx h_neq
-    simp [owner, h_neq]
-  · simp [owner, Specs.sameStorageMapContext,
+    simp [h_neq]
+  · simp [Specs.sameStorageMapContext,
       Specs.sameStorage, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
-  s'.storageAddr 0 = initialOwner := by
+  s'.storageAddr owner.slot = initialOwner := by
   simp [owner]
 
 /-! ## getOwner Correctness -/
@@ -88,7 +88,7 @@ theorem getOwner_meets_spec (s : ContractState) :
 
 theorem getOwner_returns_owner (s : ContractState) :
   let result := ((getOwner).run s).fst
-  result = s.storageAddr 0 := by
+  result = s.storageAddr owner.slot := by
   simpa [getOwner_spec] using getOwner_meets_spec s
 
 theorem getOwner_preserves_state (s : ContractState) :
@@ -102,12 +102,11 @@ theorem isOwner_meets_spec (s : ContractState) :
   let result := ((isOwner).run s).fst
   isOwner_spec result s := by
   verity_unfold isOwner
-  simp only [isOwner_spec]
-  rfl
+  simp [isOwner_spec, owner]
 
 theorem isOwner_returns_correct_value (s : ContractState) :
   let result := ((isOwner).run s).fst
-  result = (s.sender == s.storageAddr 0) := by
+  result = (s.sender == s.storageAddr owner.slot) := by
   simpa [isOwner_spec] using isOwner_meets_spec s
 
 /-! ## transferOwnership Correctness
@@ -120,7 +119,7 @@ is fully modeled and can be unfolded in proofs.
 
 /-- Helper: unfold transferOwnership when caller is owner -/
 theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
-  (h_owner : s.sender = s.storageAddr 0) :
+  (h_owner : s.sender = s.storageAddr owner.slot) :
   (transferOwnership newOwner).run s = ContractResult.success ()
     { «storage» := s.storage,
       contractStorage := s.contractStorage,
@@ -149,23 +148,23 @@ theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
   exact h_owner
 
 theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : Address)
-  (h_is_owner : s.sender = s.storageAddr 0) :
+  (h_is_owner : s.sender = s.storageAddr owner.slot) :
   let s' := ((transferOwnership newOwner).run s).snd
   transferOwnership_spec newOwner s s' := by
   rw [transferOwnership_unfold s newOwner h_is_owner]
-  refine ⟨?_, ?_, ?_⟩
-  · simp [ContractResult.snd]
+  simp [transferOwnership_spec, owner, ContractResult.snd]
+  refine ⟨rfl, ?_, ?_⟩
   · intro slotIdx h_neq
-    simp [ContractResult.snd, h_neq]
-  · simp [ContractResult.snd, Specs.sameStorageMapContext,
+    simp [h_neq]
+  · simp [Specs.sameStorageMapContext,
       Specs.sameStorage, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem transferOwnership_changes_owner_when_allowed (s : ContractState) (newOwner : Address)
-  (h_is_owner : s.sender = s.storageAddr 0) :
+  (h_is_owner : s.sender = s.storageAddr owner.slot) :
   let s' := ((transferOwnership newOwner).run s).snd
-  s'.storageAddr 0 = newOwner := by
+  s'.storageAddr owner.slot = newOwner := by
   rw [transferOwnership_unfold s newOwner h_is_owner]
-  simp [ContractResult.snd]
+  simp [owner, ContractResult.snd]
 
 /-! ## Composition Properties -/
 

--- a/Contracts/Owned/Proofs/Correctness.lean
+++ b/Contracts/Owned/Proofs/Correctness.lean
@@ -26,20 +26,21 @@ The fundamental access control property: non-owners cannot transfer ownership.
 /-- transferOwnership reverts when the caller is not the owner.
     This is the core security property of the Owned pattern. -/
 theorem transferOwnership_reverts_when_not_owner (s : ContractState) (newOwner : Address)
-  (h_not_owner : s.sender ≠ s.storageAddr 0) :
+  (h_not_owner : s.sender ≠ s.storageAddr owner.slot) :
   ∃ msg, (transferOwnership newOwner).run s = ContractResult.revert msg s := by
+  have h : s.sender ≠ s.storageAddr 0 := by simpa [owner] using h_not_owner
   simp [transferOwnership, owner,
-    msgSender, getStorageAddr,
+    msgSender, getStorageAddr, ContractState.readAddrSlot,
     Verity.require, Verity.bind, Bind.bind,
     Contract.run,
-    address_beq_false_of_ne s.sender (s.storageAddr 0) h_not_owner]
+    address_beq_false_of_ne s.sender (s.storageAddr 0) h]
 
 /-! ## Invariant Preservation -/
 
 /-- transferOwnership preserves WellFormedState when the new owner is non-empty.
     After ownership transfer, all address fields remain non-empty. -/
 theorem transferOwnership_preserves_wellformedness (s : ContractState) (newOwner : Address)
-  (h : WellFormedState s) (h_owner : s.sender = s.storageAddr 0) (h_new : newOwner ≠ 0) :
+  (h : WellFormedState s) (h_owner : s.sender = s.storageAddr owner.slot) (h_new : newOwner ≠ 0) :
   let s' := ((transferOwnership newOwner).run s).snd
   WellFormedState s' := by
   verity_frame (transferOwnership_unfold s newOwner h_owner)
@@ -55,19 +56,21 @@ theorem constructor_transferOwnership_getOwner (s : ContractState) (initialOwner
   let s2 := ((transferOwnership newOwner).run s1).snd
   ((getOwner).run s2).fst = newOwner := by
   simp [setStorageAddr, transferOwnership, owner, getOwner,
-    msgSender, getStorageAddr, setStorageAddr,
+    msgSender, getStorageAddr, ContractState.readAddrSlot, ContractState.writeAddrSlot,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
     Contract.run, ContractResult.snd, ContractResult.fst, h_sender]
 
 /-- After ownership transfer, the previous owner can no longer transfer.
     Proves that ownership is truly transferred, not just copied. -/
 theorem transferred_owner_cannot_act (s : ContractState) (newOwner : Address)
-  (h_owner : s.sender = s.storageAddr 0) (h_ne : s.sender ≠ newOwner) :
+  (h_owner : s.sender = s.storageAddr owner.slot) (h_ne : s.sender ≠ newOwner) :
   let s' := ((transferOwnership newOwner).run s).snd
   ∃ msg, (transferOwnership 42).run s' = ContractResult.revert msg s' := by
   have h_ne' : ((transferOwnership newOwner).run s).snd.sender ≠
-      ((transferOwnership newOwner).run s).snd.storageAddr 0 := by
+      ((transferOwnership newOwner).run s).snd.storageAddr owner.slot := by
     verity_frame (transferOwnership_unfold s newOwner h_owner) with h_ne
+    simp [owner] at *
+    exact h_ne
   exact transferOwnership_reverts_when_not_owner _ _ h_ne'
 
 /-! ## Summary

--- a/Contracts/Owned/Spec.lean
+++ b/Contracts/Owned/Spec.lean
@@ -15,17 +15,17 @@ open Contracts.Owned
 /-! ## Operation Specifications -/
 
 -- Constructor: sets the owner to the provided address.
-#gen_spec_addr constructor_spec for (initialOwner : Address) (0, (fun _ => initialOwner), sameStorageMapContext)
+#gen_spec_addr constructor_spec for (initialOwner : Address) (owner.slot, (fun _ => initialOwner), sameStorageMapContext)
 
 /-- getOwner: returns the current owner address -/
 def getOwner_spec (result : Address) (s : ContractState) : Prop :=
-  result = s.storageAddr 0
+  result = s.storageAddr owner.slot
 
 -- transferOwnership: updates owner to new address (owner only).
-#gen_spec_addr transferOwnership_spec for (newOwner : Address) (0, (fun _ => newOwner), sameStorageMapContext)
+#gen_spec_addr transferOwnership_spec for (newOwner : Address) (owner.slot, (fun _ => newOwner), sameStorageMapContext)
 
 /-- isOwner: returns true if sender equals current owner -/
 def isOwner_spec (result : Bool) (s : ContractState) : Prop :=
-  result = (s.sender == s.storageAddr 0)
+  result = (s.sender == s.storageAddr owner.slot)
 
 end Contracts.Owned.Spec

--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -44,7 +44,7 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   · simp [setStorageAddr, owner, Contract.run, ContractResult.snd,
       ContractState.writeAddrSlot]
   · intro slotIdx h_neq
-    simp [setStorageAddr, owner, Contract.run, ContractResult.snd, h_neq, ContractState.writeAddrSlot, ContractState.readAddrSlot, ContractState.writeSlot, ContractState.readSlot]
+    simp [setStorageAddr, owner, Contract.run, ContractResult.snd, h_neq, ContractState.writeAddrSlot]
   · simp [setStorageAddr, owner, Contract.run, ContractResult.snd,
       ContractState.writeAddrSlot,
       Specs.sameStorageMapContext, Specs.sameStorage, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
@@ -52,12 +52,12 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
   s'.storageAddr 0 = initialOwner := by
-  simp [setStorageAddr, owner, Contract.run, ContractResult.snd, ContractState.writeAddrSlot, ContractState.readAddrSlot, ContractState.writeSlot, ContractState.readSlot]
+  simp [setStorageAddr, owner, Contract.run, ContractResult.snd, ContractState.writeAddrSlot]
 
 theorem constructor_preserves_count (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
   s'.storage = s.storage := by
-  simp [setStorageAddr, owner, Contract.run, ContractResult.snd, ContractState.writeAddrSlot, ContractState.readAddrSlot, ContractState.writeSlot, ContractState.readSlot]
+  simp [setStorageAddr, owner, Contract.run, ContractResult.snd, ContractState.writeAddrSlot]
 
 /-! ## Read Operation Correctness -/
 
@@ -116,7 +116,7 @@ theorem increment_unfold (s : ContractState)
   (increment.run s) = ContractResult.success ()
     (s.writeSlot 1 (EVM.Uint256.add (s.storage 1) 1)) := by
   verity_unfold increment
-  simp [owner, count, h_owner, ContractState.writeSlot]
+  simp [owner, count, h_owner]
 
 theorem increment_meets_spec_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -124,10 +124,10 @@ theorem increment_meets_spec_when_owner (s : ContractState)
   increment_spec s s' := by
   rw [increment_unfold s h_owner]
   refine ⟨?_, ?_, ?_⟩
-  · simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot]
+  · simp [ContractResult.snd, ContractState.writeSlot]
   · intro slotIdx h_neq
-    simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot, h_neq]
-  · simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot, Specs.sameAddrMapContext, Specs.sameStorageAddr,
+    simp [ContractResult.snd, ContractState.writeSlot, h_neq]
+  · simp [ContractResult.snd, ContractState.writeSlot, Specs.sameAddrMapContext, Specs.sameStorageAddr,
       Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem increment_adds_one_when_owner (s : ContractState)
@@ -135,7 +135,7 @@ theorem increment_adds_one_when_owner (s : ContractState)
   let s' := (increment.run s).snd
   s'.storage 1 = EVM.Uint256.add (s.storage 1) 1 := by
   rw [increment_unfold s h_owner]
-  simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot]
+  simp [ContractResult.snd, ContractState.writeSlot]
 
 theorem increment_reverts_when_not_owner (s : ContractState)
   (h_not_owner : s.sender ≠ s.storageAddr 0) :
@@ -150,7 +150,7 @@ theorem decrement_unfold (s : ContractState)
   (decrement.run s) = ContractResult.success ()
     (s.writeSlot 1 (EVM.Uint256.sub (s.storage 1) 1)) := by
   verity_unfold decrement
-  simp [owner, count, h_owner, ContractState.writeSlot]
+  simp [owner, count, h_owner]
 
 theorem decrement_meets_spec_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -158,10 +158,10 @@ theorem decrement_meets_spec_when_owner (s : ContractState)
   decrement_spec s s' := by
   rw [decrement_unfold s h_owner]
   refine ⟨?_, ?_, ?_⟩
-  · simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot]
+  · simp [ContractResult.snd, ContractState.writeSlot]
   · intro slotIdx h_neq
-    simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot, h_neq]
-  · simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot, Specs.sameAddrMapContext, Specs.sameStorageAddr,
+    simp [ContractResult.snd, ContractState.writeSlot, h_neq]
+  · simp [ContractResult.snd, ContractState.writeSlot, Specs.sameAddrMapContext, Specs.sameStorageAddr,
       Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem decrement_subtracts_one_when_owner (s : ContractState)
@@ -169,7 +169,7 @@ theorem decrement_subtracts_one_when_owner (s : ContractState)
   let s' := (decrement.run s).snd
   s'.storage 1 = EVM.Uint256.sub (s.storage 1) 1 := by
   rw [decrement_unfold s h_owner]
-  simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot]
+  simp [ContractResult.snd, ContractState.writeSlot]
 
 theorem decrement_reverts_when_not_owner (s : ContractState)
   (h_not_owner : s.sender ≠ s.storageAddr 0) :
@@ -183,7 +183,7 @@ theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
   (transferOwnership newOwner).run s = ContractResult.success ()
     (s.writeAddrSlot 0 newOwner) := by
   verity_unfold transferOwnership
-  simp [owner, h_owner, ContractState.writeAddrSlot]
+  simp [owner, h_owner]
 
 theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0 ∧ s.txOrigin = 0) :
@@ -191,10 +191,10 @@ theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : 
   transferOwnership_spec newOwner s s' := by
   rw [transferOwnership_unfold s newOwner h_owner.1]
   refine ⟨?_, ?_, ?_⟩
-  · simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot]
+  · simp [ContractResult.snd, ContractState.writeAddrSlot]
   · intro slotIdx h_neq
-    simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot, h_neq]
-  · simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot, Specs.sameStorageMapContext,
+    simp [ContractResult.snd, ContractState.writeAddrSlot, h_neq]
+  · simp [ContractResult.snd, ContractState.writeAddrSlot, Specs.sameStorageMapContext,
       Specs.sameStorage, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem transferOwnership_changes_owner (s : ContractState) (newOwner : Address)
@@ -202,7 +202,7 @@ theorem transferOwnership_changes_owner (s : ContractState) (newOwner : Address)
   let s' := ((transferOwnership newOwner).run s).snd
   s'.storageAddr 0 = newOwner := by
   rw [transferOwnership_unfold s newOwner h_owner]
-  simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot]
+  simp [ContractResult.snd, ContractState.writeAddrSlot]
 
 theorem transferOwnership_reverts_when_not_owner (s : ContractState) (newOwner : Address)
   (h_not_owner : s.sender ≠ s.storageAddr 0) :

--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -114,30 +114,9 @@ theorem isOwner_correct (s : ContractState) :
 theorem increment_unfold (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
   (increment.run s) = ContractResult.success ()
-    { «storage» := fun slotIdx => if (slotIdx == 1) = true then EVM.Uint256.add (s.storage 1) 1 else s.storage slotIdx,
-      contractStorage := s.contractStorage,
-      transientStorage := s.transientStorage,
-      storageAddr := s.storageAddr,
-      storageMap := s.storageMap,
-      storageMapUint := s.storageMapUint,
-      storageMap2 := s.storageMap2,
-      storageArray := s.storageArray,
-      sender := s.sender,
-      thisAddress := s.thisAddress,
-      txOrigin := s.txOrigin,
-      msgValue := s.msgValue,
-      selfBalance := s.selfBalance,
-      blockTimestamp := s.blockTimestamp,
-      blockNumber := s.blockNumber,
-      chainId := s.chainId,
-      blobBaseFee := s.blobBaseFee,
-      calldataSize := s.calldataSize,
-      calldata := s.calldata,
-      memory := s.memory,
-      knownAddresses := s.knownAddresses,
-      events := s.events, calls := s.calls } := by
+    (s.writeSlot 1 (EVM.Uint256.add (s.storage 1) 1)) := by
   verity_unfold increment
-  simp [owner, count, h_owner]
+  simp [owner, count, h_owner, ContractState.writeSlot]
 
 theorem increment_meets_spec_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -145,10 +124,10 @@ theorem increment_meets_spec_when_owner (s : ContractState)
   increment_spec s s' := by
   rw [increment_unfold s h_owner]
   refine ⟨?_, ?_, ?_⟩
-  · simp [ContractResult.snd]
+  · simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot]
   · intro slotIdx h_neq
-    simp [ContractResult.snd, h_neq]
-  · simp [ContractResult.snd, Specs.sameAddrMapContext, Specs.sameStorageAddr,
+    simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot, h_neq]
+  · simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot, Specs.sameAddrMapContext, Specs.sameStorageAddr,
       Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem increment_adds_one_when_owner (s : ContractState)
@@ -156,7 +135,7 @@ theorem increment_adds_one_when_owner (s : ContractState)
   let s' := (increment.run s).snd
   s'.storage 1 = EVM.Uint256.add (s.storage 1) 1 := by
   rw [increment_unfold s h_owner]
-  simp [ContractResult.snd]
+  simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot]
 
 theorem increment_reverts_when_not_owner (s : ContractState)
   (h_not_owner : s.sender ≠ s.storageAddr 0) :
@@ -169,30 +148,9 @@ theorem increment_reverts_when_not_owner (s : ContractState)
 theorem decrement_unfold (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
   (decrement.run s) = ContractResult.success ()
-    { «storage» := fun slotIdx => if (slotIdx == 1) = true then EVM.Uint256.sub (s.storage 1) 1 else s.storage slotIdx,
-      contractStorage := s.contractStorage,
-      transientStorage := s.transientStorage,
-      storageAddr := s.storageAddr,
-      storageMap := s.storageMap,
-      storageMapUint := s.storageMapUint,
-      storageMap2 := s.storageMap2,
-      storageArray := s.storageArray,
-      sender := s.sender,
-      thisAddress := s.thisAddress,
-      txOrigin := s.txOrigin,
-      msgValue := s.msgValue,
-      selfBalance := s.selfBalance,
-      blockTimestamp := s.blockTimestamp,
-      blockNumber := s.blockNumber,
-      chainId := s.chainId,
-      blobBaseFee := s.blobBaseFee,
-      calldataSize := s.calldataSize,
-      calldata := s.calldata,
-      memory := s.memory,
-      knownAddresses := s.knownAddresses,
-      events := s.events, calls := s.calls } := by
+    (s.writeSlot 1 (EVM.Uint256.sub (s.storage 1) 1)) := by
   verity_unfold decrement
-  simp [owner, count, h_owner]
+  simp [owner, count, h_owner, ContractState.writeSlot]
 
 theorem decrement_meets_spec_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -200,10 +158,10 @@ theorem decrement_meets_spec_when_owner (s : ContractState)
   decrement_spec s s' := by
   rw [decrement_unfold s h_owner]
   refine ⟨?_, ?_, ?_⟩
-  · simp [ContractResult.snd]
+  · simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot]
   · intro slotIdx h_neq
-    simp [ContractResult.snd, h_neq]
-  · simp [ContractResult.snd, Specs.sameAddrMapContext, Specs.sameStorageAddr,
+    simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot, h_neq]
+  · simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot, Specs.sameAddrMapContext, Specs.sameStorageAddr,
       Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem decrement_subtracts_one_when_owner (s : ContractState)
@@ -211,7 +169,7 @@ theorem decrement_subtracts_one_when_owner (s : ContractState)
   let s' := (decrement.run s).snd
   s'.storage 1 = EVM.Uint256.sub (s.storage 1) 1 := by
   rw [decrement_unfold s h_owner]
-  simp [ContractResult.snd]
+  simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot]
 
 theorem decrement_reverts_when_not_owner (s : ContractState)
   (h_not_owner : s.sender ≠ s.storageAddr 0) :
@@ -223,30 +181,9 @@ theorem decrement_reverts_when_not_owner (s : ContractState)
 theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) :
   (transferOwnership newOwner).run s = ContractResult.success ()
-    { «storage» := s.storage,
-      contractStorage := s.contractStorage,
-      transientStorage := s.transientStorage,
-      storageAddr := fun slotIdx => if (slotIdx == 0) = true then newOwner else s.storageAddr slotIdx,
-      storageMap := s.storageMap,
-      storageMapUint := s.storageMapUint,
-      storageMap2 := s.storageMap2,
-      storageArray := s.storageArray,
-      sender := s.sender,
-      thisAddress := s.thisAddress,
-      txOrigin := s.txOrigin,
-      msgValue := s.msgValue,
-      selfBalance := s.selfBalance,
-      blockTimestamp := s.blockTimestamp,
-      blockNumber := s.blockNumber,
-      chainId := s.chainId,
-      blobBaseFee := s.blobBaseFee,
-       calldataSize := s.calldataSize,
-       calldata := s.calldata,
-       memory := s.memory,
-       knownAddresses := s.knownAddresses,
-       events := s.events, calls := s.calls } := by
+    (s.writeAddrSlot 0 newOwner) := by
   verity_unfold transferOwnership
-  simp [owner, h_owner]
+  simp [owner, h_owner, ContractState.writeAddrSlot]
 
 theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0 ∧ s.txOrigin = 0) :
@@ -254,10 +191,10 @@ theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : 
   transferOwnership_spec newOwner s s' := by
   rw [transferOwnership_unfold s newOwner h_owner.1]
   refine ⟨?_, ?_, ?_⟩
-  · simp [ContractResult.snd]
+  · simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot]
   · intro slotIdx h_neq
-    simp [ContractResult.snd, h_neq]
-  · simp [ContractResult.snd, Specs.sameStorageMapContext,
+    simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot, h_neq]
+  · simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot, Specs.sameStorageMapContext,
       Specs.sameStorage, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem transferOwnership_changes_owner (s : ContractState) (newOwner : Address)
@@ -265,7 +202,7 @@ theorem transferOwnership_changes_owner (s : ContractState) (newOwner : Address)
   let s' := ((transferOwnership newOwner).run s).snd
   s'.storageAddr 0 = newOwner := by
   rw [transferOwnership_unfold s newOwner h_owner]
-  simp [ContractResult.snd]
+  simp [ContractResult.snd, ContractState.writeSlot, ContractState.writeAddrSlot]
 
 theorem transferOwnership_reverts_when_not_owner (s : ContractState) (newOwner : Address)
   (h_not_owner : s.sender ≠ s.storageAddr 0) :

--- a/Contracts/OwnedCounter/Proofs/Correctness.lean
+++ b/Contracts/OwnedCounter/Proofs/Correctness.lean
@@ -32,7 +32,7 @@ private theorem transfer_sender_not_new_owner (s : ContractState) (newOwner : Ad
   let s' := ((transferOwnership newOwner).run s).snd
   s'.sender ≠ s'.storageAddr 0 := by
   rw [transferOwnership_unfold s newOwner h_owner]
-  simp [ContractResult.snd, h_ne]
+  simp [ContractResult.snd, ContractState.writeAddrSlot, h_ne]
 
 /-- After transferring ownership, the old owner cannot increment.
     The guard correctly reads the new owner from storage and rejects. -/

--- a/Contracts/OwnedCounterComposed.lean
+++ b/Contracts/OwnedCounterComposed.lean
@@ -1,0 +1,3 @@
+import Contracts.OwnedCounterComposed.OwnedCounterComposed
+import Contracts.OwnedCounterComposed.Spec
+import Contracts.OwnedCounterComposed.Proofs.Basic

--- a/Contracts/OwnedCounterComposed/OwnedCounterComposed.lean
+++ b/Contracts/OwnedCounterComposed/OwnedCounterComposed.lean
@@ -1,0 +1,28 @@
+import Contracts.Common
+import Contracts.Ownable.Ownable
+
+namespace Contracts
+
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_contract OwnedCounterComposed include Ownable where
+  storage
+    count : Uint256 := slot 1
+
+  constructor (initialOwner : Address) Ownable(initialOwner) := do
+    setStorage count 0
+
+  function increment () with onlyOwner modifies(count) : Unit := do
+    let current ← getStorage count
+    setStorage count (add current 1)
+
+  function decrement () with onlyOwner modifies(count) : Unit := do
+    let current ← getStorage count
+    setStorage count (sub current 1)
+
+  function getCount () : Uint256 := do
+    let current ← getStorage count
+    return current
+
+end Contracts

--- a/Contracts/OwnedCounterComposed/Proofs/Basic.lean
+++ b/Contracts/OwnedCounterComposed/Proofs/Basic.lean
@@ -1,0 +1,81 @@
+import Contracts.OwnedCounterComposed.Spec
+import Contracts.Ownable.Proofs.Basic
+import Contracts.Ownable.Invariants
+import Verity.Specs.Composition
+import Verity.Proofs.Stdlib.Automation
+
+namespace Contracts.OwnedCounterComposed.Proofs
+
+open Verity
+open Contracts.OwnedCounterComposed
+open Contracts.OwnedCounterComposed.Spec
+open Contracts.Ownable
+open Contracts.Ownable.Proofs
+open Contracts.Ownable.Invariants
+open Verity.Specs.Composition
+
+theorem increment_reverts_when_not_owner (s : ContractState)
+    (h_not_owner : s.sender ≠ s.storageAddr (StorageSlot.slot owner)) :
+    ∃ msg, increment.run s = ContractResult.revert msg s := by
+  rcases onlyOwner_reverts s h_not_owner with ⟨msg, hrev⟩
+  refine ⟨msg, ?_⟩
+  simp only [increment]
+  exact Verity.bind_run_revert onlyOwner _ s msg hrev
+
+theorem increment_meets_spec_when_owner (s : ContractState)
+    (h_owner : s.sender = s.storageAddr (StorageSlot.slot owner)) :
+    let s' := (increment.run s).snd
+    increment_spec s s' := by
+  have hok := onlyOwner_ok s h_owner
+  simp only [increment, Bind.bind]
+  rw [bind_run_success onlyOwner _ s () hok]
+  simp [increment_spec, count, getStorage, setStorage,
+    ContractState.readSlot, ContractState.writeSlot,
+    Verity.bind, Contract.run, ContractResult.snd,
+    Specs.storageUpdateSpec, Specs.storageUnchangedExcept,
+    Specs.sameAddrMapContext, Specs.sameStorageAddr, Specs.sameStorageMap,
+    Specs.sameStorageArray, Specs.sameContext]
+  intro _ hneq heq
+  exact (hneq heq).elim
+
+theorem increment_preserves_owner (s : ContractState)
+    (h_owner : s.sender = s.storageAddr (StorageSlot.slot owner)) :
+    ((increment.run s).snd).storageAddr (StorageSlot.slot owner)
+      = s.storageAddr (StorageSlot.slot owner) := by
+  have hok := onlyOwner_ok s h_owner
+  simp only [increment, Bind.bind]
+  rw [bind_run_success onlyOwner _ s () hok]
+  simp [count, getStorage, setStorage, ContractState.readSlot, ContractState.writeSlot,
+    Verity.bind, Contract.run, ContractResult.snd]
+
+theorem increment_writes_only_count (s : ContractState)
+    (h_owner : s.sender = s.storageAddr (StorageSlot.slot owner)) :
+    WritesOnly countFootprint s (increment.run s).snd := by
+  have hok := onlyOwner_ok s h_owner
+  simp only [increment, Bind.bind]
+  rw [bind_run_success onlyOwner _ s () hok]
+  simp [countFootprint, WritesOnly, count, getStorage, setStorage,
+    ContractState.readSlot, ContractState.writeSlot,
+    Verity.bind, Contract.run, ContractResult.snd, Specs.sameContext]
+  intro _ hneq heq
+  exact (hneq heq).elim
+
+theorem increment_preserves_ownable_inv (s : ContractState)
+    (h_owner : s.sender = s.storageAddr (StorageSlot.slot owner))
+    (hInv : Inv s) :
+    Inv (increment.run s).snd :=
+  writesOnly_preserves_other_inv
+    countFootprint
+    { addrSlots := [StorageSlot.slot owner] }
+    (disjoint_uint_addr (StorageSlot.slot count) (StorageSlot.slot owner))
+    Inv inv_depends_only_on_footprint
+    s (increment.run s).snd
+    (increment_writes_only_count s h_owner)
+    hInv
+
+theorem getCount_meets_spec (s : ContractState) :
+    getCount_spec ((getCount).run s).fst s := by
+  simp [getCount, getCount_spec, count, getStorage, ContractState.readSlot,
+    Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run]
+
+end Contracts.OwnedCounterComposed.Proofs

--- a/Contracts/OwnedCounterComposed/Spec.lean
+++ b/Contracts/OwnedCounterComposed/Spec.lean
@@ -1,0 +1,22 @@
+import Verity.Specs.Common
+import Verity.Specs.Composition
+import Verity.Macro
+import Contracts.OwnedCounterComposed.OwnedCounterComposed
+
+namespace Contracts.OwnedCounterComposed.Spec
+
+open Verity
+open Verity.EVM.Uint256
+open Verity.Specs
+open Verity.Specs.Composition
+open Contracts.OwnedCounterComposed
+
+#gen_spec increment_spec (count.slot, (fun st => add (st.storage count.slot) 1), sameAddrMapContext)
+#gen_spec decrement_spec (count.slot, (fun st => sub (st.storage count.slot) 1), sameAddrMapContext)
+
+def getCount_spec (result : Uint256) (s : ContractState) : Prop :=
+  result = s.storage count.slot
+
+def countFootprint : Footprint := { uintSlots := [count.slot] }
+
+end Contracts.OwnedCounterComposed.Spec

--- a/Contracts/ReentrancyExample/Contract.lean
+++ b/Contracts/ReentrancyExample/Contract.lean
@@ -118,11 +118,11 @@ theorem vulnerable_attack_exists :
     , callOracle := fun _ _ => 1 }
   refine ⟨s, env, ?_⟩
   constructor
-  · simp [s, balances]
+  · simp [s, balances, ContractState.ofChannels]
   constructor
-  · simp [s, totalSupply]
+  · simp [s, totalSupply, ContractState.ofChannels]
   constructor
-  · simp [s, supplyInvariant, balances, totalSupply]
+  · simp [s, supplyInvariant, balances, totalSupply, ContractState.ofChannels]
   ·
     have h_neq : (1 : Uint256) ≠ (0 : Uint256) := by decide
     -- After simplification, the invariant reduces to `1 = 0`, which is false.

--- a/Contracts/ReentrancyExample/Contract.lean
+++ b/Contracts/ReentrancyExample/Contract.lean
@@ -102,19 +102,12 @@ theorem vulnerable_attack_exists :
   -- Choose a concrete attacker and amount. We use MAX_UINT256 so that
   -- `0 - amount` wraps to 1, making the mismatch obvious.
   let s : ContractState :=
-    { storage := fun slot => if slot == totalSupply.slot then (Verity.EVM.MAX_UINT256 : Uint256) else 0
-    , transientStorage := fun _ => 0
-    , storageAddr := fun _ => 0
-    , storageMap := fun slot addr =>
-        if slot == balances.slot && addr == 0xA77AC then (Verity.EVM.MAX_UINT256 : Uint256) else 0
-    , storageMapUint := fun _ _ => 0
-    , storageMap2 := fun _ _ _ => 0
-    , storageArray := fun _ => []
-    , sender := 0xA77AC
-    , thisAddress := 0x7415
-    , msgValue := 0
-    , blockTimestamp := 0
-    , knownAddresses := fun _ => Core.FiniteAddressSet.empty }
+    ContractState.ofChannels
+      (fun slot => if slot == totalSupply.slot then (Verity.EVM.MAX_UINT256 : Uint256) else 0)
+      (mapChannel := fun slot addr =>
+        if slot == balances.slot && addr == 0xA77AC then (Verity.EVM.MAX_UINT256 : Uint256) else 0)
+      (sender := 0xA77AC)
+      (thisAddress := 0x7415)
   let env : Verity.Env :=
     { sender := s.sender
     , thisAddress := s.thisAddress

--- a/Contracts/SafeCounter/Proofs/Basic.lean
+++ b/Contracts/SafeCounter/Proofs/Basic.lean
@@ -55,31 +55,9 @@ theorem evm_add_eq_of_no_overflow (a b : Uint256) (_h : (a : Nat) + (b : Nat) �
 /-- Helper: unfold increment when no overflow -/
 private theorem increment_unfold (s : ContractState)
   (h_no_overflow : (s.storage 0 : Nat) + 1 ≤ MAX_UINT256) :
-  (increment).run s = ContractResult.success ()
-    { «storage» := fun k => if (k == 0) = true then s.storage 0 + 1 else s.storage k,
-      contractStorage := s.contractStorage,
-      transientStorage := s.transientStorage,
-      storageAddr := s.storageAddr,
-      storageMap := s.storageMap,
-      storageMapUint := s.storageMapUint,
-      storageMap2 := s.storageMap2,
-      storageArray := s.storageArray,
-      sender := s.sender,
-      thisAddress := s.thisAddress,
-      txOrigin := s.txOrigin,
-      msgValue := s.msgValue,
-      selfBalance := s.selfBalance,
-      blockTimestamp := s.blockTimestamp,
-      blockNumber := s.blockNumber,
-      chainId := s.chainId,
-      blobBaseFee := s.blobBaseFee,
-      calldataSize := s.calldataSize,
-      calldata := s.calldata,
-      memory := s.memory,
-      knownAddresses := s.knownAddresses,
-      events := s.events, calls := s.calls } := by
+  (increment).run s = ContractResult.success () (s.writeSlot 0 (s.storage 0 + 1)) := by
   verity_unfold increment
-  simp [count, requireSomeUint, Verity.pure, Pure.pure,
+  simp [count, requireSomeUint, Verity.pure, Pure.pure, ContractState.writeSlot,
     safeAdd_some (s.storage 0) 1 h_no_overflow]
 
 theorem increment_meets_spec (s : ContractState)
@@ -87,7 +65,7 @@ theorem increment_meets_spec (s : ContractState)
   let s' := ((increment).run s).snd
   increment_spec s s' := by
   rw [increment_unfold s h_no_overflow]
-  simp only [ContractResult.snd, increment_spec]
+  simp only [ContractResult.snd, ContractState.writeSlot, increment_spec]
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
   · simp [evm_add_eq_of_no_overflow (s.storage 0) 1 h_no_overflow]
   · intro k h_ne; simp [beq_iff_eq, h_ne]
@@ -101,7 +79,7 @@ theorem increment_adds_one (s : ContractState)
   let s' := ((increment).run s).snd
   s'.storage 0 = add (s.storage 0) 1 := by
   rw [increment_unfold s h_no_overflow]
-  simp [ContractResult.snd, evm_add_eq_of_no_overflow (s.storage 0) 1 h_no_overflow]
+  simp [ContractResult.snd, ContractState.writeSlot, evm_add_eq_of_no_overflow (s.storage 0) 1 h_no_overflow]
 
 theorem increment_preserves_other_slots (s : ContractState)
   (h_no_overflow : (s.storage 0 : Nat) + 1 ≤ MAX_UINT256)
@@ -109,7 +87,7 @@ theorem increment_preserves_other_slots (s : ContractState)
   let s' := ((increment).run s).snd
   s'.storage k = s.storage k := by
   rw [increment_unfold s h_no_overflow]
-  simp [ContractResult.snd, beq_iff_eq, h_ne]
+  simp [ContractResult.snd, ContractState.writeSlot, beq_iff_eq, h_ne]
 
 theorem increment_reverts_overflow (s : ContractState)
   (h_overflow : (s.storage 0 : Nat) + 1 > MAX_UINT256) :
@@ -123,31 +101,9 @@ theorem increment_reverts_overflow (s : ContractState)
 /-- Helper: unfold decrement when no underflow -/
 private theorem decrement_unfold (s : ContractState)
   (h_no_underflow : (s.storage 0 : Nat) ≥ 1) :
-  (decrement).run s = ContractResult.success ()
-    { «storage» := fun k => if (k == 0) = true then s.storage 0 - 1 else s.storage k,
-      contractStorage := s.contractStorage,
-      transientStorage := s.transientStorage,
-      storageAddr := s.storageAddr,
-      storageMap := s.storageMap,
-      storageMapUint := s.storageMapUint,
-      storageMap2 := s.storageMap2,
-      storageArray := s.storageArray,
-      sender := s.sender,
-      thisAddress := s.thisAddress,
-      txOrigin := s.txOrigin,
-      msgValue := s.msgValue,
-      selfBalance := s.selfBalance,
-      blockTimestamp := s.blockTimestamp,
-      blockNumber := s.blockNumber,
-      chainId := s.chainId,
-      blobBaseFee := s.blobBaseFee,
-      calldataSize := s.calldataSize,
-      calldata := s.calldata,
-      memory := s.memory,
-      knownAddresses := s.knownAddresses,
-      events := s.events, calls := s.calls } := by
+  (decrement).run s = ContractResult.success () (s.writeSlot 0 (s.storage 0 - 1)) := by
   verity_unfold decrement
-  simp [count, requireSomeUint, Verity.pure, Pure.pure,
+  simp [count, requireSomeUint, Verity.pure, Pure.pure, ContractState.writeSlot,
     safeSub_some (s.storage 0) 1 h_no_underflow]
 
 theorem decrement_meets_spec (s : ContractState)
@@ -155,7 +111,7 @@ theorem decrement_meets_spec (s : ContractState)
   let s' := ((decrement).run s).snd
   decrement_spec s s' := by
   rw [decrement_unfold s h_no_underflow]
-  simp only [ContractResult.snd, decrement_spec]
+  simp only [ContractResult.snd, ContractState.writeSlot, decrement_spec]
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
   · simp [HSub.hSub, sub]
   · intro k h_ne; simp [beq_iff_eq, h_ne]
@@ -169,7 +125,7 @@ theorem decrement_subtracts_one (s : ContractState)
   let s' := ((decrement).run s).snd
   s'.storage 0 = sub (s.storage 0) 1 := by
   rw [decrement_unfold s h_no_underflow]
-  simp [ContractResult.snd, HSub.hSub, sub]
+  simp [ContractResult.snd, ContractState.writeSlot, HSub.hSub, sub]
 
 theorem decrement_preserves_other_slots (s : ContractState)
   (h_no_underflow : (s.storage 0 : Nat) ≥ 1)
@@ -177,7 +133,7 @@ theorem decrement_preserves_other_slots (s : ContractState)
   let s' := ((decrement).run s).snd
   s'.storage k = s.storage k := by
   rw [decrement_unfold s h_no_underflow]
-  simp [ContractResult.snd, beq_iff_eq, h_ne]
+  simp [ContractResult.snd, ContractState.writeSlot, beq_iff_eq, h_ne]
 
 theorem decrement_reverts_underflow (s : ContractState)
   (h_underflow : s.storage 0 = 0) :
@@ -193,7 +149,7 @@ theorem increment_preserves_wellformedness (s : ContractState)
   let s' := ((increment).run s).snd
   WellFormedState s' := by
   rw [increment_unfold s h_no_overflow]
-  simp [ContractResult.snd]
+  simp [ContractResult.snd, ContractState.writeSlot]
   exact ⟨h.sender_nonzero, h.contract_nonzero⟩
 
 theorem decrement_preserves_wellformedness (s : ContractState)
@@ -201,7 +157,7 @@ theorem decrement_preserves_wellformedness (s : ContractState)
   let s' := ((decrement).run s).snd
   WellFormedState s' := by
   rw [decrement_unfold s h_no_underflow]
-  simp [ContractResult.snd]
+  simp [ContractResult.snd, ContractState.writeSlot]
   exact ⟨h.sender_nonzero, h.contract_nonzero⟩
 
 /-! ## Bounds Preservation -/
@@ -211,7 +167,7 @@ theorem increment_preserves_bounds (s : ContractState)
   let s' := ((increment).run s).snd
   count_in_bounds s' := by
   rw [increment_unfold s h_no_overflow]
-  simp [ContractResult.snd, count_in_bounds]
+  simp [ContractResult.snd, ContractState.writeSlot, count_in_bounds]
   have h_bound := Verity.Core.Uint256.val_le_max (s.storage 0 + 1)
   simp [Verity.Core.Uint256.add_comm] at h_bound
   exact h_bound
@@ -222,7 +178,7 @@ theorem decrement_preserves_bounds (s : ContractState)
   let s' := ((decrement).run s).snd
   count_in_bounds s' := by
   rw [decrement_unfold s h_no_underflow]
-  simp [ContractResult.snd, count_in_bounds]
+  simp [ContractResult.snd, ContractState.writeSlot, count_in_bounds]
   exact Verity.Core.Uint256.val_le_max (s.storage 0 - 1)
 
 /-! ## Composition: increment → getCount -/
@@ -232,7 +188,7 @@ theorem increment_getCount_correct (s : ContractState)
   let s' := ((increment).run s).snd
   ((getCount).run s').fst = add (s.storage 0) 1 := by
   rw [increment_unfold s h_no_overflow]
-  simp [getCount_run, ContractResult.snd, evm_add_eq_of_no_overflow (s.storage 0) 1 h_no_overflow]
+  simp [getCount_run, ContractResult.snd, ContractState.writeSlot, evm_add_eq_of_no_overflow (s.storage 0) 1 h_no_overflow]
 
 /-! ## Summary of Proven Properties
 

--- a/Contracts/SafeCounter/Proofs/Basic.lean
+++ b/Contracts/SafeCounter/Proofs/Basic.lean
@@ -57,7 +57,7 @@ private theorem increment_unfold (s : ContractState)
   (h_no_overflow : (s.storage 0 : Nat) + 1 ≤ MAX_UINT256) :
   (increment).run s = ContractResult.success () (s.writeSlot 0 (s.storage 0 + 1)) := by
   verity_unfold increment
-  simp [count, requireSomeUint, Verity.pure, Pure.pure, ContractState.writeSlot,
+  simp [count, requireSomeUint, Verity.pure, Pure.pure, 
     safeAdd_some (s.storage 0) 1 h_no_overflow]
 
 theorem increment_meets_spec (s : ContractState)
@@ -103,7 +103,7 @@ private theorem decrement_unfold (s : ContractState)
   (h_no_underflow : (s.storage 0 : Nat) ≥ 1) :
   (decrement).run s = ContractResult.success () (s.writeSlot 0 (s.storage 0 - 1)) := by
   verity_unfold decrement
-  simp [count, requireSomeUint, Verity.pure, Pure.pure, ContractState.writeSlot,
+  simp [count, requireSomeUint, Verity.pure, Pure.pure, 
     safeSub_some (s.storage 0) 1 h_no_underflow]
 
 theorem decrement_meets_spec (s : ContractState)

--- a/Contracts/SimpleToken/Proofs/Basic.lean
+++ b/Contracts/SimpleToken/Proofs/Basic.lean
@@ -179,7 +179,7 @@ theorem mint_meets_spec_when_owner (s : ContractState) (toAddr : Address) (amoun
   · simp -- supply updated
   · refine ⟨?_, ?_⟩
     · intro addr h_neq; simp [h_neq] -- other balances preserved
-    · intro slotIdx h_neq; intro addr; simp [h_neq] -- other mapping slots
+    · intro slotIdx h_neq addr; simp [h_neq] -- other mapping slots
   · intro slotIdx h_neq; simp [h_neq] -- other uint storage
   · trivial -- owner preserved
   · exact Specs.sameContext_rfl _

--- a/Contracts/SimpleToken/Proofs/Basic.lean
+++ b/Contracts/SimpleToken/Proofs/Basic.lean
@@ -140,33 +140,11 @@ private theorem mint_unfold (s : ContractState) (toAddr : Address) (amount : Uin
   (h_no_bal_overflow : (s.storageMap 1 toAddr : Nat) + (amount : Nat) ≤ MAX_UINT256)
   (h_no_sup_overflow : (s.storage 2 : Nat) + (amount : Nat) ≤ MAX_UINT256) :
   (mint toAddr amount).run s = ContractResult.success ()
-    { «storage» := fun slotIdx =>
-        if (slotIdx == 2) = true then EVM.Uint256.add (s.storage 2) amount else s.storage slotIdx,
-        contractStorage := s.contractStorage,
-        transientStorage := s.transientStorage,
-        storageAddr := s.storageAddr,
-        storageMap := fun slotIdx addr =>
-        if (slotIdx == 1 && addr == toAddr) = true then EVM.Uint256.add (s.storageMap 1 toAddr) amount
-        else s.storageMap slotIdx addr,
-      storageMapUint := s.storageMapUint,
-      storageMap2 := s.storageMap2,
-      storageArray := s.storageArray,
-      sender := s.sender,
-      thisAddress := s.thisAddress,
-      txOrigin := s.txOrigin,
-      msgValue := s.msgValue,
-      selfBalance := s.selfBalance,
-      blockTimestamp := s.blockTimestamp,
-      blockNumber := s.blockNumber,
-      chainId := s.chainId,
-      blobBaseFee := s.blobBaseFee,
-      calldataSize := s.calldataSize,
-      calldata := s.calldata,
-      memory := s.memory,
+    { (s.writeMap 1 toAddr (EVM.Uint256.add (s.storageMap 1 toAddr) amount)).writeSlot 2
+        (EVM.Uint256.add (s.storage 2) amount) with
       knownAddresses := fun slotIdx =>
         if slotIdx == 1 then (s.knownAddresses slotIdx).insert toAddr
-        else s.knownAddresses slotIdx,
-      events := s.events, calls := s.calls } := by
+        else s.knownAddresses slotIdx } := by
   have h_safe_bal := safeAdd_some (s.storageMap 1 toAddr) amount h_no_bal_overflow
   have h_safe_sup := safeAdd_some (s.storage 2) amount h_no_sup_overflow
   verity_unfold mint
@@ -195,7 +173,7 @@ theorem mint_meets_spec_when_owner (s : ContractState) (toAddr : Address) (amoun
   have h_unfold_apply := Contract.eq_of_run_success h_unfold
   simp only [Contract.run, ContractResult.snd, mint_spec]
   rw [h_unfold_apply]
-  simp only [ContractResult.snd]
+  simp only [ContractResult.snd, ContractState.writeSlot, ContractState.writeMap]
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
   · simp -- balance of 'toAddr' updated
   · simp -- supply updated
@@ -285,33 +263,11 @@ private theorem transfer_unfold_other (s : ContractState) (toAddr : Address) (am
   (h_ne : s.sender ≠ toAddr)
   (h_no_overflow : (s.storageMap 1 toAddr : Nat) + (amount : Nat) ≤ MAX_UINT256) :
   (transfer toAddr amount).run s = ContractResult.success ()
-    { «storage» := s.storage,
-      contractStorage := s.contractStorage,
-        transientStorage := s.transientStorage,
-        storageAddr := s.storageAddr,
-        storageMap := fun slotIdx addr =>
-        if (slotIdx == 1 && addr == toAddr) = true then EVM.Uint256.add (s.storageMap 1 toAddr) amount
-        else if (slotIdx == 1 && addr == s.sender) = true then EVM.Uint256.sub (s.storageMap 1 s.sender) amount
-        else s.storageMap slotIdx addr,
-      storageMapUint := s.storageMapUint,
-      storageMap2 := s.storageMap2,
-      storageArray := s.storageArray,
-      sender := s.sender,
-      thisAddress := s.thisAddress,
-      txOrigin := s.txOrigin,
-      msgValue := s.msgValue,
-      selfBalance := s.selfBalance,
-      blockTimestamp := s.blockTimestamp,
-      blockNumber := s.blockNumber,
-      chainId := s.chainId,
-      blobBaseFee := s.blobBaseFee,
-      calldataSize := s.calldataSize,
-      calldata := s.calldata,
-      memory := s.memory,
+    { (s.writeMap 1 s.sender (EVM.Uint256.sub (s.storageMap 1 s.sender) amount)).writeMap 1 toAddr
+        (EVM.Uint256.add (s.storageMap 1 toAddr) amount) with
       knownAddresses := fun slotIdx =>
         if slotIdx == 1 then ((s.knownAddresses slotIdx).insert s.sender).insert toAddr
-        else s.knownAddresses slotIdx,
-      events := s.events, calls := s.calls } := by
+        else s.knownAddresses slotIdx } := by
   have h_balance' := uint256_ge_val_le h_balance
   have h_safe := safeAdd_some (s.storageMap 1 toAddr) amount h_no_overflow
   simp only [transfer, Contracts.SimpleToken.balancesSlot,
@@ -350,7 +306,7 @@ theorem transfer_meets_spec_when_sufficient (s : ContractState) (toAddr : Addres
     have h_unfold_apply := Contract.eq_of_run_success h_unfold
     simp only [Contract.run, ContractResult.snd, transfer_spec]
     rw [h_unfold_apply]
-    simp only [ContractResult.snd]
+    simp only [ContractResult.snd, ContractState.writeSlot, ContractState.writeMap]
     have h_ne' := address_beq_false_of_ne s.sender toAddr h_eq
     refine ⟨h_balance, ?_, ?_, ?_, ?_, ?_⟩
     · simp [h_ne'] -- sender balance decreased

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -1,4 +1,5 @@
 import Contracts.Smoke.Helpers
+import Contracts.Smoke.Include
 import Contracts.Smoke.Intrinsics
 import Contracts.Smoke.Storage
 import Contracts.Smoke.Arithmetic

--- a/Contracts/Smoke/Include.lean
+++ b/Contracts/Smoke/Include.lean
@@ -1,0 +1,95 @@
+import Contracts.Common
+import Compiler.CheckContract
+
+namespace Contracts.Smoke
+
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_mixin IncludeOwnableMixin where
+  storage
+    owner : Address := slot 0
+
+  constructor (initialOwner : Address) := do
+    setStorageAddr owner initialOwner
+
+  modifier onlyOwner := do
+    let sender ← msgSender
+    let currentOwner ← getStorageAddr owner
+    require (sender == currentOwner) "Caller is not the owner"
+
+  function transferOwnership (newOwner : Address) with onlyOwner modifies(owner) : Unit := do
+    setStorageAddr owner newOwner
+
+verity_contract IncludeOwnedCounterHost include IncludeOwnableMixin where
+  storage
+    count : Uint256 := slot 1
+
+  constructor (initialOwner : Address) IncludeOwnableMixin(initialOwner) := do
+    setStorage count 0
+
+  function increment () with onlyOwner modifies(count) : Unit := do
+    let current ← getStorage count
+    setStorage count (add current 1)
+
+#check_contract IncludeOwnedCounterHost
+
+verity_mixin IncludeNsMixinA where
+  storage
+    storage_namespace erc7201 "verity.mixin.A"
+    flagA : Uint256 := slot 0
+
+  constructor () := do
+    setStorage flagA 1
+
+verity_mixin IncludeNsMixinB where
+  storage
+    storage_namespace erc7201 "verity.mixin.B"
+    flagB : Uint256 := slot 0
+
+  constructor () := do
+    setStorage flagB 2
+
+verity_contract IncludeTwoNamespaceHost include IncludeNsMixinA, IncludeNsMixinB where
+  storage
+    extra : Uint256 := slot 1
+
+  constructor IncludeNsMixinA() IncludeNsMixinB() := do
+    setStorage extra 3
+
+#check_contract IncludeTwoNamespaceHost
+
+/--
+error: include clash: slot 0 from mixin 'Contracts.Smoke.IncludeOwnableMixin' field 'owner' overlaps a host or earlier mixin slot
+-/
+#guard_msgs in
+verity_contract IncludeSlotOverlapRejected include IncludeOwnableMixin where
+  storage
+    ownerDup : Address := slot 0
+
+  constructor (initialOwner : Address) IncludeOwnableMixin(initialOwner) := do
+    pure ()
+
+/--
+error: include clash: field 'owner' from mixin 'Contracts.Smoke.IncludeOwnableMixin' duplicates a host or earlier mixin field
+-/
+#guard_msgs in
+verity_contract IncludeNameClashRejected include IncludeOwnableMixin where
+  storage
+    owner : Address := slot 2
+
+  constructor (initialOwner : Address) IncludeOwnableMixin(initialOwner) := do
+    pure ()
+
+/--
+error: missing mixin constructor call for 'IncludeOwnableMixin'; add `IncludeOwnableMixin(...)` to the host constructor
+-/
+#guard_msgs in
+verity_contract IncludeMissingCtorRejected include IncludeOwnableMixin where
+  storage
+    count : Uint256 := slot 1
+
+  constructor (initialOwner : Address) := do
+    setStorage count 0
+
+end Contracts.Smoke

--- a/Contracts/Smoke/Include.lean
+++ b/Contracts/Smoke/Include.lean
@@ -169,12 +169,49 @@ verity_mixin IncludeImmutableMixin where
 
 verity_contract IncludeImmutableHost include IncludeImmutableMixin where
   storage
-    count : Uint256 := slot 0
+    count : Uint256 := slot 1
 
   constructor (seed : Uint256) IncludeImmutableMixin(seed) := do
     setStorage count 0
 
 #check_contract IncludeImmutableHost
+
+/--
+error: include clash: slot 0 from mixin 'Contracts.Smoke.IncludeImmutableMixin' immutable 'version' overlaps a host or earlier mixin slot
+-/
+#guard_msgs in
+verity_contract IncludeImmutableSlotClashRejected include IncludeImmutableMixin where
+  storage
+    count : Uint256 := slot 0
+
+  constructor (seed : Uint256) IncludeImmutableMixin(seed) := do
+    setStorage count 0
+
+verity_mixin IncludeOrderMixin where
+  storage
+    flag : Uint256 := slot 0
+
+  constructor () := do
+    setStorage flag 0
+
+  modifier mixinGuard := do
+    let current ← getStorage flag
+    setStorage flag (add current 1)
+
+verity_contract IncludeModifierOrderHost include IncludeOrderMixin where
+  storage
+    last : Uint256 := slot 1
+
+  constructor IncludeOrderMixin() := do
+    setStorage last 0
+
+  modifier localGuard := do
+    setStorage last 7
+
+  function bump () with localGuard, mixinGuard modifies(flag, last) : Unit := do
+    pure ()
+
+#check_contract IncludeModifierOrderHost
 
 verity_mixin IncludeHelperMixinA where
   storage

--- a/Contracts/Smoke/Include.lean
+++ b/Contracts/Smoke/Include.lean
@@ -123,4 +123,87 @@ verity_contract IncludeRenamedCtorArgHost include IncludeOwnableMixin where
 
 #check_contract IncludeRenamedCtorArgHost
 
+verity_mixin IncludeErrorMixin where
+  storage
+    owner : Address := slot 0
+
+  errors
+    error NotOwner()
+
+  constructor (initialOwner : Address) := do
+    setStorageAddr owner initialOwner
+
+  modifier onlyOwner := do
+    let sender ← msgSender
+    let currentOwner ← getStorageAddr owner
+    requireError (sender == currentOwner) NotOwner()
+
+  function poke () with onlyOwner : Unit := do
+    pure ()
+
+verity_contract IncludeErrorHost include IncludeErrorMixin where
+  storage
+    count : Uint256 := slot 1
+
+  constructor (initialOwner : Address) IncludeErrorMixin(initialOwner) := do
+    setStorage count 0
+
+  function increment () with onlyOwner modifies(count) : Unit := do
+    let current ← getStorage count
+    setStorage count (add current 1)
+
+#check_contract IncludeErrorHost
+
+verity_mixin IncludeImmutableMixin where
+  storage
+
+  immutables
+    version : Uint256 := seed
+
+  constructor (seed : Uint256) := do
+    let _ := seed
+    pure ()
+
+  function getVersion () : Uint256 := do
+    return version
+
+verity_contract IncludeImmutableHost include IncludeImmutableMixin where
+  storage
+    count : Uint256 := slot 0
+
+  constructor (seed : Uint256) IncludeImmutableMixin(seed) := do
+    setStorage count 0
+
+#check_contract IncludeImmutableHost
+
+verity_mixin IncludeHelperMixinA where
+  storage
+    a : Uint256 := slot 0
+
+  constructor () := do
+    setStorage a 1
+
+  function internal helper (x : Uint256) : Uint256 := do
+    return x
+
+verity_mixin IncludeHelperMixinB where
+  storage
+    b : Uint256 := slot 1
+
+  constructor () := do
+    setStorage b 2
+
+  function internal helper (x : Uint256) : Uint256 := do
+    return x
+
+/--
+error: include clash: function 'helper' from mixin 'Contracts.Smoke.IncludeHelperMixinB' duplicates a host or earlier mixin function
+-/
+#guard_msgs in
+verity_contract IncludeInternalClashRejected include IncludeHelperMixinA, IncludeHelperMixinB where
+  storage
+
+  constructor IncludeHelperMixinA() IncludeHelperMixinB() := do
+    pure ()
+
 end Contracts.Smoke

--- a/Contracts/Smoke/Include.lean
+++ b/Contracts/Smoke/Include.lean
@@ -92,4 +92,35 @@ verity_contract IncludeMissingCtorRejected include IncludeOwnableMixin where
   constructor (initialOwner : Address) := do
     setStorage count 0
 
+/--
+error: duplicate mixin constructor call for 'IncludeOwnableMixin'; each included mixin may be initialized once
+-/
+#guard_msgs in
+verity_contract IncludeDupCtorRejected include IncludeOwnableMixin where
+  storage
+    count : Uint256 := slot 1
+
+  constructor (initialOwner : Address) IncludeOwnableMixin(initialOwner) IncludeOwnableMixin(initialOwner) := do
+    setStorage count 0
+
+/--
+error: mixin constructor 'IncludeOwnableMixin' expects 1 argument(s), got 0
+-/
+#guard_msgs in
+verity_contract IncludeCtorArityRejected include IncludeOwnableMixin where
+  storage
+    count : Uint256 := slot 1
+
+  constructor IncludeOwnableMixin() := do
+    setStorage count 0
+
+verity_contract IncludeRenamedCtorArgHost include IncludeOwnableMixin where
+  storage
+    count : Uint256 := slot 1
+
+  constructor (owner_ : Address) IncludeOwnableMixin(owner_) := do
+    setStorage count 0
+
+#check_contract IncludeRenamedCtorArgHost
+
 end Contracts.Smoke

--- a/Contracts/Smoke/Storage.lean
+++ b/Contracts/Smoke/Storage.lean
@@ -441,9 +441,7 @@ verity_contract StorageBoolArraySmoke where
 
 def storageAddressArrayExecutableReadsHead : Bool :=
   let seededState : Verity.ContractState :=
-    { Verity.defaultState with
-      storageArray := fun idx =>
-        if idx == StorageAddressArraySmoke.owners.slot then [11, 17] else [] }
+    Verity.defaultState.writeArray StorageAddressArraySmoke.owners.slot [11, 17]
   match StorageAddressArraySmoke.firstOwner seededState with
   | .success owner state =>
       owner == (11 : Address) &&
@@ -462,9 +460,7 @@ example : storageAddressArrayExecutablePushStoresWord = true := by decide
 
 def storageAddressArrayExecutableSetUpdatesHead : Bool :=
   let seededState : Verity.ContractState :=
-    { Verity.defaultState with
-      storageArray := fun idx =>
-        if idx == StorageAddressArraySmoke.owners.slot then [11, 17] else [] }
+    Verity.defaultState.writeArray StorageAddressArraySmoke.owners.slot [11, 17]
   match StorageAddressArraySmoke.replaceFirstOwner (29 : Address) seededState with
   | .success () state =>
       state.storageArray StorageAddressArraySmoke.owners.slot == [29, 17]
@@ -474,9 +470,7 @@ example : storageAddressArrayExecutableSetUpdatesHead = true := by decide
 
 def storageBytes32ArrayExecutableReadsHead : Bool :=
   let seededState : Verity.ContractState :=
-    { Verity.defaultState with
-      storageArray := fun idx =>
-        if idx == StorageBytes32ArraySmoke.digests.slot then [41, 43] else [] }
+    Verity.defaultState.writeArray StorageBytes32ArraySmoke.digests.slot [41, 43]
   match StorageBytes32ArraySmoke.firstDigest seededState with
   | .success digest state =>
       digest == 41 &&
@@ -487,9 +481,7 @@ example : storageBytes32ArrayExecutableReadsHead = true := by decide
 
 def storageBoolArrayExecutableReadsHead : Bool :=
   let seededState : Verity.ContractState :=
-    { Verity.defaultState with
-      storageArray := fun idx =>
-        if idx == StorageBoolArraySmoke.flags.slot then [0, 1] else [] }
+    Verity.defaultState.writeArray StorageBoolArraySmoke.flags.slot [0, 1]
   match StorageBoolArraySmoke.firstFlag seededState with
   | .success flag state =>
       flag = false &&
@@ -508,9 +500,7 @@ example : storageBoolArrayExecutablePushStoresCanonicalWord = true := by decide
 
 def storageBoolArrayExecutableSetUpdatesHead : Bool :=
   let seededState : Verity.ContractState :=
-    { Verity.defaultState with
-      storageArray := fun idx =>
-        if idx == StorageBoolArraySmoke.flags.slot then [0, 1] else [] }
+    Verity.defaultState.writeArray StorageBoolArraySmoke.flags.slot [0, 1]
   match StorageBoolArraySmoke.setFirstFlag true seededState with
   | .success () state =>
       state.storageArray StorageBoolArraySmoke.flags.slot == [1, 1]

--- a/Contracts/TypedIRTests.lean
+++ b/Contracts/TypedIRTests.lean
@@ -582,18 +582,7 @@ def counterIncrementIR : List YulStmt :=
   ]
 
 def counterTypedInitWorld : Verity.ContractState :=
-  { «storage» := fun i => if i = 0 then 41 else 0
-    transientStorage := fun _ => 0
-    storageAddr := fun _ => 0
-    storageMap := fun _ _ => 0
-    storageMapUint := fun _ _ => 0
-    storageMap2 := fun _ _ _ => 0
-    sender := 0
-    thisAddress := 0
-    msgValue := 0
-    blockTimestamp := 0
-    knownAddresses := fun _ => Verity.Core.FiniteAddressSet.empty
-    events := [] }
+  Verity.defaultState.writeSlot 0 41
 
 def counterTypedInit : TExecState :=
   { world := counterTypedInitWorld }
@@ -641,18 +630,7 @@ def simpleStorageStoreIR : List YulStmt :=
   [ .exprStmt (.call "sstore" [.lit 0, .ident "value"]) ]
 
 def simpleStorageTypedInitWorld : Verity.ContractState :=
-  { «storage» := fun i => if i = 0 then 5 else 0
-    transientStorage := fun _ => 0
-    storageAddr := fun _ => 0
-    storageMap := fun _ _ => 0
-    storageMapUint := fun _ _ => 0
-    storageMap2 := fun _ _ _ => 0
-    sender := 0
-    thisAddress := 0
-    msgValue := 0
-    blockTimestamp := 0
-    knownAddresses := fun _ => Verity.Core.FiniteAddressSet.empty
-    events := [] }
+  Verity.defaultState.writeSlot 0 5
 
 def simpleStorageTypedInit : TExecState :=
   { world := simpleStorageTypedInitWorld
@@ -880,7 +858,7 @@ example : compiledCounterLoweredFinalSlot = compiledCounterIncrementFinalSlot :=
 
 def compiledCounterDecrementFinalSlot : Option Nat :=
   let initWorld : Verity.ContractState :=
-    { counterTypedInitWorld with «storage» := fun i => if i = 0 then 41 else 0 }
+    counterTypedInitWorld.writeSlot 0 41
   let initTyped : TExecState := { world := initWorld }
   match compileFunctionNamed Contracts.Counter.spec "decrement" with
   | .error _ => none
@@ -891,7 +869,7 @@ def compiledCounterDecrementFinalSlot : Option Nat :=
 
 def compiledCounterDecrementLoweredFinalSlot : Option Nat :=
   let initWorld : Verity.ContractState :=
-    { counterTypedInitWorld with «storage» := fun i => if i = 0 then 41 else 0 }
+    counterTypedInitWorld.writeSlot 0 41
   let initTyped : TExecState := { world := initWorld }
   match compileFunctionNamed Contracts.Counter.spec "decrement" with
   | .error _ => none
@@ -904,7 +882,7 @@ example : compiledCounterDecrementLoweredFinalSlot = compiledCounterDecrementFin
 
 def compiledCounterGetCountReturn : Option Nat :=
   let initWorld : Verity.ContractState :=
-    { counterTypedInitWorld with «storage» := fun i => if i = 0 then 41 else 0 }
+    counterTypedInitWorld.writeSlot 0 41
   let initTyped : TExecState := { world := initWorld }
   match compileFunctionNamed Contracts.Counter.spec "getCount" with
   | .error _ => none
@@ -945,7 +923,7 @@ example : compiledSimpleStorageLoweredFinalSlot = compiledSimpleStorageStoreFina
 
 def compiledSimpleStorageRetrieveReturn : Option Nat :=
   let initWorld : Verity.ContractState :=
-    { simpleStorageTypedInitWorld with «storage» := fun i => if i = 0 then 77 else 0 }
+    simpleStorageTypedInitWorld.writeSlot 0 77
   let initTyped : TExecState := { world := initWorld }
   match compileFunctionNamed Contracts.SimpleStorage.spec "retrieve" with
   | .error _ => none
@@ -994,13 +972,8 @@ def compiledLedgerTransferResult : Option (Nat × Nat) :=
       match block.params with
       | [toParam, amountParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              -- sender (address 1) has balance 100 in mapping slot 0
-              storageMap := fun i addr =>
-                if i == 0 && addr == 1 then 100
-                else if i == 0 && addr == 2 then 50
-                else 0
-              sender := 1 }
+            -- sender (address 1) has balance 100 in mapping slot 0
+            { (Verity.defaultState.writeMap 0 1 100).writeMap 0 2 50 with sender := 1 }
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i =>
@@ -1031,7 +1004,7 @@ def compiledOwnedGetOwnerReturn : Option Nat :=
   | .error _ => none
   | .ok block =>
       let initWorld : Verity.ContractState :=
-        { Verity.defaultState with storageAddr := fun i => if i = 0 then 42 else 0 }
+        Verity.defaultState.writeAddrSlot 0 42
       let init : TExecState := { world := initWorld }
       execLoweredReturn 256 (mkIRStateFromTyped init block) block
 
@@ -1056,9 +1029,7 @@ def compiledOwnedTransferOwnershipSuccess : Option Nat :=
       match block.params with
       | [newOwnerParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageAddr := fun i => if i = 0 then 42 else 0
-              sender := 42 }
+            { Verity.defaultState.writeAddrSlot 0 42 with sender := 42 }
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i =>
@@ -1079,9 +1050,7 @@ def compiledOwnedTransferOwnershipReverts : Bool :=
       match block.params with
       | [newOwnerParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageAddr := fun i => if i = 0 then 42 else 0
-              sender := 99 }
+            { Verity.defaultState.writeAddrSlot 0 42 with sender := 99 }
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i =>
@@ -1120,10 +1089,7 @@ def compiledVaultDepositResult : Option (Nat × Nat × Nat) :=
       match block.params with
       | [amountParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              «storage» := fun i => if i == 0 || i == 1 then 100 else 0
-              storageMap := fun i addr =>
-                if i == 2 && addr == 1 then 100 else 0
+            { ((Verity.defaultState.writeSlot 0 100).writeSlot 1 100).writeMap 2 1 100 with
               sender := 1 }
           let init : TExecState :=
             { world := initWorld
@@ -1145,10 +1111,7 @@ def compiledVaultWithdrawSuccess : Option (Nat × Nat × Nat) :=
       match block.params with
       | [sharesParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              «storage» := fun i => if i == 0 || i == 1 then 100 else 0
-              storageMap := fun i addr =>
-                if i == 2 && addr == 1 then 100 else 0
+            { ((Verity.defaultState.writeSlot 0 100).writeSlot 1 100).writeMap 2 1 100 with
               sender := 1 }
           let init : TExecState :=
             { world := initWorld
@@ -1170,10 +1133,7 @@ def compiledVaultWithdrawReverts : Bool :=
       match block.params with
       | [sharesParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              «storage» := fun i => if i == 0 || i == 1 then 100 else 0
-              storageMap := fun i addr =>
-                if i == 2 && addr == 1 then 10 else 0
+            { ((Verity.defaultState.writeSlot 0 100).writeSlot 1 100).writeMap 2 1 10 with
               sender := 1 }
           let init : TExecState :=
             { world := initWorld
@@ -1195,10 +1155,7 @@ def compiledLedgerDepositResult : Option Nat :=
       match block.params with
       | [amountParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageMap := fun i addr =>
-                if i == 0 && addr == 1 then 100 else 0
-              sender := 1 }
+            { Verity.defaultState.writeMap 0 1 100 with sender := 1 }
           let init : TExecState :=
             { world := initWorld
               vars := { uint256 := fun i =>
@@ -1219,10 +1176,7 @@ def compiledLedgerWithdrawSuccess : Option Nat :=
       match block.params with
       | [amountParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageMap := fun i addr =>
-                if i == 0 && addr == 1 then 100 else 0
-              sender := 1 }
+            { Verity.defaultState.writeMap 0 1 100 with sender := 1 }
           let init : TExecState :=
             { world := initWorld
               vars := { uint256 := fun i =>
@@ -1243,10 +1197,7 @@ def compiledLedgerWithdrawReverts : Bool :=
       match block.params with
       | [amountParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageMap := fun i addr =>
-                if i == 0 && addr == 1 then 10 else 0
-              sender := 1 }
+            { Verity.defaultState.writeMap 0 1 10 with sender := 1 }
           let init : TExecState :=
             { world := initWorld
               vars := { uint256 := fun i =>
@@ -1265,10 +1216,7 @@ def compiledOwnedCounterIncrementSuccess : Option Nat :=
   | .error _ => none
   | .ok block =>
       let initWorld : Verity.ContractState :=
-        { Verity.defaultState with
-          storageAddr := fun i => if i = 0 then 42 else 0
-          «storage» := fun i => if i = 1 then 10 else 0
-          sender := 42 }
+        { (Verity.defaultState.writeAddrSlot 0 42).writeSlot 1 10 with sender := 42 }
       let init : TExecState := { world := initWorld }
       match evalTBlock init block with
       | .ok s => some (s.world.storage 1)
@@ -1283,10 +1231,7 @@ def compiledOwnedCounterIncrementReverts : Bool :=
   | .error _ => false
   | .ok block =>
       let initWorld : Verity.ContractState :=
-        { Verity.defaultState with
-          storageAddr := fun i => if i = 0 then 42 else 0
-          «storage» := fun i => if i = 1 then 10 else 0
-          sender := 99 }
+        { (Verity.defaultState.writeAddrSlot 0 42).writeSlot 1 10 with sender := 99 }
       let init : TExecState := { world := initWorld }
       match evalTBlock init block with
       | .ok _ => false
@@ -1310,10 +1255,7 @@ def compiledOwnedCounterTransferOwnershipSuccess : Option (Nat × Nat) :=
       match block.params with
       | [newOwnerParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageAddr := fun i => if i = 0 then 42 else 0
-              «storage» := fun i => if i = 1 then 10 else 0
-              sender := 42 }
+            { (Verity.defaultState.writeAddrSlot 0 42).writeSlot 1 10 with sender := 42 }
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i =>
@@ -1334,10 +1276,7 @@ def compiledOwnedCounterTransferOwnershipReverts : Bool :=
       match block.params with
       | [newOwnerParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageAddr := fun i => if i = 0 then 42 else 0
-              «storage» := fun i => if i = 1 then 10 else 0
-              sender := 77 }
+            { (Verity.defaultState.writeAddrSlot 0 42).writeSlot 1 10 with sender := 77 }
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i =>
@@ -1381,12 +1320,7 @@ def compiledERC20TransferFromSuccess : Option (Nat × Nat × Nat) :=
       match approveBlock.params, transferFromBlock.params with
       | [spenderParam, approveAmountParam], [fromParam, toParam, transferAmountParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageMap := fun i addr =>
-                if i == 2 && addr == 11 then 100
-                else if i == 2 && addr == 33 then 50
-                else 0
-              sender := 11 }
+            { (Verity.defaultState.writeMap 2 11 100).writeMap 2 33 50 with sender := 11 }
           let approveInit : TExecState :=
             { world := initWorld
               vars := { address := fun i =>
@@ -1422,14 +1356,8 @@ def compiledERC20TransferFromInfiniteAllowance : Option (Nat × Nat × Nat) :=
       match block.params with
       | [fromParam, toParam, amountParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageMap := fun i addr =>
-                if i == 2 && addr == 11 then 100
-                else if i == 2 && addr == 33 then 50
-                else 0
-              storageMap2 := fun i ownerAddr spenderAddr =>
-                if i == 3 && ownerAddr == 11 && spenderAddr == 22 then maxUint256 else 0
-              sender := 22 }
+            { ((Verity.defaultState.writeMap 2 11 100).writeMap 2 33 50).writeMap2 3 11 22
+                maxUint256 with sender := 22 }
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i =>
@@ -1455,12 +1383,7 @@ def compiledERC20TransferFromSelfTransfer : Option (Nat × Nat) :=
       match block.params with
       | [fromParam, toParam, amountParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageMap := fun i addr =>
-                if i == 2 && addr == 11 then 100 else 0
-              storageMap2 := fun i ownerAddr spenderAddr =>
-                if i == 3 && ownerAddr == 11 && spenderAddr == 22 then 40 else 0
-              sender := 22 }
+            { (Verity.defaultState.writeMap 2 11 100).writeMap2 3 11 22 40 with sender := 22 }
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i =>
@@ -1485,14 +1408,8 @@ def compiledERC20TransferFromInsufficientAllowanceReverts : Bool :=
       match block.params with
       | [fromParam, toParam, amountParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageMap := fun i addr =>
-                if i == 2 && addr == 11 then 100
-                else if i == 2 && addr == 33 then 50
-                else 0
-              storageMap2 := fun i ownerAddr spenderAddr =>
-                if i == 3 && ownerAddr == 11 && spenderAddr == 22 then 20 else 0
-              sender := 22 }
+            { ((Verity.defaultState.writeMap 2 11 100).writeMap 2 33 50).writeMap2 3 11 22 20
+              with sender := 22 }
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i =>
@@ -1669,9 +1586,7 @@ def compiledERC721ApproveTransferSuccess : Option (Nat × Nat × Nat × Nat) :=
       match mintBlock.params, approveBlock.params, transferBlock.params with
       | [mintToParam], [approvedParam, approveTokenParam], [fromParam, toParam, transferTokenParam] =>
           let mintInitWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageAddr := fun i => if i == 0 then 9 else 0
-              sender := 9 }
+            { Verity.defaultState.writeAddrSlot 0 9 with sender := 9 }
           let mintInit : TExecState :=
             { world := mintInitWorld
               vars := { address := fun i => if i = mintToParam.id then 11 else 0 } }
@@ -1708,9 +1623,7 @@ def compiledERC721TransferUnauthorizedReverts : Bool :=
       match mintBlock.params, transferBlock.params with
       | [mintToParam], [fromParam, toParam, transferTokenParam] =>
           let mintInitWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageAddr := fun i => if i == 0 then 9 else 0
-              sender := 9 }
+            { Verity.defaultState.writeAddrSlot 0 9 with sender := 9 }
           let mintInit : TExecState :=
             { world := mintInitWorld
               vars := { address := fun i => if i = mintToParam.id then 11 else 0 } }
@@ -1741,7 +1654,7 @@ def compiledSafeCounterIncrementSuccess : Option Nat :=
   | .error _ => none
   | .ok block =>
       let initWorld : Verity.ContractState :=
-        { Verity.defaultState with «storage» := fun i => if i = 0 then 5 else 0 }
+        Verity.defaultState.writeSlot 0 5
       let init : TExecState := { world := initWorld }
       match evalTBlock init block with
       | .ok s => some (s.world.storage 0)
@@ -1756,7 +1669,7 @@ def compiledSafeCounterDecrementSuccess : Option Nat :=
   | .error _ => none
   | .ok block =>
       let initWorld : Verity.ContractState :=
-        { Verity.defaultState with «storage» := fun i => if i = 0 then 5 else 0 }
+        Verity.defaultState.writeSlot 0 5
       let init : TExecState := { world := initWorld }
       match evalTBlock init block with
       | .ok s => some (s.world.storage 0)
@@ -1771,7 +1684,7 @@ def compiledSafeCounterDecrementUnderflow : Bool :=
   | .error _ => false
   | .ok block =>
       let initWorld : Verity.ContractState :=
-        { Verity.defaultState with «storage» := fun _ => 0 }
+        Verity.defaultState
       let init : TExecState := { world := initWorld }
       match evalTBlock init block with
       | .ok _ => false
@@ -1786,7 +1699,7 @@ def compiledSafeCounterGetCountReturn : Option Nat :=
   | .error _ => none
   | .ok block =>
       let initWorld : Verity.ContractState :=
-        { Verity.defaultState with «storage» := fun i => if i = 0 then 42 else 0 }
+        Verity.defaultState.writeSlot 0 42
       let init : TExecState := { world := initWorld }
       execLoweredReturn 256 (mkIRStateFromTyped init block) block
 
@@ -2471,9 +2384,7 @@ def compiledLedgerGetBalancePreservesState : Bool :=
       match block.params with
       | [addrParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageMap := fun i addr =>
-                if i == 0 && addr == 42 then 200 else 0 }
+            Verity.defaultState.writeMap 0 42 200
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i =>
@@ -2494,9 +2405,7 @@ def compiledSimpleTokenBalanceOfPreservesState : Bool :=
       match block.params with
       | [addrParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageMap := fun i addr =>
-                if i == 1 && addr == 42 then 500 else 0 }
+            Verity.defaultState.writeMap 1 42 500
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i =>
@@ -2515,7 +2424,7 @@ def compiledSimpleTokenTotalSupplyPreservesState : Bool :=
   | .error _ => false
   | .ok block =>
       let initWorld : Verity.ContractState :=
-        { Verity.defaultState with «storage» := fun i => if i = 2 then 1000 else 0 }
+        Verity.defaultState.writeSlot 2 1000
       let init : TExecState := { world := initWorld }
       match evalTBlock init block with
       | .ok _ => true
@@ -2530,7 +2439,7 @@ def compiledSimpleTokenOwnerPreservesState : Bool :=
   | .error _ => false
   | .ok block =>
       let initWorld : Verity.ContractState :=
-        { Verity.defaultState with storageAddr := fun i => if i = 0 then 42 else 0 }
+        Verity.defaultState.writeAddrSlot 0 42
       let init : TExecState := { world := initWorld }
       match evalTBlock init block with
       | .ok _ => true
@@ -2659,7 +2568,7 @@ def compiledERC20TotalSupplyPreservesState : Bool :=
   | .error _ => false
   | .ok block =>
       let initWorld : Verity.ContractState :=
-        { Verity.defaultState with «storage» := fun i => if i = 1 then 42000 else 0 }
+        Verity.defaultState.writeSlot 1 42000
       let init : TExecState := { world := initWorld }
       match evalTBlock init block with
       | .ok _ => true
@@ -2674,7 +2583,7 @@ def compiledERC20OwnerPreservesState : Bool :=
   | .error _ => false
   | .ok block =>
       let initWorld : Verity.ContractState :=
-        { Verity.defaultState with storageAddr := fun i => if i = 0 then 0xDEAD else 0 }
+        Verity.defaultState.writeAddrSlot 0 0xDEAD
       let init : TExecState := { world := initWorld }
       match evalTBlock init block with
       | .ok _ => true
@@ -2691,9 +2600,7 @@ def compiledERC20BalanceOfPreservesState : Bool :=
       match block.params with
       | [addrParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageMap := fun i addr =>
-                if i == 2 && addr == 42 then 500 else 0 }
+            Verity.defaultState.writeMap 2 42 500
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i =>
@@ -2714,9 +2621,7 @@ def compiledERC20AllowanceOfPreservesState : Bool :=
       match block.params with
       | [ownerParam, spenderParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              storageMap2 := fun i a1 a2 =>
-                if i == 3 && a1 == 100 && a2 == 200 then 750 else 0 }
+            Verity.defaultState.writeMap2 3 100 200 750
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i =>
@@ -2739,7 +2644,7 @@ def compiledERC20ApprovePreservesState : Bool :=
       match block.params with
       | [spenderParam, amountParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with storageMap2 := fun _ _ _ => 0 }
+            Verity.defaultState
           let init : TExecState :=
             { world := initWorld
               env := { Verity.Env.ofWorld initWorld with sender := 0xCAFE }
@@ -2770,16 +2675,8 @@ open Compiler.CompilationModel in
 /-- `SimpleToken.mint`: owner path keeps compiled/source multi-read outputs aligned. -/
 private def simpleTokenMintOwnerAgreement : Bool :=
   let init : TExecState :=
-    { world := { Verity.defaultState with
-        storageAddr := fun s => if s = 0 then 0xA11CE else 0,
-        storageMap := fun s addr =>
-          if s = 1 && addr = 0xBEEF then 7
-          else if s = 1 && addr = 0xF00D then 99
-          else 0,
-        «storage» := fun s =>
-          if s = 2 then 100
-          else if s = 9 then 444
-          else 0 }
+    { world := ((((Verity.defaultState.writeAddrSlot 0 0xA11CE).writeMap 1 0xBEEF 7).writeMap
+          1 0xF00D 99).writeSlot 2 100).writeSlot 9 444
       env := { Verity.Env.ofWorld Verity.defaultState with sender := 0xA11CE }
       vars := { address := fun i => if i = 0 then 0xBEEF else 0
                 uint256 := fun i => if i = 1 then 5 else 0 } }
@@ -2829,10 +2726,7 @@ open Compiler.CompilationModel in
 /-- `SimpleToken.mint`: non-owner path reverts identically. -/
 private def simpleTokenMintNonOwnerAgreement : Bool :=
   let init : TExecState :=
-    { world := { Verity.defaultState with
-        storageAddr := fun s => if s = 0 then 0xA11CE else 0,
-        storageMap := fun s addr => if s = 1 && addr = 0xBEEF then 7 else 0,
-        «storage» := fun s => if s = 2 then 100 else 0 }
+    { world := ((Verity.defaultState.writeAddrSlot 0 0xA11CE).writeMap 1 0xBEEF 7).writeSlot 2 100
       env := { Verity.Env.ofWorld Verity.defaultState with sender := 0xBAD }
       vars := { address := fun i => if i = 0 then 0xBEEF else 0
                 uint256 := fun i => if i = 1 then 5 else 0 } }
@@ -2995,16 +2889,8 @@ open Compiler.CompilationModel in
 /-- `ERC20.mint`: owner path keeps compiled/source multi-read outputs aligned. -/
 private def erc20MintOwnerAgreement : Bool :=
   let init : TExecState :=
-    { world := { Verity.defaultState with
-        storageAddr := fun s => if s = 0 then 0xCAFE else 0,
-        storageMap := fun s addr =>
-          if s = 2 && addr = 0xD00D then 11
-          else if s = 2 && addr = 0xABCD then 77
-          else 0,
-        «storage» := fun s =>
-          if s = 1 then 250
-          else if s = 8 then 333
-          else 0 }
+    { world := ((((Verity.defaultState.writeAddrSlot 0 0xCAFE).writeMap 2 0xD00D 11).writeMap
+          2 0xABCD 77).writeSlot 1 250).writeSlot 8 333
       env := { Verity.Env.ofWorld Verity.defaultState with sender := 0xCAFE }
       vars := { address := fun i => if i = 0 then 0xD00D else 0
                 uint256 := fun i => if i = 1 then 9 else 0 } }
@@ -3054,10 +2940,7 @@ open Compiler.CompilationModel in
 /-- `ERC20.mint`: non-owner path reverts identically. -/
 private def erc20MintNonOwnerAgreement : Bool :=
   let init : TExecState :=
-    { world := { Verity.defaultState with
-        storageAddr := fun s => if s = 0 then 0xCAFE else 0,
-        storageMap := fun s addr => if s = 2 && addr = 0xD00D then 11 else 0,
-        «storage» := fun s => if s = 1 then 250 else 0 }
+    { world := ((Verity.defaultState.writeAddrSlot 0 0xCAFE).writeMap 2 0xD00D 11).writeSlot 1 250
       env := { Verity.Env.ofWorld Verity.defaultState with sender := 0xBAD }
       vars := { address := fun i => if i = 0 then 0xD00D else 0
                 uint256 := fun i => if i = 1 then 9 else 0 } }
@@ -3124,7 +3007,7 @@ def compiledERC721GetApprovedRejectsUnminted : Bool :=
       match block.params with
       | [tokenIdParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with storageMapUint := fun _ _ => 0 }
+            Verity.defaultState
           let init : TExecState :=
             { world := initWorld
               vars := { uint256 := fun i =>
@@ -3148,11 +3031,7 @@ def compiledERC721GetApprovedLoadsApproval : Bool :=
           match tVarIdNamed? (block.params ++ block.locals) returnName with
           | some returnVarId =>
               let initWorld : Verity.ContractState :=
-                { Verity.defaultState with
-                  storageMapUint := fun i key =>
-                    if i == 4 && key == 7 then 999
-                    else if i == 5 && key == 7 then 333
-                    else 0 }
+                (Verity.defaultState.writeMapUint 4 7 999).writeMapUint 5 7 333
               let init : TExecState :=
                 { world := initWorld
                   vars := { uint256 := fun i =>
@@ -3203,7 +3082,7 @@ def compiledERC721ApproveRejectsUnminted : Bool :=
       match block.params with
       | [approvedParam, tokenIdParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with sender := 11, storageMapUint := fun _ _ => 0 }
+            { Verity.defaultState with sender := 11 }
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i => if i = approvedParam.id then 33 else 0,
@@ -3224,10 +3103,7 @@ def compiledERC721ApproveRejectsNonOwner : Bool :=
       match block.params with
       | [approvedParam, tokenIdParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              sender := 11
-              storageMapUint := fun i key =>
-                if i == 4 && key == 7 then 22 else 0 }
+            { Verity.defaultState.writeMapUint 4 7 22 with sender := 11 }
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i => if i = approvedParam.id then 33 else 0,
@@ -3248,10 +3124,7 @@ def compiledERC721ApproveWritesApproval : Bool :=
       match block.params with
       | [approvedParam, tokenIdParam] =>
           let initWorld : Verity.ContractState :=
-            { Verity.defaultState with
-              sender := 11
-              storageMapUint := fun i key =>
-                if i == 4 && key == 7 then 11 else 0 }
+            { Verity.defaultState.writeMapUint 4 7 11 with sender := 11 }
           let init : TExecState :=
             { world := initWorld
               vars := { address := fun i => if i = approvedParam.id then 33 else 0,

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -17,11 +17,13 @@ import Contracts.Ledger.Proofs.Conservation
 import Contracts.Ledger.Proofs.Correctness
 import Contracts.LocalObligationMacroSmoke.Proofs.Basic
 import Contracts.LocalObligationMacroSmoke.Proofs.Correctness
+import Contracts.Ownable.Proofs.Basic
 import Contracts.Owned.Proofs.Basic
 import Contracts.Owned.Proofs.Correctness
 import Contracts.OwnedCounter.Proofs.Basic
 import Contracts.OwnedCounter.Proofs.Correctness
 import Contracts.OwnedCounter.Proofs.Isolation
+import Contracts.OwnedCounterComposed.Proofs.Basic
 import Contracts.SafeCounter.Proofs.Basic
 import Contracts.SafeCounter.Proofs.Correctness
 import Contracts.SimpleStorage.Proofs.Basic
@@ -45,6 +47,8 @@ import Compiler.Proofs.EventSemantics
 import Compiler.Proofs.ExecutionSummary
 import Compiler.Proofs.Frames
 import Compiler.Proofs.HelperStepProofs
+import Compiler.Proofs.IRGeneration.BoundedLoopCheck
+import Compiler.Proofs.IRGeneration.BoundedLoopFuel
 import Compiler.Proofs.IRGeneration.CEISafety
 import Compiler.Proofs.IRGeneration.Contract
 import Compiler.Proofs.IRGeneration.ContractFeatureTest
@@ -392,6 +396,15 @@ end Verity.AxiomAudit
   -- Contracts/LocalObligationMacroSmoke/Proofs/Correctness.lean
   Contracts.LocalObligationMacroSmoke.Proofs.Correctness.dischargedEdge_roundtrip
 
+  -- Contracts/Ownable/Proofs/Basic.lean
+  -- Contracts.Ownable.Proofs.owner_slot_zero  -- private
+  Contracts.Ownable.Proofs.onlyOwner_ok
+  Contracts.Ownable.Proofs.onlyOwner_reverts
+  Contracts.Ownable.Proofs.transferOwnership_writes_only
+  Contracts.Ownable.Proofs.transferOwnership_meets_spec_when_owner
+  Contracts.Ownable.Proofs.getOwner_meets_spec
+  Contracts.Ownable.Proofs.constructor_sets_owner
+
   -- Contracts/Owned/Proofs/Basic.lean
   Contracts.Owned.Proofs.setStorageAddr_updates_owner
   Contracts.Owned.Proofs.getStorageAddr_reads_owner
@@ -477,6 +490,14 @@ end Verity.AxiomAudit
   Contracts.OwnedCounter.Proofs.Isolation.increment_preserves_map_storage
   Contracts.OwnedCounter.Proofs.Isolation.decrement_preserves_map_storage
   Contracts.OwnedCounter.Proofs.Isolation.transferOwnership_preserves_map_storage
+
+  -- Contracts/OwnedCounterComposed/Proofs/Basic.lean
+  Contracts.OwnedCounterComposed.Proofs.increment_reverts_when_not_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_meets_spec_when_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_preserves_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_writes_only_count
+  Contracts.OwnedCounterComposed.Proofs.increment_preserves_ownable_inv
+  Contracts.OwnedCounterComposed.Proofs.getCount_meets_spec
 
   -- Contracts/SafeCounter/Proofs/Basic.lean
   -- Contracts.SafeCounter.Proofs.getCount_run  -- private
@@ -2086,6 +2107,25 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.fullHelperAwareListWitness_of_allInterfaces_disjoint
   Compiler.Proofs.HelperStepProofs.helperFreeContractWitness
   Compiler.Proofs.HelperStepProofs.helperFreeContractWitness_disjoint
+
+  -- Compiler/Proofs/IRGeneration/BoundedLoopCheck.lean
+  Compiler.Proofs.IRGeneration.applyYulLogCall?_vars
+  Compiler.Proofs.IRGeneration.execIRStmt_exprStmt_state_vars
+  Compiler.Proofs.IRGeneration.IRState.getVar_congr_vars
+  Compiler.Proofs.IRGeneration.varUntouchedCheckCases_mem
+  Compiler.Proofs.IRGeneration.execIRStmt_getVar_of_checked
+  Compiler.Proofs.IRGeneration.execIRStmts_getVar_of_checked
+  Compiler.Proofs.IRGeneration.counter_preservation_of_checked
+
+  -- Compiler/Proofs/IRGeneration/BoundedLoopFuel.lean
+  Compiler.Proofs.IRGeneration.IRState.getVar_setVar_self
+  -- Compiler.Proofs.IRGeneration.find?_filter_ne_name  -- private
+  Compiler.Proofs.IRGeneration.IRState.getVar_setVar_ne
+  Compiler.Proofs.IRGeneration.execIRStmts_forEach_post
+  Compiler.Proofs.IRGeneration.evalIRExpr_forEach_cond
+  Compiler.Proofs.IRGeneration.stmtsFuelBound_post_eq
+  Compiler.Proofs.IRGeneration.execIRStmt_boundedFor_stable
+  Compiler.Proofs.IRGeneration.execIRStmt_boundedFor_stable_of_le
 
   -- Compiler/Proofs/IRGeneration/CEISafety.lean
   Compiler.Proofs.IRGeneration.CEIProofBackedExecution.execution_safe
@@ -6783,4 +6823,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6308 theorems/lemmas (4444 public, 1864 private, 0 sorry'd)
+-- Total: 6336 theorems/lemmas (4470 public, 1866 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -47,8 +47,6 @@ import Compiler.Proofs.EventSemantics
 import Compiler.Proofs.ExecutionSummary
 import Compiler.Proofs.Frames
 import Compiler.Proofs.HelperStepProofs
-import Compiler.Proofs.IRGeneration.BoundedLoopCheck
-import Compiler.Proofs.IRGeneration.BoundedLoopFuel
 import Compiler.Proofs.IRGeneration.CEISafety
 import Compiler.Proofs.IRGeneration.Contract
 import Compiler.Proofs.IRGeneration.ContractFeatureTest
@@ -2107,25 +2105,6 @@ end Verity.AxiomAudit
   Compiler.Proofs.HelperStepProofs.fullHelperAwareListWitness_of_allInterfaces_disjoint
   Compiler.Proofs.HelperStepProofs.helperFreeContractWitness
   Compiler.Proofs.HelperStepProofs.helperFreeContractWitness_disjoint
-
-  -- Compiler/Proofs/IRGeneration/BoundedLoopCheck.lean
-  Compiler.Proofs.IRGeneration.applyYulLogCall?_vars
-  Compiler.Proofs.IRGeneration.execIRStmt_exprStmt_state_vars
-  Compiler.Proofs.IRGeneration.IRState.getVar_congr_vars
-  Compiler.Proofs.IRGeneration.varUntouchedCheckCases_mem
-  Compiler.Proofs.IRGeneration.execIRStmt_getVar_of_checked
-  Compiler.Proofs.IRGeneration.execIRStmts_getVar_of_checked
-  Compiler.Proofs.IRGeneration.counter_preservation_of_checked
-
-  -- Compiler/Proofs/IRGeneration/BoundedLoopFuel.lean
-  Compiler.Proofs.IRGeneration.IRState.getVar_setVar_self
-  -- Compiler.Proofs.IRGeneration.find?_filter_ne_name  -- private
-  Compiler.Proofs.IRGeneration.IRState.getVar_setVar_ne
-  Compiler.Proofs.IRGeneration.execIRStmts_forEach_post
-  Compiler.Proofs.IRGeneration.evalIRExpr_forEach_cond
-  Compiler.Proofs.IRGeneration.stmtsFuelBound_post_eq
-  Compiler.Proofs.IRGeneration.execIRStmt_boundedFor_stable
-  Compiler.Proofs.IRGeneration.execIRStmt_boundedFor_stable_of_le
 
   -- Compiler/Proofs/IRGeneration/CEISafety.lean
   Compiler.Proofs.IRGeneration.CEIProofBackedExecution.execution_safe
@@ -6823,4 +6802,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6336 theorems/lemmas (4470 public, 1866 private, 0 sorry'd)
+-- Total: 6321 theorems/lemmas (4456 public, 1865 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -17,11 +17,13 @@ import Contracts.Ledger.Proofs.Conservation
 import Contracts.Ledger.Proofs.Correctness
 import Contracts.LocalObligationMacroSmoke.Proofs.Basic
 import Contracts.LocalObligationMacroSmoke.Proofs.Correctness
+import Contracts.Ownable.Proofs.Basic
 import Contracts.Owned.Proofs.Basic
 import Contracts.Owned.Proofs.Correctness
 import Contracts.OwnedCounter.Proofs.Basic
 import Contracts.OwnedCounter.Proofs.Correctness
 import Contracts.OwnedCounter.Proofs.Isolation
+import Contracts.OwnedCounterComposed.Proofs.Basic
 import Contracts.SafeCounter.Proofs.Basic
 import Contracts.SafeCounter.Proofs.Correctness
 import Contracts.SimpleStorage.Proofs.Basic
@@ -395,6 +397,15 @@ end Verity.AxiomAudit
   -- Contracts/LocalObligationMacroSmoke/Proofs/Correctness.lean
   Contracts.LocalObligationMacroSmoke.Proofs.Correctness.dischargedEdge_roundtrip
 
+  -- Contracts/Ownable/Proofs/Basic.lean
+  -- Contracts.Ownable.Proofs.owner_slot_zero  -- private
+  Contracts.Ownable.Proofs.onlyOwner_ok
+  Contracts.Ownable.Proofs.onlyOwner_reverts
+  Contracts.Ownable.Proofs.transferOwnership_writes_only
+  Contracts.Ownable.Proofs.transferOwnership_meets_spec_when_owner
+  Contracts.Ownable.Proofs.getOwner_meets_spec
+  Contracts.Ownable.Proofs.constructor_sets_owner
+
   -- Contracts/Owned/Proofs/Basic.lean
   Contracts.Owned.Proofs.setStorageAddr_updates_owner
   Contracts.Owned.Proofs.getStorageAddr_reads_owner
@@ -480,6 +491,14 @@ end Verity.AxiomAudit
   Contracts.OwnedCounter.Proofs.Isolation.increment_preserves_map_storage
   Contracts.OwnedCounter.Proofs.Isolation.decrement_preserves_map_storage
   Contracts.OwnedCounter.Proofs.Isolation.transferOwnership_preserves_map_storage
+
+  -- Contracts/OwnedCounterComposed/Proofs/Basic.lean
+  Contracts.OwnedCounterComposed.Proofs.increment_reverts_when_not_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_meets_spec_when_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_preserves_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_writes_only_count
+  Contracts.OwnedCounterComposed.Proofs.increment_preserves_ownable_inv
+  Contracts.OwnedCounterComposed.Proofs.getCount_meets_spec
 
   -- Contracts/SafeCounter/Proofs/Basic.lean
   -- Contracts.SafeCounter.Proofs.getCount_run  -- private
@@ -6818,4 +6837,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6334 theorems/lemmas (4469 public, 1865 private, 0 sorry'd)
+-- Total: 6347 theorems/lemmas (4481 public, 1866 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -17,11 +17,13 @@ import Contracts.Ledger.Proofs.Conservation
 import Contracts.Ledger.Proofs.Correctness
 import Contracts.LocalObligationMacroSmoke.Proofs.Basic
 import Contracts.LocalObligationMacroSmoke.Proofs.Correctness
+import Contracts.Ownable.Proofs.Basic
 import Contracts.Owned.Proofs.Basic
 import Contracts.Owned.Proofs.Correctness
 import Contracts.OwnedCounter.Proofs.Basic
 import Contracts.OwnedCounter.Proofs.Correctness
 import Contracts.OwnedCounter.Proofs.Isolation
+import Contracts.OwnedCounterComposed.Proofs.Basic
 import Contracts.SafeCounter.Proofs.Basic
 import Contracts.SafeCounter.Proofs.Correctness
 import Contracts.SimpleStorage.Proofs.Basic
@@ -394,6 +396,15 @@ end Verity.AxiomAudit
   -- Contracts/LocalObligationMacroSmoke/Proofs/Correctness.lean
   Contracts.LocalObligationMacroSmoke.Proofs.Correctness.dischargedEdge_roundtrip
 
+  -- Contracts/Ownable/Proofs/Basic.lean
+  -- Contracts.Ownable.Proofs.owner_slot_zero  -- private
+  Contracts.Ownable.Proofs.onlyOwner_ok
+  Contracts.Ownable.Proofs.onlyOwner_reverts
+  Contracts.Ownable.Proofs.transferOwnership_writes_only
+  Contracts.Ownable.Proofs.transferOwnership_meets_spec_when_owner
+  Contracts.Ownable.Proofs.getOwner_meets_spec
+  Contracts.Ownable.Proofs.constructor_sets_owner
+
   -- Contracts/Owned/Proofs/Basic.lean
   Contracts.Owned.Proofs.setStorageAddr_updates_owner
   Contracts.Owned.Proofs.getStorageAddr_reads_owner
@@ -479,6 +490,14 @@ end Verity.AxiomAudit
   Contracts.OwnedCounter.Proofs.Isolation.increment_preserves_map_storage
   Contracts.OwnedCounter.Proofs.Isolation.decrement_preserves_map_storage
   Contracts.OwnedCounter.Proofs.Isolation.transferOwnership_preserves_map_storage
+
+  -- Contracts/OwnedCounterComposed/Proofs/Basic.lean
+  Contracts.OwnedCounterComposed.Proofs.increment_reverts_when_not_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_meets_spec_when_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_preserves_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_writes_only_count
+  Contracts.OwnedCounterComposed.Proofs.increment_preserves_ownable_inv
+  Contracts.OwnedCounterComposed.Proofs.getCount_meets_spec
 
   -- Contracts/SafeCounter/Proofs/Basic.lean
   -- Contracts.SafeCounter.Proofs.getCount_run  -- private
@@ -6809,4 +6828,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6328 theorems/lemmas (4463 public, 1865 private, 0 sorry'd)
+-- Total: 6341 theorems/lemmas (4475 public, 1866 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -17,13 +17,11 @@ import Contracts.Ledger.Proofs.Conservation
 import Contracts.Ledger.Proofs.Correctness
 import Contracts.LocalObligationMacroSmoke.Proofs.Basic
 import Contracts.LocalObligationMacroSmoke.Proofs.Correctness
-import Contracts.Ownable.Proofs.Basic
 import Contracts.Owned.Proofs.Basic
 import Contracts.Owned.Proofs.Correctness
 import Contracts.OwnedCounter.Proofs.Basic
 import Contracts.OwnedCounter.Proofs.Correctness
 import Contracts.OwnedCounter.Proofs.Isolation
-import Contracts.OwnedCounterComposed.Proofs.Basic
 import Contracts.SafeCounter.Proofs.Basic
 import Contracts.SafeCounter.Proofs.Correctness
 import Contracts.SimpleStorage.Proofs.Basic
@@ -50,6 +48,7 @@ import Compiler.Proofs.HelperStepProofs
 import Compiler.Proofs.IRGeneration.BoundedLoopCheck
 import Compiler.Proofs.IRGeneration.BoundedLoopFuel
 import Compiler.Proofs.IRGeneration.CEISafety
+import Compiler.Proofs.IRGeneration.CompiledNameDiscipline
 import Compiler.Proofs.IRGeneration.Contract
 import Compiler.Proofs.IRGeneration.ContractFeatureTest
 import Compiler.Proofs.IRGeneration.ContractShape
@@ -396,15 +395,6 @@ end Verity.AxiomAudit
   -- Contracts/LocalObligationMacroSmoke/Proofs/Correctness.lean
   Contracts.LocalObligationMacroSmoke.Proofs.Correctness.dischargedEdge_roundtrip
 
-  -- Contracts/Ownable/Proofs/Basic.lean
-  -- Contracts.Ownable.Proofs.owner_slot_zero  -- private
-  Contracts.Ownable.Proofs.onlyOwner_ok
-  Contracts.Ownable.Proofs.onlyOwner_reverts
-  Contracts.Ownable.Proofs.transferOwnership_writes_only
-  Contracts.Ownable.Proofs.transferOwnership_meets_spec_when_owner
-  Contracts.Ownable.Proofs.getOwner_meets_spec
-  Contracts.Ownable.Proofs.constructor_sets_owner
-
   -- Contracts/Owned/Proofs/Basic.lean
   Contracts.Owned.Proofs.setStorageAddr_updates_owner
   Contracts.Owned.Proofs.getStorageAddr_reads_owner
@@ -490,14 +480,6 @@ end Verity.AxiomAudit
   Contracts.OwnedCounter.Proofs.Isolation.increment_preserves_map_storage
   Contracts.OwnedCounter.Proofs.Isolation.decrement_preserves_map_storage
   Contracts.OwnedCounter.Proofs.Isolation.transferOwnership_preserves_map_storage
-
-  -- Contracts/OwnedCounterComposed/Proofs/Basic.lean
-  Contracts.OwnedCounterComposed.Proofs.increment_reverts_when_not_owner
-  Contracts.OwnedCounterComposed.Proofs.increment_meets_spec_when_owner
-  Contracts.OwnedCounterComposed.Proofs.increment_preserves_owner
-  Contracts.OwnedCounterComposed.Proofs.increment_writes_only_count
-  Contracts.OwnedCounterComposed.Proofs.increment_preserves_ownable_inv
-  Contracts.OwnedCounterComposed.Proofs.getCount_meets_spec
 
   -- Contracts/SafeCounter/Proofs/Basic.lean
   -- Contracts.SafeCounter.Proofs.getCount_run  -- private
@@ -2139,6 +2121,14 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.CEIProofBackedExecution.no_local_unsafe_obligations
   Compiler.Proofs.IRGeneration.ceiProofBackedExecution_of_checker
   Compiler.Proofs.IRGeneration.ceiProofBackedExecution_checked_empty_body
+
+  -- Compiler/Proofs/IRGeneration/CompiledNameDiscipline.lean
+  Compiler.Proofs.IRGeneration.pickFreshName_startsWith
+  Compiler.Proofs.IRGeneration.ne_of_startsWith_of_not_startsWith
+  Compiler.Proofs.IRGeneration.loopFreeCheck_sound
+  Compiler.Proofs.IRGeneration.loopFreeCheckCases_sound
+  Compiler.Proofs.IRGeneration.loopFreeCheckDflt_sound
+  Compiler.Proofs.IRGeneration.loopFreeCheckList_sound
 
   -- Compiler/Proofs/IRGeneration/Contract.lean
   Compiler.Proofs.IRGeneration.Contract.pickUniqueFunctionByName_eq_ok_none_of_absent
@@ -6828,4 +6818,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6341 theorems/lemmas (4475 public, 1866 private, 0 sorry'd)
+-- Total: 6334 theorems/lemmas (4469 public, 1865 private, 0 sorry'd)

--- a/Verity.lean
+++ b/Verity.lean
@@ -13,5 +13,6 @@ import Verity.EVM.Uint256
 import Verity.Stdlib.Math
 import Verity.Specs.Common
 import Verity.Specs.Common.Sum
+import Verity.Specs.Composition
 import Verity.Proofs.Stdlib.Math
 import Verity.Proofs.Stdlib.ListSum

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -314,6 +314,86 @@ def readArray (s : ContractState) (slot : Nat) : List Uint256 :=
 def writeArray (s : ContractState) (slot : Nat) (values : List Uint256) : ContractState :=
   { s with storageArray := fun sl => if sl == slot then values else s.storageArray sl }
 
+/-!
+### Bulk lenses (C5)
+
+Multi-slot writes used by the denotational layer (aliased packed fields,
+word-spanning writes). Shapes match the historical raw record updates
+exactly (`targets.contains`-guarded function update), so migrating a raw
+site to a bulk lens is definitional. Like the single-slot lenses, these are
+the only sanctioned multi-slot write surface over the storage channels.
+-/
+
+/-- Write `value` at every slot in `targets` (uint channel). -/
+def writeSlots (s : ContractState) (targets : List Nat) (value : Uint256) :
+    ContractState :=
+  { s with storage := fun slot =>
+      if targets.contains slot then value else s.storage slot }
+
+/-- Read-modify-write every slot in `targets` (uint channel). -/
+def modifySlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) : ContractState :=
+  { s with storage := fun slot =>
+      if targets.contains slot then f (s.storage slot) else s.storage slot }
+
+/-- Write `value` at every transient slot in `targets`. -/
+def writeTransientSlots (s : ContractState) (targets : List Nat)
+    (value : Uint256) : ContractState :=
+  { s with transientStorage := fun slot =>
+      if targets.contains slot then value else s.transientStorage slot }
+
+/-- Read-modify-write every transient slot in `targets`. -/
+def modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) : ContractState :=
+  { s with transientStorage := fun slot =>
+      if targets.contains slot then f (s.transientStorage slot)
+      else s.transientStorage slot }
+
+/-- Write `value` at every address slot in `targets`. -/
+def writeAddrSlots (s : ContractState) (targets : List Nat) (value : Address) :
+    ContractState :=
+  { s with storageAddr := fun slot =>
+      if targets.contains slot then value else s.storageAddr slot }
+
+/-- Replace the whole uint channel through a transformer. The denotational
+layer's flat-view rebuilds (mapping writes rendered through a `Nat → Nat`
+storage view) are channel-wide, not slot-guarded; this is their sanctioned
+surface. The C5 flip reimplements it as a `.slot`-key-restricted update. -/
+def withStorageChannel (s : ContractState)
+    (f : (Nat → Uint256) → Nat → Uint256) : ContractState :=
+  { s with storage := f s.storage }
+
+/-- Canonical full-state constructor from explicit storage channels. Clients
+building a world from externally supplied channel functions (interpreter
+harnesses, counterexample states) go through this instead of a raw record
+literal, so the C5 flip can rebuild the internal representation from the
+given channels in one place. Non-storage fields start at their defaults and
+are customized by the caller with an ordinary record update. -/
+def ofChannels
+    (uintChannel : Nat → Uint256)
+    (transientChannel : Nat → Uint256 := fun _ => 0)
+    (addrChannel : Nat → Address := fun _ => 0)
+    (mapChannel : Nat → Address → Uint256 := fun _ _ => 0)
+    (mapUintChannel : Nat → Uint256 → Uint256 := fun _ _ => 0)
+    (map2Channel : Nat → Address → Address → Uint256 := fun _ _ _ => 0)
+    (arrayChannel : Nat → List Uint256 := fun _ => [])
+    (sender : Address := 0)
+    (thisAddress : Address := 0)
+    (msgValue : Uint256 := 0)
+    (blockTimestamp : Uint256 := 0) : ContractState :=
+  { storage := uintChannel
+    transientStorage := transientChannel
+    storageAddr := addrChannel
+    storageMap := mapChannel
+    storageMapUint := mapUintChannel
+    storageMap2 := map2Channel
+    storageArray := arrayChannel
+    sender := sender
+    thisAddress := thisAddress
+    msgValue := msgValue
+    blockTimestamp := blockTimestamp
+    knownAddresses := fun _ => Verity.Core.FiniteAddressSet.empty }
+
 @[storage_simps] theorem readSlot_writeSlot_same (s : ContractState) (slot : Nat) (v : Uint256) :
     (s.writeSlot slot v).readSlot slot = v := by
   simp [readSlot, writeSlot]

--- a/Verity/Core/Free/TypedIR.lean
+++ b/Verity/Core/Free/TypedIR.lean
@@ -214,34 +214,27 @@ def evalTStmtFuel : Nat → TExecState → TStmt → TExecResult
       .ok { s with vars := s.vars.set dst (evalTExpr s rhs) }
   | Nat.succ _, s, .setStorage slot value =>
       let v := evalTExpr s value
-      .ok { s with world := { s.world with
-        storage := fun i => if i == slot then v else s.world.storage i } }
+      .ok { s with world := s.world.writeSlot slot v }
   | Nat.succ _, s, .setStorageAddr slot value =>
       let v := evalTExpr s value
-      .ok { s with world := { s.world with
-        storageAddr := fun i => if i == slot then v else s.world.storageAddr i } }
+      .ok { s with world := s.world.writeAddrSlot slot v }
   | Nat.succ _, s, .setStorageWord slot value =>
       let v := evalTExpr s value
-      .ok { s with world := { s.world with
-        storage := fun i => if i == slot then v else s.world.storage i,
-        storageAddr := fun i => if i == slot then Verity.wordToAddress v else s.world.storageAddr i } }
+      .ok { s with world :=
+        (s.world.writeSlot slot v).writeAddrSlot slot (Verity.wordToAddress v) }
   | Nat.succ _, s, .setMapping slot key value =>
       let k := evalTExpr s key
       let v := evalTExpr s value
-      .ok { s with world := { s.world with
-        storageMap := fun i addr => if i == slot && addr == k then v else s.world.storageMap i addr } }
+      .ok { s with world := s.world.writeMap slot k v }
   | Nat.succ _, s, .setMapping2 slot key1 key2 value =>
       let k1 := evalTExpr s key1
       let k2 := evalTExpr s key2
       let v := evalTExpr s value
-      .ok { s with world := { s.world with
-        storageMap2 := fun i addr1 addr2 =>
-          if i == slot && addr1 == k1 && addr2 == k2 then v else s.world.storageMap2 i addr1 addr2 } }
+      .ok { s with world := s.world.writeMap2 slot k1 k2 v }
   | Nat.succ _, s, .setMappingUint slot key value =>
       let k := evalTExpr s key
       let v := evalTExpr s value
-      .ok { s with world := { s.world with
-        storageMapUint := fun i key' => if i == slot && key' == k then v else s.world.storageMapUint i key' } }
+      .ok { s with world := s.world.writeMapUint slot k v }
   | Nat.succ fuel, s, .if_ cond thenBranch elseBranch =>
       match evalTExpr s cond with
       | true => evalTStmtsFuel fuel s thenBranch

--- a/Verity/Core/Invariant.lean
+++ b/Verity/Core/Invariant.lean
@@ -34,6 +34,12 @@ theorem comp {σ : Type} {Inv : σ → Prop} {f g : σ → σ}
     Preserves Inv (fun s => f (g s)) :=
   fun s h => hf (g s) (hg s h)
 
+/-- Conjunction of invariants is preserved when each conjunct is. -/
+theorem and {σ : Type} {InvA InvB : σ → Prop} {f : σ → σ}
+    (hA : Preserves InvA f) (hB : Preserves InvB f) :
+    Preserves (fun s => InvA s ∧ InvB s) f :=
+  fun s h => ⟨hA s h.1, hB s h.2⟩
+
 end Preserves
 
 /-- A reentrant adversary as a finite *schedule* of picked entrypoints, applied

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -265,28 +265,20 @@ def writeUintSlots (world : Verity.ContractState) (slots : List Nat) (value : Na
     Verity.ContractState :=
   let word : Verity.Core.Uint256 := value
   let targets := slots.map wordNormalize
-  { world with
-    storage := fun slot =>
-      if targets.contains slot then word else world.storage slot }
+  world.writeSlots targets word
 
 def writeStorageWordSlots (world : Verity.ContractState) (slots : List Nat)
     (wordOffset value : Nat) : Verity.ContractState :=
   let word : Verity.Core.Uint256 := value
   let addr := Verity.wordToAddress word
   let targets := slots.map (fun slot => wordNormalize (slot + wordOffset))
-  { world with
-    storage := fun current =>
-      if targets.contains current then word else world.storage current,
-    storageAddr := fun current =>
-      if targets.contains current then addr else world.storageAddr current }
+  (world.writeSlots targets word).writeAddrSlots targets addr
 
 def writeAddressSlots (world : Verity.ContractState) (slots : List Nat) (value : Nat) :
     Verity.ContractState :=
   let addr := Verity.wordToAddress (value : Verity.Core.Uint256)
   let targets := slots.map wordNormalize
-  { world with
-    storageAddr := fun slot =>
-      if targets.contains slot then addr else world.storageAddr slot }
+  world.writeAddrSlots targets addr
 
 def fieldIsTransient (fields : List Field) (name : String) : Bool :=
   match findFieldWithResolvedSlot fields name with
@@ -304,9 +296,7 @@ def writeTransientTargets (world : Verity.ContractState) (targets : List Nat) (v
     Verity.ContractState :=
   let word : Verity.Core.Uint256 := value
   let targets := targets.map wordNormalize
-  { world with
-    transientStorage := fun slot =>
-      if targets.contains slot then word else world.transientStorage slot }
+  world.writeTransientSlots targets word
 
 def packedWordWrite (current value : Nat) (packed : PackedBits) : Nat :=
   let maskNat := packedMaskNat packed
@@ -324,15 +314,11 @@ def writeUintFieldSlots (fields : List Field) (fieldName : String)
       | some packed =>
           let targets := slots.map wordNormalize
           if field.isTransient then
-            { world with transientStorage := fun slot =>
-                if targets.contains slot then
-                  packedWordWrite (world.transientStorage slot).val value packed
-                else world.transientStorage slot }
+            world.modifyTransientSlots targets
+              (fun current => packedWordWrite current.val value packed)
           else
-            { world with storage := fun slot =>
-                if targets.contains slot then
-                  packedWordWrite (world.storage slot).val value packed
-                else world.storage slot }
+            world.modifySlots targets
+              (fun current => packedWordWrite current.val value packed)
       | none =>
           if field.isTransient then writeTransientTargets world slots value
           else writeUintSlots world slots value
@@ -361,9 +347,7 @@ def writeMappingTargets (fields : List Field) (fieldName : String)
     writeTransientTargets world targets value
   else
     let word : Verity.Core.Uint256 := value
-    { world with
-      storage := fun slot =>
-        if targets.map wordNormalize |>.contains slot then word else world.storage slot }
+    world.writeSlots (targets.map wordNormalize) word
 
 /-- Nat-level rendering of `Compiler.Proofs.abstractStoreMappingEntry` over a
 word-normalized storage view (see header note 3). -/
@@ -392,13 +376,9 @@ def writeAddressKeyedMappingSlots (oracle : DenoteOracle)
         slots.foldl
           (fun current slot => storeMappingEntryNat oracle current slot key value)
           (storageNatView world)
-      { world with
-        storage := fun s => ((storage (wordNormalize s) : Verity.Core.Uint256))
-        storageMap := fun baseSlot addr =>
-          if baseSlot == slot && addr == keyAddr then
-            word
-          else
-            world.storageMap baseSlot addr }
+      (world.withStorageChannel
+          (fun _ => fun s => ((storage (wordNormalize s) : Verity.Core.Uint256)))).writeMap
+        slot keyAddr word
 
 def mappingSlotChain (oracle : DenoteOracle) (baseSlot : Nat) (keys : List Nat) : Nat :=
   keys.foldl oracle.mappingSlot baseSlot
@@ -408,9 +388,7 @@ def writeAddressKeyedMappingChainSlots (oracle : DenoteOracle)
     Verity.ContractState :=
   let word : Verity.Core.Uint256 := value
   let targets := slots.map (fun slot => wordNormalize (mappingSlotChain oracle slot keys))
-  { world with
-    storage := fun slot =>
-      if targets.contains slot then word else world.storage slot }
+  world.writeSlots targets word
 
 def writeAddressKeyedMappingWordSlots (oracle : DenoteOracle)
     (world : Verity.ContractState) (slots : List Nat) (key wordOffset value : Nat) :
@@ -418,9 +396,7 @@ def writeAddressKeyedMappingWordSlots (oracle : DenoteOracle)
   let word : Verity.Core.Uint256 := value
   let targets :=
     slots.map (fun slot => wordNormalize (oracle.mappingSlot slot key + wordOffset))
-  { world with
-    storage := fun slot =>
-      if targets.contains slot then word else world.storage slot }
+  world.writeSlots targets word
 
 def readFixedUint128ArrayElement
     (world : Verity.ContractState) (slot size index : Nat) : Option Nat :=
@@ -439,9 +415,8 @@ def writeFixedUint128ArrayElementSlots
     let offset := (index % 2) * 128
     let packed : PackedBits := { offset := offset, width := 128 }
     let targets := slots.map (fun slot => wordNormalize (slot + index / 2))
-    some { world with storage := fun slot =>
-      if targets.contains slot then packedWordWrite (world.storage slot).val value packed
-      else world.storage slot }
+    some (world.modifySlots targets
+      (fun current => packedWordWrite current.val value packed))
   else
     none
 
@@ -451,12 +426,8 @@ def writeAddressKeyedMappingPackedWordSlots (oracle : DenoteOracle)
     Verity.ContractState :=
   let targets :=
     slots.map (fun slot => wordNormalize (oracle.mappingSlot slot key + wordOffset))
-  { world with
-    storage := fun slot =>
-      if targets.contains slot then
-        packedWordWrite (world.storage slot).val value packed
-      else
-        world.storage slot }
+  world.modifySlots targets
+    (fun current => packedWordWrite current.val value packed)
 
 def writeAddressKeyedMappingPackedWordFieldSlots (oracle : DenoteOracle)
     (fields : List Field) (fieldName : String)
@@ -487,13 +458,9 @@ def writeUintKeyedMappingSlots (oracle : DenoteOracle)
         slots.foldl
           (fun current slot => storeMappingEntryNat oracle current slot key value)
           (storageNatView world)
-      { world with
-        storage := fun s => ((storage (wordNormalize s) : Verity.Core.Uint256))
-        storageMapUint := fun baseSlot key' =>
-          if baseSlot == slot && key' == keyWord then
-            word
-          else
-            world.storageMapUint baseSlot key' }
+      (world.withStorageChannel
+          (fun _ => fun s => ((storage (wordNormalize s) : Verity.Core.Uint256)))).writeMapUint
+        slot keyWord word
 
 def writeAddressKeyedMapping2Slots (oracle : DenoteOracle)
     (world : Verity.ContractState) (slots : List Nat) (key1 key2 value : Nat) :
@@ -509,13 +476,9 @@ def writeAddressKeyedMapping2Slots (oracle : DenoteOracle)
           (fun current slot =>
             storeMappingEntryNat oracle current (oracle.mappingSlot slot key1) key2 value)
           (storageNatView world)
-      { world with
-        storage := fun s => ((storage (wordNormalize s) : Verity.Core.Uint256))
-        storageMap2 := fun baseSlot addr1 addr2 =>
-          if baseSlot == slot && addr1 == key1Addr && addr2 == key2Addr then
-            word
-          else
-            world.storageMap2 baseSlot addr1 addr2 }
+      (world.withStorageChannel
+          (fun _ => fun s => ((storage (wordNormalize s) : Verity.Core.Uint256)))).writeMap2
+        slot key1Addr key2Addr word
 
 def writeAddressKeyedMapping2WordSlots (oracle : DenoteOracle)
     (world : Verity.ContractState) (slots : List Nat) (key1 key2 wordOffset value : Nat) :
@@ -524,9 +487,7 @@ def writeAddressKeyedMapping2WordSlots (oracle : DenoteOracle)
   let targets := slots.map (fun slot =>
     wordNormalize
       (oracle.mappingSlot (oracle.mappingSlot slot key1) key2 + wordOffset))
-  { world with
-    storage := fun slot =>
-      if targets.contains slot then word else world.storage slot }
+  world.writeSlots targets word
 
 def writeAddressKeyedMappingWordFieldSlots (oracle : DenoteOracle)
     (fields : List Field) (fieldName : String)
@@ -591,12 +552,8 @@ def writeAddressKeyedMapping2PackedWordSlots (oracle : DenoteOracle)
   let targets := slots.map (fun slot =>
     wordNormalize
       (oracle.mappingSlot (oracle.mappingSlot slot key1) key2 + wordOffset))
-  { world with
-    storage := fun slot =>
-      if targets.contains slot then
-        packedWordWrite (world.storage slot).val value packed
-      else
-        world.storage slot }
+  world.modifySlots targets
+    (fun current => packedWordWrite current.val value packed)
 
 def writeAddressKeyedMapping2PackedWordFieldSlots (oracle : DenoteOracle)
     (fields : List Field) (fieldName : String)

--- a/Verity/Core/Model/Types.lean
+++ b/Verity/Core/Model/Types.lean
@@ -1535,6 +1535,50 @@ structure CompilationModel where
   storageNamespace : Option Nat := none
   deriving Repr
 
+/-- Concatenate mixin constructor bodies in include order, then the host body. -/
+def mergeConstructorSpecs (mixins : List (Option ConstructorSpec)) (host : Option ConstructorSpec) :
+    Option ConstructorSpec :=
+  let mixinCtors := mixins.filterMap id
+  match mixinCtors, host with
+  | [], host => host
+  | m :: rest, none =>
+      some {
+        params := m.params
+        isPayable := false
+        body := (m :: rest).flatMap (·.body)
+        localObligations := (m :: rest).flatMap (·.localObligations)
+      }
+  | ms, some h =>
+      some {
+        h with
+        body := ms.flatMap (·.body) ++ h.body
+        localObligations := ms.flatMap (·.localObligations) ++ h.localObligations
+      }
+
+/-- Host CompilationModel is mixin specs (include order) then host fields/functions. -/
+def mergeIncludedSpecs (name : String) (mixins : List CompilationModel) (host : CompilationModel) :
+    CompilationModel :=
+  { host with
+    name := name
+    fields := mixins.flatMap (·.fields) ++ host.fields
+    immutables := mixins.flatMap (·.immutables) ++ host.immutables
+    roles := mixins.flatMap (·.roles) ++ host.roles
+    errors := mixins.flatMap (·.errors) ++ host.errors
+    events := mixins.flatMap (·.events) ++ host.events
+    functions := mixins.flatMap (·.functions) ++ host.functions
+    externals := mixins.flatMap (·.externals) ++ host.externals
+    adtTypes := mixins.flatMap (·.adtTypes) ++ host.adtTypes
+    constructor := mergeConstructorSpecs (mixins.map (·.constructor)) host.constructor
+  }
+
+/-- Public functions that share an ABI name across mixin and host specs. -/
+def selectorCollision? (mixins : List CompilationModel) (host : CompilationModel) : Option String :=
+  let publicName (fn : FunctionSpec) : Option String :=
+    if fn.isInternal then none else some fn.name
+  let mixinNames := mixins.flatMap (fun m => m.functions.filterMap publicName)
+  let hostNames := host.functions.filterMap publicName
+  hostNames.find? (fun n => mixinNames.contains n)
+
 /-!
 ## IR Generation from Spec
 

--- a/Verity/Core/Model/Types.lean
+++ b/Verity/Core/Model/Types.lean
@@ -1535,7 +1535,10 @@ structure CompilationModel where
   storageNamespace : Option Nat := none
   deriving Repr
 
-/-- Concatenate mixin constructor bodies in include order, then the host body. -/
+/-- Concatenate mixin constructor bodies in include order, then the host body.
+    Prefer expanding mixin inits into the host constructor *before* merge so
+    argument substitution is hygienic. This helper remains for callers that
+    already performed that expansion (or have matching parameter names). -/
 def mergeConstructorSpecs (mixins : List (Option ConstructorSpec)) (host : Option ConstructorSpec) :
     Option ConstructorSpec :=
   let mixinCtors := mixins.filterMap id
@@ -1555,7 +1558,10 @@ def mergeConstructorSpecs (mixins : List (Option ConstructorSpec)) (host : Optio
         localObligations := ms.flatMap (·.localObligations) ++ h.localObligations
       }
 
-/-- Host CompilationModel is mixin specs (include order) then host fields/functions. -/
+/-- Host CompilationModel is mixin specs (include order) then host fields/functions.
+    The host constructor is already the full sequence (mixin inits with
+    substituted arguments, then the host body); do not concatenate mixin
+    constructor bodies a second time. -/
 def mergeIncludedSpecs (name : String) (mixins : List CompilationModel) (host : CompilationModel) :
     CompilationModel :=
   { host with
@@ -1568,7 +1574,9 @@ def mergeIncludedSpecs (name : String) (mixins : List CompilationModel) (host : 
     functions := mixins.flatMap (·.functions) ++ host.functions
     externals := mixins.flatMap (·.externals) ++ host.externals
     adtTypes := mixins.flatMap (·.adtTypes) ++ host.adtTypes
-    constructor := mergeConstructorSpecs (mixins.map (·.constructor)) host.constructor
+    reservedSlotRanges := mixins.flatMap (·.reservedSlotRanges) ++ host.reservedSlotRanges
+    slotAliasRanges := mixins.flatMap (·.slotAliasRanges) ++ host.slotAliasRanges
+    constructor := host.constructor
   }
 
 /-- Public functions that share an ABI name across mixin and host specs. -/

--- a/Verity/Core/Model/Types.lean
+++ b/Verity/Core/Model/Types.lean
@@ -1559,9 +1559,10 @@ def mergeConstructorSpecs (mixins : List (Option ConstructorSpec)) (host : Optio
       }
 
 /-- Host CompilationModel is mixin specs (include order) then host fields/functions.
-    The host constructor is already the full sequence (mixin inits with
-    substituted arguments, then the host body); do not concatenate mixin
-    constructor bodies a second time. -/
+    The host constructor is already the full sequence: mixin immutable
+    `setImmutable` statements (with host-substituted initializers), mixin
+    user-ctor bodies with hygienic argument bindings, then the host body.
+    Do not concatenate mixin constructor bodies a second time. -/
 def mergeIncludedSpecs (name : String) (mixins : List CompilationModel) (host : CompilationModel) :
     CompilationModel :=
   { host with

--- a/Verity/Macro/Bridge.lean
+++ b/Verity/Macro/Bridge.lean
@@ -266,7 +266,8 @@ private def mkFieldFrameConjunct (field : StorageFieldDecl) : CommandElabM Term 
     (#1729, Axis 3 Step 1b) -/
 def mkFrameDefCommand
     (fields : Array StorageFieldDecl)
-    (fnDecl : FunctionDecl) : CommandElabM (Array Cmd) := do
+    (fnDecl : FunctionDecl)
+    (generateExecutionFrame : Bool := true) : CommandElabM (Array Cmd) := do
   let frameName ← mkSuffixedIdent fnDecl.ident "_frame"
   let frameRflName ← mkSuffixedIdent fnDecl.ident "_frame_rfl"
   let frameHoldsName ← mkSuffixedIdent fnDecl.ident "_frame_holds"
@@ -290,7 +291,12 @@ def mkFrameDefCommand
       simp [Verity.Specs.sameContext, Verity.Specs.sameStorageSlot,
             Verity.Specs.sameStorageAddrSlot, Verity.Specs.sameStorage])
 
-  if fnDecl.requiresRole.isSome || fnDecl.nonReentrantLock.isSome || fnDecl.initGuard?.isSome then
+  -- Mixin modifiers / include hosts bind a Lean guard that the generated
+  -- `simp` proof cannot case-split. Keep the frame *definition* and skip
+  -- the automatic `_frame_holds` theorem in those cases.
+  if !generateExecutionFrame || !fnDecl.modifiers.isEmpty ||
+      fnDecl.requiresRole.isSome || fnDecl.nonReentrantLock.isSome ||
+      fnDecl.initGuard?.isSome then
     pure #[frameCmd, frameRflCmd]
   else
     let fnApp ← mkFunctionApplication fnDecl

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -91,14 +91,39 @@ private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
   validateExternalDeclsPublic externalDecls
   let mut mixinModifiers : Array ModifierDecl := #[]
   let mut mixinFields : Array StorageFieldDecl := #[]
+  let mut mixinErrorDecls : Array ErrorDecl := #[]
+  let mut mixinEventDecls : Array EventDecl := #[]
+  let mut mixinConstDecls : Array ConstantDecl := #[]
+  let mut mixinImmutableDecls : Array ImmutableDecl := #[]
+  let mut mixinExternalDecls : Array ExternalDecl := #[]
+  let mut mixinFunctions : Array FunctionDecl := #[]
+  let mut mixinRoleDecls : Array RoleDecl := #[]
+  let mut mixinParsed : Array (Name × ParsedContractSyntax) := #[]
   for mixinName in resolvedIncludes do
     match (← lookupContractSyntaxPublic mixinName) with
     | some mixin =>
         mixinModifiers := mixinModifiers ++ mixin.modifiers
         mixinFields := mixinFields ++ mixin.fields
+        mixinErrorDecls := mixinErrorDecls ++ mixin.errorDecls
+        mixinEventDecls := mixinEventDecls ++ mixin.eventDecls
+        mixinConstDecls := mixinConstDecls ++ mixin.constDecls
+        mixinImmutableDecls := mixinImmutableDecls ++ mixin.immutableDecls
+        mixinExternalDecls := mixinExternalDecls ++ mixin.externalDecls
+        mixinFunctions := mixinFunctions ++ mixin.functions
+        mixinRoleDecls := mixinRoleDecls ++ mixin.roleDecls
+        mixinParsed := mixinParsed.push (mixinName, mixin)
     | none => pure ()
-  validateFunctionDeclsPublic (mixinFields ++ fields) errorDecls eventDecls constDecls immutableDecls
-    externalDecls ctor (mixinModifiers ++ modifiers) functions
+  let translationFields := mixinFields ++ fields
+  let translationErrorDecls := mixinErrorDecls ++ errorDecls
+  let translationEventDecls := mixinEventDecls ++ eventDecls
+  let translationConstDecls := mixinConstDecls ++ constDecls
+  let translationImmutableDecls := mixinImmutableDecls ++ immutableDecls
+  let translationExternalDecls := mixinExternalDecls ++ externalDecls
+  let translationFunctions := mixinFunctions ++ functions
+  let translationRoleDecls := mixinRoleDecls ++ roleDecls
+  validateFunctionDeclsPublic translationFields translationErrorDecls translationEventDecls
+    translationConstDecls translationImmutableDecls translationExternalDecls ctor
+    (mixinModifiers ++ modifiers) translationFunctions
 
   let declarationNs ← getCurrNamespace
   elabCommand (← `(namespace $contractName))
@@ -146,11 +171,14 @@ private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
           elabCommand (← mkHostConstructorDefCommandPublic resolvedIncludes ctorDecl)
       | none => pure ()
 
-    -- Translation (not storage-def emission) must see mixin fields so
-    -- inlined mixin-modifier CompilationModel bodies can resolve slots.
-    let translationFields := mixinFields ++ fields
+    -- Translation (not storage-def emission) must see mixin fields/decls so
+    -- inlined mixin-modifier CompilationModel bodies can resolve slots,
+    -- custom errors, constants, and helpers.
     for fn in functions do
-      let fnCmds ← mkFunctionCommandsPublic translationFields roleDecls errorDecls constDecls immutableDecls externalDecls functions fn resolvedIncludes
+      let fnCmds ← mkFunctionCommandsPublic translationFields translationRoleDecls
+        translationErrorDecls translationConstDecls translationImmutableDecls
+        translationExternalDecls translationFunctions fn resolvedIncludes
+        (boundImmutableDecls := immutableDecls)
       for cmd in fnCmds do
         elabCommand cmd
       elabCommand (← mkBridgeCommand fn.ident)
@@ -160,17 +188,15 @@ private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
       else mkIdent (Name.mkSimple "host_spec")
     let mut modelCtor := ctor
     if !resolvedIncludes.isEmpty then
-      let mut mixins : Array (Name × ParsedContractSyntax) := #[]
-      for mixinName in resolvedIncludes do
-        match (← lookupContractSyntaxPublic mixinName) with
-        | some mixin => mixins := mixins.push (mixinName, mixin)
-        | none => pure ()
       match ctor with
       | some ctorDecl =>
           modelCtor := some (← expandMixinConstructorForModelPublic
-            translationFields constDecls immutableDecls externalDecls ctorDecl mixins)
+            translationFields translationConstDecls translationImmutableDecls
+            translationExternalDecls ctorDecl mixinParsed)
       | none => pure ()
-    elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls modelCtor modifiers functions adtDecls storageNamespace specName translationFields)
+    let constructorImmutableDecls :=
+      includedMixinImmutablesForHostPublic ctor mixinParsed ++ immutableDecls
+    elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls modelCtor modifiers functions adtDecls storageNamespace specName translationFields translationErrorDecls translationConstDecls translationImmutableDecls translationExternalDecls translationFunctions constructorImmutableDecls)
     if !resolvedIncludes.isEmpty then
       elabCommand (← mkMergedSpecCommandPublic (toString contractName.getId) resolvedIncludes)
 

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -158,7 +158,19 @@ private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
     let specName : Ident :=
       if resolvedIncludes.isEmpty then mkIdent (Name.mkSimple "spec")
       else mkIdent (Name.mkSimple "host_spec")
-    elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace specName)
+    let mut modelCtor := ctor
+    if !resolvedIncludes.isEmpty then
+      let mut mixins : Array (Name × ParsedContractSyntax) := #[]
+      for mixinName in resolvedIncludes do
+        match (← lookupContractSyntaxPublic mixinName) with
+        | some mixin => mixins := mixins.push (mixinName, mixin)
+        | none => pure ()
+      match ctor with
+      | some ctorDecl =>
+          modelCtor := some (← expandMixinConstructorForModelPublic
+            translationFields constDecls immutableDecls externalDecls ctorDecl mixins)
+      | none => pure ()
+    elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls modelCtor modifiers functions adtDecls storageNamespace specName translationFields)
     if !resolvedIncludes.isEmpty then
       elabCommand (← mkMergedSpecCommandPublic (toString contractName.getId) resolvedIncludes)
 

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -178,7 +178,7 @@ private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
       let fnCmds ← mkFunctionCommandsPublic translationFields translationRoleDecls
         translationErrorDecls translationConstDecls translationImmutableDecls
         translationExternalDecls translationFunctions fn resolvedIncludes
-        (boundImmutableDecls := immutableDecls)
+        (boundImmutableDecls := immutableDecls) (hostModifiers := modifiers)
       for cmd in fnCmds do
         elabCommand cmd
       elabCommand (← mkBridgeCommand fn.ident)

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -65,8 +65,7 @@ private def parseIntrinsicProofStatus (status : Ident) : CommandElabM String := 
       throwErrorAt status
         "unsupported proof status for verity_intrinsic obligation; expected proved, assumed, or unchecked"
 
-@[command_elab verityContractCmd]
-def elabVerityContract : CommandElab := fun stx => do
+private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
   let parsed ← parseContractSyntax stx
   let contractName := parsed.contractName
   let structDecls := parsed.structDecls
@@ -83,12 +82,23 @@ def elabVerityContract : CommandElab := fun stx => do
   let modifiers := parsed.modifiers
   let functions := parsed.functions
   let storageNamespace := parsed.storageNamespace
+  let isMixin := parsed.isMixin
+  let resolvedIncludes := parsed.resolvedIncludes
 
   validateGeneratedDefNamesPublic fields constDecls immutableDecls functions
   validateConstantDeclsPublic constDecls
   validateImmutableDeclsPublic fields constDecls immutableDecls ctor
   validateExternalDeclsPublic externalDecls
-  validateFunctionDeclsPublic fields errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions
+  let mut mixinModifiers : Array ModifierDecl := #[]
+  let mut mixinFields : Array StorageFieldDecl := #[]
+  for mixinName in resolvedIncludes do
+    match (← lookupContractSyntaxPublic mixinName) with
+    | some mixin =>
+        mixinModifiers := mixinModifiers ++ mixin.modifiers
+        mixinFields := mixinFields ++ mixin.fields
+    | none => pure ()
+  validateFunctionDeclsPublic (mixinFields ++ fields) errorDecls eventDecls constDecls immutableDecls
+    externalDecls ctor (mixinModifiers ++ modifiers) functions
 
   let declarationNs ← getCurrNamespace
   elabCommand (← `(namespace $contractName))
@@ -99,6 +109,10 @@ def elabVerityContract : CommandElab := fun stx => do
     for structDecl in structDecls do
       elabCommand (← mkStructDefCommandPublic structDecl)
       elabCommand (← mkStructEventArgInstanceCommandPublic structDecl)
+
+    let aliasCmds ← mkIncludeAliasCommandsPublic resolvedIncludes
+    for cmd in aliasCmds do
+      elabCommand cmd
 
     for field in fields do
       if field.emitDef then
@@ -118,13 +132,35 @@ def elabVerityContract : CommandElab := fun stx => do
     -- Use the resolved namespace from parseContractSyntax to respect custom keys.
     elabCommand (← mkStorageNamespaceCommand (toString contractName.getId) storageNamespace)
 
+    if isMixin then
+      for modDecl in modifiers do
+        elabCommand (← mkModifierDefCommandPublic modDecl)
+      match ctor with
+      | some ctorDecl =>
+          elabCommand (← mkConstructorDefCommandPublic ctorDecl)
+      | none => pure ()
+
+    if !resolvedIncludes.isEmpty then
+      match ctor with
+      | some ctorDecl =>
+          elabCommand (← mkHostConstructorDefCommandPublic resolvedIncludes ctorDecl)
+      | none => pure ()
+
+    -- Translation (not storage-def emission) must see mixin fields so
+    -- inlined mixin-modifier CompilationModel bodies can resolve slots.
+    let translationFields := mixinFields ++ fields
     for fn in functions do
-      let fnCmds ← mkFunctionCommandsPublic fields roleDecls errorDecls constDecls immutableDecls externalDecls functions fn
+      let fnCmds ← mkFunctionCommandsPublic translationFields roleDecls errorDecls constDecls immutableDecls externalDecls functions fn resolvedIncludes
       for cmd in fnCmds do
         elabCommand cmd
       elabCommand (← mkBridgeCommand fn.ident)
 
-    elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace)
+    let specName : Ident :=
+      if resolvedIncludes.isEmpty then mkIdent (Name.mkSimple "spec")
+      else mkIdent (Name.mkSimple "host_spec")
+    elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace specName)
+    if !resolvedIncludes.isEmpty then
+      elabCommand (← mkMergedSpecCommandPublic (toString contractName.getId) resolvedIncludes)
 
     let findIdxSimpCmds ← mkFindIdxFieldSimpCommandsPublic contractName fields
     for cmd in findIdxSimpCmds do
@@ -159,10 +195,13 @@ def elabVerityContract : CommandElab := fun stx => do
 
     -- Emit per-function _modifies theorem and _frame definition for
     -- functions with modifies(...) annotation (#1729, Axis 3 Step 1b).
+    -- Mixin / include functions keep the frame definition; the automatic
+    -- `_frame_holds` simp proof cannot close over mixin `require` guards.
+    let generateExecutionFrame := !isMixin && resolvedIncludes.isEmpty
     for fn in functions do
       if !fn.modifies.isEmpty then
         elabCommand (← mkModifiesTheoremCommand fn)
-        let frameCmds ← mkFrameDefCommand fields fn
+        let frameCmds ← mkFrameDefCommand translationFields fn generateExecutionFrame
         for cmd in frameCmds do
           elabCommand cmd
 
@@ -211,6 +250,14 @@ def elabVerityContract : CommandElab := fun stx => do
   catch err =>
     elabCommand (← `(end $contractName))
     throw err
+
+@[command_elab verityContractCmd]
+def elabVerityContract : CommandElab := fun stx =>
+  elabVerityContractOrMixin stx
+
+@[command_elab verityMixinCmd]
+def elabVerityMixin : CommandElab := fun stx =>
+  elabVerityContractOrMixin stx
 
 @[command_elab verityIntrinsicCmd]
 def elabVerityIntrinsic : CommandElab := fun stx => do

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -186,8 +186,12 @@ syntax "requireError " term:max ppSpace ident "(" sepBy(term, ",") ")" : doElem
 syntax (name := requireSomeUintErrorTerm) "requireSomeUintError " term:max ppSpace ident "(" sepBy(term, ",") ")" : term
 syntax "ecmBind " term:max ppSpace term:max ppSpace term:max : doElem
 syntax (priority := high) "unsafe " str " do " doSeq : doElem
-syntax "constructor " "(" sepBy(verityParam, ",") ")" (ppSpace ident "(" sepBy(term, ",") ")")? (ppSpace verityLocalObligations)? " := " term : verityConstructor
-syntax "constructor " "(" sepBy(verityParam, ",") ")" " payable" (ppSpace ident "(" sepBy(term, ",") ")")? (ppSpace verityLocalObligations)? " := " term : verityConstructor
+syntax "constructor " "(" sepBy(verityParam, ",") ")" (ppSpace ident "(" sepBy(term, ",") ")")* (ppSpace verityLocalObligations)? " := " term : verityConstructor
+syntax "constructor " "(" sepBy(verityParam, ",") ")" " payable" (ppSpace ident "(" sepBy(term, ",") ")")* (ppSpace verityLocalObligations)? " := " term : verityConstructor
+-- Parameter-less host constructors may start directly with mixin inits:
+-- `constructor Ownable() Other() := do ...`
+syntax "constructor " (ppSpace ident "(" sepBy(term, ",") ")")+ (ppSpace verityLocalObligations)? " := " term : verityConstructor
+syntax "constructor " "payable" (ppSpace ident "(" sepBy(term, ",") ")")+ (ppSpace verityLocalObligations)? " := " term : verityConstructor
 syntax "receive" (ppSpace verityLocalObligations)? " := " term : veritySpecialEntrypoint
 syntax "fallback" (ppSpace verityLocalObligations)? " := " term : veritySpecialEntrypoint
 syntax "modifier " ident " := " term : verityModifier
@@ -225,7 +229,7 @@ syntax (name := verityIntrinsicCmd)
   ident " := " term ";" ident "[" sepBy(verityIntrinsicObligation, ",") "]" : command
 
 syntax (name := verityContractCmd)
-  "verity_contract " ident (" is " ident)? " where "
+  "verity_contract " ident (" is " ident)? (" include " sepBy1(ident, ","))? " where "
   ("types " verityNewtype+)?
   ("enums " verityEnumDecl+)?
   ("inductive " verityAdtDecl+)?
@@ -241,6 +245,25 @@ syntax (name := verityContractCmd)
   ("linked_externals " verityExternal+)?
   (verityConstructor)?
   (veritySpecialEntrypoint)*
+  (verityModifier)*
+  verityFunction* : command
+
+syntax (name := verityMixinCmd)
+  "verity_mixin " ident " where "
+  ("types " verityNewtype+)?
+  ("enums " verityEnumDecl+)?
+  ("inductive " verityAdtDecl+)?
+  (verityNamespaceSpec)?
+  "storage " verityStorageItem*
+  ("roles " verityRoleDecl+)?
+  (verityStructDecl)*
+  ("errors " verityError+)?
+  ("event_defs " verityEvent+)?
+  ("constants " verityConstant+)?
+  ("immutables " verityImmutable+)?
+  ("interfaces " verityInterface+)?
+  ("linked_externals " verityExternal+)?
+  (verityConstructor)?
   (verityModifier)*
   verityFunction* : command
 

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -3603,10 +3603,17 @@ private def pushUniqueIncludeName
 private def checkIncludeClashes
     (host : ParsedContractSyntax)
     (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM Unit := do
-  let mut seenFieldNames : Array String := host.fields.flatMap fieldDeclaredNames
+  let hostImmFields :=
+    host.immutableDecls.zipIdx.map fun (imm, idx) =>
+      immutableStorageFieldDecl host.fields imm idx
+  let mut seenFieldNames : Array String :=
+    host.fields.flatMap fieldDeclaredNames ++ hostImmFields.flatMap fieldDeclaredNames
   -- Persistent and transient storage are distinct EVM spaces.
+  -- Executable immutables occupy hidden persistent slots after the
+  -- declaring contract's user fields.
   let mut seenPersistSlots : Array Nat :=
-    (host.fields.filter (fun f => !f.isTransient)).flatMap fieldOccupiedSlots
+    (host.fields.filter (fun f => !f.isTransient)).flatMap fieldOccupiedSlots ++
+      hostImmFields.flatMap fieldOccupiedSlots
   let mut seenTransientSlots : Array Nat :=
     (host.fields.filter (·.isTransient)).flatMap fieldOccupiedSlots
   let mut seenModNames : Array String := host.modifiers.map (·.name)
@@ -3648,8 +3655,22 @@ private def checkIncludeClashes
       seenEventNames ← pushUniqueIncludeName "event" mixinName ev.name seenEventNames
     for c in mixin.constDecls do
       seenConstNames ← pushUniqueIncludeName "constant" mixinName c.name seenConstNames
-    for imm in mixin.immutableDecls do
+    for (imm, idx) in mixin.immutableDecls.zipIdx do
       seenImmutableNames ← pushUniqueIncludeName "immutable" mixinName imm.name seenImmutableNames
+      let immField := immutableStorageFieldDecl mixin.fields imm idx
+      for n in fieldDeclaredNames immField do
+        if seenFieldNames.contains n then
+          throwError
+            ("include clash: field '" ++ n ++ "' from mixin '" ++ toString mixinName ++
+              "' immutable '" ++ imm.name ++ "' duplicates a host or earlier mixin field")
+        seenFieldNames := seenFieldNames.push n
+      for sl in fieldOccupiedSlots immField do
+        if seenPersistSlots.contains sl then
+          throwError
+            ("include clash: slot " ++ toString sl ++ " from mixin '" ++
+              toString mixinName ++ "' immutable '" ++ imm.name ++
+              "' overlaps a host or earlier mixin slot")
+        seenPersistSlots := seenPersistSlots.push sl
     for extDecl in mixin.externalDecls do
       seenExternalNames ← pushUniqueIncludeName "external" mixinName extDecl.name seenExternalNames
     for adtDecl in mixin.adtDecls do
@@ -3702,31 +3723,17 @@ private def finishIncludeContract
         s!"include clash: function '{fn.name}' collides with an included mixin function"
   let mixinModNames := mixinModifierNames mixins
   let localModifiers := own.modifiers.filter fun m => !mixinModNames.contains m.name
-  -- Inline only host-local modifiers. Mixin modifiers stay on the function
-  -- so CompilationModel can emit statements / the elaborator can bind the
-  -- mixin's Lean `def`.
-  let functions ← own.functions.mapM fun fn => do
-    let localUsed := fn.modifiers.filter fun id =>
-      localModifiers.any (fun m => m.name == toString id.getId)
-    let mixinUsed := fn.modifiers.filter fun id =>
-      mixinModNames.contains (toString id.getId)
+  -- Keep the declared modifier sequence. Locals and mixin modifiers are
+  -- applied in that order later (executable calls mixin defs; the model
+  -- inlines every modifier body). Splitting the list would prefix mixin
+  -- guards around already-inlined locals and reverse source order.
+  for fn in own.functions do
     for id in fn.modifiers do
       let n := toString id.getId
       unless localModifiers.any (fun m => m.name == n) || mixinModNames.contains n do
         throwErrorAt id s!"function '{fn.name}' references unknown modifier '{n}'"
-    let inlined ←
-      if localUsed.isEmpty then
-        pure fn
-      else
-        let onlyLocal := { fn with modifiers := localUsed }
-        let arr ← inlineModifierPrefixes localModifiers #[onlyLocal]
-        match arr[0]? with
-        | some inlinedFn => pure { inlinedFn with modifiers := mixinUsed }
-        | none => pure { fn with modifiers := mixinUsed }
-    pure { inlined with modifiers := mixinUsed }
   pure {
     own with
-    functions := functions
     includes := includeIdents
     resolvedIncludes := mixins.map (·.1)
   }
@@ -4316,12 +4323,14 @@ def validateFunctionDeclsPublic
       throwErrorAt fn.ident s!"function '{fn.name}': nonreentrant and cei_safe are mutually exclusive"
     validateFunctionBodyExprTypes fields errorDecls eventDecls constDecls immutableDecls externalDecls functions fn
 
-/-- Prepend calls to included mixin modifier Lean defs. CompilationModel still
-    uses `fn.modifiers` for inlined mixin-modifier statements. -/
+/-- Apply `with` modifiers in declared order: mixin modifiers call the
+    imported Lean `def`; host-local modifiers are inlined (hosts do not
+    emit modifier defs). CompilationModel inlines every modifier body. -/
 def prefixMixinModifierExecutableBody
-    (resolvedIncludes : Array Name) (fn : FunctionDecl) (body : Term) :
+    (resolvedIncludes : Array Name) (fn : FunctionDecl) (body : Term)
+    (hostModifiers : Array ModifierDecl := #[]) :
     CommandElabM Term := do
-  if fn.modifiers.isEmpty || resolvedIncludes.isEmpty then
+  if fn.modifiers.isEmpty || (resolvedIncludes.isEmpty && hostModifiers.isEmpty) then
     return body
   let mut preludes : Array (TSyntax `doElem) := #[]
   for modIdent in fn.modifiers do
@@ -4334,11 +4343,20 @@ def prefixMixinModifierExecutableBody
             if mixin.modifiers.any (fun m => m.name == modName) then
               qual? := some (mixinName ++ modIdent.getId)
         | none => pure ()
-    let target :=
-      match qual? with
-      | some q => mkIdent q
-      | none => modIdent
-    preludes := preludes.push (← `(doElem| $target:ident))
+    match qual? with
+    | some q =>
+        preludes := preludes.push (← `(doElem| $(mkIdent q):ident))
+    | none =>
+        let some localMod := hostModifiers.find? (fun m => m.name == modName)
+          | throwErrorAt modIdent s!"function '{fn.name}' references unknown modifier '{modName}'"
+        let modifierElems ← doElems localMod.body
+        let modifierLocals ← localBinderNames localMod.body.raw
+        if let some captured := modifierLocals.find? (fun name =>
+            fn.params.any (fun param => paramReservesName param name)) then
+          throwErrorAt modIdent
+            s!"modifier '{modName}' local '{captured}' conflicts with a function parameter; rename one of them"
+        preludes := preludes.push (← `(doElem| if true then $[$modifierElems:doElem]* else
+          require false "unreachable modifier scope"))
   match body with
   | `(term| do $[$elems:doElem]*) =>
       `(term| do $[$preludes:doElem]* $[$elems:doElem]*)
@@ -4424,12 +4442,13 @@ def mkFunctionCommandsPublic
     (functions : Array FunctionDecl)
     (fn : FunctionDecl)
     (resolvedIncludes : Array Name := #[])
-    (boundImmutableDecls : Array ImmutableDecl := immutableDecls) : CommandElabM (Array Cmd) := do
+    (boundImmutableDecls : Array ImmutableDecl := immutableDecls)
+    (hostModifiers : Array ModifierDecl := #[]) : CommandElabM (Array Cmd) := do
   let fnType ← mkContractFnType fn.params fn.returnTy
   -- Mixin modifiers belong after ABI/enum, init, and role guards, matching
   -- `translateBodyToStmtTerms`. Prefix them onto the source body so those
   -- wrappers stay outside.
-  let fnBodyWithMixin ← prefixMixinModifierExecutableBody resolvedIncludes fn fn.body
+  let fnBodyWithMixin ← prefixMixinModifierExecutableBody resolvedIncludes fn fn.body hostModifiers
   let fnWithMixin := { fn with body := fnBodyWithMixin }
   let fnRoleGuardedBody ← mkRoleGuardedBody fields roleDecls fnWithMixin
   let fnDecl := { fnWithMixin with body := fnRoleGuardedBody }
@@ -4446,19 +4465,19 @@ def mkFunctionCommandsPublic
   let fnValue ← mkContractFnValue fn.params fnExecutableBody
   let modelBodyName ← mkSuffixedIdent fn.ident "_modelBody"
   let modelName ← mkSuffixedIdent fn.ident "_model"
-  -- CompilationModel inlines mixin modifier statements so `modifies(...)`
-  -- can see the write set. The executable path above still binds the
-  -- mixin's Lean `def` (import, not copy).
-  let mut mixinModifiers : Array ModifierDecl := #[]
+  -- CompilationModel inlines every modifier in declared `with` order so
+  -- `modifies(...)` sees the write set. The executable path still binds
+  -- mixin Lean `def`s (import, not copy) and inlines host-local modifiers.
+  let mut allModifiers : Array ModifierDecl := hostModifiers
   for mixinName in resolvedIncludes do
     match (← lookupContractSyntax mixinName) with
-    | some mixin => mixinModifiers := mixinModifiers ++ mixin.modifiers
+    | some mixin => allModifiers := allModifiers ++ mixin.modifiers
     | none => pure ()
   let modelFn ←
-    if mixinModifiers.isEmpty then
+    if fn.modifiers.isEmpty || allModifiers.isEmpty then
       pure fn
     else
-      let arr ← inlineModifierPrefixes mixinModifiers #[fn]
+      let arr ← inlineModifierPrefixes allModifiers #[fn]
       match arr[0]? with
       | some inlined => pure inlined
       | none => pure fn

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2674,7 +2674,13 @@ private def mkSpecCommand
     (adtDecls : Array AdtDecl)
     (storageNamespace : Option Nat)
     (specIdent : Ident := mkIdent (Name.mkSimple "spec"))
-    (translationFields : Array StorageFieldDecl := fields) : CommandElabM Cmd := do
+    (translationFields : Array StorageFieldDecl := fields)
+    (translationErrorDecls : Array ErrorDecl := errorDecls)
+    (translationConstDecls : Array ConstantDecl := constDecls)
+    (translationImmutableDecls : Array ImmutableDecl := immutableDecls)
+    (translationExternalDecls : Array ExternalDecl := externalDecls)
+    (translationFunctions : Array FunctionDecl := functions)
+    (constructorImmutableDecls : Array ImmutableDecl := immutableDecls) : CommandElabM Cmd := do
   let immutableTerms ← immutableDecls.mapM fun imm => do
     let tyTerm ← modelParamTypeTerm imm.ty
     let initTerm ← translatePureExpr fields constDecls #[] (ctor.map (·.params) |>.getD #[]) #[] imm.body
@@ -2691,15 +2697,18 @@ private def mkSpecCommand
   let eventTerms ← eventDecls.mapM mkModelEventTerm
   let externalTerms ← externalDecls.mapM mkModelExternalTerm
   let constructorTerm ←
-    match ctor, immutableDecls.isEmpty with
+    match ctor, constructorImmutableDecls.isEmpty with
     | none, true => `(none)
     | some ctor, _ =>
         let ctorParams ← mkModelParamsTerm ctor.params
         let ctorPayable ← if ctor.isPayable then `(true) else `(false)
         let ctorLocalObligationTerms ←
-          (constructorLocalObligationsWithArithmetic ctor immutableDecls).mapM mkModelLocalObligationTerm
-        let immutableInitTerms ← immutableInitStmtTerms fields constDecls immutableDecls ctor.params
-        let ctorBodyTerms ← translateConstructorBodyToStmtTerms translationFields errorDecls constDecls immutableDecls externalDecls functions ctor
+          (constructorLocalObligationsWithArithmetic ctor constructorImmutableDecls).mapM mkModelLocalObligationTerm
+        let immutableInitTerms ← immutableInitStmtTerms
+          translationFields translationConstDecls constructorImmutableDecls ctor.params
+        let ctorBodyTerms ← translateConstructorBodyToStmtTerms
+          translationFields translationErrorDecls translationConstDecls
+          translationImmutableDecls translationExternalDecls translationFunctions ctor
         let enumGuardCount := ctor.params.countP fun param =>
           match param.ty with | .enum _ _ => true | _ => false
         let ctorAllTerms := ctorBodyTerms.take enumGuardCount ++ immutableInitTerms ++
@@ -2711,9 +2720,10 @@ private def mkSpecCommand
           body := [ $[$ctorAllTerms],* ]
         })
     | none, false =>
-        let immutableInitTerms ← immutableInitStmtTerms fields constDecls immutableDecls #[]
+        let immutableInitTerms ← immutableInitStmtTerms
+          translationFields translationConstDecls constructorImmutableDecls #[]
         let ctorLocalObligationTerms ←
-          (synthesizedConstructorLocalObligationsWithArithmetic immutableDecls).mapM mkModelLocalObligationTerm
+          (synthesizedConstructorLocalObligationsWithArithmetic constructorImmutableDecls).mapM mkModelLocalObligationTerm
         `(some {
           params := []
           isPayable := false
@@ -2807,7 +2817,9 @@ private def mkSpecCommand
     let bodyTerms ←
       match modDecl.body with
       | `(term| do $[$elems:doElem]*) =>
-          pure (← (translateDoElems fields constDecls immutableDecls externalDecls errorDecls functions .unit #[] #[] #[] elems)).1
+          pure (← (translateDoElems translationFields translationConstDecls
+            translationImmutableDecls translationExternalDecls
+            translationErrorDecls translationFunctions .unit #[] #[] #[] elems)).1
       | _ => throwErrorAt modDecl.body "modifier body must be a do block"
     let bodyTerms := bodyTerms.push (← `(Compiler.CompilationModel.Stmt.stop))
     `( ({
@@ -3524,6 +3536,30 @@ def expandMixinConstructorForModelPublic
     (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM ConstructorDecl :=
   expandMixinConstructorForModel hostFields hostConsts hostImmutables hostExternals host mixins
 
+/-- Mixin immutable initializers, with constructor-parameter references
+    rewritten to the host init expressions. The host CompilationModel must
+    emit `setImmutable` for these; merge keeps `host.constructor` only. -/
+private def includedMixinImmutablesForHost
+    (hostCtor : Option ConstructorDecl)
+    (mixins : Array (Name × ParsedContractSyntax)) : Array ImmutableDecl :=
+  let inits := hostCtor.map (·.mixinInits) |>.getD #[]
+  mixins.flatMap fun (mixinName, mixin) =>
+    let bindings : Array (String × Syntax) :=
+      match mixin.ctor with
+      | none => #[]
+      | some mixinCtor =>
+          match inits.find? (fun (id, _) => namesMixin (toString id.getId) mixinName) with
+          | none => #[]
+          | some (_, args) =>
+              mixinCtor.params.zip args |>.map fun (param, arg) => (param.name, arg.raw)
+    mixin.immutableDecls.map fun imm =>
+      { imm with body := substitutePureInitializerParams bindings imm.body }
+
+def includedMixinImmutablesForHostPublic
+    (hostCtor : Option ConstructorDecl)
+    (mixins : Array (Name × ParsedContractSyntax)) : Array ImmutableDecl :=
+  includedMixinImmutablesForHost hostCtor mixins
+
 private def resolveIncludedMixin (currentNs : Name) (id : Ident) :
     CommandElabM (Name × ParsedContractSyntax) := do
   let candidates := [currentNs ++ id.getId, id.getId]
@@ -3555,6 +3591,15 @@ private def fieldOccupiedSlots (field : StorageFieldDecl) : Array Nat :=
 private def fieldDeclaredNames (field : StorageFieldDecl) : Array String :=
   #[field.name] ++ field.aliases.toArray
 
+private def pushUniqueIncludeName
+    (kind : String) (mixinName : Name) (name : String) (seen : Array String) :
+    CommandElabM (Array String) := do
+  if seen.contains name then
+    throwError
+      ("include clash: " ++ kind ++ " '" ++ name ++ "' from mixin '" ++
+        toString mixinName ++ "' duplicates a host or earlier mixin " ++ kind)
+  pure (seen.push name)
+
 private def checkIncludeClashes
     (host : ParsedContractSyntax)
     (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM Unit := do
@@ -3566,8 +3611,14 @@ private def checkIncludeClashes
     (host.fields.filter (·.isTransient)).flatMap fieldOccupiedSlots
   let mut seenModNames : Array String := host.modifiers.map (·.name)
   let mut seenRoleNames : Array String := host.roleDecls.map (·.name)
-  let mut seenFnNames : Array String :=
-    host.functions.filterMap fun fn => if fn.isInternal then none else some fn.name
+  -- Internal helpers share the Yul/CompilationModel name key with entrypoints.
+  let mut seenFnNames : Array String := host.functions.map (·.name)
+  let mut seenErrorNames : Array String := host.errorDecls.map (·.name)
+  let mut seenEventNames : Array String := host.eventDecls.map (·.name)
+  let mut seenConstNames : Array String := host.constDecls.map (·.name)
+  let mut seenImmutableNames : Array String := host.immutableDecls.map (·.name)
+  let mut seenExternalNames : Array String := host.externalDecls.map (·.name)
+  let mut seenAdtNames : Array String := host.adtDecls.map (·.name)
   for (mixinName, mixin) in mixins do
     for field in mixin.fields do
       for n in fieldDeclaredNames field do
@@ -3586,18 +3637,23 @@ private def checkIncludeClashes
             throwError s!"include clash: slot {sl} from mixin '{mixinName}' field '{field.name}' overlaps a host or earlier mixin slot"
           seenPersistSlots := seenPersistSlots.push sl
     for modDecl in mixin.modifiers do
-      if seenModNames.contains modDecl.name then
-        throwError s!"include clash: modifier '{modDecl.name}' from mixin '{mixinName}' duplicates a host or earlier mixin modifier"
-      seenModNames := seenModNames.push modDecl.name
+      seenModNames ← pushUniqueIncludeName "modifier" mixinName modDecl.name seenModNames
     for role in mixin.roleDecls do
-      if seenRoleNames.contains role.name then
-        throwError s!"include clash: role '{role.name}' from mixin '{mixinName}' duplicates a host or earlier mixin role"
-      seenRoleNames := seenRoleNames.push role.name
+      seenRoleNames ← pushUniqueIncludeName "role" mixinName role.name seenRoleNames
     for fn in mixin.functions do
-      unless fn.isInternal do
-        if seenFnNames.contains fn.name then
-          throwError s!"include clash: function '{fn.name}' from mixin '{mixinName}' duplicates a host or earlier mixin entrypoint"
-        seenFnNames := seenFnNames.push fn.name
+      seenFnNames ← pushUniqueIncludeName "function" mixinName fn.name seenFnNames
+    for err in mixin.errorDecls do
+      seenErrorNames ← pushUniqueIncludeName "error" mixinName err.name seenErrorNames
+    for ev in mixin.eventDecls do
+      seenEventNames ← pushUniqueIncludeName "event" mixinName ev.name seenEventNames
+    for c in mixin.constDecls do
+      seenConstNames ← pushUniqueIncludeName "constant" mixinName c.name seenConstNames
+    for imm in mixin.immutableDecls do
+      seenImmutableNames ← pushUniqueIncludeName "immutable" mixinName imm.name seenImmutableNames
+    for extDecl in mixin.externalDecls do
+      seenExternalNames ← pushUniqueIncludeName "external" mixinName extDecl.name seenExternalNames
+    for adtDecl in mixin.adtDecls do
+      seenAdtNames ← pushUniqueIncludeName "ADT" mixinName adtDecl.name seenAdtNames
 
 private def checkMixinConstructorInits
     (host : ParsedContractSyntax)
@@ -3639,13 +3695,11 @@ private def finishIncludeContract
   let mixins ← includeIdents.mapM (resolveIncludedMixin currentNs)
   checkIncludeClashes own mixins
   checkMixinConstructorInits own mixins
-  let mixinFnNames := mixins.flatMap fun (_, mixin) =>
-    mixin.functions.filterMap fun fn => if fn.isInternal then none else some fn.name
+  let mixinFnNames := mixins.flatMap fun (_, mixin) => mixin.functions.map (·.name)
   for fn in own.functions do
-    unless fn.isInternal do
-      if mixinFnNames.contains fn.name then
-        throwErrorAt fn.ident
-          s!"include clash: function '{fn.name}' collides with an included mixin entrypoint"
+    if mixinFnNames.contains fn.name then
+      throwErrorAt fn.ident
+        s!"include clash: function '{fn.name}' collides with an included mixin function"
   let mixinModNames := mixinModifierNames mixins
   let localModifiers := own.modifiers.filter fun m => !mixinModNames.contains m.name
   -- Inline only host-local modifiers. Mixin modifiers stay on the function
@@ -4369,7 +4423,8 @@ def mkFunctionCommandsPublic
     (externalDecls : Array ExternalDecl)
     (functions : Array FunctionDecl)
     (fn : FunctionDecl)
-    (resolvedIncludes : Array Name := #[]) : CommandElabM (Array Cmd) := do
+    (resolvedIncludes : Array Name := #[])
+    (boundImmutableDecls : Array ImmutableDecl := immutableDecls) : CommandElabM (Array Cmd) := do
   let fnType ← mkContractFnType fn.params fn.returnTy
   -- Mixin modifiers belong after ABI/enum, init, and role guards, matching
   -- `translateBodyToStmtTerms`. Prefix them onto the source body so those
@@ -4379,7 +4434,10 @@ def mkFunctionCommandsPublic
   let fnRoleGuardedBody ← mkRoleGuardedBody fields roleDecls fnWithMixin
   let fnDecl := { fnWithMixin with body := fnRoleGuardedBody }
   let fnGuardedBody ← mkInitGuardedBody fields fnDecl
-  let fnBody ← mkImmutableBoundBody fields immutableDecls fn fnGuardedBody
+  -- Bind only this contract's immutables. Mixin immutables keep the hidden
+  -- slots computed in the mixin namespace; recomputing them against host
+  -- fields would shift those slots.
+  let fnBody ← mkImmutableBoundBody fields boundImmutableDecls fn fnGuardedBody
   let fnExecutableBody ← rewriteForEachExecutableBody fields externalDecls fn.params fnBody
   -- The parsed body already contains guards for the model path. Re-applying
   -- them outside all executable wrappers makes ABI validation happen before
@@ -4468,8 +4526,14 @@ def mkSpecCommandPublic
     (adtDecls : Array AdtDecl)
     (storageNamespace : Option Nat)
     (specIdent : Ident := mkIdent (Name.mkSimple "spec"))
-    (translationFields : Array StorageFieldDecl := fields) : CommandElabM Cmd :=
-  mkSpecCommand contractName fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace specIdent translationFields
+    (translationFields : Array StorageFieldDecl := fields)
+    (translationErrorDecls : Array ErrorDecl := errorDecls)
+    (translationConstDecls : Array ConstantDecl := constDecls)
+    (translationImmutableDecls : Array ImmutableDecl := immutableDecls)
+    (translationExternalDecls : Array ExternalDecl := externalDecls)
+    (translationFunctions : Array FunctionDecl := functions)
+    (constructorImmutableDecls : Array ImmutableDecl := immutableDecls) : CommandElabM Cmd :=
+  mkSpecCommand contractName fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace specIdent translationFields translationErrorDecls translationConstDecls translationImmutableDecls translationExternalDecls translationFunctions constructorImmutableDecls
 
 def mkFindIdxFieldSimpCommandsPublic
     (contractIdent : Ident)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2673,7 +2673,8 @@ private def mkSpecCommand
     (functions : Array FunctionDecl)
     (adtDecls : Array AdtDecl)
     (storageNamespace : Option Nat)
-    (specIdent : Ident := mkIdent (Name.mkSimple "spec")) : CommandElabM Cmd := do
+    (specIdent : Ident := mkIdent (Name.mkSimple "spec"))
+    (translationFields : Array StorageFieldDecl := fields) : CommandElabM Cmd := do
   let immutableTerms ← immutableDecls.mapM fun imm => do
     let tyTerm ← modelParamTypeTerm imm.ty
     let initTerm ← translatePureExpr fields constDecls #[] (ctor.map (·.params) |>.getD #[]) #[] imm.body
@@ -2698,7 +2699,7 @@ private def mkSpecCommand
         let ctorLocalObligationTerms ←
           (constructorLocalObligationsWithArithmetic ctor immutableDecls).mapM mkModelLocalObligationTerm
         let immutableInitTerms ← immutableInitStmtTerms fields constDecls immutableDecls ctor.params
-        let ctorBodyTerms ← translateConstructorBodyToStmtTerms fields errorDecls constDecls immutableDecls externalDecls functions ctor
+        let ctorBodyTerms ← translateConstructorBodyToStmtTerms translationFields errorDecls constDecls immutableDecls externalDecls functions ctor
         let enumGuardCount := ctor.params.countP fun param =>
           match param.ty with | .enum _ _ => true | _ => false
         let ctorAllTerms := ctorBodyTerms.take enumGuardCount ++ immutableInitTerms ++
@@ -3442,6 +3443,87 @@ private def mixinShortName (mixinName : Name) : String :=
 private def namesMixin (n : String) (mixinName : Name) : Bool :=
   n == mixinShortName mixinName || n == toString mixinName
 
+/-- Expand host constructor mixin inits into scoped do-elems so the
+    CompilationModel constructor references host arguments (or expressions),
+    not the mixin's original parameter names. Executable lowering still
+    calls the mixin `constructor` Lean def. -/
+private def expandMixinConstructorForModel
+    (hostFields : Array StorageFieldDecl)
+    (hostConsts : Array ConstantDecl)
+    (hostImmutables : Array ImmutableDecl)
+    (hostExternals : Array ExternalDecl)
+    (host : ConstructorDecl)
+    (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM ConstructorDecl := do
+  if host.mixinInits.isEmpty then
+    return host
+  let mut preludeElems : Array (TSyntax `doElem) := #[]
+  let mut extraObligations : Array LocalObligationDecl := #[]
+  for (mixinIdent, args) in host.mixinInits do
+    let n := toString mixinIdent.getId
+    let some (mixinName, mixin) :=
+        mixins.find? (fun (mixinName, mixin) =>
+          mixin.ctor.isSome && namesMixin n mixinName)
+      | throwErrorAt mixinIdent s!"constructor init '{n}' does not name an included mixin that has a constructor"
+    let some mixinCtor := mixin.ctor
+      | throwErrorAt mixinIdent s!"constructor init '{n}' names a mixin without a constructor"
+    if args.size != mixinCtor.params.size then
+      throwErrorAt mixinIdent
+        s!"mixin constructor '{mixinShortName mixinName}' expects {mixinCtor.params.size} argument(s), got {args.size}"
+    extraObligations := extraObligations ++ mixinCtor.localObligations
+    for (param, arg) in mixinCtor.params.zip args do
+      let argTy ← inferPureExprType
+        (mixin.fields ++ hostFields) (mixin.constDecls ++ hostConsts)
+        (mixin.immutableDecls ++ hostImmutables)
+        (mixin.externalDecls ++ hostExternals)
+        host.params #[] arg
+      unless argumentTypeMatchesParam arg argTy param.ty do
+        throwErrorAt arg
+          s!"mixin constructor parameter '{param.name}' expects {renderValueType param.ty}, got {renderValueType argTy}"
+    let mut mixinBindings : Array (TSyntax `doElem) := #[]
+    let mut dynamicParamBindings : Array (String × Syntax) := #[]
+    for (param, arg) in mixinCtor.params.zip args do
+      let directHostParam? := match stripParens arg with
+        | `(term| $name:ident) =>
+            host.params.find? (fun (hostParam : ParamDecl) =>
+              declaredNameMatches (toString name.getId) hostParam.name)
+        | _ => host.params.find? (fun hostParam =>
+            (stripParens arg).raw.reprint.getD "" == hostParam.name)
+      let isIdentityArg := directHostParam?.any (fun hostParam => hostParam.name == param.name)
+      if !isIdentityArg then
+        if host.params.any (fun hostParam => paramReservesName hostParam param.name) then
+          throwErrorAt arg
+            s!"mixin constructor parameter '{param.name}' conflicts with a host constructor parameter; rename the host parameter"
+        if valueTypeUsesDynamicData param.ty && directHostParam?.isSome then
+          dynamicParamBindings := dynamicParamBindings.push (param.name, arg.raw)
+        else
+          let normalizedArg ← normalizeParentConstructorArg param.ty arg
+          mixinBindings := mixinBindings.push (← `(doElem| let $param.ident := $normalizedArg))
+    let mixinBody := substituteDynamicParentParams dynamicParamBindings mixinCtor.body
+    let mixinElems ← doElems mixinBody
+    let scopedElem ← `(doElem| if true then
+      $[$mixinBindings:doElem]*
+      $[$mixinElems:doElem]*
+      else
+        pure ())
+    preludeElems := preludeElems.push scopedElem
+  let hostElems ← doElems host.body
+  let combined ← `(term| do $[$preludeElems:doElem]* $[$hostElems:doElem]*)
+  pure {
+    host with
+    localObligations := extraObligations ++ host.localObligations
+    mixinInits := #[]
+    body := combined
+  }
+
+def expandMixinConstructorForModelPublic
+    (hostFields : Array StorageFieldDecl)
+    (hostConsts : Array ConstantDecl)
+    (hostImmutables : Array ImmutableDecl)
+    (hostExternals : Array ExternalDecl)
+    (host : ConstructorDecl)
+    (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM ConstructorDecl :=
+  expandMixinConstructorForModel hostFields hostConsts hostImmutables hostExternals host mixins
+
 private def resolveIncludedMixin (currentNs : Name) (id : Ident) :
     CommandElabM (Name × ParsedContractSyntax) := do
   let candidates := [currentNs ++ id.getId, id.getId]
@@ -3460,26 +3542,49 @@ private def resolveIncludedMixin (currentNs : Name) (id : Ident) :
   | none =>
       throwErrorAt id s!"unknown mixin '{id.getId}'; import or declare the mixin before the host"
 
+private def fieldOccupiedSlots (field : StorageFieldDecl) : Array Nat :=
+  let extra :=
+    match field.adtInfo? with
+    | some (_, maxFields) => maxFields
+    | none =>
+        match field.ty with
+        | .scalar (.adt _ maxFields) => maxFields
+        | _ => 0
+  ((List.range (extra + 1)).map (fun i => field.slotNum + i)).toArray
+
+private def fieldDeclaredNames (field : StorageFieldDecl) : Array String :=
+  #[field.name] ++ field.aliases.toArray
+
 private def checkIncludeClashes
     (host : ParsedContractSyntax)
     (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM Unit := do
-  let mut seenFieldNames : Array String := host.fields.map (·.name)
-  let mut seenSlots : Array (Nat × String × String) :=
-    host.fields.map fun f => (f.slotNum, "host", f.name)
+  let mut seenFieldNames : Array String := host.fields.flatMap fieldDeclaredNames
+  -- Persistent and transient storage are distinct EVM spaces.
+  let mut seenPersistSlots : Array Nat :=
+    (host.fields.filter (fun f => !f.isTransient)).flatMap fieldOccupiedSlots
+  let mut seenTransientSlots : Array Nat :=
+    (host.fields.filter (·.isTransient)).flatMap fieldOccupiedSlots
   let mut seenModNames : Array String := host.modifiers.map (·.name)
   let mut seenRoleNames : Array String := host.roleDecls.map (·.name)
   let mut seenFnNames : Array String :=
     host.functions.filterMap fun fn => if fn.isInternal then none else some fn.name
   for (mixinName, mixin) in mixins do
     for field in mixin.fields do
-      if seenFieldNames.contains field.name then
-        throwError s!"include clash: field '{field.name}' from mixin '{mixinName}' duplicates a host or earlier mixin field"
-      seenFieldNames := seenFieldNames.push field.name
-      match seenSlots.find? (fun (n, _, _) => n == field.slotNum) with
-      | some _ =>
-          throwError s!"include clash: slot {field.slotNum} from mixin '{mixinName}' field '{field.name}' overlaps a host or earlier mixin slot"
-      | none =>
-          seenSlots := seenSlots.push (field.slotNum, toString mixinName, field.name)
+      for n in fieldDeclaredNames field do
+        if seenFieldNames.contains n then
+          throwError s!"include clash: field '{n}' from mixin '{mixinName}' duplicates a host or earlier mixin field"
+        seenFieldNames := seenFieldNames.push n
+      let occupied := fieldOccupiedSlots field
+      if field.isTransient then
+        for sl in occupied do
+          if seenTransientSlots.contains sl then
+            throwError s!"include clash: transient slot {sl} from mixin '{mixinName}' field '{field.name}' overlaps a host or earlier mixin slot"
+          seenTransientSlots := seenTransientSlots.push sl
+      else
+        for sl in occupied do
+          if seenPersistSlots.contains sl then
+            throwError s!"include clash: slot {sl} from mixin '{mixinName}' field '{field.name}' overlaps a host or earlier mixin slot"
+          seenPersistSlots := seenPersistSlots.push sl
     for modDecl in mixin.modifiers do
       if seenModNames.contains modDecl.name then
         throwError s!"include clash: modifier '{modDecl.name}' from mixin '{mixinName}' duplicates a host or earlier mixin modifier"
@@ -3501,19 +3606,29 @@ private def checkMixinConstructorInits
     match host.ctor with
     | some ctor => ctor.mixinInits
     | none => #[]
-  let initNames := inits.map fun (id, _) => toString id.getId
+  let mut seenInitMixins : Array Name := #[]
+  for (id, args) in inits do
+    let n := toString id.getId
+    let some (mixinName, mixin) :=
+        mixins.find? (fun (mixinName, mixin) =>
+          mixin.ctor.isSome && namesMixin n mixinName)
+      | throwErrorAt id s!"constructor init '{n}' does not name an included mixin that has a constructor"
+    if seenInitMixins.any (fun prev => namesMixin (mixinShortName prev) mixinName) then
+      throwErrorAt id
+        s!"duplicate mixin constructor call for '{mixinShortName mixinName}'; each included mixin may be initialized once"
+    seenInitMixins := seenInitMixins.push mixinName
+    match mixin.ctor with
+    | some mixinCtor =>
+        if args.size != mixinCtor.params.size then
+          throwErrorAt id
+            s!"mixin constructor '{mixinShortName mixinName}' expects {mixinCtor.params.size} argument(s), got {args.size}"
+    | none => pure ()
   for (mixinName, mixin) in mixins do
     if mixin.ctor.isSome then
       let shortName := mixinShortName mixinName
-      unless initNames.any (fun n => namesMixin n mixinName) do
+      unless inits.any (fun (id, _) => namesMixin (toString id.getId) mixinName) do
         throwError
           s!"missing mixin constructor call for '{shortName}'; add `{shortName}(...)` to the host constructor"
-  for (id, _) in inits do
-    let n := toString id.getId
-    let known := mixins.any fun (mixinName, mixin) =>
-      mixin.ctor.isSome && namesMixin n mixinName
-    unless known do
-      throwErrorAt id s!"constructor init '{n}' does not name an included mixin that has a constructor"
 
 private def mixinModifierNames (mixins : Array (Name × ParsedContractSyntax)) : Array String :=
   mixins.flatMap fun (_, mixin) => mixin.modifiers.map (·.name)
@@ -4256,8 +4371,13 @@ def mkFunctionCommandsPublic
     (fn : FunctionDecl)
     (resolvedIncludes : Array Name := #[]) : CommandElabM (Array Cmd) := do
   let fnType ← mkContractFnType fn.params fn.returnTy
-  let fnRoleGuardedBody ← mkRoleGuardedBody fields roleDecls fn
-  let fnDecl := { fn with body := fnRoleGuardedBody }
+  -- Mixin modifiers belong after ABI/enum, init, and role guards, matching
+  -- `translateBodyToStmtTerms`. Prefix them onto the source body so those
+  -- wrappers stay outside.
+  let fnBodyWithMixin ← prefixMixinModifierExecutableBody resolvedIncludes fn fn.body
+  let fnWithMixin := { fn with body := fnBodyWithMixin }
+  let fnRoleGuardedBody ← mkRoleGuardedBody fields roleDecls fnWithMixin
+  let fnDecl := { fnWithMixin with body := fnRoleGuardedBody }
   let fnGuardedBody ← mkInitGuardedBody fields fnDecl
   let fnBody ← mkImmutableBoundBody fields immutableDecls fn fnGuardedBody
   let fnExecutableBody ← rewriteForEachExecutableBody fields externalDecls fn.params fnBody
@@ -4265,7 +4385,6 @@ def mkFunctionCommandsPublic
   -- them outside all executable wrappers makes ABI validation happen before
   -- initializer, role, and modifier effects (the inner copy is harmless).
   let fnExecutableBody ← prependEnumGuards fn.params fnExecutableBody
-  let fnExecutableBody ← prefixMixinModifierExecutableBody resolvedIncludes fn fnExecutableBody
   let fnValue ← mkContractFnValue fn.params fnExecutableBody
   let modelBodyName ← mkSuffixedIdent fn.ident "_modelBody"
   let modelName ← mkSuffixedIdent fn.ident "_model"
@@ -4348,8 +4467,9 @@ def mkSpecCommandPublic
     (functions : Array FunctionDecl)
     (adtDecls : Array AdtDecl)
     (storageNamespace : Option Nat)
-    (specIdent : Ident := mkIdent (Name.mkSimple "spec")) : CommandElabM Cmd :=
-  mkSpecCommand contractName fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace specIdent
+    (specIdent : Ident := mkIdent (Name.mkSimple "spec"))
+    (translationFields : Array StorageFieldDecl := fields) : CommandElabM Cmd :=
+  mkSpecCommand contractName fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace specIdent translationFields
 
 def mkFindIdxFieldSimpCommandsPublic
     (contractIdent : Ident)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2672,7 +2672,8 @@ private def mkSpecCommand
     (modifiers : Array ModifierDecl)
     (functions : Array FunctionDecl)
     (adtDecls : Array AdtDecl)
-    (storageNamespace : Option Nat) : CommandElabM Cmd := do
+    (storageNamespace : Option Nat)
+    (specIdent : Ident := mkIdent (Name.mkSimple "spec")) : CommandElabM Cmd := do
   let immutableTerms ← immutableDecls.mapM fun imm => do
     let tyTerm ← modelParamTypeTerm imm.ty
     let initTerm ← translatePureExpr fields constDecls #[] (ctor.map (·.params) |>.getD #[]) #[] imm.body
@@ -2841,7 +2842,7 @@ private def mkSpecCommand
   let namespaceTerm ← match storageNamespace with
     | some ns => `(some $(natTerm ns))
     | none => `(none)
-  `(command| def spec : Compiler.CompilationModel.CompilationModel := {
+  `(command| def $specIdent : Compiler.CompilationModel.CompilationModel := {
     name := $(strTerm contractName)
     fields := [ $[$fieldTerms],* ]
     «immutables» := [ $[$immutableTerms],* ]
@@ -3024,6 +3025,9 @@ structure ParsedContractSyntax where
   modifiers : Array ModifierDecl
   functions : Array FunctionDecl
   storageNamespace : Option Nat
+  isMixin : Bool := false
+  includes : Array Ident := #[]
+  resolvedIncludes : Array Name := #[]
 
 abbrev ContractSyntaxRegistry := List (Name × ParsedContractSyntax)
 
@@ -3045,6 +3049,9 @@ def registerContractSyntax (name : Name) (parsed : ParsedContractSyntax) : Comma
 private def lookupContractSyntax (name : Name) : CommandElabM (Option ParsedContractSyntax) := do
   pure (contractSyntaxExt.getState (← getEnv)
     |>.find? (fun entry => entry.1 == name) |>.map (·.2))
+
+def lookupContractSyntaxPublic (name : Name) : CommandElabM (Option ParsedContractSyntax) :=
+  lookupContractSyntax name
 
 private def doElems (body : Term) : CommandElabM (Array (TSyntax `doElem)) := do
   match body with
@@ -3427,11 +3434,146 @@ private def parseRoleDecl
               throwErrorAt fieldName s!"role '{toString roleName.getId}' uses unsupported backing field '{backingName}'; roles require an Address scalar field or Address→Uint256 mapping"
   | _ => throwErrorAt roleStx "invalid role declaration"
 
-def parseContractSyntax
+private def mixinShortName (mixinName : Name) : String :=
+  match mixinName with
+  | .str _ s => s
+  | _ => toString mixinName
+
+private def namesMixin (n : String) (mixinName : Name) : Bool :=
+  n == mixinShortName mixinName || n == toString mixinName
+
+private def resolveIncludedMixin (currentNs : Name) (id : Ident) :
+    CommandElabM (Name × ParsedContractSyntax) := do
+  let candidates := [currentNs ++ id.getId, id.getId]
+  let mut found : Option (Name × ParsedContractSyntax) := none
+  for candidate in candidates do
+    if found.isNone then
+      match (← lookupContractSyntax candidate) with
+      | some parsed =>
+          if parsed.isMixin then
+            found := some (candidate, parsed)
+          else
+            throwErrorAt id s!"include '{id.getId}' names a contract, not a verity_mixin"
+      | none => pure ()
+  match found with
+  | some result => pure result
+  | none =>
+      throwErrorAt id s!"unknown mixin '{id.getId}'; import or declare the mixin before the host"
+
+private def checkIncludeClashes
+    (host : ParsedContractSyntax)
+    (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM Unit := do
+  let mut seenFieldNames : Array String := host.fields.map (·.name)
+  let mut seenSlots : Array (Nat × String × String) :=
+    host.fields.map fun f => (f.slotNum, "host", f.name)
+  let mut seenModNames : Array String := host.modifiers.map (·.name)
+  let mut seenRoleNames : Array String := host.roleDecls.map (·.name)
+  let mut seenFnNames : Array String :=
+    host.functions.filterMap fun fn => if fn.isInternal then none else some fn.name
+  for (mixinName, mixin) in mixins do
+    for field in mixin.fields do
+      if seenFieldNames.contains field.name then
+        throwError s!"include clash: field '{field.name}' from mixin '{mixinName}' duplicates a host or earlier mixin field"
+      seenFieldNames := seenFieldNames.push field.name
+      match seenSlots.find? (fun (n, _, _) => n == field.slotNum) with
+      | some _ =>
+          throwError s!"include clash: slot {field.slotNum} from mixin '{mixinName}' field '{field.name}' overlaps a host or earlier mixin slot"
+      | none =>
+          seenSlots := seenSlots.push (field.slotNum, toString mixinName, field.name)
+    for modDecl in mixin.modifiers do
+      if seenModNames.contains modDecl.name then
+        throwError s!"include clash: modifier '{modDecl.name}' from mixin '{mixinName}' duplicates a host or earlier mixin modifier"
+      seenModNames := seenModNames.push modDecl.name
+    for role in mixin.roleDecls do
+      if seenRoleNames.contains role.name then
+        throwError s!"include clash: role '{role.name}' from mixin '{mixinName}' duplicates a host or earlier mixin role"
+      seenRoleNames := seenRoleNames.push role.name
+    for fn in mixin.functions do
+      unless fn.isInternal do
+        if seenFnNames.contains fn.name then
+          throwError s!"include clash: function '{fn.name}' from mixin '{mixinName}' duplicates a host or earlier mixin entrypoint"
+        seenFnNames := seenFnNames.push fn.name
+
+private def checkMixinConstructorInits
+    (host : ParsedContractSyntax)
+    (mixins : Array (Name × ParsedContractSyntax)) : CommandElabM Unit := do
+  let inits :=
+    match host.ctor with
+    | some ctor => ctor.mixinInits
+    | none => #[]
+  let initNames := inits.map fun (id, _) => toString id.getId
+  for (mixinName, mixin) in mixins do
+    if mixin.ctor.isSome then
+      let shortName := mixinShortName mixinName
+      unless initNames.any (fun n => namesMixin n mixinName) do
+        throwError
+          s!"missing mixin constructor call for '{shortName}'; add `{shortName}(...)` to the host constructor"
+  for (id, _) in inits do
+    let n := toString id.getId
+    let known := mixins.any fun (mixinName, mixin) =>
+      mixin.ctor.isSome && namesMixin n mixinName
+    unless known do
+      throwErrorAt id s!"constructor init '{n}' does not name an included mixin that has a constructor"
+
+private def mixinModifierNames (mixins : Array (Name × ParsedContractSyntax)) : Array String :=
+  mixins.flatMap fun (_, mixin) => mixin.modifiers.map (·.name)
+
+private def finishIncludeContract
+    (currentNs : Name) (includeIdents : Array Ident) (own : ParsedContractSyntax) :
+    CommandElabM ParsedContractSyntax := do
+  let mixins ← includeIdents.mapM (resolveIncludedMixin currentNs)
+  checkIncludeClashes own mixins
+  checkMixinConstructorInits own mixins
+  let mixinFnNames := mixins.flatMap fun (_, mixin) =>
+    mixin.functions.filterMap fun fn => if fn.isInternal then none else some fn.name
+  for fn in own.functions do
+    unless fn.isInternal do
+      if mixinFnNames.contains fn.name then
+        throwErrorAt fn.ident
+          s!"include clash: function '{fn.name}' collides with an included mixin entrypoint"
+  let mixinModNames := mixinModifierNames mixins
+  let localModifiers := own.modifiers.filter fun m => !mixinModNames.contains m.name
+  -- Inline only host-local modifiers. Mixin modifiers stay on the function
+  -- so CompilationModel can emit statements / the elaborator can bind the
+  -- mixin's Lean `def`.
+  let functions ← own.functions.mapM fun fn => do
+    let localUsed := fn.modifiers.filter fun id =>
+      localModifiers.any (fun m => m.name == toString id.getId)
+    let mixinUsed := fn.modifiers.filter fun id =>
+      mixinModNames.contains (toString id.getId)
+    for id in fn.modifiers do
+      let n := toString id.getId
+      unless localModifiers.any (fun m => m.name == n) || mixinModNames.contains n do
+        throwErrorAt id s!"function '{fn.name}' references unknown modifier '{n}'"
+    let inlined ←
+      if localUsed.isEmpty then
+        pure fn
+      else
+        let onlyLocal := { fn with modifiers := localUsed }
+        let arr ← inlineModifierPrefixes localModifiers #[onlyLocal]
+        match arr[0]? with
+        | some inlinedFn => pure { inlinedFn with modifiers := mixinUsed }
+        | none => pure { fn with modifiers := mixinUsed }
+    pure { inlined with modifiers := mixinUsed }
+  pure {
+    own with
+    functions := functions
+    includes := includeIdents
+    resolvedIncludes := mixins.map (·.1)
+  }
+
+partial def parseContractSyntax
     (stx : Syntax)
     : CommandElabM ParsedContractSyntax := do
   match stx with
-  | `(command| verity_contract $contractName:ident $[is $parentName:ident]? where $[types $[$newtypeDecls:verityNewtype]*]? $[enums $[$enumDecls:verityEnumDecl]*]? $[inductive $[$adtDecls:verityAdtDecl]*]? $[$nsSpec:verityNamespaceSpec]? storage $[$storageItems:verityStorageItem]* $[roles $[$roleDecls:verityRoleDecl]*]? $[$structDecls:verityStructDecl]* $[errors $[$errorDecls:verityError]*]? $[event_defs $[$eventDecls:verityEvent]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[interfaces $[$interfaceDecls:verityInterface]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$entrypoints:veritySpecialEntrypoint]* $[$modifierDecls:verityModifier]* $[$functions:verityFunction]*) =>
+  | `(command| verity_contract $contractName:ident $[is $parentName:ident]? $[include $[$includeNames:ident],*]? where $[types $[$newtypeDecls:verityNewtype]*]? $[enums $[$enumDecls:verityEnumDecl]*]? $[inductive $[$adtDecls:verityAdtDecl]*]? $[$nsSpec:verityNamespaceSpec]? storage $[$storageItems:verityStorageItem]* $[roles $[$roleDecls:verityRoleDecl]*]? $[$structDecls:verityStructDecl]* $[errors $[$errorDecls:verityError]*]? $[event_defs $[$eventDecls:verityEvent]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[interfaces $[$interfaceDecls:verityInterface]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$entrypoints:veritySpecialEntrypoint]* $[$modifierDecls:verityModifier]* $[$functions:verityFunction]*) =>
+      let includeIdents : Array Ident :=
+        match includeNames with
+        | some ids => ids
+        | none => #[]
+      if parentName.isSome && !includeIdents.isEmpty then
+        throwErrorAt stx "cannot combine `is` inheritance with `include` mixins"
+
       -- Resolve inheritance before parsing the child: inherited user-defined
       -- types are valid in every child declaration and function signature.
       let currentNs ← getCurrNamespace
@@ -3693,12 +3835,21 @@ def parseContractSyntax
         storageNamespace := firstNamespaceOpt
       }
       match parentName with
-      | none => pure { own with functions := (← inlineModifierPrefixes own.modifiers own.functions) }
       | some parentIdent =>
           let some parent := parent? | unreachable!
           let flattened ← flattenSingleInheritance parentIdent parent own
           pure { flattened with
             functions := (← inlineModifierPrefixes flattened.modifiers flattened.functions) }
+      | none =>
+          if includeIdents.isEmpty then
+            pure { own with functions := (← inlineModifierPrefixes own.modifiers own.functions) }
+          else
+            finishIncludeContract currentNs includeIdents own
+  | `(command| verity_mixin $contractName:ident where $[types $[$newtypeDecls:verityNewtype]*]? $[enums $[$enumDecls:verityEnumDecl]*]? $[inductive $[$adtDecls:verityAdtDecl]*]? $[$nsSpec:verityNamespaceSpec]? storage $[$storageItems:verityStorageItem]* $[roles $[$roleDecls:verityRoleDecl]*]? $[$structDecls:verityStructDecl]* $[errors $[$errorDecls:verityError]*]? $[event_defs $[$eventDecls:verityEvent]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[interfaces $[$interfaceDecls:verityInterface]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$modifierDecls:verityModifier]* $[$functions:verityFunction]*) =>
+      -- Reuse the contract parser by wrapping mixin syntax as a contract with no parent/includes/entrypoints.
+      let wrapped ← `(command| verity_contract $contractName:ident where $[types $[$newtypeDecls:verityNewtype]*]? $[enums $[$enumDecls:verityEnumDecl]*]? $[inductive $[$adtDecls:verityAdtDecl]*]? $[$nsSpec:verityNamespaceSpec]? storage $[$storageItems:verityStorageItem]* $[roles $[$roleDecls:verityRoleDecl]*]? $[$structDecls:verityStructDecl]* $[errors $[$errorDecls:verityError]*]? $[event_defs $[$eventDecls:verityEvent]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[interfaces $[$interfaceDecls:verityInterface]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$modifierDecls:verityModifier]* $[$functions:verityFunction]*)
+      let parsed ← parseContractSyntax wrapped
+      pure { parsed with isMixin := true }
   | _ => throwErrorAt stx "invalid verity_contract declaration"
 
 private def mkConstantDefCommand (constant : ConstantDecl) : CommandElabM Cmd := do
@@ -3996,6 +4147,104 @@ def validateFunctionDeclsPublic
       throwErrorAt fn.ident s!"function '{fn.name}': nonreentrant and cei_safe are mutually exclusive"
     validateFunctionBodyExprTypes fields errorDecls eventDecls constDecls immutableDecls externalDecls functions fn
 
+/-- Prepend calls to included mixin modifier Lean defs. CompilationModel still
+    uses `fn.modifiers` for inlined mixin-modifier statements. -/
+def prefixMixinModifierExecutableBody
+    (resolvedIncludes : Array Name) (fn : FunctionDecl) (body : Term) :
+    CommandElabM Term := do
+  if fn.modifiers.isEmpty || resolvedIncludes.isEmpty then
+    return body
+  let mut preludes : Array (TSyntax `doElem) := #[]
+  for modIdent in fn.modifiers do
+    let modName := toString modIdent.getId
+    let mut qual? : Option Name := none
+    for mixinName in resolvedIncludes do
+      if qual?.isNone then
+        match (← lookupContractSyntax mixinName) with
+        | some mixin =>
+            if mixin.modifiers.any (fun m => m.name == modName) then
+              qual? := some (mixinName ++ modIdent.getId)
+        | none => pure ()
+    let target :=
+      match qual? with
+      | some q => mkIdent q
+      | none => modIdent
+    preludes := preludes.push (← `(doElem| $target:ident))
+  match body with
+  | `(term| do $[$elems:doElem]*) =>
+      `(term| do $[$preludes:doElem]* $[$elems:doElem]*)
+  | _ =>
+      `(term| do $[$preludes:doElem]* $body:term)
+
+def mkModifierDefCommandPublic (modDecl : ModifierDecl) : CommandElabM Cmd := do
+  `(command| def $(modDecl.ident) : Verity.Contract Unit := $(modDecl.body))
+
+def mkConstructorDefCommandPublic (ctor : ConstructorDecl) : CommandElabM Cmd := do
+  let fnType ← mkContractFnType ctor.params .unit
+  let fnValue ← mkContractFnValue ctor.params ctor.body
+  let id : Ident := mkIdent (Name.mkSimple "constructor")
+  `(command| def $id : $fnType := $fnValue)
+
+def mkHostConstructorDefCommandPublic
+    (resolvedIncludes : Array Name) (ctor : ConstructorDecl) : CommandElabM Cmd := do
+  let fnType ← mkContractFnType ctor.params .unit
+  match ctor.body with
+  | `(term| do $[$elems:doElem]*) =>
+      let mut preludes : Array (TSyntax `doElem) := #[]
+      for (mixinIdent, args) in ctor.mixinInits do
+        let mut targetName : Option Name := none
+        for mixinName in resolvedIncludes do
+          if targetName.isNone && namesMixin (toString mixinIdent.getId) mixinName then
+            targetName := some (mixinName ++ Name.mkSimple "constructor")
+        let tgt := mkIdent (targetName.getD (mixinIdent.getId ++ Name.mkSimple "constructor"))
+        if args.isEmpty then
+          preludes := preludes.push (← `(doElem| $tgt:ident))
+        else
+          preludes := preludes.push (← `(doElem| $tgt:ident $args*))
+      let body ← `(term| do $[$preludes:doElem]* $[$elems:doElem]*)
+      let fnValue ← mkContractFnValue ctor.params body
+      let id : Ident := mkIdent (Name.mkSimple "constructor")
+      `(command| def $id : $fnType := $fnValue)
+  | _ =>
+      mkConstructorDefCommandPublic ctor
+
+def mkIncludeAliasCommandsPublic
+    (resolvedIncludes : Array Name) : CommandElabM (Array Cmd) := do
+  let mut cmds : Array Cmd := #[]
+  for mixinName in resolvedIncludes do
+    match (← lookupContractSyntax mixinName) with
+    | none => pure ()
+    | some mixin =>
+        for field in mixin.fields do
+          if field.emitDef then
+            let tgt := mkIdent (mixinName ++ field.ident.getId)
+            cmds := cmds.push (← `(command| abbrev $(field.ident) := $tgt))
+        for fn in mixin.functions do
+          unless fn.isInternal do
+            let tgt := mkIdent (mixinName ++ fn.ident.getId)
+            cmds := cmds.push (← `(command| abbrev $(fn.ident) := $tgt))
+        for modDecl in mixin.modifiers do
+          let tgt := mkIdent (mixinName ++ modDecl.ident.getId)
+          cmds := cmds.push (← `(command| abbrev $(modDecl.ident) := $tgt))
+        if mixin.ctor.isSome then
+          let tgt := mkIdent (mixinName ++ Name.mkSimple "constructor")
+          let id : Ident := mkIdent (Name.mkSimple s!"{mixinShortName mixinName}_constructor")
+          cmds := cmds.push (← `(command| abbrev $id := $tgt))
+  pure cmds
+
+def mkMergedSpecCommandPublic
+    (contractName : String)
+    (resolvedIncludes : Array Name) : CommandElabM Cmd := do
+  let mixinSpecs : Array Term :=
+    resolvedIncludes.map fun mixinName =>
+      mkIdent (mixinName ++ Name.mkSimple "spec")
+  `(command|
+    def spec : Compiler.CompilationModel.CompilationModel :=
+      Compiler.CompilationModel.mergeIncludedSpecs
+        $(strTerm contractName)
+        [ $[$mixinSpecs],* ]
+        host_spec)
+
 def mkFunctionCommandsPublic
     (fields : Array StorageFieldDecl)
     (roleDecls : Array RoleDecl)
@@ -4004,7 +4253,8 @@ def mkFunctionCommandsPublic
     (immutableDecls : Array ImmutableDecl)
     (externalDecls : Array ExternalDecl)
     (functions : Array FunctionDecl)
-    (fn : FunctionDecl) : CommandElabM (Array Cmd) := do
+    (fn : FunctionDecl)
+    (resolvedIncludes : Array Name := #[]) : CommandElabM (Array Cmd) := do
   let fnType ← mkContractFnType fn.params fn.returnTy
   let fnRoleGuardedBody ← mkRoleGuardedBody fields roleDecls fn
   let fnDecl := { fn with body := fnRoleGuardedBody }
@@ -4015,10 +4265,27 @@ def mkFunctionCommandsPublic
   -- them outside all executable wrappers makes ABI validation happen before
   -- initializer, role, and modifier effects (the inner copy is harmless).
   let fnExecutableBody ← prependEnumGuards fn.params fnExecutableBody
+  let fnExecutableBody ← prefixMixinModifierExecutableBody resolvedIncludes fn fnExecutableBody
   let fnValue ← mkContractFnValue fn.params fnExecutableBody
   let modelBodyName ← mkSuffixedIdent fn.ident "_modelBody"
   let modelName ← mkSuffixedIdent fn.ident "_model"
-  let stmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls immutableDecls externalDecls functions fn
+  -- CompilationModel inlines mixin modifier statements so `modifies(...)`
+  -- can see the write set. The executable path above still binds the
+  -- mixin's Lean `def` (import, not copy).
+  let mut mixinModifiers : Array ModifierDecl := #[]
+  for mixinName in resolvedIncludes do
+    match (← lookupContractSyntax mixinName) with
+    | some mixin => mixinModifiers := mixinModifiers ++ mixin.modifiers
+    | none => pure ()
+  let modelFn ←
+    if mixinModifiers.isEmpty then
+      pure fn
+    else
+      let arr ← inlineModifierPrefixes mixinModifiers #[fn]
+      match arr[0]? with
+      | some inlined => pure inlined
+      | none => pure fn
+  let stmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls immutableDecls externalDecls functions modelFn
   let modelParams ← mkModelParamsTerm fn.params
   let localObligationTerms ← (functionLocalObligationsWithArithmetic fn).mapM mkModelLocalObligationTerm
   let payableTerm ← if fn.isPayable then `(true) else `(false)
@@ -4080,8 +4347,9 @@ def mkSpecCommandPublic
     (modifiers : Array ModifierDecl)
     (functions : Array FunctionDecl)
     (adtDecls : Array AdtDecl)
-    (storageNamespace : Option Nat) : CommandElabM Cmd :=
-  mkSpecCommand contractName fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace
+    (storageNamespace : Option Nat)
+    (specIdent : Ident := mkIdent (Name.mkSimple "spec")) : CommandElabM Cmd :=
+  mkSpecCommand contractName fields roleDecls errorDecls eventDecls constDecls immutableDecls externalDecls ctor modifiers functions adtDecls storageNamespace specIdent
 
 def mkFindIdxFieldSimpCommandsPublic
     (contractIdent : Ident)

--- a/Verity/Macro/Translate/Parsing.lean
+++ b/Verity/Macro/Translate/Parsing.lean
@@ -609,62 +609,104 @@ def parseFunction (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl
       }
   | _ => throwErrorAt stx "invalid function declaration"
 
+private def constructorInits (parents : Array Ident) (argsArr : Array (Array Term)) :
+    Array (Ident × Array Term) :=
+  parents.zip argsArr
+
+private def firstInit (inits : Array (Ident × Array Term)) :
+    Option Ident × Array Term :=
+  match inits[0]? with
+  | some (name, args) => (some name, args)
+  | none => (none, #[])
+
 def parseConstructor (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl := #[]) (adtDecls : Array AdtDecl := #[]) (stx : Syntax) : CommandElabM ConstructorDecl := do
   match stx with
-  | `(verityConstructor| constructor ($[$params:verityParam],*) payable $parent:ident($[$args:term],*) local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+  | `(verityConstructor| constructor ($[$params:verityParam],*) payable $[$parent:ident($[$args:term],*)]* local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
         params := ← params.mapM (parseParam newtypes structDecls adtDecls)
         isPayable := true
         localObligations := ← obligations.mapM parseLocalObligation
-        parentName? := some parent
-        parentArgs := args
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
-  | `(verityConstructor| constructor ($[$params:verityParam],*) payable $parent:ident($[$args:term],*) := $body:term) =>
+  | `(verityConstructor| constructor ($[$params:verityParam],*) payable $[$parent:ident($[$args:term],*)]* := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
         params := ← params.mapM (parseParam newtypes structDecls adtDecls)
         isPayable := true
-        parentName? := some parent
-        parentArgs := args
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
-  | `(verityConstructor| constructor ($[$params:verityParam],*) $parent:ident($[$args:term],*) local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+  | `(verityConstructor| constructor ($[$params:verityParam],*) $[$parent:ident($[$args:term],*)]* local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
         params := ← params.mapM (parseParam newtypes structDecls adtDecls)
         localObligations := ← obligations.mapM parseLocalObligation
-        parentName? := some parent
-        parentArgs := args
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
-  | `(verityConstructor| constructor ($[$params:verityParam],*) $parent:ident($[$args:term],*) := $body:term) =>
+  | `(verityConstructor| constructor ($[$params:verityParam],*) $[$parent:ident($[$args:term],*)]* := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
         params := ← params.mapM (parseParam newtypes structDecls adtDecls)
-        parentName? := some parent
-        parentArgs := args
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
-  | `(verityConstructor| constructor ($[$params:verityParam],*) payable local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+  | `(verityConstructor| constructor payable $[$parent:ident($[$args:term],*)]* local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
-        params := ← params.mapM (parseParam newtypes structDecls adtDecls)
+        params := #[]
         isPayable := true
         localObligations := ← obligations.mapM parseLocalObligation
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
-  | `(verityConstructor| constructor ($[$params:verityParam],*) payable := $body:term) =>
+  | `(verityConstructor| constructor payable $[$parent:ident($[$args:term],*)]* := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
-        params := ← params.mapM (parseParam newtypes structDecls adtDecls)
+        params := #[]
         isPayable := true
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
-  | `(verityConstructor| constructor ($[$params:verityParam],*) local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+  | `(verityConstructor| constructor $[$parent:ident($[$args:term],*)]* local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
-        params := ← params.mapM (parseParam newtypes structDecls adtDecls)
+        params := #[]
         localObligations := ← obligations.mapM parseLocalObligation
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
-  | `(verityConstructor| constructor ($[$params:verityParam],*) := $body:term) =>
+  | `(verityConstructor| constructor $[$parent:ident($[$args:term],*)]* := $body:term) =>
+      let inits := constructorInits parent args
+      let (parentName?, parentArgs) := firstInit inits
       pure {
-        params := ← params.mapM (parseParam newtypes structDecls adtDecls)
+        params := #[]
+        parentName? := parentName?
+        parentArgs := parentArgs
+        mixinInits := inits
         body := body
       }
   | _ => throwErrorAt stx "invalid constructor declaration"

--- a/Verity/Macro/Types.lean
+++ b/Verity/Macro/Types.lean
@@ -280,6 +280,9 @@ structure ConstructorDecl where
   boundParentParamNames : Array String := #[]
   parentName? : Option Ident := none
   parentArgs : Array Term := #[]
+  /-- Mixin constructor inits from `constructor (...) M1(args) M2(args)`.
+      For `is Parent`, the first init is also recorded in `parentName?`/`parentArgs`. -/
+  mixinInits : Array (Ident × Array Term) := #[]
   body : Term
 
 def strTerm (s : String) : Term := ⟨Syntax.mkStrLit s⟩

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -139,9 +139,15 @@ macro_rules
         $extra
       ])
   | `(tactic| verity_frame $h:rwRule) =>
-      `(tactic| (rw [$h]; simp [ContractResult.snd]))
+      `(tactic| (rw [$h]; simp [ContractResult.snd,
+        ContractState.writeSlot, ContractState.writeAddrSlot,
+        ContractState.writeMap, ContractState.writeMapUint,
+        ContractState.writeMap2, ContractState.writeTransient]))
   | `(tactic| verity_frame $h:rwRule with $extra:simpLemma) =>
-      `(tactic| (rw [$h]; simp [ContractResult.snd, $extra]))
+      `(tactic| (rw [$h]; simp [ContractResult.snd,
+        ContractState.writeSlot, ContractState.writeAddrSlot,
+        ContractState.writeMap, ContractState.writeMapUint,
+        ContractState.writeMap2, ContractState.writeTransient, $extra]))
   | `(tactic| verity_spec $spec:simpLemma using $h:rwRule) =>
       `(tactic|
         (rw [$h]
@@ -269,7 +275,7 @@ theorem getStorage_runState (slot : StorageSlot Uint256) (state : ContractState)
 -- setStorage updates the state
 theorem setStorage_runState (slot : StorageSlot Uint256) (value : Uint256) (state : ContractState) :
     (setStorage slot value).runState state =
-      { state with storage := fun s => if s == slot.slot then value else state.storage s } := by
+      state.writeSlot slot.slot value := by
   simp [setStorage, Contract.runState, ContractState.writeSlot]
 
 -- getStorage returns correct value
@@ -326,7 +332,7 @@ theorem bind_assoc {α β γ : Type} (m : Contract α) (f : α → Contract β) 
 @[simp]
 theorem bind_getStorage_setStorage_runState (slot : StorageSlot Uint256) (f : Uint256 → Uint256) (state : ContractState) :
     (Verity.bind (getStorage slot) (fun val => setStorage slot (f val))).runState state =
-      { state with storage := fun s => if s == slot.slot then f (state.storage slot.slot) else state.storage s } := by
+      state.writeSlot slot.slot (f (state.storage slot.slot)) := by
   simp [Verity.bind, getStorage, setStorage, Contract.runState, ContractState.writeSlot,
     ContractState.readSlot]
 
@@ -359,7 +365,7 @@ theorem getStorageAddr_runState (slot : StorageSlot Address) (state : ContractSt
 -- setStorageAddr updates the state
 theorem setStorageAddr_runState (slot : StorageSlot Address) (value : Address) (state : ContractState) :
     (setStorageAddr slot value).runState state =
-      { state with storageAddr := fun s => if s == slot.slot then value else state.storageAddr s } := by
+      state.writeAddrSlot slot.slot value := by
   simp [setStorageAddr, Contract.runState, ContractState.writeAddrSlot]
 
 -- getStorageAddr returns correct value

--- a/Verity/Proofs/Stdlib/MappingAutomation.lean
+++ b/Verity/Proofs/Stdlib/MappingAutomation.lean
@@ -37,10 +37,7 @@ theorem getMapping_runValue (slot : StorageSlot (Address → Uint256)) (key : Ad
 theorem setMapping_runState (slot : StorageSlot (Address → Uint256)) (key : Address)
     (value : Uint256) (state : ContractState) :
     (setMapping slot key value).runState state =
-      { state with
-        storageMap := fun s addr =>
-          if s == slot.slot && addr == key then value
-          else state.storageMap s addr,
+      { state.writeMap slot.slot key value with
         knownAddresses := fun s =>
           if s == slot.slot then
             (state.knownAddresses s).insert key
@@ -116,10 +113,7 @@ theorem getMappingUint_runValue (slot : StorageSlot (Uint256 → Uint256)) (key 
 theorem setMappingUint_runState (slot : StorageSlot (Uint256 → Uint256)) (key : Uint256)
     (value : Uint256) (state : ContractState) :
     (setMappingUint slot key value).runState state =
-      { state with
-        storageMapUint := fun s k =>
-          if s == slot.slot && k == key then value
-          else state.storageMapUint s k } := by
+      state.writeMapUint slot.slot key value := by
   simp [setMappingUint, Contract.runState, ContractState.writeMapUint]
 
 /-- After setMappingUint, getMappingUint on the same key returns the set value. -/
@@ -196,10 +190,7 @@ theorem getMapping2_runValue (slot : StorageSlot (Address → Address → Uint25
 theorem setMapping2_runState (slot : StorageSlot (Address → Address → Uint256))
     (key1 key2 : Address) (value : Uint256) (state : ContractState) :
     (setMapping2 slot key1 key2 value).runState state =
-      { state with
-        storageMap2 := fun s addr1 addr2 =>
-          if s == slot.slot && addr1 == key1 && addr2 == key2 then value
-          else state.storageMap2 s addr1 addr2 } := by
+      state.writeMap2 slot.slot key1 key2 value := by
   simp [setMapping2, Contract.runState, ContractState.writeMap2]
 
 /-- After setMapping2, getMapping2 on the same keys returns the set value. -/

--- a/Verity/Specs/Common/Sum.lean
+++ b/Verity/Specs/Common/Sum.lean
@@ -220,9 +220,7 @@ theorem sumBalances_zero_of_all_zero {slot : Nat} {addrs : FiniteAddressSet}
 theorem balancesFinite_preserved_deposit {slot : Nat} (s : ContractState)
     (addr : Address) (amount : Uint256) :
     balancesFinite slot s →
-    balancesFinite slot { s with
-      storageMap := fun s' a =>
-        if s' == slot && a == addr then amount else s.storageMap s' a,
+    balancesFinite slot { s.writeMap slot addr amount with
       knownAddresses := fun s' =>
         if s' == slot then (s.knownAddresses s').insert addr
         else s.knownAddresses s' } := by
@@ -239,7 +237,7 @@ theorem balancesFinite_preserved_deposit {slot : Nat} (s : ContractState)
   simp only [not_or] at h_not_or
   obtain ⟨h_ne, h_not_orig⟩ := h_not_or
   -- Since addr' ≠ addr, the storageMap if-condition evaluates to false
-  simp only [BEq.beq, decide_true, Bool.true_and]
+  simp only [ContractState.writeMap, BEq.beq, decide_true, Bool.true_and]
   have h_ne' : ¬(decide (addr' = addr) = true) := by simp [h_ne]
   simp [h_ne']
   -- Now the goal reduces to s.storageMap slot addr' = 0, which follows from h_finite

--- a/Verity/Specs/Composition.lean
+++ b/Verity/Specs/Composition.lean
@@ -1,0 +1,128 @@
+/-
+  Mixin composition helpers.
+
+  A mixin owns a storage footprint. Host proofs reuse mixin theorems by
+  showing the host function writes only its own footprint, which is
+  disjoint from the mixin's, so mixin invariants are preserved.
+-/
+
+import Verity.Core
+import Verity.Core.Invariant
+import Verity.Specs.Common
+
+namespace Verity.Specs.Composition
+
+open Verity
+open Verity.Core.Invariant
+
+/-- Named storage channels a mixin (or host function) is allowed to write. -/
+structure Footprint where
+  uintSlots : List Nat := []
+  addrSlots : List Nat := []
+  mapSlots : List Nat := []
+  mapUintSlots : List Nat := []
+  map2Slots : List Nat := []
+  arraySlots : List Nat := []
+  transientSlots : List Nat := []
+  deriving Repr, DecidableEq
+
+/-- Two footprints own disjoint slot sets on every channel. -/
+def Disjoint (a b : Footprint) : Prop :=
+  (∀ s, s ∈ a.uintSlots → s ∉ b.uintSlots) ∧
+  (∀ s, s ∈ a.addrSlots → s ∉ b.addrSlots) ∧
+  (∀ s, s ∈ a.mapSlots → s ∉ b.mapSlots) ∧
+  (∀ s, s ∈ a.mapUintSlots → s ∉ b.mapUintSlots) ∧
+  (∀ s, s ∈ a.map2Slots → s ∉ b.map2Slots) ∧
+  (∀ s, s ∈ a.arraySlots → s ∉ b.arraySlots) ∧
+  (∀ s, s ∈ a.transientSlots → s ∉ b.transientSlots)
+
+theorem Disjoint.symm {a b : Footprint} (h : Disjoint a b) : Disjoint b a :=
+  ⟨fun s hb ha => h.1 s ha hb,
+    fun s hb ha => h.2.1 s ha hb,
+    fun s hb ha => h.2.2.1 s ha hb,
+    fun s hb ha => h.2.2.2.1 s ha hb,
+    fun s hb ha => h.2.2.2.2.1 s ha hb,
+    fun s hb ha => h.2.2.2.2.2.1 s ha hb,
+    fun s hb ha => h.2.2.2.2.2.2 s ha hb⟩
+
+/-- `s'` differs from `s` only inside `fp`. Context is unchanged. -/
+def WritesOnly (fp : Footprint) (s s' : ContractState) : Prop :=
+  (∀ slot, slot ∉ fp.uintSlots → s'.storage slot = s.storage slot) ∧
+  (∀ slot, slot ∉ fp.addrSlots → s'.storageAddr slot = s.storageAddr slot) ∧
+  (∀ slot, slot ∉ fp.mapSlots → ∀ k, s'.storageMap slot k = s.storageMap slot k) ∧
+  (∀ slot, slot ∉ fp.mapUintSlots → ∀ k, s'.storageMapUint slot k = s.storageMapUint slot k) ∧
+  (∀ slot, slot ∉ fp.map2Slots → ∀ k1 k2, s'.storageMap2 slot k1 k2 = s.storageMap2 slot k1 k2) ∧
+  (∀ slot, slot ∉ fp.arraySlots → s'.storageArray slot = s.storageArray slot) ∧
+  (∀ slot, slot ∉ fp.transientSlots → s'.transientStorage slot = s.transientStorage slot) ∧
+  Specs.sameContext s s'
+
+/-- `s` and `s'` agree on every slot owned by `fp`. -/
+def AgreesOn (fp : Footprint) (s s' : ContractState) : Prop :=
+  (∀ slot, slot ∈ fp.uintSlots → s'.storage slot = s.storage slot) ∧
+  (∀ slot, slot ∈ fp.addrSlots → s'.storageAddr slot = s.storageAddr slot) ∧
+  (∀ slot, slot ∈ fp.mapSlots → ∀ k, s'.storageMap slot k = s.storageMap slot k) ∧
+  (∀ slot, slot ∈ fp.mapUintSlots → ∀ k, s'.storageMapUint slot k = s.storageMapUint slot k) ∧
+  (∀ slot, slot ∈ fp.map2Slots → ∀ k1 k2, s'.storageMap2 slot k1 k2 = s.storageMap2 slot k1 k2) ∧
+  (∀ slot, slot ∈ fp.arraySlots → s'.storageArray slot = s.storageArray slot) ∧
+  (∀ slot, slot ∈ fp.transientSlots → s'.transientStorage slot = s.transientStorage slot)
+
+/-- An invariant that only inspects `fp` is unchanged when `fp` is unchanged. -/
+def InvDependsOnlyOn (Inv : ContractState → Prop) (fp : Footprint) : Prop :=
+  ∀ s s', AgreesOn fp s s' → (Inv s ↔ Inv s')
+
+theorem writesOnly_agrees_on_disjoint
+    (hostFp mixinFp : Footprint)
+    (hDisjoint : Disjoint hostFp mixinFp)
+    (s s' : ContractState)
+    (hWrite : WritesOnly hostFp s s') :
+    AgreesOn mixinFp s s' := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · intro slot hslot
+    have : slot ∉ hostFp.uintSlots := fun hin => hDisjoint.1 slot hin hslot
+    exact hWrite.1 slot this
+  · intro slot hslot
+    have : slot ∉ hostFp.addrSlots := fun hin => hDisjoint.2.1 slot hin hslot
+    exact hWrite.2.1 slot this
+  · intro slot hslot
+    have : slot ∉ hostFp.mapSlots := fun hin => hDisjoint.2.2.1 slot hin hslot
+    exact hWrite.2.2.1 slot this
+  · intro slot hslot
+    have : slot ∉ hostFp.mapUintSlots := fun hin => hDisjoint.2.2.2.1 slot hin hslot
+    exact hWrite.2.2.2.1 slot this
+  · intro slot hslot
+    have : slot ∉ hostFp.map2Slots := fun hin => hDisjoint.2.2.2.2.1 slot hin hslot
+    exact hWrite.2.2.2.2.1 slot this
+  · intro slot hslot
+    have : slot ∉ hostFp.arraySlots := fun hin => hDisjoint.2.2.2.2.2.1 slot hin hslot
+    exact hWrite.2.2.2.2.2.1 slot this
+  · intro slot hslot
+    have : slot ∉ hostFp.transientSlots := fun hin => hDisjoint.2.2.2.2.2.2 slot hin hslot
+    exact hWrite.2.2.2.2.2.2.1 slot this
+
+theorem writesOnly_preserves_other_inv
+    (hostFp mixinFp : Footprint)
+    (hDisjoint : Disjoint hostFp mixinFp)
+    (Inv : ContractState → Prop)
+    (hInv : InvDependsOnlyOn Inv mixinFp)
+    (s s' : ContractState)
+    (hWrite : WritesOnly hostFp s s')
+    (hInvS : Inv s) : Inv s' :=
+  (hInv s s' (writesOnly_agrees_on_disjoint hostFp mixinFp hDisjoint s s' hWrite)).mp hInvS
+
+/-- Address-channel and uint-channel footprints are always disjoint. -/
+theorem disjoint_addr_uint (addrSlot uintSlot : Nat) :
+    Disjoint { addrSlots := [addrSlot] } { uintSlots := [uintSlot] } := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · intro s hs; cases hs
+  · intro s _ h; cases h
+  · intro s hs; cases hs
+  · intro s hs; cases hs
+  · intro s hs; cases hs
+  · intro s hs; cases hs
+  · intro s hs; cases hs
+
+theorem disjoint_uint_addr (uintSlot addrSlot : Nat) :
+    Disjoint { uintSlots := [uintSlot] } { addrSlots := [addrSlot] } :=
+  (disjoint_addr_uint addrSlot uintSlot).symm
+
+end Verity.Specs.Composition

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -169,7 +169,7 @@
   "mechanisms": {
     "@[implemented_by": 1,
     "native_decide": 477,
-    "partial def": 170
+    "partial def": 171
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",
   "schema_version": 1

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -169,7 +169,7 @@
   "mechanisms": {
     "@[implemented_by": 1,
     "native_decide": 477,
-    "partial def": 169
+    "partial def": 171
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",
   "schema_version": 1

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,7 +1,7 @@
 {
   "codebase": {
-    "core_lines": 1070,
-    "example_contracts": 16
+    "core_lines": 1098,
+    "example_contracts": 18
   },
   "proofs": {
     "axioms": 0,
@@ -15,19 +15,21 @@
     "suites": 52
   },
   "theorems": {
-    "categories": 13,
-    "coverage_percent": 84,
+    "categories": 15,
+    "coverage_percent": 81,
     "covered": 255,
-    "excluded": 47,
-    "non_stdlib_total": 302,
+    "excluded": 59,
+    "non_stdlib_total": 314,
     "per_contract": {
       "Counter": 31,
       "ERC20": 22,
       "ERC721": 11,
       "Ledger": 33,
       "LocalObligationMacroSmoke": 4,
+      "Ownable": 6,
       "Owned": 23,
       "OwnedCounter": 48,
+      "OwnedCounterComposed": 6,
       "ReentrancyExample": 5,
       "ReentrancyRelyGuarantee": 10,
       "SafeCounter": 25,
@@ -35,9 +37,9 @@
       "SimpleToken": 61,
       "Vault": 9
     },
-    "proven": 302,
+    "proven": 314,
     "stdlib": 0,
-    "total": 302
+    "total": 314
   },
   "toolchain": {
     "lean": "leanprover/lean4:v4.31.0",

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,7 +1,7 @@
 {
   "codebase": {
     "core_lines": 1098,
-    "example_contracts": 16
+    "example_contracts": 18
   },
   "proofs": {
     "axioms": 0,
@@ -15,19 +15,21 @@
     "suites": 52
   },
   "theorems": {
-    "categories": 13,
-    "coverage_percent": 84,
+    "categories": 15,
+    "coverage_percent": 81,
     "covered": 255,
-    "excluded": 47,
-    "non_stdlib_total": 302,
+    "excluded": 59,
+    "non_stdlib_total": 314,
     "per_contract": {
       "Counter": 31,
       "ERC20": 22,
       "ERC721": 11,
       "Ledger": 33,
       "LocalObligationMacroSmoke": 4,
+      "Ownable": 6,
       "Owned": 23,
       "OwnedCounter": 48,
+      "OwnedCounterComposed": 6,
       "ReentrancyExample": 5,
       "ReentrancyRelyGuarantee": 10,
       "SafeCounter": 25,
@@ -35,9 +37,9 @@
       "SimpleToken": 61,
       "Vault": 9
     },
-    "proven": 302,
+    "proven": 314,
     "stdlib": 0,
-    "total": 302
+    "total": 314
   },
   "toolchain": {
     "lean": "leanprover/lean4:v4.31.0",

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 1098,
+    "core_lines": 1178,
     "example_contracts": 18
   },
   "proofs": {

--- a/docs-site/content/edsl/functions.mdx
+++ b/docs-site/content/edsl/functions.mdx
@@ -177,6 +177,37 @@ wrappers**, **storage namespaces** (`storage_namespace erc7201 "myapp.storage.X"
 and **mapping-of-struct** sugar (`MappingStruct`, `MappingStruct2`). Concrete
 usage shapes are in the [production patterns guide](/guides/production-solidity-patterns).
 
+## Mixins and `include`
+
+Reusable facets are `verity_mixin` modules. A host imports them with
+`include` — this is **not** `is` flatten:
+
+```verity
+verity_mixin Ownable where
+  storage
+    owner : Address := slot 0
+  modifier onlyOwner := do
+    let sender ← msgSender
+    require (sender == (← getStorageAddr owner)) "not owner"
+  function transferOwnership (newOwner : Address) with onlyOwner : Unit := do
+    setStorageAddr owner newOwner
+
+verity_contract Host include Ownable where
+  storage
+    count : Uint256 := slot 1
+  constructor (initialOwner : Address) Ownable(initialOwner) := do
+    setStorage count 0
+  function increment () with onlyOwner : Unit := do
+    setStorage count (add (← getStorage count) 1)
+```
+
+`with onlyOwner` on the host binds the mixin's Lean `onlyOwner` definition
+(same `StorageSlot`). Mixin proofs import into the host. `is Parent` still
+exists and re-elaborates a copied tree; use `include` when proofs must reuse.
+
+Name, slot, role, and modifier clashes fail closed. Mixin slots are not
+remapped. See [Modifiers and inheritance](https://github.com/lfglabs-dev/verity/blob/main/docs/MODIFIERS_AND_INHERITANCE.md).
+
 ## See also
 
 - [Storage & Data](/edsl/storage) — field declarations, immutables seeded in the constructor.

--- a/docs-site/content/guides/production-solidity-patterns.mdx
+++ b/docs-site/content/guides/production-solidity-patterns.mdx
@@ -19,7 +19,7 @@ surfaces.
 
 | Solidity pattern | Prefer this Verity surface | Notes |
 |---|---|---|
-| `onlyOwner`, role gates | `requires(ownerSlot)` or a named `modifier` | Use a mapping-backed modifier for role sets such as relayers. |
+| `onlyOwner`, role gates | `verity_mixin Ownable` + `include Ownable`, or `requires(ownerSlot)` / a named `modifier` | Prefer include so host proofs reuse mixin `onlyOwner_*` theorems. Flatten (`is`) does not reuse proofs. |
 | `nonReentrant` | `nonreentrant(reentrancyLockSlot)` | Keep the external entrypoint guard instead of sprinkling manual lock writes. |
 | `initializer` | `initializer(initializedSlot)` | Mirrors upgradeable-contract bootstrap guards. |
 | `immutable` values | `immutables` block | Constructor-visible values become read-only bindings in functions. |

--- a/docs-site/content/guides/solidity-to-verity.mdx
+++ b/docs-site/content/guides/solidity-to-verity.mdx
@@ -59,13 +59,17 @@ Use this table as your first-pass conversion checklist.
 
 Some Solidity features are not 1:1 in the current EDSL/compiler pipeline.
 
-### Inheritance -> Explicit Composition
+### Inheritance -> Mixin include (preferred) or flatten
 
 - Solidity: `contract Child is Ownable, ERC20 { ... }`
-- Verity: compose the inherited storage roots, guards, and helpers explicitly.
-- Use `storage_namespace erc7201 "..."` for each inherited ERC-7201 root when
-  the source uses namespaced storage.
-- Put shared checks in reusable EDSL helpers (for example `onlyOwner`).
+- Verity, proof reuse: declare `verity_mixin Ownable` and
+  `verity_contract Child include Ownable where` plus the host's own storage.
+  Host `with onlyOwner` calls the mixin's Lean `onlyOwner`; mixin proofs
+  import into the host. Mixin slots stay as written (put ERC-7201 on the
+  mixin itself).
+- Verity, source flatten only: `verity_contract Child is Parent where`
+  re-elaborates a copied tree. Parent proofs do not apply. One parent, no C3.
+- Do not copy Ownable storage and re-prove `onlyOwner` by hand for new ports.
 
 ### Modifiers -> Guard Helpers
 

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -17,7 +17,9 @@ Counts are theorems in each module. Read the actual statements in [`Contracts/<N
 | Counter | 19 | 9 |, |, |, | 28 |
 | SafeCounter | 20 | 8 |, |, |, | 28 |
 | Owned | 19 | 4 |, |, |, | 23 |
+| Ownable (mixin) | 6 | — |, |, |, | 6 |
 | OwnedCounter | 33 | 6 |, | 14 |, | 53 |
+| OwnedCounterComposed | 6 | — |, |, |, | 6 |
 | Ledger | 24 | 6 | 7 (conservation) |, |, | 37 |
 | SimpleToken | 40 | 10 | 6 (supply) | 12 |, | 68 |
 | ERC20 | 15 | 7 |, |, | 3 | 25 |

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -31,9 +31,9 @@ Every transition inside the proof envelope is either fully verified or recorded 
 
 <!-- BEGIN GENERATED QUICK FACTS -->
 - **Language**: Lean 4.31.0
-- **Core Size**: 1027 lines
-- **Verified Contracts**: 13 (Counter, ERC20, ERC721, Ledger, LocalObligationMacroSmoke, Owned, OwnedCounter, ReentrancyExample, ReentrancyRelyGuarantee, SafeCounter, SimpleStorage, SimpleToken, Vault)
-- **Theorems**: 302 across 13 categories, 302 fully proven
+- **Core Size**: 1098 lines
+- **Verified Contracts**: 15 (Counter, ERC20, ERC721, Ledger, LocalObligationMacroSmoke, Ownable, Owned, OwnedCounter, OwnedCounterComposed, ReentrancyExample, ReentrancyRelyGuarantee, SafeCounter, SimpleStorage, SimpleToken, Vault)
+- **Theorems**: 314 across 15 categories, 314 fully proven
 - **Axioms**: 0 documented Lean axioms (see AXIOMS.md)
 - **Tests**: 528 Foundry tests, 239 property tests
 - **Build**: `lake build` verifies all proofs

--- a/docs/MODIFIERS_AND_INHERITANCE.md
+++ b/docs/MODIFIERS_AND_INHERITANCE.md
@@ -46,8 +46,10 @@ then the host body.
 
 Name, role, modifier, function (including internal helpers), error, event,
 constant, immutable, external, type, and slot clashes fail closed at
-elaboration. Mixin modifiers validate against mixin errors/constants; mixin
-immutables are initialized in the host constructor model.
+elaboration. Hidden executable slots used by mixin immutables are reserved.
+`with` applies local and mixin modifiers in declared order. Mixin modifiers
+validate against mixin errors/constants; mixin immutables are initialized in
+the host constructor model.
 Mixin slots are absolute as written (including mixin-owned ERC-7201 roots).
 The host does not remap mixin slots. v1 has no `exclude` and no `override`
 on the include path.

--- a/docs/MODIFIERS_AND_INHERITANCE.md
+++ b/docs/MODIFIERS_AND_INHERITANCE.md
@@ -44,7 +44,10 @@ definition; it does not copy the modifier body. Constructor inits
 `M1(args) M2(args)` run the mixin `constructor` values in include order,
 then the host body.
 
-Name, role, modifier, function, and slot clashes fail closed at elaboration.
+Name, role, modifier, function (including internal helpers), error, event,
+constant, immutable, external, type, and slot clashes fail closed at
+elaboration. Mixin modifiers validate against mixin errors/constants; mixin
+immutables are initialized in the host constructor model.
 Mixin slots are absolute as written (including mixin-owned ERC-7201 roots).
 The host does not remap mixin slots. v1 has no `exclude` and no `override`
 on the include path.

--- a/docs/MODIFIERS_AND_INHERITANCE.md
+++ b/docs/MODIFIERS_AND_INHERITANCE.md
@@ -1,8 +1,10 @@
-# Modifiers and inheritance
+# Modifiers, inheritance, and mixins
 
 `verity_contract` supports precondition-only user-defined modifiers, flattened
-single inheritance, direct parent-constructor calls, and compile-time
-`virtual`/`override` specialization.
+single inheritance, mixin include (import, not flatten), direct parent/mixin
+constructor calls, and compile-time `virtual`/`override` specialization.
+
+## Modifiers
 
 Modifiers are declared with `modifier name := do ...` and attached with
 `with name`. Their statements are inserted, in declaration order, before the
@@ -10,9 +12,12 @@ function body in both executable semantics and the compilation model. The
 current stage is intended for checks such as `onlyOwner`; Solidity-style `_`
 placement and postcondition code are not supported.
 
-A child uses `verity_contract Child is Parent where`. The parent must be
-declared earlier in the same module. Storage, declarations, modifiers, and
-functions are flattened into the child. A child constructor calls its direct
+## Single-parent flatten (`is`)
+
+A child uses `verity_contract Child is Parent where`. The parent must already
+be elaborated (same module or imported `.olean`). Storage, declarations,
+modifiers, and functions are **flattened** into the child: new `StorageSlot`
+and function definitions are generated. A child constructor calls its direct
 parent with `constructor (...) Parent(args...) := do ...`; parent initialization
 runs before the child body.
 
@@ -22,5 +27,27 @@ overrides of non-virtual functions, and accidental signature collisions are
 compile-time errors. Dispatch is specialized during elaboration, so no runtime
 dispatch table or additional proof axiom is introduced.
 
-Multiple inheritance/C3 linearization, abstract body-less functions,
+Because `is` re-elaborates a copied syntax tree, parent proofs do **not**
+apply to the child. Use mixin `include` when you need proof reuse.
+
+## Mixin include (import, not flatten)
+
+`verity_mixin Name where ...` is the reusable facet form. It emits the same
+executable Lean definitions and `CompilationModel` as a contract, plus Lean
+`def`s for modifiers and the constructor. Mixins cannot use `is`, `include`,
+`receive`, or `fallback`.
+
+A host writes `verity_contract Host include M1, M2 where ...`. Include
+**imports** the mixin's existing Lean names (same `StorageSlot` values) and
+merges CompilationModels. `with onlyOwner` binds the mixin's `onlyOwner`
+definition; it does not copy the modifier body. Constructor inits
+`M1(args) M2(args)` run the mixin `constructor` values in include order,
+then the host body.
+
+Name, role, modifier, function, and slot clashes fail closed at elaboration.
+Mixin slots are absolute as written (including mixin-owned ERC-7201 roots).
+The host does not remap mixin slots. v1 has no `exclude` and no `override`
+on the include path.
+
+Multiple `is` parents / C3 linearization, abstract body-less functions,
 parameterized modifiers, and modifier postludes remain out of scope.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -30,7 +30,9 @@ EVM Bytecode
 | Counter | 31 | Complete | `Contracts/Counter/Proofs/` |
 | SafeCounter | 25 | Complete | `Contracts/SafeCounter/Proofs/` |
 | Owned | 23 | Complete | `Contracts/Owned/Proofs/` |
+| Ownable | 6 | Complete | `Contracts/Ownable/Proofs/` |
 | OwnedCounter | 48 | Complete | `Contracts/OwnedCounter/Proofs/` |
+| OwnedCounterComposed | 6 | Complete | `Contracts/OwnedCounterComposed/Proofs/` |
 | Ledger | 33 | Complete | `Contracts/Ledger/Proofs/` |
 | LocalObligationMacroSmoke | 4 | Baseline | `Contracts/LocalObligationMacroSmoke/Proofs/` |
 | SimpleToken | 61 | Complete | `Contracts/SimpleToken/Proofs/` |
@@ -40,9 +42,9 @@ EVM Bytecode
 | ReentrancyExample | 5 | Complete | `Contracts/ReentrancyExample/Contract.lean` |
 | ReentrancyRelyGuarantee | 10 | Semantic | `Contracts/ReentrancyRelyGuarantee/Contract.lean` |
 | CryptoHash | 0 | No specs | `Contracts/CryptoHash/Contract.lean` |
-| **Total** | **302** | **✅ 100%** | — |
+| **Total** | **314** | **✅ 100%** | — |
 
-> **Note**: Stdlib (0 internal proof-automation properties) is excluded from the contract-spec theorem table above but included in overall coverage statistics (302 total properties).
+> **Note**: Stdlib (0 internal proof-automation properties) is excluded from the contract-spec theorem table above but included in overall coverage statistics (314 total properties).
 
 Layer 1 uses macro-generated EDSL-to-`CompilationModel` bridge theorems backed by a generic typed-IR compilation-correctness theorem ([`TypedIRCompilerCorrectness.lean`](../Compiler/TypedIRCompilerCorrectness.lean)). Tuple/bytes/fixed-array/dynamic-array/string parameters now stay inside that proof path when they are carried as ABI head words/offsets. Advanced constructs beyond that typed-IR head-word surface (linked libraries, ECMs, fully custom ABI behavior) are still expressed directly in `CompilationModel` and trusted at that boundary. Higher-order internal helpers (function-pointer parameters, [#1747](https://github.com/lfglabs-dev/verity/issues/1747)) are eliminated by a compile-time monomorphization pre-pass that runs before any lowering, so the `CompilationModel` only ever contains first-order helpers: these calls are covered by the existing first-order proof path and introduce no new boundary trust.
 
@@ -198,17 +200,19 @@ Also note that the macro-generated `*_semantic_preservation` theorems are not co
 | SimpleStorage | 95% (19/20) | 1 proof-only |
 | OwnedCounter | 92% (44/48) | 4 proof-only |
 | Owned | 87% (20/23) | 3 proof-only |
+| Ownable | 0% (0/6) | 6 proof-only |
+| OwnedCounterComposed | 0% (0/6) | 6 proof-only |
 | SimpleToken | 85% (52/61) | 9 proof-only |
 | Counter | 74% (23/31) | 8 proof-only |
 | Stdlib | 0% (0/0) | 0 proof-only |
 
-**Status**: 84% coverage (255/302), 47 remaining exclusions all proof-only
+**Status**: 81% coverage (255/314), 59 remaining exclusions all proof-only
 
-- **Total Properties**: 302
+- **Total Properties**: 314
 - **Covered**: 255
-- **Excluded**: 47 (all proof-only)
+- **Excluded**: 59 (all proof-only)
 
-**Proof-Only Properties (47 exclusions)**: Internal proof machinery that cannot be tested in Foundry.
+**Proof-Only Properties (59 exclusions)**: Internal proof machinery that cannot be tested in Foundry.
 
 0 `sorry` remaining across `Compiler/**/*.lean` and `Verity/**/*.lean` proof modules.
 5266 theorems/lemmas (3645 public, 1621 private) verified by `lake build PrintAxioms`.

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -16,6 +16,7 @@ lean_lib «Verity» where
     .andSubmodules `Verity.Macro,
     .submodules `Verity.Stdlib,
     .andSubmodules `Verity.Specs.Common,
+    .one `Verity.Specs.Composition,
     .submodules `Verity.Proofs.Stdlib,
     .one `Verity.Proofs.LoopSimulation,
     .one `Verity.Proofs.LoopSimulationResultAware
@@ -32,7 +33,9 @@ lean_lib «Contracts» where
     .andSubmodules `Contracts.Counter,
     .andSubmodules `Contracts.SimpleStorage,
     .andSubmodules `Contracts.Owned,
+    .andSubmodules `Contracts.Ownable,
     .andSubmodules `Contracts.OwnedCounter,
+    .andSubmodules `Contracts.OwnedCounterComposed,
     .andSubmodules `Contracts.SafeCounter,
     .andSubmodules `Contracts.Ledger,
     .andSubmodules `Contracts.Vault,

--- a/packages/verity-edsl/lakefile.lean
+++ b/packages/verity-edsl/lakefile.lean
@@ -26,6 +26,7 @@ lean_lib «Verity» where
     .one `Verity.Stdlib.Math,
     .one `Verity.Specs.Common,
     .one `Verity.Specs.Common.Sum,
+    .one `Verity.Specs.Composition,
     .one `Verity.Proofs.Stdlib.Math,
     .one `Verity.Proofs.Stdlib.ListSum,
     .one `Verity.Proofs.Stdlib.Automation

--- a/scripts/check_contract_structure.py
+++ b/scripts/check_contract_structure.py
@@ -19,6 +19,8 @@ EXCLUDED_CONTRACTS = {
     "ReentrancyExample",        # Inline proofs in Examples/, no separate Proofs/ dir
     "CryptoHash",               # Axiom-based, no separate proof structure
     "ReentrancyRelyGuarantee",  # Proof-only rely-guarantee framework example, inline proofs
+    "Ownable",                  # Mixin facet: named-slot proofs + footprint, no Foundry/Yul twin
+    "OwnedCounterComposed",     # Include-host acceptance example; OwnedCounter keeps Yul/difftest
 }
 
 # Contracts excluded from property test check
@@ -26,6 +28,8 @@ EXCLUDED_FROM_PROPERTY_TESTS = {
     "CryptoHash",               # External-library contract, no property tests
     "Vault",                    # Minimal scaffolding landed before proof/property suite completion
     "ReentrancyRelyGuarantee",  # Abstract state-transformer proofs, no compiled contract to property-test
+    "Ownable",                  # Mixin proofs are reused by hosts; no compiled property harness
+    "OwnedCounterComposed",     # Proof-composition host; OwnedCounter remains the Foundry target
 }
 
 # Contracts excluded from differential test check
@@ -34,6 +38,8 @@ EXCLUDED_FROM_DIFFERENTIAL_TESTS = {
     "ReentrancyExample",        # Reentrancy model requires dedicated external-call harnessing
     "Vault",                    # Minimal scaffolding landed before differential harness completion
     "ReentrancyRelyGuarantee",  # No compiled bytecode (abstract proofs), nothing to differential-test
+    "Ownable",                  # Mixin facet; no dedicated Yul/Foundry twin
+    "OwnedCounterComposed",     # Selectors/layout stay on OwnedCounter until bit-identical
 }
 
 # Expected files for each contract (relative to ROOT)

--- a/scripts/check_storage_lens_freeze.py
+++ b/scripts/check_storage_lens_freeze.py
@@ -58,37 +58,20 @@ SHARED_SCAN_DIRS = ("Verity", "Contracts")
 # canonical `defaultState`/`emitEvent`-style literals; it is the only file
 # meant to keep raw access after the migration completes.
 BASELINE = {
-    # Lens implementations + defaultState (the permanent residue).
-    "Verity/Core.lean": 26,
-    # Denotational bulk writes (multi-slot / packed): need bulk lenses
-    # before they can migrate (C5 step 2).
-    "Verity/Core/Model/Denote.lean": 26,
-    "Verity/Core/Free/TypedIR.lean": 7,
-    # Bridge lemma statements equating monad ops with the raw update form;
-    # restated via lenses when the simp attribute moves to `storage_simps`.
-    "Verity/Proofs/Stdlib/Automation.lean": 3,
-    "Verity/Proofs/Stdlib/MappingAutomation.lean": 3,
-    "Verity/Specs/Common/Sum.lean": 1,
-    # Contract proofs spelling out full post-state record literals, and test
-    # fixtures constructing initial states by raw literal; both migrate in
-    # C5 step 2 (proofs onto `storage_simps`, fixtures onto lens chains).
-    "Contracts/Common.lean": 5,
-    "Contracts/ERC20/Proofs/Basic.lean": 16,
-    "Contracts/Interpreter.lean": 7,
-    "Contracts/Ledger/Proofs/Basic.lean": 32,
+    # Lens/bulk-lens/ofChannels implementations + defaultState — the
+    # permanent residue the C5 step-3 flip swaps in place.
+    "Verity/Core.lean": 39,
+    # 3 `let storage :=` local-binding false positives + the find?-shaped
+    # transient packed-write arm (non-defeq to a lens; step-3 burn-down).
+    "Verity/Core/Model/Denote.lean": 6,
+    # Concurrent lane (Ownable/composition session) — not ours to migrate.
     "Contracts/Owned/Proofs/Basic.lean": 8,
-    "Contracts/OwnedCounter/Proofs/Basic.lean": 24,
-    "Contracts/ReentrancyExample/Contract.lean": 7,
-    "Contracts/SafeCounter/Proofs/Basic.lean": 16,
-    "Contracts/SimpleToken/Proofs/Basic.lean": 16,
-    "Contracts/Smoke/Storage.lean": 5,
-    "Contracts/TypedIRTests.lean": 79,
-    "Compiler/CompilationModelFeatureTest.lean": 3,
-    "Compiler/Proofs/IRGeneration/SourceSemantics.lean": 8,
-    "Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean": 1,
-    "Compiler/Proofs/Storage/StructArrayStorage.lean": 1,
-    "Compiler/Proofs/StorageBounds.lean": 1,
-    "Compiler/TypedIRCompilerCorrectness.lean": 9,
+    # IRState fixture literals (field-name collision false positives).
+    "Contracts/TypedIRTests.lean": 3,
+    # `=`-guarded dual-channel writeStorageWordSlot(s) (re-guarding to `==`
+    # would reshape the GenericInduction unfold surface; step-3 burn-down)
+    # + let-binding false positives.
+    "Compiler/Proofs/IRGeneration/SourceSemantics.lean": 7,
 }
 
 

--- a/test/property_exclusions.json
+++ b/test/property_exclusions.json
@@ -50,6 +50,22 @@
   "setStorage_updates_supply",
   "transfer_sum_preserved_unique"
  ],
+ "Ownable": [
+  "constructor_sets_owner",
+  "getOwner_meets_spec",
+  "onlyOwner_ok",
+  "onlyOwner_reverts",
+  "transferOwnership_meets_spec_when_owner",
+  "transferOwnership_writes_only"
+ ],
+ "OwnedCounterComposed": [
+  "getCount_meets_spec",
+  "increment_meets_spec_when_owner",
+  "increment_preserves_ownable_inv",
+  "increment_preserves_owner",
+  "increment_reverts_when_not_owner",
+  "increment_writes_only_count"
+ ],
  "ReentrancyRelyGuarantee": [
   "any_cross_contract_schedule_preserves_I",
   "any_reentry_schedule_preserves_I",

--- a/test/property_manifest.json
+++ b/test/property_manifest.json
@@ -110,6 +110,14 @@
     "dischargedEdge_roundtrip",
     "unsafeEdge_preserves_state"
   ],
+  "Ownable": [
+    "constructor_sets_owner",
+    "getOwner_meets_spec",
+    "onlyOwner_ok",
+    "onlyOwner_reverts",
+    "transferOwnership_meets_spec_when_owner",
+    "transferOwnership_writes_only"
+  ],
   "Owned": [
     "constructor_getOwner_correct",
     "constructor_meets_spec",
@@ -184,6 +192,14 @@
     "transfer_then_decrement_reverts",
     "transfer_then_increment_reverts",
     "transfer_then_transfer_reverts"
+  ],
+  "OwnedCounterComposed": [
+    "getCount_meets_spec",
+    "increment_meets_spec_when_owner",
+    "increment_preserves_ownable_inv",
+    "increment_preserves_owner",
+    "increment_reverts_when_not_owner",
+    "increment_writes_only_count"
   ],
   "ReentrancyExample": [
     "deposit_maintains_supply",


### PR DESCRIPTION
Migrates the raw `ContractState` storage-channel record-update sites to the lens API: **304 baselined sites → 63** (39 = the lens implementations in `Verity/Core.lean`, the permanent residue the step-3 flip swaps in place).

- New Core lenses: bulk (`writeSlots`/`modifySlots`/`writeTransientSlots`/`modifyTransientSlots`/`writeAddrSlots` — definitionally equal to the historical multi-slot raw shapes), `withStorageChannel` (channel transformer for the denotational flat-view mapping writes), `ofChannels` (canonical full-state constructor for harnesses/fixtures).
- `Denote`/`SourceSemantics` write helpers route through lenses (defeq swaps where guards matched; the `=`-guarded dual-channel writers stay baselined — re-guarding them reshapes the GenericInduction unfold surface, deferred to step 3).
- Contract proof suites: `_unfold` statement literals restated as lens chains (definitionally equal); `verity_frame` extended with lens unfolds; fixtures rebuilt over `defaultState`.
- Gate `BASELINE` shrunk to 5 justified entries (net −241 sites).

⚠️ Merge après CI verte : la validation locale complète était encore en cours à la clôture de session (tous les modules touchés buildés verts individuellement ; `make check` du gate vert). Voir l'issue de suivi C5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide refactor across core storage semantics, compiler proofs, and contract verification paths; changes are mostly definitional but any lens mismatch could break soundness proofs or interpreter agreement.
> 
> **Overview**
> **Burns down raw `ContractState` storage-channel record updates** in favor of the lens API (`writeSlot`, `writeMap`, `writeSlots`, `writeArray`, `ofChannels`, etc.), shrinking the raw-update baseline from hundreds of sites to a small permanent residue in `Verity/Core.lean`.
> 
> **Compiler and semantics layers** now route slot/mapping/transient writes through lenses: `SourceSemantics` helpers delegate to `writeSlots` / `writeAddrSlots` / `writeTransientSlots`; denotation agreement and frame/storage-bridge proofs gain matching `simp` unfolds. Contract/runtime code (`Contracts/Common`, interpreter initial state) and typed-IR correctness specs use the same helpers instead of inline `{ world with storage := … }` literals.
> 
> **Contract proofs and fixtures** restate `_unfold` lemmas as lens chains (definitionally equal) and rebuild test worlds via `defaultState.writeArray` / `ofChannels`.
> 
> **Adds reusable ownership composition:** a `verity_mixin Ownable` facet with specs, footprint, and proofs; `OwnedCounterComposed` hosts it via `include` and proves count writes preserve the mixin invariant. `Contracts/Smoke/Include.lean` exercises mixin `include` (namespaces, errors, immutables, clash rejection). **CONTRIBUTING** documents the mixin workflow.
> 
> **New IR proof scaffolding:** `CompiledNameDiscipline.lean` introduces `loopFreeCheck`, `forEachCompiledBodyChecks`, and prefix lemmas for literal-bound `forEach` bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdb19069b6888f61b262c17624b6561ca421a715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->