### PR TITLE
chore(lint): bump storage-lens freeze baseline for #2377 fallout (C5 step 1)

### DIFF
--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 1733,
+    "core_lines": 1991,
     "example_contracts": 18
   },
   "proofs": {

--- a/scripts/check_storage_lens_freeze.py
+++ b/scripts/check_storage_lens_freeze.py
@@ -60,7 +60,10 @@ BASELINE = {
     # The sole canonical word-map implementation boundary. This includes the
     # single default-state literal plus the lens implementations (including
     # bulk lenses); no caller outside this file may update `storageWords`.
-    "Verity/Core.lean": 21,
+    # The count also covers the `*_set_storageWords` projection simp lemmas,
+    # whose *statements* mention `{ s with storageWords := f }` and so read as
+    # raw sites here; they are lens metatheory, not storage bypasses.
+    "Verity/Core.lean": 33,
     # IRState fixture literals (field-name collision false positives).
     "Contracts/TypedIRTests.lean": 3,
 }


### PR DESCRIPTION
## Why

Post-merge `Verify proofs` on **main** is red: run [32090929549](https://github.com/lfglabs-dev/verity/actions/runs/32090929549), `checks` job, at `Makefile:134: check`.

```
storage-lens freeze gate FAILED (C5 step 1):
  Verity/Core.lean: 33 raw storage-channel update sites (baseline 21).
```

Main SHA at failure: `2c7323de5fdd9bb39115e6a5c97d1c949a3e9ba5`.

## Root cause

#2377 (the previous red-recovery PR) added 12 `@[simp] theorem *_set_storageWords[_fun]` projection lemmas at `Verity/Core.lean:509-552`. Each is `:= rfl` and each *statement* mentions `{ s with storageWords := f }`, which the gate's regex counts as a raw storage-channel update site. 21 + 12 = 33.

## Ratchet direction

The freeze gate is a **burn-down** ratchet — the baseline is only ever supposed to shrink. This PR inverts that direction, so it deserves the scrutiny:

- The 12 new sites are **lens metatheory**, not caller-side bypasses. They are lemmas *about* how the compatibility views reduce through a `storageWords` record update — exactly the rewrites contract proofs need when they unfold `writeSlot`/`writeAddrSlot`/`writeMap`.
- They live in `Verity/Core.lean`, which the gate's own docstring designates as the canonical implementation boundary: *"the only file meant to keep raw access after the migration completes."*
- **No other baseline entry is touched.** `Contracts/TypedIRTests.lean` stays at 3.
- **No caller outside `Verity/Core.lean` gained raw access**, and the gate is not disabled, weakened, or exempted anywhere — no `# noqa`, no exception clauses. A new raw site in any other file still fails exactly as before.

The C5 step 3 flip still requires burning every *other* file to zero; this bump does not move that goalpost.

## Second, pre-existing red in the same job

Once the freeze gate passes, the very next check in `make check` fails on **pristine main** too:

```
Stale verification artifact: artifacts/verification_status.json
```

Verified by stashing this change and re-running against clean `2c7323de`. CI never reported it because the freeze gate aborted the job first. It is the *same #2377 fallout* — the regenerated delta is a single derived metric, `core_lines` 1733 → 1991, i.e. the lines #2377 added to `Verity/Core.lean`.

Regenerating it here is a deliberate scope addition beyond a pure baseline bump: without it, main stays red and needs another repair PR for the same root cause.

## Local verification

| check | result |
|---|---|
| `python3 scripts/check_storage_lens_freeze.py` | exit **0** — `OK: storage-lens freeze holds (36 baselined raw sites across 2 files)` |
| `make check` (full CI-equivalent `checks` job) | exit **0** — `All checks passed.` |
| forbidden-token scan | no `.lean` files changed; no new `sorry`/`admit`/`axiom` |

`lake build` / `lake build PrintAxioms` are running on a cold cache locally (full Mathlib build from source). This change is Python + generated-JSON only and touches no Lean source, so the Lean state is identical to `2c7323de`; CI is the authoritative validator for those two steps.

## Not done here

`Verity/Core.lean` is untouched. No force-push, no rebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Python baseline and generated JSON only; no Lean or runtime behavior changes, and the freeze gate still fails on new raw sites outside the documented Core boundary.
> 
> **Overview**
> Unblocks **main** CI after #2377 by updating the storage-lens freeze ratchet and the checked-in verification artifact—no Lean source changes.
> 
> The freeze gate baseline for `Verity/Core.lean` is raised **21 → 33** so twelve new `*_set_storageWords` `@[simp]` projection lemmas (whose statements contain `{ s with storageWords := f }`) are treated as expected lens metatheory at the canonical boundary, not new caller bypasses. Comments in `scripts/check_storage_lens_freeze.py` document that distinction; other baselines and gate logic are unchanged.
> 
> `artifacts/verification_status.json` is refreshed so **`core_lines`** matches the larger `Verity/Core.lean` from the same fallout (**1733 → 1991**), fixing the stale-artifact failure that would run immediately after the freeze check passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8831c5aa39fb2adf9504fcf7fcfda4ae68fff45e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->