### PR TITLE
feat(proofs): uint and nested mapping coherence laws

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -314,8 +314,9 @@ sibling entrypoint.
   collisions). `storageWords :=` is forbidden outside `Verity/Core.lean`.
 - Not C5 step 4 complete: `Compiler.Proofs.Storage.MappingCoherence`
   now defines `storageKeySlot` and address-keyed `MappingCoherent`,
-  with `defaultState_mappingCoherent` and the aligned
-  `writeMap`+`writeSlot` laws (same pair, plus other pairs under an
+  with `defaultState_mappingCoherent` / `MappingCoherentUint` /
+  `MappingCoherentMap2` and the aligned `writeMap`/`writeMapUint`/
+  `writeMap2`+`writeSlot` laws (same pair, plus other pairs under an
   explicit non-alias hypothesis). Global preservation and field-list
   layout are still open.
 - Zero new axioms.

--- a/Compiler/Proofs/Storage/MappingCoherence.lean
+++ b/Compiler/Proofs/Storage/MappingCoherence.lean
@@ -90,4 +90,100 @@ theorem storageKeySlot_slot (n : Nat) : storageKeySlot (.slot n) = some n := rfl
 theorem storageKeySlot_transient (n : Nat) : storageKeySlot (.transient n) = none :=
   rfl
 
+/-- Uint-keyed mapping shadow agrees with the flat channel at the derived slot. -/
+def MappingCoherentUint (s : ContractState) : Prop :=
+  ∀ (slot : Nat) (key : Uint256),
+    s.storageMapUint slot key = s.storage (solidityMappingSlot slot key.val)
+
+theorem defaultState_mappingCoherentUint : MappingCoherentUint defaultState := by
+  intro slot key
+  simp [MappingCoherentUint, storageMapUint, storage, defaultState]
+
+theorem writeMapUint_aligned_same (s : ContractState) (slot : Nat) (key v : Uint256) :
+    ((s.writeMapUint slot key v).writeSlot (solidityMappingSlot slot key.val) v).storageMapUint
+        slot key =
+      ((s.writeMapUint slot key v).writeSlot (solidityMappingSlot slot key.val) v).storage
+        (solidityMappingSlot slot key.val) := by
+  simp [storageMapUint_writeSlot, storageMapUint, writeMapUint, storage, writeSlot,
+    storage_writeMapUint]
+
+theorem writeMapUint_aligned_other (s : ContractState) (slot : Nat) (key v : Uint256)
+    (slot' : Nat) (key' : Uint256)
+    (hcoh : s.storageMapUint slot' key' = s.storage (solidityMappingSlot slot' key'.val))
+    (hkey : StorageKey.mapUint slot' key' ≠ StorageKey.mapUint slot key)
+    (hslot : solidityMappingSlot slot' key'.val ≠ solidityMappingSlot slot key.val) :
+    ((s.writeMapUint slot key v).writeSlot (solidityMappingSlot slot key.val) v).storageMapUint
+        slot' key' =
+      ((s.writeMapUint slot key v).writeSlot (solidityMappingSlot slot key.val) v).storage
+        (solidityMappingSlot slot' key'.val) := by
+  have hmap :
+      ((s.writeMapUint slot key v).writeSlot (solidityMappingSlot slot key.val) v).storageMapUint
+          slot' key' =
+        s.storageMapUint slot' key' := by
+    simp [storageMapUint_writeSlot, storageMapUint, writeMapUint, writeSlot, hkey]
+  have hflat :
+      ((s.writeMapUint slot key v).writeSlot (solidityMappingSlot slot key.val) v).storage
+          (solidityMappingSlot slot' key'.val) =
+        s.storage (solidityMappingSlot slot' key'.val) := by
+    rw [storage_writeSlot_other (s := s.writeMapUint slot key v) hslot v, storage_writeMapUint]
+  exact (hmap.trans hcoh).trans hflat.symm
+
+/-- Double-address mapping shadow agrees with the nested derived slot. -/
+def MappingCoherentMap2 (s : ContractState) : Prop :=
+  ∀ (slot : Nat) (k1 k2 : Address),
+    s.storageMap2 slot k1 k2 =
+      s.storage (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val)
+
+theorem defaultState_mappingCoherentMap2 : MappingCoherentMap2 defaultState := by
+  intro slot k1 k2
+  simp [MappingCoherentMap2, storageMap2, storage, defaultState]
+
+theorem writeMap2_aligned_same (s : ContractState) (slot : Nat) (k1 k2 : Address)
+    (v : Uint256) :
+    ((s.writeMap2 slot k1 k2 v).writeSlot
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) v).storageMap2
+        slot k1 k2 =
+      ((s.writeMap2 slot k1 k2 v).writeSlot
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) v).storage
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) := by
+  simp [storageMap2_writeSlot, storageMap2, writeMap2, storage, writeSlot, storage_writeMap2]
+
+theorem writeMap2_aligned_other (s : ContractState) (slot : Nat) (k1 k2 : Address)
+    (v : Uint256) (slot' : Nat) (k1' k2' : Address)
+    (hcoh : s.storageMap2 slot' k1' k2' =
+      s.storage (abstractNestedMappingSlot slot' (addressToWord k1').val (addressToWord k2').val))
+    (hkey : StorageKey.map2 slot' k1' k2' ≠ StorageKey.map2 slot k1 k2)
+    (hslot :
+      abstractNestedMappingSlot slot' (addressToWord k1').val (addressToWord k2').val ≠
+        abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) :
+    ((s.writeMap2 slot k1 k2 v).writeSlot
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val)
+        v).storageMap2 slot' k1' k2' =
+      ((s.writeMap2 slot k1 k2 v).writeSlot
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) v).storage
+        (abstractNestedMappingSlot slot' (addressToWord k1').val (addressToWord k2').val) := by
+  have hmap :
+      ((s.writeMap2 slot k1 k2 v).writeSlot
+          (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val)
+          v).storageMap2 slot' k1' k2' =
+        s.storageMap2 slot' k1' k2' := by
+    simp [storageMap2_writeSlot, storageMap2, writeMap2, writeSlot, hkey]
+  have hflat :
+      ((s.writeMap2 slot k1 k2 v).writeSlot
+          (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val)
+          v).storage
+          (abstractNestedMappingSlot slot' (addressToWord k1').val (addressToWord k2').val) =
+        s.storage
+          (abstractNestedMappingSlot slot' (addressToWord k1').val (addressToWord k2').val) := by
+    rw [storage_writeSlot_other (s := s.writeMap2 slot k1 k2 v) hslot v, storage_writeMap2]
+  exact (hmap.trans hcoh).trans hflat.symm
+
+theorem storageKeySlot_mapUint (slot : Nat) (key : Uint256) :
+    storageKeySlot (.mapUint slot key) = some (solidityMappingSlot slot key.val) := rfl
+
+theorem storageKeySlot_map2 (slot : Nat) (k1 k2 : Address) :
+    storageKeySlot (.map2 slot k1 k2) =
+      some (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) :=
+  rfl
+
 end Compiler.Proofs.Storage.MappingCoherence

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4660,6 +4660,14 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_map
   Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_slot
   Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_transient
+  Compiler.Proofs.Storage.MappingCoherence.defaultState_mappingCoherentUint
+  Compiler.Proofs.Storage.MappingCoherence.writeMapUint_aligned_same
+  Compiler.Proofs.Storage.MappingCoherence.writeMapUint_aligned_other
+  Compiler.Proofs.Storage.MappingCoherence.defaultState_mappingCoherentMap2
+  Compiler.Proofs.Storage.MappingCoherence.writeMap2_aligned_same
+  Compiler.Proofs.Storage.MappingCoherence.writeMap2_aligned_other
+  Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_mapUint
+  Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_map2
 
   -- Compiler/Proofs/Storage/SolidityStorage.lean
   Compiler.Proofs.Storage.mappingSlot_preimage
@@ -6856,4 +6864,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6363 theorems/lemmas (4493 public, 1870 private, 0 sorry'd)
+-- Total: 6371 theorems/lemmas (4501 public, 1870 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- add `MappingCoherentUint` and `MappingCoherentMap2`
- prove defaultState and aligned `writeMapUint`/`writeMap2`+`writeSlot` same/other laws
- other pairs still require an explicit derived-slot inequality
- C5 step 4 remains incomplete (no field-list layout, no global preservation)

## Test Plan
- `lake build Compiler.Proofs.Storage.MappingCoherence`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions with no new axioms and no semantic or compiler output changes; risk is limited to proof maintenance surface.
> 
> **Overview**
> Extends **C5 step 4** mapping coherence in `Compiler/Proofs/Storage/MappingCoherence.lean` beyond address-keyed `MappingCoherent`, mirroring the same pattern for **`storageMapUint`** and **`storageMap2`**.
> 
> New predicates **`MappingCoherentUint`** and **`MappingCoherentMap2`** tie shadow reads to `solidityMappingSlot` / `abstractNestedMappingSlot` on the flat `storage` channel. For each, the PR proves **`defaultState_*`** coherence and **`writeMapUint`/`writeMap2` + `writeSlot`** “aligned same” laws, plus “aligned other” laws that preserve coherence for distinct keys/slots under explicit **non-alias** hypotheses (still not global keccak injectivity). **`storageKeySlot_mapUint`** and **`storageKeySlot_map2`** connect `StorageKey` constructors to those derivations.
> 
> **`AUDIT.md`** documents the widened step-4 slice; **`PrintAxioms.lean`** lists eight new public theorems and bumps the theorem count (+8, still 0 sorry). Runtime/compiler behavior is unchanged; C5 step 4 remains incomplete (no global preservation or field-list layout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fa5ec1d570c3eb07ad07159e52c4f8ab86c4b7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->