### PR TITLE
feat(proofs): finite-set mapping coherence preservation

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -320,7 +320,10 @@ sibling entrypoint.
   explicit non-alias hypothesis). `FieldStorageKey` collapses a
   CompilationModel field list to a root `StorageKey` (and typed
   `map` / `mapUint` / `map2` entries) and proves `storageKeySlot`
-  of that key is the resolved slot. Global preservation, bytes32
+  of that key is the resolved slot. Finite-set address
+  `MappingCoherentOn` is preserved by an aligned write under an
+  explicit pairwise derived-slot certificate
+  (`MappingCoherenceOn`). Global (all-keys) preservation, bytes32
   keys, struct members, and alias slots are still open.
 - Zero new axioms.
 

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -26,10 +26,11 @@ C5 step 3 (`ContractState.storageWords` over injective `StorageKey`) does
 not add a keccak-injectivity axiom. Source lens laws use constructor
 injectivity; Solidity slot derivation remains compiler-side.
 
-C5 step 4's mapping-coherence and field-list slices likewise add no
-axiom: other-pair preservation is hypothesized by an explicit
-derived-slot inequality, not by keccak injectivity. `FieldStorageKey`
-is a constructor match on `FieldType` / `isTransient`.
+C5 step 4's mapping-coherence, field-list, and finite-set slices
+likewise add no axiom: other-pair and finite-list preservation is
+hypothesized by an explicit derived-slot inequality, not by keccak
+injectivity. `FieldStorageKey` is a constructor match on
+`FieldType` / `isTransient`.
 
 ## Eliminated Axioms
 

--- a/Compiler/Proofs/Storage/MappingCoherenceOn.lean
+++ b/Compiler/Proofs/Storage/MappingCoherenceOn.lean
@@ -1,0 +1,88 @@
+/-
+  C5 step 4 (finite-set preservation slice): `MappingCoherent` restricted
+  to a finite list of (slot, key) pairs is preserved by an aligned
+  `writeMap`+`writeSlot` when every other listed pair carries an explicit
+  derived-slot inequality.
+
+  This is not global preservation. A certificate for every address-keyed
+  pair would be keccak injectivity on an unbounded preimage set.
+-/
+
+import Compiler.Proofs.Storage.MappingCoherence
+
+namespace Compiler.Proofs.Storage.MappingCoherenceOn
+
+open Verity
+open Verity.ContractState
+open Compiler.Proofs
+open Compiler.Proofs.Storage.MappingCoherence
+
+def mappingAddrSlot (slot : Nat) (key : Address) : Nat :=
+  solidityMappingSlot slot (addressToWord key).val
+
+def MappingCoherentAt (s : ContractState) (slot : Nat) (key : Address) : Prop :=
+  s.storageMap slot key = s.storage (mappingAddrSlot slot key)
+
+def MappingCoherentOn (s : ContractState) (pairs : List (Nat × Address)) : Prop :=
+  ∀ p ∈ pairs, MappingCoherentAt s p.1 p.2
+
+/-- Finite non-alias certificate: distinct listed pairs have distinct
+    derived slots. Not keccak injectivity. -/
+def DerivedAddrSlotsDistinct (pairs : List (Nat × Address)) : Prop :=
+  ∀ p ∈ pairs, ∀ q ∈ pairs, p ≠ q →
+    mappingAddrSlot p.1 p.2 ≠ mappingAddrSlot q.1 q.2
+
+theorem mappingCoherentOn_of_mappingCoherent
+    (s : ContractState) (pairs : List (Nat × Address))
+    (h : MappingCoherent s) : MappingCoherentOn s pairs := by
+  intro p hp
+  exact h p.1 p.2
+
+theorem defaultState_mappingCoherentOn (pairs : List (Nat × Address)) :
+    MappingCoherentOn defaultState pairs :=
+  mappingCoherentOn_of_mappingCoherent _ _ defaultState_mappingCoherent
+
+theorem writeMap_aligned_preserves_at_same
+    (s : ContractState) (slot : Nat) (key : Address) (v : Uint256) :
+    MappingCoherentAt
+      ((s.writeMap slot key v).writeSlot (mappingAddrSlot slot key) v)
+      slot key :=
+  writeMap_aligned_same s slot key v
+
+theorem storageKey_map_ne_of_pair_ne
+    {p q : Nat × Address} (h : p ≠ q) :
+    StorageKey.map p.1 p.2 ≠ StorageKey.map q.1 q.2 := by
+  intro heq
+  apply h
+  injection heq with hs hk
+  exact Prod.ext hs hk
+
+theorem writeMap_aligned_preserves_at_other
+    (s : ContractState) (slot : Nat) (key : Address) (v : Uint256)
+    (slot' : Nat) (key' : Address)
+    (hcoh : MappingCoherentAt s slot' key')
+    (hkey : StorageKey.map slot' key' ≠ StorageKey.map slot key)
+    (hslot : mappingAddrSlot slot' key' ≠ mappingAddrSlot slot key) :
+    MappingCoherentAt
+      ((s.writeMap slot key v).writeSlot (mappingAddrSlot slot key) v)
+      slot' key' :=
+  writeMap_aligned_other s slot key v slot' key' hcoh hkey hslot
+
+theorem writeMap_aligned_preserves_on
+    (s : ContractState) (pairs : List (Nat × Address))
+    (slot : Nat) (key : Address) (v : Uint256)
+    (hcoh : MappingCoherentOn s pairs)
+    (hna : DerivedAddrSlotsDistinct pairs)
+    (hp : (slot, key) ∈ pairs) :
+    MappingCoherentOn
+      ((s.writeMap slot key v).writeSlot (mappingAddrSlot slot key) v)
+      pairs := by
+  intro p hp'
+  by_cases hpeq : p = (slot, key)
+  · subst hpeq
+    exact writeMap_aligned_preserves_at_same s slot key v
+  · exact writeMap_aligned_preserves_at_other s slot key v p.1 p.2
+      (hcoh p hp') (storageKey_map_ne_of_pair_ne hpeq)
+      (hna p hp' (slot, key) hp hpeq)
+
+end Compiler.Proofs.Storage.MappingCoherenceOn

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -109,6 +109,7 @@ import Compiler.Proofs.LoopSimulation
 import Compiler.Proofs.MappingSlot
 import Compiler.Proofs.Storage.FieldStorageKey
 import Compiler.Proofs.Storage.MappingCoherence
+import Compiler.Proofs.Storage.MappingCoherenceOn
 import Compiler.Proofs.Storage.SolidityStorage
 import Compiler.Proofs.Storage.StructArrayStorage
 import Compiler.Proofs.StorageBounds
@@ -4685,6 +4686,14 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_mapUint
   Compiler.Proofs.Storage.MappingCoherence.storageKeySlot_map2
 
+  -- Compiler/Proofs/Storage/MappingCoherenceOn.lean
+  Compiler.Proofs.Storage.MappingCoherenceOn.mappingCoherentOn_of_mappingCoherent
+  Compiler.Proofs.Storage.MappingCoherenceOn.defaultState_mappingCoherentOn
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMap_aligned_preserves_at_same
+  Compiler.Proofs.Storage.MappingCoherenceOn.storageKey_map_ne_of_pair_ne
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMap_aligned_preserves_at_other
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMap_aligned_preserves_on
+
   -- Compiler/Proofs/Storage/SolidityStorage.lean
   Compiler.Proofs.Storage.mappingSlot_preimage
   Compiler.Proofs.Storage.compiledMappingSlotPointer_eq_mappingSlotPointer
@@ -6880,4 +6889,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6384 theorems/lemmas (4514 public, 1870 private, 0 sorry'd)
+-- Total: 6390 theorems/lemmas (4520 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -198,8 +198,11 @@ defined there and proved for `defaultState` and for an aligned
 `writeMap*`+`writeSlot` pair; other pairs require an explicit
 non-alias hypothesis. A CompilationModel field list collapses to those
 keys via `FieldStorageKey` (root plus typed `map`/`mapUint`/`map2`
-entries). Keccak injectivity is **not** assumed. `storageArray` and
-`knownAddresses` are still separate fields.
+entries). A finite list of address-keyed pairs stays coherent under
+an aligned write when the list carries an explicit pairwise
+derived-slot certificate (`MappingCoherentOn`); that is not a
+global (all-keys) claim. Keccak injectivity is **not** assumed.
+`storageArray` and `knownAddresses` are still separate fields.
 
 ### External-Call Journal (`ContractState.calls`)
 `ContractState.calls` is an append-only journal of observed external calls

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,10 +43,10 @@ per-function `_bridge` theorems into one AST-induction theorem
 (`GenericInduction/LegacyCompatibility` and the compile-derived
 legacy-compatibility witness chain are already retired), then finish C5
 step 4 — remaining field-list cases (bytes32 keys, struct members,
-alias slots) and global `MappingCoherent` preservation under finite
-non-alias certificates. Implemented: address/uint/map2 coherence
-laws, plus `FieldStorageKey` (named field → root/`map`/`mapUint`/`map2`
-`StorageKey` → `storageKeySlot`). C5 step 3 (canonical
+alias slots) and global (all-keys) `MappingCoherent` preservation.
+Implemented: address/uint/map2 coherence laws, `FieldStorageKey`,
+and finite-set address `MappingCoherentOn` under an explicit
+pairwise derived-slot certificate. C5 step 3 (canonical
 `storageWords : StorageKey → Uint256` backing, lens laws by constructor
 injectivity) is on `main`; it is the enabler for FixedArray-under-mapping,
 dynamic CodeData, arbitrary transient storage and multicall/delegatecall


### PR DESCRIPTION
## Summary
- add `MappingCoherentOn` / `DerivedAddrSlotsDistinct`
- prove an aligned `writeMap`+`writeSlot` preserves address-keyed coherence on a finite pair list under an explicit pairwise derived-slot certificate
- not global (all-keys) preservation; keccak injectivity is still not assumed
- C5 step 4 remains incomplete

## Test Plan
- `lake build Compiler.Proofs.Storage.MappingCoherenceOn`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only Lean module reusing existing mapping-coherence lemmas; documentation and theorem registry updates with zero new axioms.
> 
> **Overview**
> Adds **`Compiler/Proofs/Storage/MappingCoherenceOn`**, a C5 step 4 slice that lifts address-keyed **`MappingCoherent`** to a finite list of `(slot, address)` pairs.
> 
> **New surface:** `MappingCoherentAt` / `MappingCoherentOn`, plus **`DerivedAddrSlotsDistinct`** as an explicit pairwise certificate that listed pairs have different derived mapping slots (not keccak injectivity).
> 
> **Main theorem:** an aligned **`writeMap` + `writeSlot`** at the derived slot preserves **`MappingCoherentOn`** for the whole list when the write target is in the list and the certificate holds; same-pair and other-pair cases delegate to existing **`MappingCoherence`** lemmas.
> 
> **Docs/registry:** `AUDIT.md`, `AXIOMS.md`, `TRUST_ASSUMPTIONS.md`, and `docs/ROADMAP.md` record that this is finite-set preservation only—global all-keys coherence, bytes32 keys, struct members, and alias slots remain open. **`PrintAxioms.lean`** registers the new theorems (+6 public lemmas).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9452c561dcabb08abb466231fe44a30eba083792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->