### PR TITLE
feat(proofs): writeTransient preserves finite MappingCoherentOn

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -336,8 +336,10 @@ sibling entrypoint.
   `storageKeySlot` with the flat slot `MappingCoherent*` /
   `MappingCoherentOn*` reads.
   A lone `writeSlot` preserves a finite `*On` list under an explicit
-  listed-vs-written slot inequality. Global (all-keys) preservation
-  remains open.
+  listed-vs-written slot inequality. A lone `writeTransient` preserves
+  the same lists by constructor injectivity (`StorageKey.transient`
+  vs persistent `.slot` / `.map` / `.mapUint` / `.map2`); no slot
+  inequality. Global (all-keys) preservation remains open.
   `FieldEncode` derives `findResolvedFieldAtSlot` from
   `findFieldWithResolvedSlot` plus no write-slot conflict, persistent,
   and unpacked, then identifies that slot with `encodeStorageAt`.

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -42,7 +42,10 @@ it instantiates `MappingCoherent*` / `MappingCoherentOn*` at the
 named field's derived slot. `encodeStorageAt` on an unoccupied
 mapping slot is the same shadow, still under an explicit
 non-occupation hypothesis. Lone `writeSlot` preservation of a
-finite list is the same explicit slot inequality. `FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
+finite list is the same explicit slot inequality. Lone
+`writeTransient` preservation adds no axiom: constructor
+injectivity separates transient from persistent keys.
+`FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
 from no write-slot conflict plus constructor facts.
 
 ## Eliminated Axioms

--- a/Compiler/Proofs/Storage/MappingCoherenceOn.lean
+++ b/Compiler/Proofs/Storage/MappingCoherenceOn.lean
@@ -8,6 +8,10 @@
   under an explicit derived-slot inequality between the written slot
   and every listed pair.
 
+  A lone `writeTransient` preserves every finite `*On` list by
+  constructor injectivity (`StorageKey.transient` vs persistent
+  `.slot` / `.map` / `.mapUint` / `.map2`). No slot inequality.
+
   This is not global preservation. A certificate for every pair would
   be keccak injectivity on an unbounded preimage set.
 -/
@@ -399,6 +403,53 @@ theorem writeSlot_preserves_mappingCoherentMap2On
       (s.writeSlot n v).storage (mappingMap2Slot p.1 p.2.1 p.2.2) =
         s.storage (mappingMap2Slot p.1 p.2.1 p.2.2) :=
     storage_writeSlot_other (s := s) (hna p hp) v
+  exact (hmap.trans (hcoh p hp)).trans hflat.symm
+
+/-- Transient writes leave persistent mapping views and flat word
+    slots unchanged. Constructor injectivity of `StorageKey.transient`
+    vs `.slot` / `.map` / `.mapUint` / `.map2`; no slot inequality
+    and not keccak injectivity. -/
+theorem writeTransient_preserves_mappingCoherentOn
+    (s : ContractState) (pairs : List (Nat × Address)) (n : Nat) (v : Uint256)
+    (hcoh : MappingCoherentOn s pairs) :
+    MappingCoherentOn (s.writeTransient n v) pairs := by
+  intro p hp
+  have hmap :
+      (s.writeTransient n v).storageMap p.1 p.2 = s.storageMap p.1 p.2 := by
+    simp [storageMap, writeTransient]
+  have hflat :
+      (s.writeTransient n v).storage (mappingAddrSlot p.1 p.2) =
+        s.storage (mappingAddrSlot p.1 p.2) := by
+    simp [storage, writeTransient]
+  exact (hmap.trans (hcoh p hp)).trans hflat.symm
+
+theorem writeTransient_preserves_mappingCoherentUintOn
+    (s : ContractState) (pairs : List (Nat × Uint256)) (n : Nat) (v : Uint256)
+    (hcoh : MappingCoherentUintOn s pairs) :
+    MappingCoherentUintOn (s.writeTransient n v) pairs := by
+  intro p hp
+  have hmap :
+      (s.writeTransient n v).storageMapUint p.1 p.2 = s.storageMapUint p.1 p.2 := by
+    simp [storageMapUint, writeTransient]
+  have hflat :
+      (s.writeTransient n v).storage (mappingUintSlot p.1 p.2) =
+        s.storage (mappingUintSlot p.1 p.2) := by
+    simp [storage, writeTransient]
+  exact (hmap.trans (hcoh p hp)).trans hflat.symm
+
+theorem writeTransient_preserves_mappingCoherentMap2On
+    (s : ContractState) (pairs : List (Nat × Address × Address)) (n : Nat) (v : Uint256)
+    (hcoh : MappingCoherentMap2On s pairs) :
+    MappingCoherentMap2On (s.writeTransient n v) pairs := by
+  intro p hp
+  have hmap :
+      (s.writeTransient n v).storageMap2 p.1 p.2.1 p.2.2 =
+        s.storageMap2 p.1 p.2.1 p.2.2 := by
+    simp [storageMap2, writeTransient]
+  have hflat :
+      (s.writeTransient n v).storage (mappingMap2Slot p.1 p.2.1 p.2.2) =
+        s.storage (mappingMap2Slot p.1 p.2.1 p.2.2) := by
+    simp [storage, writeTransient]
   exact (hmap.trans (hcoh p hp)).trans hflat.symm
 
 end Compiler.Proofs.Storage.MappingCoherenceOn

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4767,6 +4767,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.MappingCoherenceOn.writeSlot_preserves_mappingCoherentOn
   Compiler.Proofs.Storage.MappingCoherenceOn.writeSlot_preserves_mappingCoherentUintOn
   Compiler.Proofs.Storage.MappingCoherenceOn.writeSlot_preserves_mappingCoherentMap2On
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeTransient_preserves_mappingCoherentOn
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeTransient_preserves_mappingCoherentUintOn
+  Compiler.Proofs.Storage.MappingCoherenceOn.writeTransient_preserves_mappingCoherentMap2On
 
   -- Compiler/Proofs/Storage/SolidityStorage.lean
   Compiler.Proofs.Storage.mappingSlot_preimage
@@ -6963,4 +6966,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6455 theorems/lemmas (4585 public, 1870 private, 0 sorry'd)
+-- Total: 6458 theorems/lemmas (4588 public, 1870 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -214,7 +214,9 @@ compares against, including a finite listed pair
 (`MappingCoherentOn`). An unoccupied keccak-derived mapping slot
 encodes as that shadow via `encodeStorageAt`. A lone flat
 `writeSlot` keeps a listed pair coherent when the written word
-is distinct from that pair's derived slot. `encodeStorageAt` at a persistent unpacked uint256 or address field
+is distinct from that pair's derived slot. A lone
+`writeTransient` keeps every listed pair coherent because
+transient keys are a different `StorageKey` constructor. `encodeStorageAt` at a persistent unpacked uint256 or address field
 is the corresponding lens once `firstFieldWriteSlotConflict` is
 none; `findResolvedFieldAtSlot` is derived, not hypothesized.
 A finite list of address-, uint-, or nested-address pairs

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -54,8 +54,8 @@ compatibility `aliasSlots`
 as extra compiler write targets),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot
-certificates, including cross-channel aligned-write and lone
-`writeSlot` preservation. C5 step 3 (canonical
+certificates, including cross-channel aligned-write, lone
+`writeSlot`, and lone `writeTransient` preservation. C5 step 3 (canonical
 `storageWords : StorageKey → Uint256` backing, lens laws by constructor
 injectivity) is on `main`; it is the enabler for FixedArray-under-mapping,
 dynamic CodeData, arbitrary transient storage and multicall/delegatecall


### PR DESCRIPTION
## Summary
- add `writeTransient_preserves_mappingCoherentOn` / `UintOn` / `Map2On`
- constructor injectivity of `StorageKey.transient` vs persistent `.slot` / `.map` / `.mapUint` / `.map2`
- no listed-vs-written slot inequality; transient keys cannot alias persistent views
- not global preservation; keccak injectivity is not assumed
- C5 step 4 remains incomplete

## Test Plan
- `lake build Compiler.Proofs.Storage.MappingCoherenceOn` (1139 jobs, SUCCESS)
- `make check` (All checks passed)

## Related Issues
Further increment of C5 step 4 from #2330. Does not close #2330.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only extension to existing mapping-coherence lemmas; no compiler, runtime, or axiom changes.
> 
> **Overview**
> Adds three Lean theorems in `MappingCoherenceOn.lean` showing a lone **`writeTransient`** keeps finite **`MappingCoherentOn`**, **`MappingCoherentUintOn`**, and **`MappingCoherentMap2On`** lists intact.
> 
> Unlike lone **`writeSlot`**, no per-pair derived-slot inequality is required: **`StorageKey.transient`** is disjoint from persistent **`.slot` / `.map` / `.mapUint` / `.map2`**, so mapping views and keccak-derived flat words are unchanged. This is still **finite-list** preservation only (not global all-keys coherence).
> 
> **`PrintAxioms.lean`** registers the new public lemmas (theorem count 6455 → 6458). **`AUDIT.md`**, **`AXIOMS.md`**, **`TRUST_ASSUMPTIONS.md`**, and **`docs/ROADMAP.md`** document the slice as axiom-free C5 step 4 progress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 538f0e767cf66a0103ec71a1ae0516e9ef32077c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->