### PR TITLE
feat(proofs): writeSlot preserves finite MappingCoherentOn

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -335,7 +335,9 @@ sibling entrypoint.
   (`width < 256`). `FieldCoherence` identifies a named mapping field's
   `storageKeySlot` with the flat slot `MappingCoherent*` /
   `MappingCoherentOn*` reads.
-  Global (all-keys) preservation remains open.
+  A lone `writeSlot` preserves a finite `*On` list under an explicit
+  listed-vs-written slot inequality. Global (all-keys) preservation
+  remains open.
   `FieldEncode` derives `findResolvedFieldAtSlot` from
   `findFieldWithResolvedSlot` plus no write-slot conflict, persistent,
   and unpacked, then identifies that slot with `encodeStorageAt`.

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -41,7 +41,8 @@ is a `width < 256` calculation. `FieldCoherence` adds no axiom:
 it instantiates `MappingCoherent*` / `MappingCoherentOn*` at the
 named field's derived slot. `encodeStorageAt` on an unoccupied
 mapping slot is the same shadow, still under an explicit
-non-occupation hypothesis. `FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
+non-occupation hypothesis. Lone `writeSlot` preservation of a
+finite list is the same explicit slot inequality. `FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
 from no write-slot conflict plus constructor facts.
 
 ## Eliminated Axioms

--- a/Compiler/Proofs/Storage/MappingCoherenceOn.lean
+++ b/Compiler/Proofs/Storage/MappingCoherenceOn.lean
@@ -353,4 +353,52 @@ theorem writeMap2_aligned_preserves_uintOn
     rw [storage_writeSlot_other (s := s.writeMap2 slot k1 k2 v) (hna p hp) v, storage_writeMap2]
   exact (hmap.trans (hcoh p hp)).trans hflat.symm
 
+/-- A lone flat `writeSlot` preserves a finite address-map list when every
+    listed derived slot is distinct from the written word. Not keccak
+    injectivity and not global preservation. -/
+theorem writeSlot_preserves_mappingCoherentOn
+    (s : ContractState) (pairs : List (Nat × Address)) (n : Nat) (v : Uint256)
+    (hcoh : MappingCoherentOn s pairs)
+    (hna : ∀ p ∈ pairs, mappingAddrSlot p.1 p.2 ≠ n) :
+    MappingCoherentOn (s.writeSlot n v) pairs := by
+  intro p hp
+  have hmap :
+      (s.writeSlot n v).storageMap p.1 p.2 = s.storageMap p.1 p.2 := by
+    simp [storageMap, writeSlot]
+  have hflat :
+      (s.writeSlot n v).storage (mappingAddrSlot p.1 p.2) =
+        s.storage (mappingAddrSlot p.1 p.2) :=
+    storage_writeSlot_other (s := s) (hna p hp) v
+  exact (hmap.trans (hcoh p hp)).trans hflat.symm
+
+theorem writeSlot_preserves_mappingCoherentUintOn
+    (s : ContractState) (pairs : List (Nat × Uint256)) (n : Nat) (v : Uint256)
+    (hcoh : MappingCoherentUintOn s pairs)
+    (hna : ∀ p ∈ pairs, mappingUintSlot p.1 p.2 ≠ n) :
+    MappingCoherentUintOn (s.writeSlot n v) pairs := by
+  intro p hp
+  have hmap :
+      (s.writeSlot n v).storageMapUint p.1 p.2 = s.storageMapUint p.1 p.2 := by
+    simp [storageMapUint, writeSlot]
+  have hflat :
+      (s.writeSlot n v).storage (mappingUintSlot p.1 p.2) =
+        s.storage (mappingUintSlot p.1 p.2) :=
+    storage_writeSlot_other (s := s) (hna p hp) v
+  exact (hmap.trans (hcoh p hp)).trans hflat.symm
+
+theorem writeSlot_preserves_mappingCoherentMap2On
+    (s : ContractState) (pairs : List (Nat × Address × Address)) (n : Nat) (v : Uint256)
+    (hcoh : MappingCoherentMap2On s pairs)
+    (hna : ∀ p ∈ pairs, mappingMap2Slot p.1 p.2.1 p.2.2 ≠ n) :
+    MappingCoherentMap2On (s.writeSlot n v) pairs := by
+  intro p hp
+  have hmap :
+      (s.writeSlot n v).storageMap2 p.1 p.2.1 p.2.2 = s.storageMap2 p.1 p.2.1 p.2.2 := by
+    simp [storageMap2, writeSlot]
+  have hflat :
+      (s.writeSlot n v).storage (mappingMap2Slot p.1 p.2.1 p.2.2) =
+        s.storage (mappingMap2Slot p.1 p.2.1 p.2.2) :=
+    storage_writeSlot_other (s := s) (hna p hp) v
+  exact (hmap.trans (hcoh p hp)).trans hflat.symm
+
 end Compiler.Proofs.Storage.MappingCoherenceOn

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4764,6 +4764,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.MappingCoherenceOn.writeMapUint_aligned_preserves_map2On
   Compiler.Proofs.Storage.MappingCoherenceOn.writeMap2_aligned_preserves_addrOn
   Compiler.Proofs.Storage.MappingCoherenceOn.writeMap2_aligned_preserves_uintOn
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeSlot_preserves_mappingCoherentOn
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeSlot_preserves_mappingCoherentUintOn
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeSlot_preserves_mappingCoherentMap2On
 
   -- Compiler/Proofs/Storage/SolidityStorage.lean
   Compiler.Proofs.Storage.mappingSlot_preimage
@@ -6960,4 +6963,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6452 theorems/lemmas (4582 public, 1870 private, 0 sorry'd)
+-- Total: 6455 theorems/lemmas (4585 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -212,7 +212,9 @@ are not a different slot. For `width < 256` that extract is the
 derived `storageKeySlot` is the flat slot `MappingCoherent*`
 compares against, including a finite listed pair
 (`MappingCoherentOn`). An unoccupied keccak-derived mapping slot
-encodes as that shadow via `encodeStorageAt`. `encodeStorageAt` at a persistent unpacked uint256 or address field
+encodes as that shadow via `encodeStorageAt`. A lone flat
+`writeSlot` keeps a listed pair coherent when the written word
+is distinct from that pair's derived slot. `encodeStorageAt` at a persistent unpacked uint256 or address field
 is the corresponding lens once `firstFieldWriteSlotConflict` is
 none; `findResolvedFieldAtSlot` is derived, not hypothesized.
 A finite list of address-, uint-, or nested-address pairs

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -54,7 +54,8 @@ compatibility `aliasSlots`
 as extra compiler write targets),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot
-certificates, including cross-channel aligned-write preservation. C5 step 3 (canonical
+certificates, including cross-channel aligned-write and lone
+`writeSlot` preservation. C5 step 3 (canonical
 `storageWords : StorageKey → Uint256` backing, lens laws by constructor
 injectivity) is on `main`; it is the enabler for FixedArray-under-mapping,
 dynamic CodeData, arbitrary transient storage and multicall/delegatecall


### PR DESCRIPTION
## Summary
- add `writeSlot_preserves_mappingCoherentOn` / `UintOn` / `Map2On`
- each takes an explicit listed-vs-written derived-slot inequality
- not global preservation; keccak injectivity is not assumed
- C5 step 4 remains incomplete

## Test Plan
- `lake build Compiler.Proofs.Storage.MappingCoherenceOn`
- `make check`

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only extension of existing mapping-coherence lemmas and documentation; no runtime, compiler, or trust-boundary changes beyond registering new theorems.
> 
> **Overview**
> Adds three Lean theorems in `MappingCoherenceOn.lean` showing a **standalone** `writeSlot` keeps finite `MappingCoherentOn` / `MappingCoherentUintOn` / `MappingCoherentMap2On` lists when every listed pair’s derived slot differs from the written index `n`. The proofs reuse the same map-channel `simp` plus `storage_writeSlot_other` pattern as the existing aligned `writeMap`+`writeSlot` preservation lemmas.
> 
> This is an explicit **listed-vs-written** slot inequality only—not global all-keys coherence and not keccak injectivity. C5 step 4 is still incomplete.
> 
> `PrintAxioms.lean` registers the new public theorems (6452 → 6455 lemmas). `AUDIT.md`, `AXIOMS.md`, `TRUST_ASSUMPTIONS.md`, and `docs/ROADMAP.md` document the lone-`writeSlot` slice with zero new axioms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2971c96af20b709f4a8dadf7124141c4f55a8bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->