### PR TITLE
fix(proofs): close guarded source bridge lock goals

### DIFF
--- a/Compiler/Proofs/IRGeneration/GuardedSourceBridge.lean
+++ b/Compiler/Proofs/IRGeneration/GuardedSourceBridge.lean
@@ -73,7 +73,10 @@ theorem initialIRStateForTx_setLock (spec : CompilationModel)
        exact congrArg IRStorageWord.ofNat
          (encodeStorageAt_setLock _ world slot 1 o.toNat))
     | (funext o
-       by_cases h : o = slot <;> simp [setLock, h])
+       by_cases h : o = slot
+       · subst o
+         simp
+       · simp [h])
 
 /-- The revert projection ignores transient storage: overlaying the lock on
 the rollback state does not change it. -/


### PR DESCRIPTION
## Containment repair

Repairs the main build regression from `a083daf9b77fc778a2fe709be654b7630e6ee559` (Actions run 31716727214, build job 94506225394).

`initialIRStateForTx_setLock` previously relied on broad simplification after the storage-lens simp flip. Its two transient-storage cases now use the existing lock-read simplification surface explicitly, closing the archived `pos` and `neg` goals without weakening the bridge theorem.

Scope: one proof file; no new `sorry`, `admit`, axioms, unsafe declarations, gates, or feature work. No regression test added because the repaired executable bridge theorem is the direct failing target.

Validation:
- `lake build Compiler.Proofs.IRGeneration.GuardedSourceBridge` — passed locally (pinned Lean 4.31.0)
- `lake build` — running locally under a bounded receipt
- `lake build PrintAxioms` — queued after the full build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only tactic change in one theorem; no runtime, gates, or axioms.
> 
> **Overview**
> Repairs the **Lean proof** of `initialIRStateForTx_setLock` in `GuardedSourceBridge.lean` after a storage-lens simplification change left the transient-storage subgoal open.
> 
> The third `all_goals` branch no longer uses `by_cases` followed by `simp [setLock, h]` in one shot. It now splits on `o = slot`, uses `subst` and `simp` when equal, and `simp [h]` when not—reusing the existing lock-read simplification surface so the `pos`/`neg` goals close without weakening the bridge theorem.
> 
> **No executable or semantic changes**—only proof tactics in this file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8dd14e46212cac9200b10dafd5dc968fc799b30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->