### PR TITLE
feat(proofs): mappingStruct member slot collapse

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -324,7 +324,9 @@ sibling entrypoint.
   `MappingCoherentOn` is preserved by an aligned write under an
   explicit pairwise derived-slot certificate
   (`MappingCoherenceOn`), including uint and nested-address lists.
-  Global (all-keys) preservation, bytes32 keys, struct members, and
+  Address-keyed `mappingStruct` / `mappingStruct2` members collapse
+  to `mappingSlotLocation` / `nestedMappingSlotLocation`. Global
+  (all-keys) preservation, bytes32 keys, packed bit-ranges, and
   alias slots are still open.
 - Zero new axioms.
 

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -30,7 +30,8 @@ C5 step 4's mapping-coherence, field-list, and finite-set slices
 likewise add no axiom: other-pair and finite-list preservation
 (address / uint / map2) is hypothesized by an explicit derived-slot
 inequality, not by keccak injectivity. `FieldStorageKey` is a
-constructor match on `FieldType` / `isTransient`.
+constructor match on `FieldType` / `isTransient`; struct-member
+slots add `wordOffset` via `mappingSlotLocation`.
 
 ## Eliminated Axioms
 

--- a/Compiler/Proofs/Storage/FieldStorageKey.lean
+++ b/Compiler/Proofs/Storage/FieldStorageKey.lean
@@ -3,8 +3,10 @@
   a source StorageKey, then to the compiler slot via `storageKeySlot`.
 
   Mapping-entry constructors cover the typed cases that already have a
-  StorageKey (`map` / `mapUint` / `map2`). bytes32 keys, struct members,
-  alias slots, and global MappingCoherent preservation stay open.
+  StorageKey (`map` / `mapUint` / `map2`). Address-keyed mappingStruct
+  / mappingStruct2 members collapse to `mappingSlotLocation` /
+  `nestedMappingSlotLocation`. bytes32 keys, packed bit-ranges, alias
+  slots, and global MappingCoherent preservation stay open.
 -/
 
 import Compiler.Proofs.Storage.MappingCoherence
@@ -125,5 +127,80 @@ theorem storageKeySlot_fieldMap2Key
     Option.bind (fieldMap2Key f slot k1 k2) storageKeySlot =
       some (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) := by
   simp [fieldMap2Key, htr, hty, storageKeySlot]
+
+/-- Persistent `mapping(address => Struct)` member word. There is no
+    StorageKey constructor for a struct member; the collapse is the
+    compiler slot `mappingSlotLocation`. -/
+def fieldStructMemberSlot (f : Field) (resolvedSlot : Nat) (key : Address)
+    (memberName : String) : Option Nat :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingStruct .address members =>
+      match findStructMember members memberName with
+      | some m =>
+        some (mappingSlotLocation resolvedSlot (addressToWord key).val m.wordOffset)
+      | none => none
+    | _ => none
+
+/-- Persistent `mapping(address => mapping(address => Struct))` member word. -/
+def fieldStructMember2Slot (f : Field) (resolvedSlot : Nat) (k1 k2 : Address)
+    (memberName : String) : Option Nat :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingStruct2 .address .address members =>
+      match findStructMember members memberName with
+      | some m =>
+        some (nestedMappingSlotLocation resolvedSlot
+          (addressToWord k1).val (addressToWord k2).val m.wordOffset)
+      | none => none
+    | _ => none
+
+theorem fieldStructMemberSlot_eq
+    {f : Field} {slot : Nat} {key : Address} {memberName : String}
+    {members : List StructMember} {m : StructMember}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingStruct .address members)
+    (hmem : findStructMember members memberName = some m) :
+    fieldStructMemberSlot f slot key memberName =
+      some (mappingSlotLocation slot (addressToWord key).val m.wordOffset) := by
+  simp [fieldStructMemberSlot, htr, hty, hmem]
+
+theorem fieldStructMember2Slot_eq
+    {f : Field} {slot : Nat} {k1 k2 : Address} {memberName : String}
+    {members : List StructMember} {m : StructMember}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingStruct2 .address .address members)
+    (hmem : findStructMember members memberName = some m) :
+    fieldStructMember2Slot f slot k1 k2 memberName =
+      some (nestedMappingSlotLocation slot
+        (addressToWord k1).val (addressToWord k2).val m.wordOffset) := by
+  simp [fieldStructMember2Slot, htr, hty, hmem]
+
+/-- A struct member word is the mapping-entry `storageKeySlot` plus
+    `wordOffset`, reduced mod 2^256. -/
+theorem fieldStructMemberSlot_eq_storageKeySlot_add
+    {f : Field} {slot : Nat} {key : Address} {memberName : String}
+    {members : List StructMember} {m : StructMember}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingStruct .address members)
+    (hmem : findStructMember members memberName = some m) :
+    fieldStructMemberSlot f slot key memberName =
+      (storageKeySlot (.map slot key)).map fun base =>
+        (base + m.wordOffset) % Compiler.Constants.evmModulus := by
+  simp [fieldStructMemberSlot_eq htr hty hmem, storageKeySlot, mappingSlotLocation]
+
+theorem fieldStructMember2Slot_eq_storageKeySlot_add
+    {f : Field} {slot : Nat} {k1 k2 : Address} {memberName : String}
+    {members : List StructMember} {m : StructMember}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingStruct2 .address .address members)
+    (hmem : findStructMember members memberName = some m) :
+    fieldStructMember2Slot f slot k1 k2 memberName =
+      (storageKeySlot (.map2 slot k1 k2)).map fun base =>
+        (base + m.wordOffset) % Compiler.Constants.evmModulus := by
+  simp [fieldStructMember2Slot_eq htr hty hmem, storageKeySlot,
+    nestedMappingSlotLocation, abstractNestedMappingSlot, abstractMappingSlot]
 
 end Compiler.Proofs.Storage.FieldStorageKey

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4666,6 +4666,10 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldMapKey
   Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldMapUintKey
   Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldMap2Key
+  Compiler.Proofs.Storage.FieldStorageKey.fieldStructMemberSlot_eq
+  Compiler.Proofs.Storage.FieldStorageKey.fieldStructMember2Slot_eq
+  Compiler.Proofs.Storage.FieldStorageKey.fieldStructMemberSlot_eq_storageKeySlot_add
+  Compiler.Proofs.Storage.FieldStorageKey.fieldStructMember2Slot_eq_storageKeySlot_add
 
   -- Compiler/Proofs/Storage/MappingCoherence.lean
   Compiler.Proofs.Storage.MappingCoherence.defaultState_mappingCoherent
@@ -6901,4 +6905,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6402 theorems/lemmas (4532 public, 1870 private, 0 sorry'd)
+-- Total: 6406 theorems/lemmas (4536 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -198,7 +198,9 @@ defined there and proved for `defaultState` and for an aligned
 `writeMap*`+`writeSlot` pair; other pairs require an explicit
 non-alias hypothesis. A CompilationModel field list collapses to those
 keys via `FieldStorageKey` (root plus typed `map`/`mapUint`/`map2`
-entries). A finite list of address-, uint-, or nested-address pairs
+entries). Address-keyed `mappingStruct` / `mappingStruct2` members
+collapse to `mappingSlotLocation` / `nestedMappingSlotLocation`
+(base mapping slot plus `wordOffset`). A finite list of address-, uint-, or nested-address pairs
 stays coherent under an aligned write when the list carries an
 explicit pairwise derived-slot certificate (`MappingCoherentOn` /
 `MappingCoherentUintOn` / `MappingCoherentMap2On`); that is not a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,9 +42,10 @@ Next: derive the executable shallow program from the deep model
 per-function `_bridge` theorems into one AST-induction theorem
 (`GenericInduction/LegacyCompatibility` and the compile-derived
 legacy-compatibility witness chain are already retired), then finish C5
-step 4 — remaining field-list cases (bytes32 keys, struct members,
+step 4 — remaining field-list cases (bytes32 keys, packed bit-ranges,
 alias slots) and global (all-keys) `MappingCoherent` preservation.
-Implemented: address/uint/map2 coherence laws, `FieldStorageKey`,
+Implemented: address/uint/map2 coherence laws, `FieldStorageKey`
+(including address-keyed mappingStruct member slots),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot
 certificates. C5 step 3 (canonical


### PR DESCRIPTION
## Summary
- add `fieldStructMemberSlot` / `fieldStructMember2Slot` for address-keyed `mappingStruct` / `mappingStruct2` members
- prove they equal `mappingSlotLocation` / `nestedMappingSlotLocation`
- prove they are `storageKeySlot` of the mapping entry plus `wordOffset` (mod 2^256)
- packed bit-ranges, alias slots, bytes32 keys, and global preservation remain open
- C5 step 4 remains incomplete

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldStorageKey`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only extension of existing storage-slot correspondence lemmas with synchronized documentation; no runtime, compiler emission, or trust-boundary changes.
> 
> **Overview**
> **C5 step 4 increment:** `FieldStorageKey` now covers **address-keyed struct members inside mappings**, not only root/`map`/`mapUint`/`map2` keys.
> 
> Adds `fieldStructMemberSlot` and `fieldStructMember2Slot` for `mappingStruct` / `mappingStruct2` fields, with lemmas that they equal `mappingSlotLocation` / `nestedMappingSlotLocation`, and that each member word is the corresponding mapping entry’s `storageKeySlot` plus `wordOffset` (mod 2²⁵⁶). There is still no `StorageKey` constructor for struct members—the collapse goes straight to compiler slot arithmetic.
> 
> **Docs/registry:** `AUDIT.md`, `AXIOMS.md`, `TRUST_ASSUMPTIONS.md`, and `docs/ROADMAP.md` are updated to record this slice; `PrintAxioms.lean` gains four public theorems (6402 → 6406). **bytes32 keys, packed bit-ranges, alias slots, and global `MappingCoherent` preservation remain open**; no new axioms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5efd61fb23c33524b9bc398e653fb43f9847a12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->