### PR TITLE
feat(proofs): mixed address/uint256 nested mapping slots

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -330,9 +330,10 @@ sibling entrypoint.
   the field's `storageKeySlot`. Cross-channel finite-set preservation
   (aligned write on one mapping channel vs another channel's list)
   takes an explicit derived-slot inequality. Global (all-keys)
-  preservation, mixed-key nestings, and packed bit-ranges are still
-  open. bytes32-keyed maps collapse to `solidityMappingSlot` of the
-  32-byte word (no `StorageKey.mapBytes32`).
+  preservation and packed bit-ranges are still open. bytes32-keyed
+  maps collapse to `solidityMappingSlot` of the 32-byte word (no
+  `StorageKey.mapBytes32`). Mixed `address`/`uint256` nestings
+  collapse to `abstractNestedMappingSlot`.
 - Zero new axioms.
 
 ## CI Guards

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -35,7 +35,8 @@ constructor match on `FieldType` / `isTransient`; struct-member
 slots add `wordOffset` via `mappingSlotLocation`. Compatibility
 `aliasSlots` are extra compiler slots, not extra source keys.
 bytes32-keyed maps use the same keccak preimage as uint256 keys
-and do not add a `StorageKey` constructor.
+and do not add a `StorageKey` constructor. Mixed `address`/`uint256`
+nestings likewise add no constructor.
 
 ## Eliminated Axioms
 

--- a/Compiler/Proofs/Storage/FieldStorageKey.lean
+++ b/Compiler/Proofs/Storage/FieldStorageKey.lean
@@ -8,8 +8,9 @@
   `nestedMappingSlotLocation`. Compatibility `aliasSlots` are extra
   compiler write targets; only the resolved head has a StorageKey.
   bytes32-keyed maps collapse to `solidityMappingSlot` of the 32-byte
-  word (no `StorageKey.mapBytes32`). Packed bit-ranges and global
-  MappingCoherent preservation stay open.
+  word (no `StorageKey.mapBytes32`). Mixed-key nestings
+  (`address`/`uint256`) collapse to `abstractNestedMappingSlot`.
+  Packed bit-ranges and global MappingCoherent preservation stay open.
 -/
 
 import Compiler.Proofs.Storage.MappingCoherence
@@ -130,6 +131,43 @@ theorem storageKeySlot_fieldMap2Key
     Option.bind (fieldMap2Key f slot k1 k2) storageKeySlot =
       some (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) := by
   simp [fieldMap2Key, htr, hty, storageKeySlot]
+
+/-- Persistent `mapping(address => mapping(uint256 => uint256))` entry.
+    There is no mixed `StorageKey`; the collapse is the nested compiler slot. -/
+def fieldMapAddrUintSlot (f : Field) (resolvedSlot : Nat) (k1 : Address) (k2 : Uint256) :
+    Option Nat :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingTyped (.nested .address .uint256) =>
+      some (abstractNestedMappingSlot resolvedSlot (addressToWord k1).val k2.val)
+    | _ => none
+
+/-- Persistent `mapping(uint256 => mapping(address => uint256))` entry. -/
+def fieldMapUintAddrSlot (f : Field) (resolvedSlot : Nat) (k1 : Uint256) (k2 : Address) :
+    Option Nat :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingTyped (.nested .uint256 .address) =>
+      some (abstractNestedMappingSlot resolvedSlot k1.val (addressToWord k2).val)
+    | _ => none
+
+theorem fieldMapAddrUintSlot_eq
+    {f : Field} {slot : Nat} {k1 : Address} {k2 : Uint256}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.nested .address .uint256)) :
+    fieldMapAddrUintSlot f slot k1 k2 =
+      some (abstractNestedMappingSlot slot (addressToWord k1).val k2.val) := by
+  simp [fieldMapAddrUintSlot, htr, hty]
+
+theorem fieldMapUintAddrSlot_eq
+    {f : Field} {slot : Nat} {k1 : Uint256} {k2 : Address}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.nested .uint256 .address)) :
+    fieldMapUintAddrSlot f slot k1 k2 =
+      some (abstractNestedMappingSlot slot k1.val (addressToWord k2).val) := by
+  simp [fieldMapUintAddrSlot, htr, hty]
 
 /-- Persistent `mapping(bytes32 => uint256)` entry. There is no
     `StorageKey.mapBytes32`; Solidity ABI-encodes the 32-byte word

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4666,6 +4666,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldMapKey
   Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldMapUintKey
   Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldMap2Key
+  Compiler.Proofs.Storage.FieldStorageKey.fieldMapAddrUintSlot_eq
+  Compiler.Proofs.Storage.FieldStorageKey.fieldMapUintAddrSlot_eq
   Compiler.Proofs.Storage.FieldStorageKey.fieldMapBytes32Slot_eq
   Compiler.Proofs.Storage.FieldStorageKey.fieldStructMemberBytes32Slot_eq
   Compiler.Proofs.Storage.FieldStorageKey.fieldStructMemberBytes32Slot_eq_base_add
@@ -6917,4 +6919,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6418 theorems/lemmas (4548 public, 1870 private, 0 sorry'd)
+-- Total: 6420 theorems/lemmas (4550 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -203,7 +203,9 @@ collapse to `mappingSlotLocation` / `nestedMappingSlotLocation`
 (base mapping slot plus `wordOffset`). Compatibility `aliasSlots`
 are extra compiler write targets; only the resolved head has a
 `StorageKey`. bytes32-keyed maps collapse to `solidityMappingSlot`
-of the 32-byte word; there is no `StorageKey.mapBytes32`. A finite list of address-, uint-, or nested-address pairs
+of the 32-byte word; there is no `StorageKey.mapBytes32`. Mixed
+`address`/`uint256` nestings collapse to `abstractNestedMappingSlot`.
+A finite list of address-, uint-, or nested-address pairs
 stays coherent under an aligned write when the list carries an
 explicit pairwise derived-slot certificate (`MappingCoherentOn` /
 `MappingCoherentUintOn` / `MappingCoherentMap2On`); that is not a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,11 +42,12 @@ Next: derive the executable shallow program from the deep model
 per-function `_bridge` theorems into one AST-induction theorem
 (`GenericInduction/LegacyCompatibility` and the compile-derived
 legacy-compatibility witness chain are already retired), then finish C5
-step 4 — remaining field-list cases (packed bit-ranges, mixed-key
-nestings) and global (all-keys) `MappingCoherent` preservation.
+step 4 — remaining field-list cases (packed bit-ranges) and global
+(all-keys) `MappingCoherent` preservation.
 Implemented: address/uint/map2 coherence laws, `FieldStorageKey`
 (including address-keyed mappingStruct member slots,
-bytes32-keyed compiler slots, and compatibility `aliasSlots`
+bytes32-keyed compiler slots, mixed address/uint256 nested
+slots, and compatibility `aliasSlots`
 as extra compiler write targets),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot


### PR DESCRIPTION
## Summary
- add `fieldMapAddrUintSlot` for `mapping(address => mapping(uint256 => uint256))`
- add `fieldMapUintAddrSlot` for `mapping(uint256 => mapping(address => uint256))`
- both collapse to `abstractNestedMappingSlot`; no mixed `StorageKey` constructor
- C5 step 4 remains incomplete (packed bit-ranges, global preservation)

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldStorageKey`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions to FieldStorageKey with no axioms or runtime/compiler behavior changes; remaining C5 gaps are explicitly unchanged.
> 
> **Overview**
> Extends **C5 step 4** `FieldStorageKey` so mixed nested mappings resolve to compiler slots without new `StorageKey` constructors.
> 
> Adds `fieldMapAddrUintSlot` and `fieldMapUintAddrSlot` for `mapping(address => mapping(uint256 => uint256))` and `mapping(uint256 => mapping(address => uint256))`, each collapsing to `abstractNestedMappingSlot` (same pattern as homogenous `map2`). Includes `fieldMapAddrUintSlot_eq` / `fieldMapUintAddrSlot_eq` and registers them in `PrintAxioms.lean`.
> 
> **AUDIT**, **AXIOMS**, **TRUST_ASSUMPTIONS**, and **docs/ROADMAP** now document mixed-key collapse and drop mixed nestings from the remaining C5 step 4 checklist (packed bit-ranges and global `MappingCoherent` preservation are still open).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d07730b9793aa155badefa3a5deb91774481df96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->