### PR TITLE
feat(proofs): packed subfield extract on storageKeySlot word

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -330,7 +330,9 @@ sibling entrypoint.
   the field's `storageKeySlot`. Cross-channel finite-set preservation
   (aligned write on one mapping channel vs another channel's list)
   takes an explicit derived-slot inequality. Global (all-keys)
-  preservation and packed bit-ranges are still open. bytes32-keyed
+  preservation is still open. Packed subfields extract from the
+  `storageKeySlot` word (`packedExtract`); compiler packed-read
+  composition with SolidityStorage remains open. bytes32-keyed
   maps collapse to `solidityMappingSlot` of the 32-byte word (no
   `StorageKey.mapBytes32`). Mixed `address`/`uint256` nestings
   collapse to `abstractNestedMappingSlot`.

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -36,7 +36,8 @@ slots add `wordOffset` via `mappingSlotLocation`. Compatibility
 `aliasSlots` are extra compiler slots, not extra source keys.
 bytes32-keyed maps use the same keccak preimage as uint256 keys
 and do not add a `StorageKey` constructor. Mixed `address`/`uint256`
-nestings likewise add no constructor.
+nestings likewise add no constructor. Packed extract is a shift and
+mask on that word, not a new axiom.
 
 ## Eliminated Axioms
 

--- a/Compiler/Proofs/Storage/FieldStorageKey.lean
+++ b/Compiler/Proofs/Storage/FieldStorageKey.lean
@@ -10,15 +10,19 @@
   bytes32-keyed maps collapse to `solidityMappingSlot` of the 32-byte
   word (no `StorageKey.mapBytes32`). Mixed-key nestings
   (`address`/`uint256`) collapse to `abstractNestedMappingSlot`.
-  Packed bit-ranges and global MappingCoherent preservation stay open.
+  Packed bit-ranges extract from the same `storageKeySlot` word
+  (`packedExtract`). Compiler packed-read composition with
+  SolidityStorage and global MappingCoherent preservation stay open.
 -/
 
 import Compiler.Proofs.Storage.MappingCoherence
 import Verity.Core.Model.Types
+import Compiler.CompilationModel.ValidationHelpers
 
 namespace Compiler.Proofs.Storage.FieldStorageKey
 
 open Verity
+open Verity.ContractState
 open Compiler.CompilationModel
 open Compiler.Proofs.Storage.MappingCoherence
 open Compiler.Proofs
@@ -332,5 +336,47 @@ theorem storageKeySlot_head_of_fieldWriteSlots
       storageKeySlot (fieldRootKey f slot) := by
   rw [findFieldWriteSlots_of_resolved h, storageKeySlot_fieldRootKey, htr]
   rfl
+
+/-- Packed subfield extract: shift then mask. Lives in the same word as
+    `storageKeySlot`, not a different slot. -/
+def packedExtract (word : Nat) (pb : PackedBits) : Nat :=
+  Nat.land (word / (2 ^ pb.offset)) (packedMaskNat pb)
+
+def fieldPackedExtract (s : ContractState) (f : Field) (resolvedSlot : Nat) : Option Nat :=
+  match f.packedBits with
+  | none => none
+  | some pb =>
+    match storageKeySlot (fieldRootKey f resolvedSlot) with
+    | none => none
+    | some slot => some (packedExtract (s.storage slot).val pb)
+
+theorem packedBits_same_storageKeySlot
+    {f : Field} {slot : Nat} {pb : PackedBits}
+    (htr : f.isTransient = false) (_hpk : f.packedBits = some pb) :
+    storageKeySlot (fieldRootKey f slot) = some slot := by
+  rw [storageKeySlot_fieldRootKey, htr]
+  rfl
+
+theorem fieldPackedExtract_eq
+    {s : ContractState} {f : Field} {slot : Nat} {pb : PackedBits}
+    (htr : f.isTransient = false) (hpk : f.packedBits = some pb) :
+    fieldPackedExtract s f slot = some (packedExtract (s.storage slot).val pb) := by
+  simp [fieldPackedExtract, hpk, packedBits_same_storageKeySlot htr hpk]
+
+theorem fieldPackedExtract_writeSlot_other
+    {s : ContractState} {f : Field} {slot slot' : Nat} {v : Uint256} {pb : PackedBits}
+    (htr : f.isTransient = false) (hpk : f.packedBits = some pb)
+    (hne : slot ≠ slot') :
+    fieldPackedExtract (s.writeSlot slot' v) f slot = fieldPackedExtract s f slot := by
+  rw [fieldPackedExtract_eq htr hpk, fieldPackedExtract_eq htr hpk]
+  simp [storage_writeSlot_other (s := s) (slot := slot') (slot' := slot) hne]
+
+theorem fieldPackedExtract_writeSlot_same
+    {s : ContractState} {f : Field} {slot : Nat} {v : Uint256} {pb : PackedBits}
+    (htr : f.isTransient = false) (hpk : f.packedBits = some pb) :
+    fieldPackedExtract (s.writeSlot slot v) f slot =
+      some (packedExtract v.val pb) := by
+  rw [fieldPackedExtract_eq htr hpk]
+  simp [storage, writeSlot]
 
 end Compiler.Proofs.Storage.FieldStorageKey

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4678,6 +4678,10 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.FieldStorageKey.findFieldWriteSlotsCopyFrom_of_resolved
   Compiler.Proofs.Storage.FieldStorageKey.findFieldWriteSlots_of_resolved
   Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_head_of_fieldWriteSlots
+  Compiler.Proofs.Storage.FieldStorageKey.packedBits_same_storageKeySlot
+  Compiler.Proofs.Storage.FieldStorageKey.fieldPackedExtract_eq
+  Compiler.Proofs.Storage.FieldStorageKey.fieldPackedExtract_writeSlot_other
+  Compiler.Proofs.Storage.FieldStorageKey.fieldPackedExtract_writeSlot_same
 
   -- Compiler/Proofs/Storage/MappingCoherence.lean
   Compiler.Proofs.Storage.MappingCoherence.defaultState_mappingCoherent
@@ -6919,4 +6923,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6420 theorems/lemmas (4550 public, 1870 private, 0 sorry'd)
+-- Total: 6424 theorems/lemmas (4554 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -205,6 +205,8 @@ are extra compiler write targets; only the resolved head has a
 `StorageKey`. bytes32-keyed maps collapse to `solidityMappingSlot`
 of the 32-byte word; there is no `StorageKey.mapBytes32`. Mixed
 `address`/`uint256` nestings collapse to `abstractNestedMappingSlot`.
+Packed subfields extract from the same `storageKeySlot` word; they
+are not a different slot.
 A finite list of address-, uint-, or nested-address pairs
 stays coherent under an aligned write when the list carries an
 explicit pairwise derived-slot certificate (`MappingCoherentOn` /

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,12 +42,12 @@ Next: derive the executable shallow program from the deep model
 per-function `_bridge` theorems into one AST-induction theorem
 (`GenericInduction/LegacyCompatibility` and the compile-derived
 legacy-compatibility witness chain are already retired), then finish C5
-step 4 — remaining field-list cases (packed bit-ranges) and global
+step 4 — remaining packed compiler-read composition and global
 (all-keys) `MappingCoherent` preservation.
 Implemented: address/uint/map2 coherence laws, `FieldStorageKey`
 (including address-keyed mappingStruct member slots,
 bytes32-keyed compiler slots, mixed address/uint256 nested
-slots, and compatibility `aliasSlots`
+slots, packed word extract, and compatibility `aliasSlots`
 as extra compiler write targets),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot


### PR DESCRIPTION
## Summary
- add `packedExtract` / `fieldPackedExtract`: packed bits live in the `storageKeySlot` word
- prove other-slot writes preserve the extract; same-slot write updates it
- compiler packed-read composition with SolidityStorage remains open
- C5 step 4 remains incomplete (global all-keys preservation)

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldStorageKey`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions to `FieldStorageKey` and documentation counters; no compiler semantics, auth, or runtime behavior changes.
> 
> **Overview**
> Adds **C5 step 4** proof support for **packed storage fields**: `packedExtract` and `fieldPackedExtract` read a subfield via shift-and-mask from the same persistent word as `storageKeySlot`, not a separate slot.
> 
> Proves that packed bits use the resolved root slot (`packedBits_same_storageKeySlot`), that extraction matches `s.storage slot` (`fieldPackedExtract_eq`), and basic `writeSlot` behavior (unchanged on other slots; on the root slot, extract reflects the written word).
> 
> Registers four new theorems in `PrintAxioms.lean` (6420 → 6424). **AUDIT**, **AXIOMS**, **TRUST_ASSUMPTIONS**, and **ROADMAP** now document packed extract as implemented while **compiler packed-read composition with SolidityStorage** and **global all-keys `MappingCoherent` preservation** remain open. No new axioms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 161699e94b0947886b24f012dc7a45ff5fcd757b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->