### PR TITLE
feat(proofs): remaining MappingType.nested compiler slots

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -334,8 +334,8 @@ sibling entrypoint.
   `storageKeySlot` word (`packedExtract`); compiler packed-read
   composition with SolidityStorage remains open. bytes32-keyed
   maps collapse to `solidityMappingSlot` of the 32-byte word (no
-  `StorageKey.mapBytes32`). Mixed `address`/`uint256` nestings
-  collapse to `abstractNestedMappingSlot`.
+  `StorageKey.mapBytes32`). All nine `MappingType.nested` key-type
+  pairs collapse to `abstractNestedMappingSlot`.
 - Zero new axioms.
 
 ## CI Guards

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -35,8 +35,7 @@ constructor match on `FieldType` / `isTransient`; struct-member
 slots add `wordOffset` via `mappingSlotLocation`. Compatibility
 `aliasSlots` are extra compiler slots, not extra source keys.
 bytes32-keyed maps use the same keccak preimage as uint256 keys
-and do not add a `StorageKey` constructor. Mixed `address`/`uint256`
-nestings likewise add no constructor. Packed extract is a shift and
+and do not add a `StorageKey` constructor. Remaining `MappingType.nested` pairs likewise add no constructor. Packed extract is a shift and
 mask on that word, not a new axiom.
 
 ## Eliminated Axioms

--- a/Compiler/Proofs/Storage/FieldStorageKey.lean
+++ b/Compiler/Proofs/Storage/FieldStorageKey.lean
@@ -8,8 +8,8 @@
   `nestedMappingSlotLocation`. Compatibility `aliasSlots` are extra
   compiler write targets; only the resolved head has a StorageKey.
   bytes32-keyed maps collapse to `solidityMappingSlot` of the 32-byte
-  word (no `StorageKey.mapBytes32`). Mixed-key nestings
-  (`address`/`uint256`) collapse to `abstractNestedMappingSlot`.
+  word (no `StorageKey.mapBytes32`). All nine `MappingType.nested`
+  key-type pairs collapse to `abstractNestedMappingSlot`.
   Packed bit-ranges extract from the same `storageKeySlot` word
   (`packedExtract`). Compiler packed-read composition with
   SolidityStorage and global MappingCoherent preservation stay open.
@@ -172,6 +172,106 @@ theorem fieldMapUintAddrSlot_eq
     fieldMapUintAddrSlot f slot k1 k2 =
       some (abstractNestedMappingSlot slot k1.val (addressToWord k2).val) := by
   simp [fieldMapUintAddrSlot, htr, hty]
+
+/-- Remaining `MappingType.nested` pairs collapse to `abstractNestedMappingSlot`.
+    Word keys (uint256 / bytes32) use `.val`; address keys use `addressToWord`. -/
+def fieldMapUintUintSlot (f : Field) (resolvedSlot : Nat) (k1 k2 : Uint256) : Option Nat :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingTyped (.nested .uint256 .uint256) =>
+      some (abstractNestedMappingSlot resolvedSlot k1.val k2.val)
+    | _ => none
+
+def fieldMapBytes32Bytes32Slot (f : Field) (resolvedSlot : Nat) (k1 k2 : Uint256) : Option Nat :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingTyped (.nested .bytes32 .bytes32) =>
+      some (abstractNestedMappingSlot resolvedSlot k1.val k2.val)
+    | _ => none
+
+def fieldMapAddrBytes32Slot (f : Field) (resolvedSlot : Nat) (k1 : Address) (k2 : Uint256) :
+    Option Nat :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingTyped (.nested .address .bytes32) =>
+      some (abstractNestedMappingSlot resolvedSlot (addressToWord k1).val k2.val)
+    | _ => none
+
+def fieldMapBytes32AddrSlot (f : Field) (resolvedSlot : Nat) (k1 : Uint256) (k2 : Address) :
+    Option Nat :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingTyped (.nested .bytes32 .address) =>
+      some (abstractNestedMappingSlot resolvedSlot k1.val (addressToWord k2).val)
+    | _ => none
+
+def fieldMapUintBytes32Slot (f : Field) (resolvedSlot : Nat) (k1 k2 : Uint256) : Option Nat :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingTyped (.nested .uint256 .bytes32) =>
+      some (abstractNestedMappingSlot resolvedSlot k1.val k2.val)
+    | _ => none
+
+def fieldMapBytes32UintSlot (f : Field) (resolvedSlot : Nat) (k1 k2 : Uint256) : Option Nat :=
+  if f.isTransient then none
+  else
+    match f.ty with
+    | .mappingTyped (.nested .bytes32 .uint256) =>
+      some (abstractNestedMappingSlot resolvedSlot k1.val k2.val)
+    | _ => none
+
+theorem fieldMapUintUintSlot_eq
+    {f : Field} {slot : Nat} {k1 k2 : Uint256}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.nested .uint256 .uint256)) :
+    fieldMapUintUintSlot f slot k1 k2 =
+      some (abstractNestedMappingSlot slot k1.val k2.val) := by
+  simp [fieldMapUintUintSlot, htr, hty]
+
+theorem fieldMapBytes32Bytes32Slot_eq
+    {f : Field} {slot : Nat} {k1 k2 : Uint256}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.nested .bytes32 .bytes32)) :
+    fieldMapBytes32Bytes32Slot f slot k1 k2 =
+      some (abstractNestedMappingSlot slot k1.val k2.val) := by
+  simp [fieldMapBytes32Bytes32Slot, htr, hty]
+
+theorem fieldMapAddrBytes32Slot_eq
+    {f : Field} {slot : Nat} {k1 : Address} {k2 : Uint256}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.nested .address .bytes32)) :
+    fieldMapAddrBytes32Slot f slot k1 k2 =
+      some (abstractNestedMappingSlot slot (addressToWord k1).val k2.val) := by
+  simp [fieldMapAddrBytes32Slot, htr, hty]
+
+theorem fieldMapBytes32AddrSlot_eq
+    {f : Field} {slot : Nat} {k1 : Uint256} {k2 : Address}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.nested .bytes32 .address)) :
+    fieldMapBytes32AddrSlot f slot k1 k2 =
+      some (abstractNestedMappingSlot slot k1.val (addressToWord k2).val) := by
+  simp [fieldMapBytes32AddrSlot, htr, hty]
+
+theorem fieldMapUintBytes32Slot_eq
+    {f : Field} {slot : Nat} {k1 k2 : Uint256}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.nested .uint256 .bytes32)) :
+    fieldMapUintBytes32Slot f slot k1 k2 =
+      some (abstractNestedMappingSlot slot k1.val k2.val) := by
+  simp [fieldMapUintBytes32Slot, htr, hty]
+
+theorem fieldMapBytes32UintSlot_eq
+    {f : Field} {slot : Nat} {k1 k2 : Uint256}
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.nested .bytes32 .uint256)) :
+    fieldMapBytes32UintSlot f slot k1 k2 =
+      some (abstractNestedMappingSlot slot k1.val k2.val) := by
+  simp [fieldMapBytes32UintSlot, htr, hty]
 
 /-- Persistent `mapping(bytes32 => uint256)` entry. There is no
     `StorageKey.mapBytes32`; Solidity ABI-encodes the 32-byte word

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4668,6 +4668,12 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldMap2Key
   Compiler.Proofs.Storage.FieldStorageKey.fieldMapAddrUintSlot_eq
   Compiler.Proofs.Storage.FieldStorageKey.fieldMapUintAddrSlot_eq
+  Compiler.Proofs.Storage.FieldStorageKey.fieldMapUintUintSlot_eq
+  Compiler.Proofs.Storage.FieldStorageKey.fieldMapBytes32Bytes32Slot_eq
+  Compiler.Proofs.Storage.FieldStorageKey.fieldMapAddrBytes32Slot_eq
+  Compiler.Proofs.Storage.FieldStorageKey.fieldMapBytes32AddrSlot_eq
+  Compiler.Proofs.Storage.FieldStorageKey.fieldMapUintBytes32Slot_eq
+  Compiler.Proofs.Storage.FieldStorageKey.fieldMapBytes32UintSlot_eq
   Compiler.Proofs.Storage.FieldStorageKey.fieldMapBytes32Slot_eq
   Compiler.Proofs.Storage.FieldStorageKey.fieldStructMemberBytes32Slot_eq
   Compiler.Proofs.Storage.FieldStorageKey.fieldStructMemberBytes32Slot_eq_base_add
@@ -6923,4 +6929,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6424 theorems/lemmas (4554 public, 1870 private, 0 sorry'd)
+-- Total: 6430 theorems/lemmas (4560 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -204,7 +204,8 @@ collapse to `mappingSlotLocation` / `nestedMappingSlotLocation`
 are extra compiler write targets; only the resolved head has a
 `StorageKey`. bytes32-keyed maps collapse to `solidityMappingSlot`
 of the 32-byte word; there is no `StorageKey.mapBytes32`. Mixed
-`address`/`uint256` nestings collapse to `abstractNestedMappingSlot`.
+All nine `MappingType.nested` key-type pairs collapse to
+`abstractNestedMappingSlot`.
 Packed subfields extract from the same `storageKeySlot` word; they
 are not a different slot.
 A finite list of address-, uint-, or nested-address pairs

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -46,8 +46,8 @@ step 4 — remaining packed compiler-read composition and global
 (all-keys) `MappingCoherent` preservation.
 Implemented: address/uint/map2 coherence laws, `FieldStorageKey`
 (including address-keyed mappingStruct member slots,
-bytes32-keyed compiler slots, mixed address/uint256 nested
-slots, packed word extract, and compatibility `aliasSlots`
+bytes32-keyed compiler slots, all `MappingType.nested` key-type
+pairs, packed word extract, and compatibility `aliasSlots`
 as extra compiler write targets),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot


### PR DESCRIPTION
## Summary
- add compiler-slot collapse for the six leftover `MappingType.nested` key-type pairs
- all nine nested pairs now map to `abstractNestedMappingSlot`
- no new `StorageKey` constructor
- C5 step 4 remains incomplete (packed compiler-read composition, global preservation)

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldStorageKey`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive proof and documentation in the storage slot correspondence layer; no compiler codegen, axioms, or runtime behavior changes.
> 
> **Overview**
> Extends **C5 step 4** `FieldStorageKey` so every `MappingType.nested` key-type pair has an explicit compiler-slot collapse to `abstractNestedMappingSlot`, not only the mixed address/uint256 cases that were already there.
> 
> Six new field helpers (`fieldMapUintUintSlot`, `fieldMapBytes32Bytes32Slot`, `fieldMapAddrBytes32Slot`, `fieldMapBytes32AddrSlot`, `fieldMapUintBytes32Slot`, `fieldMapBytes32UintSlot`) plus matching `*_eq` simp lemmas follow the same pattern as the existing nested helpers: word keys use `.val`, address keys use `addressToWord`, still **no** new `StorageKey` constructor.
> 
> `PrintAxioms.lean` registers the six lemmas (theorem count 6424 → 6430). **AUDIT.md**, **AXIOMS.md**, **TRUST_ASSUMPTIONS.md**, and **docs/ROADMAP.md** now state that all nine nested pairs collapse this way. Packed compiler-read composition and global `MappingCoherent` preservation remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afdb539b583c118e8305df0f1677bd71e191b040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->