### PR TITLE
feat(proofs): bytes32 mapping compiler-slot collapse

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -330,7 +330,9 @@ sibling entrypoint.
   the field's `storageKeySlot`. Cross-channel finite-set preservation
   (aligned write on one mapping channel vs another channel's list)
   takes an explicit derived-slot inequality. Global (all-keys)
-  preservation, bytes32 keys, and packed bit-ranges are still open.
+  preservation, mixed-key nestings, and packed bit-ranges are still
+  open. bytes32-keyed maps collapse to `solidityMappingSlot` of the
+  32-byte word (no `StorageKey.mapBytes32`).
 - Zero new axioms.
 
 ## CI Guards

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -34,6 +34,8 @@ injectivity. `FieldStorageKey` is a
 constructor match on `FieldType` / `isTransient`; struct-member
 slots add `wordOffset` via `mappingSlotLocation`. Compatibility
 `aliasSlots` are extra compiler slots, not extra source keys.
+bytes32-keyed maps use the same keccak preimage as uint256 keys
+and do not add a `StorageKey` constructor.
 
 ## Eliminated Axioms
 

--- a/Compiler/Proofs/Storage/FieldStorageKey.lean
+++ b/Compiler/Proofs/Storage/FieldStorageKey.lean
@@ -7,8 +7,9 @@
   / mappingStruct2 members collapse to `mappingSlotLocation` /
   `nestedMappingSlotLocation`. Compatibility `aliasSlots` are extra
   compiler write targets; only the resolved head has a StorageKey.
-  bytes32 keys, packed bit-ranges, and global MappingCoherent
-  preservation stay open.
+  bytes32-keyed maps collapse to `solidityMappingSlot` of the 32-byte
+  word (no `StorageKey.mapBytes32`). Packed bit-ranges and global
+  MappingCoherent preservation stay open.
 -/
 
 import Compiler.Proofs.Storage.MappingCoherence
@@ -129,6 +130,57 @@ theorem storageKeySlot_fieldMap2Key
     Option.bind (fieldMap2Key f slot k1 k2) storageKeySlot =
       some (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) := by
   simp [fieldMap2Key, htr, hty, storageKeySlot]
+
+/-- Persistent `mapping(bytes32 => uint256)` entry. There is no
+    `StorageKey.mapBytes32`; Solidity ABI-encodes the 32-byte word
+    the same way as a uint256 key. The collapse is the compiler slot. -/
+def fieldMapBytes32Slot (f : Field) (resolvedSlot : Nat) (key : Uint256) : Option Nat :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingTyped (.simple .bytes32) => some (solidityMappingSlot resolvedSlot key.val)
+    | _ => none
+
+theorem fieldMapBytes32Slot_eq
+    {f : Field} {slot : Nat} {key : Uint256}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.simple .bytes32)) :
+    fieldMapBytes32Slot f slot key = some (solidityMappingSlot slot key.val) := by
+  simp [fieldMapBytes32Slot, htr, hty]
+
+/-- Persistent `mapping(bytes32 => Struct)` member word. -/
+def fieldStructMemberBytes32Slot (f : Field) (resolvedSlot : Nat) (key : Uint256)
+    (memberName : String) : Option Nat :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingStruct .bytes32 members =>
+      match findStructMember members memberName with
+      | some m =>
+        some (mappingSlotLocation resolvedSlot key.val m.wordOffset)
+      | none => none
+    | _ => none
+
+theorem fieldStructMemberBytes32Slot_eq
+    {f : Field} {slot : Nat} {key : Uint256} {memberName : String}
+    {members : List StructMember} {m : StructMember}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingStruct .bytes32 members)
+    (hmem : findStructMember members memberName = some m) :
+    fieldStructMemberBytes32Slot f slot key memberName =
+      some (mappingSlotLocation slot key.val m.wordOffset) := by
+  simp [fieldStructMemberBytes32Slot, htr, hty, hmem]
+
+theorem fieldStructMemberBytes32Slot_eq_base_add
+    {f : Field} {slot : Nat} {key : Uint256} {memberName : String}
+    {members : List StructMember} {m : StructMember}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingStruct .bytes32 members)
+    (hmem : findStructMember members memberName = some m) :
+    fieldStructMemberBytes32Slot f slot key memberName =
+      some ((solidityMappingSlot slot key.val + m.wordOffset) %
+        Compiler.Constants.evmModulus) := by
+  simp [fieldStructMemberBytes32Slot_eq htr hty hmem, mappingSlotLocation]
 
 /-- Persistent `mapping(address => Struct)` member word. There is no
     StorageKey constructor for a struct member; the collapse is the

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4666,6 +4666,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldMapKey
   Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldMapUintKey
   Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldMap2Key
+  Compiler.Proofs.Storage.FieldStorageKey.fieldMapBytes32Slot_eq
+  Compiler.Proofs.Storage.FieldStorageKey.fieldStructMemberBytes32Slot_eq
+  Compiler.Proofs.Storage.FieldStorageKey.fieldStructMemberBytes32Slot_eq_base_add
   Compiler.Proofs.Storage.FieldStorageKey.fieldStructMemberSlot_eq
   Compiler.Proofs.Storage.FieldStorageKey.fieldStructMember2Slot_eq
   Compiler.Proofs.Storage.FieldStorageKey.fieldStructMemberSlot_eq_storageKeySlot_add
@@ -6914,4 +6917,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6415 theorems/lemmas (4545 public, 1870 private, 0 sorry'd)
+-- Total: 6418 theorems/lemmas (4548 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -202,7 +202,8 @@ entries). Address-keyed `mappingStruct` / `mappingStruct2` members
 collapse to `mappingSlotLocation` / `nestedMappingSlotLocation`
 (base mapping slot plus `wordOffset`). Compatibility `aliasSlots`
 are extra compiler write targets; only the resolved head has a
-`StorageKey`. A finite list of address-, uint-, or nested-address pairs
+`StorageKey`. bytes32-keyed maps collapse to `solidityMappingSlot`
+of the 32-byte word; there is no `StorageKey.mapBytes32`. A finite list of address-, uint-, or nested-address pairs
 stays coherent under an aligned write when the list carries an
 explicit pairwise derived-slot certificate (`MappingCoherentOn` /
 `MappingCoherentUintOn` / `MappingCoherentMap2On`); that is not a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,11 +42,12 @@ Next: derive the executable shallow program from the deep model
 per-function `_bridge` theorems into one AST-induction theorem
 (`GenericInduction/LegacyCompatibility` and the compile-derived
 legacy-compatibility witness chain are already retired), then finish C5
-step 4 — remaining field-list cases (bytes32 keys, packed bit-ranges)
-and global (all-keys) `MappingCoherent` preservation.
+step 4 — remaining field-list cases (packed bit-ranges, mixed-key
+nestings) and global (all-keys) `MappingCoherent` preservation.
 Implemented: address/uint/map2 coherence laws, `FieldStorageKey`
-(including address-keyed mappingStruct member slots and
-compatibility `aliasSlots` as extra compiler write targets),
+(including address-keyed mappingStruct member slots,
+bytes32-keyed compiler slots, and compatibility `aliasSlots`
+as extra compiler write targets),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot
 certificates, including cross-channel aligned-write preservation. C5 step 3 (canonical


### PR DESCRIPTION
## Summary
- add `fieldMapBytes32Slot` for `mapping(bytes32 => uint256)`
- add `fieldStructMemberBytes32Slot` for `mapping(bytes32 => Struct)` members
- both collapse to `solidityMappingSlot` / `mappingSlotLocation` of the 32-byte word
- no `StorageKey.mapBytes32` constructor
- C5 step 4 remains incomplete (packed bit-ranges, mixed-key nestings, global preservation)

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldStorageKey`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in `FieldStorageKey.lean` with zero new axioms; scope is slot-collapse lemmas and documentation counters, not runtime or compiler behavior changes.
> 
> **Overview**
> Extends **C5 step 4** `FieldStorageKey` so `mapping(bytes32 => uint256)` and `mapping(bytes32 => Struct)` members resolve to the same compiler slots as Solidity: **`solidityMappingSlot`** for simple maps and **`mappingSlotLocation`** for struct members, using the 32-byte word as the key (ABI-encoded like `uint256`).
> 
> There is **no** `StorageKey.mapBytes32` constructor—bytes32 entries collapse directly to `Nat` slots with new defs **`fieldMapBytes32Slot`** / **`fieldStructMemberBytes32Slot`** and simp lemmas registered in **`PrintAxioms`**. Audit and trust docs now record this design and reframe remaining C5 step 4 work as packed bit-ranges, mixed-key nestings, and global `MappingCoherent` preservation (bytes32 is no longer listed as open).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0663a136e153ec0a199f8eb2c58acf572dca3be4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->