### PR TITLE
Admit string as a supported external parameter type (#2085 slice 4)

### DIFF
--- a/Compiler.lean
+++ b/Compiler.lean
@@ -40,6 +40,7 @@ import Compiler.Proofs.IRGeneration.SupportedFragment
 import Compiler.Proofs.IRGeneration.Contract
 import Compiler.Proofs.IRGeneration.Dispatch
 import Compiler.Proofs.IRGeneration.DispatchBytesParam
+import Compiler.Proofs.IRGeneration.DispatchStringParam
 import Compiler.Proofs.IRGeneration.Function
 import Compiler.Proofs.IRGeneration.FunctionBody
 import Compiler.Proofs.IRGeneration.ParamLoading

--- a/Compiler/Proofs/AbiEncoding.lean
+++ b/Compiler/Proofs/AbiEncoding.lean
@@ -930,6 +930,56 @@ theorem bindExternalParams_bytes_of_abiEncodeArgs
   simp only [bindExternalParamsFrom, hbase]
   rfl
 
+/-- The same round trip at a `string` parameter.  A `string` argument block is
+byte-for-byte an `AbiArg.bytes` block — offset word, length word, right-padded
+payload — so the encoder is reused rather than duplicated, and only the binder
+side changes type (`bindExternalParam_string_eq_bytes`). -/
+theorem bindExternalParams_string_of_abiEncodeArgs
+    (selector : Nat) (name : String) (value : AbiBytes)
+    (hwf : value.WellFormed)
+    (hsize : 4 + 32 * (abiEncodeArgs [AbiArg.bytes value]).length <
+      Compiler.Constants.evmModulus) :
+    bindExternalParams selector [{ name := name, ty := ParamType.string }]
+        (abiEncodeArgs [AbiArg.bytes value]) =
+      some
+        [ (s!"{name}_offset", 32)
+        , (s!"{name}_abs_offset", 36)
+        , (s!"{name}_length", value.byteLength)
+        , (s!"{name}_tail_head_end", 68)
+        , (s!"{name}_tail_remaining", 32 * value.dataWords.length)
+        , (s!"{name}_data_offset", 68) ] := by
+  have hbase := bindExternalParam_bytes_of_abiEncodeArgs selector name [] value [] hwf
+    (by simpa using hsize)
+  simp only [List.nil_append, List.length_nil, List.length_cons, List.flatMap_nil,
+    Nat.mul_zero, Nat.add_zero, Nat.zero_add, abiTailOffset, List.take_zero,
+    abiDynamicTailSize, List.map_nil, List.sum_nil] at hbase
+  have hcdlen : (abiEncodeArgs [AbiArg.bytes value]).length = 1 + (1 + value.dataWords.length) := by
+    simp [abiEncodeArgs]
+    omega
+  have hlen : ([{ name := name, ty := ParamType.string }] : List Param).length ≤
+      (abiEncodeArgs [AbiArg.bytes value]).length := by
+    rw [hcdlen]
+    simp
+  have hsupp : bindSupportedParams [{ name := name, ty := ParamType.string }]
+      (abiEncodeArgs [AbiArg.bytes value]) = none := by
+    have : (abiEncodeArgs [AbiArg.bytes value]) ≠ [] := by
+      intro hnil
+      rw [hnil] at hcdlen
+      simp only [List.length_nil] at hcdlen
+      omega
+    match hcd : abiEncodeArgs [AbiArg.bytes value] with
+    | [] => exact absurd hcd this
+    | w :: rest => simp [bindSupportedParams, decodeSupportedParamWord]
+  unfold bindExternalParams
+  rw [if_pos hlen, hsupp]
+  show bindExternalParamsFrom selector (abiEncodeArgs [AbiArg.bytes value])
+    (paramHeadSizeList [ParamType.string]) 4 [{ name := name, ty := ParamType.string }] 4 = _
+  have hhs : paramHeadSizeList [ParamType.string] = 32 * 1 := by
+    simp [paramHeadSizeList, paramHeadSize]
+  rw [hhs]
+  simp only [bindExternalParamsFrom, bindExternalParam_string_eq_bytes, hbase]
+  rfl
+
 end BytesRoundTrip
 
 section Examples

--- a/Compiler/Proofs/IRGeneration/DispatchStringParam.lean
+++ b/Compiler/Proofs/IRGeneration/DispatchStringParam.lean
@@ -1,0 +1,101 @@
+import Compiler.Proofs.IRGeneration.DispatchGeneric
+import Compiler.Proofs.AbiEncoding
+
+/-!
+# Dispatcher correctness at a `string` external parameter
+
+The `bytes` module next door explains why `hbindTotal` cannot be left as a
+hypothesis for a dynamic parameter: on arbitrary calldata the external binder
+returns `none`, so the generic dispatcher theorem would be vacuous at such a
+parameter.  The same reasoning applies verbatim to `string`.
+
+A `string` argument block *is* an `AbiArg.bytes` block — relative offset word
+in the head area, length word then right-padded payload in the tail.  The two
+types part ways only in the textual signature that feeds the selector hash,
+which is upstream of everything here.  So the encoder is reused as-is and the
+binder side is transported with
+`Verity.SourceSemantics.DynamicAbi.bindExternalParam_string_eq_bytes`
+(verity#2085).
+-/
+
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler
+open Compiler.CompilationModel
+open Compiler.Proofs.AbiEncoding
+open Dispatch
+
+namespace StringParamDispatch
+
+/-- The external ABI binder is total on a single `string` entrypoint parameter
+when the transaction arguments are a real ABI encoding.  This is exactly the
+`hbindTotal` obligation of the generic dispatcher theorem. -/
+theorem bindExternalParams_total_of_string_calldata
+    (model : CompilationModel) (tx : IRTransaction)
+    (name : String) (value : AbiBytes)
+    (hwf : value.WellFormed)
+    (hargs : tx.args = abiEncodeArgs [AbiArg.bytes value])
+    (hsize : 4 + 32 * tx.args.length < Compiler.Constants.evmModulus)
+    (hparams : ∀ fn ∈ selectorDispatchedFunctions model,
+      fn.params = [{ name := name, ty := ParamType.string }]) :
+    ∀ fn ∈ selectorDispatchedFunctions model,
+      fn.params.length ≤ tx.args.length →
+      ∃ bindings,
+        SourceSemantics.bindExternalParams tx.functionSelector fn.params tx.args =
+          some bindings := by
+  intro fn hfn _
+  have hbind :
+      SourceSemantics.bindExternalParams tx.functionSelector fn.params tx.args =
+        some
+          [ (s!"{name}_offset", 32)
+          , (s!"{name}_abs_offset", 36)
+          , (s!"{name}_length", value.byteLength)
+          , (s!"{name}_tail_head_end", 68)
+          , (s!"{name}_tail_remaining", 32 * value.dataWords.length)
+          , (s!"{name}_data_offset", 68) ] := by
+    rw [hparams fn hfn, hargs]
+    exact bindExternalParams_string_of_abiEncodeArgs tx.functionSelector name value hwf
+      (by rw [← hargs]; exact hsize)
+  exact ⟨_, hbind⟩
+
+/-- Whole-contract dispatcher correctness for entrypoints taking a `string`
+parameter.  `hbindTotal` is gone: it is discharged from the ABI encoding, so
+the statement is non-vacuous at `string`. -/
+theorem interpretContract_correct_of_functions_string_param
+    (P : FunctionSpec → Nat → IRFunction → Prop)
+    (model : CompilationModel) (selectors : List Nat)
+    (irFns : List IRFunction) (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (name : String) (value : AbiBytes)
+    (hwf : value.WellFormed)
+    (hargs : tx.args = abiEncodeArgs [AbiArg.bytes value])
+    (hsize : 4 + 32 * tx.args.length < Compiler.Constants.evmModulus)
+    (hparams : ∀ fn ∈ selectorDispatchedFunctions model,
+      fn.params = [{ name := name, ty := ParamType.string }])
+    (hmeta : ∀ fn sel irFn, P fn sel irFn →
+      irFn.params = fn.params.map Param.toIRParam ∧
+        irFn.selector = sel ∧ irFn.payable = fn.isPayable)
+    (hcompiled : List.Forall₂ (fun entry irFn => P entry.1 entry.2 irFn)
+      (SourceSemantics.selectorFunctionPairs model selectors) irFns)
+    (hfunction :
+      ∀ fn sel irFn bindings,
+        fn ∈ selectorDispatchedFunctions model →
+        P fn sel irFn →
+        SourceSemantics.bindExternalParams tx.functionSelector fn.params tx.args =
+          some bindings →
+        FunctionBody.sourceResultMatchesIRResult
+          (SourceSemantics.interpretFunction model fn tx initialWorld)
+          (execIRFunction irFn tx.args
+            (FunctionBody.initialIRStateForTx model tx initialWorld))) :
+    FunctionBody.sourceResultMatchesIRResult
+      (SourceSemantics.interpretContract model selectors tx initialWorld)
+      (interpretIR (runtimeContractOfFunctions model.name irFns) tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
+  interpretContract_correct_of_functions_generic_external P model selectors irFns tx
+    initialWorld hmeta hcompiled
+    (bindExternalParams_total_of_string_calldata model tx name value hwf hargs hsize hparams)
+    hfunction
+
+end StringParamDispatch
+
+end Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/IRGeneration/DynamicParamLoading.lean
+++ b/Compiler/Proofs/IRGeneration/DynamicParamLoading.lean
@@ -125,6 +125,18 @@ theorem genSingleParamLoad_bytes
   simp [genSingleParamLoad, genDynamicParamLoads, isLengthPrefixedDynamicShape,
     bytesLoaderStmts, hbase]
 
+/-- `string` is emitted through the very same loader as `bytes`: both are
+length-prefixed dynamic shapes, and `genDynamicParamLoads` branches on the
+shape, not on the type. -/
+theorem genSingleParamLoad_string
+    (loadWord : YulExpr → YulExpr) (sizeExpr : YulExpr)
+    (headSize baseOffset : Nat) (name : String) (headOffset : Nat)
+    (hbase : ¬ (baseOffset == 0) = true) :
+    genSingleParamLoad loadWord sizeExpr headSize baseOffset name ParamType.string headOffset =
+      bytesLoaderStmts loadWord sizeExpr headSize baseOffset name headOffset := by
+  simp [genSingleParamLoad, genDynamicParamLoads, isLengthPrefixedDynamicShape,
+    bytesLoaderStmts, hbase]
+
 /-! ## Executing the generated `bytes` loader -/
 
 private theorem calldataloadWord_eq (selector : Nat) (calldata : List Nat) (offset : Nat) :
@@ -452,10 +464,42 @@ theorem applyBindingsToIRState_append (state : IRState) (xs ys : List (String ×
     (headSize baseOffset : Nat) (name : String) (headOffset : Nat) :
     (bytesLoaderStmts loadWord sizeExpr headSize baseOffset name headOffset).length = 9 := rfl
 
+/-- The bytes-like half of the per-parameter composition, phrased over the two
+facts `bytes` and `string` share: the emitted block is the length-prefixed
+loader, and the binder assigned it the `bytes` bindings. -/
+private theorem exec_bytesLikeParamLoad_then
+    (state : IRState) (rest : List YulStmt) (headSize baseOffset : Nat)
+    (name : String) (ty : ParamType) (idx extraFuel : Nat) (here : List (String × Nat))
+    (hcalldataSize :
+      DynamicAbi.externalCalldataSize state.calldata < Compiler.Constants.evmModulus)
+    (hstmts : genSingleParamLoad (fun pos => YulExpr.call "calldataload" [pos])
+        (YulExpr.call "calldatasize" []) headSize baseOffset name ty (4 + 32 * idx) =
+      bytesLoaderStmts (fun pos => YulExpr.call "calldataload" [pos])
+        (YulExpr.call "calldatasize" []) headSize baseOffset name (4 + 32 * idx))
+    (hbind : DynamicAbi.bindExternalParam state.selector state.calldata headSize baseOffset
+      (4 + 32 * idx) { name := name, ty := ParamType.bytes } = some here) :
+    execIRStmts ((genSingleParamLoad (fun pos => YulExpr.call "calldataload" [pos])
+        (YulExpr.call "calldatasize" []) headSize baseOffset name ty
+        (4 + 32 * idx)).length + rest.length + extraFuel + 1) state
+      (genSingleParamLoad (fun pos => YulExpr.call "calldataload" [pos])
+        (YulExpr.call "calldatasize" []) headSize baseOffset name ty
+        (4 + 32 * idx) ++ rest) =
+      execIRStmts (rest.length + extraFuel + 1)
+        (ParamLoading.applyBindingsToIRState state here) rest := by
+  obtain ⟨relativeOffset, length, hhead, hheadBound, htailBound, hlength,
+    hpayloadBound, hhere⟩ := DynamicAbi.bindExternalParam_bytes_eq_some_inv hbind
+  subst hhere
+  rw [hstmts]
+  have hexec := exec_bytesLoaderStmts_then state rest name headSize baseOffset
+    (4 + 32 * idx) relativeOffset length extraFuel hcalldataSize hhead hheadBound
+    htailBound hlength hpayloadBound
+  simpa [bytesParamBindings, bytesLoaderStmts, Nat.add_comm, Nat.add_left_comm,
+    Nat.add_assoc] using hexec
+
 /-- Executing the statements emitted for one supported external parameter lands
 on exactly the bindings `DynamicAbi.bindExternalParam` assigns to it. This is
-the per-parameter composition: `bytes` goes through the loader refinement,
-scalars through the existing single-word lemma. -/
+the per-parameter composition: `bytes` and `string` go through the loader
+refinement, scalars through the existing single-word lemma. -/
 theorem exec_genSingleParamLoad_external_then
     (state : IRState) (rest : List YulStmt) (headSize baseOffset : Nat)
     (param : Param) (idx extraFuel : Nat) (here : List (String × Nat))
@@ -473,7 +517,8 @@ theorem exec_genSingleParamLoad_external_then
         (4 + 32 * idx) ++ rest) =
       execIRStmts (rest.length + extraFuel + 1)
         (ParamLoading.applyBindingsToIRState state here) rest := by
-  rcases supportedExternalParamType_scalar_or_bytes hsupported with hscalar | hbytes
+  rcases supportedExternalParamType_scalar_or_bytesLike hsupported with
+    hscalar | hbytes | hstring
   · obtain ⟨word, value, hword, hdecode, hhere⟩ :=
       DynamicAbi.bindExternalParam_scalar_eq_some_inv (decode_total_of_scalar hscalar) hbind
     have hwordEq : word = state.calldata.getD idx 0 % Compiler.Constants.evmModulus := by
@@ -495,19 +540,20 @@ theorem exec_genSingleParamLoad_external_then
       cases param
       simp_all
     rw [hparam] at hbind
-    obtain ⟨relativeOffset, length, hhead, hheadBound, htailBound, hlength,
-      hpayloadBound, hhere⟩ := DynamicAbi.bindExternalParam_bytes_eq_some_inv hbind
-    subst hhere
-    rw [hbytes, genSingleParamLoad_bytes _ _ _ _ _ _ hbase]
-    have hexec := exec_bytesLoaderStmts_then state rest param.name headSize baseOffset
-      (4 + 32 * idx) relativeOffset length extraFuel hcalldataSize hhead hheadBound
-      htailBound hlength hpayloadBound
-    simpa [bytesParamBindings, bytesLoaderStmts, Nat.add_comm, Nat.add_left_comm,
-      Nat.add_assoc] using hexec
+    exact exec_bytesLikeParamLoad_then state rest headSize baseOffset param.name param.ty idx
+      extraFuel here hcalldataSize (by rw [hbytes]; exact genSingleParamLoad_bytes _ _ _ _ _ _ hbase)
+      hbind
+  · have hparam : param = { name := param.name, ty := ParamType.string } := by
+      cases param
+      simp_all
+    rw [hparam, DynamicAbi.bindExternalParam_string_eq_bytes] at hbind
+    exact exec_bytesLikeParamLoad_then state rest headSize baseOffset param.name param.ty idx
+      extraFuel here hcalldataSize
+      (by rw [hstring]; exact genSingleParamLoad_string _ _ _ _ _ _ hbase) hbind
 
 /-- The parameter-list lift: the whole emitted calldata-decoding block executes
 to exactly the bindings the dispatcher's external ABI binder computes, for any
-mixture of supported scalars and `bytes`. -/
+mixture of supported scalars, `bytes` and `string`. -/
 theorem exec_genParamLoadBodyFrom_external_then
     (headSize baseOffset : Nat) (hbase : ¬ (baseOffset == 0) = true)
     (params : List Param) :
@@ -681,10 +727,10 @@ private theorem scalars_of_bindSupportedParams :
 /-- End-to-end refinement for the generated entrypoint prologue: whatever
 bindings the dispatcher's external ABI binder produces, executing the emitted
 calldata-decoding block reaches exactly that variable environment — for any
-mixture of supported scalars and `bytes` parameters (verity#2085).
+mixture of supported scalars, `bytes` and `string` parameters (verity#2085).
 
 Together with `interpretContract_correct_of_functions_generic_external` this is
-the composition that admits `bytes` into external dispatch. -/
+the composition that admits `bytes` and `string` into external dispatch. -/
 theorem exec_genParamLoads_external
     (state : IRState) (params : List Param) (bindings : List (String × Nat))
     (hsupported : ∀ param ∈ params, SupportedExternalParamType param.ty)

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -25,20 +25,21 @@ def SupportedExternalScalarParamType : ParamType → Prop
   | _ => False
 
 /-- ABI parameter types admitted by external dispatch, widened past the
-single-head-word scalars to the length-prefixed dynamic `bytes` parameter
-(verity#2085).
+single-head-word scalars to the length-prefixed dynamic `bytes` and `string`
+parameters (verity#2085).
 
-`bytes` is deliberately *not* decodable by `decodeSupportedParamWord`: it has no
-single-word value. Its head word is a relative tail offset, and the generated
-calldata loader binds six locals (`_offset`, `_abs_offset`, `_length`,
+Neither `bytes` nor `string` is decodable by `decodeSupportedParamWord`: they
+have no single-word value. Their head word is a relative tail offset, and the
+generated calldata loader binds six locals (`_offset`, `_abs_offset`, `_length`,
 `_tail_head_end`, `_tail_remaining`, `_data_offset`) that
-`DynamicAbi.bindExternalParam` reproduces semantically. Consumers that need an
-actual scalar head word — the native-backend static-scalar bridge and the legacy
-Yul compatibility witnesses — keep requiring
+`DynamicAbi.bindExternalParam` reproduces semantically. `string` is encoded
+byte-for-byte like `bytes`, so it reuses the same loader and the same binder
+lemmas. Consumers that need an actual scalar head word — the native-backend
+static-scalar bridge and the legacy Yul compatibility witnesses — keep requiring
 `SupportedExternalScalarParamType`. -/
 def SupportedExternalParamType : ParamType → Prop
   | .uint256 | .int256 | .uint8 | .uint16 | .uintN _ | .intN _ | .bytesN _
-  | .address | .bytes32 | .bool | .bytes => True
+  | .address | .bytes32 | .bool | .bytes | .string => True
   | _ => False
 
 theorem SupportedExternalParamType_of_scalar {ty : ParamType}
@@ -50,16 +51,20 @@ theorem SupportedExternalParamType_of_scalar {ty : ParamType}
 theorem SupportedExternalParamType_bytes :
     SupportedExternalParamType ParamType.bytes := trivial
 
-/-- The widened admission set is exactly the scalar set plus `bytes`. This is the
-case split every downstream calldata-loading execution lemma performs. -/
-theorem supportedExternalParamType_scalar_or_bytes {ty : ParamType}
+theorem SupportedExternalParamType_string :
+    SupportedExternalParamType ParamType.string := trivial
+
+/-- The widened admission set is exactly the scalar set plus the two bytes-like
+dynamic types. This is the case split every downstream calldata-loading
+execution lemma performs. -/
+theorem supportedExternalParamType_scalar_or_bytesLike {ty : ParamType}
     (hsupported : SupportedExternalParamType ty) :
-    SupportedExternalScalarParamType ty ∨ ty = ParamType.bytes := by
+    SupportedExternalScalarParamType ty ∨ ty = ParamType.bytes ∨ ty = ParamType.string := by
   cases ty <;> simp [SupportedExternalParamType] at hsupported <;>
     simp [SupportedExternalScalarParamType]
 
-/-- Widened parameter lists still have 32-byte ABI head words: `bytes`
-contributes a one-word relative tail pointer to the head area. -/
+/-- Widened parameter lists still have 32-byte ABI head words: `bytes` and
+`string` each contribute a one-word relative tail pointer to the head area. -/
 theorem supportedExternalParamType_headSize_eq_32 {ty : ParamType}
     (hsupported : SupportedExternalParamType ty) : paramHeadSize ty = 32 := by
   cases ty <;> simp [SupportedExternalParamType] at hsupported <;> simp [paramHeadSize]
@@ -84,11 +89,12 @@ def externalParamScalarProofSupported (ty : ParamType) : Bool :=
 
 /-- Compile-driven decision procedure for the widened external-parameter
 admission set. The scalar half still delegates to the compiler's
-`isScalarParamType`; `bytes` is the one constructor this slice adds, and it is
-named explicitly so any future compiler-side change to dynamic-parameter routing
-shows up at the agreement oracle below rather than drifting silently. -/
+`isScalarParamType`; `bytes` and `string` are the two constructors admitted on
+top of it, and they are named explicitly so any future compiler-side change to
+dynamic-parameter routing shows up at the agreement oracle below rather than
+drifting silently. -/
 def externalParamProofSupported : ParamType → Bool
-  | ParamType.bytes => true
+  | ParamType.bytes | ParamType.string => true
   | ty => isScalarParamType ty
 
 /-- Proof-side scalar-return-profile predicate tied to the compiler's scalar

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -64,6 +64,7 @@ import Compiler.Proofs.IRGeneration.DenoteFunctionAgreement
 import Compiler.Proofs.IRGeneration.Dispatch
 import Compiler.Proofs.IRGeneration.DispatchBytesParam
 import Compiler.Proofs.IRGeneration.DispatchGeneric
+import Compiler.Proofs.IRGeneration.DispatchStringParam
 import Compiler.Proofs.IRGeneration.DynamicAbiRefinement
 import Compiler.Proofs.IRGeneration.DynamicParamLoading
 import Compiler.Proofs.IRGeneration.ErrorStringPayloadIR
@@ -1153,6 +1154,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.AbiEncoding.abiEncodeArgs_getD_tail_first  -- private
   Compiler.Proofs.AbiEncoding.bindExternalParam_bytes_of_abiEncodeArgs
   Compiler.Proofs.AbiEncoding.bindExternalParams_bytes_of_abiEncodeArgs
+  Compiler.Proofs.AbiEncoding.bindExternalParams_string_of_abiEncodeArgs
 
   -- Compiler/Proofs/AbiEventObservable.lean
   -- Compiler.Proofs.AbiEventObservable.land_mod_evm_right  -- private
@@ -2526,6 +2528,10 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.interpretContractWith_correct_of_functions_generic_external
   Compiler.Proofs.IRGeneration.interpretContract_correct_of_functions_generic_external
 
+  -- Compiler/Proofs/IRGeneration/DispatchStringParam.lean
+  Compiler.Proofs.IRGeneration.StringParamDispatch.bindExternalParams_total_of_string_calldata
+  Compiler.Proofs.IRGeneration.StringParamDispatch.interpretContract_correct_of_functions_string_param
+
   -- Compiler/Proofs/IRGeneration/DynamicAbiRefinement.lean
   Compiler.Proofs.IRGeneration.DynamicAbiRefinement.arrayElementDynamicHeadOffset?_index_oob
   Compiler.Proofs.IRGeneration.DynamicAbiRefinement.arrayElementDynamicMemberDataOffset_eq_length_pos_add_word
@@ -2543,6 +2549,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.DynamicParamLoading.setVar_selector  -- private
   -- Compiler.Proofs.IRGeneration.DynamicParamLoading.execIRStmts_cons_continue  -- private
   Compiler.Proofs.IRGeneration.DynamicParamLoading.genSingleParamLoad_bytes
+  Compiler.Proofs.IRGeneration.DynamicParamLoading.genSingleParamLoad_string
   -- Compiler.Proofs.IRGeneration.DynamicParamLoading.calldataloadWord_eq  -- private
   -- Compiler.Proofs.IRGeneration.DynamicParamLoading.externalWordAt?_eq_calldataloadWord  -- private
   Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_bytesLoaderStmts_then
@@ -2554,6 +2561,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.DynamicParamLoading.applyBindingsToIRState_calldata
   Compiler.Proofs.IRGeneration.DynamicParamLoading.applyBindingsToIRState_selector
   Compiler.Proofs.IRGeneration.DynamicParamLoading.bytesLoaderStmts_length
+  -- Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_bytesLikeParamLoad_then  -- private
   Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_genSingleParamLoad_external_then
   Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_genParamLoadBodyFrom_external_then
   -- Compiler.Proofs.IRGeneration.DynamicParamLoading.headSizeFoldl_go  -- private
@@ -4504,7 +4512,8 @@ end Verity.AxiomAudit
   -- Compiler/Proofs/IRGeneration/SupportedSpec.lean
   Compiler.Proofs.IRGeneration.SupportedExternalParamType_of_scalar
   Compiler.Proofs.IRGeneration.SupportedExternalParamType_bytes
-  Compiler.Proofs.IRGeneration.supportedExternalParamType_scalar_or_bytes
+  Compiler.Proofs.IRGeneration.SupportedExternalParamType_string
+  Compiler.Proofs.IRGeneration.supportedExternalParamType_scalar_or_bytesLike
   Compiler.Proofs.IRGeneration.supportedExternalParamType_headSize_eq_32
   Compiler.Proofs.IRGeneration.eventParamSourceShapeProofSupported_of_scalar
   Compiler.Proofs.IRGeneration.SupportedExternalParamType_iff_externalParamScalarProofSupported
@@ -7231,4 +7240,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6696 theorems/lemmas (4795 public, 1901 private, 0 sorry'd)
+-- Total: 6702 theorems/lemmas (4800 public, 1902 private, 0 sorry'd)

--- a/Verity/Core/Model/DynamicAbi.lean
+++ b/Verity/Core/Model/DynamicAbi.lean
@@ -464,16 +464,8 @@ theorem bindExternalParam_string_eq_bytes
         { name := name, ty := ParamType.string } =
       bindExternalParam selector calldata headSize baseOffset headOffset
         { name := name, ty := ParamType.bytes } := by
-  have hstring :
-      decodeSupportedParamWord ParamType.string =<<
-        externalWordAt? selector calldata headOffset = none := by
-    cases externalWordAt? selector calldata headOffset <;> rfl
-  have hbytes :
-      decodeSupportedParamWord ParamType.bytes =<<
-        externalWordAt? selector calldata headOffset = none := by
-    cases externalWordAt? selector calldata headOffset <;> rfl
-  simp only [bindExternalParam]
-  rw [hstring, hbytes]
+  unfold bindExternalParam
+  cases externalWordAt? selector calldata headOffset <;> rfl
 
 /-- The `string` counterpart of `bindExternalParam_bytes_refines_dynamic_loader`:
 the same checked head word, tail length word and payload bound make the

--- a/Verity/Core/Model/DynamicAbi.lean
+++ b/Verity/Core/Model/DynamicAbi.lean
@@ -452,6 +452,81 @@ theorem bindExternalParam_bytes_eq_some_inv
       unfold dynamicParamBindings
       rw [habs, htailHead, htailRem, hdata]
 
+/-- `string` and `bytes` bind identically. The ABI encodes both as a relative
+tail offset in the head area and a length-prefixed payload in the tail; the two
+types differ only in the textual signature that feeds the selector hash, never
+in the encoding of an argument block. Every `string` fact below is therefore
+routed through the `bytes` lemmas rather than reproved (verity#2085). -/
+theorem bindExternalParam_string_eq_bytes
+    (selector : Nat) (calldata : List Nat)
+    (headSize baseOffset headOffset : Nat) (name : String) :
+    bindExternalParam selector calldata headSize baseOffset headOffset
+        { name := name, ty := ParamType.string } =
+      bindExternalParam selector calldata headSize baseOffset headOffset
+        { name := name, ty := ParamType.bytes } := by
+  have hstring :
+      decodeSupportedParamWord ParamType.string =<<
+        externalWordAt? selector calldata headOffset = none := by
+    cases externalWordAt? selector calldata headOffset <;> rfl
+  have hbytes :
+      decodeSupportedParamWord ParamType.bytes =<<
+        externalWordAt? selector calldata headOffset = none := by
+    cases externalWordAt? selector calldata headOffset <;> rfl
+  simp only [bindExternalParam]
+  rw [hstring, hbytes]
+
+/-- The `string` counterpart of `bindExternalParam_bytes_refines_dynamic_loader`:
+the same checked head word, tail length word and payload bound make the
+dispatcher bind the same six loader locals. -/
+theorem bindExternalParam_string_refines_dynamic_loader
+    {selector : Nat} {calldata : List Nat}
+    {headSize baseOffset headOffset relativeOffset length : Nat} {name : String}
+    (hhead : externalWordAt? selector calldata headOffset = some relativeOffset)
+    (hheadBound : headSize ≤ relativeOffset)
+    (htailBound : baseOffset + relativeOffset + 32 ≤ externalCalldataSize calldata)
+    (hlength : externalWordAt? selector calldata (baseOffset + relativeOffset) = some length)
+    (hpayloadBound :
+      length ≤ externalCalldataSize calldata - (baseOffset + relativeOffset + 32)) :
+    bindExternalParam selector calldata headSize baseOffset headOffset
+      { name := name, ty := ParamType.string } =
+      some
+        [ (s!"{name}_offset", relativeOffset)
+        , (s!"{name}_abs_offset", baseOffset + relativeOffset)
+        , (s!"{name}_length", length)
+        , (s!"{name}_tail_head_end", baseOffset + relativeOffset + 32)
+        , (s!"{name}_tail_remaining",
+            externalCalldataSize calldata - (baseOffset + relativeOffset + 32))
+        , (s!"{name}_data_offset", baseOffset + relativeOffset + 32) ] := by
+  rw [bindExternalParam_string_eq_bytes]
+  exact bindExternalParam_bytes_refines_dynamic_loader hhead hheadBound htailBound hlength
+    hpayloadBound
+
+/-- Converse of `bindExternalParam_string_refines_dynamic_loader`, mirroring
+`bindExternalParam_bytes_eq_some_inv`: a successful `string` binding is exactly
+the six loader locals and certifies the bounds the generated loader checks. -/
+theorem bindExternalParam_string_eq_some_inv
+    {selector : Nat} {calldata : List Nat}
+    {headSize baseOffset headOffset : Nat} {name : String}
+    {bindings : List (String × Nat)}
+    (hbind : bindExternalParam selector calldata headSize baseOffset headOffset
+      { name := name, ty := ParamType.string } = some bindings) :
+    ∃ relativeOffset length,
+      externalWordAt? selector calldata headOffset = some relativeOffset ∧
+        headSize ≤ relativeOffset ∧
+        baseOffset + relativeOffset + 32 ≤ externalCalldataSize calldata ∧
+        externalWordAt? selector calldata (baseOffset + relativeOffset) = some length ∧
+        length ≤ externalCalldataSize calldata - (baseOffset + relativeOffset + 32) ∧
+        bindings =
+          [ (s!"{name}_offset", relativeOffset)
+          , (s!"{name}_abs_offset", baseOffset + relativeOffset)
+          , (s!"{name}_length", length)
+          , (s!"{name}_tail_head_end", baseOffset + relativeOffset + 32)
+          , (s!"{name}_tail_remaining",
+              externalCalldataSize calldata - (baseOffset + relativeOffset + 32))
+          , (s!"{name}_data_offset", baseOffset + relativeOffset + 32) ] := by
+  rw [bindExternalParam_string_eq_bytes] at hbind
+  exact bindExternalParam_bytes_eq_some_inv hbind
+
 /-- Witness that one external ABI parameter is accepted by `bindExternalParam`
 at a particular absolute head offset. -/
 def ExternalParamBindingWitness


### PR DESCRIPTION
## Summary

Admits `string` into `SupportedExternalParamType`, replicating the proven `bytes` pattern from #2382 (slice 3) rather than introducing a new encoding shape.

The load-bearing observation: **a `string` argument block is byte-for-byte an `AbiArg.bytes` block** — a relative tail offset in the head area, then a length word and right-padded payload in the tail. The two types diverge only in the textual signature that feeds the selector hash, which is upstream of everything here. So every `string` fact is *transported* through the existing `bytes` lemmas by definitional reduction instead of being reproved:

```lean
theorem bindExternalParam_string_eq_bytes ... := by
  unfold bindExternalParam
  cases externalWordAt? selector calldata headOffset <;> rfl
```

Layers, mirroring #2382 exactly:

- **`Verity/Core/Model/DynamicAbi.lean`** — the transport lemma plus the `string` loader refinement and its inversion (`bindExternalParam_string_refines_dynamic_loader`, `bindExternalParam_string_eq_some_inv`).
- **`Compiler/Proofs/IRGeneration/DynamicParamLoading.lean`** — `genSingleParamLoad_string` (the compiler branches on *shape*, not type: `isLengthPrefixedDynamicShape` already admits `.string`), and a new private `exec_bytesLikeParamLoad_then` that factors the shared bytes/string execution half out of `exec_genSingleParamLoad_external_then`.
- **`Compiler/Proofs/AbiEncoding.lean`** — `bindExternalParams_string_of_abiEncodeArgs`, the round-trip that discharges the `hbindTotal` obligation from a real ABI encoding.
- **`Compiler/Proofs/IRGeneration/DispatchStringParam.lean`** (new) — whole-contract dispatcher correctness at a `string` entrypoint. As in the `bytes` module, `hbindTotal` is *discharged* rather than assumed, so the statement is non-vacuous.

`supportedExternalParamType_scalar_or_bytes` is renamed to `supportedExternalParamType_scalar_or_bytesLike` and now returns a three-way split (scalar / `bytes` / `string`) — this is the case split every downstream calldata-loading lemma performs, so widening it in one place propagates correctly.

## Scope

Slice 4 covers the `string` external-parameter surface at the same depth #2382 covers `bytes`:

- The **loader-level** lemmas (`exec_genParamLoadBodyFrom_external_then`, `exec_genParamLoads_external`) admit arbitrary mixtures of supported scalars, `bytes` and `string`.
- The **top-level hbindTotal discharge** (`bindExternalParams_string_of_abiEncodeArgs` / `interpretContract_correct_of_functions_string_param`) is stated for a single `string` entrypoint parameter, exactly as the `bytes` slice is. Multi-dynamic-parameter round-trip discharge is deferred and remains shared future work with #2382 — it is a property of the encoder round trip, not of `string`.

No UTF-8 well-formedness is asserted: Solidity's `string` carries no validity constraint at the ABI layer, so `AbiBytes.WellFormed` is the correct and only precondition.

## Gate receipts

All at pushed head `429f3147`:

| gate | exit |
| --- | --- |
| `lake build` (default target, 2473 jobs) | 0 |
| `lake build PrintAxioms` (2618 jobs) | 0 |
| `make check` | 0 |
| `scripts/check_axioms.py` | 0 — 4799 theorems, **0 sorry**, Lean builtins + 1 documented project axiom |
| `generate_trust_surface_report.py --check` | 0 (unchanged; no new `native_decide`/`implemented_by`) |
| `check_storage_lens_freeze.py` | 0 (36 baselined raw sites) |
| `check_lean_warning_regression.py` | 0 (3 observed = 3 baseline) |
| forbidden-token scan of changed Lean source | clean |

Theorem registry: 6696 → **6702** (4795→4800 public, 1901→1902 private, 0 sorry'd). All six new theorems depend only on `propext` / `Classical.choice` / `Quot.sound`.

## Test plan

- [x] `lake build` and `lake build PrintAxioms` green at the pushed head
- [x] `make check` green (includes PrintAxioms registry sync, trust-surface `--check`, storage-lens freeze)
- [x] Axiom audit shows no new axioms and no `sorryAx`
- [ ] CI confirmation on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only Lean changes extending an established `bytes` pattern; no runtime compiler behavior or auth/data-path changes, with registry and axiom gates updated.
> 
> **Overview**
> Admits **`string`** into **`SupportedExternalParamType`** and the proof stack that already covered scalars and **`bytes`**, treating a `string` calldata block as the same length-prefixed dynamic shape as **`bytes`** (only the Solidity signature differs).
> 
> **`DynamicAbi`** gains transport lemmas (`bindExternalParam_string_eq_bytes`, refinement, inversion) so `string` bindings reuse the `bytes` loader locals without a second encoding story. **`AbiEncoding`** adds **`bindExternalParams_string_of_abiEncodeArgs`**, discharging **`hbindTotal`** when calldata is a real **`AbiArg.bytes`** encoding. A new **`DispatchStringParam`** module mirrors the bytes dispatcher: totality of binding on well-formed calldata and **`interpretContract_correct_of_functions_string_param`**.
> 
> **`DynamicParamLoading`** proves **`genSingleParamLoad_string`** emits the same loader as **`bytes`**, factors shared execution through **`exec_bytesLikeParamLoad_then`**, and widens list/prologue lemmas to scalar/**`bytes`**/**`string`** mixtures. **`SupportedSpec`** adds **`.string`**, renames the case split to **`supportedExternalParamType_scalar_or_bytesLike`**, and updates **`externalParamProofSupported`**. **`PrintAxioms`** / **`Compiler.lean`** register the new public theorems (+6 in the registry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 429f314761756036468824fffcdc158208abdb64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->