### PR TITLE
feat(proofs): finite-set uint and map2 coherence

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -323,8 +323,9 @@ sibling entrypoint.
   of that key is the resolved slot. Finite-set address
   `MappingCoherentOn` is preserved by an aligned write under an
   explicit pairwise derived-slot certificate
-  (`MappingCoherenceOn`). Global (all-keys) preservation, bytes32
-  keys, struct members, and alias slots are still open.
+  (`MappingCoherenceOn`), including uint and nested-address lists.
+  Global (all-keys) preservation, bytes32 keys, struct members, and
+  alias slots are still open.
 - Zero new axioms.
 
 ## CI Guards

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -27,10 +27,10 @@ not add a keccak-injectivity axiom. Source lens laws use constructor
 injectivity; Solidity slot derivation remains compiler-side.
 
 C5 step 4's mapping-coherence, field-list, and finite-set slices
-likewise add no axiom: other-pair and finite-list preservation is
-hypothesized by an explicit derived-slot inequality, not by keccak
-injectivity. `FieldStorageKey` is a constructor match on
-`FieldType` / `isTransient`.
+likewise add no axiom: other-pair and finite-list preservation
+(address / uint / map2) is hypothesized by an explicit derived-slot
+inequality, not by keccak injectivity. `FieldStorageKey` is a
+constructor match on `FieldType` / `isTransient`.
 
 ## Eliminated Axioms
 

--- a/Compiler/Proofs/Storage/MappingCoherenceOn.lean
+++ b/Compiler/Proofs/Storage/MappingCoherenceOn.lean
@@ -85,4 +85,140 @@ theorem writeMap_aligned_preserves_on
       (hcoh p hp') (storageKey_map_ne_of_pair_ne hpeq)
       (hna p hp' (slot, key) hp hpeq)
 
+/-- Uint-keyed finite-set coherence. Same shape as the address-keyed
+    certificate; still not keccak injectivity. -/
+def mappingUintSlot (slot : Nat) (key : Uint256) : Nat :=
+  solidityMappingSlot slot key.val
+
+def MappingCoherentUintAt (s : ContractState) (slot : Nat) (key : Uint256) : Prop :=
+  s.storageMapUint slot key = s.storage (mappingUintSlot slot key)
+
+def MappingCoherentUintOn (s : ContractState) (pairs : List (Nat × Uint256)) : Prop :=
+  ∀ p ∈ pairs, MappingCoherentUintAt s p.1 p.2
+
+def DerivedUintSlotsDistinct (pairs : List (Nat × Uint256)) : Prop :=
+  ∀ p ∈ pairs, ∀ q ∈ pairs, p ≠ q →
+    mappingUintSlot p.1 p.2 ≠ mappingUintSlot q.1 q.2
+
+theorem mappingCoherentUintOn_of_mappingCoherentUint
+    (s : ContractState) (pairs : List (Nat × Uint256))
+    (h : MappingCoherentUint s) : MappingCoherentUintOn s pairs := by
+  intro p hp
+  exact h p.1 p.2
+
+theorem defaultState_mappingCoherentUintOn (pairs : List (Nat × Uint256)) :
+    MappingCoherentUintOn defaultState pairs :=
+  mappingCoherentUintOn_of_mappingCoherentUint _ _ defaultState_mappingCoherentUint
+
+theorem writeMapUint_aligned_preserves_at_same
+    (s : ContractState) (slot : Nat) (key v : Uint256) :
+    MappingCoherentUintAt
+      ((s.writeMapUint slot key v).writeSlot (mappingUintSlot slot key) v)
+      slot key :=
+  writeMapUint_aligned_same s slot key v
+
+theorem storageKey_mapUint_ne_of_pair_ne
+    {p q : Nat × Uint256} (h : p ≠ q) :
+    StorageKey.mapUint p.1 p.2 ≠ StorageKey.mapUint q.1 q.2 := by
+  intro heq
+  apply h
+  injection heq with hs hk
+  exact Prod.ext hs hk
+
+theorem writeMapUint_aligned_preserves_at_other
+    (s : ContractState) (slot : Nat) (key v : Uint256)
+    (slot' : Nat) (key' : Uint256)
+    (hcoh : MappingCoherentUintAt s slot' key')
+    (hkey : StorageKey.mapUint slot' key' ≠ StorageKey.mapUint slot key)
+    (hslot : mappingUintSlot slot' key' ≠ mappingUintSlot slot key) :
+    MappingCoherentUintAt
+      ((s.writeMapUint slot key v).writeSlot (mappingUintSlot slot key) v)
+      slot' key' :=
+  writeMapUint_aligned_other s slot key v slot' key' hcoh hkey hslot
+
+theorem writeMapUint_aligned_preserves_on
+    (s : ContractState) (pairs : List (Nat × Uint256))
+    (slot : Nat) (key v : Uint256)
+    (hcoh : MappingCoherentUintOn s pairs)
+    (hna : DerivedUintSlotsDistinct pairs)
+    (hp : (slot, key) ∈ pairs) :
+    MappingCoherentUintOn
+      ((s.writeMapUint slot key v).writeSlot (mappingUintSlot slot key) v)
+      pairs := by
+  intro p hp'
+  by_cases hpeq : p = (slot, key)
+  · subst hpeq
+    exact writeMapUint_aligned_preserves_at_same s slot key v
+  · exact writeMapUint_aligned_preserves_at_other s slot key v p.1 p.2
+      (hcoh p hp') (storageKey_mapUint_ne_of_pair_ne hpeq)
+      (hna p hp' (slot, key) hp hpeq)
+
+/-- Nested-address finite-set coherence. Pairs are `(slot, k1, k2)`. -/
+def mappingMap2Slot (slot : Nat) (k1 k2 : Address) : Nat :=
+  abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val
+
+def MappingCoherentMap2At (s : ContractState) (slot : Nat) (k1 k2 : Address) : Prop :=
+  s.storageMap2 slot k1 k2 = s.storage (mappingMap2Slot slot k1 k2)
+
+def MappingCoherentMap2On (s : ContractState)
+    (pairs : List (Nat × Address × Address)) : Prop :=
+  ∀ p ∈ pairs, MappingCoherentMap2At s p.1 p.2.1 p.2.2
+
+def DerivedMap2SlotsDistinct (pairs : List (Nat × Address × Address)) : Prop :=
+  ∀ p ∈ pairs, ∀ q ∈ pairs, p ≠ q →
+    mappingMap2Slot p.1 p.2.1 p.2.2 ≠ mappingMap2Slot q.1 q.2.1 q.2.2
+
+theorem mappingCoherentMap2On_of_mappingCoherentMap2
+    (s : ContractState) (pairs : List (Nat × Address × Address))
+    (h : MappingCoherentMap2 s) : MappingCoherentMap2On s pairs := by
+  intro p hp
+  exact h p.1 p.2.1 p.2.2
+
+theorem defaultState_mappingCoherentMap2On (pairs : List (Nat × Address × Address)) :
+    MappingCoherentMap2On defaultState pairs :=
+  mappingCoherentMap2On_of_mappingCoherentMap2 _ _ defaultState_mappingCoherentMap2
+
+theorem writeMap2_aligned_preserves_at_same
+    (s : ContractState) (slot : Nat) (k1 k2 : Address) (v : Uint256) :
+    MappingCoherentMap2At
+      ((s.writeMap2 slot k1 k2 v).writeSlot (mappingMap2Slot slot k1 k2) v)
+      slot k1 k2 :=
+  writeMap2_aligned_same s slot k1 k2 v
+
+theorem storageKey_map2_ne_of_pair_ne
+    {p q : Nat × Address × Address} (h : p ≠ q) :
+    StorageKey.map2 p.1 p.2.1 p.2.2 ≠ StorageKey.map2 q.1 q.2.1 q.2.2 := by
+  intro heq
+  apply h
+  injection heq with hs hk1 hk2
+  exact Prod.ext hs (Prod.ext hk1 hk2)
+
+theorem writeMap2_aligned_preserves_at_other
+    (s : ContractState) (slot : Nat) (k1 k2 : Address) (v : Uint256)
+    (slot' : Nat) (k1' k2' : Address)
+    (hcoh : MappingCoherentMap2At s slot' k1' k2')
+    (hkey : StorageKey.map2 slot' k1' k2' ≠ StorageKey.map2 slot k1 k2)
+    (hslot : mappingMap2Slot slot' k1' k2' ≠ mappingMap2Slot slot k1 k2) :
+    MappingCoherentMap2At
+      ((s.writeMap2 slot k1 k2 v).writeSlot (mappingMap2Slot slot k1 k2) v)
+      slot' k1' k2' :=
+  writeMap2_aligned_other s slot k1 k2 v slot' k1' k2' hcoh hkey hslot
+
+theorem writeMap2_aligned_preserves_on
+    (s : ContractState) (pairs : List (Nat × Address × Address))
+    (slot : Nat) (k1 k2 : Address) (v : Uint256)
+    (hcoh : MappingCoherentMap2On s pairs)
+    (hna : DerivedMap2SlotsDistinct pairs)
+    (hp : (slot, k1, k2) ∈ pairs) :
+    MappingCoherentMap2On
+      ((s.writeMap2 slot k1 k2 v).writeSlot (mappingMap2Slot slot k1 k2) v)
+      pairs := by
+  intro p hp'
+  by_cases hpeq : p = (slot, k1, k2)
+  · subst hpeq
+    exact writeMap2_aligned_preserves_at_same s slot k1 k2 v
+  · exact writeMap2_aligned_preserves_at_other s slot k1 k2 v p.1 p.2.1 p.2.2
+      (hcoh p hp') (storageKey_map2_ne_of_pair_ne hpeq)
+      (hna p hp' (slot, k1, k2) hp hpeq)
+
 end Compiler.Proofs.Storage.MappingCoherenceOn

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4693,6 +4693,18 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.MappingCoherenceOn.storageKey_map_ne_of_pair_ne
   Compiler.Proofs.Storage.MappingCoherenceOn.writeMap_aligned_preserves_at_other
   Compiler.Proofs.Storage.MappingCoherenceOn.writeMap_aligned_preserves_on
+  Compiler.Proofs.Storage.MappingCoherenceOn.mappingCoherentUintOn_of_mappingCoherentUint
+  Compiler.Proofs.Storage.MappingCoherenceOn.defaultState_mappingCoherentUintOn
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMapUint_aligned_preserves_at_same
+  Compiler.Proofs.Storage.MappingCoherenceOn.storageKey_mapUint_ne_of_pair_ne
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMapUint_aligned_preserves_at_other
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMapUint_aligned_preserves_on
+  Compiler.Proofs.Storage.MappingCoherenceOn.mappingCoherentMap2On_of_mappingCoherentMap2
+  Compiler.Proofs.Storage.MappingCoherenceOn.defaultState_mappingCoherentMap2On
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMap2_aligned_preserves_at_same
+  Compiler.Proofs.Storage.MappingCoherenceOn.storageKey_map2_ne_of_pair_ne
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMap2_aligned_preserves_at_other
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMap2_aligned_preserves_on
 
   -- Compiler/Proofs/Storage/SolidityStorage.lean
   Compiler.Proofs.Storage.mappingSlot_preimage
@@ -6889,4 +6901,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6390 theorems/lemmas (4520 public, 1870 private, 0 sorry'd)
+-- Total: 6402 theorems/lemmas (4532 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -198,9 +198,10 @@ defined there and proved for `defaultState` and for an aligned
 `writeMap*`+`writeSlot` pair; other pairs require an explicit
 non-alias hypothesis. A CompilationModel field list collapses to those
 keys via `FieldStorageKey` (root plus typed `map`/`mapUint`/`map2`
-entries). A finite list of address-keyed pairs stays coherent under
-an aligned write when the list carries an explicit pairwise
-derived-slot certificate (`MappingCoherentOn`); that is not a
+entries). A finite list of address-, uint-, or nested-address pairs
+stays coherent under an aligned write when the list carries an
+explicit pairwise derived-slot certificate (`MappingCoherentOn` /
+`MappingCoherentUintOn` / `MappingCoherentMap2On`); that is not a
 global (all-keys) claim. Keccak injectivity is **not** assumed.
 `storageArray` and `knownAddresses` are still separate fields.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,8 +45,9 @@ legacy-compatibility witness chain are already retired), then finish C5
 step 4 — remaining field-list cases (bytes32 keys, struct members,
 alias slots) and global (all-keys) `MappingCoherent` preservation.
 Implemented: address/uint/map2 coherence laws, `FieldStorageKey`,
-and finite-set address `MappingCoherentOn` under an explicit
-pairwise derived-slot certificate. C5 step 3 (canonical
+and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
+`MappingCoherentMap2On` under explicit pairwise derived-slot
+certificates. C5 step 3 (canonical
 `storageWords : StorageKey → Uint256` backing, lens laws by constructor
 injectivity) is on `main`; it is the enabler for FixedArray-under-mapping,
 dynamic CodeData, arbitrary transient storage and multicall/delegatecall


### PR DESCRIPTION
## Summary
- add `MappingCoherentUintOn` / `MappingCoherentMap2On` and pairwise `Derived*SlotsDistinct` certificates
- prove aligned `writeMapUint`/`writeMap2`+`writeSlot` preserve those finite lists
- not global (all-keys) preservation; keccak injectivity is still not assumed
- C5 step 4 remains incomplete

## Test Plan
- `lake build Compiler.Proofs.Storage.MappingCoherenceOn`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in `MappingCoherenceOn.lean` with no axioms, runtime, or compiler behavior changes; risk is limited to proof maintenance and doc sync.
> 
> **Overview**
> Extends **C5 step 4** finite-set mapping coherence beyond address-keyed pairs: `MappingCoherenceOn.lean` now defines **`MappingCoherentUintOn`** / **`MappingCoherentMap2On`** with pairwise **`DerivedUintSlotsDistinct`** / **`DerivedMap2SlotsDistinct`** certificates, and proves aligned **`writeMapUint`+`writeSlot`** and **`writeMap2`+`writeSlot`** preserve coherence on the listed pairs (same certificate shape as the existing address case; still not global all-keys preservation and still no keccak injectivity).
> 
> **`PrintAxioms.lean`** registers the new theorems (theorem count 6390 → 6402). **`AUDIT.md`**, **`AXIOMS.md`**, **`TRUST_ASSUMPTIONS.md`**, and **`docs/ROADMAP.md`** are updated to document uint and nested-address finite lists alongside address lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f44a211fbdffc3e27a1b2696f7fc8ac117e81b63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->