### PR TITLE
feat(proofs): named mapping fields vs MappingCoherent

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -332,7 +332,9 @@ sibling entrypoint.
   takes an explicit derived-slot inequality. Packed subfields extract
   from the `storageKeySlot` word (`packedExtract`); compiler packed-read
   composition with SolidityStorage is `fieldPackedExtract_eq_compiledPackedRead`
-  (`width < 256`). Global (all-keys) preservation remains open.
+  (`width < 256`). `FieldCoherence` identifies a named mapping field's
+  `storageKeySlot` with the flat slot `MappingCoherent*` reads.
+  Global (all-keys) preservation remains open.
   `FieldEncode` derives `findResolvedFieldAtSlot` from
   `findFieldWithResolvedSlot` plus no write-slot conflict, persistent,
   and unpacked, then identifies that slot with `encodeStorageAt`. bytes32-keyed

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -37,7 +37,8 @@ slots add `wordOffset` via `mappingSlotLocation`. Compatibility
 bytes32-keyed maps use the same keccak preimage as uint256 keys
 and do not add a `StorageKey` constructor. Remaining `MappingType.nested` pairs likewise add no constructor. Packed extract is a shift and
 mask on that word, not a new axiom. Equality with `compiledPackedRead`
-is a `width < 256` calculation. `FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
+is a `width < 256` calculation. `FieldCoherence` adds no axiom:
+it instantiates `MappingCoherent*` at the named field's derived slot. `FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
 from no write-slot conflict plus constructor facts.
 
 ## Eliminated Axioms

--- a/Compiler/Proofs/Storage/FieldCoherence.lean
+++ b/Compiler/Proofs/Storage/FieldCoherence.lean
@@ -1,0 +1,52 @@
+/-
+  C5 step 4 composition: a named mapping field's `storageKeySlot` is
+  the flat slot `MappingCoherent*` reads. Global preservation is not
+  claimed; the `*Coherent` hypothesis is still pointwise or finite-set.
+-/
+
+import Compiler.Proofs.Storage.FieldStorageKey
+import Compiler.Proofs.Storage.MappingCoherence
+
+namespace Compiler.Proofs.Storage.FieldCoherence
+
+open Verity
+open Verity.ContractState
+open Compiler.CompilationModel
+open Compiler.Proofs.Storage.FieldStorageKey
+open Compiler.Proofs.Storage.MappingCoherence
+open Compiler.Proofs
+
+theorem fieldMapKey_coherent_storageKeySlot
+    {s : ContractState} {f : Field} {slot : Nat} {key : Address}
+    (hcoh : MappingCoherent s)
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.simple .address)) :
+    (fieldMapKey f slot key).bind (fun sk =>
+      (storageKeySlot sk).map (fun n => s.storage n)) =
+      some (s.storageMap slot key) := by
+  simp [fieldMapKey, htr, hty, storageKeySlot]
+  exact (hcoh slot key).symm
+
+theorem fieldMapUintKey_coherent_storageKeySlot
+    {s : ContractState} {f : Field} {slot : Nat} {key : Uint256}
+    (hcoh : MappingCoherentUint s)
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.simple .uint256)) :
+    (fieldMapUintKey f slot key).bind (fun sk =>
+      (storageKeySlot sk).map (fun n => s.storage n)) =
+      some (s.storageMapUint slot key) := by
+  simp [fieldMapUintKey, htr, hty, storageKeySlot]
+  exact (hcoh slot key).symm
+
+theorem fieldMap2Key_coherent_storageKeySlot
+    {s : ContractState} {f : Field} {slot : Nat} {k1 k2 : Address}
+    (hcoh : MappingCoherentMap2 s)
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.nested .address .address)) :
+    (fieldMap2Key f slot k1 k2).bind (fun sk =>
+      (storageKeySlot sk).map (fun n => s.storage n)) =
+      some (s.storageMap2 slot k1 k2) := by
+  simp [fieldMap2Key, htr, hty, storageKeySlot]
+  exact (hcoh slot k1 k2).symm
+
+end Compiler.Proofs.Storage.FieldCoherence

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -107,6 +107,7 @@ import Compiler.Proofs.IRGeneration.SupportedSpec
 import Compiler.Proofs.KeccakBound
 import Compiler.Proofs.LoopSimulation
 import Compiler.Proofs.MappingSlot
+import Compiler.Proofs.Storage.FieldCoherence
 import Compiler.Proofs.Storage.FieldEncode
 import Compiler.Proofs.Storage.FieldPackedCompile
 import Compiler.Proofs.Storage.FieldStorageKey
@@ -4657,6 +4658,11 @@ end Verity.AxiomAudit
   Compiler.Proofs.solidityMappingSlot_add_lt_evmModulus
   Compiler.Proofs.solidityMappingSlot_add_wordOffset_lt_evmModulus
 
+  -- Compiler/Proofs/Storage/FieldCoherence.lean
+  Compiler.Proofs.Storage.FieldCoherence.fieldMapKey_coherent_storageKeySlot
+  Compiler.Proofs.Storage.FieldCoherence.fieldMapUintKey_coherent_storageKeySlot
+  Compiler.Proofs.Storage.FieldCoherence.fieldMap2Key_coherent_storageKeySlot
+
   -- Compiler/Proofs/Storage/FieldEncode.lean
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_of_resolved_uint256
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_of_resolved_address
@@ -6944,4 +6950,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6439 theorems/lemmas (4569 public, 1870 private, 0 sorry'd)
+-- Total: 6442 theorems/lemmas (4572 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -208,7 +208,9 @@ All nine `MappingType.nested` key-type pairs collapse to
 `abstractNestedMappingSlot`.
 Packed subfields extract from the same `storageKeySlot` word; they
 are not a different slot. For `width < 256` that extract is the
-`compiledPackedRead` of the storage word. `encodeStorageAt` at a persistent unpacked uint256 or address field
+`compiledPackedRead` of the storage word. A named mapping field's
+derived `storageKeySlot` is the flat slot `MappingCoherent*`
+compares against. `encodeStorageAt` at a persistent unpacked uint256 or address field
 is the corresponding lens once `firstFieldWriteSlotConflict` is
 none; `findResolvedFieldAtSlot` is derived, not hypothesized.
 A finite list of address-, uint-, or nested-address pairs

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,8 +47,9 @@ Implemented: address/uint/map2 coherence laws, `FieldStorageKey`
 (including address-keyed mappingStruct member slots,
 bytes32-keyed compiler slots, all `MappingType.nested` key-type
 pairs, packed word extract identified with `compiledPackedRead`,
-`findResolvedFieldAtSlot` from a named field plus no-conflict, and
-compatibility `aliasSlots`
+`findResolvedFieldAtSlot` from a named field plus no-conflict,
+named mapping fields vs `MappingCoherent*`, and compatibility
+`aliasSlots`
 as extra compiler write targets),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot


### PR DESCRIPTION
## Summary
- add `FieldCoherence`: `fieldMapKey` / `fieldMapUintKey` / `fieldMap2Key` bind `storageKeySlot` to the flat slot `MappingCoherent*` compares
- global (all-keys) preservation is not claimed
- C5 step 4 remains incomplete

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldCoherence`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only addition with no runtime, compiler, or axiom changes; risk is limited to documentation drift if the lemmas are misstated.
> 
> **Overview**
> Adds **C5 step 4** proof module `Compiler/Proofs/Storage/FieldCoherence.lean` with three lemmas: for address-, uint-, and nested-address mapping fields, binding `fieldMap*` → `storageKeySlot` → `s.storage` agrees with the flat lens (`storageMap` / `storageMapUint` / `storageMap2`) when the corresponding `MappingCoherent*` hypothesis holds.
> 
> Each proof is a short `simp` plus symmetry of the existing coherence law; **no new axioms**. Global all-keys preservation is still explicitly out of scope.
> 
> Registers the module in `PrintAxioms.lean` (+3 theorems) and updates `AUDIT.md`, `AXIOMS.md`, `TRUST_ASSUMPTIONS.md`, and `docs/ROADMAP.md` to document `FieldCoherence`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60fe885b4344a948397f4178cd082d078e72fa3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->