### PR TITLE
proof: refine dynamic bytes external calldata binding

### DIFF
--- a/Verity/Core/Model/DynamicAbi.lean
+++ b/Verity/Core/Model/DynamicAbi.lean
@@ -278,6 +278,43 @@ def bindExternalParamsFrom (selector : Nat) (calldata : List Nat)
         (headOffset + paramHeadSize param.ty)
       some (here ++ tail)
 
+/-- The semantic counterpart of the compiler's length-prefixed dynamic
+calldata loader for a `bytes` parameter.  Given the same checked head word,
+tail length word, and byte-tail bound that the generated loader establishes,
+the dispatcher binds exactly its six loader locals.
+
+This is intentionally a one-parameter refinement boundary: the next dispatch
+slice composes it with `execIRStmts` for `genDynamicParamLoads`, then lifts it
+over the parameter list. -/
+theorem bindExternalParam_bytes_refines_dynamic_loader
+    {selector : Nat} {calldata : List Nat}
+    {headSize baseOffset headOffset relativeOffset length : Nat} {name : String}
+    (hhead : externalWordAt? selector calldata headOffset = some relativeOffset)
+    (hheadBound : headSize ≤ relativeOffset)
+    (htailBound : baseOffset + relativeOffset + 32 ≤ externalCalldataSize calldata)
+    (hlength : externalWordAt? selector calldata (baseOffset + relativeOffset) = some length)
+    (hpayloadBound :
+      length ≤ externalCalldataSize calldata - (baseOffset + relativeOffset + 32)) :
+    bindExternalParam selector calldata headSize baseOffset headOffset
+      { name := name, ty := ParamType.bytes } =
+      some
+        [ (s!"{name}_offset", relativeOffset)
+        , (s!"{name}_abs_offset", baseOffset + relativeOffset)
+        , (s!"{name}_length", length)
+        , (s!"{name}_tail_head_end", baseOffset + relativeOffset + 32)
+        , (s!"{name}_tail_remaining",
+            externalCalldataSize calldata - (baseOffset + relativeOffset + 32))
+        , (s!"{name}_data_offset", baseOffset + relativeOffset + 32) ] := by
+  have hnotTailOutOfBounds : ¬ baseOffset + relativeOffset + 32 > externalCalldataSize calldata := by
+    omega
+  have hnotHeadInTail : ¬ relativeOffset < headSize := by
+    omega
+  have hdecodeBytes : decodeSupportedParamWord ParamType.bytes =<< some relativeOffset = none := rfl
+  simp [bindExternalParam, externalDynamicPayloadShape?,
+    decodeLengthPrefixedDynamicParam?, DynamicPayloadShape.fitsLength,
+    dynamicParamBindings, hhead, hdecodeBytes, hnotHeadInTail, hnotTailOutOfBounds, hlength,
+    hpayloadBound]
+
 /-- Witness that one external ABI parameter is accepted by `bindExternalParam`
 at a particular absolute head offset. -/
 def ExternalParamBindingWitness


### PR DESCRIPTION
## Summary

Lands the first provable dynamic-calldata dispatch boundary for #2085:

- `bindExternalParam_bytes_refines_dynamic_loader` proves that accepted ABI
  `bytes` head/tail calldata binds precisely the six locals emitted by the
  generated dynamic loader.
- The theorem is a semantic, one-parameter refinement boundary over the
  checked ABI head, tail length, and payload bound.

## Boundary / next slice

The generic whole-contract dispatcher is still scalar-only:
`SupportedExternalParamType` must not include `bytes` until the next slice
proves `execIRStmts` for `genDynamicParamLoads` against this theorem and lifts
it through parameter lists. That slice can then widen the support predicate
without weakening the existing scalar dispatch proof.

## Validation

- `lake build Verity.Core.Model.DynamicAbi`
- full `lake build` and `lake build PrintAxioms` receipts will be recorded on
  this PR once the bounded local runs complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only addition in `Verity/Core/Model/DynamicAbi.lean`; no runtime compiler or dispatch behavior changes.
> 
> **Overview**
> Adds **`bindExternalParam_bytes_refines_dynamic_loader`**, a Lean proof that when ABI head/tail checks match the generated length-prefixed loader (`externalWordAt?`, head ≥ `headSize`, tail length word in bounds, payload fits remaining calldata), semantic **`bindExternalParam`** for **`ParamType.bytes`** returns **exactly the six bindings** (`{name}_offset`, `_abs_offset`, `_length`, `_tail_head_end`, `_tail_remaining`, `_data_offset`) that **`genDynamicParamLoads`** emits.
> 
> This is framed as a **one-parameter refinement boundary** for dynamic external dispatch: a follow-up slice is expected to tie **`execIRStmts`** for **`genDynamicParamLoads`** to this theorem and lift over parameter lists before widening scalar-only external support to include **`bytes`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ffb9427f5d75e92caf6d62b07d27afa749502db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->