### PR TITLE
feat(proofs): field-list StorageKey to slot collapse

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -317,8 +317,11 @@ sibling entrypoint.
   with `defaultState_mappingCoherent` / `MappingCoherentUint` /
   `MappingCoherentMap2` and the aligned `writeMap`/`writeMapUint`/
   `writeMap2`+`writeSlot` laws (same pair, plus other pairs under an
-  explicit non-alias hypothesis). Global preservation and field-list
-  layout are still open.
+  explicit non-alias hypothesis). `FieldStorageKey` collapses a
+  CompilationModel field list to a root `StorageKey` (and typed
+  `map` / `mapUint` / `map2` entries) and proves `storageKeySlot`
+  of that key is the resolved slot. Global preservation, bytes32
+  keys, struct members, and alias slots are still open.
 - Zero new axioms.
 
 ## CI Guards

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -26,9 +26,10 @@ C5 step 3 (`ContractState.storageWords` over injective `StorageKey`) does
 not add a keccak-injectivity axiom. Source lens laws use constructor
 injectivity; Solidity slot derivation remains compiler-side.
 
-C5 step 4's first slice (`MappingCoherent`) likewise adds no axiom: other-pair
-preservation is hypothesized by an explicit derived-slot inequality, not by
-keccak injectivity.
+C5 step 4's mapping-coherence and field-list slices likewise add no
+axiom: other-pair preservation is hypothesized by an explicit
+derived-slot inequality, not by keccak injectivity. `FieldStorageKey`
+is a constructor match on `FieldType` / `isTransient`.
 
 ## Eliminated Axioms
 

--- a/Compiler/Proofs/Storage/FieldStorageKey.lean
+++ b/Compiler/Proofs/Storage/FieldStorageKey.lean
@@ -1,0 +1,129 @@
+/-
+  C5 step 4 (field-list slice): collapse a CompilationModel field list to
+  a source StorageKey, then to the compiler slot via `storageKeySlot`.
+
+  Mapping-entry constructors cover the typed cases that already have a
+  StorageKey (`map` / `mapUint` / `map2`). bytes32 keys, struct members,
+  alias slots, and global MappingCoherent preservation stay open.
+-/
+
+import Compiler.Proofs.Storage.MappingCoherence
+import Verity.Core.Model.Types
+
+namespace Compiler.Proofs.Storage.FieldStorageKey
+
+open Verity
+open Compiler.CompilationModel
+open Compiler.Proofs.Storage.MappingCoherence
+open Compiler.Proofs
+
+/-- Root source key for one resolved field. Transient fields stay off the
+    persistent Solidity slot map. Address scalars use `.addr`; every other
+    persistent type uses the field's resolved word as `.slot` (mapping
+    roots included). -/
+def fieldRootKey (f : Field) (resolvedSlot : Nat) : StorageKey :=
+  if f.isTransient then
+    .transient resolvedSlot
+  else
+    match f.ty with
+    | .address => .addr resolvedSlot
+    | _ => .slot resolvedSlot
+
+/-- Named field in a contract field list, if it resolves. -/
+def fieldListRootKey (fields : List Field) (name : String) : Option StorageKey :=
+  match findFieldWithResolvedSlot fields name with
+  | some (f, slot) => some (fieldRootKey f slot)
+  | none => none
+
+theorem storageKeySlot_fieldRootKey (f : Field) (slot : Nat) :
+    storageKeySlot (fieldRootKey f slot) =
+      if f.isTransient then none else some slot := by
+  unfold fieldRootKey
+  split
+  · rfl
+  · cases f.ty <;> rfl
+
+theorem fieldListRootKey_eq
+    {fields : List Field} {name : String} {f : Field} {slot : Nat}
+    (h : findFieldWithResolvedSlot fields name = some (f, slot)) :
+    fieldListRootKey fields name = some (fieldRootKey f slot) := by
+  simp [fieldListRootKey, h]
+
+theorem storageKeySlot_fieldListRootKey
+    {fields : List Field} {name : String} {f : Field} {slot : Nat}
+    (h : findFieldWithResolvedSlot fields name = some (f, slot)) :
+    Option.bind (fieldListRootKey fields name) storageKeySlot =
+      if f.isTransient then none else some slot := by
+  rw [fieldListRootKey_eq h, Option.bind_some, storageKeySlot_fieldRootKey]
+
+theorem fieldRootKey_uint256
+    {f : Field} {slot : Nat}
+    (htr : f.isTransient = false) (hty : f.ty = .uint256) :
+    fieldRootKey f slot = .slot slot := by
+  simp [fieldRootKey, htr, hty]
+
+theorem fieldRootKey_address
+    {f : Field} {slot : Nat}
+    (htr : f.isTransient = false) (hty : f.ty = .address) :
+    fieldRootKey f slot = .addr slot := by
+  simp [fieldRootKey, htr, hty]
+
+theorem fieldRootKey_mappingTyped
+    {f : Field} {slot : Nat} {mt : MappingType}
+    (htr : f.isTransient = false) (hty : f.ty = .mappingTyped mt) :
+    fieldRootKey f slot = .slot slot := by
+  simp [fieldRootKey, htr, hty]
+
+theorem fieldRootKey_transient {f : Field} {slot : Nat} (htr : f.isTransient = true) :
+    fieldRootKey f slot = .transient slot := by
+  simp [fieldRootKey, htr]
+
+/-- Persistent `mapping(address => uint256)` entry. -/
+def fieldMapKey (f : Field) (resolvedSlot : Nat) (key : Address) : Option StorageKey :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingTyped (.simple .address) => some (.map resolvedSlot key)
+    | _ => none
+
+/-- Persistent `mapping(uint256 => uint256)` entry. -/
+def fieldMapUintKey (f : Field) (resolvedSlot : Nat) (key : Uint256) : Option StorageKey :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingTyped (.simple .uint256) => some (.mapUint resolvedSlot key)
+    | _ => none
+
+/-- Persistent `mapping(address => mapping(address => uint256))` entry. -/
+def fieldMap2Key (f : Field) (resolvedSlot : Nat) (k1 k2 : Address) : Option StorageKey :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingTyped (.nested .address .address) => some (.map2 resolvedSlot k1 k2)
+    | _ => none
+
+theorem storageKeySlot_fieldMapKey
+    {f : Field} {slot : Nat} {key : Address}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.simple .address)) :
+    Option.bind (fieldMapKey f slot key) storageKeySlot =
+      some (solidityMappingSlot slot (addressToWord key).val) := by
+  simp [fieldMapKey, htr, hty, storageKeySlot]
+
+theorem storageKeySlot_fieldMapUintKey
+    {f : Field} {slot : Nat} {key : Uint256}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.simple .uint256)) :
+    Option.bind (fieldMapUintKey f slot key) storageKeySlot =
+      some (solidityMappingSlot slot key.val) := by
+  simp [fieldMapUintKey, htr, hty, storageKeySlot]
+
+theorem storageKeySlot_fieldMap2Key
+    {f : Field} {slot : Nat} {k1 k2 : Address}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.nested .address .address)) :
+    Option.bind (fieldMap2Key f slot k1 k2) storageKeySlot =
+      some (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) := by
+  simp [fieldMap2Key, htr, hty, storageKeySlot]
+
+end Compiler.Proofs.Storage.FieldStorageKey

--- a/Compiler/Proofs/Storage/MappingCoherence.lean
+++ b/Compiler/Proofs/Storage/MappingCoherence.lean
@@ -37,7 +37,7 @@ def MappingCoherent (s : ContractState) : Prop :=
 
 theorem defaultState_mappingCoherent : MappingCoherent defaultState := by
   intro slot key
-  simp [MappingCoherent, storageMap, storage, defaultState]
+  simp [storageMap, storage, defaultState]
 
 /-- The aligned write — shadow map plus the derived flat slot — makes the
     written pair coherent regardless of the prior world. -/
@@ -48,7 +48,7 @@ theorem writeMap_aligned_same (s : ContractState) (slot : Nat) (key : Address)
       ((s.writeMap slot key v).writeSlot
         (solidityMappingSlot slot (addressToWord key).val) v).storage
         (solidityMappingSlot slot (addressToWord key).val) := by
-  simp [storageMap_writeSlot, storageMap, writeMap, storage, writeSlot, storage_writeMap]
+  simp [storageMap, writeMap, storage, writeSlot]
 
 /-- Another mapping pair stays coherent when its derived slot is distinct
     from the written one. The distinctness hypothesis is the non-alias
@@ -70,7 +70,7 @@ theorem writeMap_aligned_other (s : ContractState) (slot : Nat) (key : Address)
       ((s.writeMap slot key v).writeSlot
         (solidityMappingSlot slot (addressToWord key).val) v).storageMap slot' key' =
         s.storageMap slot' key' := by
-    simp [storageMap_writeSlot, storageMap, writeMap, writeSlot, hkey]
+    simp [storageMap, writeMap, writeSlot, hkey]
   have hflat :
       ((s.writeMap slot key v).writeSlot
         (solidityMappingSlot slot (addressToWord key).val) v).storage
@@ -87,6 +87,15 @@ theorem storageKeySlot_map (slot : Nat) (key : Address) :
 
 theorem storageKeySlot_slot (n : Nat) : storageKeySlot (.slot n) = some n := rfl
 
+theorem storageKeySlot_addr (n : Nat) : storageKeySlot (.addr n) = some n := rfl
+
+theorem storageKeySlot_contractSlot_zero (n : Nat) :
+    storageKeySlot (.contractSlot 0 n) = some n := rfl
+
+theorem storageKeySlot_contractSlot_nonzero {c n : Nat} (h : c ≠ 0) :
+    storageKeySlot (.contractSlot c n) = none := by
+  simp [storageKeySlot, h]
+
 theorem storageKeySlot_transient (n : Nat) : storageKeySlot (.transient n) = none :=
   rfl
 
@@ -97,15 +106,14 @@ def MappingCoherentUint (s : ContractState) : Prop :=
 
 theorem defaultState_mappingCoherentUint : MappingCoherentUint defaultState := by
   intro slot key
-  simp [MappingCoherentUint, storageMapUint, storage, defaultState]
+  simp [storageMapUint, storage, defaultState]
 
 theorem writeMapUint_aligned_same (s : ContractState) (slot : Nat) (key v : Uint256) :
     ((s.writeMapUint slot key v).writeSlot (solidityMappingSlot slot key.val) v).storageMapUint
         slot key =
       ((s.writeMapUint slot key v).writeSlot (solidityMappingSlot slot key.val) v).storage
         (solidityMappingSlot slot key.val) := by
-  simp [storageMapUint_writeSlot, storageMapUint, writeMapUint, storage, writeSlot,
-    storage_writeMapUint]
+  simp [storageMapUint, writeMapUint, storage, writeSlot]
 
 theorem writeMapUint_aligned_other (s : ContractState) (slot : Nat) (key v : Uint256)
     (slot' : Nat) (key' : Uint256)
@@ -120,7 +128,7 @@ theorem writeMapUint_aligned_other (s : ContractState) (slot : Nat) (key v : Uin
       ((s.writeMapUint slot key v).writeSlot (solidityMappingSlot slot key.val) v).storageMapUint
           slot' key' =
         s.storageMapUint slot' key' := by
-    simp [storageMapUint_writeSlot, storageMapUint, writeMapUint, writeSlot, hkey]
+    simp [storageMapUint, writeMapUint, writeSlot, hkey]
   have hflat :
       ((s.writeMapUint slot key v).writeSlot (solidityMappingSlot slot key.val) v).storage
           (solidityMappingSlot slot' key'.val) =
@@ -136,7 +144,7 @@ def MappingCoherentMap2 (s : ContractState) : Prop :=
 
 theorem defaultState_mappingCoherentMap2 : MappingCoherentMap2 defaultState := by
   intro slot k1 k2
-  simp [MappingCoherentMap2, storageMap2, storage, defaultState]
+  simp [storageMap2, storage, defaultState]
 
 theorem writeMap2_aligned_same (s : ContractState) (slot : Nat) (k1 k2 : Address)
     (v : Uint256) :
@@ -146,7 +154,7 @@ theorem writeMap2_aligned_same (s : ContractState) (slot : Nat) (k1 k2 : Address
       ((s.writeMap2 slot k1 k2 v).writeSlot
         (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) v).storage
         (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) := by
-  simp [storageMap2_writeSlot, storageMap2, writeMap2, storage, writeSlot, storage_writeMap2]
+  simp [storageMap2, writeMap2, storage, writeSlot]
 
 theorem writeMap2_aligned_other (s : ContractState) (slot : Nat) (k1 k2 : Address)
     (v : Uint256) (slot' : Nat) (k1' k2' : Address)
@@ -167,7 +175,7 @@ theorem writeMap2_aligned_other (s : ContractState) (slot : Nat) (k1 k2 : Addres
           (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val)
           v).storageMap2 slot' k1' k2' =
         s.storageMap2 slot' k1' k2' := by
-    simp [storageMap2_writeSlot, storageMap2, writeMap2, writeSlot, hkey]
+    simp [storageMap2, writeMap2, writeSlot, hkey]
   have hflat :
       ((s.writeMap2 slot k1 k2 v).writeSlot
           (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -107,6 +107,7 @@ import Compiler.Proofs.IRGeneration.SupportedSpec
 import Compiler.Proofs.KeccakBound
 import Compiler.Proofs.LoopSimulation
 import Compiler.Proofs.MappingSlot
+import Compiler.Proofs.Storage.FieldStorageKey
 import Compiler.Proofs.Storage.MappingCoherence
 import Compiler.Proofs.Storage.SolidityStorage
 import Compiler.Proofs.Storage.StructArrayStorage
@@ -4653,12 +4654,27 @@ end Verity.AxiomAudit
   Compiler.Proofs.solidityMappingSlot_add_lt_evmModulus
   Compiler.Proofs.solidityMappingSlot_add_wordOffset_lt_evmModulus
 
+  -- Compiler/Proofs/Storage/FieldStorageKey.lean
+  Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldRootKey
+  Compiler.Proofs.Storage.FieldStorageKey.fieldListRootKey_eq
+  Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldListRootKey
+  Compiler.Proofs.Storage.FieldStorageKey.fieldRootKey_uint256
+  Compiler.Proofs.Storage.FieldStorageKey.fieldRootKey_address
+  Compiler.Proofs.Storage.FieldStorageKey.fieldRootKey_mappingTyped
+  Compiler.Proofs.Storage.FieldStorageKey.fieldRootKey_transient
+  Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldMapKey
+  Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldMapUintKey
+  Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldMap2Key
+
   -- Compiler/Proofs/Storage/MappingCoherence.lean
   Compiler.Proofs.Storage.MappingCoherence.defaultState_mappingCoherent
   Compiler.Proofs.Storage.MappingCoherence.writeMap_aligned_same
   Compiler.Proofs.Storage.MappingCoherence.writeMap_aligned_other
   Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_map
   Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_slot
+  Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_addr
+  Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_contractSlot_zero
+  Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_contractSlot_nonzero
   Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_transient
   Compiler.Proofs.Storage.MappingCoherence.defaultState_mappingCoherentUint
   Compiler.Proofs.Storage.MappingCoherence.writeMapUint_aligned_same
@@ -6864,4 +6880,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6371 theorems/lemmas (4501 public, 1870 private, 0 sorry'd)
+-- Total: 6384 theorems/lemmas (4514 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -191,12 +191,15 @@ an injective inductive (`slot` / `contractSlot` / `transient` / `addr` /
 `map` / `mapUint` / `map2`); public accessors keep the old channel names.
 This is a representation change, not a new trust boundary: lens laws use
 constructor injectivity. Solidity keccak slot derivation lives in
-`Compiler.Proofs.Storage.MappingCoherence.storageKeySlot`. Address-keyed
-shadow-vs-flat agreement (`MappingCoherent`) is defined there and proved
-for `defaultState` and for an aligned `writeMap`+`writeSlot` pair; other
-pairs require an explicit non-alias hypothesis. Keccak injectivity is
-**not** assumed. `storageArray` and `knownAddresses` are still separate
-fields.
+`Compiler.Proofs.Storage.MappingCoherence.storageKeySlot`. Address-,
+uint-, and nested-address shadow-vs-flat agreement
+(`MappingCoherent` / `MappingCoherentUint` / `MappingCoherentMap2`) is
+defined there and proved for `defaultState` and for an aligned
+`writeMap*`+`writeSlot` pair; other pairs require an explicit
+non-alias hypothesis. A CompilationModel field list collapses to those
+keys via `FieldStorageKey` (root plus typed `map`/`mapUint`/`map2`
+entries). Keccak injectivity is **not** assumed. `storageArray` and
+`knownAddresses` are still separate fields.
 
 ### External-Call Journal (`ContractState.calls`)
 `ContractState.calls` is an append-only journal of observed external calls

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,10 +42,11 @@ Next: derive the executable shallow program from the deep model
 per-function `_bridge` theorems into one AST-induction theorem
 (`GenericInduction/LegacyCompatibility` and the compile-derived
 legacy-compatibility witness chain are already retired), then finish C5
-step 4 — field-list `storageKeySlot` and global `MappingCoherent`
-preservation under finite non-alias certificates. The first slice
-(`Compiler.Proofs.Storage.MappingCoherence`: address-keyed coherence,
-aligned `writeMap`+`writeSlot` laws) is implemented. C5 step 3 (canonical
+step 4 — remaining field-list cases (bytes32 keys, struct members,
+alias slots) and global `MappingCoherent` preservation under finite
+non-alias certificates. Implemented: address/uint/map2 coherence
+laws, plus `FieldStorageKey` (named field → root/`map`/`mapUint`/`map2`
+`StorageKey` → `storageKeySlot`). C5 step 3 (canonical
 `storageWords : StorageKey → Uint256` backing, lens laws by constructor
 injectivity) is on `main`; it is the enabler for FixedArray-under-mapping,
 dynamic CodeData, arbitrary transient storage and multicall/delegatecall


### PR DESCRIPTION
## Summary
- add `Compiler.Proofs.Storage.FieldStorageKey`: named CompilationModel field → root `StorageKey` (and typed `map` / `mapUint` / `map2` entries)
- prove `storageKeySlot` of that key is the resolved slot (or the derived mapping slot)
- complete remaining `storageKeySlot` constructor lemmas (`addr`, `contractSlot`)
- C5 step 4 remains incomplete (bytes32 keys, struct members, alias slots, global preservation)

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldStorageKey Compiler.Proofs.Storage.MappingCoherence`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only storage correspondence work with no runtime or axiom changes; remaining C5 gaps are explicitly documented.
> 
> **Overview**
> **C5 step 4 increment:** connects **CompilationModel field lists** to the existing `storageKeySlot` / mapping-coherence story.
> 
> Adds **`Compiler.Proofs.Storage.FieldStorageKey`**: `fieldRootKey` / `fieldListRootKey` map a resolved field (or name in a field list) to a root `StorageKey` (`.addr` for address scalars, `.slot` for other persistent types, `.transient` off the persistent map), plus typed **`fieldMapKey` / `fieldMapUintKey` / `fieldMap2Key`** for the supported mapping shapes. Proves **`storageKeySlot`** on those keys equals the resolved word slot or the derived Solidity mapping slot.
> 
> In **`MappingCoherence`**, adds **`storageKeySlot`** lemmas for **`.addr`** and **`.contractSlot`** (zero vs nonzero contract id), and tightens several coherence proofs by **`simp`** on lens definitions instead of older helper lemmas.
> 
> Registers the new theorems in **`PrintAxioms.lean`** (+13 counted lemmas). **`AUDIT.md`**, **`AXIOMS.md`**, **`TRUST_ASSUMPTIONS.md`**, and **`docs/ROADMAP.md`** now document the field-list slice; **bytes32 keys, struct members, alias slots, and global `MappingCoherent` preservation** remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b908634268c45e809d16afb3eafa8949d7a9df7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->