### PR TITLE
feat(proofs): named mapping fields vs MappingCoherentOn

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -333,7 +333,8 @@ sibling entrypoint.
   from the `storageKeySlot` word (`packedExtract`); compiler packed-read
   composition with SolidityStorage is `fieldPackedExtract_eq_compiledPackedRead`
   (`width < 256`). `FieldCoherence` identifies a named mapping field's
-  `storageKeySlot` with the flat slot `MappingCoherent*` reads.
+  `storageKeySlot` with the flat slot `MappingCoherent*` /
+  `MappingCoherentOn*` reads.
   Global (all-keys) preservation remains open.
   `FieldEncode` derives `findResolvedFieldAtSlot` from
   `findFieldWithResolvedSlot` plus no write-slot conflict, persistent,

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -38,7 +38,8 @@ bytes32-keyed maps use the same keccak preimage as uint256 keys
 and do not add a `StorageKey` constructor. Remaining `MappingType.nested` pairs likewise add no constructor. Packed extract is a shift and
 mask on that word, not a new axiom. Equality with `compiledPackedRead`
 is a `width < 256` calculation. `FieldCoherence` adds no axiom:
-it instantiates `MappingCoherent*` at the named field's derived slot. `FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
+it instantiates `MappingCoherent*` / `MappingCoherentOn*` at the
+named field's derived slot. `FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
 from no write-slot conflict plus constructor facts.
 
 ## Eliminated Axioms

--- a/Compiler/Proofs/Storage/FieldCoherence.lean
+++ b/Compiler/Proofs/Storage/FieldCoherence.lean
@@ -6,6 +6,7 @@
 
 import Compiler.Proofs.Storage.FieldStorageKey
 import Compiler.Proofs.Storage.MappingCoherence
+import Compiler.Proofs.Storage.MappingCoherenceOn
 
 namespace Compiler.Proofs.Storage.FieldCoherence
 
@@ -14,6 +15,7 @@ open Verity.ContractState
 open Compiler.CompilationModel
 open Compiler.Proofs.Storage.FieldStorageKey
 open Compiler.Proofs.Storage.MappingCoherence
+open Compiler.Proofs.Storage.MappingCoherenceOn
 open Compiler.Proofs
 
 theorem fieldMapKey_coherent_storageKeySlot
@@ -48,5 +50,44 @@ theorem fieldMap2Key_coherent_storageKeySlot
       some (s.storageMap2 slot k1 k2) := by
   simp [fieldMap2Key, htr, hty, storageKeySlot]
   exact (hcoh slot k1 k2).symm
+
+theorem fieldMapKey_coherentOn_storageKeySlot
+    {s : ContractState} {f : Field} {slot : Nat} {key : Address}
+    {pairs : List (Nat × Address)}
+    (hcoh : MappingCoherentOn s pairs)
+    (hp : (slot, key) ∈ pairs)
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.simple .address)) :
+    (fieldMapKey f slot key).bind (fun sk =>
+      (storageKeySlot sk).map (fun n => s.storage n)) =
+      some (s.storageMap slot key) := by
+  simp [fieldMapKey, htr, hty, storageKeySlot]
+  exact (hcoh (slot, key) hp).symm
+
+theorem fieldMapUintKey_coherentOn_storageKeySlot
+    {s : ContractState} {f : Field} {slot : Nat} {key : Uint256}
+    {pairs : List (Nat × Uint256)}
+    (hcoh : MappingCoherentUintOn s pairs)
+    (hp : (slot, key) ∈ pairs)
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.simple .uint256)) :
+    (fieldMapUintKey f slot key).bind (fun sk =>
+      (storageKeySlot sk).map (fun n => s.storage n)) =
+      some (s.storageMapUint slot key) := by
+  simp [fieldMapUintKey, htr, hty, storageKeySlot]
+  exact (hcoh (slot, key) hp).symm
+
+theorem fieldMap2Key_coherentOn_storageKeySlot
+    {s : ContractState} {f : Field} {slot : Nat} {k1 k2 : Address}
+    {pairs : List (Nat × Address × Address)}
+    (hcoh : MappingCoherentMap2On s pairs)
+    (hp : (slot, k1, k2) ∈ pairs)
+    (htr : f.isTransient = false)
+    (hty : f.ty = .mappingTyped (.nested .address .address)) :
+    (fieldMap2Key f slot k1 k2).bind (fun sk =>
+      (storageKeySlot sk).map (fun n => s.storage n)) =
+      some (s.storageMap2 slot k1 k2) := by
+  simp [fieldMap2Key, htr, hty, storageKeySlot]
+  exact (hcoh (slot, k1, k2) hp).symm
 
 end Compiler.Proofs.Storage.FieldCoherence

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4662,6 +4662,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.FieldCoherence.fieldMapKey_coherent_storageKeySlot
   Compiler.Proofs.Storage.FieldCoherence.fieldMapUintKey_coherent_storageKeySlot
   Compiler.Proofs.Storage.FieldCoherence.fieldMap2Key_coherent_storageKeySlot
+  Compiler.Proofs.Storage.FieldCoherence.fieldMapKey_coherentOn_storageKeySlot
+  Compiler.Proofs.Storage.FieldCoherence.fieldMapUintKey_coherentOn_storageKeySlot
+  Compiler.Proofs.Storage.FieldCoherence.fieldMap2Key_coherentOn_storageKeySlot
 
   -- Compiler/Proofs/Storage/FieldEncode.lean
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_of_resolved_uint256
@@ -6950,4 +6953,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6442 theorems/lemmas (4572 public, 1870 private, 0 sorry'd)
+-- Total: 6445 theorems/lemmas (4575 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -210,7 +210,8 @@ Packed subfields extract from the same `storageKeySlot` word; they
 are not a different slot. For `width < 256` that extract is the
 `compiledPackedRead` of the storage word. A named mapping field's
 derived `storageKeySlot` is the flat slot `MappingCoherent*`
-compares against. `encodeStorageAt` at a persistent unpacked uint256 or address field
+compares against, including a finite listed pair
+(`MappingCoherentOn`). `encodeStorageAt` at a persistent unpacked uint256 or address field
 is the corresponding lens once `firstFieldWriteSlotConflict` is
 none; `findResolvedFieldAtSlot` is derived, not hypothesized.
 A finite list of address-, uint-, or nested-address pairs

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -48,8 +48,8 @@ Implemented: address/uint/map2 coherence laws, `FieldStorageKey`
 bytes32-keyed compiler slots, all `MappingType.nested` key-type
 pairs, packed word extract identified with `compiledPackedRead`,
 `findResolvedFieldAtSlot` from a named field plus no-conflict,
-named mapping fields vs `MappingCoherent*`, and compatibility
-`aliasSlots`
+named mapping fields vs `MappingCoherent*` / `MappingCoherentOn*`,
+and compatibility `aliasSlots`
 as extra compiler write targets),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot


### PR DESCRIPTION
## Summary
- extend `FieldCoherence` so a pair listed in `MappingCoherentOn` / `UintOn` / `Map2On` agrees at the named field's `storageKeySlot`
- global (all-keys) preservation is not claimed
- C5 step 4 remains incomplete

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldCoherence`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions that compose existing `MappingCoherentOn*` facts with `FieldStorageKey`; no runtime, auth, or compiler behavior changes.
> 
> **Overview**
> **C5 step 4** gains parallel **finite-set** composition lemmas in `FieldCoherence`: for address, `uint256`, and nested address–address mapping fields, resolving `fieldMap*Key` through `storageKeySlot` reads the same value as the legacy `storageMap*` lens when the pair is in the listed hypothesis (`MappingCoherentOn` / `MappingCoherentUintOn` / `MappingCoherentMap2On`), mirroring the existing global `MappingCoherent*` theorems.
> 
> `MappingCoherenceOn` is imported; audit/trust/roadmap copy and `PrintAxioms.lean` now list the three new theorems (**6445** public lemmas, **no new axioms**). Global all-keys preservation remains out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61da9cdf2495befbd22190554b79f6d7693531a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->