### PR TITLE
feat(proofs): storageKeySlot encodeStorageAt composition seam

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -332,7 +332,9 @@ sibling entrypoint.
   takes an explicit derived-slot inequality. Global (all-keys)
   preservation is still open. Packed subfields extract from the
   `storageKeySlot` word (`packedExtract`); compiler packed-read
-  composition with SolidityStorage remains open. bytes32-keyed
+  composition with SolidityStorage remains open.
+  `FieldEncode` names the `storageKeySlot` / `encodeStorageAt` seam
+  when `findResolvedFieldAtSlot` agrees (explicit hypothesis). bytes32-keyed
   maps collapse to `solidityMappingSlot` of the 32-byte word (no
   `StorageKey.mapBytes32`). All nine `MappingType.nested` key-type
   pairs collapse to `abstractNestedMappingSlot`.

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -36,7 +36,8 @@ slots add `wordOffset` via `mappingSlotLocation`. Compatibility
 `aliasSlots` are extra compiler slots, not extra source keys.
 bytes32-keyed maps use the same keccak preimage as uint256 keys
 and do not add a `StorageKey` constructor. Remaining `MappingType.nested` pairs likewise add no constructor. Packed extract is a shift and
-mask on that word, not a new axiom.
+mask on that word, not a new axiom. `FieldEncode` adds no axiom:
+`findResolvedFieldAtSlot` is an explicit hypothesis.
 
 ## Eliminated Axioms
 

--- a/Compiler/Proofs/Storage/FieldEncode.lean
+++ b/Compiler/Proofs/Storage/FieldEncode.lean
@@ -1,0 +1,62 @@
+/-
+  C5 step 4 composition seam: `storageKeySlot` of a persistent uint256
+  field is the slot `encodeStorageAt` reads when `findResolvedFieldAtSlot`
+  agrees. The slot-lookup hypothesis is explicit; this does not prove
+  field-list uniqueness.
+-/
+
+import Compiler.Proofs.Storage.FieldStorageKey
+import Compiler.Proofs.IRGeneration.SourceSemantics
+
+namespace Compiler.Proofs.Storage.FieldEncode
+
+open Verity
+open Verity.ContractState
+open Compiler.CompilationModel
+open Compiler.Proofs.Storage.FieldStorageKey
+open Compiler.Proofs.Storage.MappingCoherence
+open Compiler.Proofs.IRGeneration.SourceSemantics
+
+theorem encodeStorageAt_of_resolved_uint256
+    {fields : List Field} {world : ContractState} {slot : Nat} {f : Field}
+    (hresolved : findResolvedFieldAtSlot fields slot = some f)
+    (hty : f.ty = .uint256) :
+    encodeStorageAt fields world slot = (world.storage slot).val := by
+  simp [encodeStorageAt, hresolved, fieldUsesAddressStorage, fieldUsesDynamicArrayStorage, hty]
+
+theorem encodeStorageAt_of_resolved_address
+    {fields : List Field} {world : ContractState} {slot : Nat} {f : Field}
+    (hresolved : findResolvedFieldAtSlot fields slot = some f)
+    (hty : f.ty = .address) :
+    encodeStorageAt fields world slot = (world.storageAddr slot).val := by
+  simp [encodeStorageAt, hresolved, fieldUsesAddressStorage, hty]
+
+theorem encodeStorageAt_fieldRootKey_uint256
+    {fields : List Field} {name : String} {f : Field} {slot : Nat}
+    {world : ContractState}
+    (hfind : findFieldWithResolvedSlot fields name = some (f, slot))
+    (htr : f.isTransient = false)
+    (hty : f.ty = .uint256)
+    (hresolved : findResolvedFieldAtSlot fields slot = some f) :
+    fieldListRootKey fields name = some (fieldRootKey f slot) ∧
+      storageKeySlot (fieldRootKey f slot) = some slot ∧
+      encodeStorageAt fields world slot = (world.storage slot).val :=
+  ⟨fieldListRootKey_eq hfind,
+    by rw [storageKeySlot_fieldRootKey, htr]; rfl,
+    encodeStorageAt_of_resolved_uint256 hresolved hty⟩
+
+theorem encodeStorageAt_fieldRootKey_address
+    {fields : List Field} {name : String} {f : Field} {slot : Nat}
+    {world : ContractState}
+    (hfind : findFieldWithResolvedSlot fields name = some (f, slot))
+    (htr : f.isTransient = false)
+    (hty : f.ty = .address)
+    (hresolved : findResolvedFieldAtSlot fields slot = some f) :
+    fieldListRootKey fields name = some (fieldRootKey f slot) ∧
+      storageKeySlot (fieldRootKey f slot) = some slot ∧
+      encodeStorageAt fields world slot = (world.storageAddr slot).val :=
+  ⟨fieldListRootKey_eq hfind,
+    by rw [storageKeySlot_fieldRootKey, htr]; rfl,
+    encodeStorageAt_of_resolved_address hresolved hty⟩
+
+end Compiler.Proofs.Storage.FieldEncode

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -107,6 +107,7 @@ import Compiler.Proofs.IRGeneration.SupportedSpec
 import Compiler.Proofs.KeccakBound
 import Compiler.Proofs.LoopSimulation
 import Compiler.Proofs.MappingSlot
+import Compiler.Proofs.Storage.FieldEncode
 import Compiler.Proofs.Storage.FieldStorageKey
 import Compiler.Proofs.Storage.MappingCoherence
 import Compiler.Proofs.Storage.MappingCoherenceOn
@@ -4655,6 +4656,12 @@ end Verity.AxiomAudit
   Compiler.Proofs.solidityMappingSlot_add_lt_evmModulus
   Compiler.Proofs.solidityMappingSlot_add_wordOffset_lt_evmModulus
 
+  -- Compiler/Proofs/Storage/FieldEncode.lean
+  Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_of_resolved_uint256
+  Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_of_resolved_address
+  Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldRootKey_uint256
+  Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldRootKey_address
+
   -- Compiler/Proofs/Storage/FieldStorageKey.lean
   Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldRootKey
   Compiler.Proofs.Storage.FieldStorageKey.fieldListRootKey_eq
@@ -6929,4 +6936,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6430 theorems/lemmas (4560 public, 1870 private, 0 sorry'd)
+-- Total: 6434 theorems/lemmas (4564 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -207,7 +207,9 @@ of the 32-byte word; there is no `StorageKey.mapBytes32`. Mixed
 All nine `MappingType.nested` key-type pairs collapse to
 `abstractNestedMappingSlot`.
 Packed subfields extract from the same `storageKeySlot` word; they
-are not a different slot.
+are not a different slot. `encodeStorageAt` at a resolved uint256 or
+address field is the corresponding lens when
+`findResolvedFieldAtSlot` is hypothesized.
 A finite list of address-, uint-, or nested-address pairs
 stays coherent under an aligned write when the list carries an
 explicit pairwise derived-slot certificate (`MappingCoherentOn` /

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,8 +42,9 @@ Next: derive the executable shallow program from the deep model
 per-function `_bridge` theorems into one AST-induction theorem
 (`GenericInduction/LegacyCompatibility` and the compile-derived
 legacy-compatibility witness chain are already retired), then finish C5
-step 4 — remaining packed compiler-read composition and global
-(all-keys) `MappingCoherent` preservation.
+step 4 — remaining packed compiler-read composition, the
+`findResolvedFieldAtSlot` uniqueness proof, and global (all-keys)
+`MappingCoherent` preservation.
 Implemented: address/uint/map2 coherence laws, `FieldStorageKey`
 (including address-keyed mappingStruct member slots,
 bytes32-keyed compiler slots, all `MappingType.nested` key-type


### PR DESCRIPTION
## Summary
- add `FieldEncode`: `encodeStorageAt` at a resolved uint256/address field is the corresponding lens
- package with `fieldListRootKey` / `storageKeySlot` of `fieldRootKey`
- `findResolvedFieldAtSlot` is an explicit hypothesis (no field-list uniqueness proof)
- C5 step 4 remains incomplete

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldEncode`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions and documentation; no compiler or runtime behavior change and no new trust assumptions beyond an explicit slot-resolution hypothesis.
> 
> **Overview**
> Adds **`Compiler/Proofs/Storage/FieldEncode.lean`** for C5 step 4: when **`findResolvedFieldAtSlot`** names a persistent **uint256** or **address** field, **`encodeStorageAt`** equals the matching **`world.storage`** / **`world.storageAddr`** lens, and the same lemmas chain **`fieldListRootKey`** / **`storageKeySlot`** on **`fieldRootKey`**.
> 
> Slot agreement stays an **explicit hypothesis** (no field-list uniqueness proof). **AUDIT**, **AXIOMS**, **TRUST_ASSUMPTIONS**, and **ROADMAP** document the seam; **PrintAxioms** registers four new theorems (+4 total). **Zero new axioms**; packed-read composition and **`findResolvedFieldAtSlot`** uniqueness remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bf5ebce599a34bc603d43cbc5cd327bca925384. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->