### PR TITLE
feat(storage): global all-keys mapping coherence (C5 step 4, #2330)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -413,6 +413,29 @@ sibling entrypoint.
   maps collapse to `solidityMappingSlot` of the 32-byte word (no
   `StorageKey.mapBytes32`). All nine `MappingType.nested` key-type
   pairs collapse to `abstractNestedMappingSlot`.
+- C5 step 4 final slice (`Compiler.Proofs.Storage.MappingCoherentGlobal`,
+  #2330): `storageKeySlot : List Field → StorageKey → Option (Channel × Nat)`
+  is the field-list collapse — `Channel` is `persistent` / `address` /
+  `transient` / `contract c`, and `contractSlot 0` is **not** identified
+  with `slot`. `MappingCoherentAllKeys` is the all-keys (`∀ StorageKey`)
+  invariant, not a listed pair or a single key. The declared layout is
+  load-bearing: a mapping key collapses only when the resolved field at its
+  base slot declares the matching `MappingType`, so distinct mapping shapes
+  force distinct base slots and `solidityMappingSlot_injective` separates
+  their derived images. Aligned `writeMap` / `writeMapUint` / `writeMap2` +
+  `writeSlot`, `writeAddrSlot`, and `writeTransient` preserve it; a lone
+  `writeSlot` takes `DerivedMappingSlotsAvoid` (the existing image-avoidance
+  `∀`); the simple-vs-nested cross case takes the layout certificate
+  `MappingBasesNotDerived`. `readMap_eq_encodeStorageAt_of_coherent` (plus
+  `mapUint` / `map2` variants) is the lens-read = flat-read bridge under
+  that invariant. Dynamic-array element slots are an explicit
+  `unsupported` row, not an equivalence: the source model derives element
+  `i` at `solidityMappingSlot s i`
+  (`Compiler/Proofs/IRGeneration/SourceSemantics.lean:330-350`) while the
+  Yul layout uses `keccak256(bytes32(s)) + i`
+  (`Compiler/Proofs/Storage/StructArrayStorage.lean:666-671`); the collapse
+  returns `none` at dynamic-array roots
+  (`storageKeySlot_slot_dynamicArray`). Zero new axioms.
 - Zero new axioms.
 
 ## CI Guards

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -435,7 +435,7 @@ sibling entrypoint.
   Yul layout uses `keccak256(bytes32(s)) + i`
   (`Compiler/Proofs/Storage/StructArrayStorage.lean:666-671`); the collapse
   returns `none` at dynamic-array roots
-  (`storageKeySlot_slot_dynamicArray`). Zero new axioms.
+  (`storageKeySlot_slot_dynamicArray`).
 - Zero new axioms.
 
 ## CI Guards

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -43,6 +43,19 @@ finite list is the same explicit slot inequality. Lone
 injectivity separates transient from persistent keys.
 `FieldEncode` adds no axiom: `findResolvedFieldAtSlot` is derived
 from no write-slot conflict plus constructor facts.
+The all-keys global (`MappingCoherentGlobal.MappingCoherentAllKeys`,
+final slice of C5 step 4) adds no axiom either: cross-channel
+separation is the declared layout (`fieldMapKindAt` is a function of
+the base slot, so distinct mapping shapes force distinct base slots)
+plus the same `solidityMappingSlot_injective`. The simple-vs-nested
+cross case takes an explicit `MappingBasesNotDerived` layout
+certificate and a lone `writeSlot` takes `DerivedMappingSlotsAvoid`;
+both are hypotheses of the existing image-avoidance shape, discharged
+per contract. Dynamic-array element slots are **not** covered: the
+source and Yul derivations diverge and the collapse returns `none` at
+dynamic-array roots rather than claiming an equality — see the
+`unsupported` row in `TRUST_ASSUMPTIONS.md` and
+`docs/VERIFICATION_STATUS.md`.
 
 FunctionSpec call denotation (`DenoteFunctionCalls`), ETH-valued
 `externalCallBindTo`, `withPayableCallContext` crediting

--- a/Compiler/Proofs/Storage/MappingCoherentAllKeys.lean
+++ b/Compiler/Proofs/Storage/MappingCoherentAllKeys.lean
@@ -365,6 +365,94 @@ theorem simple_ne_of_base_ne {m b : Nat} {a c : Nat} (hb : m ≠ b) :
 
 /-! ### Preservation by the in-tree write helpers -/
 
+/-- The diagonal case of aligned `writeMap`: another address-keyed entry, which
+    is either the written pair itself or separated from it by key/base
+    disequality. -/
+theorem writeMap_aligned_map_case (fields : List Field) (s : ContractState)
+    (slot : Nat) (key : Address) (v : Uint256) (m : Nat) (key' : Address)
+    (hkind' : fieldMapKindAt fields m = some (.simple .address))
+    (hcoh : MappingCoherentAllKeys fields s) :
+    ((s.writeMap slot key v).writeSlot
+      (solidityMappingSlot slot (addressToWord key).val) v).storageMap m key' =
+      ((s.writeMap slot key v).writeSlot
+        (solidityMappingSlot slot (addressToWord key).val) v).storage
+        (solidityMappingSlot m (addressToWord key').val) := by
+  by_cases hm : m = slot
+  · subst hm
+    by_cases hk : key' = key
+    · subst hk
+      exact writeMap_aligned_same s m key' v
+    · have hne : StorageKey.map m key' ≠ StorageKey.map m key := by
+        intro heq; injection heq with _ hk'; exact hk hk'
+      exact writeMap_aligned_other s m key v m key'
+        (mappingCoherentAllKeys_map hcoh hkind' key') hne
+        (mappingAddrSlot_ne_of_map_ne hne)
+  · have hne : StorageKey.map m key' ≠ StorageKey.map slot key := by
+      intro heq; injection heq with hm' _; exact hm hm'
+    exact writeMap_aligned_other s slot key v m key'
+      (mappingCoherentAllKeys_map hcoh hkind' key') hne
+      (mappingAddrSlot_ne_of_map_ne hne)
+
+/-- The diagonal case of aligned `writeMapUint`. -/
+theorem writeMapUint_aligned_mapUint_case (fields : List Field) (s : ContractState)
+    (slot : Nat) (key v : Uint256) (m : Nat) (key' : Uint256)
+    (hkind' : fieldMapKindAt fields m = some (.simple .uint256))
+    (hcoh : MappingCoherentAllKeys fields s) :
+    ((s.writeMapUint slot key v).writeSlot
+      (solidityMappingSlot slot key.val) v).storageMapUint m key' =
+      ((s.writeMapUint slot key v).writeSlot
+        (solidityMappingSlot slot key.val) v).storage
+        (solidityMappingSlot m key'.val) := by
+  by_cases hm : m = slot
+  · subst hm
+    by_cases hk : key' = key
+    · subst hk
+      exact writeMapUint_aligned_same s m key' v
+    · have hne : StorageKey.mapUint m key' ≠ StorageKey.mapUint m key := by
+        intro heq; injection heq with _ hk'; exact hk hk'
+      exact writeMapUint_aligned_other s m key v m key'
+        (mappingCoherentAllKeys_mapUint hcoh hkind' key') hne
+        (mappingUintSlot_ne_of_mapUint_ne hne)
+  · have hne : StorageKey.mapUint m key' ≠ StorageKey.mapUint slot key := by
+      intro heq; injection heq with hm' _; exact hm hm'
+    exact writeMapUint_aligned_other s slot key v m key'
+      (mappingCoherentAllKeys_mapUint hcoh hkind' key') hne
+      (mappingUintSlot_ne_of_mapUint_ne hne)
+
+/-- The diagonal case of aligned `writeMap2`. -/
+theorem writeMap2_aligned_map2_case (fields : List Field) (s : ContractState)
+    (slot : Nat) (k1 k2 : Address) (v : Uint256) (m : Nat) (j1 j2 : Address)
+    (hkind' : fieldMapKindAt fields m = some (.nested .address .address))
+    (hcoh : MappingCoherentAllKeys fields s) :
+    ((s.writeMap2 slot k1 k2 v).writeSlot
+      (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val)
+      v).storageMap2 m j1 j2 =
+      ((s.writeMap2 slot k1 k2 v).writeSlot
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val)
+        v).storage
+        (abstractNestedMappingSlot m (addressToWord j1).val (addressToWord j2).val) := by
+  by_cases hm : m = slot
+  · subst hm
+    by_cases h1 : j1 = k1
+    · by_cases h2 : j2 = k2
+      · subst h1; subst h2
+        exact writeMap2_aligned_same s m j1 j2 v
+      · have hne : StorageKey.map2 m j1 j2 ≠ StorageKey.map2 m k1 k2 := by
+          intro heq; injection heq with _ _ hj2; exact h2 hj2
+        exact writeMap2_aligned_other s m k1 k2 v m j1 j2
+          (mappingCoherentAllKeys_map2 hcoh hkind' j1 j2) hne
+          (mappingMap2Slot_ne_of_map2_ne hne)
+    · have hne : StorageKey.map2 m j1 j2 ≠ StorageKey.map2 m k1 k2 := by
+        intro heq; injection heq with _ hj1 _; exact h1 hj1
+      exact writeMap2_aligned_other s m k1 k2 v m j1 j2
+        (mappingCoherentAllKeys_map2 hcoh hkind' j1 j2) hne
+        (mappingMap2Slot_ne_of_map2_ne hne)
+  · have hne : StorageKey.map2 m j1 j2 ≠ StorageKey.map2 slot k1 k2 := by
+      intro heq; injection heq with hm' _ _; exact hm hm'
+    exact writeMap2_aligned_other s slot k1 k2 v m j1 j2
+      (mappingCoherentAllKeys_map2 hcoh hkind' j1 j2) hne
+      (mappingMap2Slot_ne_of_map2_ne hne)
+
 /-- Aligned `writeMap` + `writeSlot` preserves the global all-keys invariant.
     Cross-channel separation comes from the declared layout plus
     `solidityMappingSlot_injective`; `MappingBasesNotDerived` covers only the
@@ -386,21 +474,7 @@ theorem writeMap_aligned_preserves_mappingCoherentAllKeys
   | contractSlot c m => obtain ⟨rfl, rfl⟩ := storageKeySlot_contractSlot_eq h; rfl
   | map m key' =>
       obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map_eq h
-      by_cases hm : m = slot
-      · subst hm
-        by_cases hk : key' = key
-        · subst hk
-          exact writeMap_aligned_same s m key' v
-        · have hne : StorageKey.map m key' ≠ StorageKey.map m key := by
-            intro heq; injection heq with _ hk'; exact hk hk'
-          exact writeMap_aligned_other s m key v m key'
-            (mappingCoherentAllKeys_map hcoh hkind' key') hne
-            (mappingAddrSlot_ne_of_map_ne hne)
-      · have hne : StorageKey.map m key' ≠ StorageKey.map slot key := by
-          intro heq; injection heq with hm' _; exact hm hm'
-        exact writeMap_aligned_other s slot key v m key'
-          (mappingCoherentAllKeys_map hcoh hkind' key') hne
-          (mappingAddrSlot_ne_of_map_ne hne)
+      exact writeMap_aligned_map_case fields s slot key v m key' hkind' hcoh
   | mapUint m key' =>
       obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_mapUint_eq h
       have hm : m ≠ slot := base_ne_of_kind_ne hkind' hkind (by simp)
@@ -446,21 +520,7 @@ theorem writeMapUint_aligned_preserves_mappingCoherentAllKeys
       exact hcoh'
   | mapUint m key' =>
       obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_mapUint_eq h
-      by_cases hm : m = slot
-      · subst hm
-        by_cases hk : key' = key
-        · subst hk
-          exact writeMapUint_aligned_same s m key' v
-        · have hne : StorageKey.mapUint m key' ≠ StorageKey.mapUint m key := by
-            intro heq; injection heq with _ hk'; exact hk hk'
-          exact writeMapUint_aligned_other s m key v m key'
-            (mappingCoherentAllKeys_mapUint hcoh hkind' key') hne
-            (mappingUintSlot_ne_of_mapUint_ne hne)
-      · have hne : StorageKey.mapUint m key' ≠ StorageKey.mapUint slot key := by
-          intro heq; injection heq with hm' _; exact hm hm'
-        exact writeMapUint_aligned_other s slot key v m key'
-          (mappingCoherentAllKeys_mapUint hcoh hkind' key') hne
-          (mappingUintSlot_ne_of_mapUint_ne hne)
+      exact writeMapUint_aligned_mapUint_case fields s slot key v m key' hkind' hcoh
   | map2 m k1 k2 =>
       obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map2_eq h
       have hslot :
@@ -474,7 +534,6 @@ theorem writeMapUint_aligned_preserves_mappingCoherentAllKeys
 set_option maxHeartbeats 1600000 in
 theorem writeMap2_aligned_preserves_mappingCoherentAllKeys
     (fields : List Field) (s : ContractState) (slot : Nat) (k1 k2 : Address) (v : Uint256)
-    (hkind : fieldMapKindAt fields slot = some (.nested .address .address))
     (hbases : MappingBasesNotDerived fields)
     (hcoh : MappingCoherentAllKeys fields s) :
     MappingCoherentAllKeys fields
@@ -508,27 +567,7 @@ theorem writeMap2_aligned_preserves_mappingCoherentAllKeys
       exact hcoh'
   | map2 m j1 j2 =>
       obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map2_eq h
-      by_cases hm : m = slot
-      · subst hm
-        by_cases h1 : j1 = k1
-        · by_cases h2 : j2 = k2
-          · subst h1; subst h2
-            exact writeMap2_aligned_same s m j1 j2 v
-          · have hne : StorageKey.map2 m j1 j2 ≠ StorageKey.map2 m k1 k2 := by
-              intro heq; injection heq with _ _ hj2; exact h2 hj2
-            exact writeMap2_aligned_other s m k1 k2 v m j1 j2
-              (mappingCoherentAllKeys_map2 hcoh hkind' j1 j2) hne
-              (mappingMap2Slot_ne_of_map2_ne hne)
-        · have hne : StorageKey.map2 m j1 j2 ≠ StorageKey.map2 m k1 k2 := by
-            intro heq; injection heq with _ hj1 _; exact h1 hj1
-          exact writeMap2_aligned_other s m k1 k2 v m j1 j2
-            (mappingCoherentAllKeys_map2 hcoh hkind' j1 j2) hne
-            (mappingMap2Slot_ne_of_map2_ne hne)
-      · have hne : StorageKey.map2 m j1 j2 ≠ StorageKey.map2 slot k1 k2 := by
-          intro heq; injection heq with hm' _ _; exact hm hm'
-        exact writeMap2_aligned_other s slot k1 k2 v m j1 j2
-          (mappingCoherentAllKeys_map2 hcoh hkind' j1 j2) hne
-          (mappingMap2Slot_ne_of_map2_ne hne)
+      exact writeMap2_aligned_map2_case fields s slot k1 k2 v m j1 j2 hkind' hcoh
 
 /-- A lone flat `writeSlot` keeps the global invariant when the written word is
     not the image of any layout-derived mapping entry. Same image-avoidance

--- a/Compiler/Proofs/Storage/MappingCoherentAllKeys.lean
+++ b/Compiler/Proofs/Storage/MappingCoherentAllKeys.lean
@@ -1,0 +1,670 @@
+/-
+  C5 step 4 (final slice): global all-keys shadow-vs-flat coherence.
+
+  `storageKeySlot` here is the field-list form promised by issue #2330:
+  it takes the declared `CompilationModel.Field` layout and collapses a
+  source `StorageKey` to the flat `Channel` and compiler slot it must
+  agree with. The layout is load-bearing, not decoration:
+
+  * a persistent root word backed by a `dynamicArray` field has no flat
+    word counterpart (`encodeStorageAt` reads a list length there), so it
+    collapses to `none`;
+  * a mapping entry collapses only when the declared field at its base
+    slot has the matching key shape. That is what makes *cross-channel*
+    global preservation provable: two mapping channels cannot share a
+    base slot, so `solidityMappingSlot_injective` separates their images.
+
+  `MappingCoherentAllKeys` is the all-keys (∀ `StorageKey`) form, not a
+  single-key or listed-pair form. Preservation of the in-tree aligned
+  write laws is proved against it.
+
+  Trust: the aligned `writeMap*` laws inherit
+  `solidityMappingSlot_injective` (ABI mapping-preimage collision
+  resistance), exactly as the per-channel globals in `MappingCoherence`
+  already do — see AXIOMS.md. No new axiom is introduced here. The
+  map-vs-nested-map cross case additionally takes an explicit
+  `MappingBasesNotDerived` layout certificate; it is a hypothesis of the
+  same shape as the image-avoidance `∀` that
+  `writeSlot_preserves_mappingCoherent` already takes, and it is
+  discharged per contract, not assumed globally.
+-/
+
+import Compiler.Proofs.Storage.FieldEncode
+
+namespace Compiler.Proofs.Storage.MappingCoherentGlobal
+
+open Verity
+open Verity.ContractState
+open Compiler.CompilationModel
+open Compiler.Proofs
+open Compiler.Proofs.Storage.MappingCoherence
+open Compiler.Proofs.Storage.FieldEncode
+open Compiler.Proofs.IRGeneration.SourceSemantics
+
+/-- Flat read channel a source key collapses into.
+
+    `contract c` stays a channel of its own for every `c`, including `0`:
+    the model does not identify `StorageKey.contractSlot 0 n` with
+    `StorageKey.slot n`, and claiming it would be broken by a plain
+    `writeSlot`. -/
+inductive Channel where
+  | persistent
+  | address
+  | transient
+  | contract (c : Nat)
+  deriving DecidableEq, Repr
+
+/-- Flat-channel read at a compiler slot. -/
+def channelRead (s : ContractState) : Channel → Nat → Uint256
+  | .persistent, n => s.storage n
+  | .address, n => s.storageWords (.addr n)
+  | .transient, n => s.storageWords (.transient n)
+  | .contract c, n => s.storageWords (.contractSlot c n)
+
+/-- Declared mapping key shape at a resolved persistent base slot. -/
+def fieldMapKindAt (fields : List Field) (n : Nat) : Option MappingType :=
+  match findResolvedFieldAtSlot fields n with
+  | some f => match f.ty with
+    | .mappingTyped mt => some mt
+    | _ => none
+  | none => none
+
+/-- One resolved slot carries at most one declared mapping shape, so two
+    distinct declared shapes force distinct base slots. This is the layout
+    fact that separates the mapping channels. -/
+theorem base_ne_of_kind_ne {fields : List Field} {n n' : Nat} {mt mt' : MappingType}
+    (h : fieldMapKindAt fields n = some mt) (h' : fieldMapKindAt fields n' = some mt')
+    (hne : mt ≠ mt') : n ≠ n' := by
+  intro heq
+  subst heq
+  rw [h] at h'
+  exact hne (Option.some.inj h')
+
+/-- Layout-checked collapse of a source key to its flat channel and
+    compiler slot. `none` marks a key with no flat word counterpart under
+    this layout. -/
+def storageKeySlot (fields : List Field) : StorageKey → Option (Channel × Nat)
+  | .slot n =>
+      match findResolvedFieldAtSlot fields n with
+      | some f => if fieldUsesDynamicArrayStorage f then none else some (.persistent, n)
+      | none => some (.persistent, n)
+  | .addr n => some (.address, n)
+  | .transient n => some (.transient, n)
+  | .contractSlot c n => some (.contract c, n)
+  | .map n key =>
+      match fieldMapKindAt fields n with
+      | some (.simple .address) =>
+          some (.persistent, solidityMappingSlot n (addressToWord key).val)
+      | _ => none
+  | .mapUint n key =>
+      match fieldMapKindAt fields n with
+      | some (.simple .uint256) => some (.persistent, solidityMappingSlot n key.val)
+      | _ => none
+  | .map2 n k1 k2 =>
+      match fieldMapKindAt fields n with
+      | some (.nested .address .address) =>
+          some (.persistent,
+            abstractNestedMappingSlot n (addressToWord k1).val (addressToWord k2).val)
+      | _ => none
+
+/-- Source keys whose flat image is a keccak-derived mapping slot. -/
+def isMappingEntryKey : StorageKey → Bool
+  | .map _ _ => true
+  | .mapUint _ _ => true
+  | .map2 _ _ _ => true
+  | _ => false
+
+/-- **Global all-keys shadow-vs-flat coherence.** Every source key that the
+    declared layout collapses to a flat channel holds the same word as that
+    flat channel at the derived compiler slot. Quantified over all
+    `StorageKey`s — not a single key and not a listed finite set. -/
+def MappingCoherentAllKeys (fields : List Field) (s : ContractState) : Prop :=
+  ∀ (k : StorageKey) (ch : Channel) (n : Nat),
+    storageKeySlot fields k = some (ch, n) → s.storageWords k = channelRead s ch n
+
+/-- Layout certificate: a declared mapping base slot is never itself a
+    keccak-derived slot. Same shape as the image-avoidance `∀` already
+    taken by `writeSlot_preserves_mappingCoherent`; not an axiom. -/
+def MappingBasesNotDerived (fields : List Field) : Prop :=
+  ∀ n : Nat, (fieldMapKindAt fields n).isSome → ∀ b k : Nat, solidityMappingSlot b k ≠ n
+
+/-- `n` is not the flat image of any layout-derived mapping entry. -/
+def DerivedMappingSlotsAvoid (fields : List Field) (n : Nat) : Prop :=
+  ∀ (k : StorageKey) (ch : Channel) (m : Nat),
+    storageKeySlot fields k = some (ch, m) → isMappingEntryKey k = true → m ≠ n
+
+/-! ### Shape lemmas for the collapse -/
+
+theorem storageKeySlot_slot_eq {fields : List Field} {m : Nat} {ch : Channel} {n : Nat}
+    (h : storageKeySlot fields (.slot m) = some (ch, n)) :
+    ch = .persistent ∧ n = m := by
+  simp only [storageKeySlot] at h
+  split at h
+  · split at h
+    · simp at h
+    · simp only [Option.some.injEq, Prod.mk.injEq] at h
+      exact ⟨h.1.symm, h.2.symm⟩
+  · simp only [Option.some.injEq, Prod.mk.injEq] at h
+    exact ⟨h.1.symm, h.2.symm⟩
+
+theorem storageKeySlot_addr_eq {fields : List Field} {m : Nat} {ch : Channel} {n : Nat}
+    (h : storageKeySlot fields (.addr m) = some (ch, n)) :
+    ch = .address ∧ n = m := by
+  simp only [storageKeySlot, Option.some.injEq, Prod.mk.injEq] at h
+  exact ⟨h.1.symm, h.2.symm⟩
+
+theorem storageKeySlot_transient_eq {fields : List Field} {m : Nat} {ch : Channel} {n : Nat}
+    (h : storageKeySlot fields (.transient m) = some (ch, n)) :
+    ch = .transient ∧ n = m := by
+  simp only [storageKeySlot, Option.some.injEq, Prod.mk.injEq] at h
+  exact ⟨h.1.symm, h.2.symm⟩
+
+theorem storageKeySlot_contractSlot_eq {fields : List Field} {c m : Nat} {ch : Channel}
+    {n : Nat} (h : storageKeySlot fields (.contractSlot c m) = some (ch, n)) :
+    ch = .contract c ∧ n = m := by
+  simp only [storageKeySlot, Option.some.injEq, Prod.mk.injEq] at h
+  exact ⟨h.1.symm, h.2.symm⟩
+
+/-- A collapsing `.map` key pins both the declared shape at its base slot and
+    the derived flat slot. -/
+theorem storageKeySlot_map_eq {fields : List Field} {m : Nat} {key : Address}
+    {ch : Channel} {n : Nat}
+    (h : storageKeySlot fields (.map m key) = some (ch, n)) :
+    fieldMapKindAt fields m = some (.simple .address) ∧ ch = .persistent ∧
+      n = solidityMappingSlot m (addressToWord key).val := by
+  simp only [storageKeySlot] at h
+  split at h
+  · rename_i heq
+    simp only [Option.some.injEq, Prod.mk.injEq] at h
+    exact ⟨heq, h.1.symm, h.2.symm⟩
+  · simp at h
+
+theorem storageKeySlot_mapUint_eq {fields : List Field} {m : Nat} {key : Uint256}
+    {ch : Channel} {n : Nat}
+    (h : storageKeySlot fields (.mapUint m key) = some (ch, n)) :
+    fieldMapKindAt fields m = some (.simple .uint256) ∧ ch = .persistent ∧
+      n = solidityMappingSlot m key.val := by
+  simp only [storageKeySlot] at h
+  split at h
+  · rename_i heq
+    simp only [Option.some.injEq, Prod.mk.injEq] at h
+    exact ⟨heq, h.1.symm, h.2.symm⟩
+  · simp at h
+
+theorem storageKeySlot_map2_eq {fields : List Field} {m : Nat} {k1 k2 : Address}
+    {ch : Channel} {n : Nat}
+    (h : storageKeySlot fields (.map2 m k1 k2) = some (ch, n)) :
+    fieldMapKindAt fields m = some (.nested .address .address) ∧ ch = .persistent ∧
+      n = abstractNestedMappingSlot m (addressToWord k1).val (addressToWord k2).val := by
+  simp only [storageKeySlot] at h
+  split at h
+  · rename_i heq
+    simp only [Option.some.injEq, Prod.mk.injEq] at h
+    exact ⟨heq, h.1.symm, h.2.symm⟩
+  · simp at h
+
+/-- The declared `.map` collapse in the forward direction. -/
+theorem storageKeySlot_map_of_kind {fields : List Field} {m : Nat} (key : Address)
+    (hkind : fieldMapKindAt fields m = some (.simple .address)) :
+    storageKeySlot fields (.map m key) =
+      some (.persistent, solidityMappingSlot m (addressToWord key).val) := by
+  simp only [storageKeySlot, hkind]
+
+theorem storageKeySlot_mapUint_of_kind {fields : List Field} {m : Nat} (key : Uint256)
+    (hkind : fieldMapKindAt fields m = some (.simple .uint256)) :
+    storageKeySlot fields (.mapUint m key) =
+      some (.persistent, solidityMappingSlot m key.val) := by
+  simp only [storageKeySlot, hkind]
+
+theorem storageKeySlot_map2_of_kind {fields : List Field} {m : Nat} (k1 k2 : Address)
+    (hkind : fieldMapKindAt fields m = some (.nested .address .address)) :
+    storageKeySlot fields (.map2 m k1 k2) =
+      some (.persistent,
+        abstractNestedMappingSlot m (addressToWord k1).val (addressToWord k2).val) := by
+  simp only [storageKeySlot, hkind]
+
+/-! ### Relation to the per-channel globals -/
+
+/-- The all-keys invariant follows from the three per-channel globals for
+    **any** field layout: the non-mapping channels are definitional. -/
+theorem mappingCoherentAllKeys_of_globals (fields : List Field) (s : ContractState)
+    (h1 : MappingCoherent s) (h2 : MappingCoherentUint s) (h3 : MappingCoherentMap2 s) :
+    MappingCoherentAllKeys fields s := by
+  intro k ch n h
+  cases k with
+  | slot m =>
+      obtain ⟨rfl, rfl⟩ := storageKeySlot_slot_eq h; rfl
+  | addr m =>
+      obtain ⟨rfl, rfl⟩ := storageKeySlot_addr_eq h; rfl
+  | transient m =>
+      obtain ⟨rfl, rfl⟩ := storageKeySlot_transient_eq h; rfl
+  | contractSlot c m =>
+      obtain ⟨rfl, rfl⟩ := storageKeySlot_contractSlot_eq h; rfl
+  | map m key =>
+      obtain ⟨_, rfl, rfl⟩ := storageKeySlot_map_eq h
+      exact h1 m key
+  | mapUint m key =>
+      obtain ⟨_, rfl, rfl⟩ := storageKeySlot_mapUint_eq h
+      exact h2 m key
+  | map2 m k1 k2 =>
+      obtain ⟨_, rfl, rfl⟩ := storageKeySlot_map2_eq h
+      exact h3 m k1 k2
+
+/-- Instantiation at a declared address-keyed mapping. -/
+theorem mappingCoherentAllKeys_map {fields : List Field} {s : ContractState} {m : Nat}
+    (h : MappingCoherentAllKeys fields s)
+    (hkind : fieldMapKindAt fields m = some (.simple .address)) (key : Address) :
+    s.storageMap m key = s.storage (solidityMappingSlot m (addressToWord key).val) :=
+  h (.map m key) _ _ (storageKeySlot_map_of_kind key hkind)
+
+theorem mappingCoherentAllKeys_mapUint {fields : List Field} {s : ContractState} {m : Nat}
+    (h : MappingCoherentAllKeys fields s)
+    (hkind : fieldMapKindAt fields m = some (.simple .uint256)) (key : Uint256) :
+    s.storageMapUint m key = s.storage (solidityMappingSlot m key.val) :=
+  h (.mapUint m key) _ _ (storageKeySlot_mapUint_of_kind key hkind)
+
+theorem mappingCoherentAllKeys_map2 {fields : List Field} {s : ContractState} {m : Nat}
+    (h : MappingCoherentAllKeys fields s)
+    (hkind : fieldMapKindAt fields m = some (.nested .address .address)) (k1 k2 : Address) :
+    s.storageMap2 m k1 k2 =
+      s.storage (abstractNestedMappingSlot m (addressToWord k1).val (addressToWord k2).val) :=
+  h (.map2 m k1 k2) _ _ (storageKeySlot_map2_of_kind k1 k2 hkind)
+
+theorem defaultState_mappingCoherentAllKeys (fields : List Field) :
+    MappingCoherentAllKeys fields defaultState :=
+  mappingCoherentAllKeys_of_globals fields defaultState
+    defaultState_mappingCoherent defaultState_mappingCoherentUint
+    defaultState_mappingCoherentMap2
+
+/-! ### Off-key write laws at the `storageWords` level
+
+`Verity.Core` already proves these through the `storage`/`storageMap*` lenses.
+The all-keys invariant is phrased directly on `storageWords`, so the same facts
+are restated here in `storageWords` form; that keeps the preservation proofs on
+`simp only` and away from key-normalisation. -/
+
+theorem channelRead_persistent (s : ContractState) (n : Nat) :
+    channelRead s .persistent n = s.storageWords (.slot n) := rfl
+
+theorem writeSlot_slot_of_ne (s : ContractState) (w : Nat) (v : Uint256) {n : Nat}
+    (h : n ≠ w) : (s.writeSlot w v).storageWords (.slot n) = s.storageWords (.slot n) := by
+  simp [writeSlot, h]
+
+theorem writeSlot_map (s : ContractState) (w : Nat) (v : Uint256) (m : Nat) (key : Address) :
+    (s.writeSlot w v).storageWords (.map m key) = s.storageWords (.map m key) := by
+  simp [writeSlot]
+
+theorem writeSlot_mapUint (s : ContractState) (w : Nat) (v : Uint256) (m : Nat) (key : Uint256) :
+    (s.writeSlot w v).storageWords (.mapUint m key) = s.storageWords (.mapUint m key) := by
+  simp [writeSlot]
+
+theorem writeSlot_map2 (s : ContractState) (w : Nat) (v : Uint256) (m : Nat) (k1 k2 : Address) :
+    (s.writeSlot w v).storageWords (.map2 m k1 k2) = s.storageWords (.map2 m k1 k2) := by
+  simp [writeSlot]
+
+theorem writeMap_slot (s : ContractState) (w : Nat) (key : Address) (v : Uint256) (n : Nat) :
+    (s.writeMap w key v).storageWords (.slot n) = s.storageWords (.slot n) := by
+  simp [writeMap]
+
+theorem writeMap_mapUint (s : ContractState) (w : Nat) (key : Address) (v : Uint256)
+    (m : Nat) (key' : Uint256) :
+    (s.writeMap w key v).storageWords (.mapUint m key') = s.storageWords (.mapUint m key') := by
+  simp [writeMap]
+
+theorem writeMap_map2 (s : ContractState) (w : Nat) (key : Address) (v : Uint256)
+    (m : Nat) (k1 k2 : Address) :
+    (s.writeMap w key v).storageWords (.map2 m k1 k2) = s.storageWords (.map2 m k1 k2) := by
+  simp [writeMap]
+
+theorem writeMapUint_slot (s : ContractState) (w : Nat) (key v : Uint256) (n : Nat) :
+    (s.writeMapUint w key v).storageWords (.slot n) = s.storageWords (.slot n) := by
+  simp [writeMapUint]
+
+theorem writeMapUint_map (s : ContractState) (w : Nat) (key v : Uint256)
+    (m : Nat) (key' : Address) :
+    (s.writeMapUint w key v).storageWords (.map m key') = s.storageWords (.map m key') := by
+  simp [writeMapUint]
+
+theorem writeMapUint_map2 (s : ContractState) (w : Nat) (key v : Uint256)
+    (m : Nat) (k1 k2 : Address) :
+    (s.writeMapUint w key v).storageWords (.map2 m k1 k2) = s.storageWords (.map2 m k1 k2) := by
+  simp [writeMapUint]
+
+theorem writeMap2_slot (s : ContractState) (w : Nat) (k1 k2 : Address) (v : Uint256) (n : Nat) :
+    (s.writeMap2 w k1 k2 v).storageWords (.slot n) = s.storageWords (.slot n) := by
+  simp [writeMap2]
+
+theorem writeMap2_map (s : ContractState) (w : Nat) (k1 k2 : Address) (v : Uint256)
+    (m : Nat) (key' : Address) :
+    (s.writeMap2 w k1 k2 v).storageWords (.map m key') = s.storageWords (.map m key') := by
+  simp [writeMap2]
+
+theorem writeMap2_mapUint (s : ContractState) (w : Nat) (k1 k2 : Address) (v : Uint256)
+    (m : Nat) (key' : Uint256) :
+    (s.writeMap2 w k1 k2 v).storageWords (.mapUint m key') = s.storageWords (.mapUint m key') := by
+  simp [writeMap2]
+
+/-! ### Cross-channel slot separation
+
+The layout does the work here: two mapping channels cannot be declared at the
+same base slot, so `solidityMappingSlot_injective` already separates their
+derived images. The nested-vs-simple case additionally needs that a declared
+base slot is not itself keccak-derived (`MappingBasesNotDerived`). -/
+
+theorem nested_ne_simple {fields : List Field} {m b : Nat} {a k2 c : Nat}
+    (hbases : MappingBasesNotDerived fields)
+    (hkind : (fieldMapKindAt fields b).isSome = true) :
+    abstractNestedMappingSlot m a k2 ≠ solidityMappingSlot b c := by
+  intro heq
+  simp only [abstractNestedMappingSlot, abstractMappingSlot] at heq
+  exact (hbases b hkind m a) (solidityMappingSlot_injective _ _ _ _ heq).1
+
+theorem simple_ne_of_base_ne {m b : Nat} {a c : Nat} (hb : m ≠ b) :
+    solidityMappingSlot m a ≠ solidityMappingSlot b c := fun heq =>
+  hb (solidityMappingSlot_injective _ _ _ _ heq).1
+
+/-! ### Preservation by the in-tree write helpers -/
+
+/-- Aligned `writeMap` + `writeSlot` preserves the global all-keys invariant.
+    Cross-channel separation comes from the declared layout plus
+    `solidityMappingSlot_injective`; `MappingBasesNotDerived` covers only the
+    nested-mapping case. -/
+theorem writeMap_aligned_preserves_mappingCoherentAllKeys
+    (fields : List Field) (s : ContractState) (slot : Nat) (key : Address) (v : Uint256)
+    (hkind : fieldMapKindAt fields slot = some (.simple .address))
+    (hbases : MappingBasesNotDerived fields)
+    (hcoh : MappingCoherentAllKeys fields s) :
+    MappingCoherentAllKeys fields
+      ((s.writeMap slot key v).writeSlot
+        (solidityMappingSlot slot (addressToWord key).val) v) := by
+  have hsome : (fieldMapKindAt fields slot).isSome = true := by rw [hkind]; rfl
+  intro k ch n h
+  cases k with
+  | slot m => obtain ⟨rfl, rfl⟩ := storageKeySlot_slot_eq h; rfl
+  | addr m => obtain ⟨rfl, rfl⟩ := storageKeySlot_addr_eq h; rfl
+  | transient m => obtain ⟨rfl, rfl⟩ := storageKeySlot_transient_eq h; rfl
+  | contractSlot c m => obtain ⟨rfl, rfl⟩ := storageKeySlot_contractSlot_eq h; rfl
+  | map m key' =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map_eq h
+      by_cases hm : m = slot
+      · subst hm
+        by_cases hk : key' = key
+        · subst hk
+          exact writeMap_aligned_same s m key' v
+        · have hne : StorageKey.map m key' ≠ StorageKey.map m key := by
+            intro heq; injection heq with _ hk'; exact hk hk'
+          exact writeMap_aligned_other s m key v m key'
+            (mappingCoherentAllKeys_map hcoh hkind' key') hne
+            (mappingAddrSlot_ne_of_map_ne hne)
+      · have hne : StorageKey.map m key' ≠ StorageKey.map slot key := by
+          intro heq; injection heq with hm' _; exact hm hm'
+        exact writeMap_aligned_other s slot key v m key'
+          (mappingCoherentAllKeys_map hcoh hkind' key') hne
+          (mappingAddrSlot_ne_of_map_ne hne)
+  | mapUint m key' =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_mapUint_eq h
+      have hm : m ≠ slot := base_ne_of_kind_ne hkind' hkind (by simp)
+      have hslot : solidityMappingSlot m key'.val ≠
+          solidityMappingSlot slot (addressToWord key).val := simple_ne_of_base_ne hm
+      have hcoh' := mappingCoherentAllKeys_mapUint hcoh hkind' key'
+      simp only [channelRead_persistent, writeSlot_mapUint, writeMap_mapUint,
+        writeSlot_slot_of_ne _ _ _ hslot, writeMap_slot]
+      exact hcoh'
+  | map2 m k1 k2 =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map2_eq h
+      have hslot :
+          abstractNestedMappingSlot m (addressToWord k1).val (addressToWord k2).val ≠
+            solidityMappingSlot slot (addressToWord key).val :=
+        nested_ne_simple hbases hsome
+      have hcoh' := mappingCoherentAllKeys_map2 hcoh hkind' k1 k2
+      simp only [channelRead_persistent, writeSlot_map2, writeMap_map2,
+        writeSlot_slot_of_ne _ _ _ hslot, writeMap_slot]
+      exact hcoh'
+
+theorem writeMapUint_aligned_preserves_mappingCoherentAllKeys
+    (fields : List Field) (s : ContractState) (slot : Nat) (key v : Uint256)
+    (hkind : fieldMapKindAt fields slot = some (.simple .uint256))
+    (hbases : MappingBasesNotDerived fields)
+    (hcoh : MappingCoherentAllKeys fields s) :
+    MappingCoherentAllKeys fields
+      ((s.writeMapUint slot key v).writeSlot (solidityMappingSlot slot key.val) v) := by
+  have hsome : (fieldMapKindAt fields slot).isSome = true := by rw [hkind]; rfl
+  intro k ch n h
+  cases k with
+  | slot m => obtain ⟨rfl, rfl⟩ := storageKeySlot_slot_eq h; rfl
+  | addr m => obtain ⟨rfl, rfl⟩ := storageKeySlot_addr_eq h; rfl
+  | transient m => obtain ⟨rfl, rfl⟩ := storageKeySlot_transient_eq h; rfl
+  | contractSlot c m => obtain ⟨rfl, rfl⟩ := storageKeySlot_contractSlot_eq h; rfl
+  | map m key' =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map_eq h
+      have hm : m ≠ slot := base_ne_of_kind_ne hkind' hkind (by simp)
+      have hslot : solidityMappingSlot m (addressToWord key').val ≠
+          solidityMappingSlot slot key.val := simple_ne_of_base_ne hm
+      have hcoh' := mappingCoherentAllKeys_map hcoh hkind' key'
+      simp only [channelRead_persistent, writeSlot_map, writeMapUint_map,
+        writeSlot_slot_of_ne _ _ _ hslot, writeMapUint_slot]
+      exact hcoh'
+  | mapUint m key' =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_mapUint_eq h
+      by_cases hm : m = slot
+      · subst hm
+        by_cases hk : key' = key
+        · subst hk
+          exact writeMapUint_aligned_same s m key' v
+        · have hne : StorageKey.mapUint m key' ≠ StorageKey.mapUint m key := by
+            intro heq; injection heq with _ hk'; exact hk hk'
+          exact writeMapUint_aligned_other s m key v m key'
+            (mappingCoherentAllKeys_mapUint hcoh hkind' key') hne
+            (mappingUintSlot_ne_of_mapUint_ne hne)
+      · have hne : StorageKey.mapUint m key' ≠ StorageKey.mapUint slot key := by
+          intro heq; injection heq with hm' _; exact hm hm'
+        exact writeMapUint_aligned_other s slot key v m key'
+          (mappingCoherentAllKeys_mapUint hcoh hkind' key') hne
+          (mappingUintSlot_ne_of_mapUint_ne hne)
+  | map2 m k1 k2 =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map2_eq h
+      have hslot :
+          abstractNestedMappingSlot m (addressToWord k1).val (addressToWord k2).val ≠
+            solidityMappingSlot slot key.val := nested_ne_simple hbases hsome
+      have hcoh' := mappingCoherentAllKeys_map2 hcoh hkind' k1 k2
+      simp only [channelRead_persistent, writeSlot_map2, writeMapUint_map2,
+        writeSlot_slot_of_ne _ _ _ hslot, writeMapUint_slot]
+      exact hcoh'
+
+set_option maxHeartbeats 1600000 in
+theorem writeMap2_aligned_preserves_mappingCoherentAllKeys
+    (fields : List Field) (s : ContractState) (slot : Nat) (k1 k2 : Address) (v : Uint256)
+    (hkind : fieldMapKindAt fields slot = some (.nested .address .address))
+    (hbases : MappingBasesNotDerived fields)
+    (hcoh : MappingCoherentAllKeys fields s) :
+    MappingCoherentAllKeys fields
+      ((s.writeMap2 slot k1 k2 v).writeSlot
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) v) := by
+  intro k ch n h
+  cases k with
+  | slot m => obtain ⟨rfl, rfl⟩ := storageKeySlot_slot_eq h; rfl
+  | addr m => obtain ⟨rfl, rfl⟩ := storageKeySlot_addr_eq h; rfl
+  | transient m => obtain ⟨rfl, rfl⟩ := storageKeySlot_transient_eq h; rfl
+  | contractSlot c m => obtain ⟨rfl, rfl⟩ := storageKeySlot_contractSlot_eq h; rfl
+  | map m key' =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map_eq h
+      have hsome' : (fieldMapKindAt fields m).isSome = true := by rw [hkind']; rfl
+      have hslot : solidityMappingSlot m (addressToWord key').val ≠
+          abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val :=
+        fun heq => nested_ne_simple hbases hsome' heq.symm
+      have hcoh' := mappingCoherentAllKeys_map hcoh hkind' key'
+      simp only [channelRead_persistent, writeSlot_map, writeMap2_map,
+        writeSlot_slot_of_ne _ _ _ hslot, writeMap2_slot]
+      exact hcoh'
+  | mapUint m key' =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_mapUint_eq h
+      have hsome' : (fieldMapKindAt fields m).isSome = true := by rw [hkind']; rfl
+      have hslot : solidityMappingSlot m key'.val ≠
+          abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val :=
+        fun heq => nested_ne_simple hbases hsome' heq.symm
+      have hcoh' := mappingCoherentAllKeys_mapUint hcoh hkind' key'
+      simp only [channelRead_persistent, writeSlot_mapUint, writeMap2_mapUint,
+        writeSlot_slot_of_ne _ _ _ hslot, writeMap2_slot]
+      exact hcoh'
+  | map2 m j1 j2 =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map2_eq h
+      by_cases hm : m = slot
+      · subst hm
+        by_cases h1 : j1 = k1
+        · by_cases h2 : j2 = k2
+          · subst h1; subst h2
+            exact writeMap2_aligned_same s m j1 j2 v
+          · have hne : StorageKey.map2 m j1 j2 ≠ StorageKey.map2 m k1 k2 := by
+              intro heq; injection heq with _ _ hj2; exact h2 hj2
+            exact writeMap2_aligned_other s m k1 k2 v m j1 j2
+              (mappingCoherentAllKeys_map2 hcoh hkind' j1 j2) hne
+              (mappingMap2Slot_ne_of_map2_ne hne)
+        · have hne : StorageKey.map2 m j1 j2 ≠ StorageKey.map2 m k1 k2 := by
+            intro heq; injection heq with _ hj1 _; exact h1 hj1
+          exact writeMap2_aligned_other s m k1 k2 v m j1 j2
+            (mappingCoherentAllKeys_map2 hcoh hkind' j1 j2) hne
+            (mappingMap2Slot_ne_of_map2_ne hne)
+      · have hne : StorageKey.map2 m j1 j2 ≠ StorageKey.map2 slot k1 k2 := by
+          intro heq; injection heq with hm' _ _; exact hm hm'
+        exact writeMap2_aligned_other s slot k1 k2 v m j1 j2
+          (mappingCoherentAllKeys_map2 hcoh hkind' j1 j2) hne
+          (mappingMap2Slot_ne_of_map2_ne hne)
+
+/-- A lone flat `writeSlot` keeps the global invariant when the written word is
+    not the image of any layout-derived mapping entry. Same image-avoidance
+    shape as `writeSlot_preserves_mappingCoherent`. -/
+theorem writeSlot_preserves_mappingCoherentAllKeys
+    (fields : List Field) (s : ContractState) (w : Nat) (v : Uint256)
+    (havoid : DerivedMappingSlotsAvoid fields w)
+    (hcoh : MappingCoherentAllKeys fields s) :
+    MappingCoherentAllKeys fields (s.writeSlot w v) := by
+  intro k ch n h
+  cases k with
+  | slot m => obtain ⟨rfl, rfl⟩ := storageKeySlot_slot_eq h; rfl
+  | addr m => obtain ⟨rfl, rfl⟩ := storageKeySlot_addr_eq h; rfl
+  | transient m => obtain ⟨rfl, rfl⟩ := storageKeySlot_transient_eq h; rfl
+  | contractSlot c m => obtain ⟨rfl, rfl⟩ := storageKeySlot_contractSlot_eq h; rfl
+  | map m key' =>
+      have hne := havoid _ _ _ h rfl
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map_eq h
+      have hcoh' := mappingCoherentAllKeys_map hcoh hkind' key'
+      simp only [channelRead_persistent, writeSlot_map, writeSlot_slot_of_ne _ _ _ hne]
+      exact hcoh'
+  | mapUint m key' =>
+      have hne := havoid _ _ _ h rfl
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_mapUint_eq h
+      have hcoh' := mappingCoherentAllKeys_mapUint hcoh hkind' key'
+      simp only [channelRead_persistent, writeSlot_mapUint, writeSlot_slot_of_ne _ _ _ hne]
+      exact hcoh'
+  | map2 m j1 j2 =>
+      have hne := havoid _ _ _ h rfl
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map2_eq h
+      have hcoh' := mappingCoherentAllKeys_map2 hcoh hkind' j1 j2
+      simp only [channelRead_persistent, writeSlot_map2, writeSlot_slot_of_ne _ _ _ hne]
+      exact hcoh'
+
+/-- `writeAddrSlot` never writes a `StorageKey.slot`, so it discharges the
+    image-avoidance side condition outright. -/
+theorem writeAddrSlot_preserves_mappingCoherentAllKeys
+    (fields : List Field) (s : ContractState) (w : Nat) (a : Address)
+    (hcoh : MappingCoherentAllKeys fields s) :
+    MappingCoherentAllKeys fields (s.writeAddrSlot w a) := by
+  intro k ch n h
+  cases k with
+  | slot m => obtain ⟨rfl, rfl⟩ := storageKeySlot_slot_eq h; rfl
+  | addr m => obtain ⟨rfl, rfl⟩ := storageKeySlot_addr_eq h; rfl
+  | transient m => obtain ⟨rfl, rfl⟩ := storageKeySlot_transient_eq h; rfl
+  | contractSlot c m => obtain ⟨rfl, rfl⟩ := storageKeySlot_contractSlot_eq h; rfl
+  | map m key' =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map_eq h
+      simpa [channelRead, storageMap, storage, writeAddrSlot] using
+        mappingCoherentAllKeys_map hcoh hkind' key'
+  | mapUint m key' =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_mapUint_eq h
+      simpa [channelRead, storageMapUint, storage, writeAddrSlot] using
+        mappingCoherentAllKeys_mapUint hcoh hkind' key'
+  | map2 m j1 j2 =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map2_eq h
+      simpa [channelRead, storageMap2, storage, writeAddrSlot] using
+        mappingCoherentAllKeys_map2 hcoh hkind' j1 j2
+
+/-- Transient writes land on a different `StorageKey` constructor. -/
+theorem writeTransient_preserves_mappingCoherentAllKeys
+    (fields : List Field) (s : ContractState) (w : Nat) (v : Uint256)
+    (hcoh : MappingCoherentAllKeys fields s) :
+    MappingCoherentAllKeys fields (s.writeTransient w v) := by
+  intro k ch n h
+  cases k with
+  | slot m => obtain ⟨rfl, rfl⟩ := storageKeySlot_slot_eq h; rfl
+  | addr m => obtain ⟨rfl, rfl⟩ := storageKeySlot_addr_eq h; rfl
+  | transient m => obtain ⟨rfl, rfl⟩ := storageKeySlot_transient_eq h; rfl
+  | contractSlot c m => obtain ⟨rfl, rfl⟩ := storageKeySlot_contractSlot_eq h; rfl
+  | map m key' =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map_eq h
+      simpa [channelRead, storageMap, storage, writeTransient] using
+        mappingCoherentAllKeys_map hcoh hkind' key'
+  | mapUint m key' =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_mapUint_eq h
+      simpa [channelRead, storageMapUint, storage, writeTransient] using
+        mappingCoherentAllKeys_mapUint hcoh hkind' key'
+  | map2 m j1 j2 =>
+      obtain ⟨hkind', rfl, rfl⟩ := storageKeySlot_map2_eq h
+      simpa [channelRead, storageMap2, storage, writeTransient] using
+        mappingCoherentAllKeys_map2 hcoh hkind' j1 j2
+
+/-! ### End-to-end read bridge
+
+Lens read = flat `encodeStorageAt` read at the derived slot, under the global
+all-keys invariant. The two non-occupation side conditions say the derived
+keccak slot is not also a declared field slot and not a dynamic-array element
+slot; they are the same hypotheses `FieldEncode` already uses. -/
+
+/-- **Lens read = flat read.** `readMap` at a declared `mapping(address => uint256)`
+    is exactly what `encodeStorageAt` returns at the derived Solidity slot. -/
+theorem readMap_eq_encodeStorageAt_of_coherent
+    {fields : List Field} {s : ContractState} {slot : Nat} {key : Address}
+    (hcoh : MappingCoherentAllKeys fields s)
+    (hkind : fieldMapKindAt fields slot = some (.simple .address))
+    (hresolved :
+      findResolvedFieldAtSlot fields
+        (solidityMappingSlot slot (addressToWord key).val) = none)
+    (hdyn :
+      findDynamicArrayElementAtSlot fields s
+        (solidityMappingSlot slot (addressToWord key).val) = none) :
+    (s.readMap slot key).val =
+      encodeStorageAt fields s (solidityMappingSlot slot (addressToWord key).val) := by
+  rw [encodeStorageAt_of_unresolved hresolved hdyn]
+  exact congrArg Core.Uint256.val (mappingCoherentAllKeys_map hcoh hkind key)
+
+theorem readMapUint_eq_encodeStorageAt_of_coherent
+    {fields : List Field} {s : ContractState} {slot : Nat} {key : Uint256}
+    (hcoh : MappingCoherentAllKeys fields s)
+    (hkind : fieldMapKindAt fields slot = some (.simple .uint256))
+    (hresolved :
+      findResolvedFieldAtSlot fields (solidityMappingSlot slot key.val) = none)
+    (hdyn :
+      findDynamicArrayElementAtSlot fields s (solidityMappingSlot slot key.val) = none) :
+    (s.readMapUint slot key).val =
+      encodeStorageAt fields s (solidityMappingSlot slot key.val) := by
+  rw [encodeStorageAt_of_unresolved hresolved hdyn]
+  exact congrArg Core.Uint256.val (mappingCoherentAllKeys_mapUint hcoh hkind key)
+
+theorem readMap2_eq_encodeStorageAt_of_coherent
+    {fields : List Field} {s : ContractState} {slot : Nat} {k1 k2 : Address}
+    (hcoh : MappingCoherentAllKeys fields s)
+    (hkind : fieldMapKindAt fields slot = some (.nested .address .address))
+    (hresolved :
+      findResolvedFieldAtSlot fields
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) =
+        none)
+    (hdyn :
+      findDynamicArrayElementAtSlot fields s
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) =
+        none) :
+    (s.readMap2 slot k1 k2).val =
+      encodeStorageAt fields s
+        (abstractNestedMappingSlot slot (addressToWord k1).val (addressToWord k2).val) := by
+  rw [encodeStorageAt_of_unresolved hresolved hdyn]
+  exact congrArg Core.Uint256.val (mappingCoherentAllKeys_map2 hcoh hkind k1 k2)
+
+end Compiler.Proofs.Storage.MappingCoherentGlobal

--- a/Compiler/Proofs/Storage/MappingCoherentAllKeys.lean
+++ b/Compiler/Proofs/Storage/MappingCoherentAllKeys.lean
@@ -667,4 +667,39 @@ theorem readMap2_eq_encodeStorageAt_of_coherent
   rw [encodeStorageAt_of_unresolved hresolved hdyn]
   exact congrArg Core.Uint256.val (mappingCoherentAllKeys_map2 hcoh hkind k1 k2)
 
+/-! ### Known divergence: dynamic-array element slots — `unsupported`
+
+The source semantics and the Yul/EVM layout derive dynamic-array element
+addresses differently, and this slice does **not** reconcile them.
+
+* Source model —
+  `Compiler/Proofs/IRGeneration/SourceSemantics.lean:330-350`,
+  `findDynamicArrayElementAtSlot`: element `i` of the array rooted at slot
+  `s` sits at `solidityMappingSlot s i`, i.e. `keccak256(abi.encode(i, s))`,
+  a **64-byte mapping preimage**.
+* Yul / EVM model —
+  `Compiler/Proofs/Storage/StructArrayStorage.lean:666-671`,
+  `storageArrayBasePointer` / `storageArrayElementPointer`: element `i` sits
+  at `keccak256(bytes32(s)) + i`, a **32-byte preimage plus an arithmetic
+  offset**. This is the real Solidity layout.
+
+Missing feature, precisely: *the source semantics has no array-element slot
+derivation of the form `keccak256(bytes32(slot)) + index`* — it reuses the
+mapping derivation instead. Closing the gap means changing
+`findDynamicArrayElementAtSlot` (and everything that computes against it),
+not adding a Yul-side shim; nothing here asserts the two derivations equal.
+
+Containment: `storageKeySlot` returns `none` at a persistent root whose
+resolved field is a `dynamicArray`, so `MappingCoherentAllKeys` claims
+nothing about dynamic-array roots (`encodeStorageAt` reads a list length
+there, not a word). Element words are ordinary persistent slots and the
+invariant is the identity on them; the divergence is about *which* slot the
+source model believes an element occupies. -/
+
+theorem storageKeySlot_slot_dynamicArray {fields : List Field} {n : Nat} {f : Field}
+    (hf : findResolvedFieldAtSlot fields n = some f)
+    (hdyn : fieldUsesDynamicArrayStorage f = true) :
+    storageKeySlot fields (.slot n) = none := by
+  simp only [storageKeySlot, hf, hdyn, if_true]
+
 end Compiler.Proofs.Storage.MappingCoherentGlobal

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -114,6 +114,7 @@ import Compiler.Proofs.Storage.FieldPackedCompile
 import Compiler.Proofs.Storage.FieldStorageKey
 import Compiler.Proofs.Storage.MappingCoherence
 import Compiler.Proofs.Storage.MappingCoherenceOn
+import Compiler.Proofs.Storage.MappingCoherentAllKeys
 import Compiler.Proofs.Storage.SeparateChannels
 import Compiler.Proofs.Storage.SolidityStorage
 import Compiler.Proofs.Storage.StructArrayStorage
@@ -4835,6 +4836,50 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.MappingCoherenceOn.writeMapUint_aligned_preserves_uintOn_of_mappingCoherentUint
   Compiler.Proofs.Storage.MappingCoherenceOn.writeMap2_aligned_preserves_map2On_of_mappingCoherentMap2
 
+  -- Compiler/Proofs/Storage/MappingCoherentAllKeys.lean
+  Compiler.Proofs.Storage.MappingCoherentGlobal.base_ne_of_kind_ne
+  Compiler.Proofs.Storage.MappingCoherentGlobal.storageKeySlot_slot_eq
+  Compiler.Proofs.Storage.MappingCoherentGlobal.storageKeySlot_addr_eq
+  Compiler.Proofs.Storage.MappingCoherentGlobal.storageKeySlot_transient_eq
+  Compiler.Proofs.Storage.MappingCoherentGlobal.storageKeySlot_contractSlot_eq
+  Compiler.Proofs.Storage.MappingCoherentGlobal.storageKeySlot_map_eq
+  Compiler.Proofs.Storage.MappingCoherentGlobal.storageKeySlot_mapUint_eq
+  Compiler.Proofs.Storage.MappingCoherentGlobal.storageKeySlot_map2_eq
+  Compiler.Proofs.Storage.MappingCoherentGlobal.storageKeySlot_map_of_kind
+  Compiler.Proofs.Storage.MappingCoherentGlobal.storageKeySlot_mapUint_of_kind
+  Compiler.Proofs.Storage.MappingCoherentGlobal.storageKeySlot_map2_of_kind
+  Compiler.Proofs.Storage.MappingCoherentGlobal.mappingCoherentAllKeys_of_globals
+  Compiler.Proofs.Storage.MappingCoherentGlobal.mappingCoherentAllKeys_map
+  Compiler.Proofs.Storage.MappingCoherentGlobal.mappingCoherentAllKeys_mapUint
+  Compiler.Proofs.Storage.MappingCoherentGlobal.mappingCoherentAllKeys_map2
+  Compiler.Proofs.Storage.MappingCoherentGlobal.defaultState_mappingCoherentAllKeys
+  Compiler.Proofs.Storage.MappingCoherentGlobal.channelRead_persistent
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeSlot_slot_of_ne
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeSlot_map
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeSlot_mapUint
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeSlot_map2
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMap_slot
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMap_mapUint
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMap_map2
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMapUint_slot
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMapUint_map
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMapUint_map2
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMap2_slot
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMap2_map
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMap2_mapUint
+  Compiler.Proofs.Storage.MappingCoherentGlobal.nested_ne_simple
+  Compiler.Proofs.Storage.MappingCoherentGlobal.simple_ne_of_base_ne
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMap_aligned_preserves_mappingCoherentAllKeys
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMapUint_aligned_preserves_mappingCoherentAllKeys
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMap2_aligned_preserves_mappingCoherentAllKeys
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeSlot_preserves_mappingCoherentAllKeys
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeAddrSlot_preserves_mappingCoherentAllKeys
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeTransient_preserves_mappingCoherentAllKeys
+  Compiler.Proofs.Storage.MappingCoherentGlobal.readMap_eq_encodeStorageAt_of_coherent
+  Compiler.Proofs.Storage.MappingCoherentGlobal.readMapUint_eq_encodeStorageAt_of_coherent
+  Compiler.Proofs.Storage.MappingCoherentGlobal.readMap2_eq_encodeStorageAt_of_coherent
+  Compiler.Proofs.Storage.MappingCoherentGlobal.storageKeySlot_slot_dynamicArray
+
   -- Compiler/Proofs/Storage/SeparateChannels.lean
   Compiler.Proofs.Storage.SeparateChannels.storageArray_independent_of_writeSlot
   Compiler.Proofs.Storage.SeparateChannels.storageArray_independent_of_writeAddrSlot
@@ -7048,4 +7093,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6534 theorems/lemmas (4663 public, 1871 private, 0 sorry'd)
+-- Total: 6576 theorems/lemmas (4705 public, 1871 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4869,6 +4869,9 @@ end Verity.AxiomAudit
   Compiler.Proofs.Storage.MappingCoherentGlobal.writeMap2_mapUint
   Compiler.Proofs.Storage.MappingCoherentGlobal.nested_ne_simple
   Compiler.Proofs.Storage.MappingCoherentGlobal.simple_ne_of_base_ne
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMap_aligned_map_case
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMapUint_aligned_mapUint_case
+  Compiler.Proofs.Storage.MappingCoherentGlobal.writeMap2_aligned_map2_case
   Compiler.Proofs.Storage.MappingCoherentGlobal.writeMap_aligned_preserves_mappingCoherentAllKeys
   Compiler.Proofs.Storage.MappingCoherentGlobal.writeMapUint_aligned_preserves_mappingCoherentAllKeys
   Compiler.Proofs.Storage.MappingCoherentGlobal.writeMap2_aligned_preserves_mappingCoherentAllKeys
@@ -7093,4 +7096,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6576 theorems/lemmas (4705 public, 1871 private, 0 sorry'd)
+-- Total: 6579 theorems/lemmas (4708 public, 1871 private, 0 sorry'd)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -232,6 +232,47 @@ is complete under `solidityMappingSlot_injective`: global aligned
 for `writeAddrSlot` and `writeArray` (they never write
 `StorageKey.slot`). Keccak injectivity on
 arbitrary byte strings is **not** assumed.
+The all-keys (`∀ StorageKey`) form of that claim is
+`Compiler.Proofs.Storage.MappingCoherentGlobal.MappingCoherentAllKeys`,
+stated against the field-list collapse
+`storageKeySlot : List Field → StorageKey → Option (Channel × Nat)`
+(`Channel` = `persistent` / `address` / `transient` / `contract c`; the
+model does not identify `contractSlot 0` with `slot`). The declared
+layout is load-bearing, not decoration: a mapping key collapses only
+when the resolved field at its base slot declares the matching
+`MappingType`, so two mapping channels cannot share a base slot and
+`solidityMappingSlot_injective` separates their derived images.
+Aligned `writeMap` / `writeMapUint` / `writeMap2` + `writeSlot`,
+`writeAddrSlot`, and `writeTransient` preserve it; a lone `writeSlot`
+takes the same image-avoidance `∀` (`DerivedMappingSlotsAvoid`). The
+simple-vs-nested cross case additionally takes an explicit per-contract
+layout certificate `MappingBasesNotDerived` (a declared mapping base
+slot is not itself keccak-derived) — a hypothesis discharged per
+contract, not an axiom. Under that invariant the lens read equals the
+flat `encodeStorageAt` read at the derived slot
+(`readMap_eq_encodeStorageAt_of_coherent` and the `mapUint` / `map2`
+variants), reusing the same non-occupation hypotheses `FieldEncode`
+already takes.
+
+**Known divergence — dynamic-array element slots (`unsupported`).**
+The source model and the Yul model derive dynamic-array element
+addresses differently and are **not** reconciled here.
+`Compiler/Proofs/IRGeneration/SourceSemantics.lean:330-350`
+(`findDynamicArrayElementAtSlot`) places element `i` of the array
+rooted at slot `s` at `solidityMappingSlot s i` =
+`keccak256(abi.encode(i, s))`, a 64-byte mapping preimage.
+`Compiler/Proofs/Storage/StructArrayStorage.lean:666-671`
+(`storageArrayBasePointer` / `storageArrayElementPointer`) uses the
+real Solidity layout `keccak256(bytes32(s)) + i`, a 32-byte preimage
+plus an arithmetic offset. Missing feature, precisely: *the source
+semantics has no array-element slot derivation of the form
+`keccak256(bytes32(slot)) + index`* — it reuses the mapping
+derivation. No shim asserts the two equal. Containment:
+`storageKeySlot` returns `none` at a persistent root whose resolved
+field is a `dynamicArray`
+(`storageKeySlot_slot_dynamicArray`), so `MappingCoherentAllKeys`
+claims nothing about dynamic-array roots; `encodeStorageAt` reads a
+list length there, not a word.
 `storageArray` and `knownAddresses` are still separate fields;
 word-channel / array-channel independence is proved in
 `Compiler.Proofs.Storage.SeparateChannels`.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -240,6 +240,21 @@ Status legend:
 | Event ABI parity for indexed dynamic/tuple payloads | supported | supported | supported | supported | supported |
 | Storage layout controls (packing + explicit slots) | partial | partial | partial | partial | partial |
 | ABI JSON artifact generation | partial | partial | n/a | partial | partial |
+| Dynamic-array element slot derivation (`keccak256(bytes32(slot)) + index`) | unsupported | supported | unsupported | partial | unsupported |
+
+The dynamic-array row records a *model* divergence, not a codegen gap. The
+source semantics
+(`Compiler/Proofs/IRGeneration/SourceSemantics.lean:330-350`,
+`findDynamicArrayElementAtSlot`) places element `i` of the array rooted at
+slot `s` at `solidityMappingSlot s i` = `keccak256(abi.encode(i, s))` — the
+64-byte *mapping* preimage — while the Yul layout
+(`Compiler/Proofs/Storage/StructArrayStorage.lean:666-671`,
+`storageArrayBasePointer` / `storageArrayElementPointer`) uses the real
+Solidity `keccak256(bytes32(s)) + i`. The missing feature is an
+array-element slot derivation of that second form in the source semantics.
+Nothing asserts the two equal; the global storage-coherence collapse
+returns `none` at dynamic-array roots instead
+(`Compiler.Proofs.Storage.MappingCoherentGlobal.storageKeySlot_slot_dynamicArray`).
 
 Diagnostics policy for unsupported constructs:
 1. Report the exact unsupported construct at compile time.


### PR DESCRIPTION
## Summary

Final slice of the C5 storage flip (étape 4 of #2330): closes the shadow-vs-flat gap by making the mapping shadow channels readable through a layout-driven slot derivation, and proving the write helpers preserve the resulting global invariant.

- **`storageKeySlot : List Field → StorageKey → Option (Channel × Nat)`** — the étape-4 deliverable, implemented over the field-list layout. The `List Field` parameter is load-bearing: mapping constructors only resolve when the declared field at the base slot carries the matching `MappingType`, which forces distinct mapping shapes onto distinct base slots and lets `solidityMappingSlot_injective` separate their derived images.
- **`MappingCoherentAllKeys`** — global all-keys invariant (not single-key): shadow channel = flat channel at *every* derived slot.
- **Preservation proofs** for `writeMap` / `writeMapUint` / `writeMap2` (aligned laws from #2337), plus `writeSlot`, `writeAddrSlot`, `writeTransient`.
- **`readMap_eq_encodeStorageAt_of_coherent`** (+ `readMapUint` / `readMap2` variants) — lens read = flat `encodeStorageAt` read under global coherence.
- **Dynamic-array divergence: documented-unsupported**, not faked. `storageKeySlot` returns `none` on a `.slot n` whose resolved field is a dynamic array, and `storageKeySlot_slot_dynamicArray` makes that containment machine-checkable.

**Zero new axioms.** `MappingBasesNotDerived` and `DerivedMappingSlotsAvoid` are hypotheses on the theorems, not axioms. The only axiom used remains `solidityMappingSlot_injective`, whose use here is exactly what AXIOMS.md already sanctions for global aligned `writeMap*` preservation.

## The invariant

```lean
def MappingCoherentAllKeys (fields : List Field) (s : ContractState) : Prop :=
  ∀ (k : StorageKey) (ch : Channel) (n : Nat),
    storageKeySlot fields k = some (ch, n) → s.storageWords k = channelRead s ch n
```

## Known divergence (unsupported row)

Dynamic-array element slots diverge between the two models and this PR does **not** assert them equal:

| | derivation | preimage |
|---|---|---|
| Source (`Compiler/Proofs/IRGeneration/SourceSemantics.lean:330-350`, `findDynamicArrayElementAtSlot`) | `solidityMappingSlot slot idx` = `keccak256(abi.encode(idx, slot))` | 64 bytes |
| Yul (`Compiler/Proofs/Storage/StructArrayStorage.lean:666-671`, `storageArrayElementPointer`) | `keccak256(bytes32(slot)) + idx` | 32 bytes + offset |

Missing feature, named precisely: *the source semantics has no array-element slot derivation of the form `keccak256(bytes32(slot)) + index`* — it reuses the mapping derivation. Recorded as an `unsupported` row in `docs/VERIFICATION_STATUS.md` and in `TRUST_ASSUMPTIONS.md`. No Yul shim asserts equivalence.

## Test plan

- [x] `lake build` — exit 0, zero new `sorry`
- [x] `lake build PrintAxioms` — exit 0 (2610 jobs); totals `6579 theorems (4708 public, 1871 private, 0 sorry'd)`
- [x] `python3 scripts/check_storage_lens_freeze.py` — exit 0
- [x] `python3 scripts/generate_print_axioms.py --check` — exit 0
- [x] `python3 scripts/generate_trust_surface_report.py --check` — exit 0 (no new `native_decide` / `@[implemented_by]` sites)
- [x] `python3 scripts/check_lean_warning_regression.py` — exit 0
- [x] `make check` — exit 0 (`All checks passed.`)
- [x] Proof-length gate — exit 0, no allowlist entry added (see note below)
- [x] Forbidden-token scan over added `.lean` lines — 0 declaration sites (the only hits are prose comments and the generated PrintAxioms `0 sorry'd` inventory line)

## Note on proof length

The three aligned-write preservation proofs initially ran 52/51/61 lines against the repo's 50-line hard limit. Rather than add allowlist entries, each proof's *diagonal* case — where the read key is the same mapping constructor that was just written — is factored into its own lemma: `writeMap_aligned_map_case`, `writeMapUint_aligned_mapUint_case`, `writeMap2_aligned_map2_case`. The parent proofs are now comfortably under the limit and the off-diagonal (cross-channel) reasoning stays where it is legible.

`writeMap2_aligned_preserves_mappingCoherentAllKeys` also drops its `hkind` hypothesis: the proof never referenced it (it derives the kind at the *read* base from `storageKeySlot_map2_eq` instead), so it tripped the unused-variable linter. Removing it strengthens the theorem.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new proof surface in storage semantics (C5 critical path) relying on layout certificates and the existing mapping-slot axiom; dynamic-array element slots remain an explicit model gap.
> 
> **Overview**
> Closes **C5 step 4** (#2330) by adding a field-list–driven global storage coherence layer: layout-aware `storageKeySlot` collapses every `StorageKey` to a flat `Channel` × slot (or `none`), and **`MappingCoherentAllKeys`** states that shadow `storageWords` reads match flat channel reads wherever the collapse succeeds.
> 
> **New proof module** `MappingCoherentAllKeys.lean` (`MappingCoherentGlobal`): preservation for aligned `writeMap` / `writeMapUint` / `writeMap2` + `writeSlot`, plus `writeAddrSlot`, `writeTransient`, and lone `writeSlot` under `DerivedMappingSlotsAvoid`; simple-vs-nested cross-channel cases use per-contract **`MappingBasesNotDerived`**. **`readMap*_eq_encodeStorageAt_of_coherent`** bridges lens reads to `encodeStorageAt` under the same non-occupation hypotheses as `FieldEncode`. Dynamic-array **roots** collapse to `none` (`storageKeySlot_slot_dynamicArray`); element-slot source vs Yul divergence is documented as **unsupported**, not equated.
> 
> **Audit/docs**: `AUDIT.md`, `AXIOMS.md`, `TRUST_ASSUMPTIONS.md`, and `docs/VERIFICATION_STATUS.md` updated; **`PrintAxioms.lean`** registers ~45 new theorems (6579 total). **No new Lean axioms** — still only `solidityMappingSlot_injective` where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35bc583d7454ae11c9f2f02b17b7c94d5f4ae2be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->