### PR TITLE
feat(semantics): FunctionSpec calls, ETH value, multi-contract hops

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -193,6 +193,30 @@ sibling entrypoint.
   Journal".
 - **Axiom-free**: `AXIOMS.md` unchanged.
 
+## FunctionSpec Calls, ETH Value, Multi-Contract World (2026-08)
+
+- `Denote.evalExpr` / `execStmt` still map `Expr.call` and
+  `Stmt.externalCallBind` to `none` / `.revert`, so
+  `DenoteAgreement` stays definitional against `SourceSemantics`.
+  The widened fragment is `Verity.Core.Model.DenoteFunctionCalls`:
+  `evalExprCall` / `execExternalCallBind` take a `CallEnv`
+  (`AdversaryModel` + link-time target / value / siteId), debit
+  `selfBalance` only on a successful `call`, and journal the real
+  target and value.
+- Base `withTransactionContext` is unchanged (keeps
+  `DenoteAgreement` / `_frame_holds` stable). Payable calls use
+  `withPayableCallContext`, which credits `selfBalance` with
+  `msg.value`. `MultiContract.withCallContext` does the same on
+  each hop.
+- EDSL `Contracts.externalCallBind` stays name-keyed (`target`/`value`
+  = 0). `externalCallBindTo` records target and value and debits ETH
+  on success. Callee state is not in that single-world stub.
+- `Verity.MultiContract` is a finite `Address → ContractState` world
+  with ETH-valued hops. The P-ETH-1 ensemble is
+  Bus → Gateway → Vault → (Lido | request). Model-plane only: those
+  names are not compiled contracts and not an L2 claim.
+- Zero new axioms.
+
 ## EDSL Executable Plane: Linked External Calls Journal (2026-08)
 
 - The EDSL executable stubs for linked external calls are no longer silent:

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -48,6 +48,12 @@ injectivity separates transient from persistent keys.
 `FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
 from no write-slot conflict plus constructor facts.
 
+FunctionSpec call denotation (`DenoteFunctionCalls`), ETH-valued
+`externalCallBindTo`, `withPayableCallContext` crediting
+`selfBalance`, and `MultiContract` add no axiom: callee behaviour
+is an explicit `AdversaryModel` / `calleeStep` parameter, not an
+assumed transition.
+
 ## Eliminated Axioms
 
 ### 1. `solidityMappingSlot_lt_evmModulus` (eliminated)

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -598,6 +598,15 @@ def linkedCallEntry (name : String) (argWords : List Uint256)
     returndata := returndata
     name := name }
 
+/-- Address- and value-keyed journal entry for the ETH-aware bind. -/
+def linkedCallEntryTo (name : String) (target : Address) (value : Uint256)
+    (argWords : List Uint256)
+    (control : ExternalCallControl := .success)
+    (returndata : List Nat := []) : ExternalCall :=
+  { linkedCallEntry name argWords control returndata with
+    target := target.toNat
+    value := value.val }
+
 /-- Append one entry to the `ContractState.calls` journal. This is the sole
 observable-effect primitive of the executable linked-call family; a
 subsequent monadic revert rolls the entry back through `Contract.run`'s
@@ -643,6 +652,32 @@ def externalCallBind {α : Type} [ExternalArg α] (names : List String) (name : 
     if success then ContractResult.success () next
     else ContractResult.revert "external call failed" next
 
+/-- Linked bind with explicit target and ETH value. Debits `selfBalance`
+    only on success; insufficient balance or a failing stub reverts the
+    pre-call world (including the journal). Callee state lives in
+    `Verity.MultiContract`, not in this single-world stub. -/
+def externalCallBindTo {α : Type} [ExternalArg α]
+    (target : Address) (value : Uint256)
+    (names : List String) (name : String) (args : List α) : Contract Unit :=
+  fun state =>
+    if value ≤ state.selfBalance then
+      let argWords := args.flatMap ExternalArg.toWords
+      let success := externalCallStubSuccess name
+      let entry := linkedCallEntryTo name target value argWords
+        (if success then .success else .failure)
+        (if success then
+          names.map (fun _ => (externalCallStubWord name argWords : Nat))
+        else [])
+      if success then
+        ContractResult.success ()
+          { state with
+            selfBalance := state.selfBalance - value
+            calls := state.calls ++ [entry] }
+      else
+        ContractResult.revert "external call failed" state
+    else
+      ContractResult.revert "insufficient balance" state
+
 /-! ### Run laws for the executable linked-call family
 
 Successful primitives append exactly one journal entry, so a duplicated,
@@ -667,6 +702,28 @@ definitional (`rfl`). -/
       else ContractResult.revert "external call failed" s := by
   by_cases h : externalCallStubSuccess name = true <;>
     simp [Contract.run, externalCallBind, h]
+
+theorem externalCallBindTo_run {α : Type} [ExternalArg α]
+    (target : Address) (value : Uint256)
+    (names : List String) (name : String) (args : List α) (s : ContractState) :
+    (externalCallBindTo target value names name args).run s =
+      if value ≤ s.selfBalance then
+        if externalCallStubSuccess name then
+          ContractResult.success ()
+            { s with
+              selfBalance := s.selfBalance - value
+              calls := s.calls ++
+                [linkedCallEntryTo name target value (args.flatMap ExternalArg.toWords)
+                  .success
+                  (names.map fun _ =>
+                    (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat))] }
+        else ContractResult.revert "external call failed" s
+      else ContractResult.revert "insufficient balance" s := by
+  by_cases hbal : value ≤ s.selfBalance
+  · by_cases h : externalCallStubSuccess name = true
+    · simp [Contract.run, externalCallBindTo, hbal, h, linkedCallEntryTo]
+    · simp [Contract.run, externalCallBindTo, hbal, h]
+  · simp [Contract.run, externalCallBindTo, hbal]
 
 @[simp] theorem callResultWords_run {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (s : ContractState) :

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -10,6 +10,7 @@ import Contracts.Smoke.StructMappings
 import Contracts.Smoke.ExternalCalls
 import Contracts.Smoke.ExternalCallObservability
 import Contracts.Smoke.ExternalCallInBodySmoke
+import Contracts.Smoke.ExternalCallValue
 import Contracts.Smoke.SpecGenAndChecks
 import Contracts.Smoke.Effects
 import Contracts.Smoke.Namespaces

--- a/Contracts/Smoke/ExternalCallValue.lean
+++ b/Contracts/Smoke/ExternalCallValue.lean
@@ -1,0 +1,16 @@
+import Contracts.Common
+import Verity.Core.Model.DenoteFunctionCalls
+import Verity.Core.Model.MultiContract
+
+namespace Contracts.Smoke.ExternalCallValue
+
+open Contracts
+open Verity hiding pure bind
+open Compiler.CompilationModel.DenoteFunctionCalls
+open Verity.MultiContract
+
+example :
+    (lookup (fundedBus 5) busAddr).selfBalance = (5 : Uint256) :=
+  fundedBus_bus_balance 5
+
+end Contracts.Smoke.ExternalCallValue

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -275,6 +275,23 @@ of byte-for-byte EVM ABI layout. Trust boundaries of that plane:
 - **`callExternal name(args)` surface and the mapping stubs**
   (`getMappingWord`/`setMappingWord`/`getMappingN`/`setMappingN`) remain
   unmodeled no-ops at this plane.
+- **`externalCallBindTo` journals target and value and debits ETH
+  on success.** It is still a stub for the callee return word
+  (`externalCallStubWord`). Real callee state is the model-plane
+  `AdversaryModel` / `Verity.MultiContract` hop, not this stub.
+- **Base `FunctionSpec` denotation (`Denote.evalExpr` /
+  `execStmt`) still treats raw `Expr.call` and
+  `Stmt.externalCallBind` as outside the SourceSemantics-agreeing
+  fragment.** The widened fragment is
+  `DenoteFunctionCalls.denoteFunctionWithCalls`.
+- **Base `withTransactionContext` still does not credit
+  `selfBalance`.** Payable FunctionSpec denotation uses
+  `withPayableCallContext`. Multi-contract hops use
+  `MultiContract.withCallContext`. A call that uses neither still
+  has a stale balance.
+- **`MultiContract` Bus → Gateway → Vault → (Lido | request) is a
+  model ensemble**, not a compiled protocol and not an L2
+  preservation claim.
 - A full monadic revert through `Contract.run` rolls the journal back with
   the rest of the snapshot (top-level EVM semantics), unlike the model
   plane's caller-side rollback survival described above.

--- a/Verity/Core/Model/DenoteFunctionCalls.lean
+++ b/Verity/Core/Model/DenoteFunctionCalls.lean
@@ -1,0 +1,333 @@
+import Verity.Core.Model.Denote
+import Verity.Core.Model.DenoteExternalCalls
+
+/-!
+# FunctionSpec denotation of raw and linked external calls
+
+`Denote.evalExpr` / `Denote.execStmt` still map `Expr.call` /
+`Stmt.externalCallBind` to `none` / `.revert`, matching
+`SourceSemantics` so `DenoteAgreement` stays definitional.
+
+This module is the widened fragment: a `CallEnv` supplies the
+`AdversaryModel` (callee effect) and the link-time
+target / value / siteId for a named external. ETH is debited from
+the caller `selfBalance` only on a successful `call`. Failure and
+revert keep the pre-call balance (journal still records the
+attempt). No keccak injectivity, no new axiom.
+-/
+
+namespace Compiler.CompilationModel.DenoteFunctionCalls
+
+open Compiler.CompilationModel
+open Compiler.CompilationModel.Denote
+open Compiler.CompilationModel.DenoteExternalCalls
+open Verity
+
+/-- Link-time resolution of a named external. -/
+structure LinkedExternal where
+  target : Nat
+  value : Nat := 0
+  siteId : Nat := 0
+  deriving Repr
+
+/-- Environment for the widened call fragment. -/
+structure CallEnv where
+  oracle : DenoteOracle
+  adversary : AdversaryModel
+  resolve : String → Option LinkedExternal
+
+/-- Word-addressed calldata read for `Expr.call` memory operands. -/
+def readMemoryWords (mem : Nat → Core.Uint256) (offset size : Nat) : List Nat :=
+  (List.range size).map (fun i => (mem (offset + i)).val)
+
+/-- Word-addressed returndata write. Writes `min words.length outSize` words. -/
+def writeMemoryWords (mem : Nat → Core.Uint256) (offset : Nat) :
+    List Nat → Nat → (Nat → Core.Uint256)
+  | _, 0 => mem
+  | [], _ => mem
+  | w :: rest, n + 1 =>
+      writeMemoryWords
+        (fun o => if o = offset then (w : Core.Uint256) else mem o)
+        (offset + 1) rest n
+
+def identityAdversary : AdversaryModel where
+  stateTransition := fun _ w => w
+  result := fun _ _ => .success []
+  gasUsed := fun _ _ => 0
+
+def echoAdversary : AdversaryModel where
+  stateTransition := fun _ w => w
+  result := fun site _ => .success site.calldata
+  gasUsed := fun _ _ => 0
+
+/-- Payable-call frame: `withTransactionContext` plus `selfBalance`
+    credited by `msg.value`. The base helper is left unchanged. -/
+def withPayableCallContext (world : ContractState) (tx : DenoteTransaction) :
+    ContractState :=
+  let framed := withTransactionContext world tx
+  { framed with selfBalance := framed.selfBalance + tx.msgValue }
+
+theorem selfBalance_withPayableCallContext
+    (world : ContractState) (tx : DenoteTransaction) :
+    (withPayableCallContext world tx).selfBalance =
+      world.selfBalance + tx.msgValue :=
+  rfl
+
+/-- Debit `value` from `selfBalance` when the account can pay. -/
+def debitSelfBalance (w : ContractState) (value : Nat) : Option ContractState :=
+  if value ≤ w.selfBalance.val then
+    some { w with selfBalance := w.selfBalance - (value : Core.Uint256) }
+  else
+    none
+
+/-- Successful `call` commits the adversary transition, journals, debits
+    ETH, and writes returndata into memory. Failure / revert keeps the
+    pre-call balance and still journals. -/
+def applyRawCall (env : CallEnv) (state : DenoteState) (site : CallSite)
+    (outOff outSize : Nat) : Option (Nat × DenoteState) :=
+  match site.kind with
+  | .call =>
+      match debitSelfBalance state.world site.value with
+      | none => some (0, state)
+      | some paid =>
+          let obs := denoteCallJournaled env.adversary site
+            { world := paid, gasRemaining := site.gas }
+          match obs.result with
+          | .success data =>
+              let mem := writeMemoryWords obs.state.world.memory outOff data outSize
+              some (1, { state with world := { obs.state.world with memory := mem } })
+          | .failure _ | .revert _ =>
+              some (0, { state with
+                world := { state.world with
+                  calls := state.world.calls ++
+                    [journalEntry site obs.result] } })
+  | .staticcall | .delegatecall =>
+      let obs := denoteCallJournaled env.adversary site
+        { world := state.world, gasRemaining := site.gas }
+      match obs.result with
+      | .success data =>
+          let mem := writeMemoryWords obs.state.world.memory outOff data outSize
+          some (1, { state with world := { obs.state.world with memory := mem } })
+      | .failure _ | .revert _ =>
+          some (0, { state with
+            world := { state.world with
+              calls := state.world.calls ++
+                [journalEntry site obs.result] } })
+
+/-- Denote `Expr.call` / `staticcall` / `delegatecall`. Returns the EVM
+    success bit and the post-call state. Other expressions stay
+    observationally silent (same as `evalExpr`). -/
+def evalExprCall (env : CallEnv) (fields : List Field) (state : DenoteState) :
+    Expr → Option (Nat × DenoteState)
+  | .call gas target value inOff inSize outOff outSize => do
+      let g ← evalExpr env.oracle fields state gas
+      let t ← evalExpr env.oracle fields state target
+      let v ← evalExpr env.oracle fields state value
+      let io ← evalExpr env.oracle fields state inOff
+      let isz ← evalExpr env.oracle fields state inSize
+      let oo ← evalExpr env.oracle fields state outOff
+      let osz ← evalExpr env.oracle fields state outSize
+      let site : CallSite :=
+        { siteId := t, kind := .call, target := t, value := v
+          calldata := readMemoryWords state.world.memory io isz, gas := g }
+      applyRawCall env state site oo osz
+  | .staticcall gas target inOff inSize outOff outSize => do
+      let g ← evalExpr env.oracle fields state gas
+      let t ← evalExpr env.oracle fields state target
+      let io ← evalExpr env.oracle fields state inOff
+      let isz ← evalExpr env.oracle fields state inSize
+      let oo ← evalExpr env.oracle fields state outOff
+      let osz ← evalExpr env.oracle fields state outSize
+      let site : CallSite :=
+        { siteId := t, kind := .staticcall, target := t, value := 0
+          calldata := readMemoryWords state.world.memory io isz, gas := g }
+      applyRawCall env state site oo osz
+  | .delegatecall gas target inOff inSize outOff outSize => do
+      let g ← evalExpr env.oracle fields state gas
+      let t ← evalExpr env.oracle fields state target
+      let io ← evalExpr env.oracle fields state inOff
+      let isz ← evalExpr env.oracle fields state inSize
+      let oo ← evalExpr env.oracle fields state outOff
+      let osz ← evalExpr env.oracle fields state outSize
+      let site : CallSite :=
+        { siteId := t, kind := .delegatecall, target := t, value := 0
+          calldata := readMemoryWords state.world.memory io isz, gas := g }
+      applyRawCall env state site oo osz
+  | e =>
+      (evalExpr env.oracle fields state e).map (fun n => (n, state))
+
+def bindResultWords (bindings : Env) : List String → List Nat → Env
+  | [], _ => bindings
+  | _ :: _, [] => bindings
+  | name :: names, w :: ws =>
+      bindResultWords (bindValue bindings name (wordNormalize w)) names ws
+
+/-- `Stmt.externalCallBind`: named linked call with resolved target and
+    value. Auto-reverts on failure or missing link, matching the AST
+    comment. -/
+def execExternalCallBind (env : CallEnv) (fields : List Field)
+    (state : DenoteState) (resultVars : List String) (externalName : String)
+    (args : List Expr) : StmtOutcome :=
+  match env.resolve externalName, evalExprList env.oracle fields state args with
+  | some link, some argWords =>
+      match debitSelfBalance state.world link.value with
+      | none => .revert
+      | some paid =>
+          let site : CallSite :=
+            { siteId := link.siteId, kind := .call, target := link.target
+              value := link.value, calldata := argWords, gas := paid.selfBalance.val }
+          let obs := denoteCallJournaled env.adversary site
+            { world := paid, gasRemaining := site.gas }
+          match obs.result with
+          | .success data =>
+              if data.length < resultVars.length then .revert
+              else
+                .continue
+                  { state with
+                    world := obs.state.world
+                    bindings := bindResultWords state.bindings resultVars data }
+          | .failure _ | .revert _ => .revert
+  | _, _ => .revert
+
+/-- `Stmt.tryExternalCallBind`: same call, but binds a success flag
+    instead of reverting. -/
+def execTryExternalCallBind (env : CallEnv) (fields : List Field)
+    (state : DenoteState) (successVar : String) (resultVars : List String)
+    (externalName : String) (args : List Expr) : StmtOutcome :=
+  match env.resolve externalName, evalExprList env.oracle fields state args with
+  | some link, some argWords =>
+      match debitSelfBalance state.world link.value with
+      | none =>
+          .continue
+            { state with
+              bindings := bindValue state.bindings successVar 0 }
+      | some paid =>
+          let site : CallSite :=
+            { siteId := link.siteId, kind := .call, target := link.target
+              value := link.value, calldata := argWords, gas := paid.selfBalance.val }
+          let obs := denoteCallJournaled env.adversary site
+            { world := paid, gasRemaining := site.gas }
+          match obs.result with
+          | .success data =>
+              .continue
+                { state with
+                  world := obs.state.world
+                  bindings :=
+                    bindResultWords
+                      (bindValue state.bindings successVar 1) resultVars data }
+          | .failure _ | .revert _ =>
+              .continue
+                { state with
+                  world :=
+                    { state.world with
+                      calls := state.world.calls ++
+                        [journalEntry site obs.result] }
+                  bindings := bindValue state.bindings successVar 0 }
+  | _, _ =>
+      .continue { state with bindings := bindValue state.bindings successVar 0 }
+
+mutual
+  def execStmtWithCalls (env : CallEnv) (fields : List Field) :
+      DenoteState → Stmt → StmtOutcome
+    | state, .externalCallBind resultVars name args =>
+        execExternalCallBind env fields state resultVars name args
+    | state, .tryExternalCallBind successVar resultVars name args =>
+        execTryExternalCallBind env fields state successVar resultVars name args
+    | state, .ite cond thenBranch elseBranch =>
+        match evalExpr env.oracle fields state cond with
+        | some resolved =>
+            if resolved != 0 then
+              execStmtListWithCalls env fields state thenBranch
+            else
+              execStmtListWithCalls env fields state elseBranch
+        | none => .revert
+    | state, .forEach varName count body =>
+        match evalExpr env.oracle fields state count with
+        | some bound =>
+            let initialLoopState :=
+              { state with bindings := bindValue state.bindings varName (wordNormalize 0) }
+            execForEachLoop varName
+              (fun loopState => execStmtListWithCalls env fields loopState body)
+              initialLoopState 0 bound
+        | none => .revert
+    | state, .forEachSetBit varName bitmap body =>
+        match evalExpr env.oracle fields state bitmap with
+        | some bits =>
+            execForEachSetBitLoop varName
+              (fun loopState => execStmtListWithCalls env fields loopState body)
+              256 state bits
+        | none => .revert
+    | state, other =>
+        execStmt env.oracle fields state other
+
+  def execStmtListWithCalls (env : CallEnv) (fields : List Field) :
+      DenoteState → List Stmt → StmtOutcome
+    | state, [] => .continue state
+    | state, stmt :: rest =>
+        match execStmtWithCalls env fields state stmt with
+        | .continue next => execStmtListWithCalls env fields next rest
+        | .stop next => .stop next
+        | .return value next => .return value next
+        | .revert => .revert
+end
+
+/-- Canonical FunctionSpec denotation with raw / linked calls in-fragment. -/
+def denoteFunctionWithCalls (env : CallEnv) (spec : CompilationModel)
+    (fn : FunctionSpec) (tx : DenoteTransaction) (initialWorld : ContractState) :
+    DenoteResult :=
+  let worldWithTx := withPayableCallContext initialWorld tx
+  let fields := effectiveFields spec
+  match bindExternalParams tx.functionSelector fn.params tx.args with
+  | none => revertedResult env.oracle spec worldWithTx
+  | some bindings =>
+      match execStmtListWithCalls env fields
+          { world := worldWithTx, bindings := bindings, selector := tx.functionSelector }
+          fn.body with
+      | .continue state => successResult env.oracle spec state.world none
+      | .stop state => successResult env.oracle spec state.world none
+      | .return value state => successResult env.oracle spec state.world (some value)
+      | .revert => revertedResult env.oracle spec worldWithTx
+
+/-! ## Laws -/
+
+theorem debitSelfBalance_none_of_lt (w : ContractState) (value : Nat)
+    (h : w.selfBalance.val < value) :
+    debitSelfBalance w value = none := by
+  simp [debitSelfBalance, Nat.not_le_of_gt h]
+
+theorem debitSelfBalance_some (w : ContractState) (value : Nat)
+    (h : value ≤ w.selfBalance.val) :
+    debitSelfBalance w value =
+      some { w with selfBalance := w.selfBalance - (value : Core.Uint256) } := by
+  simp [debitSelfBalance, h]
+
+theorem evalExpr_call_still_none (oracle : DenoteOracle) (fields : List Field)
+    (state : DenoteState)
+    (g t v io isz oo osz : Expr) :
+    evalExpr oracle fields state (.call g t v io isz oo osz) = none :=
+  rfl
+
+theorem execStmt_externalCallBind_still_reverts (oracle : DenoteOracle)
+    (fields : List Field) (state : DenoteState)
+    (vars : List String) (name : String) (args : List Expr) :
+    execStmt oracle fields state (.externalCallBind vars name args) = .revert :=
+  rfl
+
+private def dummyOracle : DenoteOracle :=
+  { mappingSlot := fun _ _ => 0
+    keccakMemorySlice := fun _ _ _ => 0 }
+
+theorem evalExpr_call_outside_base_fragment :
+    evalExpr dummyOracle []
+      { world := defaultState, bindings := [] }
+      (.call (.literal 0) (.literal 1) (.literal 0)
+        (.literal 0) (.literal 0) (.literal 0) (.literal 0)) = none :=
+  rfl
+
+theorem execStmt_externalCallBind_outside_base_fragment :
+    execStmt dummyOracle []
+      { world := defaultState, bindings := [] }
+      (.externalCallBind ["r"] "echo" [.literal 42]) = .revert :=
+  rfl
+
+end Compiler.CompilationModel.DenoteFunctionCalls

--- a/Verity/Core/Model/MultiContract.lean
+++ b/Verity/Core/Model/MultiContract.lean
@@ -1,0 +1,156 @@
+import Verity.Core
+
+/-!
+# Multi-contract world with ETH-valued calls
+
+A finite map `Address → ContractState`. A hop debits the caller,
+credits the callee (so `selfBalance` is the post-call balance),
+installs the call context (`sender` / `thisAddress` / `msgValue`),
+applies an explicit callee step, and journals `target` and `value`
+on the caller.
+
+The P-ETH-1 ensemble is `Bus → Gateway → Vault → (Lido | request)`.
+This is a model-plane composition, not a claim that those contracts
+are compiled or L2-proved. No keccak injectivity, no new axiom.
+-/
+
+namespace Verity.MultiContract
+
+/-- One named account in the ensemble. -/
+structure Account where
+  address : Address
+  state : ContractState
+  deriving Repr
+
+/-- Finite multi-contract world. Missing addresses read as `defaultState`. -/
+structure MultiWorld where
+  accounts : List Account
+  deriving Repr
+
+def lookup (w : MultiWorld) (addr : Address) : ContractState :=
+  match w.accounts.find? (fun a => a.address == addr) with
+  | some a => a.state
+  | none => defaultState
+
+def upsert (w : MultiWorld) (addr : Address) (s : ContractState) : MultiWorld :=
+  if w.accounts.any (fun a => a.address == addr) then
+    { accounts := w.accounts.map (fun a =>
+        if a.address == addr then { a with state := s } else a) }
+  else
+    { accounts := w.accounts ++ [{ address := addr, state := s }] }
+
+/-- Call-frame context installed on the callee: sender, this, msg.value,
+    and `selfBalance` after receiving `value`. -/
+def withCallContext (callee : ContractState) (caller this : Address)
+    (value : Core.Uint256) : ContractState :=
+  { callee with
+    sender := caller
+    thisAddress := this
+    msgValue := value
+    selfBalance := callee.selfBalance + value }
+
+def totalSelfBalance (w : MultiWorld) : Nat :=
+  w.accounts.foldl (fun acc a => acc + a.state.selfBalance.val) 0
+
+/-- One ETH-valued hop. Fails when the caller cannot pay. The callee
+    step sees the credited, re-contextualized world. -/
+def callValue (w : MultiWorld) (caller callee : Address) (value : Core.Uint256)
+    (name : String := "") (calldata : List Nat := [])
+    (calleeStep : ContractState → ContractState := id) : Option MultiWorld :=
+  let fromS := lookup w caller
+  let toS := lookup w callee
+  if value ≤ fromS.selfBalance then
+    let fromPaid : ContractState :=
+      { fromS with selfBalance := fromS.selfBalance - value }
+    let toAfter := calleeStep (withCallContext toS caller callee value)
+    let fromJournaled : ContractState :=
+      { fromPaid with
+        calls := fromPaid.calls ++
+          [{ siteId := callee.toNat
+             kind := .call
+             target := callee.toNat
+             value := value.val
+             calldata := calldata
+             control := .success
+             returndata := []
+             name := name }] }
+    some (upsert (upsert w caller fromJournaled) callee toAfter)
+  else
+    none
+
+/-! ## P-ETH-1 ensemble: Bus → Gateway → Vault → (Lido | request) -/
+
+def busAddr : Address := (1 : Address)
+def gatewayAddr : Address := (2 : Address)
+def vaultAddr : Address := (3 : Address)
+def lidoAddr : Address := (4 : Address)
+def requestAddr : Address := (5 : Address)
+
+inductive VaultRoute where
+  | lido
+  | request
+  deriving DecidableEq, Repr
+
+def accountAt (addr : Address) (bal : Nat) : Account :=
+  { address := addr
+    state := { defaultState with thisAddress := addr, selfBalance := bal } }
+
+def fundedBus (busWei : Nat) : MultiWorld :=
+  { accounts :=
+      [accountAt busAddr busWei,
+       accountAt gatewayAddr 0,
+       accountAt vaultAddr 0,
+       accountAt lidoAddr 0,
+       accountAt requestAddr 0] }
+
+/-- Forward `value` along Bus → Gateway → Vault → route. -/
+def routeEth (w : MultiWorld) (value : Core.Uint256) (route : VaultRoute) :
+    Option MultiWorld :=
+  match callValue w busAddr gatewayAddr value (name := "busToGateway") with
+  | none => none
+  | some w1 =>
+      match callValue w1 gatewayAddr vaultAddr value (name := "gatewayToVault") with
+      | none => none
+      | some w2 =>
+          match route with
+          | .lido =>
+              callValue w2 vaultAddr lidoAddr value (name := "vaultToLido")
+          | .request =>
+              callValue w2 vaultAddr requestAddr value (name := "vaultToRequest")
+
+/-! ## Laws -/
+
+theorem withCallContext_selfBalance (callee : ContractState)
+    (caller this : Address) (value : Core.Uint256) :
+    (withCallContext callee caller this value).selfBalance =
+      callee.selfBalance + value :=
+  rfl
+
+theorem withCallContext_msgValue (callee : ContractState)
+    (caller this : Address) (value : Core.Uint256) :
+    (withCallContext callee caller this value).msgValue = value :=
+  rfl
+
+theorem withCallContext_this (callee : ContractState)
+    (caller this : Address) (value : Core.Uint256) :
+    (withCallContext callee caller this value).thisAddress = this :=
+  rfl
+
+theorem withCallContext_sender (callee : ContractState)
+    (caller this : Address) (value : Core.Uint256) :
+    (withCallContext callee caller this value).sender = caller :=
+  rfl
+
+theorem callValue_none_of_cannot_pay (w : MultiWorld)
+    (caller callee : Address) (value : Core.Uint256)
+    (h : (lookup w caller).selfBalance < value) :
+    callValue w caller callee value = none := by
+  simpa [callValue] using h
+
+theorem fundedBus_bus_balance (n : Nat) :
+    (lookup (fundedBus n) busAddr).selfBalance =
+      (n : Core.Uint256) := by
+  unfold lookup fundedBus accountAt
+  simp [busAddr]
+
+end Verity.MultiContract

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -55,7 +55,13 @@ as extra compiler write targets),
 and finite-set `MappingCoherentOn` / `MappingCoherentUintOn` /
 `MappingCoherentMap2On` under explicit pairwise derived-slot
 certificates, including cross-channel aligned-write, lone
-`writeSlot`, and lone `writeTransient` preservation. C5 step 3 (canonical
+`writeSlot`, and lone `writeTransient` preservation. FunctionSpec
+raw/linked calls with target, value and ETH debit are denoted in
+`DenoteFunctionCalls` (base `evalExpr`/`execStmt` stay
+`none`/`.revert` so `DenoteAgreement` holds). Payable calls credit
+`selfBalance` via `withPayableCallContext`. `MultiContract` models
+Bus → Gateway → Vault → (Lido | request) as an ETH-valued hop
+ensemble; it is not an L2 claim. C5 step 3 (canonical
 `storageWords : StorageKey → Uint256` backing, lens laws by constructor
 injectivity) is on `main`; it is the enabler for FixedArray-under-mapping,
 dynamic CodeData, arbitrary transient storage and multicall/delegatecall


### PR DESCRIPTION
## Summary
- FunctionSpec denotation of `Expr.call` / `Stmt.externalCallBind` in `DenoteFunctionCalls` (target, value, ETH debit, explicit `AdversaryModel` callee effect)
- Base `evalExpr` / `execStmt` remain `none` / `.revert` so `DenoteAgreement` stays definitional
- `externalCallBindTo` journals real target and value and debits `selfBalance` on success
- `withPayableCallContext` credits `selfBalance` with `msg.value` without changing base `withTransactionContext`
- `MultiContract` ensemble: Bus → Gateway → Vault → (Lido | request)
- Zero new axioms. C5 step 4 remains incomplete.

## Test Plan
- `lake build Verity.Core.Model.DenoteFunctionCalls Verity.Core.Model.MultiContract Contracts.Smoke.ExternalCallValue` (1214 jobs, SUCCESS)
- `make check` (All checks passed)

## Related
Further increment of the external-call / ETH surface from issue 2330. That issue stays open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 52a9664b284374c1d445feea480d51b8fd759d0c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->