### PR TITLE
feat(proofs): first C5 step-4 mapping-coherence slice

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -312,9 +312,12 @@ sibling entrypoint.
 - The freeze baseline shrinks to `Verity/Core.lean` (lens
   implementations) plus `Contracts/TypedIRTests.lean` (IRState field-name
   collisions). `storageWords :=` is forbidden outside `Verity/Core.lean`.
-- Not C5 step 4: there is still no proved `storageKeySlot` /
-  `MappingCoherent` correspondence between these source keys and
-  CompilationModel/Yul slots.
+- Not C5 step 4 complete: `Compiler.Proofs.Storage.MappingCoherence`
+  now defines `storageKeySlot` and address-keyed `MappingCoherent`,
+  with `defaultState_mappingCoherent` and the aligned
+  `writeMap`+`writeSlot` laws (same pair, plus other pairs under an
+  explicit non-alias hypothesis). Global preservation and field-list
+  layout are still open.
 - Zero new axioms.
 
 ## CI Guards

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -26,6 +26,10 @@ C5 step 3 (`ContractState.storageWords` over injective `StorageKey`) does
 not add a keccak-injectivity axiom. Source lens laws use constructor
 injectivity; Solidity slot derivation remains compiler-side.
 
+C5 step 4's first slice (`MappingCoherent`) likewise adds no axiom: other-pair
+preservation is hypothesized by an explicit derived-slot inequality, not by
+keccak injectivity.
+
 ## Eliminated Axioms
 
 ### 1. `solidityMappingSlot_lt_evmModulus` (eliminated)

--- a/Compiler/Proofs/Storage/MappingCoherence.lean
+++ b/Compiler/Proofs/Storage/MappingCoherence.lean
@@ -1,0 +1,93 @@
+/-
+  C5 step 4 (first slice): structural StorageKey → Solidity-slot collapse
+  and shadow-vs-flat mapping coherence.
+
+  Source `StorageKey` constructors stay injective. Keccak layout lives only
+  here, on the compiler side. Global preservation of `MappingCoherent` is
+  not claimed: that needs finite non-alias certificates, because keccak
+  injectivity is not assumed.
+-/
+
+import Verity.Core
+import Compiler.Proofs.MappingSlot
+
+namespace Compiler.Proofs.Storage.MappingCoherence
+
+open Verity
+open Verity.ContractState
+open Compiler.Proofs
+
+/-- Collapse a source key to a compiler word slot when the key is persistent. -/
+def storageKeySlot : StorageKey → Option Nat
+  | .slot n => some n
+  | .addr n => some n
+  | .map n key => some (solidityMappingSlot n (addressToWord key).val)
+  | .mapUint n key => some (solidityMappingSlot n key.val)
+  | .map2 n k1 k2 =>
+      some (abstractNestedMappingSlot n (addressToWord k1).val (addressToWord k2).val)
+  | .transient _ => none
+  | .contractSlot c n => if c = 0 then some n else none
+
+/-- Address-keyed mapping shadow agrees with the flat channel at the
+    derived Solidity slot. -/
+def MappingCoherent (s : ContractState) : Prop :=
+  ∀ (slot : Nat) (key : Address),
+    s.storageMap slot key =
+      s.storage (solidityMappingSlot slot (addressToWord key).val)
+
+theorem defaultState_mappingCoherent : MappingCoherent defaultState := by
+  intro slot key
+  simp [MappingCoherent, storageMap, storage, defaultState]
+
+/-- The aligned write — shadow map plus the derived flat slot — makes the
+    written pair coherent regardless of the prior world. -/
+theorem writeMap_aligned_same (s : ContractState) (slot : Nat) (key : Address)
+    (v : Uint256) :
+    ((s.writeMap slot key v).writeSlot
+      (solidityMappingSlot slot (addressToWord key).val) v).storageMap slot key =
+      ((s.writeMap slot key v).writeSlot
+        (solidityMappingSlot slot (addressToWord key).val) v).storage
+        (solidityMappingSlot slot (addressToWord key).val) := by
+  simp [storageMap_writeSlot, storageMap, writeMap, storage, writeSlot, storage_writeMap]
+
+/-- Another mapping pair stays coherent when its derived slot is distinct
+    from the written one. The distinctness hypothesis is the non-alias
+    certificate; it is not keccak injectivity. -/
+theorem writeMap_aligned_other (s : ContractState) (slot : Nat) (key : Address)
+    (v : Uint256) (slot' : Nat) (key' : Address)
+    (hcoh : s.storageMap slot' key' =
+      s.storage (solidityMappingSlot slot' (addressToWord key').val))
+    (hkey : StorageKey.map slot' key' ≠ StorageKey.map slot key)
+    (hslot :
+      solidityMappingSlot slot' (addressToWord key').val ≠
+        solidityMappingSlot slot (addressToWord key).val) :
+    ((s.writeMap slot key v).writeSlot
+      (solidityMappingSlot slot (addressToWord key).val) v).storageMap slot' key' =
+      ((s.writeMap slot key v).writeSlot
+        (solidityMappingSlot slot (addressToWord key).val) v).storage
+        (solidityMappingSlot slot' (addressToWord key').val) := by
+  have hmap :
+      ((s.writeMap slot key v).writeSlot
+        (solidityMappingSlot slot (addressToWord key).val) v).storageMap slot' key' =
+        s.storageMap slot' key' := by
+    simp [storageMap_writeSlot, storageMap, writeMap, writeSlot, hkey]
+  have hflat :
+      ((s.writeMap slot key v).writeSlot
+        (solidityMappingSlot slot (addressToWord key).val) v).storage
+        (solidityMappingSlot slot' (addressToWord key').val) =
+        s.storage (solidityMappingSlot slot' (addressToWord key').val) := by
+    rw [storage_writeSlot_other (s := s.writeMap slot key v) hslot v,
+      storage_writeMap]
+  exact (hmap.trans hcoh).trans hflat.symm
+
+/-- `storageKeySlot` on an address-keyed map is exactly the Solidity derivation. -/
+theorem storageKeySlot_map (slot : Nat) (key : Address) :
+    storageKeySlot (.map slot key) =
+      some (solidityMappingSlot slot (addressToWord key).val) := rfl
+
+theorem storageKeySlot_slot (n : Nat) : storageKeySlot (.slot n) = some n := rfl
+
+theorem storageKeySlot_transient (n : Nat) : storageKeySlot (.transient n) = none :=
+  rfl
+
+end Compiler.Proofs.Storage.MappingCoherence

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -107,6 +107,7 @@ import Compiler.Proofs.IRGeneration.SupportedSpec
 import Compiler.Proofs.KeccakBound
 import Compiler.Proofs.LoopSimulation
 import Compiler.Proofs.MappingSlot
+import Compiler.Proofs.Storage.MappingCoherence
 import Compiler.Proofs.Storage.SolidityStorage
 import Compiler.Proofs.Storage.StructArrayStorage
 import Compiler.Proofs.StorageBounds
@@ -4652,6 +4653,14 @@ end Verity.AxiomAudit
   Compiler.Proofs.solidityMappingSlot_add_lt_evmModulus
   Compiler.Proofs.solidityMappingSlot_add_wordOffset_lt_evmModulus
 
+  -- Compiler/Proofs/Storage/MappingCoherence.lean
+  Compiler.Proofs.Storage.MappingCoherence.defaultState_mappingCoherent
+  Compiler.Proofs.Storage.MappingCoherence.writeMap_aligned_same
+  Compiler.Proofs.Storage.MappingCoherence.writeMap_aligned_other
+  Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_map
+  Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_slot
+  Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_transient
+
   -- Compiler/Proofs/Storage/SolidityStorage.lean
   Compiler.Proofs.Storage.mappingSlot_preimage
   Compiler.Proofs.Storage.compiledMappingSlotPointer_eq_mappingSlotPointer
@@ -6847,4 +6856,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6357 theorems/lemmas (4487 public, 1870 private, 0 sorry'd)
+-- Total: 6363 theorems/lemmas (4493 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -190,10 +190,13 @@ Word-valued source storage is one map `StorageKey → Uint256`. The key is
 an injective inductive (`slot` / `contractSlot` / `transient` / `addr` /
 `map` / `mapUint` / `map2`); public accessors keep the old channel names.
 This is a representation change, not a new trust boundary: lens laws use
-constructor injectivity. Solidity keccak slot derivation, and any
-shadow-vs-flat mapping coherence, remain compiler-side (C5 step 4) and are
-**not** assumed here. `storageArray` and `knownAddresses` are still
-separate fields.
+constructor injectivity. Solidity keccak slot derivation lives in
+`Compiler.Proofs.Storage.MappingCoherence.storageKeySlot`. Address-keyed
+shadow-vs-flat agreement (`MappingCoherent`) is defined there and proved
+for `defaultState` and for an aligned `writeMap`+`writeSlot` pair; other
+pairs require an explicit non-alias hypothesis. Keccak injectivity is
+**not** assumed. `storageArray` and `knownAddresses` are still separate
+fields.
 
 ### External-Call Journal (`ContractState.calls`)
 `ContractState.calls` is an append-only journal of observed external calls

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,11 +41,13 @@ Next: derive the executable shallow program from the deep model
 (`Stmt.denote`, macro retarget per-contract behind a flag), collapse the
 per-function `_bridge` theorems into one AST-induction theorem
 (`GenericInduction/LegacyCompatibility` and the compile-derived
-legacy-compatibility witness chain are already retired), then prove C5
-step 4 — structural `StorageKey` ↔ CompilationModel/Yul slot coherence
-(`storageKeySlot` / shadow-vs-flat `MappingCoherent`). C5 step 3 (canonical
+legacy-compatibility witness chain are already retired), then finish C5
+step 4 — field-list `storageKeySlot` and global `MappingCoherent`
+preservation under finite non-alias certificates. The first slice
+(`Compiler.Proofs.Storage.MappingCoherence`: address-keyed coherence,
+aligned `writeMap`+`writeSlot` laws) is implemented. C5 step 3 (canonical
 `storageWords : StorageKey → Uint256` backing, lens laws by constructor
-injectivity) is implemented; it is the enabler for FixedArray-under-mapping,
+injectivity) is on `main`; it is the enabler for FixedArray-under-mapping,
 dynamic CodeData, arbitrary transient storage and multicall/delegatecall
 (#1962, #1967, #1976, #1889).
 


### PR DESCRIPTION
## Summary
- add `Compiler.Proofs.Storage.MappingCoherence` with `storageKeySlot` and address-keyed `MappingCoherent`
- prove `defaultState_mappingCoherent` and aligned `writeMap`+`writeSlot` same/other laws
- other-pair preservation takes an explicit derived-slot inequality (non-alias certificate), not keccak injectivity
- document the slice in AUDIT / TRUST_ASSUMPTIONS / AXIOMS / ROADMAP; **C5 step 4 is not complete**

## Test Plan
- `lake build Compiler.Proofs.Storage.MappingCoherence`
- `make check`
- proof-length and freeze gates

## Related Issues
Addresses the first executable increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only addition with no compiler or runtime behavior change; extends documented storage trust boundaries without new axioms.
> 
> **Overview**
> Adds **`Compiler.Proofs.Storage.MappingCoherence`** as the first executable slice of C5 step 4: compiler-side **`storageKeySlot`** (persistent `StorageKey` → Solidity word slot) and address-keyed **`MappingCoherent`** (shadow `storageMap` matches flat `storage` at `solidityMappingSlot`).
> 
> Proves **`defaultState_mappingCoherent`**, **`writeMap_aligned_same`** (aligned `writeMap` + `writeSlot` fixes the written pair), and **`writeMap_aligned_other`** (other pairs stay coherent under explicit derived-slot inequality and `StorageKey` injectivity—not keccak injectivity). Registers the module in **`PrintAxioms.lean`** (+6 public theorems).
> 
> **AUDIT**, **TRUST_ASSUMPTIONS**, **AXIOMS**, and **docs/ROADMAP** now document this slice and stress that **C5 step 4 is not complete** (global preservation and field-list layout remain open). **No new axioms.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cdef847edec9e7962e2444131fd7bd47b2a84f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->