### PR TITLE
feat(semantics): execute external calls through explicit frames

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -229,8 +229,10 @@ sibling entrypoint.
   preserve both snapshots (apart from the caller's append-only observation).
 - `DenoteFunctionCalls.executeFunctionWithCalls` retains the FunctionSpec
   post-world and execution control. `runFunctionInFrame` is the first
-  source-shaped adapter into the framed boundary; the legacy `DenoteResult`
-  projection is derived from the same execution.
+  source-shaped adapter into the framed boundary; `callFunction` is the
+  official checked composition and does not accept a separately supplied
+  observation or post-state. The legacy `DenoteResult` projection is derived
+  from the same execution.
 - This slice deliberately supports ordinary `call` only. `staticcall` and
   `delegatecall` need distinct frame invariants before admission.
 - Zero new axioms.

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -217,6 +217,24 @@ sibling entrypoint.
   names are not compiled contracts and not an L2 claim.
 - Zero new axioms.
 
+## Execution-Backed External Call Frames (2026-08)
+
+- `MultiContract.CallFrame` retains distinct caller-before, callee-before, and
+  callee-entry states. `callEntry` checks distinct accounts, `call` kind,
+  target/address agreement, and sufficient caller balance before producing a
+  frame.
+- `MultiContract.executeCall` consumes a `CalleeExecution`; its produced
+  control and returndata determine commit/rollback and the journal entry.
+  Success commits the caller debit and callee post-state. Failure/revert
+  preserve both snapshots (apart from the caller's append-only observation).
+- `DenoteFunctionCalls.executeFunctionWithCalls` retains the FunctionSpec
+  post-world and execution control. `runFunctionInFrame` is the first
+  source-shaped adapter into the framed boundary; the legacy `DenoteResult`
+  projection is derived from the same execution.
+- This slice deliberately supports ordinary `call` only. `staticcall` and
+  `delegatecall` need distinct frame invariants before admission.
+- Zero new axioms.
+
 ## EDSL Executable Plane: Linked External Calls Journal (2026-08)
 
 - The EDSL executable stubs for linked external calls are no longer silent:

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -291,7 +291,15 @@ of byte-for-byte EVM ABI layout. Trust boundaries of that plane:
   has a stale balance.
 - **`MultiContract` Bus → Gateway → Vault → (Lido | request) is a
   model ensemble**, not a compiled protocol and not an L2
-  preservation claim.
+  preservation claim. The generic `CallFrame` / `executeCall` boundary now
+  obtains control, returndata, the committed callee post-state, and the caller
+  journal from one `CalleeExecution`; failed/reverted executions restore the
+  caller/callee snapshots apart from the caller observation. The first
+  official adapter executes a source-shaped `FunctionSpec` through
+  `DenoteFunctionCalls.runFunctionInFrame`. This boundary currently rejects
+  `staticcall`, `delegatecall`, self-calls, and target/address mismatches;
+  admitting those requires their distinct frame invariants rather than
+  pretending ordinary-call semantics apply.
 - A full monadic revert through `Contract.run` rolls the journal back with
   the rest of the snapshot (top-level EVM semantics), unlike the model
   plane's caller-side rollback survival described above.

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -299,7 +299,9 @@ of byte-for-byte EVM ABI layout. Trust boundaries of that plane:
   journal from one `CalleeExecution`; failed/reverted executions restore the
   caller/callee snapshots apart from the caller observation. The first
   official adapter executes a source-shaped `FunctionSpec` through
-  `DenoteFunctionCalls.runFunctionInFrame`. This boundary currently rejects
+  `DenoteFunctionCalls.callFunction`; unlike the lower-level executor callback,
+  that entrypoint does not accept injected control, returndata, or post-state.
+  This boundary currently rejects
   `staticcall`, `delegatecall`, self-calls, and target/address mismatches;
   admitting those requires their distinct frame invariants rather than
   pretending ordinary-call semantics apply.

--- a/Verity/Core/Model/DenoteFunctionCalls.lean
+++ b/Verity/Core/Model/DenoteFunctionCalls.lean
@@ -1,5 +1,6 @@
 import Verity.Core.Model.Denote
 import Verity.Core.Model.DenoteExternalCalls
+import Verity.Core.Model.MultiContract
 
 /-!
 # FunctionSpec denotation of raw and linked external calls
@@ -271,22 +272,57 @@ mutual
         | .revert => .revert
 end
 
-/-- Canonical FunctionSpec denotation with raw / linked calls in-fragment. -/
-def denoteFunctionWithCalls (env : CallEnv) (spec : CompilationModel)
+/-- Execution-level result retained for composition into an explicit callee
+frame.  Unlike `DenoteResult`, this keeps the actual post-world. -/
+structure FunctionExecution where
+  result : ExternalCallResult
+  world : ContractState
+
+/-- Execute a FunctionSpec with raw / linked calls in-fragment. -/
+def executeFunctionWithCalls (env : CallEnv) (spec : CompilationModel)
     (fn : FunctionSpec) (tx : DenoteTransaction) (initialWorld : ContractState) :
-    DenoteResult :=
+    FunctionExecution :=
   let worldWithTx := withPayableCallContext initialWorld tx
   let fields := effectiveFields spec
   match bindExternalParams tx.functionSelector fn.params tx.args with
-  | none => revertedResult env.oracle spec worldWithTx
+  | none => { result := .revert [], world := worldWithTx }
   | some bindings =>
       match execStmtListWithCalls env fields
           { world := worldWithTx, bindings := bindings, selector := tx.functionSelector }
           fn.body with
-      | .continue state => successResult env.oracle spec state.world none
-      | .stop state => successResult env.oracle spec state.world none
-      | .return value state => successResult env.oracle spec state.world (some value)
-      | .revert => revertedResult env.oracle spec worldWithTx
+      | .continue state | .stop state =>
+          { result := .success [], world := state.world }
+      | .return value state =>
+          { result := .success [value], world := state.world }
+      | .revert => { result := .revert [], world := worldWithTx }
+
+/-- Canonical FunctionSpec denotation, projected from the composable
+execution result so the two semantics cannot drift. -/
+def denoteFunctionWithCalls (env : CallEnv) (spec : CompilationModel)
+    (fn : FunctionSpec) (tx : DenoteTransaction) (initialWorld : ContractState) :
+    DenoteResult :=
+  let execution := executeFunctionWithCalls env spec fn tx initialWorld
+  match execution.result with
+  | .success [] => successResult env.oracle spec execution.world none
+  | .success (word :: _) => successResult env.oracle spec execution.world (some word)
+  | .failure _ | .revert _ => revertedResult env.oracle spec execution.world
+
+/-- Adapt a source-shaped FunctionSpec execution to the official framed
+multi-contract boundary.  The frame's pre-credit callee snapshot is supplied
+to the function denotation; `msg.value` is credited exactly once by its
+payable transaction context. -/
+def runFunctionInFrame (env : CallEnv) (spec : CompilationModel)
+    (fn : FunctionSpec) (selector : Nat)
+    (frame : Verity.MultiContract.CallFrame) :
+    Verity.MultiContract.CalleeExecution :=
+  let execution := executeFunctionWithCalls env spec fn
+    { sender := frame.caller.toNat
+      msgValue := frame.site.value
+      thisAddress := frame.callee.toNat
+      functionSelector := selector
+      args := frame.site.calldata }
+    frame.calleeBefore
+  { result := execution.result, post := execution.world }
 
 /-! ## Laws -/
 

--- a/Verity/Core/Model/DenoteFunctionCalls.lean
+++ b/Verity/Core/Model/DenoteFunctionCalls.lean
@@ -324,6 +324,26 @@ def runFunctionInFrame (env : CallEnv) (spec : CompilationModel)
     frame.calleeBefore
   { result := execution.result, post := execution.world }
 
+/-- Official source-shaped multi-contract call path.  Frame construction,
+FunctionSpec execution, value transfer, commit/rollback, returndata, and the
+call journal are composed here; callers cannot supply an observed result or
+post-state independently of the executed function. -/
+def callFunction (env : CallEnv) (spec : CompilationModel)
+    (fn : FunctionSpec) (selector : Nat) (world : Verity.MultiContract.MultiWorld)
+    (caller callee : Address) (site : CallSite) :
+    Option Verity.MultiContract.FramedCallObservation :=
+  Verity.MultiContract.call world caller callee site
+    (runFunctionInFrame env spec fn selector)
+
+theorem callFunction_eq (env : CallEnv) (spec : CompilationModel)
+    (fn : FunctionSpec) (selector : Nat) (world : Verity.MultiContract.MultiWorld)
+    (caller callee : Address) (site : CallSite) :
+    callFunction env spec fn selector world caller callee site = (do
+      let frame ← Verity.MultiContract.callEntry world caller callee site
+      some (Verity.MultiContract.executeCall world frame
+        (runFunctionInFrame env spec fn selector))) :=
+  rfl
+
 /-! ## Laws -/
 
 theorem debitSelfBalance_none_of_lt (w : ContractState) (value : Nat)

--- a/Verity/Core/Model/MultiContract.lean
+++ b/Verity/Core/Model/MultiContract.lean
@@ -1,4 +1,4 @@
-import Verity.Core
+import Verity.Core.Model.DenoteExternalCalls
 
 /-!
 # Multi-contract world with ETH-valued calls
@@ -15,6 +15,8 @@ are compiled or L2-proved. No keccak injectivity, no new axiom.
 -/
 
 namespace Verity.MultiContract
+
+open Compiler.CompilationModel.DenoteExternalCalls
 
 /-- One named account in the ensemble. -/
 structure Account where
@@ -77,6 +79,85 @@ def callValue (w : MultiWorld) (caller callee : Address) (value : Core.Uint256)
     some (upsert (upsert w caller fromJournaled) callee toAfter)
   else
     none
+
+/-! ## Execution-backed call frames
+
+`callValue` above is the compatibility success-only helper.  The semantics
+below is the generic boundary: the callee runs in an explicit frame and its
+actual control result determines commit or rollback. -/
+
+/-- Immutable caller/callee snapshot and the context installed for execution. -/
+structure CallFrame where
+  caller : Address
+  callee : Address
+  site : CallSite
+  callerBefore : ContractState
+  calleeBefore : ContractState
+  calleeEntry : ContractState
+
+/-- Result produced by executing the callee body in `calleeEntry`. -/
+structure CalleeExecution where
+  result : ExternalCallResult
+  post : ContractState
+
+/-- Observable result of one framed call.  Keeping the frame in the result
+prevents a continuation from silently replacing the caller/callee snapshot. -/
+structure FramedCallObservation where
+  frame : CallFrame
+  result : ExternalCallResult
+  world : MultiWorld
+
+def callEntry (w : MultiWorld) (caller callee : Address) (site : CallSite) :
+    Option CallFrame :=
+  let callerBefore := lookup w caller
+  let calleeBefore := lookup w callee
+  if caller = callee then none
+  else if site.kind != .call then none
+  else if site.target != callee.toNat then none
+  else if site.value ≤ callerBefore.selfBalance.val then
+    some
+      { caller := caller
+        callee := callee
+        site := site
+        callerBefore := callerBefore
+        calleeBefore := calleeBefore
+        calleeEntry :=
+          withCallContext calleeBefore caller callee (site.value : Core.Uint256) }
+  else
+    none
+
+def framedJournalEntry (frame : CallFrame) (result : ExternalCallResult) :
+    ExternalCall :=
+  journalEntry frame.site result
+
+/-- Execute one source-shaped external call.  Success commits the debit and
+callee post-state.  Failure/revert restore both account snapshots.  Every
+outcome appends the control and returndata produced by the execution itself
+to the caller journal. -/
+def executeCall (w : MultiWorld) (frame : CallFrame)
+    (runCallee : CallFrame → CalleeExecution) : FramedCallObservation :=
+  let execution := runCallee frame
+  let entry := framedJournalEntry frame execution.result
+  let callerJournaled : ContractState :=
+    { frame.callerBefore with calls := frame.callerBefore.calls ++ [entry] }
+  let nextWorld :=
+    match execution.result with
+    | .success _ =>
+        let callerCommitted : ContractState :=
+          { callerJournaled with
+            selfBalance :=
+              frame.callerBefore.selfBalance - (frame.site.value : Core.Uint256) }
+        upsert (upsert w frame.caller callerCommitted) frame.callee execution.post
+    | .failure _ | .revert _ =>
+        upsert (upsert w frame.caller callerJournaled)
+          frame.callee frame.calleeBefore
+  { frame := frame, result := execution.result, world := nextWorld }
+
+/-- Construct and execute a frame in one checked operation. -/
+def call (w : MultiWorld) (caller callee : Address) (site : CallSite)
+    (runCallee : CallFrame → CalleeExecution) : Option FramedCallObservation := do
+  let frame ← callEntry w caller callee site
+  some (executeCall w frame runCallee)
 
 /-! ## P-ETH-1 ensemble: Bus → Gateway → Vault → (Lido | request) -/
 
@@ -146,6 +227,69 @@ theorem callValue_none_of_cannot_pay (w : MultiWorld)
     (h : (lookup w caller).selfBalance < value) :
     callValue w caller callee value = none := by
   simpa [callValue] using h
+
+@[simp] theorem executeCall_frame (w : MultiWorld) (frame : CallFrame)
+    (runCallee : CallFrame → CalleeExecution) :
+    (executeCall w frame runCallee).frame = frame :=
+  rfl
+
+@[simp] theorem executeCall_result (w : MultiWorld) (frame : CallFrame)
+    (runCallee : CallFrame → CalleeExecution) :
+    (executeCall w frame runCallee).result = (runCallee frame).result :=
+  rfl
+
+/-- Checked rollback is definitionally driven by execution control, not by a
+separately injected post-state or observation. -/
+theorem executeCall_revert_world (w : MultiWorld) (frame : CallFrame)
+    (runCallee : CallFrame → CalleeExecution) (data : List Nat)
+    (h : (runCallee frame).result = .revert data) :
+    (executeCall w frame runCallee).world =
+      upsert
+        (upsert w frame.caller
+          { frame.callerBefore with
+            calls := frame.callerBefore.calls ++
+              [framedJournalEntry frame (.revert data)] })
+        frame.callee frame.calleeBefore := by
+  simp [executeCall, h]
+
+theorem executeCall_failure_world (w : MultiWorld) (frame : CallFrame)
+    (runCallee : CallFrame → CalleeExecution) (data : List Nat)
+    (h : (runCallee frame).result = .failure data) :
+    (executeCall w frame runCallee).world =
+      upsert
+        (upsert w frame.caller
+          { frame.callerBefore with
+            calls := frame.callerBefore.calls ++
+              [framedJournalEntry frame (.failure data)] })
+        frame.callee frame.calleeBefore := by
+  simp [executeCall, h]
+
+theorem executeCall_success_world (w : MultiWorld) (frame : CallFrame)
+    (runCallee : CallFrame → CalleeExecution) (data : List Nat)
+    (h : (runCallee frame).result = .success data) :
+    (executeCall w frame runCallee).world =
+      upsert
+        (upsert w frame.caller
+          { frame.callerBefore with
+            selfBalance := frame.callerBefore.selfBalance -
+              (frame.site.value : Core.Uint256)
+            calls := frame.callerBefore.calls ++
+              [framedJournalEntry frame (.success data)] })
+        frame.callee (runCallee frame).post := by
+  simp [executeCall, h]
+
+theorem callEntry_calleeEntry (w : MultiWorld) (caller callee : Address)
+    (site : CallSite) (frame : CallFrame)
+    (h : callEntry w caller callee site = some frame) :
+    frame.calleeEntry =
+      withCallContext frame.calleeBefore frame.caller frame.callee
+        (frame.site.value : Core.Uint256) := by
+  simp only [callEntry] at h
+  split at h <;> try contradiction
+  split at h <;> try contradiction
+  split at h <;> try contradiction
+  split at h <;> try contradiction
+  next _ => cases h; rfl
 
 theorem fundedBus_bus_balance (n : Nat) :
     (lookup (fundedBus n) busAddr).selfBalance =

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -70,7 +70,9 @@ ensemble; it is not an L2 claim.
 `MultiContract.CallFrame` now separates caller/callee snapshots and the
 callee entry context; execution-produced control/returndata drive commit,
 checked rollback, and journaling. `runFunctionInFrame` adapts an actual
-source-shaped `FunctionSpec` execution to that boundary. The honest generic
+source-shaped `FunctionSpec` execution to that boundary, and `callFunction`
+is the checked composition that accepts no injected observation/post-state.
+The honest generic
 boundary currently admits ordinary cross-account `call` only; static and
 delegate frame invariants plus SupportedSpec/L2 wiring remain next.
 C5 step 3 (canonical

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,7 +61,14 @@ raw/linked calls with target, value and ETH debit are denoted in
 `none`/`.revert` so `DenoteAgreement` holds). Payable calls credit
 `selfBalance` via `withPayableCallContext`. `MultiContract` models
 Bus → Gateway → Vault → (Lido | request) as an ETH-valued hop
-ensemble; it is not an L2 claim. C5 step 3 (canonical
+ensemble; it is not an L2 claim.
+`MultiContract.CallFrame` now separates caller/callee snapshots and the
+callee entry context; execution-produced control/returndata drive commit,
+checked rollback, and journaling. `runFunctionInFrame` adapts an actual
+source-shaped `FunctionSpec` execution to that boundary. The honest generic
+boundary currently admits ordinary cross-account `call` only; static and
+delegate frame invariants plus SupportedSpec/L2 wiring remain next.
+C5 step 3 (canonical
 `storageWords : StorageKey → Uint256` backing, lens laws by constructor
 injectivity) is on `main`; it is the enabler for FixedArray-under-mapping,
 dynamic CodeData, arbitrary transient storage and multicall/delegatecall


### PR DESCRIPTION
## Summary

- add checked caller/callee `CallFrame` construction for ordinary cross-account calls
- drive commit, rollback, returndata, and journals from one execution-produced `CalleeExecution`
- retain FunctionSpec post-world/control and adapt source-shaped execution into the official framed boundary
- document the honest boundary: staticcall/delegatecall and L2 SupportedSpec wiring remain follow-ups

Advances #1963 and #2084. This is dependency infrastructure for #2094; it does not touch #1990 storage/footprint or C5/forEach surfaces.

## Verification

- `lake build Verity.Core.Model.MultiContract`
- `lake build Verity.Core.Model.DenoteFunctionCalls`
- direct `#print axioms` on the four new laws: only `propext`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/lean_lint.py --only axioms`
- `python3 scripts/lean_lint.py --only trust_surface_registry`
- `make check` (665 tests; zero sorry hygiene)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model-plane external-call semantics and ETH commit/rollback behavior used by future multi-contract proofs; scope is limited to ordinary `call` with no new axioms, but incorrect frame invariants would affect downstream L2 wiring.
> 
> **Overview**
> Introduces an **execution-backed multi-contract call boundary** so ETH-valued external hops are no longer success-only stubs: `CallFrame` snapshots caller/callee state, `callEntry` validates ordinary `call` preconditions, and `executeCall` commits or rolls back from a single `CalleeExecution` (control, returndata, journal).
> 
> **`DenoteFunctionCalls`** now exposes `executeFunctionWithCalls` / `FunctionExecution` (retaining post-world and control) and projects `denoteFunctionWithCalls` from that so semantics cannot drift. **`runFunctionInFrame`** and **`callFunction`** wire real `FunctionSpec` execution into the frame API without accepting injected results or post-states; `callFunction_eq` pins the composition.
> 
> Docs (`AUDIT.md`, `TRUST_ASSUMPTIONS.md`, `ROADMAP.md`) record the honest scope: **ordinary cross-account `call` only** — `staticcall`, `delegatecall`, and L2/SupportedSpec wiring are explicit follow-ups. **Zero new axioms.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d9d2d1e88a7a8eb78f8a13c8407b18e3a2b91bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->