### PR TITLE
feat(proofs): encodeStorageAt on unoccupied map2 slots

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -339,8 +339,8 @@ sibling entrypoint.
   `FieldEncode` derives `findResolvedFieldAtSlot` from
   `findFieldWithResolvedSlot` plus no write-slot conflict, persistent,
   and unpacked, then identifies that slot with `encodeStorageAt`.
-  An unoccupied mapping-derived slot encodes as the `MappingCoherent*`
-  shadow. bytes32-keyed
+  An unoccupied mapping-derived slot (address, uint, or map2) encodes
+  as the `MappingCoherent*` shadow. bytes32-keyed
   maps collapse to `solidityMappingSlot` of the 32-byte word (no
   `StorageKey.mapBytes32`). All nine `MappingType.nested` key-type
   pairs collapse to `abstractNestedMappingSlot`.

--- a/Compiler/Proofs/Storage/FieldEncode.lean
+++ b/Compiler/Proofs/Storage/FieldEncode.lean
@@ -117,4 +117,18 @@ theorem encodeStorageAt_fieldMapUintKey
       (s.storageMapUint slot key).val := by
   rw [encodeStorageAt_of_unresolved hresolved hdyn, hcoh slot key]
 
+theorem encodeStorageAt_fieldMap2Key
+    {fields : List Field} {s : ContractState} {slot : Nat} {k1 k2 : Address}
+    (hcoh : MappingCoherentMap2 s)
+    (hresolved :
+      findResolvedFieldAtSlot fields
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) = none)
+    (hdyn :
+      findDynamicArrayElementAtSlot fields s
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) = none) :
+    encodeStorageAt fields s
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) =
+      (s.storageMap2 slot k1 k2).val := by
+  rw [encodeStorageAt_of_unresolved hresolved hdyn, hcoh slot k1 k2]
+
 end Compiler.Proofs.Storage.FieldEncode

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4675,6 +4675,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_of_unresolved
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldMapKey
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldMapUintKey
+  Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldMap2Key
 
   -- Compiler/Proofs/Storage/FieldPackedCompile.lean
   Compiler.Proofs.Storage.FieldPackedCompile.packedExtract_eq_yulReadPackedWord
@@ -6956,4 +6957,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6448 theorems/lemmas (4578 public, 1870 private, 0 sorry'd)
+-- Total: 6449 theorems/lemmas (4579 public, 1870 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- add `encodeStorageAt_fieldMap2Key` for unoccupied `abstractNestedMappingSlot`
- C5 step 4 remains incomplete

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldEncode`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only addition with no compiler or runtime behavior changes; follows the established `FieldEncode` pattern and adds no axioms.
> 
> **Overview**
> Extends **C5 step 4** `FieldEncode` with **`encodeStorageAt_fieldMap2Key`**, matching the existing address- and uint-key mapping lemmas: when a nested **`abstractNestedMappingSlot`** is not a resolved field or dynamic-array element, **`encodeStorageAt`** reads **`storageMap2`** under **`MappingCoherentMap2`**.
> 
> **`AUDIT.md`** now states that unoccupied mapping-derived slots cover address, uint, and map2 shadows. **`PrintAxioms.lean`** registers the new theorem (6449 total; still 0 sorry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 483fb9418a3ef2d48d896c2a7d8bd03fcc201237. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->