### PR TITLE
feat(proofs): aliasSlots as extra compiler write targets

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -325,9 +325,10 @@ sibling entrypoint.
   explicit pairwise derived-slot certificate
   (`MappingCoherenceOn`), including uint and nested-address lists.
   Address-keyed `mappingStruct` / `mappingStruct2` members collapse
-  to `mappingSlotLocation` / `nestedMappingSlotLocation`. Global
-  (all-keys) preservation, bytes32 keys, packed bit-ranges, and
-  alias slots are still open.
+  to `mappingSlotLocation` / `nestedMappingSlotLocation`. Compatibility
+  `aliasSlots` are extra compiler write targets; the resolved head is
+  the field's `storageKeySlot`. Global (all-keys) preservation, bytes32
+  keys, and packed bit-ranges are still open.
 - Zero new axioms.
 
 ## CI Guards

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -31,7 +31,8 @@ likewise add no axiom: other-pair and finite-list preservation
 (address / uint / map2) is hypothesized by an explicit derived-slot
 inequality, not by keccak injectivity. `FieldStorageKey` is a
 constructor match on `FieldType` / `isTransient`; struct-member
-slots add `wordOffset` via `mappingSlotLocation`.
+slots add `wordOffset` via `mappingSlotLocation`. Compatibility
+`aliasSlots` are extra compiler slots, not extra source keys.
 
 ## Eliminated Axioms
 

--- a/Compiler/Proofs/Storage/FieldStorageKey.lean
+++ b/Compiler/Proofs/Storage/FieldStorageKey.lean
@@ -5,8 +5,10 @@
   Mapping-entry constructors cover the typed cases that already have a
   StorageKey (`map` / `mapUint` / `map2`). Address-keyed mappingStruct
   / mappingStruct2 members collapse to `mappingSlotLocation` /
-  `nestedMappingSlotLocation`. bytes32 keys, packed bit-ranges, alias
-  slots, and global MappingCoherent preservation stay open.
+  `nestedMappingSlotLocation`. Compatibility `aliasSlots` are extra
+  compiler write targets; only the resolved head has a StorageKey.
+  bytes32 keys, packed bit-ranges, and global MappingCoherent
+  preservation stay open.
 -/
 
 import Compiler.Proofs.Storage.MappingCoherence
@@ -202,5 +204,43 @@ theorem fieldStructMember2Slot_eq_storageKeySlot_add
         (base + m.wordOffset) % Compiler.Constants.evmModulus := by
   simp [fieldStructMember2Slot_eq htr hty hmem, storageKeySlot,
     nestedMappingSlotLocation, abstractNestedMappingSlot, abstractMappingSlot]
+
+/-- `findFieldWriteSlots` is the resolved slot cons the compatibility
+    aliases. Aliases have no `StorageKey`. -/
+theorem findFieldWriteSlotsCopyFrom_of_resolved
+    (fields : List Field) (idx : Nat) (name : String) {f : Field} {slot : Nat}
+    (h : findFieldWithResolvedSlotCopyFrom fields idx name = some (f, slot)) :
+    findFieldWriteSlotsCopyFrom fields idx name = some (slot :: f.aliasSlots) := by
+  induction fields generalizing idx with
+  | nil =>
+    simp [findFieldWithResolvedSlotCopyFrom] at h
+  | cons hd tl ih =>
+    simp only [findFieldWithResolvedSlotCopyFrom, findFieldWriteSlotsCopyFrom] at h ⊢
+    split
+    · next hname =>
+      simp [hname] at h
+      rcases h with ⟨rfl, rfl⟩
+      rfl
+    · next hname =>
+      simp [hname] at h
+      exact ih (idx + 1) h
+
+theorem findFieldWriteSlots_of_resolved
+    {fields : List Field} {name : String} {f : Field} {slot : Nat}
+    (h : findFieldWithResolvedSlot fields name = some (f, slot)) :
+    findFieldWriteSlots fields name = some (slot :: f.aliasSlots) := by
+  rw [findFieldWriteSlots_eq_CopyFrom, findFieldWithResolvedSlot_eq_CopyFrom] at *
+  exact findFieldWriteSlotsCopyFrom_of_resolved fields 0 name h
+
+/-- The persistent field's `storageKeySlot` is the head of the write-slot
+    list. Aliases are extra compiler slots, not extra source keys. -/
+theorem storageKeySlot_head_of_fieldWriteSlots
+    {fields : List Field} {name : String} {f : Field} {slot : Nat}
+    (h : findFieldWithResolvedSlot fields name = some (f, slot))
+    (htr : f.isTransient = false) :
+    (findFieldWriteSlots fields name).bind List.head? =
+      storageKeySlot (fieldRootKey f slot) := by
+  rw [findFieldWriteSlots_of_resolved h, storageKeySlot_fieldRootKey, htr]
+  rfl
 
 end Compiler.Proofs.Storage.FieldStorageKey

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4670,6 +4670,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.FieldStorageKey.fieldStructMember2Slot_eq
   Compiler.Proofs.Storage.FieldStorageKey.fieldStructMemberSlot_eq_storageKeySlot_add
   Compiler.Proofs.Storage.FieldStorageKey.fieldStructMember2Slot_eq_storageKeySlot_add
+  Compiler.Proofs.Storage.FieldStorageKey.findFieldWriteSlotsCopyFrom_of_resolved
+  Compiler.Proofs.Storage.FieldStorageKey.findFieldWriteSlots_of_resolved
+  Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_head_of_fieldWriteSlots
 
   -- Compiler/Proofs/Storage/MappingCoherence.lean
   Compiler.Proofs.Storage.MappingCoherence.defaultState_mappingCoherent
@@ -6905,4 +6908,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6406 theorems/lemmas (4536 public, 1870 private, 0 sorry'd)
+-- Total: 6409 theorems/lemmas (4539 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -200,7 +200,9 @@ non-alias hypothesis. A CompilationModel field list collapses to those
 keys via `FieldStorageKey` (root plus typed `map`/`mapUint`/`map2`
 entries). Address-keyed `mappingStruct` / `mappingStruct2` members
 collapse to `mappingSlotLocation` / `nestedMappingSlotLocation`
-(base mapping slot plus `wordOffset`). A finite list of address-, uint-, or nested-address pairs
+(base mapping slot plus `wordOffset`). Compatibility `aliasSlots`
+are extra compiler write targets; only the resolved head has a
+`StorageKey`. A finite list of address-, uint-, or nested-address pairs
 stays coherent under an aligned write when the list carries an
 explicit pairwise derived-slot certificate (`MappingCoherentOn` /
 `MappingCoherentUintOn` / `MappingCoherentMap2On`); that is not a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,10 +42,11 @@ Next: derive the executable shallow program from the deep model
 per-function `_bridge` theorems into one AST-induction theorem
 (`GenericInduction/LegacyCompatibility` and the compile-derived
 legacy-compatibility witness chain are already retired), then finish C5
-step 4 — remaining field-list cases (bytes32 keys, packed bit-ranges,
-alias slots) and global (all-keys) `MappingCoherent` preservation.
+step 4 — remaining field-list cases (bytes32 keys, packed bit-ranges)
+and global (all-keys) `MappingCoherent` preservation.
 Implemented: address/uint/map2 coherence laws, `FieldStorageKey`
-(including address-keyed mappingStruct member slots),
+(including address-keyed mappingStruct member slots and
+compatibility `aliasSlots` as extra compiler write targets),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot
 certificates. C5 step 3 (canonical


### PR DESCRIPTION
## Summary
- prove `findFieldWriteSlots` is the resolved slot cons `aliasSlots`
- prove a persistent field's `storageKeySlot` is the head of that write-slot list
- aliases are extra compiler slots, not extra source keys
- C5 step 4 remains incomplete (bytes32 keys, packed bit-ranges, global preservation)

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldStorageKey`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions and documentation alignment for existing `aliasSlots` semantics; no compiler behavior or axiom changes.
> 
> **Overview**
> Adds **C5 step 4** lemmas in `FieldStorageKey.lean` tying compiler write-slot lists to source `StorageKey`s: **`findFieldWriteSlots`** is **`resolvedSlot :: f.aliasSlots`**, and for persistent fields the list head’s **`storageKeySlot`** matches **`fieldRootKey`**.
> 
> **Trust/audit docs** (`AUDIT.md`, `AXIOMS.md`, `TRUST_ASSUMPTIONS.md`, `docs/ROADMAP.md`) now state that compatibility **`aliasSlots`** are extra compiler write targets only—the canonical head carries the **`StorageKey`**, not each alias. C5 step 4 is still open on bytes32 keys, packed bit-ranges, and global **`MappingCoherent`** preservation; **`aliasSlots`** are no longer listed as an open item.
> 
> **`PrintAxioms.lean`** registers the three new theorems (6406 → 6409 lemmas, no new axioms).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 524fd42cc83e3bebc4a60ba6b9bf7fd38c6e2089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->