### PR TITLE
feat(proofs): decidable admission gates for literal-bound forEach bodies

### DIFF
--- a/Compiler/Proofs/IRGeneration/CompiledNameDiscipline.lean
+++ b/Compiler/Proofs/IRGeneration/CompiledNameDiscipline.lean
@@ -1,0 +1,146 @@
+import Compiler.Proofs.IRGeneration.BoundedLoopCheck
+import Compiler.Proofs.IRGeneration.SupportedFragment
+
+/-!
+# Name discipline of compiled fragment output
+
+The `forEach` loop coupling needs: the compiled body never binds or assigns
+the loop's synthetic counters.  The compiler guarantees this by scope
+threading — `forEachBodyScope` places the counters in `inScopeNames`, so
+every `pickFreshName`-generated scratch name avoids them, and every other
+emitted target is a source name.  This module packages that discipline:
+
+- a prefix-discrimination toolkit (`pickFreshName_startsWith`,
+  `ne_of_startsWith_of_not_startsWith`) in the kernel-friendly
+  `String.startsWith` style of `ReservedScratchNames.lean`;
+- (next step) `supportedStmtList_compiled_varUntouched`, by induction over
+  `SupportedStmtList`: each fragment constructor's compiled shape is
+  explicit, its targets are source names or `__compat_*`/`__evt_*` scratch,
+  and `varUntouchedCheck` never inspects expression innards.
+-/
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler.CompilationModel
+
+/-- `pickFreshName` output always extends its base. -/
+theorem pickFreshName_startsWith (base : String) (usedNames : List String) :
+    (pickFreshName base usedNames).startsWith base = true := by
+  unfold pickFreshName
+  by_cases h : usedNames.contains base
+  · simp only [h, Bool.not_true, Bool.false_eq_true, if_false]
+    rw [String.startsWith_string_iff]
+    exact ⟨_, by simp [String.toList_append, List.append_assoc]; rfl⟩
+  · have hnot : base ∉ usedNames := by simpa using h
+    simp [List.contains_eq_mem, hnot]
+
+/-- Prefix discrimination: a name extending `p` is distinct from any name
+that does not extend `p`. -/
+theorem ne_of_startsWith_of_not_startsWith
+    {v s p : String}
+    (hv : v.startsWith p = true) (hs : s.startsWith p = false) :
+    v ≠ s := by
+  intro hEq
+  rw [hEq, hs] at hv
+  cases hv
+
+open Compiler.Yul
+
+mutual
+
+/-- Executable mirror of `LoopFree`. -/
+def loopFreeCheck : YulStmt → Bool
+  | .if_ _ body => loopFreeCheckList body
+  | .block stmts => loopFreeCheckList stmts
+  | .switch _ cases dflt => loopFreeCheckCases cases && loopFreeCheckDflt dflt
+  | .for_ _ _ _ _ => false
+  | _ => true
+
+def loopFreeCheckCases : List (Nat × List YulStmt) → Bool
+  | [] => true
+  | c :: rest => loopFreeCheckList c.2 && loopFreeCheckCases rest
+
+def loopFreeCheckDflt : Option (List YulStmt) → Bool
+  | none => true
+  | some stmts => loopFreeCheckList stmts
+
+def loopFreeCheckList : List YulStmt → Bool
+  | [] => true
+  | s :: rest => loopFreeCheck s && loopFreeCheckList rest
+
+end
+
+mutual
+
+/-- Soundness: a checked statement is loop-free. -/
+theorem loopFreeCheck_sound : ∀ (s : YulStmt), loopFreeCheck s = true → LoopFree s
+  | .if_ _ body, h => by
+      simp only [LoopFree]
+      exact loopFreeCheckList_sound body (by simpa [loopFreeCheck] using h)
+  | .block stmts, h => by
+      simp only [LoopFree]
+      exact loopFreeCheckList_sound stmts (by simpa [loopFreeCheck] using h)
+  | .switch _ cases dflt, h => by
+      obtain ⟨hc, hd⟩ : loopFreeCheckCases cases = true ∧
+          loopFreeCheckDflt dflt = true := by
+        simpa [loopFreeCheck, Bool.and_eq_true] using h
+      exact ⟨loopFreeCheckCases_sound cases hc, loopFreeCheckDflt_sound dflt hd⟩
+  | .for_ _ _ _ _, h => by simp [loopFreeCheck] at h
+  | .comment _, _ => trivial
+  | .let_ _ _, _ => trivial
+  | .letMany _ _, _ => trivial
+  | .assign _ _, _ => trivial
+  | .leave, _ => trivial
+  | .funcDef _ _ _ _, _ => trivial
+  | .exprStmt _, _ => trivial
+
+theorem loopFreeCheckCases_sound :
+    ∀ (cs : List (Nat × List YulStmt)), loopFreeCheckCases cs = true →
+      LoopFreeCases cs
+  | [], _ => trivial
+  | c :: rest, h => by
+      obtain ⟨hc, hrest⟩ : loopFreeCheckList c.2 = true ∧
+          loopFreeCheckCases rest = true := by
+        simpa [loopFreeCheckCases, Bool.and_eq_true] using h
+      exact ⟨loopFreeCheckList_sound c.2 hc, loopFreeCheckCases_sound rest hrest⟩
+
+theorem loopFreeCheckDflt_sound :
+    ∀ (d : Option (List YulStmt)), loopFreeCheckDflt d = true → LoopFreeDflt d
+  | none, _ => trivial
+  | some stmts, h =>
+      loopFreeCheckList_sound stmts (by simpa [loopFreeCheckDflt] using h)
+
+theorem loopFreeCheckList_sound :
+    ∀ (xs : List YulStmt), loopFreeCheckList xs = true → LoopFreeList xs
+  | [], _ => trivial
+  | s :: rest, h => by
+      obtain ⟨hs, hrest⟩ : loopFreeCheck s = true ∧
+          loopFreeCheckList rest = true := by
+        simpa [loopFreeCheckList, Bool.and_eq_true] using h
+      exact ⟨loopFreeCheck_sound s hs, loopFreeCheckList_sound rest hrest⟩
+
+end
+
+/-- Per-contract decidable gate for admitting a literal-bound `forEach` body:
+the compiled body must be loop-free and must never touch the loop's synthetic
+counters.  Discharged by `decide` on concrete contracts; a generic
+name-discipline theorem can later eliminate the counter checks. -/
+def forEachCompiledBodyChecks
+    (fields : List Compiler.CompilationModel.Field)
+    (scope : List String) (varName : String)
+    (count : Compiler.CompilationModel.Expr)
+    (body : List Compiler.CompilationModel.Stmt) : Bool :=
+  let forUsedNames := varName :: (scope ++
+    Compiler.CompilationModel.collectExprNames count ++
+    Compiler.CompilationModel.collectStmtListNames body)
+  let idxName := Compiler.CompilationModel.pickFreshName "__forEach_idx" forUsedNames
+  let countName := Compiler.CompilationModel.pickFreshName "__forEach_count"
+    (idxName :: forUsedNames)
+  match Compiler.CompilationModel.compileStmtList fields [] [] .calldata [] false
+      (Compiler.CompilationModel.forEachBodyScope scope varName count body) [] body with
+  | .ok ir =>
+      loopFreeCheckList ir &&
+        varUntouchedCheckList idxName ir &&
+        varUntouchedCheckList countName ir
+  | .error _ => false
+
+end Compiler.Proofs.IRGeneration

--- a/Compiler/TypedIRCompilerCorrectness.lean
+++ b/Compiler/TypedIRCompilerCorrectness.lean
@@ -1127,7 +1127,7 @@ theorem compile_setStorage_literal_semantics
       .ok { init with world := execSourceSetStorageLiteral init.world slot n } := by
   simp [execCompiledSetStorageLiteral, execSourceSetStorageLiteral,
     compileStmts_single_setStorage_literal_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for the supported two-statement subset:
 compiling and running `letVar tmp (literal n); setStorage fieldName (localVar tmp)`
@@ -1144,7 +1144,7 @@ theorem compile_let_setStorage_local_literal_semantics
             vars := init.vars.set { id := 0, ty := Ty.uint256 } (n : Verity.Core.Uint256) }) := by
   simp [execCompiledLetSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for a broader supported three-statement subset:
 compiling and running
@@ -1164,7 +1164,7 @@ theorem compile_let_assign_setStorage_local_literal_semantics
               { id := 1, ty := Ty.uint256 } (m : Verity.Core.Uint256) }) := by
   simp [execCompiledLetAssignSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_assign_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for an arithmetic supported three-statement subset:
 compiling and running
@@ -1186,7 +1186,7 @@ theorem compile_let_assign_add_setStorage_local_literal_semantics
                 ((n : Verity.Core.Uint256).add (m : Verity.Core.Uint256)) }) := by
   simp [execCompiledLetAssignAddSetStorageLocalLiteral, execSourceSetStorageLiteral,
     compileStmts_let_assign_add_literal_setStorage_local_run, hfind, evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel]
+  simp [evalTStmtsFuel, evalTStmtFuel, Verity.ContractState.writeSlot]
 
 /-- Semantic-preservation theorem for an arithmetic supported three-statement subset:
 compiling and running

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -17,11 +17,13 @@ import Contracts.Ledger.Proofs.Conservation
 import Contracts.Ledger.Proofs.Correctness
 import Contracts.LocalObligationMacroSmoke.Proofs.Basic
 import Contracts.LocalObligationMacroSmoke.Proofs.Correctness
+import Contracts.Ownable.Proofs.Basic
 import Contracts.Owned.Proofs.Basic
 import Contracts.Owned.Proofs.Correctness
 import Contracts.OwnedCounter.Proofs.Basic
 import Contracts.OwnedCounter.Proofs.Correctness
 import Contracts.OwnedCounter.Proofs.Isolation
+import Contracts.OwnedCounterComposed.Proofs.Basic
 import Contracts.SafeCounter.Proofs.Basic
 import Contracts.SafeCounter.Proofs.Correctness
 import Contracts.SimpleStorage.Proofs.Basic
@@ -395,6 +397,15 @@ end Verity.AxiomAudit
   -- Contracts/LocalObligationMacroSmoke/Proofs/Correctness.lean
   Contracts.LocalObligationMacroSmoke.Proofs.Correctness.dischargedEdge_roundtrip
 
+  -- Contracts/Ownable/Proofs/Basic.lean
+  -- Contracts.Ownable.Proofs.owner_slot_zero  -- private
+  Contracts.Ownable.Proofs.onlyOwner_ok
+  Contracts.Ownable.Proofs.onlyOwner_reverts
+  Contracts.Ownable.Proofs.transferOwnership_writes_only
+  Contracts.Ownable.Proofs.transferOwnership_meets_spec_when_owner
+  Contracts.Ownable.Proofs.getOwner_meets_spec
+  Contracts.Ownable.Proofs.constructor_sets_owner
+
   -- Contracts/Owned/Proofs/Basic.lean
   Contracts.Owned.Proofs.setStorageAddr_updates_owner
   Contracts.Owned.Proofs.getStorageAddr_reads_owner
@@ -480,6 +491,14 @@ end Verity.AxiomAudit
   Contracts.OwnedCounter.Proofs.Isolation.increment_preserves_map_storage
   Contracts.OwnedCounter.Proofs.Isolation.decrement_preserves_map_storage
   Contracts.OwnedCounter.Proofs.Isolation.transferOwnership_preserves_map_storage
+
+  -- Contracts/OwnedCounterComposed/Proofs/Basic.lean
+  Contracts.OwnedCounterComposed.Proofs.increment_reverts_when_not_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_meets_spec_when_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_preserves_owner
+  Contracts.OwnedCounterComposed.Proofs.increment_writes_only_count
+  Contracts.OwnedCounterComposed.Proofs.increment_preserves_ownable_inv
+  Contracts.OwnedCounterComposed.Proofs.getCount_meets_spec
 
   -- Contracts/SafeCounter/Proofs/Basic.lean
   -- Contracts.SafeCounter.Proofs.getCount_run  -- private
@@ -6818,4 +6837,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6334 theorems/lemmas (4469 public, 1865 private, 0 sorry'd)
+-- Total: 6347 theorems/lemmas (4481 public, 1866 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -17,13 +17,11 @@ import Contracts.Ledger.Proofs.Conservation
 import Contracts.Ledger.Proofs.Correctness
 import Contracts.LocalObligationMacroSmoke.Proofs.Basic
 import Contracts.LocalObligationMacroSmoke.Proofs.Correctness
-import Contracts.Ownable.Proofs.Basic
 import Contracts.Owned.Proofs.Basic
 import Contracts.Owned.Proofs.Correctness
 import Contracts.OwnedCounter.Proofs.Basic
 import Contracts.OwnedCounter.Proofs.Correctness
 import Contracts.OwnedCounter.Proofs.Isolation
-import Contracts.OwnedCounterComposed.Proofs.Basic
 import Contracts.SafeCounter.Proofs.Basic
 import Contracts.SafeCounter.Proofs.Correctness
 import Contracts.SimpleStorage.Proofs.Basic
@@ -50,6 +48,7 @@ import Compiler.Proofs.HelperStepProofs
 import Compiler.Proofs.IRGeneration.BoundedLoopCheck
 import Compiler.Proofs.IRGeneration.BoundedLoopFuel
 import Compiler.Proofs.IRGeneration.CEISafety
+import Compiler.Proofs.IRGeneration.CompiledNameDiscipline
 import Compiler.Proofs.IRGeneration.Contract
 import Compiler.Proofs.IRGeneration.ContractFeatureTest
 import Compiler.Proofs.IRGeneration.ContractShape
@@ -396,15 +395,6 @@ end Verity.AxiomAudit
   -- Contracts/LocalObligationMacroSmoke/Proofs/Correctness.lean
   Contracts.LocalObligationMacroSmoke.Proofs.Correctness.dischargedEdge_roundtrip
 
-  -- Contracts/Ownable/Proofs/Basic.lean
-  -- Contracts.Ownable.Proofs.owner_slot_zero  -- private
-  Contracts.Ownable.Proofs.onlyOwner_ok
-  Contracts.Ownable.Proofs.onlyOwner_reverts
-  Contracts.Ownable.Proofs.transferOwnership_writes_only
-  Contracts.Ownable.Proofs.transferOwnership_meets_spec_when_owner
-  Contracts.Ownable.Proofs.getOwner_meets_spec
-  Contracts.Ownable.Proofs.constructor_sets_owner
-
   -- Contracts/Owned/Proofs/Basic.lean
   Contracts.Owned.Proofs.setStorageAddr_updates_owner
   Contracts.Owned.Proofs.getStorageAddr_reads_owner
@@ -490,14 +480,6 @@ end Verity.AxiomAudit
   Contracts.OwnedCounter.Proofs.Isolation.increment_preserves_map_storage
   Contracts.OwnedCounter.Proofs.Isolation.decrement_preserves_map_storage
   Contracts.OwnedCounter.Proofs.Isolation.transferOwnership_preserves_map_storage
-
-  -- Contracts/OwnedCounterComposed/Proofs/Basic.lean
-  Contracts.OwnedCounterComposed.Proofs.increment_reverts_when_not_owner
-  Contracts.OwnedCounterComposed.Proofs.increment_meets_spec_when_owner
-  Contracts.OwnedCounterComposed.Proofs.increment_preserves_owner
-  Contracts.OwnedCounterComposed.Proofs.increment_writes_only_count
-  Contracts.OwnedCounterComposed.Proofs.increment_preserves_ownable_inv
-  Contracts.OwnedCounterComposed.Proofs.getCount_meets_spec
 
   -- Contracts/SafeCounter/Proofs/Basic.lean
   -- Contracts.SafeCounter.Proofs.getCount_run  -- private
@@ -2139,6 +2121,14 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.CEIProofBackedExecution.no_local_unsafe_obligations
   Compiler.Proofs.IRGeneration.ceiProofBackedExecution_of_checker
   Compiler.Proofs.IRGeneration.ceiProofBackedExecution_checked_empty_body
+
+  -- Compiler/Proofs/IRGeneration/CompiledNameDiscipline.lean
+  Compiler.Proofs.IRGeneration.pickFreshName_startsWith
+  Compiler.Proofs.IRGeneration.ne_of_startsWith_of_not_startsWith
+  Compiler.Proofs.IRGeneration.loopFreeCheck_sound
+  Compiler.Proofs.IRGeneration.loopFreeCheckCases_sound
+  Compiler.Proofs.IRGeneration.loopFreeCheckDflt_sound
+  Compiler.Proofs.IRGeneration.loopFreeCheckList_sound
 
   -- Compiler/Proofs/IRGeneration/Contract.lean
   Compiler.Proofs.IRGeneration.Contract.pickUniqueFunctionByName_eq_ok_none_of_absent
@@ -6828,4 +6818,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6341 theorems/lemmas (4475 public, 1866 private, 0 sorry'd)
+-- Total: 6334 theorems/lemmas (4469 public, 1865 private, 0 sorry'd)


### PR DESCRIPTION
First slice of the forEach fragment-admission arc (#2330), on top of the #2328 bounded-loop foundation.

- **Prefix-discrimination toolkit**: `pickFreshName_startsWith` (fresh names always extend their base) + `ne_of_startsWith_of_not_startsWith` — kernel-friendly `String.startsWith` style (as `ReservedScratchNames.lean`).
- **`loopFreeCheck`**: executable mirror of `LoopFree` with mutual soundness (`spliceSimCheck` style).
- **`forEachCompiledBodyChecks`**: per-contract decidable gate — compiles the body in `forEachBodyScope` and requires loop-free + the synthetic counters (`__forEach_idx`/`__forEach_count`) never bound or assigned. Discharged by `decide` per contract; the generic name-discipline theorem (#2330 PR-C) can later eliminate the counter checks entirely.

Next slice (#2330 PR-A remainder): `forEach_loop_coupling` + `compiledStmtStep_forEach_literal` consuming these gates.

## Verification
Validated in an isolated worktree on `upstream/main` (d390de23): full `lake build` green, `make check` green, artifacts regenerated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions and trivial simp tweaks in correctness lemmas; no compiler runtime or auth paths.
> 
> **Overview**
> Introduces **`Compiler/Proofs/IRGeneration/CompiledNameDiscipline.lean`** as the first slice of forEach fragment admission: **`pickFreshName_startsWith`** and **`ne_of_startsWith_of_not_startsWith`** for scratch-name prefix reasoning, an executable **`loopFreeCheck`** mirror of **`LoopFree`** with mutual soundness lemmas, and **`forEachCompiledBodyChecks`** — compile the body under **`forEachBodyScope`**, then require loop-free IR and that synthetic **`__forEach_idx`** / **`__forEach_count`** names are never bound or assigned (via existing **`varUntouchedCheckList`**).
> 
> **`PrintAxioms.lean`** imports the module and lists the six new public theorems (theorem count bumps to 6347).
> 
> **`TypedIRCompilerCorrectness.lean`** only extends three **`setStorage`** semantic-preservation proofs with **`Verity.ContractState.writeSlot`** in the final **`simp`** step so goals close after related API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8db26ea68f52c5373d64ffed10a487712828c002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->