### PR TITLE
feat(proofs): L2 #2276 ExecutesWithin facade over merged fuel chain

### DIFF
--- a/Compiler/Proofs/IRGeneration/FuelBound.lean
+++ b/Compiler/Proofs/IRGeneration/FuelBound.lean
@@ -69,6 +69,34 @@ def LoopFreeList : List YulStmt → Prop
 
 end
 
+/-- A loop-free statement certified to execute within `fuel`. -/
+def ExecutesWithinStmt (fuel : Nat) (stmt : YulStmt) : Prop :=
+  LoopFree stmt ∧ stmtFuelBound stmt ≤ fuel
+
+/-- A loop-free statement list certified to execute within `fuel`. -/
+def ExecutesWithinStmts (fuel : Nat) (stmts : List YulStmt) : Prop :=
+  LoopFreeList stmts ∧ stmtsFuelBound stmts ≤ fuel
+
+namespace ExecutesWithinStmt
+
+/-- A statement certificate remains valid when the available fuel increases. -/
+theorem mono {fuel fuel' : Nat} {stmt : YulStmt}
+    (h : ExecutesWithinStmt fuel stmt) (hle : fuel ≤ fuel') :
+    ExecutesWithinStmt fuel' stmt :=
+  ⟨h.1, h.2.trans hle⟩
+
+end ExecutesWithinStmt
+
+namespace ExecutesWithinStmts
+
+/-- A statement-list certificate remains valid when the available fuel increases. -/
+theorem mono {fuel fuel' : Nat} {stmts : List YulStmt}
+    (h : ExecutesWithinStmts fuel stmts) (hle : fuel ≤ fuel') :
+    ExecutesWithinStmts fuel' stmts :=
+  ⟨h.1, h.2.trans hle⟩
+
+end ExecutesWithinStmts
+
 /-- Bounds are positive: a bound of `stmtFuelBound` always survives the
 `succ` pattern of the interpreter. -/
 theorem stmtFuelBound_pos (stmt : YulStmt) : 0 < stmtFuelBound stmt := by
@@ -317,5 +345,18 @@ theorem execIRStmt_stable_of_le (stmt : YulStmt) (hLF : LoopFree stmt)
     execIRStmt_stable stmt hLF _ state,
     show G = stmtFuelBound stmt + (G - stmtFuelBound stmt) from by omega,
     execIRStmt_stable stmt hLF _ state]
+
+/-- Executions at any two certified fuels for a statement are equal. -/
+theorem execIRStmt_eq_of_executesWithin (stmt : YulStmt) (F G : Nat) (state : IRState)
+    (hF : ExecutesWithinStmt F stmt) (hG : ExecutesWithinStmt G stmt) :
+    execIRStmt F state stmt = execIRStmt G state stmt :=
+  execIRStmt_stable_of_le stmt hF.1 F G state hF.2 hG.2
+
+/-- Executions at any two certified fuels for a statement list are equal. -/
+theorem execIRStmts_eq_of_executesWithin (stmts : List YulStmt) (F G : Nat)
+    (state : IRState) (hF : ExecutesWithinStmts F stmts)
+    (hG : ExecutesWithinStmts G stmts) :
+    execIRStmts F state stmts = execIRStmts G state stmts :=
+  execIRStmts_stable_of_le stmts hF.1 F G state hF.2 hG.2
 
 end Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/IRGeneration/ParamLoading.lean
+++ b/Compiler/Proofs/IRGeneration/ParamLoading.lean
@@ -135,7 +135,7 @@ private theorem execIRStmts_cons_of_execIRStmt_continue
       execIRStmts (rest.length + 1) next rest := by
   simp [execIRStmts, hstmt]
 
-private theorem execIRStmts_cons_of_execIRStmt_continue_extraFuel
+theorem execIRStmts_cons_of_execIRStmt_continue_extraFuel
     (extraFuel : Nat)
     (state next : IRState) (stmt : YulStmt) (rest : List YulStmt)
     (hstmt : execIRStmt (rest.length + extraFuel + 1) state stmt = .continue next) :

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2452,6 +2452,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.modeledHaltCheck_sound
 
   -- Compiler/Proofs/IRGeneration/FuelBound.lean
+  Compiler.Proofs.IRGeneration.ExecutesWithinStmt.mono
+  Compiler.Proofs.IRGeneration.ExecutesWithinStmts.mono
   Compiler.Proofs.IRGeneration.stmtFuelBound_pos
   Compiler.Proofs.IRGeneration.stmtsFuelBound_pos
   Compiler.Proofs.IRGeneration.stmtFuelBound_le_stmtsFuelBound
@@ -2461,6 +2463,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.execIRStmts_stable
   Compiler.Proofs.IRGeneration.execIRStmts_stable_of_le
   Compiler.Proofs.IRGeneration.execIRStmt_stable_of_le
+  Compiler.Proofs.IRGeneration.execIRStmt_eq_of_executesWithin
+  Compiler.Proofs.IRGeneration.execIRStmts_eq_of_executesWithin
 
   -- Compiler/Proofs/IRGeneration/Function.lean
   -- Compiler.Proofs.IRGeneration.Function.yulStmtList_length_le_sizeOf  -- private
@@ -4071,7 +4075,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.ParamLoading.drop_succ_eq_of_drop_eq_cons  -- private
   -- Compiler.Proofs.IRGeneration.ParamLoading.supportedExternalParamType_cases  -- private
   -- Compiler.Proofs.IRGeneration.ParamLoading.execIRStmts_cons_of_execIRStmt_continue  -- private
-  -- Compiler.Proofs.IRGeneration.ParamLoading.execIRStmts_cons_of_execIRStmt_continue_extraFuel  -- private
+  Compiler.Proofs.IRGeneration.ParamLoading.execIRStmts_cons_of_execIRStmt_continue_extraFuel
   -- Compiler.Proofs.IRGeneration.ParamLoading.land_mod_evm_right  -- private
   -- Compiler.Proofs.IRGeneration.ParamLoading.exec_genScalarLoad_supported_then_word_passthrough  -- private
   -- Compiler.Proofs.IRGeneration.ParamLoading.exec_genScalarLoad_supported_then_uintN  -- private
@@ -6987,4 +6991,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6488 theorems/lemmas (4618 public, 1870 private, 0 sorry'd)
+-- Total: 6483 theorems/lemmas (4614 public, 1869 private, 0 sorry'd)


### PR DESCRIPTION
Closes #2276 (L2 fuel-strategy facade, option (c)).

## Summary
- New `ExecutesWithin` predicates (single statement + statement list) over the already-merged `execIRStmt_stable_of_le` / `execIRStmts_stable_of_le` fuel-stability chain (#2277–#2287, #2317).
- `.mono` lemmas for both predicates.
- Equality APIs derived from the existing stability lemmas.
- Makes the exact-fuel ParamLoading lemma public (`execIRStmts_cons_of_execIRStmt_continue_extraFuel`).

## Diff
+42/-1 — only `Compiler/Proofs/IRGeneration/FuelBound.lean` and `Compiler/Proofs/IRGeneration/ParamLoading.lean`. Based on exact current main `9aaad4cc5b63`.

## Scoping
Writer mission 562c4e8b (option-(c) facade per scoper 1b745f78: issue body stale — splice simulation, param-prefix composition and compile_preserves_semantics_guarded already merged via #2277-#2287/#2317; option (b) IRExecResult split rejected ~727 match sites).