### PR TITLE
proof: expose scalar ABI head composition

### DIFF
--- a/Compiler/Proofs/AbiEncoding.lean
+++ b/Compiler/Proofs/AbiEncoding.lean
@@ -71,6 +71,47 @@ def abiScalarNormalize : ParamType → Nat → Nat
     abiScalarNormalize (ParamType.newtypeOf name baseType) v =
       abiScalarNormalize baseType v := rfl
 
+/-- The ABI head word for one scalar argument.  Every scalar in this fragment
+occupies one 32-byte ABI head slot; the word value is its ABI normalization.
+
+This deliberately exposes words rather than a byte list: the Yul backend's
+`mstore` observable is word-addressed, and the bridge lemmas below establish
+that its stored words are precisely these heads. -/
+def abiEncodeScalarHead (ty : ParamType) (value : Nat) : Nat :=
+  abiScalarNormalize ty value
+
+/-- ABI head encoding for a sequence of scalar arguments.  Keeping the type
+tag paired with its value makes concatenation structural and avoids any
+implicit positional convention at typed ABI boundaries. -/
+def abiEncodeScalarHeads (args : List (ParamType × Nat)) : List Nat :=
+  args.map (fun arg => abiEncodeScalarHead arg.1 arg.2)
+
+@[simp] theorem abiEncodeScalarHead_uint256 (value : Nat) :
+    abiEncodeScalarHead .uint256 value = value := rfl
+
+/-- ABI addresses are left-zero-padded: only their low 160 bits occupy the
+rightmost portion of the 256-bit head word. -/
+@[simp] theorem abiEncodeScalarHead_address (value : Nat) :
+    abiEncodeScalarHead .address value =
+      ((value % Compiler.Constants.evmModulus) &&& Compiler.Constants.addressMask) := rfl
+
+/-- ABI booleans are canonical full words, zero for false and one for true. -/
+@[simp] theorem abiEncodeScalarHead_bool (value : Nat) :
+    abiEncodeScalarHead .bool value =
+      (if value % Compiler.Constants.evmModulus = 0 then 0 else 1) := rfl
+
+/-- `bytes32` already fills a complete ABI head word, so it has no padding or
+sign-extension transformation. -/
+@[simp] theorem abiEncodeScalarHead_bytes32 (value : Nat) :
+    abiEncodeScalarHead .bytes32 value = value := rfl
+
+/-- Scalar ABI heads compose by concatenation, as required for the static
+head portion of `abi.encode(a₁, …, aₙ)`. -/
+theorem abiEncodeScalarHeads_append (left right : List (ParamType × Nat)) :
+    abiEncodeScalarHeads (left ++ right) =
+      abiEncodeScalarHeads left ++ abiEncodeScalarHeads right := by
+  simp [abiEncodeScalarHeads]
+
 private theorem lit_255_mod_evm :
     (255 : Nat) % Compiler.Constants.evmModulus = 255 :=
   Nat.mod_eq_of_lt (by norm_num [Compiler.Constants.evmModulus])

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1051,6 +1051,11 @@ end Verity.AxiomAudit
   Compiler.Proofs.AbiEncoding.abiScalarNormalize_address
   Compiler.Proofs.AbiEncoding.abiScalarNormalize_bool
   Compiler.Proofs.AbiEncoding.abiScalarNormalize_newtypeOf
+  Compiler.Proofs.AbiEncoding.abiEncodeScalarHead_uint256
+  Compiler.Proofs.AbiEncoding.abiEncodeScalarHead_address
+  Compiler.Proofs.AbiEncoding.abiEncodeScalarHead_bool
+  Compiler.Proofs.AbiEncoding.abiEncodeScalarHead_bytes32
+  Compiler.Proofs.AbiEncoding.abiEncodeScalarHeads_append
   -- Compiler.Proofs.AbiEncoding.lit_255_mod_evm  -- private
   -- Compiler.Proofs.AbiEncoding.lit_65535_mod_evm  -- private
   -- Compiler.Proofs.AbiEncoding.addressMask_mod_evm  -- private
@@ -6987,4 +6992,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6488 theorems/lemmas (4618 public, 1870 private, 0 sorry'd)
+-- Total: 6484 theorems/lemmas (4614 public, 1870 private, 0 sorry'd)


### PR DESCRIPTION
Summary: expose ABI scalar heads for uint256, address, bool, and bytes32; prove structural head concatenation for typed ABI consumers. Existing scalar event and Error(string) revert observables remain the downstream bridge.

Validation: lake build; lake build PrintAxioms; forbidden-token scan; git diff --check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions that alias existing normalization; no compiler runtime, auth, or data-path changes.
> 
> **Overview**
> Adds a **word-level ABI head API** on top of existing `abiScalarNormalize`: `abiEncodeScalarHead` (one 32-byte head per scalar) and `abiEncodeScalarHeads` for typed `(ParamType × Nat)` argument lists, aimed at Yul `mstore` / static `abi.encode` head reasoning rather than byte lists.
> 
> New `@[simp]` characterizations cover **uint256**, **address**, **bool**, and **bytes32** heads, plus **`abiEncodeScalarHeads_append`** so head sequences split across list concatenation. The five new lemmas are registered in **`PrintAxioms.lean`** (theorem count 6483 → 6488); existing event and custom-error bridges are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b07e524b81bbbf1378421e8a578a6fc2a8f96dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->