### PR TITLE
feat(core): canonical StorageKey backing for ContractState

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -298,6 +298,25 @@ sibling entrypoint.
   `TypedIRCompilerCorrectness`, and the contract proof suites). No theorem
   statement changed; no semantic change; zero axioms.
 
+## StorageKey Canonical Backing — C5 Step 3 (2026-08)
+
+- `ContractState` now stores word-valued channels in one
+  `storageWords : StorageKey → Uint256` map. `StorageKey` is an injective
+  inductive (`slot` / `contractSlot` / `transient` / `addr` / `map` /
+  `mapUint` / `map2`). Solidity keccak slot derivation stays on the
+  compiler side; lens laws use constructor injectivity, not hash
+  injectivity.
+- Public accessors keep the old names (`storage`, `storageAddr`,
+  `storageMap`, …). Specs that read those views do not change shape.
+  `storageArray` and `knownAddresses` remain separate fields this step.
+- The freeze baseline shrinks to `Verity/Core.lean` (lens
+  implementations) plus `Contracts/TypedIRTests.lean` (IRState field-name
+  collisions). `storageWords :=` is forbidden outside `Verity/Core.lean`.
+- Not C5 step 4: there is still no proved `storageKeySlot` /
+  `MappingCoherent` correspondence between these source keys and
+  CompilationModel/Yul slots.
+- Zero new axioms.
+
 ## CI Guards
 
 - `make check` validates generated reports, bridge coverage synchronization,

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -22,6 +22,10 @@ by replacing the opaque FFI-based keccak256 call with the kernel-computable
 Keccak engine (`Compiler/Keccak/Sponge.lean`), which exposes the 32-byte
 output-length guarantee to Lean's proof system.
 
+C5 step 3 (`ContractState.storageWords` over injective `StorageKey`) does
+not add a keccak-injectivity axiom. Source lens laws use constructor
+injectivity; Solidity slot derivation remains compiler-side.
+
 ## Eliminated Axioms
 
 ### 1. `solidityMappingSlot_lt_evmModulus` (eliminated)

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -5523,8 +5523,7 @@ private def expectedWord : Nat := 1 + 7 * 2 ^ 1 + 9 * 2 ^ 113
 
 private def preservesAdjacentPackedFields : Bool :=
   let world : Verity.ContractState :=
-    { Verity.defaultState with
-      «storage» := fun s => if s == packedSlot then oldWord else 0 }
+    Verity.ContractState.writeSlot Verity.defaultState packedSlot oldWord
   let state : Denote.DenoteState := { world := world, bindings := [] }
   match Denote.execStmt oracle fields state
       (Stmt.setStructMember "deposits" (.literal key) "stake" (.literal 7)) with

--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -240,7 +240,16 @@ theorem writeAddressKeyedMappingSlots_eq
         SourceSemantics.writeAddressKeyedMappingSlots,
         Verity.ContractState.withStorageChannel, Verity.ContractState.writeMap]
       congr 1
-      exact storage_field_eq_of_rel h
+      funext storageKey
+      by_cases hmap :
+          storageKey =
+            Verity.StorageKey.map slot (Verity.wordToAddress (Verity.Core.Uint256.ofNat k))
+      · subst hmap; simp
+      · simp [hmap]
+        cases storageKey with
+        | slot s =>
+            exact congrFun (storage_field_eq_of_rel h) s
+        | _ => rfl
 
 theorem writeUintKeyedMappingSlots_eq
     (w : Verity.ContractState) (slots : List Nat) (k v : Nat) :
@@ -254,7 +263,15 @@ theorem writeUintKeyedMappingSlots_eq
         SourceSemantics.writeUintKeyedMappingSlots,
         Verity.ContractState.withStorageChannel, Verity.ContractState.writeMapUint]
       congr 1
-      exact storage_field_eq_of_rel h
+      funext storageKey
+      by_cases hmap :
+          storageKey = Verity.StorageKey.mapUint slot (Verity.Core.Uint256.ofNat k)
+      · subst hmap; simp
+      · simp [hmap]
+        cases storageKey with
+        | slot s =>
+            exact congrFun (storage_field_eq_of_rel h) s
+        | _ => rfl
 
 theorem writeAddressKeyedMapping2Slots_eq
     (w : Verity.ContractState) (slots : List Nat) (k1 k2 v : Nat) :
@@ -269,7 +286,18 @@ theorem writeAddressKeyedMapping2Slots_eq
         SourceSemantics.writeAddressKeyedMapping2Slots,
         Verity.ContractState.withStorageChannel, Verity.ContractState.writeMap2]
       congr 1
-      exact storage_field_eq_of_rel h
+      funext storageKey
+      by_cases hmap :
+          storageKey =
+            Verity.StorageKey.map2 slot
+              (Verity.wordToAddress (Verity.Core.Uint256.ofNat k1))
+              (Verity.wordToAddress (Verity.Core.Uint256.ofNat k2))
+      · subst hmap; simp
+      · simp [hmap]
+        cases storageKey with
+        | slot s =>
+            exact congrFun (storage_field_eq_of_rel h) s
+        | _ => rfl
 
 @[simp] theorem fieldIsTransient_eq (fields : List Field) (fieldName : String) :
     Denote.fieldIsTransient fields fieldName =

--- a/Compiler/Proofs/IRGeneration/FunctionBody/Stmt.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody/Stmt.lean
@@ -460,7 +460,10 @@ theorem runtimeStateMatchesIR_setTransientStorage
     funext o
     by_cases ho : o = offset
     · subst ho
-      simp only [ite_true, Verity.Core.Uint256.ofNat, Nat.mod_eq_of_lt hvalue]
+      simp [ite_true, Verity.ContractState.transientStorage_writeTransient_same,
+        Verity.Core.Uint256.ofNat]
+      have hmod : Verity.Core.Uint256.modulus = Compiler.Constants.evmModulus := rfl
+      exact (Nat.mod_eq_of_lt (hmod ▸ hvalue)).symm
     · simp [ho]
       exact congrFun htrans o
 

--- a/Compiler/Proofs/IRGeneration/FunctionBody/Stmt.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody/Stmt.lean
@@ -444,10 +444,7 @@ theorem runtimeStateMatchesIR_setTransientStorage
     (hvalue : value < Verity.Core.Uint256.modulus) :
     runtimeStateMatchesIR fields
       { runtime with
-          world := {
-            runtime.world with
-            transientStorage := fun o => if o = offset then value else runtime.world.transientStorage o
-          } }
+          world := runtime.world.writeTransient offset value }
       { state with
           transientStorage := fun o => if o = offset then value else state.transientStorage o } := by
   cases runtime
@@ -3451,11 +3448,7 @@ theorem exec_compileStmtList_core
           let offsetKey := offsetNat % Compiler.Constants.evmModulus
           let runtime' :=
             { runtime with
-              world := {
-                runtime.world with
-                transientStorage := fun o =>
-                  if o = offsetKey then valueNat else runtime.world.transientStorage o
-              } }
+              world := runtime.world.writeTransient offsetKey valueNat }
           let state' := { state with
             transientStorage := fun o => if o = offsetKey then valueNat else state.transientStorage o }
           have hvalueLt := evalExpr_lt_evmModulus_core_onExpr hvalue
@@ -3950,11 +3943,7 @@ theorem exec_compileStmtList_core_extraFuel
           let offsetKey := offsetNat % Compiler.Constants.evmModulus
           let runtime' :=
             { runtime with
-              world := {
-                runtime.world with
-                transientStorage := fun o =>
-                  if o = offsetKey then valueNat else runtime.world.transientStorage o
-              } }
+              world := runtime.world.writeTransient offsetKey valueNat }
           let state' := { state with
             transientStorage := fun o => if o = offsetKey then valueNat else state.transientStorage o }
           have hvalueLt := evalExpr_lt_evmModulus_core_onExpr hvalue
@@ -7804,11 +7793,7 @@ theorem exec_compileStmtList_terminal_core_sizeOf_extraFuel
           let offsetKey := offsetNat % Compiler.Constants.evmModulus
           let runtime' :=
             { runtime with
-              world := {
-                runtime.world with
-                transientStorage := fun o =>
-                  if o = offsetKey then valueNat else runtime.world.transientStorage o
-              } }
+              world := runtime.world.writeTransient offsetKey valueNat }
           let state' := { state with
             transientStorage := fun o => if o = offsetKey then valueNat else state.transientStorage o }
           have hvalueLt := evalExpr_lt_evmModulus_core_of_scope hvalue hexact hinScopeValue hbounded hpresentValue hruntime

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
@@ -2836,11 +2836,7 @@ private theorem compiledStmtStep_tstore_single_preserves
       let offsetKey := offsetNat % Compiler.Constants.evmModulus
       set runtime' := {
         runtime with
-        world := {
-          runtime.world with
-          transientStorage := fun o =>
-            if o = offsetKey then valueNat else runtime.world.transientStorage o
-        }
+        world := runtime.world.writeTransient offsetKey valueNat
       }
       have hSrcExec : SourceSemantics.execStmt fields runtime
           (.tstore offset value) = .continue runtime' := by

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
@@ -12,9 +12,14 @@ open Compiler.CompilationModel
 open Compiler.Yul
 
 attribute [local simp] CompilationModel.compileExprWithInternals_nil_eq
-attribute [local simp] Verity.ContractState.storage Verity.ContractState.storageAddr
-  Verity.ContractState.transientStorage Verity.ContractState.storageMap
-  Verity.ContractState.storageMapUint Verity.ContractState.storageMap2
+
+private theorem singleton_contains_false {x y : Nat} (h : y ≠ x) :
+    [x].contains y = false :=
+  Bool.eq_false_iff.2 fun hcont =>
+    h (List.mem_singleton.mp ((List.contains_iff_mem).mp hcont))
+
+private theorem singleton_contains_true (x : Nat) : [x].contains x = true :=
+  (List.contains_iff_mem).mpr (List.mem_singleton.mpr rfl)
 
 private theorem compileExprWithInternals_nil_ok
     {fields : List Field} {dynamicSource : DynamicDataSource} {expr : Expr} {exprIR : YulExpr}
@@ -43,10 +48,10 @@ private theorem encodeStorageAt_writeUintSlots_singleton_other
   · have hneq' : query ≠ slot % Compiler.Constants.evmModulus := by
       simpa [SourceSemantics.wordNormalize] using hneq
     simp [SourceSemantics.writeUintSlots, SourceSemantics.wordNormalize]
-    have hfalse : [slot % Compiler.Constants.evmModulus].contains query = false := by
-      simp [List.contains, hneq']
+    have hfalse : [slot % Compiler.Constants.evmModulus].contains query = false :=
+      singleton_contains_false hneq'
     exact Verity.ContractState.storage_writeSlots_not_mem _ _ _ hfalse
-  · simp [SourceSemantics.writeUintSlots]
+  · simp [SourceSemantics.writeUintSlots, Verity.ContractState.storageAddr_writeSlots]
   · simp [SourceSemantics.writeUintSlots]
 
 private theorem encodeStorageAt_writeUintSlots_other
@@ -64,7 +69,7 @@ private theorem encodeStorageAt_writeUintSlots_other
     have hfalse : (slots.map SourceSemantics.wordNormalize).contains query = false := by
       simpa [List.contains_iff_mem] using hnotMem
     exact Verity.ContractState.storage_writeSlots_not_mem _ _ _ hfalse
-  · simp [SourceSemantics.writeUintSlots]
+  · simp [SourceSemantics.writeUintSlots, Verity.ContractState.storageAddr_writeSlots]
   · simp [SourceSemantics.writeUintSlots]
 
 set_option maxHeartbeats 800000 in
@@ -122,10 +127,11 @@ private theorem encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_oth
       SourceSemantics.wordNormalize]
     have hfalse :
         [SourceSemantics.mappingSlotChain slot keys % Compiler.Constants.evmModulus].contains query =
-          false := by
-      simp [List.contains, hneq']
+          false :=
+      singleton_contains_false hneq'
     exact Verity.ContractState.storage_writeSlots_not_mem _ _ _ hfalse
-  · simp [SourceSemantics.writeAddressKeyedMappingChainSlots]
+  · simp [SourceSemantics.writeAddressKeyedMappingChainSlots,
+      Verity.ContractState.storageAddr_writeSlots]
   · simp [SourceSemantics.writeAddressKeyedMappingChainSlots]
 
 def mappingWordTargetSlot (slot key wordOffset : Nat) : Nat :=
@@ -209,6 +215,13 @@ theorem mapping2WordTargetSlot_eq_uint256_add (slot key1 key2 wordOffset : Nat) 
   unfold mapping2WordTargetSlot SourceSemantics.wordNormalize
   simpa [Compiler.Proofs.abstractMappingSlot_eq_solidity]
 
+private theorem mapping2WordTargetSlot_eq_mod (slot key1 key2 wordOffset : Nat) :
+    mapping2WordTargetSlot slot key1 key2 wordOffset =
+      (Compiler.Proofs.solidityMappingSlot
+        (Compiler.Proofs.solidityMappingSlot slot key1) key2 + wordOffset) %
+        Compiler.Constants.evmModulus := by
+  rw [mapping2WordTargetSlot_eq_uint256_add, uint256_add_val_eq_mod, Nat.add_comm]
+
 private theorem encodeStorageAt_writeAddressKeyedMappingWordSlots_singleton_other
     {fields : List Field}
     {world : Verity.ContractState}
@@ -239,9 +252,13 @@ private theorem encodeStorageAt_writeAddressKeyedMappingWordSlots_singleton_othe
         exact hEq.trans hslotEq.symm
       exact hneq htarget
     · simp [SourceSemantics.writeAddressKeyedMappingWordSlots, List.map_cons, List.map_nil]
-      intro hbad
-      exact False.elim (hEq hbad)
-  · simp [SourceSemantics.writeAddressKeyedMappingWordSlots]
+      have hfalse :
+          [(Compiler.Proofs.solidityMappingSlot slot key + wordOffset) %
+              Compiler.Constants.evmModulus].contains query = false :=
+        singleton_contains_false hEq
+      exact Verity.ContractState.storage_writeSlots_not_mem _ _ _ hfalse
+  · simp [SourceSemantics.writeAddressKeyedMappingWordSlots,
+      Verity.ContractState.storageAddr_writeSlots]
   · simp [SourceSemantics.writeAddressKeyedMappingWordSlots]
 
 private theorem encodeStorageAt_writeAddressKeyedMappingPackedWordSlots_singleton_other
@@ -276,9 +293,13 @@ private theorem encodeStorageAt_writeAddressKeyedMappingPackedWordSlots_singleto
         exact hEq.trans hslotEq.symm
       exact hneq htarget
     · simp [SourceSemantics.writeAddressKeyedMappingPackedWordSlots, List.map_cons, List.map_nil]
-      intro hbad
-      exact False.elim (hEq hbad)
-  · simp [SourceSemantics.writeAddressKeyedMappingPackedWordSlots]
+      have hfalse :
+          [(Compiler.Proofs.solidityMappingSlot slot key + wordOffset) %
+              Compiler.Constants.evmModulus].contains query = false :=
+        singleton_contains_false hEq
+      exact Verity.ContractState.storage_modifySlots_not_mem _ _ _ hfalse
+  · simp [SourceSemantics.writeAddressKeyedMappingPackedWordSlots,
+      Verity.ContractState.storageAddr_modifySlots]
   · simp [SourceSemantics.writeAddressKeyedMappingPackedWordSlots]
 
 def findResolvedFieldAtSlotCopy (fields : List Field) (slot : Nat) : Option Field :=
@@ -991,7 +1012,10 @@ private theorem encodeStorageAt_writeUintKeyedMappingSlots_singleton_eq_written
     rw [findDynamicArrayElementAtSlotCopy_wordNormalize]
     exact hdyn
   simp only [hdyn']
-  simp only [SourceSemantics.writeUintKeyedMappingSlots, List.foldl_cons, List.foldl_nil]
+  simp only [SourceSemantics.writeUintKeyedMappingSlots]
+  rw [Verity.ContractState.storage_writeMapUint,
+    Verity.ContractState.storage_withStorageChannel]
+  simp only [List.foldl_cons, List.foldl_nil]
   simp only [Compiler.Proofs.abstractStoreMappingEntry, Compiler.Proofs.abstractMappingSlot]
   simp only [IRStorageSlot.ofNat_wordNormalize, ite_true, Verity.Core.Uint256.val_ofNat,
     Compiler.Proofs.IRGeneration.IRStorageWord.toNat_ofNat,
@@ -1039,8 +1063,9 @@ private theorem encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_eq_
     rw [findDynamicArrayElementAtSlotCopy_wordNormalize]
     exact hdyn
   simp only [hdyn']
-  simp only [SourceSemantics.writeAddressKeyedMappingChainSlots, List.map_cons, List.map_nil,
-    List.contains_cons, List.contains_nil, Bool.or_false, beq_iff_eq, ite_true]
+  simp only [SourceSemantics.writeAddressKeyedMappingChainSlots, List.map_cons, List.map_nil]
+  rw [Verity.ContractState.storage_writeSlots_mem _ _ _
+    (singleton_contains_true _)]
   simp only [Verity.Core.Uint256.val_ofNat]
   exact Nat.mod_eq_of_lt hvalue
 
@@ -1229,7 +1254,10 @@ private theorem encodeStorageAt_writeAddressKeyedMapping2Slots_singleton_eq_writ
     rw [findDynamicArrayElementAtSlotCopy_wordNormalize]
     exact hdyn
   simp only [hdyn']
-  simp only [SourceSemantics.writeAddressKeyedMapping2Slots, List.foldl_cons, List.foldl_nil]
+  simp only [SourceSemantics.writeAddressKeyedMapping2Slots]
+  rw [Verity.ContractState.storage_writeMap2,
+    Verity.ContractState.storage_withStorageChannel]
+  simp only [List.foldl_cons, List.foldl_nil]
   simp only [Compiler.Proofs.abstractStoreMappingEntry, Compiler.Proofs.abstractMappingSlot]
   simp only [IRStorageSlot.ofNat_wordNormalize, ite_true, Verity.Core.Uint256.val_ofNat,
     Compiler.Proofs.IRGeneration.IRStorageWord.toNat_ofNat,
@@ -1254,37 +1282,12 @@ private theorem encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_oth
           (Compiler.Proofs.solidityMappingSlot
             (Compiler.Proofs.solidityMappingSlot slot key1) key2 + wordOffset) %
             Compiler.Constants.evmModulus
-    · exfalso
-      have htarget : query = mapping2WordTargetSlot slot key1 key2 wordOffset := by
-        rw [mapping2WordTargetSlot_eq_uint256_add]
-        have hslotEq :
-            (Verity.Core.Uint256.ofNat wordOffset +
-              Verity.Core.Uint256.ofNat
-                (Compiler.Proofs.solidityMappingSlot
-                  (Compiler.Proofs.solidityMappingSlot slot key1) key2)).val =
-            (Compiler.Proofs.solidityMappingSlot
-              (Compiler.Proofs.solidityMappingSlot slot key1) key2 + wordOffset) %
-              Compiler.Constants.evmModulus := by
-          change
-            (wordOffset % Compiler.Constants.evmModulus +
-                Compiler.Proofs.solidityMappingSlot
-                  (Compiler.Proofs.solidityMappingSlot slot key1) key2 %
-                  Compiler.Constants.evmModulus) %
-              Compiler.Constants.evmModulus =
-            (Compiler.Proofs.solidityMappingSlot
-              (Compiler.Proofs.solidityMappingSlot slot key1) key2 + wordOffset) %
-              Compiler.Constants.evmModulus
-          rw [Nat.add_comm]
-          exact (Nat.add_mod
-            (Compiler.Proofs.solidityMappingSlot
-              (Compiler.Proofs.solidityMappingSlot slot key1) key2)
-            wordOffset Compiler.Constants.evmModulus).symm
-        exact hEq.trans hslotEq.symm
-      exact hneq htarget
+    · exact (hneq (hEq.trans (mapping2WordTargetSlot_eq_mod slot key1 key2 wordOffset).symm)).elim
     · simp [SourceSemantics.writeAddressKeyedMapping2WordSlots, List.map_cons, List.map_nil]
-      intro hbad
-      exact False.elim (hEq hbad)
-  · simp [SourceSemantics.writeAddressKeyedMapping2WordSlots]
+      exact Verity.ContractState.storage_writeSlots_not_mem _ _ _
+        (singleton_contains_false hEq)
+  · simp [SourceSemantics.writeAddressKeyedMapping2WordSlots,
+      Verity.ContractState.storageAddr_writeSlots]
   · simp [SourceSemantics.writeAddressKeyedMapping2WordSlots]
 
 private theorem encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_eq_written
@@ -1405,9 +1408,9 @@ private theorem runtimeStateMatchesIR_writeUintSlot
           (show findResolvedFieldAtSlotCopy fields (SourceSemantics.wordNormalize slot) = some f from
             by rw [findResolvedFieldAtSlotCopy_wordNormalize]; exact hresolved)
       rw [encodeStorageAt_eq_storage_of_resolvedSlot hresolved' hnotAddr hnotDyn]
-      simp [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
+      simp [SourceSemantics.writeUintSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
         SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
-        Verity.Core.UINT256_MODULUS, Verity.Core.Uint256.val_ofNat]
+        Verity.Core.UINT256_MODULUS]
       exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
         (Nat.mod_eq_of_lt hvalue).symm
     · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
@@ -1416,6 +1419,24 @@ private theorem runtimeStateMatchesIR_writeUintSlot
       exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
         (encodeStorageAt_writeUintSlots_singleton_other
           (IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat hEq)).symm
+
+private theorem encodeStorageAt_writeStorageWordSlots_singleton_other
+    {fields : List Field}
+    {world : Verity.ContractState}
+    {slot query value : Nat}
+    (hneq : query ≠ slot % Compiler.Constants.evmModulus) :
+    SourceSemantics.encodeStorageAt fields
+      (SourceSemantics.writeStorageWordSlots world [slot] 0 value) query =
+      SourceSemantics.encodeStorageAt fields world query := by
+  apply SourceSemantics.encodeStorageAt_congr
+  · simp [SourceSemantics.writeStorageWordSlots, SourceSemantics.wordNormalize]
+    exact Verity.ContractState.storage_writeSlots_not_mem _ _ _
+      (singleton_contains_false hneq)
+  · simp [SourceSemantics.writeStorageWordSlots, SourceSemantics.wordNormalize]
+    rw [Verity.ContractState.storageAddr_writeAddrSlots_not_mem _ _ _
+      (singleton_contains_false hneq)]
+    rw [Verity.ContractState.storageAddr_writeSlots]
+  · simp [SourceSemantics.writeStorageWordSlots]
 
 private theorem runtimeStateMatchesIR_writeStorageWordSlot_zeroOffset
     {fields : List Field}
@@ -1449,7 +1470,7 @@ private theorem runtimeStateMatchesIR_writeStorageWordSlot_zeroOffset
       rw [encodeStorageAt_eq_storage_of_resolvedSlot hresolved' hnotAddr hnotDyn]
       simp [SourceSemantics.writeStorageWordSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
         SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
-        Verity.Core.UINT256_MODULUS, Verity.Core.Uint256.val_ofNat]
+        Verity.Core.UINT256_MODULUS]
       exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
         (Nat.mod_eq_of_lt hvalue).symm
     · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
@@ -1457,13 +1478,10 @@ private theorem runtimeStateMatchesIR_writeStorageWordSlot_zeroOffset
       rw [hstorage]
       symm
       refine congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat ?_
-      have hneqNat := IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat hEq
       have hneqNat' : query.toNat ≠ slot % Compiler.Constants.evmModulus := by
-        simpa [SourceSemantics.wordNormalize] using hneqNat
-      apply SourceSemantics.encodeStorageAt_congr
-      · simp [SourceSemantics.writeStorageWordSlots, SourceSemantics.wordNormalize, hneqNat']
-      · simp [SourceSemantics.writeStorageWordSlots, SourceSemantics.wordNormalize, hneqNat']
-      · simp [SourceSemantics.writeStorageWordSlots]
+        simpa [SourceSemantics.wordNormalize] using
+          IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat hEq
+      exact encodeStorageAt_writeStorageWordSlots_singleton_other hneqNat'
 
 private theorem runtimeStateMatchesIR_writeAddressSlot
     {fields : List Field}
@@ -1495,15 +1513,14 @@ private theorem runtimeStateMatchesIR_writeAddressSlot
           (show findResolvedFieldAtSlotCopy fields (SourceSemantics.wordNormalize slot) = some f from
             by rw [findResolvedFieldAtSlotCopy_wordNormalize]; exact hresolved)
       rw [encodeStorageAt_eq_storageAddr_of_resolvedSlot hresolved' haddr hnotDyn]
-      simp [SourceSemantics.writeAddressSlots, Verity.ContractState.writeAddrSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
+      simp [SourceSemantics.writeAddressSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
         SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
         Verity.Core.UINT256_MODULUS,
         Verity.wordToAddress, Verity.Core.Address.ofNat, Verity.Core.Uint256.val_ofNat,
         Verity.Core.Address.modulus, Compiler.Constants.addressMask]
-      rw [Nat.mod_eq_of_lt hvalue]
       refine congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat ?_
       simpa [Compiler.Constants.addressMask, Verity.Core.Address.modulus,
-        Verity.Core.ADDRESS_MODULUS] using
+        Verity.Core.ADDRESS_MODULUS, Nat.mod_eq_of_lt hvalue] using
         (Nat.and_two_pow_sub_one_eq_mod (n := 160) value)
     · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
       simp only [hEq, ↓reduceIte]
@@ -1514,9 +1531,11 @@ private theorem runtimeStateMatchesIR_writeAddressSlot
       have hneqNat' : query.toNat ≠ slot % Compiler.Constants.evmModulus := by
         simpa [SourceSemantics.wordNormalize] using hneqNat
       apply SourceSemantics.encodeStorageAt_congr
-      · simp [SourceSemantics.writeAddressSlots, Verity.ContractState.writeAddrSlots]
-      · simp [SourceSemantics.writeAddressSlots, Verity.ContractState.writeAddrSlots, SourceSemantics.wordNormalize, hneqNat']
-      · simp [SourceSemantics.writeAddressSlots, Verity.ContractState.writeAddrSlots]
+      · simp [SourceSemantics.writeAddressSlots]
+      · simp [SourceSemantics.writeAddressSlots, SourceSemantics.wordNormalize]
+        exact Verity.ContractState.storageAddr_writeAddrSlots_not_mem _ _ _
+          (singleton_contains_false hneqNat')
+      · simp [SourceSemantics.writeAddressSlots]
 
 private theorem runtimeStateMatchesIR_writeUintSlots
     {fields : List Field}
@@ -1560,10 +1579,9 @@ private theorem runtimeStateMatchesIR_writeUintSlots
                 (slot % Verity.Core.Uint256.modulus) = true := by
             simpa [SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
               Verity.Core.UINT256_MODULUS, Verity.Core.Uint256.modulus] using hcontains
-        simp only [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
-            SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
-            Verity.Core.UINT256_MODULUS, hcontains',
-            ↓reduceIte, Verity.Core.Uint256.val_ofNat]
+        simp only [SourceSemantics.writeUintSlots, IRStorageSlot.toNat_ofNat_wordNormalize]
+        rw [Verity.ContractState.storage_writeSlots_mem _ _ _ hcontains]
+        simp only [Verity.Core.Uint256.val_ofNat]
         exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (Nat.mod_eq_of_lt hvalue).symm
       · simp only [hmem, ↓reduceIte]
         rw [hstorage]
@@ -1636,20 +1654,21 @@ private theorem runtimeStateMatchesIR_writeTransientTarget
   · funext query
     rw [hstorage]
     exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-      (SourceSemantics.encodeStorageAt_congr (by simp [SourceSemantics.writeTransientTargets, Verity.ContractState.writeTransientSlots])
-        (by simp [SourceSemantics.writeTransientTargets, Verity.ContractState.writeTransientSlots])
-        (by simp [SourceSemantics.writeTransientTargets, Verity.ContractState.writeTransientSlots]))
+      (SourceSemantics.encodeStorageAt_congr
+        (by simp [SourceSemantics.writeTransientTargets])
+        (by simp [SourceSemantics.writeTransientTargets])
+        (by simp [SourceSemantics.writeTransientTargets]))
   · funext slot
     by_cases hslot : slot = SourceSemantics.wordNormalize target
     · subst hslot
-      simp [SourceSemantics.writeTransientTargets, Verity.ContractState.writeTransientSlots]
+      simp [SourceSemantics.writeTransientTargets]
       exact (Nat.mod_eq_of_lt (by
         simpa [Compiler.Constants.evmModulus, Verity.Core.UINT256_MODULUS,
           Verity.Core.Uint256.modulus] using hvalue)).symm
-    · simp [SourceSemantics.writeTransientTargets, Verity.ContractState.writeTransientSlots, hslot]
-      have hslot' : slot ≠ target % Compiler.Constants.evmModulus := by
+    · have hslot' : slot ≠ target % Compiler.Constants.evmModulus := by
         simpa [SourceSemantics.wordNormalize] using hslot
-      simp [hslot', congrFun htransient slot]
+      simp [SourceSemantics.writeTransientTargets, hslot, hslot']
+      exact congrFun htransient slot
 
 private theorem runtimeStateMatchesIR_writeAddressKeyedMappingChainSlot
     {fields : List Field}
@@ -5231,6 +5250,13 @@ private theorem compiledStmtStep_setMappingPackedWord_singleSlot_of_slotSafety_p
                 simp [oldWordNat, storedWordNat,
                   SourceSemantics.writeAddressKeyedMappingPackedWordFieldSlots, htrans,
                   htargetNorm, htargetModSelf, hquery, hbeq, hqueryTarget, htransient]
+                have hne :
+                    query ≠
+                      (Compiler.Proofs.solidityMappingSlot slot keyNat + wordOffset) %
+                        Compiler.Constants.evmModulus :=
+                  fun h => hqueryTarget h.symm
+                rw [Verity.ContractState.transientStorage_modifyTransientSlots_not_mem _ _ _
+                  (singleton_contains_false hne)]
                 exact congrFun htransient query
             · simpa [SourceSemantics.writeAddressKeyedMappingPackedWordFieldSlots, htrans,
                 state4, state3, state2, state1] using hsender

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
@@ -12,6 +12,9 @@ open Compiler.CompilationModel
 open Compiler.Yul
 
 attribute [local simp] CompilationModel.compileExprWithInternals_nil_eq
+attribute [local simp] Verity.ContractState.storage Verity.ContractState.storageAddr
+  Verity.ContractState.transientStorage Verity.ContractState.storageMap
+  Verity.ContractState.storageMapUint Verity.ContractState.storageMap2
 
 private theorem compileExprWithInternals_nil_ok
     {fields : List Field} {dynamicSource : DynamicDataSource} {expr : Expr} {exprIR : YulExpr}
@@ -39,9 +42,12 @@ private theorem encodeStorageAt_writeUintSlots_singleton_other
   apply SourceSemantics.encodeStorageAt_congr
   · have hneq' : query ≠ slot % Compiler.Constants.evmModulus := by
       simpa [SourceSemantics.wordNormalize] using hneq
-    simp [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots, SourceSemantics.wordNormalize, hneq']
-  · simp [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots]
-  · simp [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots]
+    simp [SourceSemantics.writeUintSlots, SourceSemantics.wordNormalize]
+    have hfalse : [slot % Compiler.Constants.evmModulus].contains query = false := by
+      simp [List.contains, hneq']
+    exact Verity.ContractState.storage_writeSlots_not_mem _ _ _ hfalse
+  · simp [SourceSemantics.writeUintSlots]
+  · simp [SourceSemantics.writeUintSlots]
 
 private theorem encodeStorageAt_writeUintSlots_other
     {fields : List Field}
@@ -54,12 +60,12 @@ private theorem encodeStorageAt_writeUintSlots_other
       query =
       SourceSemantics.encodeStorageAt fields world query := by
   apply SourceSemantics.encodeStorageAt_congr
-  · simp only [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots]
-    rw [show (slots.map SourceSemantics.wordNormalize).contains query = false from by
-      simpa using hnotMem]
-    simp
-  · simp [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots]
-  · simp [SourceSemantics.writeUintSlots, Verity.ContractState.writeSlots]
+  · simp only [SourceSemantics.writeUintSlots]
+    have hfalse : (slots.map SourceSemantics.wordNormalize).contains query = false := by
+      simpa [List.contains_iff_mem] using hnotMem
+    exact Verity.ContractState.storage_writeSlots_not_mem _ _ _ hfalse
+  · simp [SourceSemantics.writeUintSlots]
+  · simp [SourceSemantics.writeUintSlots]
 
 set_option maxHeartbeats 800000 in
 private theorem encodeStorageAt_writeUintKeyedMappingSlots_singleton_other
@@ -92,7 +98,9 @@ private theorem encodeStorageAt_writeUintKeyedMappingSlots_singleton_other
       hneq', hslotNe, hqueryMod, SourceSemantics.wordNormalize]
     apply Verity.Core.Uint256.ext
     simp [Verity.Core.Uint256.modulus, Nat.mod_eq_of_lt (world.storage query).isLt]
-  · simp [SourceSemantics.writeUintKeyedMappingSlots]
+  · simp [SourceSemantics.writeUintKeyedMappingSlots,
+      Verity.ContractState.storageAddr_writeMapUint,
+      Verity.ContractState.storageAddr_withStorageChannel]
   · simp [SourceSemantics.writeUintKeyedMappingSlots]
 
 private theorem encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_other
@@ -111,7 +119,12 @@ private theorem encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_oth
         query ≠ SourceSemantics.mappingSlotChain slot keys % Compiler.Constants.evmModulus := by
       simpa [SourceSemantics.wordNormalize] using hneq
     simp [SourceSemantics.writeAddressKeyedMappingChainSlots,
-      SourceSemantics.wordNormalize, hneq']
+      SourceSemantics.wordNormalize]
+    have hfalse :
+        [SourceSemantics.mappingSlotChain slot keys % Compiler.Constants.evmModulus].contains query =
+          false := by
+      simp [List.contains, hneq']
+    exact Verity.ContractState.storage_writeSlots_not_mem _ _ _ hfalse
   · simp [SourceSemantics.writeAddressKeyedMappingChainSlots]
   · simp [SourceSemantics.writeAddressKeyedMappingChainSlots]
 

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -387,22 +387,14 @@ def writeStorageWordSlot (world : Verity.ContractState) (slot wordOffset value :
   let word : Verity.Core.Uint256 := value
   let addr := Verity.wordToAddress word
   let target := wordNormalize (slot + wordOffset)
-  { world with
-    storage := fun current =>
-      if current = target then word else world.storage current,
-    storageAddr := fun current =>
-      if current = target then addr else world.storageAddr current }
+  (world.writeSlot target word).writeAddrSlot target addr
 
 def writeStorageWordSlots (world : Verity.ContractState) (slots : List Nat) (wordOffset value : Nat) :
     Verity.ContractState :=
   let word : Verity.Core.Uint256 := value
   let addr := Verity.wordToAddress word
   let targets := slots.map (fun slot => wordNormalize (slot + wordOffset))
-  { world with
-    storage := fun current =>
-      if targets.contains current then word else world.storage current,
-    storageAddr := fun current =>
-      if targets.contains current then addr else world.storageAddr current }
+  (world.writeSlots targets word).writeAddrSlots targets addr
 
 def writeAddressSlots (world : Verity.ContractState) (slots : List Nat) (value : Nat) :
     Verity.ContractState :=
@@ -444,15 +436,11 @@ def writeUintFieldSlots (fields : List Field) (fieldName : String)
       | some packed =>
           let targets := slots.map wordNormalize
           if field.isTransient then
-            { world with transientStorage := fun slot =>
-                if targets.contains slot then
-                  packedWordWrite (world.transientStorage slot).val value packed
-                else world.transientStorage slot }
+            world.modifyTransientSlots targets
+              (fun current => packedWordWrite current.val value packed)
           else
-            { world with storage := fun slot =>
-                if targets.contains slot then
-                  packedWordWrite (world.storage slot).val value packed
-                else world.storage slot }
+            world.modifySlots targets
+              (fun current => packedWordWrite current.val value packed)
       | none =>
           if field.isTransient then writeTransientTargets world slots value
           else writeUintSlots world slots value
@@ -480,10 +468,7 @@ def writeMappingTargets (fields : List Field) (fieldName : String)
   if fieldIsTransient fields fieldName then
     writeTransientTargets world targets value
   else
-    let word : Verity.Core.Uint256 := value
-    { world with
-      storage := fun slot =>
-        if targets.map wordNormalize |>.contains slot then word else world.storage slot }
+    world.writeSlots (targets.map wordNormalize) (value : Verity.Core.Uint256)
 
 def writeAddressKeyedMappingSlots
     (world : Verity.ContractState) (slots : List Nat) (key value : Nat) :
@@ -501,15 +486,10 @@ def writeAddressKeyedMappingSlots
           (fun current slot =>
             Compiler.Proofs.abstractStoreMappingEntry current slot key value)
         storageNat
-      { world with
-        storage := fun s =>
-          (Compiler.Proofs.IRGeneration.IRStorageWord.toNat
-            (storage (Compiler.Proofs.IRGeneration.IRStorageSlot.ofNat s)) : Verity.Core.Uint256)
-        storageMap := fun baseSlot addr =>
-          if baseSlot == slot && addr == keyAddr then
-            word
-          else
-            world.storageMap baseSlot addr }
+      (world.withStorageChannel (fun _ s =>
+        (Compiler.Proofs.IRGeneration.IRStorageWord.toNat
+          (storage (Compiler.Proofs.IRGeneration.IRStorageSlot.ofNat s)) : Verity.Core.Uint256))).writeMap
+        slot keyAddr word
 
 def mappingSlotChain (baseSlot : Nat) (keys : List Nat) : Nat :=
   keys.foldl Compiler.Proofs.abstractMappingSlot baseSlot
@@ -519,9 +499,7 @@ def writeAddressKeyedMappingChainSlots
     Verity.ContractState :=
   let word : Verity.Core.Uint256 := value
   let targets := slots.map (fun slot => wordNormalize (mappingSlotChain slot keys))
-  { world with
-    storage := fun slot =>
-      if targets.contains slot then word else world.storage slot }
+  world.writeSlots targets word
 
 def writeAddressKeyedMappingWordSlots
     (world : Verity.ContractState) (slots : List Nat) (key wordOffset value : Nat) :
@@ -530,9 +508,7 @@ def writeAddressKeyedMappingWordSlots
   let targets :=
     slots.map (fun slot =>
       wordNormalize (Compiler.Proofs.abstractMappingSlot slot key + wordOffset))
-  { world with
-    storage := fun slot =>
-      if targets.contains slot then word else world.storage slot }
+  world.writeSlots targets word
 
 def readFixedUint128ArrayElement
     (world : Verity.ContractState) (slot size index : Nat) : Option Nat :=
@@ -551,9 +527,7 @@ def writeFixedUint128ArrayElementSlots
     let offset := (index % 2) * 128
     let packed : PackedBits := { offset := offset, width := 128 }
     let targets := slots.map (fun slot => wordNormalize (slot + index / 2))
-    some { world with storage := fun slot =>
-      if targets.contains slot then packedWordWrite (world.storage slot).val value packed
-      else world.storage slot }
+    some (world.modifySlots targets (fun current => packedWordWrite current.val value packed))
   else
     none
 
@@ -564,12 +538,7 @@ def writeAddressKeyedMappingPackedWordSlots
   let targets :=
     slots.map (fun slot =>
       wordNormalize (Compiler.Proofs.abstractMappingSlot slot key + wordOffset))
-  { world with
-    storage := fun slot =>
-      if targets.contains slot then
-        packedWordWrite (world.storage slot).val value packed
-      else
-        world.storage slot }
+  world.modifySlots targets (fun current => packedWordWrite current.val value packed)
 
 def writeAddressKeyedMappingPackedWordFieldSlots
     (fields : List Field) (fieldName : String)
@@ -580,14 +549,7 @@ def writeAddressKeyedMappingPackedWordFieldSlots
     slots.map (fun slot =>
       wordNormalize (Compiler.Proofs.abstractMappingSlot slot key + wordOffset))
   if fieldIsTransient fields fieldName then
-    let wordAt := fun slot => (world.transientStorage slot).val
-    let updated := targets.map (fun slot =>
-      (slot, packedWordWrite (wordAt slot) value packed))
-    { world with
-      transientStorage := fun slot =>
-        match updated.find? (fun entry => entry.fst == slot) with
-        | some (_, word) => word
-        | none => world.transientStorage slot }
+    world.modifyTransientSlots targets (fun current => packedWordWrite current.val value packed)
   else
     writeAddressKeyedMappingPackedWordSlots world slots key wordOffset packed value
 
@@ -600,12 +562,7 @@ def writeAddressKeyedMapping2PackedWordSlots
       wordNormalize
         (Compiler.Proofs.abstractMappingSlot
           (Compiler.Proofs.abstractMappingSlot slot key1) key2 + wordOffset))
-  { world with
-    storage := fun slot =>
-      if targets.contains slot then
-        packedWordWrite (world.storage slot).val value packed
-      else
-        world.storage slot }
+  world.modifySlots targets (fun current => packedWordWrite current.val value packed)
 
 def writeAddressKeyedMapping2PackedWordFieldSlots
     (fields : List Field) (fieldName : String)
@@ -618,14 +575,7 @@ def writeAddressKeyedMapping2PackedWordFieldSlots
         (Compiler.Proofs.abstractMappingSlot
           (Compiler.Proofs.abstractMappingSlot slot key1) key2 + wordOffset))
   if fieldIsTransient fields fieldName then
-    let wordAt := fun slot => (world.transientStorage slot).val
-    let updated := targets.map (fun slot =>
-      (slot, packedWordWrite (wordAt slot) value packed))
-    { world with
-      transientStorage := fun slot =>
-        match updated.find? (fun entry => entry.fst == slot) with
-        | some (_, word) => word
-        | none => world.transientStorage slot }
+    world.modifyTransientSlots targets (fun current => packedWordWrite current.val value packed)
   else
     writeAddressKeyedMapping2PackedWordSlots world slots key1 key2 wordOffset packed value
 
@@ -645,15 +595,10 @@ def writeUintKeyedMappingSlots
           (fun current slot =>
             Compiler.Proofs.abstractStoreMappingEntry current slot key value)
         storageNat
-      { world with
-        storage := fun s =>
-          (Compiler.Proofs.IRGeneration.IRStorageWord.toNat
-            (storage (Compiler.Proofs.IRGeneration.IRStorageSlot.ofNat s)) : Verity.Core.Uint256)
-        storageMapUint := fun baseSlot key' =>
-          if baseSlot == slot && key' == keyWord then
-            word
-          else
-            world.storageMapUint baseSlot key' }
+      (world.withStorageChannel (fun _ s =>
+        (Compiler.Proofs.IRGeneration.IRStorageWord.toNat
+          (storage (Compiler.Proofs.IRGeneration.IRStorageSlot.ofNat s)) : Verity.Core.Uint256))).writeMapUint
+        slot keyWord word
 
 def writeAddressKeyedMapping2Slots
     (world : Verity.ContractState) (slots : List Nat) (key1 key2 value : Nat) :
@@ -676,15 +621,10 @@ def writeAddressKeyedMapping2Slots
               key2
               value)
         storageNat
-      { world with
-        storage := fun s =>
-          (Compiler.Proofs.IRGeneration.IRStorageWord.toNat
-            (storage (Compiler.Proofs.IRGeneration.IRStorageSlot.ofNat s)) : Verity.Core.Uint256)
-        storageMap2 := fun baseSlot addr1 addr2 =>
-          if baseSlot == slot && addr1 == key1Addr && addr2 == key2Addr then
-            word
-          else
-            world.storageMap2 baseSlot addr1 addr2 }
+      (world.withStorageChannel (fun _ s =>
+        (Compiler.Proofs.IRGeneration.IRStorageWord.toNat
+          (storage (Compiler.Proofs.IRGeneration.IRStorageSlot.ofNat s)) : Verity.Core.Uint256))).writeMap2
+        slot key1Addr key2Addr word
 
 def writeAddressKeyedMapping2WordSlots
     (world : Verity.ContractState) (slots : List Nat) (key1 key2 wordOffset value : Nat) :
@@ -695,9 +635,7 @@ def writeAddressKeyedMapping2WordSlots
       (Compiler.Proofs.abstractMappingSlot
         (Compiler.Proofs.abstractMappingSlot slot key1)
         key2 + wordOffset))
-  { world with
-    storage := fun slot =>
-      if targets.contains slot then word else world.storage slot }
+  world.writeSlots targets word
 
 def writeAddressKeyedMappingWordFieldSlots
     (fields : List Field) (fieldName : String)
@@ -2633,11 +2571,7 @@ mutual
             let resolvedOffset := wordNormalize resolvedOffset
             .continue {
               state with
-              world := {
-                state.world with
-                transientStorage := fun o =>
-                  if o = resolvedOffset then resolvedValue else state.world.transientStorage o
-              }
+              world := state.world.writeTransient resolvedOffset resolvedValue
             }
         | _, _ => .revert
     | state, .require cond _ =>
@@ -2921,11 +2855,7 @@ mutual
             let resolvedOffset := wordNormalize resolvedOffset
             .continue {
               state with
-              world := {
-                state.world with
-                transientStorage := fun o =>
-                  if o = resolvedOffset then resolvedValue else state.world.transientStorage o
-              }
+              world := state.world.writeTransient resolvedOffset resolvedValue
             }
         | _, _ => .revert
     | state, .require cond _ =>
@@ -4223,11 +4153,7 @@ mutual
             let resolvedOffset := wordNormalize resolvedOffset
             .continue {
               state with
-              world := {
-                state.world with
-                transientStorage := fun o =>
-                  if o = resolvedOffset then resolvedValue else state.world.transientStorage o
-              }
+              world := state.world.writeTransient resolvedOffset resolvedValue
             }
         | _, _ => .revert
     | .require cond _ =>

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -1087,8 +1087,7 @@ def storageArrayDropLast? : List Verity.Core.Uint256 → Option (List Verity.Cor
 
 def writeStorageArray (world : Verity.ContractState) (slot : Nat)
     (values : List Verity.Core.Uint256) : Verity.ContractState :=
-  { world with
-    storageArray := fun s => if s == slot then values else world.storageArray s }
+  world.writeArray slot values
 
 /-- Ceiling-division helper matching Solidity's `Math256.ceilDiv`.
     Factored out so the mutual block's equation-lemma derivation stays simple. -/
@@ -6336,6 +6335,6 @@ private def storageArraySourceSpec : CompilationModel :=
           body := [Stmt.storageArrayPop "queue", .stop] } ] }
 
 private def storageArrayInitialWorld : Verity.ContractState :=
-  { Verity.defaultState with storageArray := fun slot => if slot = 7 then [11, 17] else [] }
+  Verity.defaultState.writeArray 7 [11, 17]
 
 end Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -3158,6 +3158,39 @@ def withConstructorTransactionContext (world : Verity.ContractState) (tx : IRTra
     calldataSize := Verity.Core.Uint256.ofNat (tx.args.length * 32)
     calldata := tx.args }
 
+/-- Call-frame updates keep `storageWords`, so the storage views are unchanged. -/
+@[simp] theorem storage_withTransactionContext
+    (world : Verity.ContractState) (tx : IRTransaction) :
+    (withTransactionContext world tx).storage = world.storage := by
+  funext slot
+  simp [withTransactionContext, Verity.ContractState.storage]
+
+@[simp] theorem storageAddr_withTransactionContext
+    (world : Verity.ContractState) (tx : IRTransaction) :
+    (withTransactionContext world tx).storageAddr = world.storageAddr := by
+  funext slot
+  simp [withTransactionContext, Verity.ContractState.storageAddr]
+
+@[simp] theorem storageArray_withTransactionContext
+    (world : Verity.ContractState) (tx : IRTransaction) :
+    (withTransactionContext world tx).storageArray = world.storageArray := rfl
+
+@[simp] theorem storage_withConstructorTransactionContext
+    (world : Verity.ContractState) (tx : IRTransaction) :
+    (withConstructorTransactionContext world tx).storage = world.storage := by
+  funext slot
+  simp [withConstructorTransactionContext, Verity.ContractState.storage]
+
+@[simp] theorem storageAddr_withConstructorTransactionContext
+    (world : Verity.ContractState) (tx : IRTransaction) :
+    (withConstructorTransactionContext world tx).storageAddr = world.storageAddr := by
+  funext slot
+  simp [withConstructorTransactionContext, Verity.ContractState.storageAddr]
+
+@[simp] theorem storageArray_withConstructorTransactionContext
+    (world : Verity.ContractState) (tx : IRTransaction) :
+    (withConstructorTransactionContext world tx).storageArray = world.storageArray := rfl
+
 theorem findDynamicArrayElementAtSlot_withTransactionContext
     (fields : List Field)
     (world : Verity.ContractState)
@@ -3269,9 +3302,9 @@ theorem encodeStorageAt_congr
       encodeStorageAt fields world slot := by
   unfold encodeStorageAt
   split
-  · simp [withTransactionContext]
+  · simp
   · rw [findDynamicArrayElementAtSlot_withTransactionContext]
-    simp [withTransactionContext]
+    simp
 
 @[simp] theorem encodeStorage_withTransactionContext
     (spec : CompilationModel)
@@ -3295,8 +3328,8 @@ theorem encodeStorageAt_congr
     (world1 := withConstructorTransactionContext world tx)
     (world2 := world)
     (slot := slot)
-    (by simp [withConstructorTransactionContext])
-    (by simp [withConstructorTransactionContext])
+    (by simp)
+    (by simp)
     (by simp [withConstructorTransactionContext])
 
 @[simp] theorem encodeStorage_withConstructorTransactionContext

--- a/Compiler/Proofs/Storage/SolidityStorage.lean
+++ b/Compiler/Proofs/Storage/SolidityStorage.lean
@@ -108,7 +108,7 @@ theorem compiledMappingSlotPointer_eq_sourceMappingSlotRead
   simp only [SourceSemantics.evalExpr]
   rw [hfield]
   simp [mappingSlotBridgeField, mappingSlotBridgeState, SourceSemantics.readFieldWord,
-    Verity.ContractState.withStorageChannel, SourceSemantics.wordNormalize]
+    Verity.ContractState.storage_withStorageChannel, SourceSemantics.wordNormalize]
   change Compiler.Proofs.solidityMappingSlot baseSlot key =
     Compiler.Proofs.solidityMappingSlot baseSlot
       (key % Compiler.Constants.evmModulus) % Compiler.Constants.evmModulus
@@ -340,7 +340,7 @@ theorem compiledPackedRead_eq_sourceEvalPackedRead (word : Word) (offset width :
     unfold packedReadBridgeSourceExpr
     rw [SourceSemantics.evalExpr, hfield]
     simp [packedReadBridgeField, packedReadBridgeState,
-      Verity.ContractState.withStorageChannel,
+      Verity.ContractState.storage_withStorageChannel,
       SourceSemantics.readFieldWord, SourceSemantics.wordNormalize]
   have hextract := uint256_packed_extract (word.toNat % Verity.Core.Uint256.modulus)
     { offset := offset, width := width } hraw hoffset

--- a/Compiler/Proofs/Storage/StructArrayStorage.lean
+++ b/Compiler/Proofs/Storage/StructArrayStorage.lean
@@ -175,7 +175,7 @@ theorem compiledStructMemberSlot_eq_sourceStructMemberSlotRead
     unfold sourceStructMemberSlotRead
     rw [SourceSemantics.evalExpr]
     simp only [SourceSemantics.evalExpr, hfield, hmembers, structBridgeMember,
-      structMemberBridgeState, Verity.ContractState.withStorageChannel,
+      structMemberBridgeState, Verity.ContractState.storage_withStorageChannel,
       SourceSemantics.wordNormalize_eq_mod, Nat.mod_eq_of_lt hkey]
     simp only [structBridgeField, SourceSemantics.readFieldWord,
       SourceSemantics.wordNormalize]
@@ -742,11 +742,10 @@ theorem storageArrayLength_eq_storageArrayLength (slot : Nat)
     have hfield : findFieldWithResolvedSlot [arrayBridgeField slot] "__array_bridge" =
         some (arrayBridgeField slot, slot) := rfl
     rw [SourceSemantics.evalExpr, hfield]
-    simp [arrayBridgeField, arrayBridgeState, Verity.ContractState.writeArray,
-      Verity.ContractState.writeSlot]
+    simp [arrayBridgeField, arrayBridgeState, Verity.ContractState.writeArray]
   rw [hsource, compiledStorageArrayLength_eq]
   simp only [Except.toOption, Option.bind_some, interpretSloadLit, arrayBridgeState,
-    Verity.ContractState.writeArray, Verity.ContractState.writeSlot,
+    Verity.ContractState.writeArray,
     SourceSemantics.wordNormalize]
   simp only [Option.some.injEq]
   simp [Verity.Core.Uint256.ofNat]
@@ -832,7 +831,7 @@ theorem storageArrayElement_eq_sourceEval (storage : SolidityStorage)
         (.storageArrayElement "__array_bridge" (.literal index)) := by
   have hcanonical : index < (storage id (slotPointer slot)).toNat := by
     have hlength := hcoherent.1
-    simp [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] at hlength
+    simp [arrayBridgeState, Verity.ContractState.writeArray] at hlength
     rw [hlength]
     exact hindex
   rw [storageArrayElement_eq_storageArrayElement storage id slot index hcanonical]
@@ -848,9 +847,9 @@ theorem storageArrayElement_eq_sourceEval (storage : SolidityStorage)
     rw [SourceSemantics.evalExpr]
     simp only [SourceSemantics.evalExpr, SourceSemantics.wordNormalize_eq_mod,
       Nat.mod_eq_of_lt hword, hfield]
-    simp [arrayBridgeField, arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot, hvalue]
+    simp [arrayBridgeField, arrayBridgeState, Verity.ContractState.writeArray, hvalue]
   rw [hsource]
-  exact congrArg some (hcoherent.2 index value (by simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using hvalue))
+  exact congrArg some (hcoherent.2 index value (by simpa [arrayBridgeState, Verity.ContractState.writeArray] using hvalue))
 
 /-- A checked read rejects an index at or beyond the length loaded from the
     canonical array slot. -/
@@ -1311,7 +1310,7 @@ theorem setStorageArrayElement_exec_preserved
     rw [SourceSemantics.execStmt, hfield]
     simp only [arrayBridgeField]
     simp [SourceSemantics.evalExpr, SourceSemantics.wordNormalize_eq_mod,
-      Nat.mod_eq_of_lt hindex, Nat.mod_eq_of_lt hvalue, arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot, hset]
+      Nat.mod_eq_of_lt hindex, Nat.mod_eq_of_lt hvalue, arrayBridgeState, Verity.ContractState.writeArray, hset]
   · simp [applyStateRewrite, storageArrayElementWrite]
 
 /-- Executable push appends at the source length, while the interpreted Yul
@@ -1340,7 +1339,7 @@ theorem pushStorageArray_exec_preserved
     rw [SourceSemantics.execStmt, hfield]
     simp only [arrayBridgeField]
     simp [SourceSemantics.evalExpr, SourceSemantics.wordNormalize_eq_mod,
-      Nat.mod_eq_of_lt hvalue, arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot]
+      Nat.mod_eq_of_lt hvalue, arrayBridgeState, Verity.ContractState.writeArray]
   · dsimp
     constructor
     · simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite, hdistinct]
@@ -1360,7 +1359,7 @@ theorem popStorageArray_exec_empty (storage : SolidityStorage)
   · have hfield : findFieldWithResolvedSlot [arrayBridgeField slot] "__array_bridge" =
         some (arrayBridgeField slot, slot) := rfl
     rw [SourceSemantics.execStmt, hfield]
-    simp [arrayBridgeField, arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot, SourceSemantics.storageArrayDropLast?]
+    simp [arrayBridgeField, arrayBridgeState, Verity.ContractState.writeArray, SourceSemantics.storageArrayDropLast?]
   · exact popStorageArray_empty storage currentContract slot hempty
 
 /-- For a nonempty executable pop, the source removes the last value and the
@@ -1387,7 +1386,7 @@ theorem popStorageArray_exec_preserved
   · have hfield : findFieldWithResolvedSlot [arrayBridgeField slot] "__array_bridge" =
         some (arrayBridgeField slot, slot) := rfl
     rw [SourceSemantics.execStmt, hfield]
-    simp [arrayBridgeField, arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot, hdrop]
+    simp [arrayBridgeField, arrayBridgeState, Verity.ContractState.writeArray, hdrop]
   · dsimp
     constructor
     · simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite, hdistinct]
@@ -1418,7 +1417,7 @@ theorem setStorageArrayElement_compiled_exec_coherent
       (IRStorageWord.ofNat value)] storage) currentContract slot
       (SourceSemantics.writeStorageArray (arrayBridgeState slot values).world slot updated) := by
   have hcanonical : index < (storage currentContract (slotPointer slot)).toNat := by
-    rw [hcoherent.1]; simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using hindex
+    rw [hcoherent.1]; simpa [arrayBridgeState, Verity.ContractState.writeArray] using hindex
   constructor
   · have hind : index % uint256Modulus = index := Nat.mod_eq_of_lt hword
     have hvaluemod : value % uint256Modulus = value := Nat.mod_eq_of_lt hvalue
@@ -1433,7 +1432,7 @@ theorem setStorageArrayElement_compiled_exec_coherent
       · simp [applyStateRewrite, storageArrayElementWrite,
           Ne.symm hlengthSlot, SourceSemantics.writeStorageArray,
           sourceStorageArraySetAt_length values updated index value hset]
-        simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using hcoherent.1
+        simpa [arrayBridgeState, Verity.ContractState.writeArray] using hcoherent.1
       · intro j x hj
         simp [SourceSemantics.writeStorageArray] at hj
         by_cases hji : j = index
@@ -1446,7 +1445,7 @@ theorem setStorageArrayElement_compiled_exec_coherent
         · have hsep := helementSlots j (List.getElem?_eq_some_iff.mp hj).1 hji
           simp [applyStateRewrite, storageArrayElementWrite, hsep]
           apply hcoherent.2 j x
-          simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using sourceStorageArraySetAt_getElem?_of_ne
+          simpa [arrayBridgeState, Verity.ContractState.writeArray] using sourceStorageArraySetAt_getElem?_of_ne
             values updated index j value x hset hji hj
 
 /-- Push derives its index from the canonical length word; coherence identifies
@@ -1467,7 +1466,7 @@ theorem pushStorageArray_compiled_exec_coherent
     StorageArrayCoherent (applyStateRewrite [storageArrayElementWrite currentContract slot values.length (IRStorageWord.ofNat value),
           storageArrayLengthWrite currentContract slot (values.length + 1)] storage)
       currentContract slot (SourceSemantics.writeStorageArray (arrayBridgeState slot values).world slot (values ++ [(value : Verity.Core.Uint256)])) := by
-  have hlength : (storage currentContract (slotPointer slot)).toNat = values.length := by simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using hcoherent.1
+  have hlength : (storage currentContract (slotPointer slot)).toNat = values.length := by simpa [arrayBridgeState, Verity.ContractState.writeArray] using hcoherent.1
   have hvaluemod : value % uint256Modulus = value := Nat.mod_eq_of_lt hvalue
   constructor
   · simpa [hlength, hvaluemod] using pushStorageArray_eq_compiledStorageArrayPush
@@ -1495,7 +1494,7 @@ theorem pushStorageArray_compiled_exec_coherent
           apply hcoherent.2 j x
           have hx : values[j] = x := by simpa [List.getElem?_append, hjlt] using hj
           have hold : values[j]? = some x := by rw [List.getElem?_eq_getElem hjlt, hx]
-          simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using hold
+          simpa [arrayBridgeState, Verity.ContractState.writeArray] using hold
 
 /-- Pop's empty guard and decremented index are both derived from the same
     canonical length word that coherence relates to the source array. -/
@@ -1516,7 +1515,7 @@ theorem popStorageArray_compiled_exec_coherent
           storageArrayLengthWrite currentContract slot updated.length] storage)
       currentContract slot
       (SourceSemantics.writeStorageArray (arrayBridgeState slot values).world slot updated) := by
-  have hlength : (storage currentContract (slotPointer slot)).toNat = values.length := by simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using hcoherent.1
+  have hlength : (storage currentContract (slotPointer slot)).toNat = values.length := by simpa [arrayBridgeState, Verity.ContractState.writeArray] using hcoherent.1
   have hlen : updated.length + 1 = values.length := sourceStorageArrayDropLast_length values updated hdrop
   have hnonempty : 0 < (storage currentContract (slotPointer slot)).toNat := by
     rw [hlength, ← hlen]; omega
@@ -1541,7 +1540,7 @@ theorem popStorageArray_compiled_exec_coherent
         have hsep := helementSlots j hjlt; have hlengthSep := hlengthElements j hjlt
         simp [applyStateRewrite, storageArrayElementWrite, storageArrayLengthWrite,
           hsep, hlengthSep]
-        apply hcoherent.2 j x; simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using
+        apply hcoherent.2 j x; simpa [arrayBridgeState, Verity.ContractState.writeArray] using
           sourceStorageArrayDropLast_getElem? values updated j x hdrop hj
 
 /-- Empty pop is coherent end-to-end: both executable source semantics and the
@@ -1555,6 +1554,6 @@ theorem popStorageArray_compiled_exec_empty_coherent
     Option.bind (compiledStorageArrayPop slot).toOption
         (interpretCompiledStorageArrayPop storage currentContract) = none := by
   apply popStorageArray_exec_empty
-  simpa [arrayBridgeState, Verity.ContractState.writeArray, Verity.ContractState.writeSlot] using hcoherent.1
+  simpa [arrayBridgeState, Verity.ContractState.writeArray] using hcoherent.1
 
 end Compiler.Proofs.Storage

--- a/Compiler/TypedIRCompilerCorrectness.lean
+++ b/Compiler/TypedIRCompilerCorrectness.lean
@@ -1780,20 +1780,26 @@ theorem compile_letCaller_letStorageAddr_reqEq_letMapping_letStorage_setMapping_
   by_cases hEq : init.env.sender = init.world.storageAddr ownerSlot
   · simp [evalTStmtsFuel, evalTStmtFuel, evalTExpr, hEq, TVars.set, TVars.get,
       Verity.ContractState.writeMap, Verity.ContractState.writeSlot]
-    constructor
-    · funext i
-      by_cases hi : i = supplySlot
-      · subst hi
+    funext key
+    cases key with
+    | slot slot =>
+      by_cases h : slot = supplySlot
+      · subst slot
         simp
-        change Verity.Core.Uint256.add (init.world.storage i) (init.vars.uint256 1) =
-          Verity.Core.Uint256.add (init.world.storage i) (init.vars.uint256 1)
+        change Verity.Core.Uint256.add (init.world.storage supplySlot) (init.vars.uint256 1) =
+          Verity.Core.Uint256.add (init.world.storage supplySlot) (init.vars.uint256 1)
         rfl
-      · simp [hi]
-    · funext i a
-      by_cases hia : i = mappingSlot ∧ a = init.vars.address 0
-      · simp [hia]
+      · simp [h]
+    | map slot mapKey =>
+      by_cases h : slot = mappingSlot ∧ mapKey = init.vars.address 0
+      · simp [h]
         exact Verity.Core.Uint256.add_comm _ _
-      · simp [hia]
+      · simp [h]
+    | contractSlot contract slot => simp
+    | transient slot => simp
+    | addr slot => simp
+    | mapUint slot mapKey => simp
+    | map2 slot key1 key2 => simp
   · simp [evalTStmtsFuel, evalTStmtFuel, evalTExpr, hEq, TVars.set, TVars.get]
 
 /-- Semantic-preservation for the Morpho enableIrm pattern. -/

--- a/Contracts/Owned/Proofs/Basic.lean
+++ b/Contracts/Owned/Proofs/Basic.lean
@@ -67,7 +67,8 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
   constructor_spec initialOwner s s' := by
   simp [constructor_spec, owner]
-  refine ⟨rfl, ?_, ?_⟩
+  refine ⟨?_, ?_, ?_⟩
+  · simp
   · intro slotIdx h_neq
     simp [h_neq]
   · simp [Specs.sameStorageMapContext,
@@ -132,7 +133,8 @@ theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : 
   transferOwnership_spec newOwner s s' := by
   rw [transferOwnership_unfold s newOwner h_is_owner]
   simp [transferOwnership_spec, owner, ContractResult.snd]
-  refine ⟨rfl, ?_, ?_⟩
+  refine ⟨?_, ?_, ?_⟩
+  · simp
   · intro slotIdx h_neq
     simp [h_neq]
   · simp [Specs.sameStorageMapContext,

--- a/Contracts/Owned/Proofs/Basic.lean
+++ b/Contracts/Owned/Proofs/Basic.lean
@@ -121,28 +121,7 @@ is fully modeled and can be unfolded in proofs.
 theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr owner.slot) :
   (transferOwnership newOwner).run s = ContractResult.success ()
-    { «storage» := s.storage,
-      contractStorage := s.contractStorage,
-      transientStorage := s.transientStorage,
-      storageAddr := fun slotIdx => if (slotIdx == 0) = true then newOwner else s.storageAddr slotIdx,
-      storageMap := s.storageMap,
-      storageMapUint := s.storageMapUint,
-      storageMap2 := s.storageMap2,
-      storageArray := s.storageArray,
-      sender := s.sender,
-      thisAddress := s.thisAddress,
-      txOrigin := s.txOrigin,
-      msgValue := s.msgValue,
-      selfBalance := s.selfBalance,
-      blockTimestamp := s.blockTimestamp,
-      blockNumber := s.blockNumber,
-      chainId := s.chainId,
-      blobBaseFee := s.blobBaseFee,
-      calldataSize := s.calldataSize,
-      calldata := s.calldata,
-      memory := s.memory,
-      knownAddresses := s.knownAddresses,
-      events := s.events, calls := s.calls } := by
+    (s.writeAddrSlot 0 newOwner) := by
   verity_unfold transferOwnership with h_owner
   simp [owner]
   exact h_owner

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4210,6 +4210,12 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.SourceSemantics.bindExternalParams_eq_some_of_bindSupportedParams
   Compiler.Proofs.IRGeneration.SourceSemantics.bindExternalParams_eq_none_of_not_length_le
   Compiler.Proofs.IRGeneration.SourceSemantics.bindSupportedParams_take_param_length
+  Compiler.Proofs.IRGeneration.SourceSemantics.storage_withTransactionContext
+  Compiler.Proofs.IRGeneration.SourceSemantics.storageAddr_withTransactionContext
+  Compiler.Proofs.IRGeneration.SourceSemantics.storageArray_withTransactionContext
+  Compiler.Proofs.IRGeneration.SourceSemantics.storage_withConstructorTransactionContext
+  Compiler.Proofs.IRGeneration.SourceSemantics.storageAddr_withConstructorTransactionContext
+  Compiler.Proofs.IRGeneration.SourceSemantics.storageArray_withConstructorTransactionContext
   Compiler.Proofs.IRGeneration.SourceSemantics.findDynamicArrayElementAtSlot_withTransactionContext
   Compiler.Proofs.IRGeneration.SourceSemantics.findDynamicArrayElementAtSlot_congr_storageArray
   Compiler.Proofs.IRGeneration.SourceSemantics.encodeStorageAt_congr
@@ -6837,4 +6843,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6347 theorems/lemmas (4481 public, 1866 private, 0 sorry'd)
+-- Total: 6353 theorems/lemmas (4487 public, 1866 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3447,6 +3447,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.stmtListScopeDiscipline_scope_names
 
   -- Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
+  -- Compiler.Proofs.IRGeneration.singleton_contains_false  -- private
+  -- Compiler.Proofs.IRGeneration.singleton_contains_true  -- private
   -- Compiler.Proofs.IRGeneration.compileExprWithInternals_nil_ok  -- private
   -- Compiler.Proofs.IRGeneration.compileExprListWithInternals_nil_ok  -- private
   -- Compiler.Proofs.IRGeneration.encodeStorageAt_writeUintSlots_singleton_other  -- private
@@ -3463,6 +3465,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.uint256_add_val_eq_mod  -- private
   Compiler.Proofs.IRGeneration.mappingWordTargetSlot_eq_uint256_add
   Compiler.Proofs.IRGeneration.mapping2WordTargetSlot_eq_uint256_add
+  -- Compiler.Proofs.IRGeneration.mapping2WordTargetSlot_eq_mod  -- private
   -- Compiler.Proofs.IRGeneration.encodeStorageAt_writeAddressKeyedMappingWordSlots_singleton_other  -- private
   -- Compiler.Proofs.IRGeneration.encodeStorageAt_writeAddressKeyedMappingPackedWordSlots_singleton_other  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.wordNormalize_idem  -- private
@@ -3503,6 +3506,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_eq_written  -- private
   -- Compiler.Proofs.IRGeneration.abstractStoreStorageOrMappingMany_eq  -- private
   -- Compiler.Proofs.IRGeneration.runtimeStateMatchesIR_writeUintSlot  -- private
+  -- Compiler.Proofs.IRGeneration.encodeStorageAt_writeStorageWordSlots_singleton_other  -- private
   -- Compiler.Proofs.IRGeneration.runtimeStateMatchesIR_writeStorageWordSlot_zeroOffset  -- private
   -- Compiler.Proofs.IRGeneration.runtimeStateMatchesIR_writeAddressSlot  -- private
   -- Compiler.Proofs.IRGeneration.runtimeStateMatchesIR_writeUintSlots  -- private
@@ -6843,4 +6847,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6353 theorems/lemmas (4487 public, 1866 private, 0 sorry'd)
+-- Total: 6357 theorems/lemmas (4487 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -185,6 +185,16 @@ semantics provably collapses to the plain one). Outside the proven fragment:
   machine-checked at the theorem surface, but the trust-report slice does
   **not** enumerate it — the slice only ever names `rawLog`.
 
+### Canonical `StorageKey` backing (`ContractState.storageWords`)
+Word-valued source storage is one map `StorageKey → Uint256`. The key is
+an injective inductive (`slot` / `contractSlot` / `transient` / `addr` /
+`map` / `mapUint` / `map2`); public accessors keep the old channel names.
+This is a representation change, not a new trust boundary: lens laws use
+constructor injectivity. Solidity keccak slot derivation, and any
+shadow-vs-flat mapping coherence, remain compiler-side (C5 step 4) and are
+**not** assumed here. `storageArray` and `knownAddresses` are still
+separate fields.
+
 ### External-Call Journal (`ContractState.calls`)
 `ContractState.calls` is an append-only journal of observed external calls
 (`Verity.ExternalCall`: site id, kind, target, value, calldata, control,

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -613,6 +613,24 @@ def readArray (s : ContractState) (slot : Nat) : List Uint256 :=
 def writeArray (s : ContractState) (slot : Nat) (values : List Uint256) : ContractState :=
   { s with storageArray := fun sl => if sl == slot then values else s.storageArray sl }
 
+@[simp] theorem storage_writeArray (s : ContractState) (slot : Nat)
+    (values : List Uint256) :
+    (s.writeArray slot values).storage = s.storage := rfl
+
+@[simp] theorem storageArray_writeArray_same (s : ContractState) (slot : Nat)
+    (values : List Uint256) :
+    (s.writeArray slot values).storageArray slot = values := by
+  simp [writeArray]
+
+@[simp] theorem storageArray_writeArray_other (s : ContractState)
+    {slot slot' : Nat} (h : slot' ≠ slot) (values : List Uint256) :
+    (s.writeArray slot values).storageArray slot' = s.storageArray slot' := by
+  simp [writeArray, h]
+
+@[simp] theorem storageArray_writeSlot (s : ContractState) (slot : Nat)
+    (value : Uint256) :
+    (s.writeSlot slot value).storageArray = s.storageArray := rfl
+
 /-!
 ### Bulk lenses (C5)
 
@@ -843,6 +861,52 @@ private theorem not_mem_of_contains_false {α : Type} [BEq α] [LawfulBEq α]
       s.transientStorage slot := by
   have hmem := not_mem_of_contains_false h
   simp [transientStorage, modifyTransientSlots, hmem]
+
+@[simp] theorem sender_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).sender = s.sender := rfl
+@[simp] theorem thisAddress_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).thisAddress = s.thisAddress := rfl
+@[simp] theorem msgValue_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).msgValue = s.msgValue := rfl
+@[simp] theorem selfBalance_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).selfBalance = s.selfBalance := rfl
+@[simp] theorem blockTimestamp_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).blockTimestamp = s.blockTimestamp := rfl
+@[simp] theorem blockNumber_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).blockNumber = s.blockNumber := rfl
+@[simp] theorem chainId_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).chainId = s.chainId := rfl
+@[simp] theorem blobBaseFee_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).blobBaseFee = s.blobBaseFee := rfl
+@[simp] theorem calldataSize_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).calldataSize = s.calldataSize := rfl
+@[simp] theorem events_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).events = s.events := rfl
+@[simp] theorem memory_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).memory = s.memory := rfl
+@[simp] theorem txOrigin_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).txOrigin = s.txOrigin := rfl
+@[simp] theorem calldata_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).calldata = s.calldata := rfl
+@[simp] theorem knownAddresses_modifyTransientSlots (s : ContractState)
+    (targets : List Nat) (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).knownAddresses = s.knownAddresses := rfl
+@[simp] theorem calls_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).calls = s.calls := rfl
 
 @[simp] theorem storage_withStorageChannel (s : ContractState)
     (f : (Nat → Uint256) → Nat → Uint256) :

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -410,6 +410,25 @@ def writeMap (s : ContractState) (slot : Nat) (key : Address) (value : Uint256) 
   simp [storageMap2, writeSlot]
 
 /-- Address-slot writes leave word-slot and mapping compatibility views intact. -/
+@[simp] theorem storage_writeSlot_same (s : ContractState) (slot : Nat) (value : Uint256) :
+    (s.writeSlot slot value).storage slot = value := by
+  simp [storage, writeSlot]
+
+@[simp] theorem storage_writeSlot_other (s : ContractState) {slot slot' : Nat}
+    (h : slot' ≠ slot) (value : Uint256) :
+    (s.writeSlot slot value).storage slot' = s.storage slot' := by
+  simp [storage, writeSlot, h]
+
+@[simp] theorem transientStorage_writeTransient_same (s : ContractState) (slot : Nat)
+    (value : Uint256) :
+    (s.writeTransient slot value).transientStorage slot = value := by
+  simp [transientStorage, writeTransient]
+
+@[simp] theorem transientStorage_writeTransient_other (s : ContractState)
+    {slot slot' : Nat} (h : slot' ≠ slot) (value : Uint256) :
+    (s.writeTransient slot value).transientStorage slot' = s.transientStorage slot' := by
+  simp [transientStorage, writeTransient, h]
+
 @[simp] theorem storage_writeAddrSlot (s : ContractState) (slot : Nat) (value : Address) :
     (s.writeAddrSlot slot value).storage = s.storage := by
   funext wordSlot
@@ -429,6 +448,58 @@ def writeMap (s : ContractState) (slot : Nat) (key : Address) (value : Uint256) 
     (s.writeAddrSlot slot value).storageMap2 = s.storageMap2 := by
   funext mapSlot mapKey1 mapKey2
   simp [storageMap2, writeAddrSlot]
+
+/-- Same-slot address view after a write. High bits of the backing word
+    are not part of the address payload. -/
+@[simp] theorem storageAddr_writeAddrSlot_same (s : ContractState) (slot : Nat)
+    (value : Address) :
+    (s.writeAddrSlot slot value).storageAddr slot = value := by
+  simpa [storageAddr, writeAddrSlot] using
+    wordToAddress_writeAddressWord (s.storageWords (.addr slot)) value
+
+@[simp] theorem storageAddr_writeAddrSlot_other (s : ContractState)
+    {slot slot' : Nat} (h : slot' ≠ slot) (value : Address) :
+    (s.writeAddrSlot slot value).storageAddr slot' = s.storageAddr slot' := by
+  simp [storageAddr, writeAddrSlot, h]
+
+@[simp] theorem sender_writeAddrSlot (s : ContractState) (slot : Nat) (value : Address) :
+    (s.writeAddrSlot slot value).sender = s.sender := rfl
+
+@[simp] theorem thisAddress_writeAddrSlot (s : ContractState) (slot : Nat)
+    (value : Address) :
+    (s.writeAddrSlot slot value).thisAddress = s.thisAddress := rfl
+
+@[simp] theorem storageArray_writeAddrSlot (s : ContractState) (slot : Nat)
+    (value : Address) :
+    (s.writeAddrSlot slot value).storageArray = s.storageArray := rfl
+
+@[simp] theorem msgValue_writeAddrSlot (s : ContractState) (slot : Nat)
+    (value : Address) :
+    (s.writeAddrSlot slot value).msgValue = s.msgValue := rfl
+
+@[simp] theorem selfBalance_writeAddrSlot (s : ContractState) (slot : Nat)
+    (value : Address) :
+    (s.writeAddrSlot slot value).selfBalance = s.selfBalance := rfl
+
+@[simp] theorem blockTimestamp_writeAddrSlot (s : ContractState) (slot : Nat)
+    (value : Address) :
+    (s.writeAddrSlot slot value).blockTimestamp = s.blockTimestamp := rfl
+
+@[simp] theorem blockNumber_writeAddrSlot (s : ContractState) (slot : Nat)
+    (value : Address) :
+    (s.writeAddrSlot slot value).blockNumber = s.blockNumber := rfl
+
+@[simp] theorem chainId_writeAddrSlot (s : ContractState) (slot : Nat)
+    (value : Address) :
+    (s.writeAddrSlot slot value).chainId = s.chainId := rfl
+
+@[simp] theorem blobBaseFee_writeAddrSlot (s : ContractState) (slot : Nat)
+    (value : Address) :
+    (s.writeAddrSlot slot value).blobBaseFee = s.blobBaseFee := rfl
+
+@[simp] theorem calldataSize_writeAddrSlot (s : ContractState) (slot : Nat)
+    (value : Address) :
+    (s.writeAddrSlot slot value).calldataSize = s.calldataSize := rfl
 
 /-- Mapping writes leave word-slot and address compatibility views intact. -/
 @[simp] theorem storage_writeMap (s : ContractState) (slot : Nat) (key : Address) (value : Uint256) :
@@ -597,6 +668,199 @@ def withStorageChannel (s : ContractState)
   { s with storageWords := fun key => match key with
       | .slot slot => f s.storage slot
       | _ => s.storageWords key }
+
+private theorem mem_of_contains_true {α : Type} [BEq α] [LawfulBEq α]
+    {xs : List α} {x : α} (h : xs.contains x = true) : x ∈ xs :=
+  (List.contains_iff_mem).mp h
+
+private theorem not_mem_of_contains_false {α : Type} [BEq α] [LawfulBEq α]
+    {xs : List α} {x : α} (h : xs.contains x = false) : x ∉ xs := by
+  intro hmem
+  have := (List.contains_iff_mem).mpr hmem
+  exact Bool.noConfusion (this.symm.trans h)
+
+@[simp] theorem storageArray_writeSlots (s : ContractState) (targets : List Nat)
+    (value : Uint256) :
+    (s.writeSlots targets value).storageArray = s.storageArray := rfl
+
+@[simp] theorem storageArray_writeAddrSlots (s : ContractState) (targets : List Nat)
+    (value : Address) :
+    (s.writeAddrSlots targets value).storageArray = s.storageArray := rfl
+
+@[simp] theorem storageArray_writeTransientSlots (s : ContractState)
+    (targets : List Nat) (value : Uint256) :
+    (s.writeTransientSlots targets value).storageArray = s.storageArray := rfl
+
+@[simp] theorem storageArray_modifySlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifySlots targets f).storageArray = s.storageArray := rfl
+
+@[simp] theorem storageArray_modifyTransientSlots (s : ContractState)
+    (targets : List Nat) (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).storageArray = s.storageArray := rfl
+
+@[simp] theorem storageArray_withStorageChannel (s : ContractState)
+    (f : (Nat → Uint256) → Nat → Uint256) :
+    (s.withStorageChannel f).storageArray = s.storageArray := rfl
+
+@[simp] theorem storageArray_writeMap (s : ContractState) (slot : Nat) (key : Address)
+    (value : Uint256) :
+    (s.writeMap slot key value).storageArray = s.storageArray := rfl
+
+@[simp] theorem storageArray_writeMapUint (s : ContractState) (slot : Nat)
+    (key value : Uint256) :
+    (s.writeMapUint slot key value).storageArray = s.storageArray := rfl
+
+@[simp] theorem storageArray_writeMap2 (s : ContractState) (slot : Nat)
+    (key1 key2 : Address) (value : Uint256) :
+    (s.writeMap2 slot key1 key2 value).storageArray = s.storageArray := rfl
+
+@[simp] theorem storage_writeSlots_mem (s : ContractState) (targets : List Nat)
+    (value : Uint256) {slot : Nat} (h : targets.contains slot = true) :
+    (s.writeSlots targets value).storage slot = value := by
+  have hmem := mem_of_contains_true h
+  simp [storage, writeSlots, hmem]
+
+@[simp] theorem storage_writeSlots_not_mem (s : ContractState) (targets : List Nat)
+    (value : Uint256) {slot : Nat} (h : targets.contains slot = false) :
+    (s.writeSlots targets value).storage slot = s.storage slot := by
+  have hmem := not_mem_of_contains_false h
+  simp [storage, writeSlots, hmem]
+
+@[simp] theorem storageAddr_writeSlots (s : ContractState) (targets : List Nat)
+    (value : Uint256) :
+    (s.writeSlots targets value).storageAddr = s.storageAddr := by
+  funext slot
+  simp [storageAddr, writeSlots]
+
+@[simp] theorem transientStorage_writeSlots (s : ContractState) (targets : List Nat)
+    (value : Uint256) :
+    (s.writeSlots targets value).transientStorage = s.transientStorage := by
+  funext slot
+  simp [transientStorage, writeSlots]
+
+@[simp] theorem storage_writeAddrSlots (s : ContractState) (targets : List Nat)
+    (value : Address) :
+    (s.writeAddrSlots targets value).storage = s.storage := by
+  funext slot
+  simp [storage, writeAddrSlots]
+
+@[simp] theorem storageAddr_writeAddrSlots_mem (s : ContractState) (targets : List Nat)
+    (value : Address) {slot : Nat} (h : targets.contains slot = true) :
+    (s.writeAddrSlots targets value).storageAddr slot = value := by
+  have hmem := mem_of_contains_true h
+  simpa [storageAddr, writeAddrSlots, hmem] using
+    wordToAddress_writeAddressWord (s.storageWords (.addr slot)) value
+
+@[simp] theorem storageAddr_writeAddrSlots_not_mem (s : ContractState)
+    (targets : List Nat) (value : Address) {slot : Nat}
+    (h : targets.contains slot = false) :
+    (s.writeAddrSlots targets value).storageAddr slot = s.storageAddr slot := by
+  have hmem := not_mem_of_contains_false h
+  simp [storageAddr, writeAddrSlots, hmem]
+
+@[simp] theorem transientStorage_writeAddrSlots (s : ContractState)
+    (targets : List Nat) (value : Address) :
+    (s.writeAddrSlots targets value).transientStorage = s.transientStorage := by
+  funext slot
+  simp [transientStorage, writeAddrSlots]
+
+@[simp] theorem storage_writeTransientSlots (s : ContractState) (targets : List Nat)
+    (value : Uint256) :
+    (s.writeTransientSlots targets value).storage = s.storage := by
+  funext slot
+  simp [storage, writeTransientSlots]
+
+@[simp] theorem storageAddr_writeTransientSlots (s : ContractState)
+    (targets : List Nat) (value : Uint256) :
+    (s.writeTransientSlots targets value).storageAddr = s.storageAddr := by
+  funext slot
+  simp [storageAddr, writeTransientSlots]
+
+@[simp] theorem transientStorage_writeTransientSlots_mem (s : ContractState)
+    (targets : List Nat) (value : Uint256) {slot : Nat}
+    (h : targets.contains slot = true) :
+    (s.writeTransientSlots targets value).transientStorage slot = value := by
+  have hmem := mem_of_contains_true h
+  simp [transientStorage, writeTransientSlots, hmem]
+
+@[simp] theorem transientStorage_writeTransientSlots_not_mem (s : ContractState)
+    (targets : List Nat) (value : Uint256) {slot : Nat}
+    (h : targets.contains slot = false) :
+    (s.writeTransientSlots targets value).transientStorage slot =
+      s.transientStorage slot := by
+  have hmem := not_mem_of_contains_false h
+  simp [transientStorage, writeTransientSlots, hmem]
+
+@[simp] theorem storage_modifySlots_not_mem (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) {slot : Nat} (h : targets.contains slot = false) :
+    (s.modifySlots targets f).storage slot = s.storage slot := by
+  have hmem := not_mem_of_contains_false h
+  simp [storage, modifySlots, hmem]
+
+@[simp] theorem storage_modifySlots_mem (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) {slot : Nat} (h : targets.contains slot = true) :
+    (s.modifySlots targets f).storage slot = f (s.storage slot) := by
+  have hmem := mem_of_contains_true h
+  simp [storage, modifySlots, hmem]
+
+@[simp] theorem storageAddr_modifySlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifySlots targets f).storageAddr = s.storageAddr := by
+  funext slot
+  simp [storageAddr, modifySlots]
+
+@[simp] theorem transientStorage_modifySlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifySlots targets f).transientStorage = s.transientStorage := by
+  funext slot
+  simp [transientStorage, modifySlots]
+
+@[simp] theorem storage_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).storage = s.storage := by
+  funext slot
+  simp [storage, modifyTransientSlots]
+
+@[simp] theorem storageAddr_modifyTransientSlots (s : ContractState)
+    (targets : List Nat) (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).storageAddr = s.storageAddr := by
+  funext slot
+  simp [storageAddr, modifyTransientSlots]
+
+@[simp] theorem transientStorage_modifyTransientSlots_mem (s : ContractState)
+    (targets : List Nat) (f : Uint256 → Uint256) {slot : Nat}
+    (h : targets.contains slot = true) :
+    (s.modifyTransientSlots targets f).transientStorage slot =
+      f (s.transientStorage slot) := by
+  have hmem := mem_of_contains_true h
+  simp [transientStorage, modifyTransientSlots, hmem]
+
+@[simp] theorem transientStorage_modifyTransientSlots_not_mem (s : ContractState)
+    (targets : List Nat) (f : Uint256 → Uint256) {slot : Nat}
+    (h : targets.contains slot = false) :
+    (s.modifyTransientSlots targets f).transientStorage slot =
+      s.transientStorage slot := by
+  have hmem := not_mem_of_contains_false h
+  simp [transientStorage, modifyTransientSlots, hmem]
+
+@[simp] theorem storage_withStorageChannel (s : ContractState)
+    (f : (Nat → Uint256) → Nat → Uint256) :
+    (s.withStorageChannel f).storage = f s.storage := by
+  funext slot
+  simp [storage, withStorageChannel]
+
+@[simp] theorem storageAddr_withStorageChannel (s : ContractState)
+    (f : (Nat → Uint256) → Nat → Uint256) :
+    (s.withStorageChannel f).storageAddr = s.storageAddr := by
+  funext slot
+  simp [storageAddr, withStorageChannel]
+
+@[simp] theorem transientStorage_withStorageChannel (s : ContractState)
+    (f : (Nat → Uint256) → Nat → Uint256) :
+    (s.withStorageChannel f).transientStorage = s.transientStorage := by
+  funext slot
+  simp [transientStorage, withStorageChannel]
 
 /-- Canonical full-state constructor from explicit storage channels. Clients
 building a world from externally supplied channel functions (interpreter

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -204,17 +204,26 @@ structure ExternalCall where
   name : String := ""
   deriving DecidableEq, Repr
 
+/-! Canonical, injective names for every word-valued storage location.
+
+The source model deliberately keeps these names separate from compiler-level
+keccak slot derivation.  Thus the lens laws below use constructor injectivity,
+rather than assuming that a hash is injective. -/
+inductive StorageKey where
+  | slot (slot : Nat)
+  | contractSlot (contract slot : Nat)
+  | transient (slot : Nat)
+  | addr (slot : Nat)
+  | map (slot : Nat) (key : Address)
+  | mapUint (slot : Nat) (key : Uint256)
+  | map2 (slot : Nat) (key1 key2 : Address)
+  deriving DecidableEq, Repr
+
 -- State monad for contract execution
 structure ContractState where
-  storage : Nat → Uint256                -- Uint256 storage mapping
-  /-- Storage worlds for explicitly identified contracts. Contract id `0` is
-      represented by `storage` through the compatibility lenses below. -/
-  contractStorage : Nat → Nat → Uint256 := fun _ _ => 0
-  transientStorage : Nat → Uint256       -- EIP-1153 transient storage mapping
-  storageAddr : Nat → Address            -- Address storage mapping
-  storageMap : Nat → Address → Uint256  -- Mapping storage (Address → Uint256)
-  storageMapUint : Nat → Uint256 → Uint256  -- Uint256-keyed mapping storage (#154)
-  storageMap2 : Nat → Address → Address → Uint256  -- Double mapping storage (#154)
+  /-- The sole word-valued storage backing map. `StorageKey` retains the
+      source-level channel/layout distinction injectively. -/
+  storageWords : StorageKey → Uint256
   storageArray : Nat → List Uint256  -- Dynamic-array storage grouped by base slot (#1571)
   sender : Address
   thisAddress : Address
@@ -259,11 +268,33 @@ slot derivation) is a swap of lens implementations under stable names and
 the `storage_simps` simp set — not another ~1400-site rewrite.
 -/
 
-def readSlot (s : ContractState) (slot : Nat) : Uint256 :=
-  s.storage slot
+def storage (s : ContractState) : Nat → Uint256 :=
+  fun slot => s.storageWords (.slot slot)
+
+/-- Compatibility view for explicitly identified contract worlds. Contract
+    `0` remains the unqualified storage world. -/
+def contractStorage (s : ContractState) : Nat → Nat → Uint256 :=
+  fun contract slot => if contract == 0 then s.storage slot else s.storageWords (.contractSlot contract slot)
+
+def transientStorage (s : ContractState) : Nat → Uint256 :=
+  fun slot => s.storageWords (.transient slot)
+
+def storageAddr (s : ContractState) : Nat → Address :=
+  fun slot => wordToAddress (s.storageWords (.addr slot))
+
+def storageMap (s : ContractState) : Nat → Address → Uint256 :=
+  fun slot key => s.storageWords (.map slot key)
+
+def storageMapUint (s : ContractState) : Nat → Uint256 → Uint256 :=
+  fun slot key => s.storageWords (.mapUint slot key)
+
+def storageMap2 (s : ContractState) : Nat → Address → Address → Uint256 :=
+  fun slot key1 key2 => s.storageWords (.map2 slot key1 key2)
+
+def readSlot (s : ContractState) (slot : Nat) : Uint256 := s.storage slot
 
 def writeSlot (s : ContractState) (slot : Nat) (value : Uint256) : ContractState :=
-  { s with storage := fun sl => if sl == slot then value else s.storage sl }
+  { s with storageWords := fun key => if key == .slot slot then value else s.storageWords key }
 
 /-- Read a word from a contract-separated storage world. Contract id `0`
     deliberately denotes the legacy, unqualified `storage` world. -/
@@ -276,42 +307,43 @@ def writeContractSlot (s : ContractState) (contract : Nat) (slot : Nat)
     (value : Uint256) : ContractState :=
   if contract == 0 then s.writeSlot slot value
   else
-    { s with contractStorage := fun c sl =>
-        if c == contract && sl == slot then value else s.contractStorage c sl }
+    { s with storageWords := fun key =>
+        if key == .contractSlot contract slot then value else s.storageWords key }
 
 def readAddrSlot (s : ContractState) (slot : Nat) : Address :=
   s.storageAddr slot
 
 def writeAddrSlot (s : ContractState) (slot : Nat) (value : Address) : ContractState :=
-  { s with storageAddr := fun sl => if sl == slot then value else s.storageAddr sl }
+  { s with storageWords := fun key =>
+      if key == .addr slot then addressToWord value else s.storageWords key }
 
 def readTransient (s : ContractState) (slot : Nat) : Uint256 :=
   s.transientStorage slot
 
 def writeTransient (s : ContractState) (slot : Nat) (value : Uint256) : ContractState :=
-  { s with transientStorage := fun sl => if sl == slot then value else s.transientStorage sl }
+  { s with storageWords := fun key => if key == .transient slot then value else s.storageWords key }
 
 def readMap (s : ContractState) (slot : Nat) (key : Address) : Uint256 :=
   s.storageMap slot key
 
 def writeMap (s : ContractState) (slot : Nat) (key : Address) (value : Uint256) : ContractState :=
-  { s with storageMap := fun sl k =>
-      if sl == slot && k == key then value else s.storageMap sl k }
+  { s with storageWords := fun storageKey =>
+      if storageKey == .map slot key then value else s.storageWords storageKey }
 
 def readMapUint (s : ContractState) (slot : Nat) (key : Uint256) : Uint256 :=
   s.storageMapUint slot key
 
 def writeMapUint (s : ContractState) (slot : Nat) (key : Uint256) (value : Uint256) : ContractState :=
-  { s with storageMapUint := fun sl k =>
-      if sl == slot && k == key then value else s.storageMapUint sl k }
+  { s with storageWords := fun storageKey =>
+      if storageKey == .mapUint slot key then value else s.storageWords storageKey }
 
 def readMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) : Uint256 :=
   s.storageMap2 slot key1 key2
 
 def writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) (value : Uint256) :
     ContractState :=
-  { s with storageMap2 := fun sl k1 k2 =>
-      if sl == slot && k1 == key1 && k2 == key2 then value else s.storageMap2 sl k1 k2 }
+  { s with storageWords := fun storageKey =>
+      if storageKey == .map2 slot key1 key2 then value else s.storageWords storageKey }
 
 def readArray (s : ContractState) (slot : Nat) : List Uint256 :=
   s.storageArray slot
@@ -332,33 +364,37 @@ the only sanctioned multi-slot write surface over the storage channels.
 /-- Write `value` at every slot in `targets` (uint channel). -/
 def writeSlots (s : ContractState) (targets : List Nat) (value : Uint256) :
     ContractState :=
-  { s with storage := fun slot =>
-      if targets.contains slot then value else s.storage slot }
+  { s with storageWords := fun key => match key with
+      | .slot slot => if targets.contains slot then value else s.storageWords key
+      | _ => s.storageWords key }
 
 /-- Read-modify-write every slot in `targets` (uint channel). -/
 def modifySlots (s : ContractState) (targets : List Nat)
     (f : Uint256 → Uint256) : ContractState :=
-  { s with storage := fun slot =>
-      if targets.contains slot then f (s.storage slot) else s.storage slot }
+  { s with storageWords := fun key => match key with
+      | .slot slot => if targets.contains slot then f (s.storageWords key) else s.storageWords key
+      | _ => s.storageWords key }
 
 /-- Write `value` at every transient slot in `targets`. -/
 def writeTransientSlots (s : ContractState) (targets : List Nat)
     (value : Uint256) : ContractState :=
-  { s with transientStorage := fun slot =>
-      if targets.contains slot then value else s.transientStorage slot }
+  { s with storageWords := fun key => match key with
+      | .transient slot => if targets.contains slot then value else s.storageWords key
+      | _ => s.storageWords key }
 
 /-- Read-modify-write every transient slot in `targets`. -/
 def modifyTransientSlots (s : ContractState) (targets : List Nat)
     (f : Uint256 → Uint256) : ContractState :=
-  { s with transientStorage := fun slot =>
-      if targets.contains slot then f (s.transientStorage slot)
-      else s.transientStorage slot }
+  { s with storageWords := fun key => match key with
+      | .transient slot => if targets.contains slot then f (s.storageWords key) else s.storageWords key
+      | _ => s.storageWords key }
 
 /-- Write `value` at every address slot in `targets`. -/
 def writeAddrSlots (s : ContractState) (targets : List Nat) (value : Address) :
     ContractState :=
-  { s with storageAddr := fun slot =>
-      if targets.contains slot then value else s.storageAddr slot }
+  { s with storageWords := fun key => match key with
+      | .addr slot => if targets.contains slot then addressToWord value else s.storageWords key
+      | _ => s.storageWords key }
 
 /-- Replace the whole uint channel through a transformer. The denotational
 layer's flat-view rebuilds (mapping writes rendered through a `Nat → Nat`
@@ -366,7 +402,9 @@ storage view) are channel-wide, not slot-guarded; this is their sanctioned
 surface. The C5 flip reimplements it as a `.slot`-key-restricted update. -/
 def withStorageChannel (s : ContractState)
     (f : (Nat → Uint256) → Nat → Uint256) : ContractState :=
-  { s with storage := f s.storage }
+  { s with storageWords := fun key => match key with
+      | .slot slot => f s.storage slot
+      | _ => s.storageWords key }
 
 /-- Canonical full-state constructor from explicit storage channels. Clients
 building a world from externally supplied channel functions (interpreter
@@ -386,12 +424,14 @@ def ofChannels
     (thisAddress : Address := 0)
     (msgValue : Uint256 := 0)
     (blockTimestamp : Uint256 := 0) : ContractState :=
-  { storage := uintChannel
-    transientStorage := transientChannel
-    storageAddr := addrChannel
-    storageMap := mapChannel
-    storageMapUint := mapUintChannel
-    storageMap2 := map2Channel
+  { storageWords := fun key => match key with
+      | .slot slot => uintChannel slot
+      | .contractSlot _ _ => 0
+      | .transient slot => transientChannel slot
+      | .addr slot => addressToWord (addrChannel slot)
+      | .map slot key => mapChannel slot key
+      | .mapUint slot key => mapUintChannel slot key
+      | .map2 slot key1 key2 => map2Channel slot key1 key2
     storageArray := arrayChannel
     sender := sender
     thisAddress := thisAddress
@@ -492,12 +532,7 @@ end ContractState
 -- Default zero state — all storage zero, empty addresses, no events.
 -- Use `{ defaultState with sender := Address.ofNat 0xA11CE }` to customize fields.
 def defaultState : ContractState where
-  storage := fun _ => 0
-  transientStorage := fun _ => 0
-  storageAddr := fun _ => 0
-  storageMap := fun _ _ => 0
-  storageMapUint := fun _ _ => 0
-  storageMap2 := fun _ _ _ => 0
+  storageWords := fun _ => 0
   storageArray := fun _ => []
   sender := 0
   thisAddress := 0
@@ -715,9 +750,7 @@ def setPackedTransientStorage (s : StorageSlot Uint256) (offset width : Nat)
   (getStorage s).run state = ContractResult.success (state.storage s.slot) state := rfl
 
 @[simp] theorem setStorage_run (s : StorageSlot Uint256) (value : Uint256) (state : ContractState) :
-  (setStorage s value).run state = ContractResult.success () { state with
-    storage := fun slot => if slot == s.slot then value else state.storage slot
-  } := rfl
+  (setStorage s value).run state = ContractResult.success () (state.writeSlot s.slot value) := rfl
 
 -- Storage operations for Address (routed through the canonical lens API)
 def getStorageAddr (s : StorageSlot Address) : Contract Address :=
@@ -730,9 +763,7 @@ def setStorageAddr (s : StorageSlot Address) (value : Address) : Contract Unit :
   (getStorageAddr s).run state = ContractResult.success (state.storageAddr s.slot) state := rfl
 
 @[simp] theorem setStorageAddr_run (s : StorageSlot Address) (value : Address) (state : ContractState) :
-  (setStorageAddr s value).run state = ContractResult.success () { state with
-    storageAddr := fun slot => if slot == s.slot then value else state.storageAddr slot
-  } := rfl
+  (setStorageAddr s value).run state = ContractResult.success () (state.writeAddrSlot s.slot value) := rfl
 
 -- Mapping operations (Address → Uint256), routed through the canonical lens API.
 -- `setMapping` additionally tracks the key in `knownAddresses` (sum properties).
@@ -752,10 +783,7 @@ def setMapping (s : StorageSlot (Address → Uint256)) (key : Address) (value : 
   (getMapping s key).run state = ContractResult.success (state.storageMap s.slot key) state := rfl
 
 @[simp] theorem setMapping_run (s : StorageSlot (Address → Uint256)) (key : Address) (value : Uint256) (state : ContractState) :
-  (setMapping s key value).run state = ContractResult.success () { state with
-    storageMap := fun slot addr =>
-      if slot == s.slot && addr == key then value
-      else state.storageMap slot addr,
+  (setMapping s key value).run state = ContractResult.success () { state.writeMap s.slot key value with
     knownAddresses := fun slot =>
       if slot == s.slot then
         (state.knownAddresses slot).insert key
@@ -792,11 +820,8 @@ def setMapping2 (s : StorageSlot (Address → Address → Uint256)) (key1 key2 :
   (getMapping2 s key1 key2).run state = ContractResult.success (state.storageMap2 s.slot key1 key2) state := rfl
 
 @[simp] theorem setMapping2_run (s : StorageSlot (Address → Address → Uint256)) (key1 key2 : Address) (value : Uint256) (state : ContractState) :
-  (setMapping2 s key1 key2 value).run state = ContractResult.success () { state with
-    storageMap2 := fun slot addr1 addr2 =>
-      if slot == s.slot && addr1 == key1 && addr2 == key2 then value
-      else state.storageMap2 slot addr1 addr2
-  } := rfl
+  (setMapping2 s key1 key2 value).run state = ContractResult.success ()
+    (state.writeMap2 s.slot key1 key2 value) := rfl
 
 -- Uint256-keyed mapping operations (#154)
 def getMappingUint (s : StorageSlot (Uint256 → Uint256)) (key : Uint256) : Contract Uint256 :=
@@ -810,11 +835,8 @@ def setMappingUint (s : StorageSlot (Uint256 → Uint256)) (key : Uint256) (valu
   (getMappingUint s key).run state = ContractResult.success (state.storageMapUint s.slot key) state := rfl
 
 @[simp] theorem setMappingUint_run (s : StorageSlot (Uint256 → Uint256)) (key : Uint256) (value : Uint256) (state : ContractState) :
-  (setMappingUint s key value).run state = ContractResult.success () { state with
-    storageMapUint := fun slot k =>
-      if slot == s.slot && k == key then value
-      else state.storageMapUint slot k
-  } := rfl
+  (setMappingUint s key value).run state = ContractResult.success ()
+    (state.writeMapUint s.slot key value) := rfl
 
 def getMappingUintAddr (s : StorageSlot (Uint256 → Uint256)) (key : Uint256) : Contract Address :=
   fun state => ContractResult.success (wordToAddress (state.readMapUint s.slot key)) state
@@ -1106,20 +1128,12 @@ concerns of storage-slot guards. -/
 def nonReentrantTransient (lockOffset : Uint256) (body : Contract α) : Contract α :=
   fun s =>
     if s.transientStorage (lockOffset : Nat) == 0 then
-      let sLocked := { s with
-        transientStorage := fun i =>
-          if i == (lockOffset : Nat) then 1 else s.transientStorage i }
+      let sLocked := s.writeTransient (lockOffset : Nat) 1
       match body sLocked with
       | ContractResult.success a s' =>
-          ContractResult.success a
-            { s' with
-              transientStorage := fun i =>
-                if i == (lockOffset : Nat) then 0 else s'.transientStorage i }
+          ContractResult.success a (s'.writeTransient (lockOffset : Nat) 0)
       | ContractResult.revert msg s' =>
-          ContractResult.revert msg
-            { s' with
-              transientStorage := fun i =>
-                if i == (lockOffset : Nat) then 0 else s'.transientStorage i }
+          ContractResult.revert msg (s'.writeTransient (lockOffset : Nat) 0)
     else
       ContractResult.revert "ReentrancyGuardTransient: reentrant call" s
 

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -399,6 +399,16 @@ def writeMap (s : ContractState) (slot : Nat) (key : Address) (value : Uint256) 
   funext mapSlot mapKey
   simp [storageMap, writeSlot]
 
+@[simp] theorem storageMapUint_writeSlot (s : ContractState) (slot : Nat) (value : Uint256) :
+    (s.writeSlot slot value).storageMapUint = s.storageMapUint := by
+  funext mapSlot mapKey
+  simp [storageMapUint, writeSlot]
+
+@[simp] theorem storageMap2_writeSlot (s : ContractState) (slot : Nat) (value : Uint256) :
+    (s.writeSlot slot value).storageMap2 = s.storageMap2 := by
+  funext mapSlot mapKey1 mapKey2
+  simp [storageMap2, writeSlot]
+
 /-- Address-slot writes leave word-slot and mapping compatibility views intact. -/
 @[simp] theorem storage_writeAddrSlot (s : ContractState) (slot : Nat) (value : Address) :
     (s.writeAddrSlot slot value).storage = s.storage := by
@@ -409,6 +419,16 @@ def writeMap (s : ContractState) (slot : Nat) (key : Address) (value : Uint256) 
     (s.writeAddrSlot slot value).storageMap = s.storageMap := by
   funext mapSlot mapKey
   simp [storageMap, writeAddrSlot]
+
+@[simp] theorem storageMapUint_writeAddrSlot (s : ContractState) (slot : Nat) (value : Address) :
+    (s.writeAddrSlot slot value).storageMapUint = s.storageMapUint := by
+  funext mapSlot mapKey
+  simp [storageMapUint, writeAddrSlot]
+
+@[simp] theorem storageMap2_writeAddrSlot (s : ContractState) (slot : Nat) (value : Address) :
+    (s.writeAddrSlot slot value).storageMap2 = s.storageMap2 := by
+  funext mapSlot mapKey1 mapKey2
+  simp [storageMap2, writeAddrSlot]
 
 /-- Mapping writes leave word-slot and address compatibility views intact. -/
 @[simp] theorem storage_writeMap (s : ContractState) (slot : Nat) (key : Address) (value : Uint256) :
@@ -421,12 +441,57 @@ def writeMap (s : ContractState) (slot : Nat) (key : Address) (value : Uint256) 
   funext addrSlot
   simp [storageAddr, writeMap]
 
+@[simp] theorem storageMapUint_writeMap (s : ContractState) (slot : Nat) (key : Address)
+    (value : Uint256) : (s.writeMap slot key value).storageMapUint = s.storageMapUint := by
+  funext mapSlot mapKey
+  simp [storageMapUint, writeMap]
+
+@[simp] theorem storageMap2_writeMap (s : ContractState) (slot : Nat) (key : Address)
+    (value : Uint256) : (s.writeMap slot key value).storageMap2 = s.storageMap2 := by
+  funext mapSlot mapKey1 mapKey2
+  simp [storageMap2, writeMap]
+
 def readMapUint (s : ContractState) (slot : Nat) (key : Uint256) : Uint256 :=
   s.storageMapUint slot key
 
 def writeMapUint (s : ContractState) (slot : Nat) (key : Uint256) (value : Uint256) : ContractState :=
   { s with storageWords := fun storageKey =>
       if storageKey == .mapUint slot key then value else s.storageWords storageKey }
+
+@[simp] theorem storage_writeMapUint (s : ContractState) (slot : Nat) (key value : Uint256) :
+    (s.writeMapUint slot key value).storage = s.storage := by
+  funext wordSlot
+  simp [storage, writeMapUint]
+
+@[simp] theorem storageAddr_writeMapUint (s : ContractState) (slot : Nat) (key value : Uint256) :
+    (s.writeMapUint slot key value).storageAddr = s.storageAddr := by
+  funext addrSlot
+  simp [storageAddr, writeMapUint]
+
+@[simp] theorem storageMap_writeMapUint (s : ContractState) (slot : Nat) (key value : Uint256) :
+    (s.writeMapUint slot key value).storageMap = s.storageMap := by
+  funext mapSlot mapKey
+  simp [storageMap, writeMapUint]
+
+@[simp] theorem storageMap2_writeMapUint (s : ContractState) (slot : Nat) (key value : Uint256) :
+    (s.writeMapUint slot key value).storageMap2 = s.storageMap2 := by
+  funext mapSlot mapKey1 mapKey2
+  simp [storageMap2, writeMapUint]
+
+@[simp] theorem sender_writeMapUint (s : ContractState) (slot : Nat) (key value : Uint256) :
+    (s.writeMapUint slot key value).sender = s.sender := rfl
+@[simp] theorem thisAddress_writeMapUint (s : ContractState) (slot : Nat) (key value : Uint256) :
+    (s.writeMapUint slot key value).thisAddress = s.thisAddress := rfl
+@[simp] theorem knownAddresses_writeMapUint (s : ContractState) (slot : Nat) (key value : Uint256) :
+    (s.writeMapUint slot key value).knownAddresses = s.knownAddresses := rfl
+@[simp] theorem msgValue_writeMapUint (s : ContractState) (slot : Nat) (key value : Uint256) :
+    (s.writeMapUint slot key value).msgValue = s.msgValue := rfl
+@[simp] theorem blockTimestamp_writeMapUint (s : ContractState) (slot : Nat) (key value : Uint256) :
+    (s.writeMapUint slot key value).blockTimestamp = s.blockTimestamp := rfl
+@[simp] theorem blockNumber_writeMapUint (s : ContractState) (slot : Nat) (key value : Uint256) :
+    (s.writeMapUint slot key value).blockNumber = s.blockNumber := rfl
+@[simp] theorem events_writeMapUint (s : ContractState) (slot : Nat) (key value : Uint256) :
+    (s.writeMapUint slot key value).events = s.events := rfl
 
 def readMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) : Uint256 :=
   s.storageMap2 slot key1 key2
@@ -435,6 +500,41 @@ def writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) (value : Ui
     ContractState :=
   { s with storageWords := fun storageKey =>
       if storageKey == .map2 slot key1 key2 then value else s.storageWords storageKey }
+
+@[simp] theorem storage_writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address)
+    (value : Uint256) : (s.writeMap2 slot key1 key2 value).storage = s.storage := by
+  funext wordSlot
+  simp [storage, writeMap2]
+
+@[simp] theorem storageAddr_writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address)
+    (value : Uint256) : (s.writeMap2 slot key1 key2 value).storageAddr = s.storageAddr := by
+  funext addrSlot
+  simp [storageAddr, writeMap2]
+
+@[simp] theorem storageMap_writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address)
+    (value : Uint256) : (s.writeMap2 slot key1 key2 value).storageMap = s.storageMap := by
+  funext mapSlot mapKey
+  simp [storageMap, writeMap2]
+
+@[simp] theorem storageMapUint_writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address)
+    (value : Uint256) : (s.writeMap2 slot key1 key2 value).storageMapUint = s.storageMapUint := by
+  funext mapSlot mapKey
+  simp [storageMapUint, writeMap2]
+
+@[simp] theorem sender_writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) (value : Uint256) :
+    (s.writeMap2 slot key1 key2 value).sender = s.sender := rfl
+@[simp] theorem thisAddress_writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) (value : Uint256) :
+    (s.writeMap2 slot key1 key2 value).thisAddress = s.thisAddress := rfl
+@[simp] theorem knownAddresses_writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) (value : Uint256) :
+    (s.writeMap2 slot key1 key2 value).knownAddresses = s.knownAddresses := rfl
+@[simp] theorem msgValue_writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) (value : Uint256) :
+    (s.writeMap2 slot key1 key2 value).msgValue = s.msgValue := rfl
+@[simp] theorem blockTimestamp_writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) (value : Uint256) :
+    (s.writeMap2 slot key1 key2 value).blockTimestamp = s.blockTimestamp := rfl
+@[simp] theorem blockNumber_writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) (value : Uint256) :
+    (s.writeMap2 slot key1 key2 value).blockNumber = s.blockNumber := rfl
+@[simp] theorem events_writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) (value : Uint256) :
+    (s.writeMap2 slot key1 key2 value).events = s.events := rfl
 
 def readArray (s : ContractState) (slot : Nat) : List Uint256 :=
   s.storageArray slot

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -388,6 +388,39 @@ def writeMap (s : ContractState) (slot : Nat) (key : Address) (value : Uint256) 
   { s with storageWords := fun storageKey =>
       if storageKey == .map slot key then value else s.storageWords storageKey }
 
+/-- Word-slot writes leave the address and mapping compatibility views intact. -/
+@[simp] theorem storageAddr_writeSlot (s : ContractState) (slot : Nat) (value : Uint256) :
+    (s.writeSlot slot value).storageAddr = s.storageAddr := by
+  funext addrSlot
+  simp [storageAddr, writeSlot]
+
+@[simp] theorem storageMap_writeSlot (s : ContractState) (slot : Nat) (value : Uint256) :
+    (s.writeSlot slot value).storageMap = s.storageMap := by
+  funext mapSlot mapKey
+  simp [storageMap, writeSlot]
+
+/-- Address-slot writes leave word-slot and mapping compatibility views intact. -/
+@[simp] theorem storage_writeAddrSlot (s : ContractState) (slot : Nat) (value : Address) :
+    (s.writeAddrSlot slot value).storage = s.storage := by
+  funext wordSlot
+  simp [storage, writeAddrSlot]
+
+@[simp] theorem storageMap_writeAddrSlot (s : ContractState) (slot : Nat) (value : Address) :
+    (s.writeAddrSlot slot value).storageMap = s.storageMap := by
+  funext mapSlot mapKey
+  simp [storageMap, writeAddrSlot]
+
+/-- Mapping writes leave word-slot and address compatibility views intact. -/
+@[simp] theorem storage_writeMap (s : ContractState) (slot : Nat) (key : Address) (value : Uint256) :
+    (s.writeMap slot key value).storage = s.storage := by
+  funext wordSlot
+  simp [storage, writeMap]
+
+@[simp] theorem storageAddr_writeMap (s : ContractState) (slot : Nat) (key : Address)
+    (value : Uint256) : (s.writeMap slot key value).storageAddr = s.storageAddr := by
+  funext addrSlot
+  simp [storageAddr, writeMap]
+
 def readMapUint (s : ContractState) (slot : Nat) (key : Uint256) : Uint256 :=
   s.storageMapUint slot key
 

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -441,12 +441,12 @@ def ofChannels
 
 @[storage_simps] theorem readSlot_writeSlot_same (s : ContractState) (slot : Nat) (v : Uint256) :
     (s.writeSlot slot v).readSlot slot = v := by
-  simp [readSlot, writeSlot]
+  simp [readSlot, storage, writeSlot]
 
 @[storage_simps] theorem readSlot_writeSlot_other (s : ContractState) {slot slot' : Nat}
     (h : slot' ≠ slot) (v : Uint256) :
     (s.writeSlot slot v).readSlot slot' = s.readSlot slot' := by
-  simp [readSlot, writeSlot, h]
+  simp [readSlot, storage, writeSlot, h]
 
 @[storage_simps] theorem readContractSlot_zero (s : ContractState) (slot : Nat) :
     s.readContractSlot 0 slot = s.readSlot slot := by
@@ -457,8 +457,8 @@ def ofChannels
     (s.writeContractSlot contract slot v).readContractSlot contract slot = v := by
   by_cases h : contract = 0
   · subst contract
-    simp [readContractSlot, writeContractSlot, readSlot, writeSlot]
-  · simp [readContractSlot, writeContractSlot, h]
+    simp [readContractSlot, readSlot, storage, writeContractSlot, writeSlot]
+  · simp [readContractSlot, contractStorage, writeContractSlot, h]
 
 @[storage_simps] theorem readContractSlot_writeContractSlot_other_contract
     (s : ContractState) {contract contract' slot : Nat} (h : contract' ≠ contract)
@@ -468,48 +468,57 @@ def ofChannels
   by_cases hc : contract = 0
   · subst contract
     have hc' : contract' ≠ 0 := h
-    simp [readContractSlot, writeContractSlot, writeSlot, hc']
+    simp [readContractSlot, contractStorage, writeContractSlot, writeSlot, hc']
   · by_cases hc' : contract' = 0
     · subst contract'
-      simp [readContractSlot, writeContractSlot, readSlot, hc]
-    · simp [readContractSlot, writeContractSlot, hc, hc', h]
+      simp [readContractSlot, writeContractSlot, readSlot, storage, hc]
+    · simp [readContractSlot, contractStorage, writeContractSlot, hc, hc', h]
 
 @[storage_simps] theorem readAddrSlot_writeAddrSlot_same (s : ContractState) (slot : Nat)
     (v : Address) : (s.writeAddrSlot slot v).readAddrSlot slot = v := by
-  simp [readAddrSlot, writeAddrSlot]
+  have hlt : v.toNat < Verity.Core.Uint256.modulus := by
+    calc
+      v.toNat < Verity.Core.Address.modulus := v.isLt
+      _ < Verity.Core.Uint256.modulus := by
+        change 2 ^ 160 < 2 ^ 256
+        exact Nat.pow_lt_pow_right (by decide) (by decide)
+  apply Verity.Core.Address.ext
+  simp [readAddrSlot, storageAddr, writeAddrSlot, wordToAddress, addressToWord]
+  rw [Nat.mod_eq_of_lt hlt]
+  exact Verity.Core.Address.val_mod_modulus v
 
 @[storage_simps] theorem readAddrSlot_writeAddrSlot_other (s : ContractState)
     {slot slot' : Nat} (h : slot' ≠ slot) (v : Address) :
     (s.writeAddrSlot slot v).readAddrSlot slot' = s.readAddrSlot slot' := by
-  simp [readAddrSlot, writeAddrSlot, h]
+  simp [readAddrSlot, storageAddr, writeAddrSlot, h]
 
 @[storage_simps] theorem readTransient_writeTransient_same (s : ContractState) (slot : Nat)
     (v : Uint256) : (s.writeTransient slot v).readTransient slot = v := by
-  simp [readTransient, writeTransient]
+  simp [readTransient, transientStorage, writeTransient]
 
 @[storage_simps] theorem readTransient_writeTransient_other (s : ContractState)
     {slot slot' : Nat} (h : slot' ≠ slot) (v : Uint256) :
     (s.writeTransient slot v).readTransient slot' = s.readTransient slot' := by
-  simp [readTransient, writeTransient, h]
+  simp [readTransient, transientStorage, writeTransient, h]
 
 @[storage_simps] theorem readMap_writeMap_same (s : ContractState) (slot : Nat) (key : Address)
     (v : Uint256) : (s.writeMap slot key v).readMap slot key = v := by
-  simp [readMap, writeMap]
+  simp [readMap, storageMap, writeMap]
 
 @[storage_simps] theorem readMap_writeMap_other_key (s : ContractState) (slot : Nat)
     {key key' : Address} (h : key' ≠ key) (v : Uint256) :
     (s.writeMap slot key v).readMap slot key' = s.readMap slot key' := by
-  simp [readMap, writeMap, h]
+  simp [readMap, storageMap, writeMap, h]
 
 @[storage_simps] theorem readMapUint_writeMapUint_same (s : ContractState) (slot : Nat)
     (key : Uint256) (v : Uint256) :
     (s.writeMapUint slot key v).readMapUint slot key = v := by
-  simp [readMapUint, writeMapUint]
+  simp [readMapUint, storageMapUint, writeMapUint]
 
 @[storage_simps] theorem readMap2_writeMap2_same (s : ContractState) (slot : Nat)
     (key1 key2 : Address) (v : Uint256) :
     (s.writeMap2 slot key1 key2 v).readMap2 slot key1 key2 = v := by
-  simp [readMap2, writeMap2]
+  simp [readMap2, storageMap2, writeMap2]
 
 @[storage_simps] theorem readArray_writeArray_same (s : ContractState) (slot : Nat)
     (vs : List Uint256) : (s.writeArray slot vs).readArray slot = vs := by

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -136,6 +136,64 @@ abbrev Bytes31 := BytesN 31
 @[simp] def wordToAddress (w : Uint256) : Address :=
   Verity.Core.Address.ofNat (w : Nat)
 
+/-- Replace only the address-sized low bits of a storage word.  Address
+views are lenses into word storage, so reserved upper bits survive writes. -/
+def writeAddressWord (word : Uint256) (value : Address) : Uint256 :=
+  word - addressToWord (wordToAddress word) + addressToWord value
+
+@[simp] theorem writeAddressWord_wordToAddress (word : Uint256) :
+    writeAddressWord word (wordToAddress word) = word := by
+  simpa only [writeAddressWord, Verity.Core.Uint256.add_comm] using
+    Verity.Core.Uint256.sub_add_cancel_left word (addressToWord (wordToAddress word))
+
+@[simp] theorem wordToAddress_writeAddressWord (word : Uint256) (value : Address) :
+    wordToAddress (writeAddressWord word value) = value := by
+  apply Verity.Core.Address.ext
+  change (writeAddressWord word value).val % Verity.Core.Address.modulus = value.val
+  have hvalue : (addressToWord value).val = value.val := by
+    simp [addressToWord, Verity.Core.Uint256.ofNat]
+    exact Nat.mod_eq_of_lt (by
+      calc
+        value.val < Verity.Core.Address.modulus := value.isLt
+        _ < Verity.Core.Uint256.modulus := by
+          change 2 ^ 160 < 2 ^ 256
+          exact Nat.pow_lt_pow_right (by decide) (by decide))
+  have hlow : (addressToWord (wordToAddress word)).val =
+      word.val % Verity.Core.Address.modulus := by
+    simp [addressToWord, wordToAddress, Verity.Core.Uint256.ofNat]
+    exact Nat.mod_eq_of_lt (Nat.lt_trans
+      (Nat.mod_lt _ Verity.Core.Address.modulus_pos)
+      (by
+        change 2 ^ 160 < 2 ^ 256
+        exact Nat.pow_lt_pow_right (by decide) (by decide)))
+  have hsub : (word - addressToWord (wordToAddress word)).val =
+      word.val - word.val % Verity.Core.Address.modulus := by
+    change (Verity.Core.Uint256.sub word (addressToWord (wordToAddress word))).val =
+      word.val - word.val % Verity.Core.Address.modulus
+    rw [Verity.Core.Uint256.subNoWrap]
+    · rw [hlow]
+    · rw [hlow]
+      exact Nat.mod_le _ _
+  have hdiv : Verity.Core.Address.modulus ∣ Verity.Core.Uint256.modulus := by
+    refine ⟨2 ^ 96, ?_⟩
+    change 2 ^ 256 = 2 ^ 160 * 2 ^ 96
+    rw [← Nat.pow_add]
+  change (word - addressToWord (wordToAddress word) + addressToWord value).val %
+      Verity.Core.Address.modulus = value.val
+  rw [show (word - addressToWord (wordToAddress word) + addressToWord value).val =
+      ((word - addressToWord (wordToAddress word)).val + (addressToWord value).val) %
+        Verity.Core.Uint256.modulus by rfl]
+  rw [Nat.mod_mod_of_dvd _ hdiv, hsub, hvalue]
+  have hdecomp : word.val % Verity.Core.Address.modulus +
+      Verity.Core.Address.modulus * (word.val / Verity.Core.Address.modulus) = word.val := by
+    simpa [Nat.mul_comm] using (Nat.mod_add_div word.val Verity.Core.Address.modulus)
+  have hsub' : word.val - word.val % Verity.Core.Address.modulus =
+      Verity.Core.Address.modulus * (word.val / Verity.Core.Address.modulus) := by
+    omega
+  rw [hsub']
+  rw [Nat.add_comm, Nat.add_mul_mod_self_left]
+  exact Nat.mod_eq_of_lt value.isLt
+
 @[simp] def boolToWord (b : Bool) : Uint256 :=
   if b then 1 else 0
 
@@ -315,7 +373,7 @@ def readAddrSlot (s : ContractState) (slot : Nat) : Address :=
 
 def writeAddrSlot (s : ContractState) (slot : Nat) (value : Address) : ContractState :=
   { s with storageWords := fun key =>
-      if key == .addr slot then addressToWord value else s.storageWords key }
+      if key == .addr slot then writeAddressWord (s.storageWords key) value else s.storageWords key }
 
 def readTransient (s : ContractState) (slot : Nat) : Uint256 :=
   s.transientStorage slot
@@ -393,7 +451,8 @@ def modifyTransientSlots (s : ContractState) (targets : List Nat)
 def writeAddrSlots (s : ContractState) (targets : List Nat) (value : Address) :
     ContractState :=
   { s with storageWords := fun key => match key with
-      | .addr slot => if targets.contains slot then addressToWord value else s.storageWords key
+      | .addr slot => if targets.contains slot then writeAddressWord (s.storageWords key) value
+        else s.storageWords key
       | _ => s.storageWords key }
 
 /-- Replace the whole uint channel through a transformer. The denotational
@@ -476,16 +535,23 @@ def ofChannels
 
 @[storage_simps] theorem readAddrSlot_writeAddrSlot_same (s : ContractState) (slot : Nat)
     (v : Address) : (s.writeAddrSlot slot v).readAddrSlot slot = v := by
-  have hlt : v.toNat < Verity.Core.Uint256.modulus := by
-    calc
-      v.toNat < Verity.Core.Address.modulus := v.isLt
-      _ < Verity.Core.Uint256.modulus := by
-        change 2 ^ 160 < 2 ^ 256
-        exact Nat.pow_lt_pow_right (by decide) (by decide)
-  apply Verity.Core.Address.ext
-  simp [readAddrSlot, storageAddr, writeAddrSlot, wordToAddress, addressToWord]
-  rw [Nat.mod_eq_of_lt hlt]
-  exact Verity.Core.Address.val_mod_modulus v
+  simpa [readAddrSlot, storageAddr, writeAddrSlot] using
+    wordToAddress_writeAddressWord (s.storageWords (.addr slot)) v
+
+/-- Address-slot get-put holds even when the canonical backing word has
+nonzero bits above the 160-bit address payload. -/
+@[storage_simps] theorem writeAddrSlot_readAddrSlot (s : ContractState) (slot : Nat) :
+    s.writeAddrSlot slot (s.readAddrSlot slot) = s := by
+  cases s
+  simp only [writeAddrSlot, readAddrSlot, storageAddr]
+  congr
+  funext key
+  by_cases h : key = StorageKey.addr slot
+  · subst key
+    have hself : (StorageKey.addr slot == StorageKey.addr slot) = true := by simp
+    rw [if_pos hself]
+    exact writeAddressWord_wordToAddress _
+  · simp [h]
 
 @[storage_simps] theorem readAddrSlot_writeAddrSlot_other (s : ContractState)
     {slot slot' : Nat} (h : slot' ≠ slot) (v : Address) :

--- a/Verity/Core/Model/ContractNamespaceTest.lean
+++ b/Verity/Core/Model/ContractNamespaceTest.lean
@@ -30,8 +30,8 @@ example (state : Verity.ContractState) (slot : Nat) :
 /-- Legacy single-contract writes update the original storage field. -/
 example (state : Verity.ContractState) (slot : Nat) (value : Verity.Uint256) :
     (state.writeContractSlot 0 slot value).readSlot slot = value := by
-  simp [Verity.ContractState.writeContractSlot, Verity.ContractState.writeSlot,
-    Verity.ContractState.readSlot]
+  simp [Verity.ContractState.writeContractSlot]
+  exact Verity.ContractState.readSlot_writeSlot_same state slot value
 
 /-- A write in one contract world is invisible at the same slot in another. -/
 example (state : Verity.ContractState) (slot : Nat) (value : Verity.Uint256) :

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -372,12 +372,12 @@ def writeAddressKeyedMappingSlots (oracle : DenoteOracle)
   | slot :: _ =>
       let keyAddr := Verity.wordToAddress (key : Verity.Core.Uint256)
       let word : Verity.Core.Uint256 := value
-      let storage :=
+      let flatStorage :=
         slots.foldl
           (fun current slot => storeMappingEntryNat oracle current slot key value)
           (storageNatView world)
       (world.withStorageChannel
-          (fun _ => fun s => ((storage (wordNormalize s) : Verity.Core.Uint256)))).writeMap
+          (fun _ => fun s => ((flatStorage (wordNormalize s) : Verity.Core.Uint256)))).writeMap
         slot keyAddr word
 
 def mappingSlotChain (oracle : DenoteOracle) (baseSlot : Nat) (keys : List Nat) : Nat :=
@@ -449,12 +449,12 @@ def writeUintKeyedMappingSlots (oracle : DenoteOracle)
   | slot :: _ =>
       let keyWord : Verity.Core.Uint256 := key
       let word : Verity.Core.Uint256 := value
-      let storage :=
+      let flatStorage :=
         slots.foldl
           (fun current slot => storeMappingEntryNat oracle current slot key value)
           (storageNatView world)
       (world.withStorageChannel
-          (fun _ => fun s => ((storage (wordNormalize s) : Verity.Core.Uint256)))).writeMapUint
+          (fun _ => fun s => ((flatStorage (wordNormalize s) : Verity.Core.Uint256)))).writeMapUint
         slot keyWord word
 
 def writeAddressKeyedMapping2Slots (oracle : DenoteOracle)
@@ -466,13 +466,13 @@ def writeAddressKeyedMapping2Slots (oracle : DenoteOracle)
       let key1Addr := Verity.wordToAddress (key1 : Verity.Core.Uint256)
       let key2Addr := Verity.wordToAddress (key2 : Verity.Core.Uint256)
       let word : Verity.Core.Uint256 := value
-      let storage :=
+      let flatStorage :=
         slots.foldl
           (fun current slot =>
             storeMappingEntryNat oracle current (oracle.mappingSlot slot key1) key2 value)
           (storageNatView world)
       (world.withStorageChannel
-          (fun _ => fun s => ((storage (wordNormalize s) : Verity.Core.Uint256)))).writeMap2
+          (fun _ => fun s => ((flatStorage (wordNormalize s) : Verity.Core.Uint256)))).writeMap2
         slot key1Addr key2Addr word
 
 def writeAddressKeyedMapping2WordSlots (oracle : DenoteOracle)

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -436,13 +436,8 @@ def writeAddressKeyedMappingPackedWordFieldSlots (oracle : DenoteOracle)
     Verity.ContractState :=
   let targets := slots.map (fun slot => wordNormalize (oracle.mappingSlot slot key + wordOffset))
   if fieldIsTransient fields fieldName then
-    let wordAt := fun slot => (world.transientStorage slot).val
-    let updated := targets.map (fun slot => (slot, packedWordWrite (wordAt slot) value packed))
-    { world with
-      transientStorage := fun slot =>
-        match updated.find? (fun entry => entry.fst == slot) with
-        | some (_, word) => word
-        | none => world.transientStorage slot }
+    world.modifyTransientSlots targets
+      (fun current => packedWordWrite current.val value packed)
   else
     writeAddressKeyedMappingPackedWordSlots oracle world slots key wordOffset packed value
 
@@ -563,13 +558,8 @@ def writeAddressKeyedMapping2PackedWordFieldSlots (oracle : DenoteOracle)
   let targets := slots.map (fun slot =>
     wordNormalize (oracle.mappingSlot (oracle.mappingSlot slot key1) key2 + wordOffset))
   if fieldIsTransient fields fieldName then
-    let wordAt := fun slot => (world.transientStorage slot).val
-    let updated := targets.map (fun slot => (slot, packedWordWrite (wordAt slot) value packed))
-    { world with
-      transientStorage := fun slot =>
-        match updated.find? (fun entry => entry.fst == slot) with
-        | some (_, word) => word
-        | none => world.transientStorage slot }
+    world.modifyTransientSlots targets
+      (fun current => packedWordWrite current.val value packed)
   else
     writeAddressKeyedMapping2PackedWordSlots oracle world slots key1 key2 wordOffset packed value
 
@@ -1252,11 +1242,7 @@ mutual
             let resolvedOffset := wordNormalize resolvedOffset
             .continue {
               state with
-              world := {
-                state.world with
-                transientStorage := fun o =>
-                  if o = resolvedOffset then resolvedValue else state.world.transientStorage o
-              }
+              world := state.world.writeTransient resolvedOffset resolvedValue
             }
         | _, _ => .revert
     | state, .require cond _ =>

--- a/Verity/Core/Model/NonReentrantGuard.lean
+++ b/Verity/Core/Model/NonReentrantGuard.lean
@@ -36,12 +36,14 @@ def setLock (slot : Nat) (value : Uint256) (s : ContractState) : ContractState :
 
 @[simp] theorem setLock_reads (slot : Nat) (value : Uint256) (s : ContractState) :
     (setLock slot value s).transientStorage slot = value := by
-  simp [setLock, ContractState.writeTransient]
+  simpa [setLock, ContractState.readTransient] using
+    ContractState.readTransient_writeTransient_same s slot value
 
 @[simp] theorem setLock_reads_other (slot k : Nat) (value : Uint256)
     (s : ContractState) (h : k ≠ slot) :
     (setLock slot value s).transientStorage k = s.transientStorage k := by
-  simp [setLock, ContractState.writeTransient, h]
+  simpa [setLock, ContractState.readTransient] using
+    ContractState.readTransient_writeTransient_other s h value
 
 /-- Executable semantics of a `nonreentrant(slot)` entrypoint. -/
 def guarded (slot : Nat) (body : Contract α) : Contract α :=

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -287,7 +287,7 @@ theorem getStorage_runValue (slot : StorageSlot Uint256) (state : ContractState)
 theorem setStorage_getStorage (slot : StorageSlot Uint256) (value : Uint256) (state : ContractState) :
     (getStorage slot).runValue ((setStorage slot value).runState state) = value := by
   simp [setStorage, getStorage, Contract.runState, Contract.runValue, ContractState.writeSlot,
-    ContractState.readSlot]
+    ContractState.readSlot, ContractState.storage]
 
 -- getStorage for different slot is unchanged after setStorage
 theorem setStorage_getStorage_diff (slot1 slot2 : StorageSlot Uint256) (value : Uint256) (state : ContractState)
@@ -297,7 +297,7 @@ theorem setStorage_getStorage_diff (slot1 slot2 : StorageSlot Uint256) (value : 
   unfold setStorage getStorage Contract.runState Contract.runValue
   by_cases h_eq : slot2.slot = slot1.slot
   · exact (h h_eq.symm).elim
-  · simp [h_eq, ContractState.writeSlot, ContractState.readSlot]
+  · simp [h_eq, ContractState.writeSlot, ContractState.readSlot, ContractState.storage]
 
 /-!
 ## Monadic Composition Lemmas
@@ -960,55 +960,59 @@ like `count` or `storedData`. These eliminate per-contract duplication of
 theorem setStorage_preserves_storageAddr (slot : StorageSlot Uint256) (value : Uint256)
     (state : ContractState) :
     ((setStorage slot value).run state).snd.storageAddr = state.storageAddr := by
-  simp
+  change (state.writeSlot slot.slot value).storageAddr = state.storageAddr
+  exact ContractState.storageAddr_writeSlot state slot.slot value
 
 /-- setStorage on any uint256 slot preserves the mapping storage. -/
 theorem setStorage_preserves_storageMap (slot : StorageSlot Uint256) (value : Uint256)
     (state : ContractState) :
     ((setStorage slot value).run state).snd.storageMap = state.storageMap := by
-  simp
+  change (state.writeSlot slot.slot value).storageMap = state.storageMap
+  exact ContractState.storageMap_writeSlot state slot.slot value
 
 /-- setStorage on any uint256 slot preserves the sender. -/
 theorem setStorage_preserves_sender (slot : StorageSlot Uint256) (value : Uint256)
     (state : ContractState) :
     ((setStorage slot value).run state).snd.sender = state.sender := by
-  simp
+  simp [ContractState.writeSlot]
 
 /-- setStorage on any uint256 slot preserves the contract address. -/
 theorem setStorage_preserves_thisAddress (slot : StorageSlot Uint256) (value : Uint256)
     (state : ContractState) :
     ((setStorage slot value).run state).snd.thisAddress = state.thisAddress := by
-  simp
+  simp [ContractState.writeSlot]
 
 /-- setStorage on any uint256 slot preserves other uint256 slots. -/
 theorem setStorage_preserves_other_storage (slot : StorageSlot Uint256) (value : Uint256)
     (state : ContractState) (n : Nat) (h : n ≠ slot.slot) :
     ((setStorage slot value).run state).snd.storage n = state.storage n := by
-  simp [h]
+  simp [ContractState.writeSlot, ContractState.storage, h]
 
 /-- setStorageAddr on any address slot preserves the uint256 storage. -/
 theorem setStorageAddr_preserves_storage (slot : StorageSlot Address) (value : Address)
     (state : ContractState) :
     ((setStorageAddr slot value).run state).snd.storage = state.storage := by
-  simp
+  change (state.writeAddrSlot slot.slot value).storage = state.storage
+  exact ContractState.storage_writeAddrSlot state slot.slot value
 
 /-- setStorageAddr on any address slot preserves the mapping storage. -/
 theorem setStorageAddr_preserves_storageMap (slot : StorageSlot Address) (value : Address)
     (state : ContractState) :
     ((setStorageAddr slot value).run state).snd.storageMap = state.storageMap := by
-  simp
+  change (state.writeAddrSlot slot.slot value).storageMap = state.storageMap
+  exact ContractState.storageMap_writeAddrSlot state slot.slot value
 
 /-- setStorageAddr on any address slot preserves the sender. -/
 theorem setStorageAddr_preserves_sender (slot : StorageSlot Address) (value : Address)
     (state : ContractState) :
     ((setStorageAddr slot value).run state).snd.sender = state.sender := by
-  simp
+  simp [ContractState.writeAddrSlot]
 
 /-- setStorageAddr on any address slot preserves the contract address. -/
 theorem setStorageAddr_preserves_thisAddress (slot : StorageSlot Address) (value : Address)
     (state : ContractState) :
     ((setStorageAddr slot value).run state).snd.thisAddress = state.thisAddress := by
-  simp
+  simp [ContractState.writeAddrSlot]
 
 /-!
 ## Generic setMapping Preservation
@@ -1018,25 +1022,27 @@ theorem setStorageAddr_preserves_thisAddress (slot : StorageSlot Address) (value
 theorem setMapping_preserves_storage (slot : StorageSlot (Address → Uint256))
     (key : Address) (value : Uint256) (state : ContractState) :
     ((setMapping slot key value).run state).snd.storage = state.storage := by
-  simp
+  change (state.writeMap slot.slot key value).storage = state.storage
+  exact ContractState.storage_writeMap state slot.slot key value
 
 /-- setMapping preserves the address storage. -/
 theorem setMapping_preserves_storageAddr (slot : StorageSlot (Address → Uint256))
     (key : Address) (value : Uint256) (state : ContractState) :
     ((setMapping slot key value).run state).snd.storageAddr = state.storageAddr := by
-  simp
+  change (state.writeMap slot.slot key value).storageAddr = state.storageAddr
+  exact ContractState.storageAddr_writeMap state slot.slot key value
 
 /-- setMapping preserves the sender. -/
 theorem setMapping_preserves_sender (slot : StorageSlot (Address → Uint256))
     (key : Address) (value : Uint256) (state : ContractState) :
     ((setMapping slot key value).run state).snd.sender = state.sender := by
-  simp
+  simp [ContractState.writeMap]
 
 /-- setMapping preserves the contract address. -/
 theorem setMapping_preserves_thisAddress (slot : StorageSlot (Address → Uint256))
     (key : Address) (value : Uint256) (state : ContractState) :
     ((setMapping slot key value).run state).snd.thisAddress = state.thisAddress := by
-  simp
+  simp [ContractState.writeMap]
 
 /-!
 ## Generic msgValue / blockTimestamp / blockNumber / knownAddresses Preservation
@@ -1048,67 +1054,67 @@ Storage mutations never touch context fields or (for non-mapping ops) knownAddre
 theorem setStorage_preserves_msgValue (slot : StorageSlot Uint256) (value : Uint256)
     (state : ContractState) :
     ((setStorage slot value).run state).snd.msgValue = state.msgValue := by
-  simp
+  simp [ContractState.writeSlot]
 
 /-- setStorageAddr preserves msgValue. -/
 theorem setStorageAddr_preserves_msgValue (slot : StorageSlot Address) (value : Address)
     (state : ContractState) :
     ((setStorageAddr slot value).run state).snd.msgValue = state.msgValue := by
-  simp
+  simp [ContractState.writeAddrSlot]
 
 /-- setMapping preserves msgValue. -/
 theorem setMapping_preserves_msgValue (slot : StorageSlot (Address → Uint256))
     (key : Address) (value : Uint256) (state : ContractState) :
     ((setMapping slot key value).run state).snd.msgValue = state.msgValue := by
-  simp
+  simp [ContractState.writeMap]
 
 /-- setStorage preserves blockTimestamp. -/
 theorem setStorage_preserves_blockTimestamp (slot : StorageSlot Uint256) (value : Uint256)
     (state : ContractState) :
     ((setStorage slot value).run state).snd.blockTimestamp = state.blockTimestamp := by
-  simp
+  simp [ContractState.writeSlot]
 
 /-- setStorageAddr preserves blockTimestamp. -/
 theorem setStorageAddr_preserves_blockTimestamp (slot : StorageSlot Address) (value : Address)
     (state : ContractState) :
     ((setStorageAddr slot value).run state).snd.blockTimestamp = state.blockTimestamp := by
-  simp
+  simp [ContractState.writeAddrSlot]
 
 /-- setMapping preserves blockTimestamp. -/
 theorem setMapping_preserves_blockTimestamp (slot : StorageSlot (Address → Uint256))
     (key : Address) (value : Uint256) (state : ContractState) :
     ((setMapping slot key value).run state).snd.blockTimestamp = state.blockTimestamp := by
-  simp
+  simp [ContractState.writeMap]
 
 /-- setStorage preserves blockNumber. -/
 theorem setStorage_preserves_blockNumber (slot : StorageSlot Uint256) (value : Uint256)
     (state : ContractState) :
     ((setStorage slot value).run state).snd.blockNumber = state.blockNumber := by
-  simp
+  simp [ContractState.writeSlot]
 
 /-- setStorageAddr preserves blockNumber. -/
 theorem setStorageAddr_preserves_blockNumber (slot : StorageSlot Address) (value : Address)
     (state : ContractState) :
     ((setStorageAddr slot value).run state).snd.blockNumber = state.blockNumber := by
-  simp
+  simp [ContractState.writeAddrSlot]
 
 /-- setMapping preserves blockNumber. -/
 theorem setMapping_preserves_blockNumber (slot : StorageSlot (Address → Uint256))
     (key : Address) (value : Uint256) (state : ContractState) :
     ((setMapping slot key value).run state).snd.blockNumber = state.blockNumber := by
-  simp
+  simp [ContractState.writeMap]
 
 /-- setStorage preserves knownAddresses. -/
 theorem setStorage_preserves_knownAddresses (slot : StorageSlot Uint256) (value : Uint256)
     (state : ContractState) :
     ((setStorage slot value).run state).snd.knownAddresses = state.knownAddresses := by
-  simp
+  simp [ContractState.writeSlot]
 
 /-- setStorageAddr preserves knownAddresses. -/
 theorem setStorageAddr_preserves_knownAddresses (slot : StorageSlot Address) (value : Address)
     (state : ContractState) :
     ((setStorageAddr slot value).run state).snd.knownAddresses = state.knownAddresses := by
-  simp
+  simp [ContractState.writeAddrSlot]
 
 /-!
 ## Generic Event Preservation
@@ -1120,19 +1126,19 @@ Storage mutations never touch the `events` append-only log.
 theorem setStorage_preserves_events (slot : StorageSlot Uint256) (value : Uint256)
     (state : ContractState) :
     ((setStorage slot value).run state).snd.events = state.events := by
-  simp
+  simp [ContractState.writeSlot]
 
 /-- setStorageAddr on any address slot preserves the event log. -/
 theorem setStorageAddr_preserves_events (slot : StorageSlot Address) (value : Address)
     (state : ContractState) :
     ((setStorageAddr slot value).run state).snd.events = state.events := by
-  simp
+  simp [ContractState.writeAddrSlot]
 
 /-- setMapping preserves the event log. -/
 theorem setMapping_preserves_events (slot : StorageSlot (Address → Uint256))
     (key : Address) (value : Uint256) (state : ContractState) :
     ((setMapping slot key value).run state).snd.events = state.events := by
-  simp
+  simp [ContractState.writeMap]
 
 /-!
 ## Event Emission Helpers

--- a/Verity/Proofs/Stdlib/MappingAutomation.lean
+++ b/Verity/Proofs/Stdlib/MappingAutomation.lean
@@ -21,6 +21,9 @@ namespace Verity.Proofs.Stdlib.MappingAutomation
 open Verity
 open Verity.Proofs.Stdlib.Automation
 
+attribute [local simp] ContractState.storage ContractState.storageAddr
+  ContractState.storageMap ContractState.storageMapUint ContractState.storageMap2
+
 /-!
 ## Address-Keyed Mapping Lemmas (Address → Uint256)
 -/
@@ -57,8 +60,7 @@ theorem setMapping_getMapping_diff (slot : StorageSlot (Address → Uint256))
     state.storageMap slot.slot key2 := by
   simp only [getMapping, setMapping, ContractState.readMap, ContractState.writeMap,
     Contract.runState, Contract.runValue]
-  have : (key2 == key1) = false := beq_eq_false_iff_ne.mpr (Ne.symm h)
-  simp [this]
+  simp [Ne.symm h]
 
 /-- setMapping preserves storageMap on a different slot. -/
 theorem setMapping_preserves_other_slot (slot1 : StorageSlot (Address → Uint256))
@@ -68,8 +70,7 @@ theorem setMapping_preserves_other_slot (slot1 : StorageSlot (Address → Uint25
     state.storageMap slot2 := by
   simp only [setMapping, ContractState.writeMap, Contract.runState, ContractState.writeMap]
   funext addr
-  have h_slot : (slot2 == slot1.slot) = false := beq_eq_false_iff_ne.mpr (Ne.symm h)
-  simp [h_slot]
+  simp [Ne.symm h]
 
 /-- setMapping updates knownAddresses at the target slot by inserting the key. -/
 theorem setMapping_knownAddresses_same_slot (slot : StorageSlot (Address → Uint256))
@@ -129,8 +130,7 @@ theorem setMappingUint_getMappingUint_diff (slot : StorageSlot (Uint256 → Uint
     state.storageMapUint slot.slot key2 := by
   simp only [getMappingUint, setMappingUint, ContractState.readMapUint,
     ContractState.writeMapUint, Contract.runState, Contract.runValue]
-  have : (key2 == key1) = false := beq_eq_false_iff_ne.mpr (Ne.symm h)
-  simp [this]
+  simp [Ne.symm h]
 
 /-- setMappingUint preserves uint256 storage. -/
 theorem setMappingUint_preserves_storage (slot : StorageSlot (Uint256 → Uint256))
@@ -206,8 +206,7 @@ theorem setMapping2_getMapping2_diff_key1 (slot : StorageSlot (Address → Addre
     state.storageMap2 slot.slot k1' k2' := by
   simp only [getMapping2, setMapping2, ContractState.readMap2, ContractState.writeMap2,
     Contract.runState, Contract.runValue]
-  have : (k1' == k1) = false := beq_eq_false_iff_ne.mpr (Ne.symm h)
-  simp [this]
+  simp [Ne.symm h]
 
 /-- setMapping2 with different second key preserves getMapping2. -/
 theorem setMapping2_getMapping2_diff_key2 (slot : StorageSlot (Address → Address → Uint256))
@@ -216,8 +215,7 @@ theorem setMapping2_getMapping2_diff_key2 (slot : StorageSlot (Address → Addre
     state.storageMap2 slot.slot k1 k2' := by
   simp only [getMapping2, setMapping2, ContractState.readMap2, ContractState.writeMap2,
     Contract.runState, Contract.runValue]
-  have : (k2' == k2) = false := beq_eq_false_iff_ne.mpr (Ne.symm h)
-  simp [this]
+  simp [Ne.symm h]
 
 /-- setMapping2 preserves uint256 storage. -/
 theorem setMapping2_preserves_storage (slot : StorageSlot (Address → Address → Uint256))
@@ -309,13 +307,15 @@ theorem setMapping2_preserves_blockNumber (slot : StorageSlot (Address → Addre
 theorem setMapping_preserves_storageMapUint (slot : StorageSlot (Address → Uint256))
     (key : Address) (value : Uint256) (state : ContractState) :
     ((setMapping slot key value).run state).snd.storageMapUint = state.storageMapUint := by
-  simp
+  change (state.writeMap slot.slot key value).storageMapUint = state.storageMapUint
+  exact ContractState.storageMapUint_writeMap state slot.slot key value
 
 /-- setMapping preserves double mapping storage. -/
 theorem setMapping_preserves_storageMap2 (slot : StorageSlot (Address → Uint256))
     (key : Address) (value : Uint256) (state : ContractState) :
     ((setMapping slot key value).run state).snd.storageMap2 = state.storageMap2 := by
-  simp
+  change (state.writeMap slot.slot key value).storageMap2 = state.storageMap2
+  exact ContractState.storageMap2_writeMap state slot.slot key value
 
 /-!
 ## Cross-Type Preservation: setStorage vs additional mapping types

--- a/Verity/Specs/Common/Sum.lean
+++ b/Verity/Specs/Common/Sum.lean
@@ -236,11 +236,11 @@ theorem balancesFinite_preserved_deposit {slot : Nat} (s : ContractState)
   have h_not_or := mt (FiniteSet.mem_elements_insert addr' addr (s.knownAddresses slot).addresses).mpr h_not_in
   simp only [not_or] at h_not_or
   obtain ⟨h_ne, h_not_orig⟩ := h_not_or
-  -- Since addr' ≠ addr, the storageMap if-condition evaluates to false
-  simp only [ContractState.writeMap, BEq.beq, decide_true, Bool.true_and]
-  have h_ne' : ¬(decide (addr' = addr) = true) := by simp [h_ne]
-  simp [h_ne']
-  -- Now the goal reduces to s.storageMap slot addr' = 0, which follows from h_finite
+  -- The `knownAddresses` record update does not alter the canonical word
+  -- lens, and constructor injectivity makes the different-key write inert.
+  change (s.writeMap slot addr amount).storageMap slot addr' = 0
+  rw [← ContractState.readMap]
+  rw [ContractState.readMap_writeMap_other_key s slot h_ne amount]
   exact h_finite addr' h_not_orig
 
 end Verity.Specs.Common

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 1183,
+    "core_lines": 1197,
     "example_contracts": 18
   },
   "proofs": {

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 1476,
+    "core_lines": 1669,
     "example_contracts": 18
   },
   "proofs": {

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 1206,
+    "core_lines": 1272,
     "example_contracts": 18
   },
   "proofs": {

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 1476,
+    "core_lines": 1733,
     "example_contracts": 18
   },
   "proofs": {

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 1405,
+    "core_lines": 1476,
     "example_contracts": 18
   },
   "proofs": {

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 1272,
+    "core_lines": 1305,
     "example_contracts": 18
   },
   "proofs": {

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 1197,
+    "core_lines": 1206,
     "example_contracts": 18
   },
   "proofs": {

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 1305,
+    "core_lines": 1405,
     "example_contracts": 18
   },
   "proofs": {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,11 +41,13 @@ Next: derive the executable shallow program from the deep model
 (`Stmt.denote`, macro retarget per-contract behind a flag), collapse the
 per-function `_bridge` theorems into one AST-induction theorem
 (`GenericInduction/LegacyCompatibility` and the compile-derived
-legacy-compatibility witness chain are already retired), then flatten
-`ContractState`'s typed storage channels into one word-addressed map with
-lens views — the enabler for FixedArray-under-mapping, dynamic CodeData,
-arbitrary transient storage and multicall/delegatecall (#1962, #1967,
-#1976, #1889).
+legacy-compatibility witness chain are already retired), then prove C5
+step 4 — structural `StorageKey` ↔ CompilationModel/Yul slot coherence
+(`storageKeySlot` / shadow-vs-flat `MappingCoherent`). C5 step 3 (canonical
+`storageWords : StorageKey → Uint256` backing, lens laws by constructor
+injectivity) is implemented; it is the enabler for FixedArray-under-mapping,
+dynamic CodeData, arbitrary transient storage and multicall/delegatecall
+(#1962, #1967, #1976, #1889).
 
 ---
 

--- a/scripts/check_storage_lens_freeze.py
+++ b/scripts/check_storage_lens_freeze.py
@@ -58,20 +58,11 @@ SHARED_SCAN_DIRS = ("Verity", "Contracts")
 # canonical `defaultState`/`emitEvent`-style literals; it is the only file
 # meant to keep raw access after the migration completes.
 BASELINE = {
-    # Lens/bulk-lens/ofChannels implementations + defaultState — the
-    # permanent residue the C5 step-3 flip swaps in place.
-    "Verity/Core.lean": 39,
-    # 3 `let storage :=` local-binding false positives + the find?-shaped
-    # transient packed-write arm (non-defeq to a lens; step-3 burn-down).
-    "Verity/Core/Model/Denote.lean": 6,
-    # Concurrent lane (Ownable/composition session) — not ours to migrate.
-    "Contracts/Owned/Proofs/Basic.lean": 8,
+    # `storageArray` remains a separate list-valued field; its implementation
+    # and executable array helpers are the only raw channel-update residue.
+    "Verity/Core.lean": 6,
     # IRState fixture literals (field-name collision false positives).
     "Contracts/TypedIRTests.lean": 3,
-    # `=`-guarded dual-channel writeStorageWordSlot(s) (re-guarding to `==`
-    # would reshape the GenericInduction unfold surface; step-3 burn-down)
-    # + let-binding false positives.
-    "Compiler/Proofs/IRGeneration/SourceSemantics.lean": 7,
 }
 
 

--- a/scripts/check_storage_lens_freeze.py
+++ b/scripts/check_storage_lens_freeze.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Storage-lens API freeze gate (C5 step 1).
 
-The C5 storage-representation flip (one word-addressed `Nat -> Uint256` map
+The C5 storage-representation flip (one word-addressed `StorageKey -> Uint256` map
 with Solidity-layout slot derivation) requires that every read/write of
 `Verity.ContractState`'s storage channels go through the canonical lens API
 (`readSlot`/`writeSlot`/`writeMap`/... in `Verity/Core.lean`) instead of raw
@@ -15,16 +15,14 @@ baseline until only `Verity/Core.lean` remains, at which point the flip
 (C5 step 3) can swap the representation under stable lens names.
 
 Scope notes:
-- The six channels unique to `ContractState` (`contractStorage`,
-  `storageAddr`, `storageMap`, `storageMapUint`, `storageMap2`,
-  `storageArray`) are checked repo-wide.
-- `storage :=` / `transientStorage :=` are only checked under `Verity/` and
-  `Contracts/`: under `Compiler/` those field names also belong to
-  `IRState`/`DenoteState`-style records, which are proof-side runtime states,
-  not the source `ContractState`.  Raw `ContractState` writes under
-  `Compiler/` on those two fields are therefore NOT caught by this gate
-  (known v1 boundary; they are enumerated in the baseline where they use a
-  unique channel).
+- `storageWords` is checked repo-wide. It is the canonical word backing
+  field and may only be updated by the implementations in `Verity/Core.lean`.
+- `storage :=` / `transientStorage :=` are checked under `Verity/` and
+  `Contracts/`, and are additionally checked in `Compiler/` when the record
+  receiver is statically declared as `ContractState`. Compiler has unrelated
+  IR runtime records with the same field names, which this small type-aware
+  filter deliberately leaves out rather than freezing a false-positive
+  baseline.
 """
 
 from __future__ import annotations
@@ -36,6 +34,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 
 UNIQUE_CHANNELS = (
+    "storageWords",
     "contractStorage",
     "storageAddr",
     "storageMap",
@@ -58,12 +57,24 @@ SHARED_SCAN_DIRS = ("Verity", "Contracts")
 # canonical `defaultState`/`emitEvent`-style literals; it is the only file
 # meant to keep raw access after the migration completes.
 BASELINE = {
-    # `storageArray` remains a separate list-valued field; its implementation
-    # and executable array helpers are the only raw channel-update residue.
-    "Verity/Core.lean": 6,
+    # The sole canonical word-map implementation boundary. This includes the
+    # single default-state literal plus the lens implementations (including
+    # bulk lenses); no caller outside this file may update `storageWords`.
+    "Verity/Core.lean": 21,
     # IRState fixture literals (field-name collision false positives).
     "Contracts/TypedIRTests.lean": 3,
 }
+
+RECORD_UPDATE_RE = re.compile(
+    r"\{\s*([A-Za-z_][\w']*)\s+with\s+(?:«)?(storage|transientStorage)(?:»)?\s*:=",
+    re.MULTILINE,
+)
+CONTRACT_STATE_BINDING_RE = re.compile(
+    r"(?:\(|\{|,)\s*([A-Za-z_][\w']*)\s*:\s*(?:Verity\.)?ContractState\b"
+)
+CONTRACT_STATE_ASCRIPTION_RE = re.compile(
+    r"\{\s*([A-Za-z_][\w']*)\s+with\s+(?:«)?(?:storage|transientStorage)(?:»)?\s*:=[\s\S]{0,400}?\}\s*:\s*(?:Verity\.)?ContractState\b"
+)
 
 
 def count_sites(path: Path) -> int:
@@ -72,8 +83,21 @@ def count_sites(path: Path) -> int:
     # Strip line comments to avoid counting documentation.
     text = re.sub(r"--[^\n]*", "", text)
     count = len(UNIQUE_RE.findall(text))
-    if rel.split("/", 1)[0] in SHARED_SCAN_DIRS:
+    top = rel.split("/", 1)[0]
+    if top in SHARED_SCAN_DIRS:
         count += len(SHARED_RE.findall(text))
+    elif top == "Compiler":
+        # `storage` and `transientStorage` are also fields of Compiler's IR
+        # states. Count only record updates whose receiver is known to be a
+        # source `ContractState`, plus explicitly ascribed ContractState
+        # literals. This catches the source-world bypass without inventing a
+        # baseline for every IR-state update in Compiler proofs.
+        source_names = set(CONTRACT_STATE_BINDING_RE.findall(text))
+        source_names.update(CONTRACT_STATE_ASCRIPTION_RE.findall(text))
+        count += sum(
+            receiver in source_names
+            for receiver, _field in RECORD_UPDATE_RE.findall(text)
+        )
     return count
 
 

--- a/scripts/check_storage_lens_freeze.py
+++ b/scripts/check_storage_lens_freeze.py
@@ -67,8 +67,8 @@ BASELINE = {
 
 RECORD_UPDATE_RE = re.compile(
     r"\{\s*([A-Za-z_][\w']*(?:\.[A-Za-z_][\w']*)*)\s+with\s+"
-    r"(?:«)?(storage|transientStorage)(?:»)?\s*:=",
-    re.MULTILINE,
+    r"(?:(?!\}).)*?\b(?:«)?(storage|transientStorage)(?:»)?\s*:=",
+    re.MULTILINE | re.DOTALL,
 )
 CONTRACT_STATE_BINDING_RE = re.compile(
     r"(?:\(|\{|,)\s*([A-Za-z_][\w']*)\s*:\s*(?:Verity\.)?ContractState\b"

--- a/scripts/check_storage_lens_freeze.py
+++ b/scripts/check_storage_lens_freeze.py
@@ -66,14 +66,20 @@ BASELINE = {
 }
 
 RECORD_UPDATE_RE = re.compile(
-    r"\{\s*([A-Za-z_][\w']*)\s+with\s+(?:«)?(storage|transientStorage)(?:»)?\s*:=",
+    r"\{\s*([A-Za-z_][\w']*(?:\.[A-Za-z_][\w']*)*)\s+with\s+"
+    r"(?:«)?(storage|transientStorage)(?:»)?\s*:=",
     re.MULTILINE,
 )
 CONTRACT_STATE_BINDING_RE = re.compile(
     r"(?:\(|\{|,)\s*([A-Za-z_][\w']*)\s*:\s*(?:Verity\.)?ContractState\b"
 )
+CONTRACT_STATE_FIELD_RE = re.compile(
+    r"\b([A-Za-z_][\w']*)\s*:\s*(?:Verity\.)?ContractState\b"
+)
 CONTRACT_STATE_ASCRIPTION_RE = re.compile(
-    r"\{\s*([A-Za-z_][\w']*)\s+with\s+(?:«)?(?:storage|transientStorage)(?:»)?\s*:=[\s\S]{0,400}?\}\s*:\s*(?:Verity\.)?ContractState\b"
+    r"\{\s*([A-Za-z_][\w']*(?:\.[A-Za-z_][\w']*)*)\s+with\s+"
+    r"(?:«)?(?:storage|transientStorage)(?:»)?\s*:=[\s\S]{0,400}?\}\s*"
+    r":\s*(?:Verity\.)?ContractState\b"
 )
 
 
@@ -90,12 +96,15 @@ def count_sites(path: Path) -> int:
         # `storage` and `transientStorage` are also fields of Compiler's IR
         # states. Count only record updates whose receiver is known to be a
         # source `ContractState`, plus explicitly ascribed ContractState
-        # literals. This catches the source-world bypass without inventing a
-        # baseline for every IR-state update in Compiler proofs.
+        # literals and projections through fields declared as ContractState.
+        # This catches the source-world bypass without inventing a baseline
+        # for every IR-state update in Compiler proofs.
         source_names = set(CONTRACT_STATE_BINDING_RE.findall(text))
         source_names.update(CONTRACT_STATE_ASCRIPTION_RE.findall(text))
+        source_field_names = set(CONTRACT_STATE_FIELD_RE.findall(text))
         count += sum(
             receiver in source_names
+            or receiver.rsplit(".", 1)[-1] in source_field_names
             for receiver, _field in RECORD_UPDATE_RE.findall(text)
         )
     return count

--- a/scripts/check_storage_lens_freeze.py
+++ b/scripts/check_storage_lens_freeze.py
@@ -99,7 +99,11 @@ def count_sites(path: Path) -> int:
         # literals and projections through fields declared as ContractState.
         # This catches the source-world bypass without inventing a baseline
         # for every IR-state update in Compiler proofs.
-        source_names = set(CONTRACT_STATE_BINDING_RE.findall(text))
+        # `Verity.defaultState` has the concrete source-state type even when
+        # no local binding carries an annotation, so treat a record update
+        # rooted there as a source-world write too.
+        source_names = {"Verity.defaultState"}
+        source_names.update(CONTRACT_STATE_BINDING_RE.findall(text))
         source_names.update(CONTRACT_STATE_ASCRIPTION_RE.findall(text))
         source_field_names = set(CONTRACT_STATE_FIELD_RE.findall(text))
         count += sum(

--- a/scripts/test_check_storage_lens_freeze.py
+++ b/scripts/test_check_storage_lens_freeze.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Regression tests for the C5 storage-lens freeze boundary."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_storage_lens_freeze
+
+
+class StorageLensFreezeTests(unittest.TestCase):
+    def run_gate(self, files: dict[str, str]) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            for relative, contents in files.items():
+                target = root / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(contents, encoding="utf-8")
+            old_root = check_storage_lens_freeze.ROOT
+            old_baseline = check_storage_lens_freeze.BASELINE
+            try:
+                check_storage_lens_freeze.ROOT = root
+                check_storage_lens_freeze.BASELINE = {}
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    status = check_storage_lens_freeze.main()
+                return status, output.getvalue()
+            finally:
+                check_storage_lens_freeze.ROOT = old_root
+                check_storage_lens_freeze.BASELINE = old_baseline
+
+    def test_rejects_contracts_storage_words_bypass(self) -> None:
+        status, output = self.run_gate({
+            "Contracts/Bypass.lean": "def bypass (s : ContractState) := { s with storageWords := fun _ => 0 }\n",
+        })
+        self.assertEqual(status, 1)
+        self.assertIn("Contracts/Bypass.lean", output)
+
+    def test_rejects_compiler_contract_state_transient_bypass(self) -> None:
+        status, output = self.run_gate({
+            "Compiler/Bypass.lean": (
+                "def bypass (world : Verity.ContractState) :=\n"
+                "  { world with transientStorage := fun _ => 0 }\n"
+            ),
+        })
+        self.assertEqual(status, 1)
+        self.assertIn("Compiler/Bypass.lean", output)
+
+    def test_ignores_compiler_ir_state_field_collision(self) -> None:
+        status, output = self.run_gate({
+            "Compiler/IRState.lean": (
+                "structure IRState where transientStorage : Nat → Nat\n"
+                "def update (state : IRState) := { state with transientStorage := fun _ => 0 }\n"
+            ),
+        })
+        self.assertEqual(status, 0, output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_storage_lens_freeze.py
+++ b/scripts/test_check_storage_lens_freeze.py
@@ -50,6 +50,16 @@ class StorageLensFreezeTests(unittest.TestCase):
         self.assertEqual(status, 1)
         self.assertIn("Compiler/Bypass.lean", output)
 
+    def test_rejects_compiler_contract_state_shared_field_after_other_update(self) -> None:
+        status, output = self.run_gate({
+            "Compiler/Bypass.lean": (
+                "def bypass (world : Verity.ContractState) :=\n"
+                "  { world with sender := 0, transientStorage := fun _ => 0 }\n"
+            ),
+        })
+        self.assertEqual(status, 1)
+        self.assertIn("Compiler/Bypass.lean", output)
+
     def test_rejects_compiler_projected_contract_state_bypass(self) -> None:
         status, output = self.run_gate({
             "Compiler/Bypass.lean": (

--- a/scripts/test_check_storage_lens_freeze.py
+++ b/scripts/test_check_storage_lens_freeze.py
@@ -50,6 +50,17 @@ class StorageLensFreezeTests(unittest.TestCase):
         self.assertEqual(status, 1)
         self.assertIn("Compiler/Bypass.lean", output)
 
+    def test_rejects_compiler_projected_contract_state_bypass(self) -> None:
+        status, output = self.run_gate({
+            "Compiler/Bypass.lean": (
+                "structure Runtime where world : Verity.ContractState\n"
+                "def bypass (state : Runtime) : Verity.ContractState :=\n"
+                "  { state.world with transientStorage := fun _ => 0 }\n"
+            ),
+        })
+        self.assertEqual(status, 1)
+        self.assertIn("Compiler/Bypass.lean", output)
+
     def test_ignores_compiler_ir_state_field_collision(self) -> None:
         status, output = self.run_gate({
             "Compiler/IRState.lean": (

--- a/scripts/test_check_storage_lens_freeze.py
+++ b/scripts/test_check_storage_lens_freeze.py
@@ -61,6 +61,16 @@ class StorageLensFreezeTests(unittest.TestCase):
         self.assertEqual(status, 1)
         self.assertIn("Compiler/Bypass.lean", output)
 
+    def test_rejects_compiler_default_state_bypass(self) -> None:
+        status, output = self.run_gate({
+            "Compiler/Bypass.lean": (
+                "def bypass :=\n"
+                "  { Verity.defaultState with storage := fun _ => 0 }\n"
+            ),
+        })
+        self.assertEqual(status, 1)
+        self.assertIn("Compiler/Bypass.lean", output)
+
     def test_ignores_compiler_ir_state_field_collision(self) -> None:
         status, output = self.run_gate({
             "Compiler/IRState.lean": (


### PR DESCRIPTION
## Summary

Short description: C5 step 3 certification closes canonical StorageKey lens-law proofs, freezes raw storageWords writes at the Core boundary, and repairs the downstream map-lens proof regression.

- explicitly unfolds compatibility storage accessors in the 15 storage_simps laws;
- proves address word round-tripping through the 160-bit/256-bit bounds;
- rejects raw storageWords writes repo-wide and source ContractState storage/transient writes in Compiler;
- adds persistent negative mutants for Contracts storageWords and Compiler transientStorage bypasses;
- repairs balancesFinite preservation to use the constructor-injective map lens law.

## Validation

Final build, make-check, freeze mutants, and PrintAxioms receipts are being collected on the current head.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `ContractState` representation and a large proof/compiler surface, but it is a certified representation flip with zero new axioms and an enforced lens freeze rather than a semantic or trust-boundary change.
> 
> **Overview**
> **C5 step 3** replaces separate `storage` / `transientStorage` / mapping channel fields with a single **`storageWords : StorageKey → Uint256`** map. **`StorageKey`** is an injective inductive (`slot`, `contractSlot`, `transient`, `addr`, `map`, `mapUint`, `map2`); public accessors (`storage`, `storageMap`, …) are compatibility views, and bulk helpers (`writeSlots`, `withStorageChannel`, `writeTransient`, …) update `storageWords` by key kind. Address slots use **`writeAddressWord`** so non-address high bits in the backing word are preserved.
> 
> Call sites stop using raw record updates: **source semantics**, **Denote**, contract proofs, and IR-generation proofs route through lenses; **DenoteAgreement** and **GenericInduction/Storage** are adjusted (including `storageKey` case splits and new `storage_*` simp lemmas). **`check_storage_lens_freeze`** now forbids **`storageWords :=`** outside **`Verity/Core.lean`**, tightens the baseline, and type-aware **`Compiler/`** checks for **`ContractState`** `storage` / `transientStorage` bypasses, with unit tests for negative mutants.
> 
> **AUDIT**, **AXIOMS**, **TRUST_ASSUMPTIONS**, and **ROADMAP** document step 3 and clarify that keccak slot / Yul coherence remains **step 4**. **`storageArray`** and **`knownAddresses`** stay separate fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8bd096ad9da94b650dd6b3dbad8e9d003fe1628. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->