### PR TITLE
feat(proofs): encodeStorageAt on listed MappingCoherentOn pairs

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -340,7 +340,7 @@ sibling entrypoint.
   `findFieldWithResolvedSlot` plus no write-slot conflict, persistent,
   and unpacked, then identifies that slot with `encodeStorageAt`.
   An unoccupied mapping-derived slot (address, uint, or map2) encodes
-  as the `MappingCoherent*` shadow. bytes32-keyed
+  as the `MappingCoherent*` / `MappingCoherentOn*` shadow. bytes32-keyed
   maps collapse to `solidityMappingSlot` of the 32-byte word (no
   `StorageKey.mapBytes32`). All nine `MappingType.nested` key-type
   pairs collapse to `abstractNestedMappingSlot`.

--- a/Compiler/Proofs/Storage/FieldEncode.lean
+++ b/Compiler/Proofs/Storage/FieldEncode.lean
@@ -7,6 +7,7 @@
 
 import Compiler.Proofs.Storage.FieldStorageKey
 import Compiler.Proofs.Storage.MappingCoherence
+import Compiler.Proofs.Storage.MappingCoherenceOn
 import Compiler.Proofs.IRGeneration.SourceSemantics
 import Compiler.Proofs.IRGeneration.GenericInduction.Storage
 import Compiler.CompilationModel.LayoutValidation
@@ -18,6 +19,7 @@ open Verity.ContractState
 open Compiler.CompilationModel
 open Compiler.Proofs.Storage.FieldStorageKey
 open Compiler.Proofs.Storage.MappingCoherence
+open Compiler.Proofs.Storage.MappingCoherenceOn
 open Compiler.Proofs
 open Compiler.Proofs.IRGeneration
 open Compiler.Proofs.IRGeneration.SourceSemantics
@@ -130,5 +132,52 @@ theorem encodeStorageAt_fieldMap2Key
         (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) =
       (s.storageMap2 slot k1 k2).val := by
   rw [encodeStorageAt_of_unresolved hresolved hdyn, hcoh slot k1 k2]
+
+theorem encodeStorageAt_fieldMapKey_on
+    {fields : List Field} {s : ContractState} {slot : Nat} {key : Address}
+    {pairs : List (Nat × Address)}
+    (hcoh : MappingCoherentOn s pairs)
+    (hp : (slot, key) ∈ pairs)
+    (hresolved :
+      findResolvedFieldAtSlot fields
+        (solidityMappingSlot slot (addressToWord key).val) = none)
+    (hdyn :
+      findDynamicArrayElementAtSlot fields s
+        (solidityMappingSlot slot (addressToWord key).val) = none) :
+    encodeStorageAt fields s (solidityMappingSlot slot (addressToWord key).val) =
+      (s.storageMap slot key).val := by
+  rw [encodeStorageAt_of_unresolved hresolved hdyn, hcoh (slot, key) hp]
+  rfl
+
+theorem encodeStorageAt_fieldMapUintKey_on
+    {fields : List Field} {s : ContractState} {slot : Nat} {key : Uint256}
+    {pairs : List (Nat × Uint256)}
+    (hcoh : MappingCoherentUintOn s pairs)
+    (hp : (slot, key) ∈ pairs)
+    (hresolved :
+      findResolvedFieldAtSlot fields (solidityMappingSlot slot key.val) = none)
+    (hdyn :
+      findDynamicArrayElementAtSlot fields s (solidityMappingSlot slot key.val) = none) :
+    encodeStorageAt fields s (solidityMappingSlot slot key.val) =
+      (s.storageMapUint slot key).val := by
+  rw [encodeStorageAt_of_unresolved hresolved hdyn, hcoh (slot, key) hp]
+  rfl
+
+theorem encodeStorageAt_fieldMap2Key_on
+    {fields : List Field} {s : ContractState} {slot : Nat} {k1 k2 : Address}
+    {pairs : List (Nat × Address × Address)}
+    (hcoh : MappingCoherentMap2On s pairs)
+    (hp : (slot, k1, k2) ∈ pairs)
+    (hresolved :
+      findResolvedFieldAtSlot fields
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) = none)
+    (hdyn :
+      findDynamicArrayElementAtSlot fields s
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) = none) :
+    encodeStorageAt fields s
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) =
+      (s.storageMap2 slot k1 k2).val := by
+  rw [encodeStorageAt_of_unresolved hresolved hdyn, hcoh (slot, k1, k2) hp]
+  rfl
 
 end Compiler.Proofs.Storage.FieldEncode

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4676,6 +4676,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldMapKey
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldMapUintKey
   Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldMap2Key
+  Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldMapKey_on
+  Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldMapUintKey_on
+  Compiler.Proofs.Storage.FieldEncode.encodeStorageAt_fieldMap2Key_on
 
   -- Compiler/Proofs/Storage/FieldPackedCompile.lean
   Compiler.Proofs.Storage.FieldPackedCompile.packedExtract_eq_yulReadPackedWord
@@ -6957,4 +6960,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6449 theorems/lemmas (4579 public, 1870 private, 0 sorry'd)
+-- Total: 6452 theorems/lemmas (4582 public, 1870 private, 0 sorry'd)


### PR DESCRIPTION
## Summary
- add `encodeStorageAt_fieldMapKey_on` / `_uint` / `_map2` for pairs listed in `MappingCoherentOn*`
- occupation is still an explicit `none` hypothesis
- C5 step 4 remains incomplete

## Test Plan
- `lake build Compiler.Proofs.Storage.FieldEncode`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in storage encoding lemmas; no compiler or runtime behavior changes.
> 
> **Overview**
> Extends **C5 step 4** `FieldEncode` so `encodeStorageAt` on mapping-derived slots can be discharged from **finite** mapping coherence (`MappingCoherentOn` / `MappingCoherentUintOn` / `MappingCoherentMap2On`) for explicitly listed `(slot, key)` pairs, not only from global `MappingCoherent*`.
> 
> Adds `encodeStorageAt_fieldMapKey_on`, `encodeStorageAt_fieldMapUintKey_on`, and `encodeStorageAt_fieldMap2Key_on` (import `MappingCoherenceOn`, same `encodeStorageAt_of_unresolved` + occupation `none` hypotheses as the global lemmas). **AUDIT.md** and **PrintAxioms.lean** register the three public theorems (+3 total count). C5 step 4 remains incomplete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cfbab4567f3803a19decc043e864e733a3b1719. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->