### PR TITLE
feat(proofs): identify packedExtract with compiledPackedRead

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -329,10 +329,10 @@ sibling entrypoint.
   `aliasSlots` are extra compiler write targets; the resolved head is
   the field's `storageKeySlot`. Cross-channel finite-set preservation
   (aligned write on one mapping channel vs another channel's list)
-  takes an explicit derived-slot inequality. Global (all-keys)
-  preservation is still open. Packed subfields extract from the
-  `storageKeySlot` word (`packedExtract`); compiler packed-read
-  composition with SolidityStorage remains open.
+  takes an explicit derived-slot inequality. Packed subfields extract
+  from the `storageKeySlot` word (`packedExtract`); compiler packed-read
+  composition with SolidityStorage is `fieldPackedExtract_eq_compiledPackedRead`
+  (`width < 256`). Global (all-keys) preservation remains open.
   `FieldEncode` derives `findResolvedFieldAtSlot` from
   `findFieldWithResolvedSlot` plus no write-slot conflict, persistent,
   and unpacked, then identifies that slot with `encodeStorageAt`. bytes32-keyed

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -36,7 +36,8 @@ slots add `wordOffset` via `mappingSlotLocation`. Compatibility
 `aliasSlots` are extra compiler slots, not extra source keys.
 bytes32-keyed maps use the same keccak preimage as uint256 keys
 and do not add a `StorageKey` constructor. Remaining `MappingType.nested` pairs likewise add no constructor. Packed extract is a shift and
-mask on that word, not a new axiom. `FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
+mask on that word, not a new axiom. Equality with `compiledPackedRead`
+is a `width < 256` calculation. `FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
 from no write-slot conflict plus constructor facts.
 
 ## Eliminated Axioms

--- a/Compiler/Proofs/Storage/FieldPackedCompile.lean
+++ b/Compiler/Proofs/Storage/FieldPackedCompile.lean
@@ -1,0 +1,53 @@
+/-
+  C5 step 4 packed compiler-read composition: `fieldPackedExtract` is
+  the same Nat as `compiledPackedRead` of the storage word. Packed
+  bit-range validity (`offset < 256`, `width < 256`) is explicit.
+-/
+
+import Compiler.Proofs.Storage.FieldStorageKey
+import Compiler.Proofs.Storage.SolidityStorage
+
+namespace Compiler.Proofs.Storage.FieldPackedCompile
+
+open Verity
+open Verity.ContractState
+open Compiler.CompilationModel
+open Compiler.Proofs.Storage.FieldStorageKey
+open Compiler.Proofs.Storage
+open Compiler.Proofs.IRGeneration
+
+theorem packedExtract_eq_yulReadPackedWord
+    (word : Nat) (offset width : Nat)
+    (hword : word < 2 ^ 256) (hwidth : width < 256) :
+    packedExtract word { offset := offset, width := width } =
+      (yulReadPackedWord (IRStorageWord.ofNat word) offset width).toNat := by
+  have hwle : width ≤ 256 := Nat.le_of_lt hwidth
+  rw [packedExtract_eq_mod (pb := { offset := offset, width := width }) word hwidth]
+  unfold yulReadPackedWord
+  rw [IRStorageWord.toNat_ofNat, IRStorageWord.toNat_ofNat]
+  have hsize : (2 : Nat) ^ 256 = EvmYul.UInt256.size := by
+    unfold EvmYul.UInt256.size; rfl
+  have hword' : word % EvmYul.UInt256.size = word := by
+    rw [← hsize, Nat.mod_eq_of_lt hword]
+  rw [hword']
+  have hlt : (word / 2 ^ offset) % 2 ^ width < EvmYul.UInt256.size := by
+    have hpow : (2 : Nat) ^ width < 2 ^ 256 :=
+      Nat.pow_lt_pow_right (by decide) hwidth
+    rw [← hsize]
+    exact Nat.lt_trans (Nat.mod_lt _ (Nat.two_pow_pos width)) hpow
+  exact (Nat.mod_eq_of_lt hlt).symm
+
+theorem fieldPackedExtract_eq_compiledPackedRead
+    {s : ContractState} {f : Field} {slot : Nat} {pb : PackedBits}
+    (htr : f.isTransient = false) (hpk : f.packedBits = some pb)
+    (hwidth : pb.width < 256) :
+    fieldPackedExtract s f slot =
+      some (compiledPackedRead
+        (IRStorageWord.ofNat (s.storage slot).val) pb.offset pb.width).toNat := by
+  have hword : (s.storage slot).val < 2 ^ 256 := (s.storage slot).isLt
+  have hwle : pb.width ≤ 256 := Nat.le_of_lt hwidth
+  rw [fieldPackedExtract_eq htr hpk,
+    packedExtract_eq_yulReadPackedWord _ pb.offset pb.width hword hwidth,
+    yulReadPackedWord_eq_compiledExpr _ _ _ hwle]
+
+end Compiler.Proofs.Storage.FieldPackedCompile

--- a/Compiler/Proofs/Storage/FieldStorageKey.lean
+++ b/Compiler/Proofs/Storage/FieldStorageKey.lean
@@ -479,4 +479,20 @@ theorem fieldPackedExtract_writeSlot_same
   rw [fieldPackedExtract_eq htr hpk]
   simp [storage, writeSlot]
 
+/-- Same formula as the Yul packed read (`div` then `mod 2^width`). -/
+theorem packedExtract_eq_mod (word : Nat) (pb : PackedBits)
+    (hwidth : pb.width < 256) :
+    packedExtract word pb = (word / 2 ^ pb.offset) % 2 ^ pb.width := by
+  unfold packedExtract packedMaskNat
+  have : ¬pb.width ≥ 256 := Nat.not_le.mpr hwidth
+  simp [this, Nat.and_two_pow_sub_one_eq_mod]
+
+theorem fieldPackedExtract_eq_mod
+    {s : ContractState} {f : Field} {slot : Nat} {pb : PackedBits}
+    (htr : f.isTransient = false) (hpk : f.packedBits = some pb)
+    (hwidth : pb.width < 256) :
+    fieldPackedExtract s f slot =
+      some ((s.storage slot).val / 2 ^ pb.offset % 2 ^ pb.width) := by
+  rw [fieldPackedExtract_eq htr hpk, packedExtract_eq_mod _ _ hwidth]
+
 end Compiler.Proofs.Storage.FieldStorageKey

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -108,6 +108,7 @@ import Compiler.Proofs.KeccakBound
 import Compiler.Proofs.LoopSimulation
 import Compiler.Proofs.MappingSlot
 import Compiler.Proofs.Storage.FieldEncode
+import Compiler.Proofs.Storage.FieldPackedCompile
 import Compiler.Proofs.Storage.FieldStorageKey
 import Compiler.Proofs.Storage.MappingCoherence
 import Compiler.Proofs.Storage.MappingCoherenceOn
@@ -4663,6 +4664,10 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldRootKey_uint256
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldRootKey_address
 
+  -- Compiler/Proofs/Storage/FieldPackedCompile.lean
+  Compiler.Proofs.Storage.FieldPackedCompile.packedExtract_eq_yulReadPackedWord
+  Compiler.Proofs.Storage.FieldPackedCompile.fieldPackedExtract_eq_compiledPackedRead
+
   -- Compiler/Proofs/Storage/FieldStorageKey.lean
   Compiler.Proofs.Storage.FieldStorageKey.storageKeySlot_fieldRootKey
   Compiler.Proofs.Storage.FieldStorageKey.fieldListRootKey_eq
@@ -4696,6 +4701,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.FieldStorageKey.fieldPackedExtract_eq
   Compiler.Proofs.Storage.FieldStorageKey.fieldPackedExtract_writeSlot_other
   Compiler.Proofs.Storage.FieldStorageKey.fieldPackedExtract_writeSlot_same
+  Compiler.Proofs.Storage.FieldStorageKey.packedExtract_eq_mod
+  Compiler.Proofs.Storage.FieldStorageKey.fieldPackedExtract_eq_mod
 
   -- Compiler/Proofs/Storage/MappingCoherence.lean
   Compiler.Proofs.Storage.MappingCoherence.defaultState_mappingCoherent
@@ -6937,4 +6944,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6435 theorems/lemmas (4565 public, 1870 private, 0 sorry'd)
+-- Total: 6439 theorems/lemmas (4569 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -207,7 +207,8 @@ of the 32-byte word; there is no `StorageKey.mapBytes32`. Mixed
 All nine `MappingType.nested` key-type pairs collapse to
 `abstractNestedMappingSlot`.
 Packed subfields extract from the same `storageKeySlot` word; they
-are not a different slot. `encodeStorageAt` at a persistent unpacked uint256 or address field
+are not a different slot. For `width < 256` that extract is the
+`compiledPackedRead` of the storage word. `encodeStorageAt` at a persistent unpacked uint256 or address field
 is the corresponding lens once `firstFieldWriteSlotConflict` is
 none; `findResolvedFieldAtSlot` is derived, not hypothesized.
 A finite list of address-, uint-, or nested-address pairs

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,13 +42,13 @@ Next: derive the executable shallow program from the deep model
 per-function `_bridge` theorems into one AST-induction theorem
 (`GenericInduction/LegacyCompatibility` and the compile-derived
 legacy-compatibility witness chain are already retired), then finish C5
-step 4 — remaining packed compiler-read composition and global
-(all-keys) `MappingCoherent` preservation.
+step 4 — remaining global (all-keys) `MappingCoherent` preservation.
 Implemented: address/uint/map2 coherence laws, `FieldStorageKey`
 (including address-keyed mappingStruct member slots,
 bytes32-keyed compiler slots, all `MappingType.nested` key-type
-pairs, packed word extract, `findResolvedFieldAtSlot` from a named
-field plus no-conflict, and compatibility `aliasSlots`
+pairs, packed word extract identified with `compiledPackedRead`,
+`findResolvedFieldAtSlot` from a named field plus no-conflict, and
+compatibility `aliasSlots`
 as extra compiler write targets),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot


### PR DESCRIPTION
## Summary
- prove `packedExtract` equals `(word / 2^offset) % 2^width` when `width < 256`
- identify `fieldPackedExtract` with `compiledPackedRead` of the storage word
- C5 step 4 remains incomplete (global all-keys `MappingCoherent`)

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldPackedCompile Compiler.Proofs.Storage.FieldStorageKey`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only storage lemmas and documentation; no runtime, auth, or axiom changes.
> 
> **Overview**
> Closes a C5 step 4 gap by proving that **packed field reads** in the storage model match what the compiler emits.
> 
> New lemmas show `packedExtract` is `(word / 2^offset) % 2^width` when `width < 256`, and **`fieldPackedExtract`** equals **`compiledPackedRead`** on the slot word. A dedicated proof module wires this through `yulReadPackedWord` and existing `SolidityStorage` bridge facts.
> 
> Audit and roadmap text now record this composition as proved; **global (all-keys) `MappingCoherent` preservation** stays open. **`PrintAxioms`** registers four new theorems (6435 → 6439); no new axioms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09cb7ef6dfb5047afa702e36fa4501865309885a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->