### PR TITLE
feat(proofs): encodeStorageAt on unoccupied mapping slots

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -338,7 +338,9 @@ sibling entrypoint.
   Global (all-keys) preservation remains open.
   `FieldEncode` derives `findResolvedFieldAtSlot` from
   `findFieldWithResolvedSlot` plus no write-slot conflict, persistent,
-  and unpacked, then identifies that slot with `encodeStorageAt`. bytes32-keyed
+  and unpacked, then identifies that slot with `encodeStorageAt`.
+  An unoccupied mapping-derived slot encodes as the `MappingCoherent*`
+  shadow. bytes32-keyed
   maps collapse to `solidityMappingSlot` of the 32-byte word (no
   `StorageKey.mapBytes32`). All nine `MappingType.nested` key-type
   pairs collapse to `abstractNestedMappingSlot`.

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -39,7 +39,9 @@ and do not add a `StorageKey` constructor. Remaining `MappingType.nested` pairs 
 mask on that word, not a new axiom. Equality with `compiledPackedRead`
 is a `width < 256` calculation. `FieldCoherence` adds no axiom:
 it instantiates `MappingCoherent*` / `MappingCoherentOn*` at the
-named field's derived slot. `FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
+named field's derived slot. `encodeStorageAt` on an unoccupied
+mapping slot is the same shadow, still under an explicit
+non-occupation hypothesis. `FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
 from no write-slot conflict plus constructor facts.
 
 ## Eliminated Axioms

--- a/Compiler/Proofs/Storage/FieldEncode.lean
+++ b/Compiler/Proofs/Storage/FieldEncode.lean
@@ -6,6 +6,7 @@
 -/
 
 import Compiler.Proofs.Storage.FieldStorageKey
+import Compiler.Proofs.Storage.MappingCoherence
 import Compiler.Proofs.IRGeneration.SourceSemantics
 import Compiler.Proofs.IRGeneration.GenericInduction.Storage
 import Compiler.CompilationModel.LayoutValidation
@@ -17,6 +18,7 @@ open Verity.ContractState
 open Compiler.CompilationModel
 open Compiler.Proofs.Storage.FieldStorageKey
 open Compiler.Proofs.Storage.MappingCoherence
+open Compiler.Proofs
 open Compiler.Proofs.IRGeneration
 open Compiler.Proofs.IRGeneration.SourceSemantics
 
@@ -80,5 +82,39 @@ theorem encodeStorageAt_fieldRootKey_address
     by rw [storageKeySlot_fieldRootKey, htr]; rfl,
     encodeStorageAt_of_resolved_address
       (findResolvedFieldAtSlot_of_fieldRoot hnoConflict hfind htr hunpacked) hty⟩
+
+/-- A slot that is not a named field and not a dynamic-array element
+    is the flat `storage` word. Mapping-derived keccak slots usually
+    look like this. -/
+theorem encodeStorageAt_of_unresolved
+    {fields : List Field} {world : ContractState} {slot : Nat}
+    (hresolved : findResolvedFieldAtSlot fields slot = none)
+    (hdyn : findDynamicArrayElementAtSlot fields world slot = none) :
+    encodeStorageAt fields world slot = (world.storage slot).val := by
+  simp [encodeStorageAt, hresolved, hdyn]
+
+theorem encodeStorageAt_fieldMapKey
+    {fields : List Field} {s : ContractState} {slot : Nat} {key : Address}
+    (hcoh : MappingCoherent s)
+    (hresolved :
+      findResolvedFieldAtSlot fields
+        (solidityMappingSlot slot (addressToWord key).val) = none)
+    (hdyn :
+      findDynamicArrayElementAtSlot fields s
+        (solidityMappingSlot slot (addressToWord key).val) = none) :
+    encodeStorageAt fields s (solidityMappingSlot slot (addressToWord key).val) =
+      (s.storageMap slot key).val := by
+  rw [encodeStorageAt_of_unresolved hresolved hdyn, hcoh slot key]
+
+theorem encodeStorageAt_fieldMapUintKey
+    {fields : List Field} {s : ContractState} {slot : Nat} {key : Uint256}
+    (hcoh : MappingCoherentUint s)
+    (hresolved :
+      findResolvedFieldAtSlot fields (solidityMappingSlot slot key.val) = none)
+    (hdyn :
+      findDynamicArrayElementAtSlot fields s (solidityMappingSlot slot key.val) = none) :
+    encodeStorageAt fields s (solidityMappingSlot slot key.val) =
+      (s.storageMapUint slot key).val := by
+  rw [encodeStorageAt_of_unresolved hresolved hdyn, hcoh slot key]
 
 end Compiler.Proofs.Storage.FieldEncode

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4672,6 +4672,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.FieldEncode.findResolvedFieldAtSlot_of_fieldRoot
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldRootKey_uint256
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldRootKey_address
+  Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_of_unresolved
+  Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldMapKey
+  Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldMapUintKey
 
   -- Compiler/Proofs/Storage/FieldPackedCompile.lean
   Compiler.Proofs.Storage.FieldPackedCompile.packedExtract_eq_yulReadPackedWord
@@ -6953,4 +6956,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6445 theorems/lemmas (4575 public, 1870 private, 0 sorry'd)
+-- Total: 6448 theorems/lemmas (4578 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -211,7 +211,8 @@ are not a different slot. For `width < 256` that extract is the
 `compiledPackedRead` of the storage word. A named mapping field's
 derived `storageKeySlot` is the flat slot `MappingCoherent*`
 compares against, including a finite listed pair
-(`MappingCoherentOn`). `encodeStorageAt` at a persistent unpacked uint256 or address field
+(`MappingCoherentOn`). An unoccupied keccak-derived mapping slot
+encodes as that shadow via `encodeStorageAt`. `encodeStorageAt` at a persistent unpacked uint256 or address field
 is the corresponding lens once `firstFieldWriteSlotConflict` is
 none; `findResolvedFieldAtSlot` is derived, not hypothesized.
 A finite list of address-, uint-, or nested-address pairs

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,7 +49,8 @@ bytes32-keyed compiler slots, all `MappingType.nested` key-type
 pairs, packed word extract identified with `compiledPackedRead`,
 `findResolvedFieldAtSlot` from a named field plus no-conflict,
 named mapping fields vs `MappingCoherent*` / `MappingCoherentOn*`,
-and compatibility `aliasSlots`
+`encodeStorageAt` on unoccupied mapping-derived slots, and
+compatibility `aliasSlots`
 as extra compiler write targets),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot


### PR DESCRIPTION
## Summary
- add `encodeStorageAt_of_unresolved` (no named field, no dynamic-array element)
- add `encodeStorageAt_fieldMapKey` / `encodeStorageAt_fieldMapUintKey`: unoccupied derived slot encodes as the `MappingCoherent*` shadow
- C5 step 4 remains incomplete (global preservation)

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldEncode`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only lemmas and documentation; no runtime, auth, or axiom changes. Global `MappingCoherent` preservation remains explicitly out of scope.
> 
> **Overview**
> Extends **C5 step 4** `FieldEncode` so compiler `encodeStorageAt` matches mapping shadows on keccak-derived slots that are not named fields or dynamic-array elements.
> 
> New lemmas: `encodeStorageAt_of_unresolved` (flat `storage` word), plus `encodeStorageAt_fieldMapKey` / `encodeStorageAt_fieldMapUintKey` (rewrite through `MappingCoherent*` when occupation hypotheses hold). `MappingCoherence` is imported for the composition seam.
> 
> **AUDIT**, **AXIOMS**, **TRUST_ASSUMPTIONS**, and **ROADMAP** document that unoccupied mapping slots encode like the coherence shadow with **no new axioms**. **PrintAxioms** registers the three theorems (+3 public count).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13bfebeaa6e18b273a7ceaa441daa3e1fa721915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->