### PR TITLE
feat(proofs): derive findResolvedFieldAtSlot from named field

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -333,8 +333,9 @@ sibling entrypoint.
   preservation is still open. Packed subfields extract from the
   `storageKeySlot` word (`packedExtract`); compiler packed-read
   composition with SolidityStorage remains open.
-  `FieldEncode` names the `storageKeySlot` / `encodeStorageAt` seam
-  when `findResolvedFieldAtSlot` agrees (explicit hypothesis). bytes32-keyed
+  `FieldEncode` derives `findResolvedFieldAtSlot` from
+  `findFieldWithResolvedSlot` plus no write-slot conflict, persistent,
+  and unpacked, then identifies that slot with `encodeStorageAt`. bytes32-keyed
   maps collapse to `solidityMappingSlot` of the 32-byte word (no
   `StorageKey.mapBytes32`). All nine `MappingType.nested` key-type
   pairs collapse to `abstractNestedMappingSlot`.

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -36,8 +36,8 @@ slots add `wordOffset` via `mappingSlotLocation`. Compatibility
 `aliasSlots` are extra compiler slots, not extra source keys.
 bytes32-keyed maps use the same keccak preimage as uint256 keys
 and do not add a `StorageKey` constructor. Remaining `MappingType.nested` pairs likewise add no constructor. Packed extract is a shift and
-mask on that word, not a new axiom. `FieldEncode` adds no axiom:
-`findResolvedFieldAtSlot` is an explicit hypothesis.
+mask on that word, not a new axiom. `FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
+from no write-slot conflict plus constructor facts.
 
 ## Eliminated Axioms
 

--- a/Compiler/Proofs/Storage/FieldEncode.lean
+++ b/Compiler/Proofs/Storage/FieldEncode.lean
@@ -1,12 +1,14 @@
 /-
-  C5 step 4 composition seam: `storageKeySlot` of a persistent uint256
-  field is the slot `encodeStorageAt` reads when `findResolvedFieldAtSlot`
-  agrees. The slot-lookup hypothesis is explicit; this does not prove
-  field-list uniqueness.
+  C5 step 4 composition seam: `storageKeySlot` of a persistent unpacked
+  uint256/address field is the slot `encodeStorageAt` reads, once the
+  field list has no write-slot conflict. `findResolvedFieldAtSlot` is
+  derived, not hypothesized.
 -/
 
 import Compiler.Proofs.Storage.FieldStorageKey
 import Compiler.Proofs.IRGeneration.SourceSemantics
+import Compiler.Proofs.IRGeneration.GenericInduction.Storage
+import Compiler.CompilationModel.LayoutValidation
 
 namespace Compiler.Proofs.Storage.FieldEncode
 
@@ -15,6 +17,7 @@ open Verity.ContractState
 open Compiler.CompilationModel
 open Compiler.Proofs.Storage.FieldStorageKey
 open Compiler.Proofs.Storage.MappingCoherence
+open Compiler.Proofs.IRGeneration
 open Compiler.Proofs.IRGeneration.SourceSemantics
 
 theorem encodeStorageAt_of_resolved_uint256
@@ -31,32 +34,51 @@ theorem encodeStorageAt_of_resolved_address
     encodeStorageAt fields world slot = (world.storageAddr slot).val := by
   simp [encodeStorageAt, hresolved, fieldUsesAddressStorage, hty]
 
+/-- Persistent unpacked field with no write-slot conflict: the named
+    field's resolved slot is the `findResolvedFieldAtSlot` hit. Aliases
+    may exist; this names the canonical head, not an alias. -/
+theorem findResolvedFieldAtSlot_of_fieldRoot
+    {fields : List Field} {name : String} {f : Field} {slot : Nat}
+    (hnoConflict : firstFieldWriteSlotConflict fields = none)
+    (hfind : findFieldWithResolvedSlot fields name = some (f, slot))
+    (htr : f.isTransient = false)
+    (hunpacked : f.packedBits = none) :
+    findResolvedFieldAtSlot fields slot = some f := by
+  have hwrite := findFieldWriteSlots_of_resolved hfind
+  rw [findResolvedFieldAtSlotCopy_eq]
+  exact findResolvedFieldAtSlotCopy_of_findFieldWithResolvedSlot_member
+    hnoConflict hfind hwrite (by simp) htr hunpacked
+
 theorem encodeStorageAt_fieldRootKey_uint256
     {fields : List Field} {name : String} {f : Field} {slot : Nat}
     {world : ContractState}
+    (hnoConflict : firstFieldWriteSlotConflict fields = none)
     (hfind : findFieldWithResolvedSlot fields name = some (f, slot))
     (htr : f.isTransient = false)
-    (hty : f.ty = .uint256)
-    (hresolved : findResolvedFieldAtSlot fields slot = some f) :
+    (hunpacked : f.packedBits = none)
+    (hty : f.ty = .uint256) :
     fieldListRootKey fields name = some (fieldRootKey f slot) ∧
       storageKeySlot (fieldRootKey f slot) = some slot ∧
       encodeStorageAt fields world slot = (world.storage slot).val :=
   ⟨fieldListRootKey_eq hfind,
     by rw [storageKeySlot_fieldRootKey, htr]; rfl,
-    encodeStorageAt_of_resolved_uint256 hresolved hty⟩
+    encodeStorageAt_of_resolved_uint256
+      (findResolvedFieldAtSlot_of_fieldRoot hnoConflict hfind htr hunpacked) hty⟩
 
 theorem encodeStorageAt_fieldRootKey_address
     {fields : List Field} {name : String} {f : Field} {slot : Nat}
     {world : ContractState}
+    (hnoConflict : firstFieldWriteSlotConflict fields = none)
     (hfind : findFieldWithResolvedSlot fields name = some (f, slot))
     (htr : f.isTransient = false)
-    (hty : f.ty = .address)
-    (hresolved : findResolvedFieldAtSlot fields slot = some f) :
+    (hunpacked : f.packedBits = none)
+    (hty : f.ty = .address) :
     fieldListRootKey fields name = some (fieldRootKey f slot) ∧
       storageKeySlot (fieldRootKey f slot) = some slot ∧
       encodeStorageAt fields world slot = (world.storageAddr slot).val :=
   ⟨fieldListRootKey_eq hfind,
     by rw [storageKeySlot_fieldRootKey, htr]; rfl,
-    encodeStorageAt_of_resolved_address hresolved hty⟩
+    encodeStorageAt_of_resolved_address
+      (findResolvedFieldAtSlot_of_fieldRoot hnoConflict hfind htr hunpacked) hty⟩
 
 end Compiler.Proofs.Storage.FieldEncode

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4659,6 +4659,7 @@ end Verity.AxiomAudit
   -- Compiler/Proofs/Storage/FieldEncode.lean
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_of_resolved_uint256
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_of_resolved_address
+  Compiler.Proofs.Storage.FieldEncode.findResolvedFieldAtSlot_of_fieldRoot
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldRootKey_uint256
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldRootKey_address
 
@@ -6936,4 +6937,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6434 theorems/lemmas (4564 public, 1870 private, 0 sorry'd)
+-- Total: 6435 theorems/lemmas (4565 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -207,9 +207,9 @@ of the 32-byte word; there is no `StorageKey.mapBytes32`. Mixed
 All nine `MappingType.nested` key-type pairs collapse to
 `abstractNestedMappingSlot`.
 Packed subfields extract from the same `storageKeySlot` word; they
-are not a different slot. `encodeStorageAt` at a resolved uint256 or
-address field is the corresponding lens when
-`findResolvedFieldAtSlot` is hypothesized.
+are not a different slot. `encodeStorageAt` at a persistent unpacked uint256 or address field
+is the corresponding lens once `firstFieldWriteSlotConflict` is
+none; `findResolvedFieldAtSlot` is derived, not hypothesized.
 A finite list of address-, uint-, or nested-address pairs
 stays coherent under an aligned write when the list carries an
 explicit pairwise derived-slot certificate (`MappingCoherentOn` /

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,13 +42,13 @@ Next: derive the executable shallow program from the deep model
 per-function `_bridge` theorems into one AST-induction theorem
 (`GenericInduction/LegacyCompatibility` and the compile-derived
 legacy-compatibility witness chain are already retired), then finish C5
-step 4 — remaining packed compiler-read composition, the
-`findResolvedFieldAtSlot` uniqueness proof, and global (all-keys)
-`MappingCoherent` preservation.
+step 4 — remaining packed compiler-read composition and global
+(all-keys) `MappingCoherent` preservation.
 Implemented: address/uint/map2 coherence laws, `FieldStorageKey`
 (including address-keyed mappingStruct member slots,
 bytes32-keyed compiler slots, all `MappingType.nested` key-type
-pairs, packed word extract, and compatibility `aliasSlots`
+pairs, packed word extract, `findResolvedFieldAtSlot` from a named
+field plus no-conflict, and compatibility `aliasSlots`
 as extra compiler write targets),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot


### PR DESCRIPTION
## Summary
- add `findResolvedFieldAtSlot_of_fieldRoot`: persistent unpacked named field with `firstFieldWriteSlotConflict = none` is the `findResolvedFieldAtSlot` hit
- drop the `hresolved` hypothesis from `encodeStorageAt_fieldRootKey_uint256` / `_address`
- aliases may exist; the theorem names the canonical head slot, not an alias
- C5 step 4 remains incomplete (packed compiler-read composition, global preservation)

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldEncode`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only change in storage composition lemmas; no new axioms and no compiler or runtime behavior changes.
> 
> **Overview**
> For C5 step 4 **FieldEncode**, `findResolvedFieldAtSlot` is no longer an explicit hypothesis on the root-key `encodeStorageAt` lemmas.
> 
> **`findResolvedFieldAtSlot_of_fieldRoot`** shows that for a persistent, unpacked field named via `findFieldWithResolvedSlot`, with `firstFieldWriteSlotConflict = none`, the canonical resolved slot is exactly the `findResolvedFieldAtSlot` result (alias slots may still exist; the theorem pins the head slot).
> 
> **`encodeStorageAt_fieldRootKey_uint256`** and **`encodeStorageAt_fieldRootKey_address`** now take `hnoConflict` and `hunpacked` instead of `hresolved`, and discharge slot resolution through the new theorem (wired via `GenericInduction/Storage`). Audit, axiom, trust, and roadmap text are updated to match; **`PrintAxioms`** registers the new public theorem (+1 counted lemma).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a815bef6ff01292e6d7a95aae3cc925c2f40c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->