### PR TITLE
fix(proofs): repair main red — agreement memory arrays + simp lemmas

### DIFF
--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -92,11 +92,30 @@ theorem denote_evalExpr_eq (fields : List Field) (s : DenoteState) :
       bindAgree (denote_evalExpr_eq fields s a) fun _ => rfl
   | .memoryArrayElement name a =>
       bindAgree (denote_evalExpr_eq fields s a) fun idx => by
-        simp only [Denote.evalExpr, SourceSemantics.evalExpr, toRuntimeState_bindings,
-          toRuntimeState_world]
-        rcases hBinding : Denote.dynamicArrayBinding? s.bindings name with _ | ⟨dataOffset, length⟩
-        · rfl
-        · by_cases hidx : idx < length <;> simp [hBinding, hidx]
+        have hB1 :
+            Denote.dynamicArrayBinding? s.bindings name =
+              SourceSemantics.dynamicArrayBinding? (toRuntimeState s).bindings name := by
+          simp [toRuntimeState_bindings,
+            Denote.dynamicArrayBinding?, SourceSemantics.dynamicArrayBinding?]
+        have hB2 :
+            (fun hx => (Denote.dynamicArrayBinding? s.bindings name).bind
+              fun p => some (s.world.memory
+                (Verity.wordNormalize (p.1 + 32 * hx))).val) idx =
+              (SourceSemantics.dynamicArrayBinding? (toRuntimeState s).bindings name).bind
+                fun p => some (s.world.memory
+                  (SourceSemantics.wordNormalize (p.1 + 32 * idx))).val := by
+          cases hBinding : Denote.dynamicArrayBinding? s.bindings name with
+          | none =>
+              rw [hBinding] at hB1 ⊢
+              have := hB1.symm
+              simp_all [SourceSemantics.dynamicArrayBinding?,
+                Denote.dynamicArrayBinding?]
+          | some p =>
+              rw [hBinding, hB1]
+              simp [SourceSemantics.dynamicArrayBinding?, Denote.dynamicArrayBinding?]
+        have hIdx := hB2.trans_eq rfl
+        simp [Denote.evalExpr, SourceSemantics.evalExpr, toRuntimeState_bindings] at hIdx ⊢
+        exact hIdx
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
   | .bitAnd a b | .bitOr a b | .bitXor a b | .shl a b | .shr a b | .sar a b
   | .byte a b | .signextend a b | .eq a b | .ge a b | .gt a b | .sgt a b

--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -84,13 +84,19 @@ theorem denote_evalExpr_eq (fields : List Field) (s : DenoteState) :
   | .mapping _ a | .mappingWord _ a _ | .mappingPackedWord _ a _ _
   | .mappingUint _ a | .mappingChain _ [a] | .structMember _ a _
   | .storageArrayElement _ a
-  | .memoryArrayElement _ a
   | .arrayElement _ a
   | .arrayElementDynamicWord _ a _
   | .arrayElementDynamicDataOffset _ a
   | .arrayElementDynamicMemberLength _ a _
   | .arrayElementDynamicMemberDataOffset _ a _ =>
       bindAgree (denote_evalExpr_eq fields s a) fun _ => rfl
+  | .memoryArrayElement name a =>
+      bindAgree (denote_evalExpr_eq fields s a) fun idx => by
+        simp only [Denote.evalExpr, SourceSemantics.evalExpr, toRuntimeState_bindings,
+          toRuntimeState_world]
+        rcases hBinding : Denote.dynamicArrayBinding? s.bindings name with _ | ⟨dataOffset, length⟩
+        · rfl
+        · by_cases hidx : idx < length <;> simp [hBinding, hidx]
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
   | .bitAnd a b | .bitOr a b | .bitXor a b | .shl a b | .shr a b | .sar a b
   | .byte a b | .signextend a b | .eq a b | .ge a b | .gt a b | .sgt a b

--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -69,7 +69,7 @@ theorem denote_evalExpr_eq (fields : List Field) (s : DenoteState) :
   | .literal _ | .param _ | .immutable _ | .constructorArg _ | .storage _ | .storageAddr _
   | .mappingChain _ [] | .mappingChain _ (_ :: _ :: _ :: _) | .localVar _
   | .storageArrayLength _ | .dynamicBytesEq ..
-  | .memoryArrayLength _ | .memoryArrayElement .. | .paramDynamicMemberLength ..
+  | .memoryArrayLength _ | .paramDynamicMemberLength ..
   | .paramDynamicMemberDataOffset .. | .paramDynamicMemberElement ..
   | .paramDynamicStaticComposite .. | .paramDynamicHeadWord ..
   | .arrayLength _ | .arrayElementWord ..
@@ -84,6 +84,7 @@ theorem denote_evalExpr_eq (fields : List Field) (s : DenoteState) :
   | .mapping _ a | .mappingWord _ a _ | .mappingPackedWord _ a _ _
   | .mappingUint _ a | .mappingChain _ [a] | .structMember _ a _
   | .storageArrayElement _ a
+  | .memoryArrayElement _ a
   | .arrayElement _ a
   | .arrayElementDynamicWord _ a _
   | .arrayElementDynamicDataOffset _ a
@@ -245,7 +246,7 @@ theorem writeAddressKeyedMappingSlots_eq
           storageKey =
             Verity.StorageKey.map slot (Verity.wordToAddress (Verity.Core.Uint256.ofNat k))
       · subst hmap; simp
-      · simp [hmap]
+      · simp
         cases storageKey with
         | slot s =>
             exact congrFun (storage_field_eq_of_rel h) s
@@ -293,7 +294,7 @@ theorem writeAddressKeyedMapping2Slots_eq
               (Verity.wordToAddress (Verity.Core.Uint256.ofNat k1))
               (Verity.wordToAddress (Verity.Core.Uint256.ofNat k2))
       · subst hmap; simp
-      · simp [hmap]
+      · simp
         cases storageKey with
         | slot s =>
             exact congrFun (storage_field_eq_of_rel h) s

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -1123,7 +1123,7 @@ theorem initialIRStateForTx_matches_constructor_runtime
       SourceSemantics.withConstructorTransactionContext, Verity.wordToAddress, hsenderWord, hthisWord,
       htxOriginWord, Nat.mod_eq_of_lt hmsgValue, Nat.mod_eq_of_lt htimestamp, Nat.mod_eq_of_lt hnumber,
       Nat.mod_eq_of_lt hchain, Nat.mod_eq_of_lt hblob]
-    exact hcalldataSizeFits'
+    exact ⟨rfl, hcalldataSizeFits'⟩
 
 theorem initialIRStateForTx_matches_bound_constructor_runtime
     (model : CompilationModel)

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -3209,6 +3209,11 @@ def withConstructorTransactionContext (world : Verity.ContractState) (tx : IRTra
     (world : Verity.ContractState) (tx : IRTransaction) :
     (withConstructorTransactionContext world tx).transientStorage = world.transientStorage := rfl
 
+@[simp] theorem transientStorage_at_withConstructorTransactionContext
+    (world : Verity.ContractState) (tx : IRTransaction) (slot : Nat) :
+    (withConstructorTransactionContext world tx).transientStorage slot =
+      world.transientStorage slot := rfl
+
 theorem findDynamicArrayElementAtSlot_withTransactionContext
     (fields : List Field)
     (world : Verity.ContractState)

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -1116,8 +1116,15 @@ private abbrev arrayElementDynamicMemberElement? :=
   DynamicAbi.arrayElementDynamicMemberElement?
 
 def evalExpr (fields : List Field) (state : RuntimeState) : Expr → Option Nat
-  | .memoryArrayLength _ => none
-  | .memoryArrayElement _ _ => none
+  | .memoryArrayLength name =>
+      lookupBinding? state.bindings s!"{name}_length"
+  | .memoryArrayElement name index => do
+      let idx ← evalExpr fields state index
+      let (dataOffset, length) ← dynamicArrayBinding? state.bindings name
+      if idx < length then
+        some (state.world.memory (wordNormalize (dataOffset + 32 * idx))).val
+      else
+        none
   | .arrayLength name =>
       lookupBinding? state.bindings s!"{name}_length"
   | .arrayElement name index => do
@@ -1618,7 +1625,8 @@ private theorem evalExpr_memoryArrayLength
     (fields : List Field)
     (state : RuntimeState)
     (name : String) :
-    evalExpr fields state (.memoryArrayLength name) = none := rfl
+    evalExpr fields state (.memoryArrayLength name) =
+      lookupBinding? state.bindings s!"{name}_length" := rfl
 
 private theorem evalExpr_dynamicBytesEq
     (fields : List Field)
@@ -2071,7 +2079,13 @@ private theorem evalExpr_memoryArrayElement
     (state : RuntimeState)
     (name : String)
     (index : Expr) :
-    evalExpr fields state (.memoryArrayElement name index) = none := rfl
+    evalExpr fields state (.memoryArrayElement name index) =
+      (do let idx ← evalExpr fields state index
+          let (dataOffset, length) ← dynamicArrayBinding? state.bindings name
+          if idx < length then
+            some (state.world.memory (wordNormalize (dataOffset + 32 * idx))).val
+          else
+            none) := rfl
 
 private theorem evalExpr_arrayElementWord
     (fields : List Field)
@@ -3191,6 +3205,10 @@ def withConstructorTransactionContext (world : Verity.ContractState) (tx : IRTra
     (world : Verity.ContractState) (tx : IRTransaction) :
     (withConstructorTransactionContext world tx).storageArray = world.storageArray := rfl
 
+@[simp] theorem transientStorage_withConstructorTransactionContext
+    (world : Verity.ContractState) (tx : IRTransaction) :
+    (withConstructorTransactionContext world tx).transientStorage = world.transientStorage := rfl
+
 theorem findDynamicArrayElementAtSlot_withTransactionContext
     (fields : List Field)
     (world : Verity.ContractState)
@@ -3897,6 +3915,15 @@ mutual
         let off ← evalExprWithHelpers spec fields fuel state offExpr
         let size ← evalExprWithHelpers spec fields fuel state sizeExpr
         some (keccakMemorySlice state.world.memory off size)
+    | .memoryArrayLength name =>
+        lookupBinding? state.bindings s!"{name}_length"
+    | .memoryArrayElement name index => do
+        let idx ← evalExprWithHelpers spec fields fuel state index
+        let (dataOffset, length) ← dynamicArrayBinding? state.bindings name
+        if idx < length then
+          some (state.world.memory (wordNormalize (dataOffset + 32 * idx))).val
+        else
+          none
     | .arrayLength name =>
         lookupBinding? state.bindings s!"{name}_length"
     | .arrayElement name index => do
@@ -3944,8 +3971,6 @@ mutual
     | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
     | .paramDynamicMemberLength _ _
     | .paramDynamicMemberDataOffset _ _ | .paramDynamicMemberElement _ _ _
-    | .memoryArrayLength _
-    | .memoryArrayElement _ _
     | .arrayElementWord _ _ _ _
     | .extcodesize _ | .returndataSize | .returndataOptionalBoolAt _
     | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
@@ -5313,7 +5338,11 @@ mutual
     | arrayElement _ b =>
         simp [exprTouchesUnsupportedHelperSurface] at hsurface
     | memoryArrayElement _ b =>
-        simp [evalExprWithHelpers, evalExpr_memoryArrayElement]
+        simp only [exprTouchesUnsupportedHelperSurface] at hsurface
+        have hb :=
+          evalExprWithHelpers_eq_evalExpr_of_helperSurfaceClosed spec fields fuel state b hsurface
+        simp [evalExprWithHelpers, evalExpr_memoryArrayElement, hb,
+          SourceSemantics.wordNormalize_eq_mod]
     | arrayElementWord _ b _ _ =>
         simp [evalExprWithHelpers, evalExpr_arrayElementWord]
     | arrayElementDynamicWord _ b _ =>

--- a/Compiler/Proofs/Storage/StructArrayStorage.lean
+++ b/Compiler/Proofs/Storage/StructArrayStorage.lean
@@ -175,7 +175,7 @@ theorem compiledStructMemberSlot_eq_sourceStructMemberSlotRead
     unfold sourceStructMemberSlotRead
     rw [SourceSemantics.evalExpr]
     simp only [SourceSemantics.evalExpr, hfield, hmembers, structBridgeMember,
-      structMemberBridgeState, Verity.ContractState.storage_withStorageChannel,
+      structMemberBridgeState,
       SourceSemantics.wordNormalize_eq_mod, Nat.mod_eq_of_lt hkey]
     simp only [structBridgeField, SourceSemantics.readFieldWord,
       SourceSemantics.wordNormalize]

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4227,6 +4227,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.SourceSemantics.storageAddr_withConstructorTransactionContext
   Compiler.Proofs.IRGeneration.SourceSemantics.storageArray_withConstructorTransactionContext
   Compiler.Proofs.IRGeneration.SourceSemantics.transientStorage_withConstructorTransactionContext
+  Compiler.Proofs.IRGeneration.SourceSemantics.transientStorage_at_withConstructorTransactionContext
   Compiler.Proofs.IRGeneration.SourceSemantics.findDynamicArrayElementAtSlot_withTransactionContext
   Compiler.Proofs.IRGeneration.SourceSemantics.findDynamicArrayElementAtSlot_congr_storageArray
   Compiler.Proofs.IRGeneration.SourceSemantics.encodeStorageAt_congr
@@ -6975,4 +6976,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6467 theorems/lemmas (4597 public, 1870 private, 0 sorry'd)
+-- Total: 6468 theorems/lemmas (4598 public, 1870 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4226,6 +4226,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.SourceSemantics.storage_withConstructorTransactionContext
   Compiler.Proofs.IRGeneration.SourceSemantics.storageAddr_withConstructorTransactionContext
   Compiler.Proofs.IRGeneration.SourceSemantics.storageArray_withConstructorTransactionContext
+  Compiler.Proofs.IRGeneration.SourceSemantics.transientStorage_withConstructorTransactionContext
   Compiler.Proofs.IRGeneration.SourceSemantics.findDynamicArrayElementAtSlot_withTransactionContext
   Compiler.Proofs.IRGeneration.SourceSemantics.findDynamicArrayElementAtSlot_congr_storageArray
   Compiler.Proofs.IRGeneration.SourceSemantics.encodeStorageAt_congr
@@ -6974,4 +6975,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6466 theorems/lemmas (4596 public, 1870 private, 0 sorry'd)
+-- Total: 6467 theorems/lemmas (4597 public, 1870 private, 0 sorry'd)

--- a/Verity/Core/Model/NonReentrantGuard.lean
+++ b/Verity/Core/Model/NonReentrantGuard.lean
@@ -36,8 +36,7 @@ def setLock (slot : Nat) (value : Uint256) (s : ContractState) : ContractState :
 
 @[simp] theorem setLock_reads (slot : Nat) (value : Uint256) (s : ContractState) :
     (setLock slot value s).transientStorage slot = value := by
-  simpa [setLock, ContractState.readTransient] using
-    ContractState.readTransient_writeTransient_same s slot value
+  exact ContractState.readTransient_writeTransient_same s slot value
 
 @[simp] theorem setLock_reads_other (slot k : Nat) (value : Uint256)
     (s : ContractState) (h : k ≠ slot) :


### PR DESCRIPTION
- Extend SourceSemantics.evalExpr memory arms to mirror Denote additions (memoryArrayLength binding lookup, memoryArrayElement word load), so the agreement theorem holds across the whole memory-array surface (denote_evalExpr_eq moves the case into the bindAgree arm).
- Match the private lemmas evalExpr_memoryArray{Length,Element} to the new computing arms.
- Add sourceSemantics.wordNormalize_eq_mod to the fuel / WithHelpers agreement arm.
- Add `transientStorage_withConstructorTransactionContext` (and the storageArray sibling already present) so the fork conformance (EVMYulLean simp set) converges in `initialIRStateForTx_matches_constructor_runtime`.
- Drop unused simp args in `DenoteAgreement` (sites 245,293) and `StructArrayStorage`.
- Migrate `NonReentrantGuard.setLock_reads` from simpa to direct simp rewrite.

Local validation: `lake build Compiler.Proofs.IRGeneration.SourceSemantics` (1202/1202 ✔), `Compiler.Proofs.IRGeneration.DenoteAgreement` (1204/1204 ✔). `Function` and a full check remain for the CI runner (budget 45m). No new sorry/axiom. Plan: exact-head certification once the green job arrives.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch core IR expression semantics and the Denote/SourceSemantics agreement layer; mistakes could silently weaken certification, but the diff is localized to proof/semantics alignment with no auth or runtime deployment impact.
> 
> **Overview**
> **SourceSemantics** now evaluates **memory-backed dynamic arrays** instead of returning `none`: `memoryArrayLength` reads the `{name}_length` binding, and `memoryArrayElement` loads a normalized memory word after bounds checking via `dynamicArrayBinding?`. The same behavior is wired through **`evalExprWithHelpers`**, and the private `rfl` lemmas are updated to match.
> 
> The **`denote_evalExpr_eq`** agreement proof gains a dedicated **`memoryArrayElement`** case (binding lookup + index bind congruence), and the helper-surface lemma for that constructor now closes using **`wordNormalize_eq_mod`**. Constructor transaction context picks up **`transientStorage`** simp lemmas so **`initialIRStateForTx`** fork proofs can simplify; **`Function.lean`** supplies an explicit **`⟨rfl, …⟩`** pair where the goal expected a product.
> 
> Proof hygiene only elsewhere: drop redundant **`simp [hmap]`** args in mapping-write agreement, trim an unused simp list in struct-array storage, switch **`NonReentrantGuard.setLock_reads`** to a direct rewrite, and bump the **`PrintAxioms`** theorem count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c11ed97cb89641af83413da392131b7e433c7782. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->