### PR TITLE
feat(proofs): cross-channel finite-set coherence

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -327,8 +327,10 @@ sibling entrypoint.
   Address-keyed `mappingStruct` / `mappingStruct2` members collapse
   to `mappingSlotLocation` / `nestedMappingSlotLocation`. Compatibility
   `aliasSlots` are extra compiler write targets; the resolved head is
-  the field's `storageKeySlot`. Global (all-keys) preservation, bytes32
-  keys, and packed bit-ranges are still open.
+  the field's `storageKeySlot`. Cross-channel finite-set preservation
+  (aligned write on one mapping channel vs another channel's list)
+  takes an explicit derived-slot inequality. Global (all-keys)
+  preservation, bytes32 keys, and packed bit-ranges are still open.
 - Zero new axioms.
 
 ## CI Guards

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -28,8 +28,9 @@ injectivity; Solidity slot derivation remains compiler-side.
 
 C5 step 4's mapping-coherence, field-list, and finite-set slices
 likewise add no axiom: other-pair and finite-list preservation
-(address / uint / map2) is hypothesized by an explicit derived-slot
-inequality, not by keccak injectivity. `FieldStorageKey` is a
+(address / uint / map2, including cross-channel lists) is
+hypothesized by an explicit derived-slot inequality, not by keccak
+injectivity. `FieldStorageKey` is a
 constructor match on `FieldType` / `isTransient`; struct-member
 slots add `wordOffset` via `mappingSlotLocation`. Compatibility
 `aliasSlots` are extra compiler slots, not extra source keys.

--- a/Compiler/Proofs/Storage/MappingCoherenceOn.lean
+++ b/Compiler/Proofs/Storage/MappingCoherenceOn.lean
@@ -4,8 +4,12 @@
   `writeMap`+`writeSlot` when every other listed pair carries an explicit
   derived-slot inequality.
 
-  This is not global preservation. A certificate for every address-keyed
-  pair would be keccak injectivity on an unbounded preimage set.
+  Cross-channel aligned writes preserve another channel's finite list
+  under an explicit derived-slot inequality between the written slot
+  and every listed pair.
+
+  This is not global preservation. A certificate for every pair would
+  be keccak injectivity on an unbounded preimage set.
 -/
 
 import Compiler.Proofs.Storage.MappingCoherence
@@ -220,5 +224,133 @@ theorem writeMap2_aligned_preserves_on
   · exact writeMap2_aligned_preserves_at_other s slot k1 k2 v p.1 p.2.1 p.2.2
       (hcoh p hp') (storageKey_map2_ne_of_pair_ne hpeq)
       (hna p hp' (slot, k1, k2) hp hpeq)
+
+/-- Cross-channel: an aligned address-map write preserves a uint-keyed
+    finite list when every listed derived slot is distinct from the
+    written one. Not keccak injectivity. -/
+theorem writeMap_aligned_preserves_uintOn
+    (s : ContractState) (pairs : List (Nat × Uint256))
+    (slot : Nat) (key : Address) (v : Uint256)
+    (hcoh : MappingCoherentUintOn s pairs)
+    (hna : ∀ p ∈ pairs, mappingUintSlot p.1 p.2 ≠ mappingAddrSlot slot key) :
+    MappingCoherentUintOn
+      ((s.writeMap slot key v).writeSlot (mappingAddrSlot slot key) v)
+      pairs := by
+  intro p hp
+  have hmap :
+      ((s.writeMap slot key v).writeSlot (mappingAddrSlot slot key) v).storageMapUint p.1 p.2 =
+        s.storageMapUint p.1 p.2 := by
+    simp [storageMapUint, writeMap, writeSlot]
+  have hflat :
+      ((s.writeMap slot key v).writeSlot (mappingAddrSlot slot key) v).storage
+        (mappingUintSlot p.1 p.2) =
+        s.storage (mappingUintSlot p.1 p.2) := by
+    rw [storage_writeSlot_other (s := s.writeMap slot key v) (hna p hp) v, storage_writeMap]
+  exact (hmap.trans (hcoh p hp)).trans hflat.symm
+
+theorem writeMap_aligned_preserves_map2On
+    (s : ContractState) (pairs : List (Nat × Address × Address))
+    (slot : Nat) (key : Address) (v : Uint256)
+    (hcoh : MappingCoherentMap2On s pairs)
+    (hna : ∀ p ∈ pairs, mappingMap2Slot p.1 p.2.1 p.2.2 ≠ mappingAddrSlot slot key) :
+    MappingCoherentMap2On
+      ((s.writeMap slot key v).writeSlot (mappingAddrSlot slot key) v)
+      pairs := by
+  intro p hp
+  have hmap :
+      ((s.writeMap slot key v).writeSlot (mappingAddrSlot slot key) v).storageMap2
+          p.1 p.2.1 p.2.2 =
+        s.storageMap2 p.1 p.2.1 p.2.2 := by
+    simp [storageMap2, writeMap, writeSlot]
+  have hflat :
+      ((s.writeMap slot key v).writeSlot (mappingAddrSlot slot key) v).storage
+        (mappingMap2Slot p.1 p.2.1 p.2.2) =
+        s.storage (mappingMap2Slot p.1 p.2.1 p.2.2) := by
+    rw [storage_writeSlot_other (s := s.writeMap slot key v) (hna p hp) v, storage_writeMap]
+  exact (hmap.trans (hcoh p hp)).trans hflat.symm
+
+theorem writeMapUint_aligned_preserves_addrOn
+    (s : ContractState) (pairs : List (Nat × Address))
+    (slot : Nat) (key v : Uint256)
+    (hcoh : MappingCoherentOn s pairs)
+    (hna : ∀ p ∈ pairs, mappingAddrSlot p.1 p.2 ≠ mappingUintSlot slot key) :
+    MappingCoherentOn
+      ((s.writeMapUint slot key v).writeSlot (mappingUintSlot slot key) v)
+      pairs := by
+  intro p hp
+  have hmap :
+      ((s.writeMapUint slot key v).writeSlot (mappingUintSlot slot key) v).storageMap p.1 p.2 =
+        s.storageMap p.1 p.2 := by
+    simp [storageMap, writeMapUint, writeSlot]
+  have hflat :
+      ((s.writeMapUint slot key v).writeSlot (mappingUintSlot slot key) v).storage
+        (mappingAddrSlot p.1 p.2) =
+        s.storage (mappingAddrSlot p.1 p.2) := by
+    rw [storage_writeSlot_other (s := s.writeMapUint slot key v) (hna p hp) v,
+      storage_writeMapUint]
+  exact (hmap.trans (hcoh p hp)).trans hflat.symm
+
+theorem writeMapUint_aligned_preserves_map2On
+    (s : ContractState) (pairs : List (Nat × Address × Address))
+    (slot : Nat) (key v : Uint256)
+    (hcoh : MappingCoherentMap2On s pairs)
+    (hna : ∀ p ∈ pairs, mappingMap2Slot p.1 p.2.1 p.2.2 ≠ mappingUintSlot slot key) :
+    MappingCoherentMap2On
+      ((s.writeMapUint slot key v).writeSlot (mappingUintSlot slot key) v)
+      pairs := by
+  intro p hp
+  have hmap :
+      ((s.writeMapUint slot key v).writeSlot (mappingUintSlot slot key) v).storageMap2
+          p.1 p.2.1 p.2.2 =
+        s.storageMap2 p.1 p.2.1 p.2.2 := by
+    simp [storageMap2, writeMapUint, writeSlot]
+  have hflat :
+      ((s.writeMapUint slot key v).writeSlot (mappingUintSlot slot key) v).storage
+        (mappingMap2Slot p.1 p.2.1 p.2.2) =
+        s.storage (mappingMap2Slot p.1 p.2.1 p.2.2) := by
+    rw [storage_writeSlot_other (s := s.writeMapUint slot key v) (hna p hp) v,
+      storage_writeMapUint]
+  exact (hmap.trans (hcoh p hp)).trans hflat.symm
+
+theorem writeMap2_aligned_preserves_addrOn
+    (s : ContractState) (pairs : List (Nat × Address))
+    (slot : Nat) (k1 k2 : Address) (v : Uint256)
+    (hcoh : MappingCoherentOn s pairs)
+    (hna : ∀ p ∈ pairs, mappingAddrSlot p.1 p.2 ≠ mappingMap2Slot slot k1 k2) :
+    MappingCoherentOn
+      ((s.writeMap2 slot k1 k2 v).writeSlot (mappingMap2Slot slot k1 k2) v)
+      pairs := by
+  intro p hp
+  have hmap :
+      ((s.writeMap2 slot k1 k2 v).writeSlot (mappingMap2Slot slot k1 k2) v).storageMap p.1 p.2 =
+        s.storageMap p.1 p.2 := by
+    simp [storageMap, writeMap2, writeSlot]
+  have hflat :
+      ((s.writeMap2 slot k1 k2 v).writeSlot (mappingMap2Slot slot k1 k2) v).storage
+        (mappingAddrSlot p.1 p.2) =
+        s.storage (mappingAddrSlot p.1 p.2) := by
+    rw [storage_writeSlot_other (s := s.writeMap2 slot k1 k2 v) (hna p hp) v, storage_writeMap2]
+  exact (hmap.trans (hcoh p hp)).trans hflat.symm
+
+theorem writeMap2_aligned_preserves_uintOn
+    (s : ContractState) (pairs : List (Nat × Uint256))
+    (slot : Nat) (k1 k2 : Address) (v : Uint256)
+    (hcoh : MappingCoherentUintOn s pairs)
+    (hna : ∀ p ∈ pairs, mappingUintSlot p.1 p.2 ≠ mappingMap2Slot slot k1 k2) :
+    MappingCoherentUintOn
+      ((s.writeMap2 slot k1 k2 v).writeSlot (mappingMap2Slot slot k1 k2) v)
+      pairs := by
+  intro p hp
+  have hmap :
+      ((s.writeMap2 slot k1 k2 v).writeSlot (mappingMap2Slot slot k1 k2) v).storageMapUint
+          p.1 p.2 =
+        s.storageMapUint p.1 p.2 := by
+    simp [storageMapUint, writeMap2, writeSlot]
+  have hflat :
+      ((s.writeMap2 slot k1 k2 v).writeSlot (mappingMap2Slot slot k1 k2) v).storage
+        (mappingUintSlot p.1 p.2) =
+        s.storage (mappingUintSlot p.1 p.2) := by
+    rw [storage_writeSlot_other (s := s.writeMap2 slot k1 k2 v) (hna p hp) v, storage_writeMap2]
+  exact (hmap.trans (hcoh p hp)).trans hflat.symm
 
 end Compiler.Proofs.Storage.MappingCoherenceOn

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4712,6 +4712,12 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.MappingCoherenceOn.storageKey_map2_ne_of_pair_ne
   Compiler.Proofs.Storage.MappingCoherenceOn.writeMap2_aligned_preserves_at_other
   Compiler.Proofs.Storage.MappingCoherenceOn.writeMap2_aligned_preserves_on
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMap_aligned_preserves_uintOn
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMap_aligned_preserves_map2On
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMapUint_aligned_preserves_addrOn
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMapUint_aligned_preserves_map2On
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMap2_aligned_preserves_addrOn
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeMap2_aligned_preserves_uintOn
 
   -- Compiler/Proofs/Storage/SolidityStorage.lean
   Compiler.Proofs.Storage.mappingSlot_preimage
@@ -6908,4 +6914,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6409 theorems/lemmas (4539 public, 1870 private, 0 sorry'd)
+-- Total: 6415 theorems/lemmas (4545 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -206,7 +206,9 @@ are extra compiler write targets; only the resolved head has a
 stays coherent under an aligned write when the list carries an
 explicit pairwise derived-slot certificate (`MappingCoherentOn` /
 `MappingCoherentUintOn` / `MappingCoherentMap2On`); that is not a
-global (all-keys) claim. Keccak injectivity is **not** assumed.
+global (all-keys) claim. Cross-channel preservation of another
+list likewise takes an explicit derived-slot inequality. Keccak
+injectivity is **not** assumed.
 `storageArray` and `knownAddresses` are still separate fields.
 
 ### External-Call Journal (`ContractState.calls`)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,7 +49,7 @@ Implemented: address/uint/map2 coherence laws, `FieldStorageKey`
 compatibility `aliasSlots` as extra compiler write targets),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot
-certificates. C5 step 3 (canonical
+certificates, including cross-channel aligned-write preservation. C5 step 3 (canonical
 `storageWords : StorageKey → Uint256` backing, lens laws by constructor
 injectivity) is on `main`; it is the enabler for FixedArray-under-mapping,
 dynamic CodeData, arbitrary transient storage and multicall/delegatecall


### PR DESCRIPTION
## Summary
- add six cross-channel laws: an aligned write on one mapping channel preserves another channel's finite `*On` list
- each law takes an explicit derived-slot inequality (`hna`); keccak injectivity is not assumed
- C5 step 4 remains incomplete (global all-keys preservation, bytes32 keys, packed bit-ranges)

## Test Plan
- `lake build Compiler.Proofs.Storage.MappingCoherenceOn`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only storage coherence lemmas and documentation; no runtime, compiler output, or trust-surface axiom changes.
> 
> **Overview**
> Extends **C5 step 4** finite-set `MappingCoherent*On` preservation so an aligned write on one mapping channel (`writeMap` / `writeMapUint` / `writeMap2` + matching `writeSlot`) still preserves finite coherence lists on the *other* channels.
> 
> Adds **six** Lean theorems in `MappingCoherenceOn.lean` (e.g. `writeMap_aligned_preserves_uintOn`, `writeMapUint_aligned_preserves_map2On`), each requiring an explicit **derived-slot inequality** (`hna`) between the written slot and every listed pair—not keccak injectivity. Same-channel `*On` laws are unchanged.
> 
> **AUDIT**, **AXIOMS**, **TRUST_ASSUMPTIONS**, and **docs/ROADMAP** now describe cross-channel preservation; **PrintAxioms** registers the new public lemmas (+6 theorems). **Zero new axioms**; global all-keys preservation and remaining field-list cases stay open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b13a655b65a4b0a30d99569e8212cdf946746df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->