### PR TITLE
fix(proofs): restore dynamicArrayBinding?/wordNormalize visibility for DenoteAgreement

### DIFF
--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -100,7 +100,7 @@ theorem denote_evalExpr_eq (fields : List Field) (s : DenoteState) :
         have hB2 :
             (fun hx => (Denote.dynamicArrayBinding? s.bindings name).bind
               fun p => some (s.world.memory
-                (Verity.wordNormalize (p.1 + 32 * hx))).val) idx =
+                (Denote.wordNormalize (p.1 + 32 * hx))).val) idx =
               (SourceSemantics.dynamicArrayBinding? (toRuntimeState s).bindings name).bind
                 fun p => some (s.world.memory
                   (SourceSemantics.wordNormalize (p.1 + 32 * idx))).val := by

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -1094,7 +1094,7 @@ def writeStorageArray (world : Verity.ContractState) (slot : Nat)
 private def ceilDivVal (lhs rhs : Verity.Core.Uint256) : Nat :=
   if lhs == 0 then 0 else ((lhs - 1) / rhs + 1).val
 
-private abbrev dynamicArrayBinding? :=
+abbrev dynamicArrayBinding? :=
   DynamicAbi.dynamicArrayBinding?
 
 private abbrev arrayElement? :=


### PR DESCRIPTION
## Repair

Fixes the elaboration failures on `main` at `9aaad4cc5b63b52c4cc13ad10055be60e2c21a1a` in `Compiler/Proofs/IRGeneration/DenoteAgreement.lean`:

- `SourceSemantics.dynamicArrayBinding?` unknown at 97:14, 99:41, and 104:15: re-expose the existing `DynamicAbi.dynamicArrayBinding?` alias as a public `SourceSemantics` declaration.
- `Verity.wordNormalize` unknown at 103:17: use the canonical `Denote.wordNormalize` name after the denotation namespace refactor.
- The unsolved goals at 94:59 and 97:87 consequently elaborate again with the theorem statement unchanged.

## Local build receipt

- Command: `lake build`
- Exit code: `0`
- Target count: `1204` Lake targets

No `sorry`, `admit`, or `axiom` was added.
