### PR TITLE
feat(edsl): journal linked external calls in the executable plane

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -193,6 +193,37 @@ sibling entrypoint.
   Journal".
 - **Axiom-free**: `AXIOMS.md` unchanged.
 
+## EDSL Executable Plane: Linked External Calls Journal (2026-08)
+
+- The EDSL executable stubs for linked external calls are no longer silent:
+  `Contracts.externalCallBind`, `Contracts.callResultWords`,
+  `Contracts.tryExternalCallWords`, and the `safeTransfer`/`safeApprove`
+  family now append a `Verity.ExternalCall` entry to `ContractState.calls`
+  (via `Contracts.linkedCallEntry`/`recordLinkedCall`). Previously they were
+  `pure ()`-shaped no-ops, so any executable-plane theorem "about" an
+  external call was vacuously insensitive to duplicated, omitted, reordered,
+  renamed, or argument-mutated calls.
+- Linked externals are name-keyed (address bound at link time), so
+  `ExternalCall` gained a defaulted `name : String := ""` field; model-plane
+  entries (`DenoteExternalCalls.journalEntry`) leave it `""` and are
+  otherwise unchanged. `siteId`/`target` are `0` in executable-plane entries;
+  journal position records call order and `calldata` records the exact
+  argument words.
+- In-band results are unchanged and remain deterministic stubs
+  (`externalCallStubWord`); `callResultWords`/`tryExternalCallWords` report
+  `success := (name != "fail")` (`externalCallStubSuccess`), giving specs a
+  reserved name to exercise failure paths. `externalCallWords` (the pure
+  expression form) still returns the stub word without journaling — it is
+  not monadic and cannot observe state; this remaining gap is documented in
+  `TRUST_ASSUMPTIONS.md`.
+- The model plane (`DenoteExternalCalls`, `ContractExternalCall`,
+  `ExternalCallResult.control`) is untouched; all its laws hold verbatim.
+- Discriminating evidence: `Contracts/Smoke/ExternalCallObservability.lean`
+  separates duplicated/omitted/reordered/renamed/zeroed-arg mutants from the
+  original programs over arbitrary pre-states, and pins the
+  revert-rolls-back-journal behaviour of `Contract.run`.
+- **Axiom-free**: `AXIOMS.md` unchanged.
+
 ## Guarded Event Preservation + Checked Arithmetic Completion (2026-08)
 
 - `Compiler/Proofs/IRGeneration/GuardedScalarEvents.lean`:

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -203,14 +203,23 @@ sibling entrypoint.
   `pure ()`-shaped no-ops, so any executable-plane theorem "about" an
   external call was vacuously insensitive to duplicated, omitted, reordered,
   renamed, or argument-mutated calls.
-- Linked externals are name-keyed (address bound at link time), so
+- General linked externals are name-keyed (address bound at link time), so
   `ExternalCall` gained a defaulted `name : String := ""` field; model-plane
-  entries (`DenoteExternalCalls.journalEntry`) leave it `""` and are
-  otherwise unchanged. `siteId`/`target` are `0` in executable-plane entries;
-  journal position records call order and `calldata` records the exact
-  argument words.
-- In-band results are unchanged and remain deterministic stubs
-  (`externalCallStubWord`); `callResultWords`/`tryExternalCallWords` report
+  entries (`DenoteExternalCalls.journalEntry`) leave it `""` and are otherwise
+  unchanged. Their executable-plane `siteId`/`target` are `0`. ERC-20 write
+  wrappers instead record the token address as `target` and the actual wrapper
+  arguments (excluding that target) as `calldata`; all retain the wrapper name.
+  Journal position records call order.
+- `ExternalArg.toWords` is a canonical, content-preserving journal encoding:
+  scalars occupy one word, while arrays and byte arrays carry a length prefix
+  followed by every recursively encoded element/byte. It deliberately does not
+  claim byte-for-byte EVM ABI layout, but unlike the former size-only word it
+  distinguishes same-length content mutations.
+- In-band results remain deterministic stubs (`externalCallStubWord`);
+  `callResultWords` and successful `tryExternalCallWords` with a supported
+  single-word result decode and return the same word recorded in journal
+  returndata. Aggregate/no-result executable stubs retain their inhabited
+  default, as do failures. Both report
   `success := (name != "fail")` (`externalCallStubSuccess`), giving specs a
   reserved name to exercise failure paths. `externalCallWords` (the pure
   expression form) still returns the stub word without journaling — it is
@@ -219,8 +228,9 @@ sibling entrypoint.
 - The model plane (`DenoteExternalCalls`, `ContractExternalCall`,
   `ExternalCallResult.control`) is untouched; all its laws hold verbatim.
 - Discriminating evidence: `Contracts/Smoke/ExternalCallObservability.lean`
-  separates duplicated/omitted/reordered/renamed/zeroed-arg mutants from the
-  original programs over arbitrary pre-states, and pins the
+  separates duplicated/omitted/reordered/renamed/zeroed-arg and equal-length
+  dynamic-content mutants over arbitrary pre-states, pins returned-value /
+  returndata agreement and ERC-20 targets/calldata, and pins the
   revert-rolls-back-journal behaviour of `Contract.run`.
 - **Axiom-free**: `AXIOMS.md` unchanged.
 

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -633,15 +633,23 @@ def tryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
 def externalCallBind {α : Type} [ExternalArg α] (names : List String) (name : String) (args : List α) : Contract Unit :=
   fun state =>
     let argWords := args.flatMap ExternalArg.toWords
-    let entry := linkedCallEntry name argWords .success
-      (names.map (fun _ => (externalCallStubWord name argWords : Nat)))
-    ContractResult.success () { state with calls := state.calls ++ [entry] }
+    let success := externalCallStubSuccess name
+    let entry := linkedCallEntry name argWords
+      (if success then .success else .failure)
+      (if success then
+        names.map (fun _ => (externalCallStubWord name argWords : Nat))
+      else [])
+    let next := { state with calls := state.calls ++ [entry] }
+    if success then ContractResult.success () next
+    else ContractResult.revert "external call failed" next
 
 /-! ### Run laws for the executable linked-call family
 
-Each primitive succeeds and appends exactly one journal entry, so a
-duplicated, omitted, reordered, or argument-altered call is observably
-different at `ContractState.calls`. All laws are definitional (`rfl`). -/
+Successful primitives append exactly one journal entry, so a duplicated,
+omitted, reordered, or argument-altered call is observably different at
+`ContractState.calls`. A failing `externalCallBind` reverts, and `Contract.run`
+rolls its failure entry back with the rest of the call state. All laws are
+definitional (`rfl`). -/
 
 @[simp] theorem recordLinkedCall_run (entry : ExternalCall) (s : ContractState) :
     (recordLinkedCall entry).run s =
@@ -650,11 +658,15 @@ different at `ContractState.calls`. All laws are definitional (`rfl`). -/
 @[simp] theorem externalCallBind_run {α : Type} [ExternalArg α]
     (names : List String) (name : String) (args : List α) (s : ContractState) :
     (externalCallBind names name args).run s =
-      ContractResult.success ()
-        { s with calls := s.calls ++
-            [linkedCallEntry name (args.flatMap ExternalArg.toWords) .success
-              (names.map fun _ =>
-                (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat))] } := rfl
+      if externalCallStubSuccess name then
+        ContractResult.success ()
+          { s with calls := s.calls ++
+              [linkedCallEntry name (args.flatMap ExternalArg.toWords) .success
+                (names.map fun _ =>
+                  (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat))] }
+      else ContractResult.revert "external call failed" s := by
+  by_cases h : externalCallStubSuccess name = true <;>
+    simp [Contract.run, externalCallBind, h]
 
 @[simp] theorem callResultWords_run {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (s : ContractState) :
@@ -733,7 +745,9 @@ def erc20WriteEntry (name : String) (token : Address) (args : List Uint256) : Ex
 
 def erc20ReadEntry (name : String) (token : Address) (args : List Uint256)
     (result : Uint256) : ExternalCall :=
-  { linkedCallEntry name args .success [(result : Nat)] with target := token.toNat }
+  { linkedCallEntry name args .success [(result : Nat)] with
+      kind := .staticcall
+      target := token.toNat }
 
 def erc20Read (name : String) (token : Address) (args : List Uint256) : Contract Uint256 :=
   fun state =>

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -493,30 +493,39 @@ def rawLog (topics : List Uint256) (dataOffset dataSize : Uint256) : Contract Un
 def mstore (_offset _value : Uint256) : Contract Unit := pure ()
 def tstore (offset value : Uint256) : Contract Unit := fun state =>
   ContractResult.success () (state.writeTransient (offset : Nat) value)
+/-- Canonical journal-word encoding for executable external-call arguments.
+Scalars occupy one word. Dynamic values start with their element/byte count
+and retain every recursively encoded element, making equal-length content
+mutations observable without claiming byte-for-byte EVM ABI layout. -/
 class ExternalArg (α : Type) where
-  toWord : α → Uint256
+  toWords : α → List Uint256
 class ExternalResult (α : Type) where
   fromWord : Uint256 → α
+/-- Aggregate/no-result executable stubs have no single-word decoding. Keep
+their historical inhabited default; concrete scalar decoders below have the
+normal higher priority and therefore return the journaled stub word. -/
+instance (priority := 100) [Inhabited α] : ExternalResult α where
+  fromWord _ := Inhabited.default
 instance : ExternalArg Uint256 where
-  toWord value := value
+  toWords value := [value]
 instance : ExternalArg Uint16 where
-  toWord value := value.toUint256
+  toWords value := [value.toUint256]
 instance : ExternalArg (UIntN bits) where
-  toWord value := value.toUint256
+  toWords value := [value.toUint256]
 instance : ExternalArg (IntN bits) where
-  toWord value := value.toUint256
+  toWords value := [value.toUint256]
 instance : ExternalArg (BytesN bytes) where
-  toWord value := value.toUint256
+  toWords value := [value.toUint256]
 instance : ExternalArg Int256 where
-  toWord value := value.word
+  toWords value := [value.word]
 instance : ExternalArg Address where
-  toWord value := value.toNat
+  toWords value := [value.toNat]
 instance : ExternalArg Bool where
-  toWord value := if value then 1 else 0
+  toWords value := [if value then 1 else 0]
 instance [ExternalArg α] : ExternalArg (Array α) where
-  toWord values := values.size
+  toWords values := values.size :: (values.toList.flatMap ExternalArg.toWords)
 instance : ExternalArg ByteArray where
-  toWord bytes := bytes.size
+  toWords bytes := bytes.size :: (bytes.data.toList.map (fun byte => (byte.toNat : Uint256)))
 instance : ExternalResult Uint256 where
   fromWord value := value
 instance : ExternalResult Uint16 where
@@ -609,17 +618,21 @@ def callResultWords {α : Type} [ExternalResult α] [Inhabited α] (name : Strin
     (if success then [(word : Nat)] else [])
   ContractResult.success { success := success, returndata := payload }
     { state with calls := state.calls ++ [entry] }
-def tryExternalCallWords {α : Type} [Inhabited α] (name : String) (args : List Uint256) : Contract (Bool × α) :=
+def tryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
+    (name : String) (args : List Uint256) : Contract (Bool × α) :=
   fun state =>
     let success := externalCallStubSuccess name
+    let word := externalCallStubWord name args
+    let payload : α :=
+      if success then ExternalResult.fromWord word else Inhabited.default
     let entry := linkedCallEntry name args
       (if success then .success else .failure)
-      (if success then [(externalCallStubWord name args : Nat)] else [])
-    ContractResult.success (success, (Inhabited.default : α))
+      (if success then [(word : Nat)] else [])
+    ContractResult.success (success, payload)
       { state with calls := state.calls ++ [entry] }
 def externalCallBind {α : Type} [ExternalArg α] (names : List String) (name : String) (args : List α) : Contract Unit :=
   fun state =>
-    let argWords := args.map ExternalArg.toWord
+    let argWords := args.flatMap ExternalArg.toWords
     let entry := linkedCallEntry name argWords .success
       (names.map (fun _ => (externalCallStubWord name argWords : Nat)))
     ContractResult.success () { state with calls := state.calls ++ [entry] }
@@ -639,9 +652,9 @@ different at `ContractState.calls`. All laws are definitional (`rfl`). -/
     (externalCallBind names name args).run s =
       ContractResult.success ()
         { s with calls := s.calls ++
-            [linkedCallEntry name (args.map ExternalArg.toWord) .success
+            [linkedCallEntry name (args.flatMap ExternalArg.toWords) .success
               (names.map fun _ =>
-                (externalCallStubWord name (args.map ExternalArg.toWord) : Nat))] } := rfl
+                (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat))] } := rfl
 
 @[simp] theorem callResultWords_run {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (s : ContractState) :
@@ -659,10 +672,14 @@ different at `ContractState.calls`. All laws are definitional (`rfl`). -/
                 [(externalCallStubWord name args : Nat)]
               else [])] } := rfl
 
-@[simp] theorem tryExternalCallWords_run {α : Type} [Inhabited α]
+@[simp] theorem tryExternalCallWords_run {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (s : ContractState) :
     (tryExternalCallWords (α := α) name args).run s =
-      ContractResult.success (externalCallStubSuccess name, (Inhabited.default : α))
+      ContractResult.success
+        (externalCallStubSuccess name,
+          if externalCallStubSuccess name then
+            ExternalResult.fromWord (externalCallStubWord name args)
+          else Inhabited.default)
         { s with calls := s.calls ++
             [linkedCallEntry name args
               (if externalCallStubSuccess name then .success else .failure)
@@ -674,17 +691,20 @@ private def erc20ReadStubWord (name : String) (args : List Uint256) : Uint256 :=
   externalCallStubWord name args
 macro_rules
   | `(term| externalCall $name:ident [ $[$args:term],* ]) =>
-      `(externalCallWords $(Lean.quote (toString name.getId)) [ $[ExternalArg.toWord $args],* ])
+      `(externalCallWords $(Lean.quote (toString name.getId))
+          (List.flatten [ $[ExternalArg.toWords $args],* ]))
   | `(term| externalCall $name:str [ $[$args:term],* ]) =>
-      `(externalCallWords $name [ $[ExternalArg.toWord $args],* ])
+      `(externalCallWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]))
   | `(term| callResult $name:str [ $[$args:term],* ]) =>
-      `(callResultWords $name [ $[ExternalArg.toWord $args],* ])
+      `(callResultWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]))
   | `(term| callResult $name:ident [ $[$args:term],* ]) =>
-      `(callResultWords $(Lean.quote (toString name.getId)) [ $[ExternalArg.toWord $args],* ])
+      `(callResultWords $(Lean.quote (toString name.getId))
+          (List.flatten [ $[ExternalArg.toWords $args],* ]))
   | `(term| tryExternalCall $name:str [ $[$args:term],* ]) =>
-      `(tryExternalCallWords $name [ $[ExternalArg.toWord $args],* ])
+      `(tryExternalCallWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]))
   | `(term| tryExternalCall $name:ident [ $[$args:term],* ]) =>
-      `(tryExternalCallWords $(Lean.quote (toString name.getId)) [ $[ExternalArg.toWord $args],* ])
+      `(tryExternalCallWords $(Lean.quote (toString name.getId))
+          (List.flatten [ $[ExternalArg.toWords $args],* ]))
 def getMappingWord (_slot : StorageSlot (Uint256 → Uint256)) (_key _wordOffset : Uint256) :
     Contract Uint256 := pure 0
 def setMappingWord (_slot : StorageSlot (Uint256 → Uint256)) (_key _wordOffset _value : Uint256) :
@@ -708,45 +728,47 @@ def setStructMember {κ α : Type} (_field : String) (_key : κ) (_member : Stri
     Contract Unit := pure ()
 def setStructMember2 {κ₁ κ₂ α : Type}
     (_field : String) (_key1 : κ₁) (_key2 : κ₂) (_member : String) (_value : α) : Contract Unit := pure ()
+def erc20WriteEntry (name : String) (token : Address) (args : List Uint256) : ExternalCall :=
+  { linkedCallEntry name args with target := token.toNat }
+
 def safeTransfer (token toAddr : Address) (amount : Uint256) : Contract Unit :=
-  recordLinkedCall (linkedCallEntry "safeTransfer"
-    [Verity.addressToWord token, Verity.addressToWord toAddr, amount])
+  recordLinkedCall (erc20WriteEntry "safeTransfer" token
+    [Verity.addressToWord toAddr, amount])
 def safeTransferFrom (token fromAddr toAddr : Address) (amount : Uint256) : Contract Unit :=
-  recordLinkedCall (linkedCallEntry "safeTransferFrom"
-    [Verity.addressToWord token, Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount])
+  recordLinkedCall (erc20WriteEntry "safeTransferFrom" token
+    [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount])
 def safeApprove (token spender : Address) (amount : Uint256) : Contract Unit :=
-  recordLinkedCall (linkedCallEntry "safeApprove"
-    [Verity.addressToWord token, Verity.addressToWord spender, amount])
+  recordLinkedCall (erc20WriteEntry "safeApprove" token
+    [Verity.addressToWord spender, amount])
 def legacyStringSafeTransfer (token toAddr : Address) (amount : Uint256) : Contract Unit :=
-  recordLinkedCall (linkedCallEntry "legacyStringSafeTransfer"
-    [Verity.addressToWord token, Verity.addressToWord toAddr, amount])
+  recordLinkedCall (erc20WriteEntry "legacyStringSafeTransfer" token
+    [Verity.addressToWord toAddr, amount])
 def legacyStringSafeTransferFrom (token fromAddr toAddr : Address) (amount : Uint256) : Contract Unit :=
-  recordLinkedCall (linkedCallEntry "legacyStringSafeTransferFrom"
-    [Verity.addressToWord token, Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount])
+  recordLinkedCall (erc20WriteEntry "legacyStringSafeTransferFrom" token
+    [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount])
 
 @[simp] theorem safeTransfer_run (token toAddr : Address) (amount : Uint256) (s : ContractState) :
     (safeTransfer token toAddr amount).run s =
       ContractResult.success ()
         { s with calls := s.calls ++
-            [linkedCallEntry "safeTransfer"
-              [Verity.addressToWord token, Verity.addressToWord toAddr, amount]] } := rfl
+            [erc20WriteEntry "safeTransfer" token
+              [Verity.addressToWord toAddr, amount]] } := rfl
 
 @[simp] theorem safeTransferFrom_run (token fromAddr toAddr : Address) (amount : Uint256)
     (s : ContractState) :
     (safeTransferFrom token fromAddr toAddr amount).run s =
       ContractResult.success ()
         { s with calls := s.calls ++
-            [linkedCallEntry "safeTransferFrom"
-              [Verity.addressToWord token, Verity.addressToWord fromAddr,
-                Verity.addressToWord toAddr, amount]] } := rfl
+            [erc20WriteEntry "safeTransferFrom" token
+              [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]] } := rfl
 
 @[simp] theorem safeApprove_run (token spender : Address) (amount : Uint256)
     (s : ContractState) :
     (safeApprove token spender amount).run s =
       ContractResult.success ()
         { s with calls := s.calls ++
-            [linkedCallEntry "safeApprove"
-              [Verity.addressToWord token, Verity.addressToWord spender, amount]] } := rfl
+            [erc20WriteEntry "safeApprove" token
+              [Verity.addressToWord spender, amount]] } := rfl
 
 def balanceOf (token owner : Address) : Contract Uint256 := pure <| erc20ReadStubWord "balanceOf" [token.toNat, owner.toNat]
 def allowance (token owner spender : Address) : Contract Uint256 := pure <| erc20ReadStubWord "allowance" [token.toNat, owner.toNat, spender.toNat]

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -557,25 +557,119 @@ end Result
 
 end Call
 
-private def externalCallStubWord (name : String) (args : List Uint256) : Uint256 :=
+/-- Deterministic executable stand-in for a linked external call's return
+word. Public (not `private`) so specs and tests can state the executable
+plane's in-band results and journal entries verbatim. -/
+def externalCallStubWord (name : String) (args : List Uint256) : Uint256 :=
   match name, args with
   | "echo", [value] => value
   | _, _ => args.foldl add name.length
+
+/-- Executable success bit for a linked external call: every linked callee
+succeeds except the reserved name `"fail"`, which lets tests exercise the
+failure path of `callResult`/`tryExternalCall`. -/
+def externalCallStubSuccess (name : String) : Bool :=
+  name != "fail"
+
+/-- The journal entry recorded by the EDSL executable plane for one linked
+external call. Linked externals are name-keyed (the target address is bound
+at link time), so the callee identity lives in `name` and `siteId`/`target`
+are zero; the journal position records call order. `calldata` is the exact
+argument-word list in call order, so a call with omitted, reordered, or
+altered arguments journals a different entry. -/
+def linkedCallEntry (name : String) (argWords : List Uint256)
+    (control : ExternalCallControl := .success)
+    (returndata : List Nat := []) : ExternalCall :=
+  { siteId := 0
+    kind := .call
+    target := 0
+    value := 0
+    calldata := argWords.map (fun w => (w : Nat))
+    control := control
+    returndata := returndata
+    name := name }
+
+/-- Append one entry to the `ContractState.calls` journal. This is the sole
+observable-effect primitive of the executable linked-call family; a
+subsequent monadic revert rolls the entry back through `Contract.run`'s
+snapshot semantics, matching EVM top-level revert observability. -/
+def recordLinkedCall (entry : ExternalCall) : Contract Unit := fun state =>
+  ContractResult.success () { state with calls := state.calls ++ [entry] }
+
 def externalCallWords {α : Type} [ExternalResult α] (name : String) (args : List Uint256) : α :=
   ExternalResult.fromWord (externalCallStubWord name args)
 def callResultWords {α : Type} [ExternalResult α] [Inhabited α] (name : String) (args : List Uint256) :
-    Contract (Call.Result α) :=
-  let success := name != "fail"
-  let payload :=
-    if success then
-      ExternalResult.fromWord (externalCallStubWord name args)
-    else
-      Inhabited.default
-  pure { success := success, returndata := payload }
-def tryExternalCallWords {α : Type} [Inhabited α] (_name : String) (_args : List Uint256) : Contract (Bool × α) :=
-  pure (false, (Inhabited.default : α))
-def externalCallBind {α : Type} [ExternalArg α] (_names : List String) (_name : String) (_args : List α) : Contract Unit :=
-  pure ()
+    Contract (Call.Result α) := fun state =>
+  let success := externalCallStubSuccess name
+  let word := externalCallStubWord name args
+  let payload : α :=
+    if success then ExternalResult.fromWord word else Inhabited.default
+  let entry := linkedCallEntry name args
+    (if success then .success else .failure)
+    (if success then [(word : Nat)] else [])
+  ContractResult.success { success := success, returndata := payload }
+    { state with calls := state.calls ++ [entry] }
+def tryExternalCallWords {α : Type} [Inhabited α] (name : String) (args : List Uint256) : Contract (Bool × α) :=
+  fun state =>
+    let success := externalCallStubSuccess name
+    let entry := linkedCallEntry name args
+      (if success then .success else .failure)
+      (if success then [(externalCallStubWord name args : Nat)] else [])
+    ContractResult.success (success, (Inhabited.default : α))
+      { state with calls := state.calls ++ [entry] }
+def externalCallBind {α : Type} [ExternalArg α] (names : List String) (name : String) (args : List α) : Contract Unit :=
+  fun state =>
+    let argWords := args.map ExternalArg.toWord
+    let entry := linkedCallEntry name argWords .success
+      (names.map (fun _ => (externalCallStubWord name argWords : Nat)))
+    ContractResult.success () { state with calls := state.calls ++ [entry] }
+
+/-! ### Run laws for the executable linked-call family
+
+Each primitive succeeds and appends exactly one journal entry, so a
+duplicated, omitted, reordered, or argument-altered call is observably
+different at `ContractState.calls`. All laws are definitional (`rfl`). -/
+
+@[simp] theorem recordLinkedCall_run (entry : ExternalCall) (s : ContractState) :
+    (recordLinkedCall entry).run s =
+      ContractResult.success () { s with calls := s.calls ++ [entry] } := rfl
+
+@[simp] theorem externalCallBind_run {α : Type} [ExternalArg α]
+    (names : List String) (name : String) (args : List α) (s : ContractState) :
+    (externalCallBind names name args).run s =
+      ContractResult.success ()
+        { s with calls := s.calls ++
+            [linkedCallEntry name (args.map ExternalArg.toWord) .success
+              (names.map fun _ =>
+                (externalCallStubWord name (args.map ExternalArg.toWord) : Nat))] } := rfl
+
+@[simp] theorem callResultWords_run {α : Type} [ExternalResult α] [Inhabited α]
+    (name : String) (args : List Uint256) (s : ContractState) :
+    (callResultWords (α := α) name args).run s =
+      ContractResult.success
+        { success := externalCallStubSuccess name
+          returndata :=
+            if externalCallStubSuccess name then
+              ExternalResult.fromWord (externalCallStubWord name args)
+            else Inhabited.default }
+        { s with calls := s.calls ++
+            [linkedCallEntry name args
+              (if externalCallStubSuccess name then .success else .failure)
+              (if externalCallStubSuccess name then
+                [(externalCallStubWord name args : Nat)]
+              else [])] } := rfl
+
+@[simp] theorem tryExternalCallWords_run {α : Type} [Inhabited α]
+    (name : String) (args : List Uint256) (s : ContractState) :
+    (tryExternalCallWords (α := α) name args).run s =
+      ContractResult.success (externalCallStubSuccess name, (Inhabited.default : α))
+        { s with calls := s.calls ++
+            [linkedCallEntry name args
+              (if externalCallStubSuccess name then .success else .failure)
+              (if externalCallStubSuccess name then
+                [(externalCallStubWord name args : Nat)]
+              else [])] } := rfl
+
 private def erc20ReadStubWord (name : String) (args : List Uint256) : Uint256 :=
   externalCallStubWord name args
 macro_rules
@@ -614,11 +708,46 @@ def setStructMember {κ α : Type} (_field : String) (_key : κ) (_member : Stri
     Contract Unit := pure ()
 def setStructMember2 {κ₁ κ₂ α : Type}
     (_field : String) (_key1 : κ₁) (_key2 : κ₂) (_member : String) (_value : α) : Contract Unit := pure ()
-def safeTransfer (_token _to : Address) (_amount : Uint256) : Contract Unit := pure ()
-def safeTransferFrom (_token _fromAddr _to : Address) (_amount : Uint256) : Contract Unit := pure ()
-def safeApprove (_token _spender : Address) (_amount : Uint256) : Contract Unit := pure ()
-def legacyStringSafeTransfer (_token _to : Address) (_amount : Uint256) : Contract Unit := pure ()
-def legacyStringSafeTransferFrom (_token _fromAddr _to : Address) (_amount : Uint256) : Contract Unit := pure ()
+def safeTransfer (token toAddr : Address) (amount : Uint256) : Contract Unit :=
+  recordLinkedCall (linkedCallEntry "safeTransfer"
+    [Verity.addressToWord token, Verity.addressToWord toAddr, amount])
+def safeTransferFrom (token fromAddr toAddr : Address) (amount : Uint256) : Contract Unit :=
+  recordLinkedCall (linkedCallEntry "safeTransferFrom"
+    [Verity.addressToWord token, Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount])
+def safeApprove (token spender : Address) (amount : Uint256) : Contract Unit :=
+  recordLinkedCall (linkedCallEntry "safeApprove"
+    [Verity.addressToWord token, Verity.addressToWord spender, amount])
+def legacyStringSafeTransfer (token toAddr : Address) (amount : Uint256) : Contract Unit :=
+  recordLinkedCall (linkedCallEntry "legacyStringSafeTransfer"
+    [Verity.addressToWord token, Verity.addressToWord toAddr, amount])
+def legacyStringSafeTransferFrom (token fromAddr toAddr : Address) (amount : Uint256) : Contract Unit :=
+  recordLinkedCall (linkedCallEntry "legacyStringSafeTransferFrom"
+    [Verity.addressToWord token, Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount])
+
+@[simp] theorem safeTransfer_run (token toAddr : Address) (amount : Uint256) (s : ContractState) :
+    (safeTransfer token toAddr amount).run s =
+      ContractResult.success ()
+        { s with calls := s.calls ++
+            [linkedCallEntry "safeTransfer"
+              [Verity.addressToWord token, Verity.addressToWord toAddr, amount]] } := rfl
+
+@[simp] theorem safeTransferFrom_run (token fromAddr toAddr : Address) (amount : Uint256)
+    (s : ContractState) :
+    (safeTransferFrom token fromAddr toAddr amount).run s =
+      ContractResult.success ()
+        { s with calls := s.calls ++
+            [linkedCallEntry "safeTransferFrom"
+              [Verity.addressToWord token, Verity.addressToWord fromAddr,
+                Verity.addressToWord toAddr, amount]] } := rfl
+
+@[simp] theorem safeApprove_run (token spender : Address) (amount : Uint256)
+    (s : ContractState) :
+    (safeApprove token spender amount).run s =
+      ContractResult.success ()
+        { s with calls := s.calls ++
+            [linkedCallEntry "safeApprove"
+              [Verity.addressToWord token, Verity.addressToWord spender, amount]] } := rfl
+
 def balanceOf (token owner : Address) : Contract Uint256 := pure <| erc20ReadStubWord "balanceOf" [token.toNat, owner.toNat]
 def allowance (token owner spender : Address) : Contract Uint256 := pure <| erc20ReadStubWord "allowance" [token.toNat, owner.toNat, spender.toNat]
 def totalSupply (token : Address) : Contract Uint256 := pure <| erc20ReadStubWord "totalSupply" [token.toNat]

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -731,6 +731,16 @@ def setStructMember2 {κ₁ κ₂ α : Type}
 def erc20WriteEntry (name : String) (token : Address) (args : List Uint256) : ExternalCall :=
   { linkedCallEntry name args with target := token.toNat }
 
+def erc20ReadEntry (name : String) (token : Address) (args : List Uint256)
+    (result : Uint256) : ExternalCall :=
+  { linkedCallEntry name args .success [(result : Nat)] with target := token.toNat }
+
+def erc20Read (name : String) (token : Address) (args : List Uint256) : Contract Uint256 :=
+  fun state =>
+    let result := erc20ReadStubWord name (Verity.addressToWord token :: args)
+    ContractResult.success result
+      { state with calls := state.calls ++ [erc20ReadEntry name token args result] }
+
 def safeTransfer (token toAddr : Address) (amount : Uint256) : Contract Unit :=
   recordLinkedCall (erc20WriteEntry "safeTransfer" token
     [Verity.addressToWord toAddr, amount])
@@ -770,9 +780,36 @@ def legacyStringSafeTransferFrom (token fromAddr toAddr : Address) (amount : Uin
             [erc20WriteEntry "safeApprove" token
               [Verity.addressToWord spender, amount]] } := rfl
 
-def balanceOf (token owner : Address) : Contract Uint256 := pure <| erc20ReadStubWord "balanceOf" [token.toNat, owner.toNat]
-def allowance (token owner spender : Address) : Contract Uint256 := pure <| erc20ReadStubWord "allowance" [token.toNat, owner.toNat, spender.toNat]
-def totalSupply (token : Address) : Contract Uint256 := pure <| erc20ReadStubWord "totalSupply" [token.toNat]
+def balanceOf (token owner : Address) : Contract Uint256 :=
+  erc20Read "balanceOf" token [Verity.addressToWord owner]
+def allowance (token owner spender : Address) : Contract Uint256 :=
+  erc20Read "allowance" token
+    [Verity.addressToWord owner, Verity.addressToWord spender]
+def totalSupply (token : Address) : Contract Uint256 := erc20Read "totalSupply" token []
+
+@[simp] theorem balanceOf_run (token owner : Address) (s : ContractState) :
+    (balanceOf token owner).run s =
+      let result := erc20ReadStubWord "balanceOf"
+        [Verity.addressToWord token, Verity.addressToWord owner]
+      ContractResult.success result
+        { s with calls := s.calls ++
+            [erc20ReadEntry "balanceOf" token [Verity.addressToWord owner] result] } := rfl
+
+@[simp] theorem allowance_run (token owner spender : Address) (s : ContractState) :
+    (allowance token owner spender).run s =
+      let result := erc20ReadStubWord "allowance"
+        [Verity.addressToWord token, Verity.addressToWord owner,
+          Verity.addressToWord spender]
+      ContractResult.success result
+        { s with calls := s.calls ++
+            [erc20ReadEntry "allowance" token
+              [Verity.addressToWord owner, Verity.addressToWord spender] result] } := rfl
+
+@[simp] theorem totalSupply_run (token : Address) (s : ContractState) :
+    (totalSupply token).run s =
+      let result := erc20ReadStubWord "totalSupply" [Verity.addressToWord token]
+      ContractResult.success result
+        { s with calls := s.calls ++ [erc20ReadEntry "totalSupply" token [] result] } := rfl
 def forEach (_name : String) (_count : Uint256) (body : Contract Unit) : Contract Unit := body
 def blockTimestamp : Contract Uint256 := Verity.blockTimestamp
 def blockNumber : Contract Uint256 := Verity.blockNumber

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -8,6 +8,7 @@ import Contracts.Smoke.StructsAndArrays
 import Contracts.Smoke.HelperCalls
 import Contracts.Smoke.StructMappings
 import Contracts.Smoke.ExternalCalls
+import Contracts.Smoke.ExternalCallObservability
 import Contracts.Smoke.ExternalCallInBodySmoke
 import Contracts.Smoke.SpecGenAndChecks
 import Contracts.Smoke.Effects

--- a/Contracts/Smoke/ExternalCallObservability.lean
+++ b/Contracts/Smoke/ExternalCallObservability.lean
@@ -153,6 +153,28 @@ example :
         { defaultState with
             calls := [Contracts.linkedCallEntry "echo" [37] .success [37]] } := rfl
 
+/-- ERC-20 reads journal the token as target, ABI arguments as calldata, and
+the returned stub word as returndata. -/
+example (token owner : Address) :
+    ((Contracts.balanceOf token owner).run defaultState).snd.calls =
+      [Contracts.erc20ReadEntry "balanceOf" token
+        [Verity.addressToWord owner]
+        (Contracts.externalCallStubWord "balanceOf"
+          [Verity.addressToWord token, Verity.addressToWord owner])] := rfl
+
+example (token owner spender : Address) :
+    ((Contracts.allowance token owner spender).run defaultState).snd.calls =
+      [Contracts.erc20ReadEntry "allowance" token
+        [Verity.addressToWord owner, Verity.addressToWord spender]
+        (Contracts.externalCallStubWord "allowance"
+          [Verity.addressToWord token, Verity.addressToWord owner,
+            Verity.addressToWord spender])] := rfl
+
+example (token : Address) :
+    ((Contracts.totalSupply token).run defaultState).snd.calls =
+      [Contracts.erc20ReadEntry "totalSupply" token []
+        (Contracts.externalCallStubWord "totalSupply" [Verity.addressToWord token])] := rfl
+
 /-- Dynamic array encoding is length-delimited and retains every element. -/
 example : ExternalArg.toWords (#[11, 12] : Array Uint256) = [2, 11, 12] := rfl
 

--- a/Contracts/Smoke/ExternalCallObservability.lean
+++ b/Contracts/Smoke/ExternalCallObservability.lean
@@ -119,12 +119,12 @@ theorem double_send_observable (token toAddr : Address) (amount : Uint256)
       ((Contracts.safeTransfer token toAddr amount).run s).snd.calls := by
   intro h
   have hlen := congrArg List.length h
-  have : (s.calls ++ [Contracts.linkedCallEntry "safeTransfer"
-      [Verity.addressToWord token, Verity.addressToWord toAddr, amount]] ++
-      [Contracts.linkedCallEntry "safeTransfer"
-        [Verity.addressToWord token, Verity.addressToWord toAddr, amount]]).length =
-      (s.calls ++ [Contracts.linkedCallEntry "safeTransfer"
-        [Verity.addressToWord token, Verity.addressToWord toAddr, amount]]).length := hlen
+  have : (s.calls ++ [Contracts.erc20WriteEntry "safeTransfer" token
+      [Verity.addressToWord toAddr, amount]] ++
+      [Contracts.erc20WriteEntry "safeTransfer" token
+        [Verity.addressToWord toAddr, amount]]).length =
+      (s.calls ++ [Contracts.erc20WriteEntry "safeTransfer" token
+        [Verity.addressToWord toAddr, amount]]).length := hlen
   simp only [List.length_append, List.length_cons, List.length_nil] at this
   omega
 
@@ -143,6 +143,78 @@ example :
       [Contracts.linkedCallEntry "quote" [3, 4] .success
         [(Contracts.externalCallStubWord "quote" [3, 4] : Nat)]] := rfl
 
+/-- Successful `tryExternalCall` returns the same decoded word that its
+journal exposes as returndata. This distinguishes the old default-return
+mutant even when the call itself succeeded. -/
+example :
+    ((Contracts.tryExternalCallWords "echo" [37] :
+        Contract (Bool × Uint256)).run defaultState) =
+      ContractResult.success (true, 37)
+        { defaultState with
+            calls := [Contracts.linkedCallEntry "echo" [37] .success [37]] } := rfl
+
+/-- Dynamic array encoding is length-delimited and retains every element. -/
+example : ExternalArg.toWords (#[11, 12] : Array Uint256) = [2, 11, 12] := rfl
+
+/-- Same-length array content mutations are observable at the journal. -/
+theorem same_length_array_mutation_observable (s : ContractState) :
+    ((Contracts.externalCallBind ([] : List String) "arrayArg"
+        [(#[11, 12] : Array Uint256)]).run s).snd.calls ≠
+      ((Contracts.externalCallBind ([] : List String) "arrayArg"
+        [(#[11, 13] : Array Uint256)]).run s).snd.calls := by
+  show s.calls ++ [Contracts.linkedCallEntry "arrayArg" [2, 11, 12]] ≠
+      s.calls ++ [Contracts.linkedCallEntry "arrayArg" [2, 11, 13]]
+  intro h
+  have hpair := List.append_cancel_left h
+  have hhead : Contracts.linkedCallEntry "arrayArg" [2, 11, 12] =
+      Contracts.linkedCallEntry "arrayArg" [2, 11, 13] := by
+    simpa using congrArg
+      (List.headD · (Contracts.linkedCallEntry "arrayArg" [2, 11, 12])) hpair
+  exact absurd hhead (by decide)
+
+/-- Dynamic byte encoding is length-delimited and retains every byte. -/
+example : ExternalArg.toWords (⟨#[0x11, 0x12]⟩ : ByteArray) = [2, 0x11, 0x12] := rfl
+
+/-- Same-length byte content mutations are observable at the journal. -/
+theorem same_length_bytes_mutation_observable (s : ContractState) :
+    ((Contracts.externalCallBind ([] : List String) "bytesArg"
+        [(⟨#[0x11, 0x12]⟩ : ByteArray)]).run s).snd.calls ≠
+      ((Contracts.externalCallBind ([] : List String) "bytesArg"
+        [(⟨#[0x11, 0x13]⟩ : ByteArray)]).run s).snd.calls := by
+  show s.calls ++ [Contracts.linkedCallEntry "bytesArg" [2, 0x11, 0x12]] ≠
+      s.calls ++ [Contracts.linkedCallEntry "bytesArg" [2, 0x11, 0x13]]
+  intro h
+  have hpair := List.append_cancel_left h
+  have hhead : Contracts.linkedCallEntry "bytesArg" [2, 0x11, 0x12] =
+      Contracts.linkedCallEntry "bytesArg" [2, 0x11, 0x13] := by
+    simpa using congrArg
+      (List.headD · (Contracts.linkedCallEntry "bytesArg" [2, 0x11, 0x12])) hpair
+  exact absurd hhead (by decide)
+
+/-- ERC-20 wrappers journal the token as the actual call target and only the
+wrapper arguments as calldata. -/
+example (token toAddr : Address) (amount : Uint256) :
+    ((Contracts.safeTransfer token toAddr amount).run defaultState).snd.calls =
+      [{ siteId := 0, kind := .call, target := token.toNat, value := 0
+         calldata := [Core.Uint256.ofNat toAddr.toNat, amount], control := .success
+         returndata := [], name := "safeTransfer" }] := by
+  simp [Contracts.erc20WriteEntry, Contracts.linkedCallEntry, Verity.defaultState]
+
+example (token fromAddr toAddr : Address) (amount : Uint256) :
+    ((Contracts.safeTransferFrom token fromAddr toAddr amount).run defaultState).snd.calls =
+      [{ siteId := 0, kind := .call, target := token.toNat, value := 0
+         calldata := [Core.Uint256.ofNat fromAddr.toNat,
+           Core.Uint256.ofNat toAddr.toNat, amount], control := .success
+         returndata := [], name := "safeTransferFrom" }] := by
+  simp [Contracts.erc20WriteEntry, Contracts.linkedCallEntry, Verity.defaultState]
+
+example (token spender : Address) (amount : Uint256) :
+    ((Contracts.safeApprove token spender amount).run defaultState).snd.calls =
+      [{ siteId := 0, kind := .call, target := token.toNat, value := 0
+         calldata := [Core.Uint256.ofNat spender.toNat, amount], control := .success
+         returndata := [], name := "safeApprove" }] := by
+  simp [Contracts.erc20WriteEntry, Contracts.linkedCallEntry, Verity.defaultState]
+
 /-- The reserved `"fail"` callee journals a failure-control entry with no
 returndata, and reports `success := false` in-band. -/
 example :
@@ -155,6 +227,13 @@ example :
         Contract (Contracts.Call.Result Uint256)).run defaultState) =
       ContractResult.success
         { success := false, returndata := (Inhabited.default : Uint256) }
+        { defaultState with
+            calls := [Contracts.linkedCallEntry "fail" [9] .failure []] } := rfl
+
+example :
+    ((Contracts.tryExternalCallWords "fail" [9] :
+        Contract (Bool × Uint256)).run defaultState) =
+      ContractResult.success (false, (Inhabited.default : Uint256))
         { defaultState with
             calls := [Contracts.linkedCallEntry "fail" [9] .failure []] } := rfl
 

--- a/Contracts/Smoke/ExternalCallObservability.lean
+++ b/Contracts/Smoke/ExternalCallObservability.lean
@@ -154,13 +154,18 @@ example :
             calls := [Contracts.linkedCallEntry "echo" [37] .success [37]] } := rfl
 
 /-- ERC-20 reads journal the token as target, ABI arguments as calldata, and
-the returned stub word as returndata. -/
+the returned stub word as returndata, using the same `staticcall` kind as the
+compiled ERC-20 modules. -/
 example (token owner : Address) :
     ((Contracts.balanceOf token owner).run defaultState).snd.calls =
       [Contracts.erc20ReadEntry "balanceOf" token
         [Verity.addressToWord owner]
         (Contracts.externalCallStubWord "balanceOf"
           [Verity.addressToWord token, Verity.addressToWord owner])] := rfl
+
+example (token owner : Address) :
+    ((Contracts.balanceOf token owner).run defaultState).snd.calls.map
+      (fun call => call.kind) = [.staticcall] := rfl
 
 example (token owner spender : Address) :
     ((Contracts.allowance token owner spender).run defaultState).snd.calls =
@@ -258,6 +263,13 @@ example :
       ContractResult.success (false, (Inhabited.default : Uint256))
         { defaultState with
             calls := [Contracts.linkedCallEntry "fail" [9] .failure []] } := rfl
+
+/-- Bubbling linked calls do not continue after the reserved failure stub.
+`Contract.run` rolls the failed crossing back to the caller's snapshot. -/
+example (s : ContractState) :
+    (Contracts.externalCallBind ([] : List String) "fail"
+      ([9] : List Uint256)).run s =
+      ContractResult.revert "external call failed" s := rfl
 
 /-- A monadic revert after a call rolls the journal entry back through
 `Contract.run`'s snapshot semantics: a fully reverted execution leaves

--- a/Contracts/Smoke/ExternalCallObservability.lean
+++ b/Contracts/Smoke/ExternalCallObservability.lean
@@ -1,0 +1,171 @@
+import Contracts.Common
+
+/-!
+# Observability of the executable linked-call family
+
+Discriminating checks that the EDSL executable plane's external-call
+primitives (`externalCallBind`, `callResultWords`, `tryExternalCallWords`,
+and the `safeTransfer` family) thread an observable effect through
+`ContractState.calls`. Each theorem *runs* a program and separates it from a
+mutant at the journal:
+
+* a duplicated call is observably different from a single call;
+* an omitted call is observably different from the original program;
+* reordered calls are observably different from the original order;
+* a renamed callee or an altered/zeroed argument journals a different entry;
+* a monadic revert after a call rolls the entry back through `Contract.run`,
+  matching EVM top-level revert observability.
+
+The mutant separations are stated over an arbitrary pre-state, not just
+`defaultState`, so they hold in every reachable world.
+-/
+
+namespace Contracts.Smoke.ExternalCallObservability
+
+open Contracts
+open Verity hiding pure bind
+
+private def notify (arg : Uint256) : Contract Unit :=
+  Contracts.externalCallBind ([] : List String) "notify" [arg]
+
+private def notifyEntry (arg : Uint256) : ExternalCall :=
+  Contracts.linkedCallEntry "notify" [arg]
+
+/-- One call appends exactly one journal entry. -/
+theorem single_call_journals_one_entry (s : ContractState) :
+    ((notify 1).run s).snd.calls = s.calls ++ [notifyEntry 1] := rfl
+
+/-- (a) Duplication is observable: calling twice journals two entries, so the
+double-call mutant is separated from the original program by `calls` — in
+every pre-state. This is the executable-plane rejection of the double-send
+mutant class. -/
+theorem duplicated_call_observable (s : ContractState) :
+    (((do notify 1; notify 1) : Contract Unit).run s).snd.calls ≠
+      ((notify 1).run s).snd.calls := by
+  show s.calls ++ [notifyEntry 1] ++ [notifyEntry 1] ≠ s.calls ++ [notifyEntry 1]
+  intro h
+  have hlen := congrArg List.length h
+  simp only [List.length_append, List.length_cons, List.length_nil] at hlen
+  omega
+
+/-- (b) Omission is observable: dropping the second call of a two-call
+program changes the journal in every pre-state. -/
+theorem omitted_call_observable (s : ContractState) :
+    (((do notify 1; notify 2) : Contract Unit).run s).snd.calls ≠
+      ((notify 1).run s).snd.calls := by
+  show s.calls ++ [notifyEntry 1] ++ [notifyEntry 2] ≠ s.calls ++ [notifyEntry 1]
+  intro h
+  have hlen := congrArg List.length h
+  simp only [List.length_append, List.length_cons, List.length_nil] at hlen
+  omega
+
+/-- (b) Reordering is observable: `alpha; beta` and `beta; alpha` journal
+different traces in every pre-state. -/
+theorem reordered_calls_observable (s : ContractState) :
+    (((do Contracts.externalCallBind ([] : List String) "alpha" ([1] : List Uint256)
+          Contracts.externalCallBind ([] : List String) "beta" ([1] : List Uint256)) :
+        Contract Unit).run s).snd.calls ≠
+      (((do Contracts.externalCallBind ([] : List String) "beta" ([1] : List Uint256)
+            Contracts.externalCallBind ([] : List String) "alpha" ([1] : List Uint256)) :
+        Contract Unit).run s).snd.calls := by
+  show s.calls ++ [Contracts.linkedCallEntry "alpha" [1]] ++
+        [Contracts.linkedCallEntry "beta" [1]] ≠
+      s.calls ++ [Contracts.linkedCallEntry "beta" [1]] ++
+        [Contracts.linkedCallEntry "alpha" [1]]
+  rw [List.append_assoc, List.append_assoc]
+  intro h
+  have hpair := List.append_cancel_left h
+  have hhead : Contracts.linkedCallEntry "alpha" [1] =
+      Contracts.linkedCallEntry "beta" [1] := by
+    simpa using congrArg (List.headD · (Contracts.linkedCallEntry "alpha" [1])) hpair
+  exact absurd hhead (by decide)
+
+/-- (b) A renamed callee is observable: the journal entry carries the linked
+name, so calling `transferFrom` instead of `transfer` is separated in every
+pre-state. -/
+theorem renamed_call_observable (s : ContractState) :
+    ((Contracts.externalCallBind ([] : List String) "transfer"
+        ([2] : List Uint256)).run s).snd.calls ≠
+      ((Contracts.externalCallBind ([] : List String) "transferFrom"
+        ([2] : List Uint256)).run s).snd.calls := by
+  show s.calls ++ [Contracts.linkedCallEntry "transfer" [2]] ≠
+      s.calls ++ [Contracts.linkedCallEntry "transferFrom" [2]]
+  intro h
+  have hpair := List.append_cancel_left h
+  have hhead : Contracts.linkedCallEntry "transfer" [2] =
+      Contracts.linkedCallEntry "transferFrom" [2] := by
+    simpa using congrArg (List.headD · (Contracts.linkedCallEntry "transfer" [2])) hpair
+  exact absurd hhead (by decide)
+
+/-- (b) A zeroed argument is observable: `calldata` records the exact
+argument words, so `notify 0` is separated from `notify 7`. -/
+theorem zeroed_arg_observable (s : ContractState) :
+    ((notify 7).run s).snd.calls ≠ ((notify 0).run s).snd.calls := by
+  show s.calls ++ [notifyEntry 7] ≠ s.calls ++ [notifyEntry 0]
+  intro h
+  have hpair := List.append_cancel_left h
+  have hhead : notifyEntry 7 = notifyEntry 0 := by
+    simpa using congrArg (List.headD · (notifyEntry 7)) hpair
+  exact absurd hhead (by decide)
+
+/-- The double-send separation in `safeTransfer` form: sending twice is
+observably different from sending once, in every pre-state. A deposit-style
+theorem quantified over `calls` therefore rejects the double-send mutant by
+running the program, not by auxiliary record arithmetic. -/
+theorem double_send_observable (token toAddr : Address) (amount : Uint256)
+    (s : ContractState) :
+    (((do Contracts.safeTransfer token toAddr amount
+          Contracts.safeTransfer token toAddr amount) : Contract Unit).run s).snd.calls ≠
+      ((Contracts.safeTransfer token toAddr amount).run s).snd.calls := by
+  intro h
+  have hlen := congrArg List.length h
+  have : (s.calls ++ [Contracts.linkedCallEntry "safeTransfer"
+      [Verity.addressToWord token, Verity.addressToWord toAddr, amount]] ++
+      [Contracts.linkedCallEntry "safeTransfer"
+        [Verity.addressToWord token, Verity.addressToWord toAddr, amount]]).length =
+      (s.calls ++ [Contracts.linkedCallEntry "safeTransfer"
+        [Verity.addressToWord token, Verity.addressToWord toAddr, amount]]).length := hlen
+  simp only [List.length_append, List.length_cons, List.length_nil] at this
+  omega
+
+/-- `callResult` and `tryExternalCall` journal their crossing too: the
+success path records the callee name, argument words, control, and the
+in-band stub word. -/
+example :
+    ((Contracts.callResultWords "quote" [3, 4] :
+        Contract (Contracts.Call.Result Uint256)).run defaultState).snd.calls =
+      [Contracts.linkedCallEntry "quote" [3, 4] .success
+        [(Contracts.externalCallStubWord "quote" [3, 4] : Nat)]] := rfl
+
+example :
+    ((Contracts.tryExternalCallWords "quote" [3, 4] :
+        Contract (Bool × Uint256)).run defaultState).snd.calls =
+      [Contracts.linkedCallEntry "quote" [3, 4] .success
+        [(Contracts.externalCallStubWord "quote" [3, 4] : Nat)]] := rfl
+
+/-- The reserved `"fail"` callee journals a failure-control entry with no
+returndata, and reports `success := false` in-band. -/
+example :
+    ((Contracts.callResultWords "fail" [9] :
+        Contract (Contracts.Call.Result Uint256)).run defaultState).snd.calls =
+      [Contracts.linkedCallEntry "fail" [9] .failure []] := rfl
+
+example :
+    ((Contracts.callResultWords "fail" [9] :
+        Contract (Contracts.Call.Result Uint256)).run defaultState) =
+      ContractResult.success
+        { success := false, returndata := (Inhabited.default : Uint256) }
+        { defaultState with
+            calls := [Contracts.linkedCallEntry "fail" [9] .failure []] } := rfl
+
+/-- A monadic revert after a call rolls the journal entry back through
+`Contract.run`'s snapshot semantics: a fully reverted execution leaves
+nothing observable, matching EVM top-level behaviour (and the documented
+contrast with the model plane's revert-surviving journal). -/
+theorem revert_rolls_back_journal (token toAddr : Address) (amount : Uint256)
+    (s : ContractState) :
+    (((do Contracts.safeTransfer token toAddr amount
+          require false "boom") : Contract Unit).run s) =
+      ContractResult.revert "boom" s := rfl
+
+end Contracts.Smoke.ExternalCallObservability

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -71,7 +71,8 @@ example :
         defaultState =
       ContractResult.success
         { success := true, returndata := (7 : Uint256) }
-        defaultState := by
+        { defaultState with
+            calls := [Contracts.linkedCallEntry "echo" [7] .success [7]] } := by
   rfl
 
 namespace StatefulExternalSmoke

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -211,15 +211,20 @@ verbatim.
 
 The **EDSL executable plane** journals through the same field: the linked-call
 primitives (`Contracts.externalCallBind`, `Contracts.callResultWords`,
-`Contracts.tryExternalCallWords`, the `safeTransfer` family) append a
-name-keyed entry (`Contracts.linkedCallEntry`, `siteId`/`target` = 0, exact
-argument words in `calldata`) per call. Trust boundaries of that plane:
+`Contracts.tryExternalCallWords`, the `safeTransfer` family) append one entry
+per call. General linked calls are name-keyed (`Contracts.linkedCallEntry`,
+`siteId`/`target` = 0). ERC-20 writes record the token as `target`, their actual
+wrapper arguments as `calldata`, and the wrapper name. `ExternalArg.toWords`
+retains scalar values and length-prefixes arrays/byte arrays before their full
+recursive content; this is a deterministic journal-word encoding, not a claim
+of byte-for-byte EVM ABI layout. Trust boundaries of that plane:
 - **Return values are deterministic stubs, not adversary models.** In-band
   words come from `externalCallStubWord`; the success bit is
   `externalCallStubSuccess` (`false` only for the reserved callee name
-  `"fail"`). Executable-plane theorems about call *outcomes* are therefore
-  claims about the stub, not about a real callee; adversarial reasoning
-  lives in the model plane (`DenoteExternalCalls`).
+  `"fail"`). Supported single-word results decode that same word; aggregate
+  and no-result stubs use their inhabited default. Executable-plane theorems
+  about call *outcomes* are therefore claims about the stub, not about a real
+  callee; adversarial reasoning lives in the model plane (`DenoteExternalCalls`).
 - **`externalCallWords` (pure expression form) does not journal.** It is not
   monadic, so `externalCall name [args]` used as a pure expression remains
   observationally silent; only the monadic forms journal. Specs that need

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -209,6 +209,28 @@ primitive `externalCall` (`Verity.Core.Model.ContractExternalCall`):
 `denoteCall` itself is unchanged; all previously proven world/gas laws hold
 verbatim.
 
+The **EDSL executable plane** journals through the same field: the linked-call
+primitives (`Contracts.externalCallBind`, `Contracts.callResultWords`,
+`Contracts.tryExternalCallWords`, the `safeTransfer` family) append a
+name-keyed entry (`Contracts.linkedCallEntry`, `siteId`/`target` = 0, exact
+argument words in `calldata`) per call. Trust boundaries of that plane:
+- **Return values are deterministic stubs, not adversary models.** In-band
+  words come from `externalCallStubWord`; the success bit is
+  `externalCallStubSuccess` (`false` only for the reserved callee name
+  `"fail"`). Executable-plane theorems about call *outcomes* are therefore
+  claims about the stub, not about a real callee; adversarial reasoning
+  lives in the model plane (`DenoteExternalCalls`).
+- **`externalCallWords` (pure expression form) does not journal.** It is not
+  monadic, so `externalCall name [args]` used as a pure expression remains
+  observationally silent; only the monadic forms journal. Specs that need
+  call observability must use the monadic primitives.
+- **`callExternal name(args)` surface and the mapping stubs**
+  (`getMappingWord`/`setMappingWord`/`getMappingN`/`setMappingN`) remain
+  unmodeled no-ops at this plane.
+- A full monadic revert through `Contract.run` rolls the journal back with
+  the rest of the snapshot (top-level EVM semantics), unlike the model
+  plane's caller-side rollback survival described above.
+
 ### Reentrancy Guard (`nonreentrant(lockField)`)
 Functions annotated `nonreentrant(lockField)` are compiled with a
 **transient-storage** reentrancy guard prologue (#1893): an

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -197,6 +197,11 @@ structure ExternalCall where
   calldata : List Nat := []
   control : ExternalCallControl
   returndata : List Nat := []
+  /-- Linked-external name for entries journaled by the EDSL executable
+  plane, where callees are keyed by name rather than address (the address
+  is bound at link time). Address-keyed model-plane entries
+  (`DenoteExternalCalls.journalEntry`) leave it empty. -/
+  name : String := ""
   deriving DecidableEq, Repr
 
 -- State monad for contract execution

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 1178,
+    "core_lines": 1183,
     "example_contracts": 18
   },
   "proofs": {


### PR DESCRIPTION
## Summary

The EDSL executable plane's linked-call primitives (`externalCallBind`, `callResultWords`, `tryExternalCallWords`, and the `safeTransfer` family) were `pure ()` no-ops: executable-plane theorems quantified over `ContractState.calls` could not observe whether a call happened at all, so double-send, omission, reorder, rename, and argument mutants were indistinguishable at run level.

This PR makes each primitive append a name-keyed `ExternalCall` entry to `ContractState.calls`:

- `Verity.Core.ExternalCall` gains a defaulted `name : String := ""` field (existing address-keyed model-plane entries unaffected).
- `Contracts.linkedCallEntry` builds the entry: exact argument words as calldata, `.success`/`.failure` control, in-band stub returndata; `externalCallStubWord` is now public and `externalCallStubSuccess` reserves the `"fail"` callee for the failure path.
- All run-lemmas are `@[simp] … := rfl`; the compiler pipeline consumes model bodies (IR constructors), so Yul generation and difftests are unaffected.
- New smoke module `Contracts/Smoke/ExternalCallObservability.lean` *runs* the programs and separates every mutant class from the original over an **arbitrary pre-state**: duplicated call, omitted call, reordered calls, renamed callee, zeroed argument, and the `safeTransfer` double-send form. It also proves a monadic revert rolls the journal entry back through `Contract.run`'s snapshot semantics (EVM top-level revert observability).
- `TRUST_ASSUMPTIONS.md` documents the remaining boundary (stub-not-adversary; the pure `externalCallWords` form stays non-journaling; unmodeled `callExternal`/mapping stubs); `AUDIT.md` records the new axiom-free surface.

Adopted from an abandoned unpushed WIP based on `0fd1c2f8` (= current main), completed with compile fixes: `to` is a reserved token in the Lean grammar (binders renamed `toAddr`), a no-progress `simp only` removed, and the `"fail"`-callee example restated as a full `ContractResult` equality to avoid a missing `Inhabited (Call.Result Uint256)` instance.

Campaign context: continues the bounded Verity→Lido closure campaign from milestone minimal-11 `25c82e13`, with the Lido model pinned to Verity main `04729a9` (Lido PR #69 remains review-first and unmerged). A vacuous `externalCallBind := pure ()` was explicitly ruled out as a TX close; this PR is the non-vacuous repair.

## Test Plan

- [x] `lake build` — exit 0 (2471 jobs)
- [x] `lake build Contracts PrintAxioms Compiler.CompilationModelFeatureTest` — exit 0 (2695 jobs); zero `sorry` in the log; no warnings in touched files
- [x] Zero new proof escapes: `git diff | grep -E '^\+.*(sorry|admit|\baxiom\b|unsafe|native_decide|@\[implemented_by)'` → no matches (also checked the new smoke file)
- [x] `make check` — green except `test_profile_ci_resources` (container lacks GNU `/usr/bin/time`; environmental, unrelated to this diff)
- [x] `artifacts/verification_status.json` regenerated (core_lines 1098→1103)
- [ ] Foundry difftests (`FOUNDRY_PROFILE=difftest forge test`) — forge unavailable in this container; deferred to CI
- [ ] Exact-head CI (verify.yml) on this PR head

## Related Issues

Addresses part of #2084 (Tier 4 — external calls & low-level mechanics): run-level observability of the executable linked-call family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes executable-plane semantics for external-call stubs and ERC-20 helpers used in specs and smoke tests, but leaves the adversary model plane untouched and documents remaining gaps (pure `externalCallWords`, stub outcomes).
> 
> **Overview**
> Linked-call primitives in the EDSL executable plane (`externalCallBind`, `callResultWords`, `tryExternalCallWords`, ERC-20 helpers) **append** `Verity.ExternalCall` entries to `ContractState.calls` instead of behaving as silent no-ops, so run-level specs can distinguish duplicate, omitted, reordered, renamed, and argument-mutated call patterns.
> 
> `ExternalCall` gains a defaulted `name` field for name-keyed linked externals; `ExternalArg.toWords` replaces size-only encoding with length-prefixed full content for arrays and bytes. Stub semantics (`externalCallStubWord`, `externalCallStubSuccess` with reserved `"fail"`) drive in-band results and journal returndata; pure `externalCallWords` still does not journal.
> 
> New `Contracts/Smoke/ExternalCallObservability.lean` proves mutant separation over arbitrary pre-states and revert rollback of the journal via `Contract.run`. `AUDIT.md` and `TRUST_ASSUMPTIONS.md` document the executable-plane boundaries; model plane unchanged and axiom-free.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6543ff1cb92091901fb638ecf310cea42548890f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->