### PR TITLE
proof(L2): admit array/fixedArray/tuple external params (Tier 6 slice 5)

### DIFF
--- a/Compiler.lean
+++ b/Compiler.lean
@@ -40,6 +40,7 @@ import Compiler.Proofs.IRGeneration.Expr
 import Compiler.Proofs.IRGeneration.SupportedFragment
 import Compiler.Proofs.IRGeneration.Contract
 import Compiler.Proofs.IRGeneration.Dispatch
+import Compiler.Proofs.IRGeneration.DispatchArrayParam
 import Compiler.Proofs.IRGeneration.DispatchBytesParam
 import Compiler.Proofs.IRGeneration.DispatchStringParam
 import Compiler.Proofs.IRGeneration.Function

--- a/Compiler/CompilationModel/AbiTypeLayout.lean
+++ b/Compiler/CompilationModel/AbiTypeLayout.lean
@@ -129,6 +129,14 @@ def dynamicArrayElementStrideWords (elemTy : ParamType) : Nat :=
   else
     max 1 (paramHeadSize elemTy / 32)
 
+theorem dynamicArrayElementStrideWords_eq_one_of_singleWordStatic {elemTy : ParamType}
+    (helem : isSingleWordStaticParamType elemTy = true) :
+    dynamicArrayElementStrideWords elemTy = 1 := by
+  simp only [isSingleWordStaticParamType, Bool.and_eq_true, Bool.not_eq_true',
+    beq_iff_eq] at helem
+  obtain ⟨hnotDyn, hsize⟩ := helem
+  simp [dynamicArrayElementStrideWords, hnotDyn, hsize]
+
 theorem dynamicArrayElementStrideWords_pos (elemTy : ParamType) :
     0 < dynamicArrayElementStrideWords elemTy := by
   unfold dynamicArrayElementStrideWords

--- a/Compiler/CompilationModel/AbiTypeLayout.lean
+++ b/Compiler/CompilationModel/AbiTypeLayout.lean
@@ -101,4 +101,41 @@ def isWordArrayParam : ParamType → Bool
   | ParamType.array elemTy => isSingleWordStaticParamType elemTy
   | _ => false
 
+/-- Whether the dynamic param shape is length-prefixed in the ABI tail.
+    Dynamic arrays (`T[]`), `bytes`, and `string` all begin with a 32-byte
+    length word followed by data. Dynamic tuples (structs containing nested
+    dynamic members) do not — their offset pointer dereferences directly
+    to the first head word of the tuple's encoding. (verity#1839)
+
+Lives here rather than beside the calldata loader so the ABI model
+(`Verity/Core/Model/DynamicAbi.lean`) and the Yul emitter can share one
+definition (verity#2085). -/
+def isLengthPrefixedDynamicShape : ParamType → Bool
+  | ParamType.bytes | ParamType.string | ParamType.array _ => true
+  | _ => false
+
+/-- Number of 32-byte words one element of a dynamic array occupies in the
+array's tail.  A dynamically sized element contributes a single offset word to
+the array's own head area; a static element contributes its whole head.
+
+Lives here rather than beside the calldata loader so the ABI model
+(`Verity/Core/Model/DynamicAbi.lean`) and the Yul emitter can share one
+definition: the emitted `div` bound and the model's `fitsLength` bound are then
+the same number by construction rather than by a restated case list
+(verity#2085). -/
+def dynamicArrayElementStrideWords (elemTy : ParamType) : Nat :=
+  if isDynamicParamType elemTy then
+    1
+  else
+    max 1 (paramHeadSize elemTy / 32)
+
+theorem dynamicArrayElementStrideWords_pos (elemTy : ParamType) :
+    0 < dynamicArrayElementStrideWords elemTy := by
+  unfold dynamicArrayElementStrideWords
+  split <;> omega
+
+@[simp] theorem max_one_dynamicArrayElementStrideWords (elemTy : ParamType) :
+    Nat.max 1 (dynamicArrayElementStrideWords elemTy) = dynamicArrayElementStrideWords elemTy :=
+  Nat.max_eq_right (dynamicArrayElementStrideWords_pos elemTy)
+
 end Compiler.CompilationModel

--- a/Compiler/CompilationModel/ParamLoading.lean
+++ b/Compiler/CompilationModel/ParamLoading.lean
@@ -17,21 +17,6 @@ def isScalarParamType : ParamType → Bool
   | ParamType.address | ParamType.bool | ParamType.bytes32 => true
   | _ => false
 
-private def dynamicArrayElementStrideWords (elemTy : ParamType) : Nat :=
-  if isDynamicParamType elemTy then
-    1
-  else
-    max 1 (paramHeadSize elemTy / 32)
-
-/-- Whether the dynamic param shape is length-prefixed in the ABI tail.
-    Dynamic arrays (`T[]`), `bytes`, and `string` all begin with a 32-byte
-    length word followed by data. Dynamic tuples (structs containing nested
-    dynamic members) do not — their offset pointer dereferences directly
-    to the first head word of the tuple's encoding. (verity#1839) -/
-def isLengthPrefixedDynamicShape : ParamType → Bool
-  | ParamType.bytes | ParamType.string | ParamType.array _ => true
-  | _ => false
-
 /-- Statement block emitted for a dynamically encoded external parameter. Public
 so the IR-execution refinement proofs can step through the generated loader
 (verity#2085). -/

--- a/Compiler/Proofs/AbiEncoding.lean
+++ b/Compiler/Proofs/AbiEncoding.lean
@@ -980,6 +980,146 @@ theorem bindExternalParams_string_of_abiEncodeArgs
   simp only [bindExternalParamsFrom, bindExternalParam_string_eq_bytes, hbase]
   rfl
 
+/-- Decode-of-encode for a `T[]` argument at an arbitrary position of a
+well-formed ABI argument block. The element type must be single-word static,
+which is exactly what `AbiArg.scalarArray` encodes: one normalised word per
+element after the length word. -/
+theorem bindExternalParam_scalarArray_of_abiEncodeArgs
+    (selector : Nat) (name : String)
+    (pre : List AbiArg) (elementType : ParamType) (values : List Nat) (suffix : List AbiArg)
+    (helem : isSingleWordStaticParamType elementType = true)
+    (hsize : 4 + 32 * (abiEncodeArgs (pre ++ .scalarArray elementType values :: suffix)).length <
+      Compiler.Constants.evmModulus) :
+    bindExternalParam selector
+        (abiEncodeArgs (pre ++ .scalarArray elementType values :: suffix))
+        (32 * (pre ++ .scalarArray elementType values :: suffix).length) 4
+        (4 + 32 * pre.length)
+        { name := name, ty := ParamType.array elementType } =
+      some
+        [ (s!"{name}_offset",
+            abiTailOffset (pre ++ .scalarArray elementType values :: suffix) pre.length)
+        , (s!"{name}_abs_offset",
+            4 + abiTailOffset (pre ++ .scalarArray elementType values :: suffix) pre.length)
+        , (s!"{name}_length", values.length)
+        , (s!"{name}_tail_head_end",
+            4 + abiTailOffset (pre ++ .scalarArray elementType values :: suffix) pre.length + 32)
+        , (s!"{name}_tail_remaining",
+            32 * (values.length + (suffix.flatMap AbiArg.tail).length))
+        , (s!"{name}_data_offset",
+            4 + abiTailOffset (pre ++ .scalarArray elementType values :: suffix)
+              pre.length + 32) ] := by
+  have hdyn : (AbiArg.scalarArray elementType values).isDynamic = true := rfl
+  have htotal :
+      ((pre ++ .scalarArray elementType values :: suffix).flatMap AbiArg.tail).length =
+      (pre.flatMap AbiArg.tail).length + (1 + values.length) +
+        (suffix.flatMap AbiArg.tail).length := by
+    simp [List.flatMap_append, List.flatMap_cons]
+    omega
+  have hcdlen : (abiEncodeArgs (pre ++ .scalarArray elementType values :: suffix)).length =
+      (pre ++ .scalarArray elementType values :: suffix).length +
+        ((pre ++ .scalarArray elementType values :: suffix).flatMap AbiArg.tail).length := by
+    simp [abiEncodeArgs]
+  have hcsz :
+      externalCalldataSize (abiEncodeArgs (pre ++ .scalarArray elementType values :: suffix)) =
+      4 + 32 * (abiEncodeArgs (pre ++ .scalarArray elementType values :: suffix)).length := rfl
+  have hoff := abiTailOffset_append_cons pre (.scalarArray elementType values) suffix
+  have hheadVal :
+      (abiEncodeArgs (pre ++ .scalarArray elementType values :: suffix)).getD pre.length 0 =
+      abiTailOffset (pre ++ .scalarArray elementType values :: suffix) pre.length :=
+    abiEncodeArgs_getD_dynamic_head pre _ suffix hdyn
+  have hhead : externalWordAt? selector
+      (abiEncodeArgs (pre ++ .scalarArray elementType values :: suffix))
+      (4 + 32 * pre.length) =
+      some (abiTailOffset (pre ++ .scalarArray elementType values :: suffix) pre.length) := by
+    rw [← hheadVal]
+    refine externalWordAt?_aligned _ _ _ ?_ ?_
+    · simp only [hcdlen, htotal, List.length_append, List.length_cons]
+      omega
+    · rw [hheadVal, hoff]
+      omega
+  have hlenVal := abiEncodeArgs_getD_tail_first pre (.scalarArray elementType values) suffix
+    values.length (values.map (abiScalarNormalize elementType)) rfl
+  have hlenIdx : 4 + abiTailOffset (pre ++ .scalarArray elementType values :: suffix)
+        pre.length =
+      4 + 32 * ((pre ++ .scalarArray elementType values :: suffix).length +
+        (pre.flatMap AbiArg.tail).length) := by
+    rw [hoff]
+    omega
+  have hlength : externalWordAt? selector
+      (abiEncodeArgs (pre ++ .scalarArray elementType values :: suffix))
+      (4 + abiTailOffset (pre ++ .scalarArray elementType values :: suffix) pre.length) =
+      some values.length := by
+    rw [hlenIdx, ← hlenVal]
+    refine externalWordAt?_aligned _ _ _ ?_ ?_
+    · omega
+    · rw [hlenVal]
+      omega
+  have hrewrite :
+      externalCalldataSize (abiEncodeArgs (pre ++ .scalarArray elementType values :: suffix)) -
+          (4 + abiTailOffset (pre ++ .scalarArray elementType values :: suffix)
+            pre.length + 32) =
+        32 * (values.length + (suffix.flatMap AbiArg.tail).length) := by
+    omega
+  have hpayload : values.length ≤
+      (externalCalldataSize (abiEncodeArgs (pre ++ .scalarArray elementType values :: suffix)) -
+        (4 + abiTailOffset (pre ++ .scalarArray elementType values :: suffix)
+          pre.length + 32)) / (32 * dynamicArrayElementStrideWords elementType) := by
+    rw [dynamicArrayElementStrideWords_eq_one_of_singleWordStatic helem, Nat.mul_one, hrewrite]
+    omega
+  rw [← hrewrite]
+  exact bindExternalParam_array_refines_dynamic_loader hhead (by omega) (by omega) hlength
+    hpayload
+
+/-- The whole-parameter-list binder succeeds on a single `T[]` parameter whose
+calldata is a real ABI encoding. -/
+theorem bindExternalParams_scalarArray_of_abiEncodeArgs
+    (selector : Nat) (name : String) (elementType : ParamType) (values : List Nat)
+    (helem : isSingleWordStaticParamType elementType = true)
+    (hsize : 4 + 32 * (abiEncodeArgs [AbiArg.scalarArray elementType values]).length <
+      Compiler.Constants.evmModulus) :
+    bindExternalParams selector [{ name := name, ty := ParamType.array elementType }]
+        (abiEncodeArgs [AbiArg.scalarArray elementType values]) =
+      some
+        [ (s!"{name}_offset", 32)
+        , (s!"{name}_abs_offset", 36)
+        , (s!"{name}_length", values.length)
+        , (s!"{name}_tail_head_end", 68)
+        , (s!"{name}_tail_remaining", 32 * values.length)
+        , (s!"{name}_data_offset", 68) ] := by
+  have hbase := bindExternalParam_scalarArray_of_abiEncodeArgs selector name [] elementType
+    values [] helem (by simpa using hsize)
+  simp only [List.nil_append, List.length_nil, List.length_cons, List.flatMap_nil,
+    Nat.mul_zero, Nat.add_zero, Nat.zero_add, abiTailOffset, List.take_zero,
+    abiDynamicTailSize, List.map_nil, List.sum_nil] at hbase
+  have hcdlen : (abiEncodeArgs [AbiArg.scalarArray elementType values]).length =
+      1 + (1 + values.length) := by
+    simp [abiEncodeArgs]
+    omega
+  have hlen : ([{ name := name, ty := ParamType.array elementType }] : List Param).length ≤
+      (abiEncodeArgs [AbiArg.scalarArray elementType values]).length := by
+    rw [hcdlen]
+    simp
+  have hsupp : bindSupportedParams [{ name := name, ty := ParamType.array elementType }]
+      (abiEncodeArgs [AbiArg.scalarArray elementType values]) = none := by
+    have hne : (abiEncodeArgs [AbiArg.scalarArray elementType values]) ≠ [] := by
+      intro hnil
+      rw [hnil] at hcdlen
+      simp only [List.length_nil] at hcdlen
+      omega
+    match hcd : abiEncodeArgs [AbiArg.scalarArray elementType values] with
+    | [] => exact absurd hcd hne
+    | w :: rest => simp [bindSupportedParams, decodeSupportedParamWord]
+  unfold bindExternalParams
+  rw [if_pos hlen, hsupp]
+  show bindExternalParamsFrom selector (abiEncodeArgs [AbiArg.scalarArray elementType values])
+    (paramHeadSizeList [ParamType.array elementType]) 4
+    [{ name := name, ty := ParamType.array elementType }] 4 = _
+  have hhs : paramHeadSizeList [ParamType.array elementType] = 32 * 1 := by
+    simp [paramHeadSizeList, paramHeadSize]
+  rw [hhs]
+  simp only [bindExternalParamsFrom, hbase]
+  rfl
+
 end BytesRoundTrip
 
 section Examples

--- a/Compiler/Proofs/IRGeneration/DispatchArrayParam.lean
+++ b/Compiler/Proofs/IRGeneration/DispatchArrayParam.lean
@@ -1,0 +1,99 @@
+import Compiler.Proofs.IRGeneration.DispatchGeneric
+import Compiler.Proofs.AbiEncoding
+
+/-!
+# Dispatcher correctness at a `T[]` external parameter
+
+The `bytes` module explains why `hbindTotal` cannot be left as a hypothesis for
+a dynamic parameter: on arbitrary calldata the external binder returns `none`,
+so the generic dispatcher theorem would be vacuous at such a parameter.  The
+same reasoning applies to a dynamic array.
+
+A `T[]` argument block is a relative offset word in the head area, then an
+element count followed by one normalised word per element in the tail — which is
+`AbiArg.scalarArray`.  The element type must be single-word static, so the
+loader's strided payload guard reduces to the plain word bound (verity#2085).
+-/
+
+namespace Compiler.Proofs.IRGeneration
+
+open Compiler
+open Compiler.CompilationModel
+open Compiler.Proofs.AbiEncoding
+open Dispatch
+
+namespace ArrayParamDispatch
+
+/-- The external ABI binder is total on a single `T[]` entrypoint parameter when
+the transaction arguments are a real ABI encoding.  This is exactly the
+`hbindTotal` obligation of the generic dispatcher theorem. -/
+theorem bindExternalParams_total_of_array_calldata
+    (model : CompilationModel) (tx : IRTransaction)
+    (name : String) (elementType : ParamType) (values : List Nat)
+    (helem : isSingleWordStaticParamType elementType = true)
+    (hargs : tx.args = abiEncodeArgs [AbiArg.scalarArray elementType values])
+    (hsize : 4 + 32 * tx.args.length < Compiler.Constants.evmModulus)
+    (hparams : ∀ fn ∈ selectorDispatchedFunctions model,
+      fn.params = [{ name := name, ty := ParamType.array elementType }]) :
+    ∀ fn ∈ selectorDispatchedFunctions model,
+      fn.params.length ≤ tx.args.length →
+      ∃ bindings,
+        SourceSemantics.bindExternalParams tx.functionSelector fn.params tx.args =
+          some bindings := by
+  intro fn hfn _
+  have hbind :
+      SourceSemantics.bindExternalParams tx.functionSelector fn.params tx.args =
+        some
+          [ (s!"{name}_offset", 32)
+          , (s!"{name}_abs_offset", 36)
+          , (s!"{name}_length", values.length)
+          , (s!"{name}_tail_head_end", 68)
+          , (s!"{name}_tail_remaining", 32 * values.length)
+          , (s!"{name}_data_offset", 68) ] := by
+    rw [hparams fn hfn, hargs]
+    exact bindExternalParams_scalarArray_of_abiEncodeArgs tx.functionSelector name elementType
+      values helem (by rw [← hargs]; exact hsize)
+  exact ⟨_, hbind⟩
+
+/-- Whole-contract dispatcher correctness for entrypoints taking a `T[]`
+parameter.  `hbindTotal` is gone: it is discharged from the ABI encoding, so the
+statement is non-vacuous at `T[]`. -/
+theorem interpretContract_correct_of_functions_array_param
+    (P : FunctionSpec → Nat → IRFunction → Prop)
+    (model : CompilationModel) (selectors : List Nat)
+    (irFns : List IRFunction) (tx : IRTransaction)
+    (initialWorld : Verity.ContractState)
+    (name : String) (elementType : ParamType) (values : List Nat)
+    (helem : isSingleWordStaticParamType elementType = true)
+    (hargs : tx.args = abiEncodeArgs [AbiArg.scalarArray elementType values])
+    (hsize : 4 + 32 * tx.args.length < Compiler.Constants.evmModulus)
+    (hparams : ∀ fn ∈ selectorDispatchedFunctions model,
+      fn.params = [{ name := name, ty := ParamType.array elementType }])
+    (hmeta : ∀ fn sel irFn, P fn sel irFn →
+      irFn.params = fn.params.map Param.toIRParam ∧
+        irFn.selector = sel ∧ irFn.payable = fn.isPayable)
+    (hcompiled : List.Forall₂ (fun entry irFn => P entry.1 entry.2 irFn)
+      (SourceSemantics.selectorFunctionPairs model selectors) irFns)
+    (hfunction :
+      ∀ fn sel irFn bindings,
+        fn ∈ selectorDispatchedFunctions model →
+        P fn sel irFn →
+        SourceSemantics.bindExternalParams tx.functionSelector fn.params tx.args =
+          some bindings →
+        FunctionBody.sourceResultMatchesIRResult
+          (SourceSemantics.interpretFunction model fn tx initialWorld)
+          (execIRFunction irFn tx.args
+            (FunctionBody.initialIRStateForTx model tx initialWorld))) :
+    FunctionBody.sourceResultMatchesIRResult
+      (SourceSemantics.interpretContract model selectors tx initialWorld)
+      (interpretIR (runtimeContractOfFunctions model.name irFns) tx
+        (FunctionBody.initialIRStateForTx model tx initialWorld)) :=
+  interpretContract_correct_of_functions_generic_external P model selectors irFns tx
+    initialWorld hmeta hcompiled
+    (bindExternalParams_total_of_array_calldata model tx name elementType values helem hargs
+      hsize hparams)
+    hfunction
+
+end ArrayParamDispatch
+
+end Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/IRGeneration/DynamicParamLoading.lean
+++ b/Compiler/Proofs/IRGeneration/DynamicParamLoading.lean
@@ -93,10 +93,31 @@ private theorem execIRStmts_cons_continue
 
 /-! ## Statement shape emitted for a `bytes` parameter -/
 
-/-- The nine statements `genSingleParamLoad` emits for a `bytes` external
-parameter, at a non-zero ABI base offset (external dispatch uses `4`). -/
-def bytesLoaderStmts (loadWord : YulExpr → YulExpr) (sizeExpr : YulExpr)
-    (headSize baseOffset : Nat) (name : String) (headOffset : Nat) : List YulStmt :=
+/-- The revert guard a `bytes`/`string` loader puts on the payload length: the
+payload must fit in the calldata remaining after the length word. -/
+def bytesPayloadGuard (name : String) : YulStmt :=
+  YulStmt.if_ (YulExpr.call "gt"
+    [ YulExpr.ident s!"{name}_length", YulExpr.ident s!"{name}_tail_remaining" ])
+    [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
+
+/-- The revert guard a `T[]` loader puts on the element count: as many elements
+as fit in the remaining calldata at one `dynamicArrayElementStrideWords` each. -/
+def arrayPayloadGuard (name : String) (elemTy : ParamType) : YulStmt :=
+  YulStmt.if_ (YulExpr.call "gt"
+    [ YulExpr.ident s!"{name}_length"
+    , YulExpr.call "div"
+        [ YulExpr.ident s!"{name}_tail_remaining"
+        , YulExpr.lit (32 * dynamicArrayElementStrideWords elemTy) ] ])
+    [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
+
+/-- The nine statements `genSingleParamLoad` emits for a length-prefixed dynamic
+external parameter, at a non-zero ABI base offset (external dispatch uses `4`).
+Only the eighth — the payload guard — depends on which length-prefixed type is
+being loaded, so it is left abstract here and the execution refinement is proved
+once (verity#2085). -/
+def lengthPrefixedLoaderStmts (loadWord : YulExpr → YulExpr) (sizeExpr : YulExpr)
+    (headSize baseOffset : Nat) (name : String) (headOffset : Nat)
+    (payloadGuard : YulStmt) : List YulStmt :=
   [ YulStmt.let_ s!"{name}_offset" (loadWord (YulExpr.lit headOffset))
   , YulStmt.if_ (YulExpr.call "lt" [YulExpr.ident s!"{name}_offset", YulExpr.lit headSize])
       [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
@@ -111,10 +132,41 @@ def bytesLoaderStmts (loadWord : YulExpr → YulExpr) (sizeExpr : YulExpr)
       (YulExpr.call "add" [YulExpr.ident s!"{name}_abs_offset", YulExpr.lit 32])
   , YulStmt.let_ s!"{name}_tail_remaining"
       (YulExpr.call "sub" [sizeExpr, YulExpr.ident s!"{name}_tail_head_end"])
-  , YulStmt.if_ (YulExpr.call "gt"
-      [ YulExpr.ident s!"{name}_length", YulExpr.ident s!"{name}_tail_remaining" ])
-      [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
+  , payloadGuard
   , YulStmt.let_ s!"{name}_data_offset" (YulExpr.ident s!"{name}_tail_head_end") ]
+
+/-- The nine statements `genSingleParamLoad` emits for a `bytes` external
+parameter, at a non-zero ABI base offset (external dispatch uses `4`). -/
+def bytesLoaderStmts (loadWord : YulExpr → YulExpr) (sizeExpr : YulExpr)
+    (headSize baseOffset : Nat) (name : String) (headOffset : Nat) : List YulStmt :=
+  lengthPrefixedLoaderStmts loadWord sizeExpr headSize baseOffset name headOffset
+    (bytesPayloadGuard name)
+
+/-- The nine statements `genSingleParamLoad` emits for a `T[]` external
+parameter. Identical to the `bytes` loader except for the payload guard, which
+divides the remaining tail by the element stride before comparing. -/
+def arrayLoaderStmts (loadWord : YulExpr → YulExpr) (sizeExpr : YulExpr)
+    (headSize baseOffset : Nat) (name : String) (elemTy : ParamType) (headOffset : Nat) :
+    List YulStmt :=
+  lengthPrefixedLoaderStmts loadWord sizeExpr headSize baseOffset name headOffset
+    (arrayPayloadGuard name elemTy)
+
+/-- The five statements `genSingleParamLoad` emits for a dynamic composite with
+no length word — a `tuple` with a dynamic member, or a `fixedArray` of such. The
+head word dereferences straight to the composite's own head area, so
+`_data_offset` is just `_abs_offset` (verity#1839). -/
+def dynamicCompositeLoaderStmts (loadWord : YulExpr → YulExpr) (sizeExpr : YulExpr)
+    (headSize baseOffset : Nat) (name : String) (headOffset : Nat) : List YulStmt :=
+  [ YulStmt.let_ s!"{name}_offset" (loadWord (YulExpr.lit headOffset))
+  , YulStmt.if_ (YulExpr.call "lt" [YulExpr.ident s!"{name}_offset", YulExpr.lit headSize])
+      [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
+  , YulStmt.let_ s!"{name}_abs_offset"
+      (YulExpr.call "add" [YulExpr.lit baseOffset, YulExpr.ident s!"{name}_offset"])
+  , YulStmt.if_ (YulExpr.call "gt"
+      [ YulExpr.ident s!"{name}_abs_offset"
+      , YulExpr.call "sub" [sizeExpr, YulExpr.lit 32] ])
+      [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
+  , YulStmt.let_ s!"{name}_data_offset" (YulExpr.ident s!"{name}_abs_offset") ]
 
 theorem genSingleParamLoad_bytes
     (loadWord : YulExpr → YulExpr) (sizeExpr : YulExpr)
@@ -123,7 +175,7 @@ theorem genSingleParamLoad_bytes
     genSingleParamLoad loadWord sizeExpr headSize baseOffset name ParamType.bytes headOffset =
       bytesLoaderStmts loadWord sizeExpr headSize baseOffset name headOffset := by
   simp [genSingleParamLoad, genDynamicParamLoads, isLengthPrefixedDynamicShape,
-    bytesLoaderStmts, hbase]
+    bytesLoaderStmts, lengthPrefixedLoaderStmts, bytesPayloadGuard, hbase]
 
 /-- `string` is emitted through the very same loader as `bytes`: both are
 length-prefixed dynamic shapes, and `genDynamicParamLoads` branches on the
@@ -135,7 +187,39 @@ theorem genSingleParamLoad_string
     genSingleParamLoad loadWord sizeExpr headSize baseOffset name ParamType.string headOffset =
       bytesLoaderStmts loadWord sizeExpr headSize baseOffset name headOffset := by
   simp [genSingleParamLoad, genDynamicParamLoads, isLengthPrefixedDynamicShape,
-    bytesLoaderStmts, hbase]
+    bytesLoaderStmts, lengthPrefixedLoaderStmts, bytesPayloadGuard, hbase]
+
+theorem genSingleParamLoad_array
+    (loadWord : YulExpr → YulExpr) (sizeExpr : YulExpr)
+    (headSize baseOffset : Nat) (name : String) (elemTy : ParamType) (headOffset : Nat)
+    (hbase : ¬ (baseOffset == 0) = true) :
+    genSingleParamLoad loadWord sizeExpr headSize baseOffset name (ParamType.array elemTy)
+        headOffset =
+      arrayLoaderStmts loadWord sizeExpr headSize baseOffset name elemTy headOffset := by
+  simp [genSingleParamLoad, genDynamicParamLoads, isLengthPrefixedDynamicShape,
+    arrayLoaderStmts, lengthPrefixedLoaderStmts, arrayPayloadGuard, hbase]
+
+theorem genSingleParamLoad_dynamicTuple
+    (loadWord : YulExpr → YulExpr) (sizeExpr : YulExpr)
+    (headSize baseOffset : Nat) (name : String) (elemTys : List ParamType) (headOffset : Nat)
+    (hbase : ¬ (baseOffset == 0) = true)
+    (hdynamic : isDynamicParamTypeList elemTys = true) :
+    genSingleParamLoad loadWord sizeExpr headSize baseOffset name (ParamType.tuple elemTys)
+        headOffset =
+      dynamicCompositeLoaderStmts loadWord sizeExpr headSize baseOffset name headOffset := by
+  simp [genSingleParamLoad, genDynamicParamLoads, isLengthPrefixedDynamicShape,
+    dynamicCompositeLoaderStmts, isDynamicParamType, hdynamic, hbase]
+
+theorem genSingleParamLoad_dynamicFixedArray
+    (loadWord : YulExpr → YulExpr) (sizeExpr : YulExpr)
+    (headSize baseOffset : Nat) (name : String) (elemTy : ParamType) (n headOffset : Nat)
+    (hbase : ¬ (baseOffset == 0) = true)
+    (hdynamic : isDynamicParamType elemTy = true) :
+    genSingleParamLoad loadWord sizeExpr headSize baseOffset name
+        (ParamType.fixedArray elemTy n) headOffset =
+      dynamicCompositeLoaderStmts loadWord sizeExpr headSize baseOffset name headOffset := by
+  simp [genSingleParamLoad, genDynamicParamLoads, isLengthPrefixedDynamicShape,
+    dynamicCompositeLoaderStmts, isDynamicParamType, hdynamic, hbase]
 
 /-! ## Executing the generated `bytes` loader -/
 
@@ -166,16 +250,28 @@ def bytesParamBindings (name : String) (calldataSize baseOffset relativeOffset l
   , (s!"{name}_tail_remaining", calldataSize - (baseOffset + relativeOffset + 32))
   , (s!"{name}_data_offset", baseOffset + relativeOffset + 32) ]
 
-/-- Executing the nine statements the compiler emits for a `bytes` external
-parameter binds exactly the six values the ABI model assigns to it, and never
-reverts, whenever the calldata satisfies the model's decoding side conditions.
+/-- The IR state a length-prefixed loader is in once its first seven statements
+have run: the five locals bound before the payload guard. -/
+def lengthPrefixedLoaderState (state : IRState) (name : String)
+    (calldataSize baseOffset relativeOffset length : Nat) : IRState :=
+  ((((state.setVar s!"{name}_offset" relativeOffset).setVar s!"{name}_abs_offset"
+      (baseOffset + relativeOffset)).setVar s!"{name}_length" length).setVar
+        s!"{name}_tail_head_end" (baseOffset + relativeOffset + 32)).setVar
+          s!"{name}_tail_remaining" (calldataSize - (baseOffset + relativeOffset + 32))
 
-This is the execution half of the refinement opened by verity#2373: combined
-with `DynamicAbi.bindExternalParam_bytes_refines_dynamic_loader` it says the
-generated loader implements `bindExternalParam` for `bytes`. -/
-theorem exec_bytesLoaderStmts_then
+/-- Executing the nine statements the compiler emits for a length-prefixed
+dynamic external parameter binds exactly the six values the ABI model assigns to
+it, and never reverts, whenever the calldata satisfies the model's decoding side
+conditions and the type's own payload guard passes.
+
+This is the execution half of the refinement opened by verity#2373. The guard is
+abstract because the eight surrounding statements are the same for every
+length-prefixed type; `bytes`/`string` and `T[]` differ only in what they
+compare the length against (verity#2085). -/
+theorem exec_lengthPrefixedLoaderStmts_then
     (state : IRState) (rest : List YulStmt) (name : String)
     (headSize baseOffset headOffset relativeOffset length extraFuel : Nat)
+    (payloadGuard : YulStmt)
     (hcalldataSize :
       DynamicAbi.externalCalldataSize state.calldata < Compiler.Constants.evmModulus)
     (hhead : DynamicAbi.externalWordAt? state.selector state.calldata headOffset =
@@ -186,12 +282,17 @@ theorem exec_bytesLoaderStmts_then
     (hlength :
       DynamicAbi.externalWordAt? state.selector state.calldata (baseOffset + relativeOffset) =
         some length)
-    (hpayloadBound :
-      length ≤
-        DynamicAbi.externalCalldataSize state.calldata - (baseOffset + relativeOffset + 32)) :
+    (hguard : ∀ f : Nat,
+      execIRStmt (f + 1)
+          (lengthPrefixedLoaderState state name
+            (DynamicAbi.externalCalldataSize state.calldata) baseOffset relativeOffset length)
+          payloadGuard =
+        .continue (lengthPrefixedLoaderState state name
+          (DynamicAbi.externalCalldataSize state.calldata) baseOffset relativeOffset length)) :
     execIRStmts (rest.length + extraFuel + 10) state
-        (bytesLoaderStmts (fun pos => YulExpr.call "calldataload" [pos])
-          (YulExpr.call "calldatasize" []) headSize baseOffset name headOffset ++ rest) =
+        (lengthPrefixedLoaderStmts (fun pos => YulExpr.call "calldataload" [pos])
+          (YulExpr.call "calldatasize" []) headSize baseOffset name headOffset payloadGuard
+          ++ rest) =
       execIRStmts (rest.length + extraFuel + 1)
         (ParamLoading.applyBindingsToIRState state
           (bytesParamBindings name (DynamicAbi.externalCalldataSize state.calldata)
@@ -199,7 +300,8 @@ theorem exec_bytesLoaderStmts_then
   have hcsz : DynamicAbi.externalCalldataSize state.calldata =
       4 + state.calldata.length * 32 := by
     simp [DynamicAbi.externalCalldataSize, Nat.mul_comm]
-  rw [hcsz] at hcalldataSize htailBound hpayloadBound ⊢
+  rw [hcsz] at hcalldataSize htailBound hguard ⊢
+  simp only [lengthPrefixedLoaderState] at hguard
   have hro : Compiler.Proofs.YulGeneration.calldataloadWord state.selector state.calldata
       headOffset = relativeOffset := externalWordAt?_eq_calldataloadWord hhead
   have hlenWord : Compiler.Proofs.YulGeneration.calldataloadWord state.selector state.calldata
@@ -209,9 +311,6 @@ theorem exec_bytesLoaderStmts_then
   have hHeadSizeLt : headSize < Compiler.Constants.evmModulus := by omega
   have hAbsLt : baseOffset + relativeOffset < Compiler.Constants.evmModulus := by omega
   have hTheLt : baseOffset + relativeOffset + 32 < Compiler.Constants.evmModulus := by omega
-  have hLengthLt : length < Compiler.Constants.evmModulus := by omega
-  have hTrLt : 4 + state.calldata.length * 32 - (baseOffset + relativeOffset + 32) <
-      Compiler.Constants.evmModulus := by omega
   have hSizeLt : 4 + state.calldata.length * 32 < Compiler.Constants.evmModulus := hcalldataSize
   -- `calldatasize() - 32` and `calldatasize() - {name}_tail_head_end` in EVM word arithmetic
   have hSub32 : (Compiler.Constants.evmModulus + (4 + state.calldata.length * 32) - 32) %
@@ -334,35 +433,7 @@ theorem exec_bytesLoaderStmts_then
       Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
       Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean,
       Nat.mod_eq_of_lt hSizeLt, Nat.mod_eq_of_lt hTheLt, hSubTail]
-  -- Statement 8: `if gt({name}_length, {name}_tail_remaining) { revert }` — never taken
-  have h8 : ∀ f : Nat, execIRStmt (f + 1)
-      (((((state.setVar nOffset relativeOffset).setVar nAbs
-        (baseOffset + relativeOffset)).setVar nLength length).setVar nTailHeadEnd
-          (baseOffset + relativeOffset + 32)).setVar nTailRemaining
-            (4 + state.calldata.length * 32 - (baseOffset + relativeOffset + 32)))
-      (YulStmt.if_ (YulExpr.call "gt"
-        [YulExpr.ident nLength, YulExpr.ident nTailRemaining])
-        [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]) =
-      .continue (((((state.setVar nOffset relativeOffset).setVar nAbs
-        (baseOffset + relativeOffset)).setVar nLength length).setVar nTailHeadEnd
-          (baseOffset + relativeOffset + 32)).setVar nTailRemaining
-            (4 + state.calldata.length * 32 - (baseOffset + relativeOffset + 32))) := by
-    intro f
-    have hgetLength : (((((state.setVar nOffset relativeOffset).setVar nAbs
-        (baseOffset + relativeOffset)).setVar nLength length).setVar nTailHeadEnd
-          (baseOffset + relativeOffset + 32)).setVar nTailRemaining
-            (4 + state.calldata.length * 32 -
-              (baseOffset + relativeOffset + 32))).getVar nLength = some length := by
-      rw [getVar_setVar_of_ne _ _ _ _ hLenNeTr, getVar_setVar_of_ne _ _ _ _ hLenNeThe,
-        getVar_setVar_self]
-    -- `gt(length, tailRemaining)` is false: the payload fits in the tail.
-    have hnot : ¬ (4 + state.calldata.length * 32 - (baseOffset + relativeOffset + 32)) %
-        Compiler.Constants.evmModulus < length % Compiler.Constants.evmModulus := by
-      rw [Nat.mod_eq_of_lt hLengthLt, Nat.mod_eq_of_lt hTrLt]
-      omega
-    simp [execIRStmt, evalIRExpr, evalIRCall, evalIRExprs, getVar_setVar_self, hgetLength,
-      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
-      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean, hnot]
+  -- Statement 8: the type-specific payload guard — never taken, by `hguard`.
   -- Statement 9: `let {name}_data_offset := {name}_tail_head_end`
   have h9 : ∀ f : Nat, execIRStmt (f + 1)
       (((((state.setVar nOffset relativeOffset).setVar nAbs
@@ -384,8 +455,8 @@ theorem exec_bytesLoaderStmts_then
         some (baseOffset + relativeOffset + 32) := by
       rw [getVar_setVar_of_ne _ _ _ _ hTheNeTr, getVar_setVar_self]
     simp [execIRStmt, evalIRExpr, hget]
-  simp only [bytesLoaderStmts, bytesParamBindings, ParamLoading.applyBindingsToIRState,
-    List.cons_append, List.nil_append]
+  simp only [lengthPrefixedLoaderStmts, bytesParamBindings,
+    ParamLoading.applyBindingsToIRState, List.cons_append, List.nil_append]
   rw [execIRStmts_cons_continue _ _ _ _ _ (h1 (rest.length + extraFuel + 8)),
     execIRStmts_cons_continue _ _ _ _ _ (h2 (rest.length + extraFuel + 7)),
     execIRStmts_cons_continue _ _ _ _ _ (h3 (rest.length + extraFuel + 6)),
@@ -393,8 +464,289 @@ theorem exec_bytesLoaderStmts_then
     execIRStmts_cons_continue _ _ _ _ _ (h5 (rest.length + extraFuel + 4)),
     execIRStmts_cons_continue _ _ _ _ _ (h6 (rest.length + extraFuel + 3)),
     execIRStmts_cons_continue _ _ _ _ _ (h7 (rest.length + extraFuel + 2)),
-    execIRStmts_cons_continue _ _ _ _ _ (h8 (rest.length + extraFuel + 1)),
+    execIRStmts_cons_continue _ _ _ _ _ (hguard (rest.length + extraFuel + 1)),
     execIRStmts_cons_continue _ _ _ _ _ (h9 (rest.length + extraFuel))]
+
+/-- The `bytes`/`string` payload guard never reverts when the model's payload
+bound holds: the length word is at most the calldata remaining after it. -/
+private theorem exec_bytesPayloadGuard_noop
+    (state : IRState) (name : String)
+    (baseOffset relativeOffset length : Nat)
+    (hcalldataSize :
+      DynamicAbi.externalCalldataSize state.calldata < Compiler.Constants.evmModulus)
+    (hpayloadBound :
+      length ≤
+        DynamicAbi.externalCalldataSize state.calldata - (baseOffset + relativeOffset + 32))
+    (f : Nat) :
+    execIRStmt (f + 1)
+        (lengthPrefixedLoaderState state name
+          (DynamicAbi.externalCalldataSize state.calldata) baseOffset relativeOffset length)
+        (bytesPayloadGuard name) =
+      .continue (lengthPrefixedLoaderState state name
+        (DynamicAbi.externalCalldataSize state.calldata) baseOffset relativeOffset length) := by
+  set calldataSize := DynamicAbi.externalCalldataSize state.calldata with hsize
+  have hLengthLt : length < Compiler.Constants.evmModulus := by omega
+  have hTrLt :
+      calldataSize - (baseOffset + relativeOffset + 32) < Compiler.Constants.evmModulus := by
+    omega
+  have hgetLength :
+      (lengthPrefixedLoaderState state name calldataSize baseOffset relativeOffset
+        length).getVar s!"{name}_length" = some length := by
+    rw [lengthPrefixedLoaderState,
+      getVar_setVar_of_ne _ _ _ _ (length_ne_tailRemaining name),
+      getVar_setVar_of_ne _ _ _ _ (length_ne_tailHeadEnd name), getVar_setVar_self]
+  simp only [lengthPrefixedLoaderState] at hgetLength
+  have hnot : ¬ (calldataSize - (baseOffset + relativeOffset + 32)) %
+      Compiler.Constants.evmModulus < length % Compiler.Constants.evmModulus := by
+    rw [Nat.mod_eq_of_lt hLengthLt, Nat.mod_eq_of_lt hTrLt]; omega
+  simp [bytesPayloadGuard, execIRStmt, evalIRExpr, evalIRCall, evalIRExprs, hgetLength,
+    lengthPrefixedLoaderState, getVar_setVar_self,
+    Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
+    Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean, hnot]
+
+/-- Executing the nine statements the compiler emits for a `bytes` external
+parameter binds exactly the six values the ABI model assigns to it, and never
+reverts, whenever the calldata satisfies the model's decoding side conditions. -/
+theorem exec_bytesLoaderStmts_then
+    (state : IRState) (rest : List YulStmt) (name : String)
+    (headSize baseOffset headOffset relativeOffset length extraFuel : Nat)
+    (hcalldataSize :
+      DynamicAbi.externalCalldataSize state.calldata < Compiler.Constants.evmModulus)
+    (hhead : DynamicAbi.externalWordAt? state.selector state.calldata headOffset =
+      some relativeOffset)
+    (hheadBound : headSize ≤ relativeOffset)
+    (htailBound :
+      baseOffset + relativeOffset + 32 ≤ DynamicAbi.externalCalldataSize state.calldata)
+    (hlength :
+      DynamicAbi.externalWordAt? state.selector state.calldata (baseOffset + relativeOffset) =
+        some length)
+    (hpayloadBound :
+      length ≤
+        DynamicAbi.externalCalldataSize state.calldata - (baseOffset + relativeOffset + 32)) :
+    execIRStmts (rest.length + extraFuel + 10) state
+        (bytesLoaderStmts (fun pos => YulExpr.call "calldataload" [pos])
+          (YulExpr.call "calldatasize" []) headSize baseOffset name headOffset ++ rest) =
+      execIRStmts (rest.length + extraFuel + 1)
+        (ParamLoading.applyBindingsToIRState state
+          (bytesParamBindings name (DynamicAbi.externalCalldataSize state.calldata)
+            baseOffset relativeOffset length)) rest :=
+  exec_lengthPrefixedLoaderStmts_then state rest name headSize baseOffset headOffset
+    relativeOffset length extraFuel (bytesPayloadGuard name) hcalldataSize hhead hheadBound
+    htailBound hlength
+    (exec_bytesPayloadGuard_noop state name baseOffset relativeOffset length hcalldataSize
+      hpayloadBound)
+
+/-- The `T[]` payload guard never reverts when the model's element-count bound
+holds. The emitted `div` agrees with `Nat` division because the stride literal
+is below `2 ^ 256` (`hstride`), which is exactly the side condition
+`SupportedExternalParamType` carries for arrays. -/
+private theorem exec_arrayPayloadGuard_noop
+    (state : IRState) (name : String) (elemTy : ParamType)
+    (baseOffset relativeOffset length : Nat)
+    (hcalldataSize :
+      DynamicAbi.externalCalldataSize state.calldata < Compiler.Constants.evmModulus)
+    (hstride :
+      32 * dynamicArrayElementStrideWords elemTy < Compiler.Constants.evmModulus)
+    (hpayloadBound :
+      length ≤
+        (DynamicAbi.externalCalldataSize state.calldata - (baseOffset + relativeOffset + 32)) /
+          (32 * dynamicArrayElementStrideWords elemTy))
+    (f : Nat) :
+    execIRStmt (f + 1)
+        (lengthPrefixedLoaderState state name
+          (DynamicAbi.externalCalldataSize state.calldata) baseOffset relativeOffset length)
+        (arrayPayloadGuard name elemTy) =
+      .continue (lengthPrefixedLoaderState state name
+        (DynamicAbi.externalCalldataSize state.calldata) baseOffset relativeOffset length) := by
+  set calldataSize := DynamicAbi.externalCalldataSize state.calldata with hsize
+  have hstridePos : 0 < 32 * dynamicArrayElementStrideWords elemTy := by
+    have := dynamicArrayElementStrideWords_pos elemTy
+    omega
+  have hTrLt :
+      calldataSize - (baseOffset + relativeOffset + 32) < Compiler.Constants.evmModulus := by
+    omega
+  have hquotLe :
+      (calldataSize - (baseOffset + relativeOffset + 32)) /
+          (32 * dynamicArrayElementStrideWords elemTy) ≤
+        calldataSize - (baseOffset + relativeOffset + 32) := Nat.div_le_self _ _
+  have hLengthLt : length < Compiler.Constants.evmModulus := by omega
+  have hgetLength :
+      (lengthPrefixedLoaderState state name calldataSize baseOffset relativeOffset
+        length).getVar s!"{name}_length" = some length := by
+    rw [lengthPrefixedLoaderState,
+      getVar_setVar_of_ne _ _ _ _ (length_ne_tailRemaining name),
+      getVar_setVar_of_ne _ _ _ _ (length_ne_tailHeadEnd name), getVar_setVar_self]
+  simp only [lengthPrefixedLoaderState] at hgetLength
+  have hstrideMod : 32 * dynamicArrayElementStrideWords elemTy %
+      Compiler.Constants.evmModulus = 32 * dynamicArrayElementStrideWords elemTy :=
+    Nat.mod_eq_of_lt hstride
+  have hstrideNe : ¬ 32 * dynamicArrayElementStrideWords elemTy %
+      Compiler.Constants.evmModulus = 0 := by
+    rw [hstrideMod]; omega
+  have hquotLt :
+      (calldataSize - (baseOffset + relativeOffset + 32)) /
+        (32 * dynamicArrayElementStrideWords elemTy) < Compiler.Constants.evmModulus := by
+    omega
+  have hnot : ¬ ((calldataSize - (baseOffset + relativeOffset + 32)) %
+      Compiler.Constants.evmModulus /
+      (32 * dynamicArrayElementStrideWords elemTy % Compiler.Constants.evmModulus)) %
+      Compiler.Constants.evmModulus < length % Compiler.Constants.evmModulus := by
+    rw [hstrideMod, Nat.mod_eq_of_lt hTrLt, Nat.mod_eq_of_lt hquotLt,
+      Nat.mod_eq_of_lt hLengthLt]
+    omega
+  simp [arrayPayloadGuard, execIRStmt, evalIRExpr, evalIRCall, evalIRExprs, hgetLength,
+    lengthPrefixedLoaderState, getVar_setVar_self,
+    Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
+    Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean,
+    hstrideNe, hnot]
+
+/-- Executing the nine statements the compiler emits for a `T[]` external
+parameter binds exactly the six values the ABI model assigns to it, and never
+reverts (verity#2085). -/
+theorem exec_arrayLoaderStmts_then
+    (state : IRState) (rest : List YulStmt) (name : String) (elemTy : ParamType)
+    (headSize baseOffset headOffset relativeOffset length extraFuel : Nat)
+    (hcalldataSize :
+      DynamicAbi.externalCalldataSize state.calldata < Compiler.Constants.evmModulus)
+    (hstride :
+      32 * dynamicArrayElementStrideWords elemTy < Compiler.Constants.evmModulus)
+    (hhead : DynamicAbi.externalWordAt? state.selector state.calldata headOffset =
+      some relativeOffset)
+    (hheadBound : headSize ≤ relativeOffset)
+    (htailBound :
+      baseOffset + relativeOffset + 32 ≤ DynamicAbi.externalCalldataSize state.calldata)
+    (hlength :
+      DynamicAbi.externalWordAt? state.selector state.calldata (baseOffset + relativeOffset) =
+        some length)
+    (hpayloadBound :
+      length ≤
+        (DynamicAbi.externalCalldataSize state.calldata - (baseOffset + relativeOffset + 32)) /
+          (32 * dynamicArrayElementStrideWords elemTy)) :
+    execIRStmts (rest.length + extraFuel + 10) state
+        (arrayLoaderStmts (fun pos => YulExpr.call "calldataload" [pos])
+          (YulExpr.call "calldatasize" []) headSize baseOffset name elemTy headOffset ++ rest) =
+      execIRStmts (rest.length + extraFuel + 1)
+        (ParamLoading.applyBindingsToIRState state
+          (bytesParamBindings name (DynamicAbi.externalCalldataSize state.calldata)
+            baseOffset relativeOffset length)) rest :=
+  exec_lengthPrefixedLoaderStmts_then state rest name headSize baseOffset headOffset
+    relativeOffset length extraFuel (arrayPayloadGuard name elemTy) hcalldataSize hhead
+    hheadBound htailBound hlength
+    (exec_arrayPayloadGuard_noop state name elemTy baseOffset relativeOffset length
+      hcalldataSize hstride hpayloadBound)
+
+/-- The bindings `DynamicAbi.bindExternalParam` produces for a dynamic composite
+with no length word, as an `IRState` update. -/
+def dynamicCompositeParamBindings (name : String) (baseOffset relativeOffset : Nat) :
+    List (String × Nat) :=
+  [ (s!"{name}_offset", relativeOffset)
+  , (s!"{name}_abs_offset", baseOffset + relativeOffset)
+  , (s!"{name}_data_offset", baseOffset + relativeOffset) ]
+
+/-- Executing the five statements the compiler emits for a dynamic composite
+external parameter binds exactly the three values the ABI model assigns to it,
+and never reverts. There is no length word to guard, so the only side conditions
+are the two the offset itself must satisfy (verity#2085). -/
+theorem exec_dynamicCompositeLoaderStmts_then
+    (state : IRState) (rest : List YulStmt) (name : String)
+    (headSize baseOffset headOffset relativeOffset extraFuel : Nat)
+    (hcalldataSize :
+      DynamicAbi.externalCalldataSize state.calldata < Compiler.Constants.evmModulus)
+    (hhead : DynamicAbi.externalWordAt? state.selector state.calldata headOffset =
+      some relativeOffset)
+    (hheadBound : headSize ≤ relativeOffset)
+    (htailBound :
+      baseOffset + relativeOffset + 32 ≤ DynamicAbi.externalCalldataSize state.calldata) :
+    execIRStmts (rest.length + extraFuel + 6) state
+        (dynamicCompositeLoaderStmts (fun pos => YulExpr.call "calldataload" [pos])
+          (YulExpr.call "calldatasize" []) headSize baseOffset name headOffset ++ rest) =
+      execIRStmts (rest.length + extraFuel + 1)
+        (ParamLoading.applyBindingsToIRState state
+          (dynamicCompositeParamBindings name baseOffset relativeOffset)) rest := by
+  have hcsz : DynamicAbi.externalCalldataSize state.calldata =
+      4 + state.calldata.length * 32 := by
+    simp [DynamicAbi.externalCalldataSize, Nat.mul_comm]
+  rw [hcsz] at hcalldataSize htailBound
+  have hro : Compiler.Proofs.YulGeneration.calldataloadWord state.selector state.calldata
+      headOffset = relativeOffset := externalWordAt?_eq_calldataloadWord hhead
+  have hEvm : (32 : Nat) < Compiler.Constants.evmModulus := by omega
+  have hroLt : relativeOffset < Compiler.Constants.evmModulus := by omega
+  have hHeadSizeLt : headSize < Compiler.Constants.evmModulus := by omega
+  have hAbsLt : baseOffset + relativeOffset < Compiler.Constants.evmModulus := by omega
+  have hSizeLt : 4 + state.calldata.length * 32 < Compiler.Constants.evmModulus := hcalldataSize
+  have hSub32 : (Compiler.Constants.evmModulus + (4 + state.calldata.length * 32) - 32) %
+      Compiler.Constants.evmModulus = 4 + state.calldata.length * 32 - 32 := by
+    have hrw : Compiler.Constants.evmModulus + (4 + state.calldata.length * 32) - 32 =
+        Compiler.Constants.evmModulus + (4 + state.calldata.length * 32 - 32) := by omega
+    rw [hrw, Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
+  set nOffset := s!"{name}_offset" with hnOffset
+  set nAbs := s!"{name}_abs_offset" with hnAbs
+  set nDataOffset := s!"{name}_data_offset" with hnDataOffset
+  -- Statement 1: `let {name}_offset := calldataload(headOffset)`
+  have h1 : ∀ f : Nat, execIRStmt (f + 1) state
+      (YulStmt.let_ nOffset (YulExpr.call "calldataload" [YulExpr.lit headOffset])) =
+      .continue (state.setVar nOffset relativeOffset) := by
+    intro f
+    simp [execIRStmt, evalIRExpr, evalIRCall, evalIRExprs,
+      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
+      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean, hro]
+  -- Statement 2: `if lt({name}_offset, headSize) { revert }` — never taken
+  have h2 : ∀ f : Nat, execIRStmt (f + 1) (state.setVar nOffset relativeOffset)
+      (YulStmt.if_ (YulExpr.call "lt" [YulExpr.ident nOffset, YulExpr.lit headSize])
+        [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]) =
+      .continue (state.setVar nOffset relativeOffset) := by
+    intro f
+    have hnot : ¬ relativeOffset % Compiler.Constants.evmModulus <
+        headSize % Compiler.Constants.evmModulus := by
+      rw [Nat.mod_eq_of_lt hroLt, Nat.mod_eq_of_lt hHeadSizeLt]; omega
+    simp [execIRStmt, evalIRExpr, evalIRCall, evalIRExprs, getVar_setVar_self,
+      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
+      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean, hnot]
+  -- Statement 3: `let {name}_abs_offset := add(baseOffset, {name}_offset)`
+  have h3 : ∀ f : Nat, execIRStmt (f + 1) (state.setVar nOffset relativeOffset)
+      (YulStmt.let_ nAbs
+        (YulExpr.call "add" [YulExpr.lit baseOffset, YulExpr.ident nOffset])) =
+      .continue ((state.setVar nOffset relativeOffset).setVar nAbs
+        (baseOffset + relativeOffset)) := by
+    intro f
+    simp [execIRStmt, evalIRExpr, evalIRCall, evalIRExprs, getVar_setVar_self,
+      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
+      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean,
+      Nat.mod_eq_of_lt hAbsLt]
+  -- Statement 4: `if gt({name}_abs_offset, sub(calldatasize(), 32)) { revert }` — never taken
+  have h4 : ∀ f : Nat, execIRStmt (f + 1)
+      ((state.setVar nOffset relativeOffset).setVar nAbs (baseOffset + relativeOffset))
+      (YulStmt.if_ (YulExpr.call "gt"
+        [ YulExpr.ident nAbs
+        , YulExpr.call "sub" [YulExpr.call "calldatasize" [], YulExpr.lit 32] ])
+        [YulStmt.exprStmt (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]) =
+      .continue ((state.setVar nOffset relativeOffset).setVar nAbs
+        (baseOffset + relativeOffset)) := by
+    intro f
+    have hnot : ¬ (4 + state.calldata.length * 32 - 32) % Compiler.Constants.evmModulus <
+        (baseOffset + relativeOffset) % Compiler.Constants.evmModulus := by
+      rw [Nat.mod_eq_of_lt (show 4 + state.calldata.length * 32 - 32 <
+          Compiler.Constants.evmModulus by omega), Nat.mod_eq_of_lt hAbsLt]
+      omega
+    simp [execIRStmt, evalIRExpr, evalIRCall, evalIRExprs, getVar_setVar_self,
+      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
+      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean,
+      Nat.mod_eq_of_lt hSizeLt, Nat.mod_eq_of_lt hEvm, hSub32, hnot]
+  -- Statement 5: `let {name}_data_offset := {name}_abs_offset`
+  have h5 : ∀ f : Nat, execIRStmt (f + 1)
+      ((state.setVar nOffset relativeOffset).setVar nAbs (baseOffset + relativeOffset))
+      (YulStmt.let_ nDataOffset (YulExpr.ident nAbs)) =
+      .continue (((state.setVar nOffset relativeOffset).setVar nAbs
+        (baseOffset + relativeOffset)).setVar nDataOffset (baseOffset + relativeOffset)) := by
+    intro f
+    simp [execIRStmt, evalIRExpr, getVar_setVar_self]
+  simp only [dynamicCompositeLoaderStmts, dynamicCompositeParamBindings,
+    ParamLoading.applyBindingsToIRState, List.cons_append, List.nil_append]
+  rw [execIRStmts_cons_continue _ _ _ _ _ (h1 (rest.length + extraFuel + 4)),
+    execIRStmts_cons_continue _ _ _ _ _ (h2 (rest.length + extraFuel + 3)),
+    execIRStmts_cons_continue _ _ _ _ _ (h3 (rest.length + extraFuel + 2)),
+    execIRStmts_cons_continue _ _ _ _ _ (h4 (rest.length + extraFuel + 1)),
+    execIRStmts_cons_continue _ _ _ _ _ (h5 (rest.length + extraFuel))]
 
 /-! ### Lifting the single-parameter refinement over parameter lists -/
 
@@ -464,6 +816,18 @@ theorem applyBindingsToIRState_append (state : IRState) (xs ys : List (String ×
     (headSize baseOffset : Nat) (name : String) (headOffset : Nat) :
     (bytesLoaderStmts loadWord sizeExpr headSize baseOffset name headOffset).length = 9 := rfl
 
+@[simp] theorem lengthPrefixedLoaderStmts_length
+    (loadWord : YulExpr → YulExpr) (sizeExpr : YulExpr)
+    (headSize baseOffset : Nat) (name : String) (headOffset : Nat) (payloadGuard : YulStmt) :
+    (lengthPrefixedLoaderStmts loadWord sizeExpr headSize baseOffset name headOffset
+      payloadGuard).length = 9 := rfl
+
+@[simp] theorem dynamicCompositeLoaderStmts_length
+    (loadWord : YulExpr → YulExpr) (sizeExpr : YulExpr)
+    (headSize baseOffset : Nat) (name : String) (headOffset : Nat) :
+    (dynamicCompositeLoaderStmts loadWord sizeExpr headSize baseOffset name headOffset).length =
+      5 := rfl
+
 /-- The bytes-like half of the per-parameter composition, phrased over the two
 facts `bytes` and `string` share: the emitted block is the length-prefixed
 loader, and the binder assigned it the `bytes` bindings. -/
@@ -496,10 +860,74 @@ private theorem exec_bytesLikeParamLoad_then
   simpa [bytesParamBindings, bytesLoaderStmts, Nat.add_comm, Nat.add_left_comm,
     Nat.add_assoc] using hexec
 
+/-- The `T[]` half of the per-parameter composition. -/
+private theorem exec_arrayParamLoad_then
+    (state : IRState) (rest : List YulStmt) (headSize baseOffset : Nat)
+    (name : String) (ty elemTy : ParamType) (idx extraFuel : Nat) (here : List (String × Nat))
+    (hcalldataSize :
+      DynamicAbi.externalCalldataSize state.calldata < Compiler.Constants.evmModulus)
+    (hstride : 32 * dynamicArrayElementStrideWords elemTy < Compiler.Constants.evmModulus)
+    (hstmts : genSingleParamLoad (fun pos => YulExpr.call "calldataload" [pos])
+        (YulExpr.call "calldatasize" []) headSize baseOffset name ty (4 + 32 * idx) =
+      arrayLoaderStmts (fun pos => YulExpr.call "calldataload" [pos])
+        (YulExpr.call "calldatasize" []) headSize baseOffset name elemTy (4 + 32 * idx))
+    (hbind : DynamicAbi.bindExternalParam state.selector state.calldata headSize baseOffset
+      (4 + 32 * idx) { name := name, ty := ParamType.array elemTy } = some here) :
+    execIRStmts ((genSingleParamLoad (fun pos => YulExpr.call "calldataload" [pos])
+        (YulExpr.call "calldatasize" []) headSize baseOffset name ty
+        (4 + 32 * idx)).length + rest.length + extraFuel + 1) state
+      (genSingleParamLoad (fun pos => YulExpr.call "calldataload" [pos])
+        (YulExpr.call "calldatasize" []) headSize baseOffset name ty
+        (4 + 32 * idx) ++ rest) =
+      execIRStmts (rest.length + extraFuel + 1)
+        (ParamLoading.applyBindingsToIRState state here) rest := by
+  obtain ⟨relativeOffset, length, hhead, hheadBound, htailBound, hlength,
+    hpayloadBound, hhere⟩ := DynamicAbi.bindExternalParam_array_eq_some_inv hbind
+  subst hhere
+  rw [hstmts]
+  have hexec := exec_arrayLoaderStmts_then state rest name elemTy headSize baseOffset
+    (4 + 32 * idx) relativeOffset length extraFuel hcalldataSize hstride hhead hheadBound
+    htailBound hlength hpayloadBound
+  simpa [bytesParamBindings, arrayLoaderStmts, Nat.add_comm, Nat.add_left_comm,
+    Nat.add_assoc] using hexec
+
+/-- The dynamic-composite half of the per-parameter composition, shared by
+`tuple`s with dynamic members and fixed-size arrays of such. -/
+private theorem exec_dynamicCompositeParamLoad_then
+    (state : IRState) (rest : List YulStmt) (headSize baseOffset : Nat)
+    (name : String) (ty : ParamType) (idx extraFuel : Nat) (here : List (String × Nat))
+    (hcalldataSize :
+      DynamicAbi.externalCalldataSize state.calldata < Compiler.Constants.evmModulus)
+    (hdynamic : isDynamicParamType ty = true)
+    (hnotLengthPrefixed : isLengthPrefixedDynamicShape ty = false)
+    (hstmts : genSingleParamLoad (fun pos => YulExpr.call "calldataload" [pos])
+        (YulExpr.call "calldatasize" []) headSize baseOffset name ty (4 + 32 * idx) =
+      dynamicCompositeLoaderStmts (fun pos => YulExpr.call "calldataload" [pos])
+        (YulExpr.call "calldatasize" []) headSize baseOffset name (4 + 32 * idx))
+    (hbind : DynamicAbi.bindExternalParam state.selector state.calldata headSize baseOffset
+      (4 + 32 * idx) { name := name, ty := ty } = some here) :
+    execIRStmts ((genSingleParamLoad (fun pos => YulExpr.call "calldataload" [pos])
+        (YulExpr.call "calldatasize" []) headSize baseOffset name ty
+        (4 + 32 * idx)).length + rest.length + extraFuel + 1) state
+      (genSingleParamLoad (fun pos => YulExpr.call "calldataload" [pos])
+        (YulExpr.call "calldatasize" []) headSize baseOffset name ty
+        (4 + 32 * idx) ++ rest) =
+      execIRStmts (rest.length + extraFuel + 1)
+        (ParamLoading.applyBindingsToIRState state here) rest := by
+  obtain ⟨relativeOffset, hhead, hheadBound, htailBound, hhere⟩ :=
+    DynamicAbi.bindExternalParam_dynamicComposite_eq_some_inv hdynamic hnotLengthPrefixed hbind
+  subst hhere
+  rw [hstmts]
+  have hexec := exec_dynamicCompositeLoaderStmts_then state rest name headSize baseOffset
+    (4 + 32 * idx) relativeOffset extraFuel hcalldataSize hhead hheadBound htailBound
+  simpa [dynamicCompositeParamBindings, Nat.add_comm, Nat.add_left_comm,
+    Nat.add_assoc] using hexec
+
 /-- Executing the statements emitted for one supported external parameter lands
 on exactly the bindings `DynamicAbi.bindExternalParam` assigns to it. This is
-the per-parameter composition: `bytes` and `string` go through the loader
-refinement, scalars through the existing single-word lemma. -/
+the per-parameter composition: `bytes`, `string`, `T[]` and dynamic composites
+go through the loader refinements, scalars through the existing single-word
+lemma. -/
 theorem exec_genSingleParamLoad_external_then
     (state : IRState) (rest : List YulStmt) (headSize baseOffset : Nat)
     (param : Param) (idx extraFuel : Nat) (here : List (String × Nat))
@@ -517,8 +945,9 @@ theorem exec_genSingleParamLoad_external_then
         (4 + 32 * idx) ++ rest) =
       execIRStmts (rest.length + extraFuel + 1)
         (ParamLoading.applyBindingsToIRState state here) rest := by
-  rcases supportedExternalParamType_scalar_or_bytesLike hsupported with
-    hscalar | hbytes | hstring
+  rcases supportedExternalParamType_cases hsupported with
+    hscalar | hbytes | hstring | ⟨elemTy, harray, hstride⟩ |
+      ⟨elemTy, n, hfixed, hdynElem⟩ | ⟨elemTys, htuple, hdynList⟩
   · obtain ⟨word, value, hword, hdecode, hhere⟩ :=
       DynamicAbi.bindExternalParam_scalar_eq_some_inv (decode_total_of_scalar hscalar) hbind
     have hwordEq : word = state.calldata.getD idx 0 % Compiler.Constants.evmModulus := by
@@ -550,6 +979,25 @@ theorem exec_genSingleParamLoad_external_then
     exact exec_bytesLikeParamLoad_then state rest headSize baseOffset param.name param.ty idx
       extraFuel here hcalldataSize
       (by rw [hstring]; exact genSingleParamLoad_string _ _ _ _ _ _ hbase) hbind
+  · have hparam : param = { name := param.name, ty := ParamType.array elemTy } := by
+      cases param
+      simp_all
+    rw [hparam] at hbind
+    exact exec_arrayParamLoad_then state rest headSize baseOffset param.name param.ty elemTy idx
+      extraFuel here hcalldataSize hstride
+      (by rw [harray]; exact genSingleParamLoad_array _ _ _ _ _ _ _ hbase) hbind
+  · have hparam : param = { name := param.name, ty := param.ty } := rfl
+    exact exec_dynamicCompositeParamLoad_then state rest headSize baseOffset param.name param.ty
+      idx extraFuel here hcalldataSize (by rw [hfixed]; simpa [isDynamicParamType] using hdynElem)
+      (by rw [hfixed]; rfl)
+      (by rw [hfixed]; exact genSingleParamLoad_dynamicFixedArray _ _ _ _ _ _ _ _ hbase hdynElem)
+      (by rw [← hparam]; exact hbind)
+  · have hparam : param = { name := param.name, ty := param.ty } := rfl
+    exact exec_dynamicCompositeParamLoad_then state rest headSize baseOffset param.name param.ty
+      idx extraFuel here hcalldataSize (by rw [htuple]; simpa [isDynamicParamType] using hdynList)
+      (by rw [htuple]; rfl)
+      (by rw [htuple]; exact genSingleParamLoad_dynamicTuple _ _ _ _ _ _ _ hbase hdynList)
+      (by rw [← hparam]; exact hbind)
 
 /-- The parameter-list lift: the whole emitted calldata-decoding block executes
 to exactly the bindings the dispatcher's external ABI binder computes, for any

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -91,12 +91,10 @@ theorem SupportedExternalParamType_array {elemTy : ParamType}
 theorem SupportedExternalParamType_wordArray {elemTy : ParamType}
     (hword : isSingleWordStaticParamType elemTy = true) :
     SupportedExternalParamType (ParamType.array elemTy) := by
-  simp only [isSingleWordStaticParamType, Bool.and_eq_true, Bool.not_eq_true',
-    beq_iff_eq] at hword
-  obtain ⟨hnotDyn, hsize⟩ := hword
   show ExternalArrayStrideFitsWord elemTy
-  simp [ExternalArrayStrideFitsWord, dynamicArrayElementStrideWords, hnotDyn, hsize,
-    Compiler.Constants.evmModulus]
+  rw [ExternalArrayStrideFitsWord,
+    dynamicArrayElementStrideWords_eq_one_of_singleWordStatic hword]
+  simp [Compiler.Constants.evmModulus]
 
 theorem SupportedExternalParamType_dynamicFixedArray {elemTy : ParamType} {n : Nat}
     (hdynamic : isDynamicParamType elemTy = true) :

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -24,22 +24,50 @@ def SupportedExternalScalarParamType : ParamType → Prop
   | .address | .bytes32 | .bool => True
   | _ => False
 
-/-- ABI parameter types admitted by external dispatch, widened past the
-single-head-word scalars to the length-prefixed dynamic `bytes` and `string`
-parameters (verity#2085).
+/-- Side condition on a dynamic array's element type: the stride literal the
+loader divides the remaining tail by must be representable as an EVM word.
+Below `2 ^ 256` the emitted `div` agrees with `Nat` division, so the generated
+revert guard and `DynamicPayloadShape.fitsLength` accept exactly the same
+lengths; at or above it the emitted `div` would saturate to `0` and the two
+would diverge. `dynamicArrayElementStrideWords` is positive, so this also rules
+out the EVM's division-by-zero convention. -/
+def ExternalArrayStrideFitsWord (elemTy : ParamType) : Prop :=
+  32 * dynamicArrayElementStrideWords elemTy < Compiler.Constants.evmModulus
 
-Neither `bytes` nor `string` is decodable by `decodeSupportedParamWord`: they
-have no single-word value. Their head word is a relative tail offset, and the
-generated calldata loader binds six locals (`_offset`, `_abs_offset`, `_length`,
-`_tail_head_end`, `_tail_remaining`, `_data_offset`) that
-`DynamicAbi.bindExternalParam` reproduces semantically. `string` is encoded
-byte-for-byte like `bytes`, so it reuses the same loader and the same binder
-lemmas. Consumers that need an actual scalar head word — the native-backend
+/-- ABI parameter types admitted by external dispatch, widened past the
+single-head-word scalars to every dynamic parameter whose head contribution is a
+single relative tail offset (verity#2085).
+
+None of these is decodable by `decodeSupportedParamWord`: they have no
+single-word value. Their head word is a relative tail offset, and the generated
+calldata loader binds locals that `DynamicAbi.bindExternalParam` reproduces
+semantically. Two shapes occur:
+
+* Length-prefixed (`bytes`, `string`, `T[]`) — the offset points at a length
+  word, and the loader binds six locals (`_offset`, `_abs_offset`, `_length`,
+  `_tail_head_end`, `_tail_remaining`, `_data_offset`). `string` is encoded
+  byte-for-byte like `bytes`, so it reuses the same loader and binder lemmas.
+  Arrays additionally carry `ExternalArrayStrideFitsWord`.
+* Length-word-free composites (a `tuple` with a dynamic member, or a
+  `fixedArray` of such) — the offset points straight at the composite's own head
+  area, and the loader binds three locals (`_offset`, `_abs_offset`,
+  `_data_offset`).
+
+*Statically* sized composites are deliberately excluded: their head is wider
+than one word, so they would break `supportedExternalParamType_headSize_eq_32`,
+and `bindExternalParam` returns `none` for them anyway. `newtypeOf` is excluded
+for a different reason: the emitter erases it to its base type while the binder
+does not, so admitting it would relate two different loaders.
+
+Consumers that need an actual scalar head word — the native-backend
 static-scalar bridge and the legacy Yul compatibility witnesses — keep requiring
 `SupportedExternalScalarParamType`. -/
 def SupportedExternalParamType : ParamType → Prop
   | .uint256 | .int256 | .uint8 | .uint16 | .uintN _ | .intN _ | .bytesN _
   | .address | .bytes32 | .bool | .bytes | .string => True
+  | .array elemTy => ExternalArrayStrideFitsWord elemTy
+  | .fixedArray elemTy _ => isDynamicParamType elemTy = true
+  | .tuple elemTys => isDynamicParamTypeList elemTys = true
   | _ => False
 
 theorem SupportedExternalParamType_of_scalar {ty : ParamType}
@@ -54,20 +82,51 @@ theorem SupportedExternalParamType_bytes :
 theorem SupportedExternalParamType_string :
     SupportedExternalParamType ParamType.string := trivial
 
-/-- The widened admission set is exactly the scalar set plus the two bytes-like
-dynamic types. This is the case split every downstream calldata-loading
-execution lemma performs. -/
-theorem supportedExternalParamType_scalar_or_bytesLike {ty : ParamType}
-    (hsupported : SupportedExternalParamType ty) :
-    SupportedExternalScalarParamType ty ∨ ty = ParamType.bytes ∨ ty = ParamType.string := by
-  cases ty <;> simp [SupportedExternalParamType] at hsupported <;>
-    simp [SupportedExternalScalarParamType]
+theorem SupportedExternalParamType_array {elemTy : ParamType}
+    (hstride : ExternalArrayStrideFitsWord elemTy) :
+    SupportedExternalParamType (ParamType.array elemTy) := hstride
 
-/-- Widened parameter lists still have 32-byte ABI head words: `bytes` and
-`string` each contribute a one-word relative tail pointer to the head area. -/
+/-- Every single-word element type has stride `1`, so word arrays — `uint256[]`,
+`address[]`, `bytes32[]`, … — are admitted unconditionally. -/
+theorem SupportedExternalParamType_wordArray {elemTy : ParamType}
+    (hword : isSingleWordStaticParamType elemTy = true) :
+    SupportedExternalParamType (ParamType.array elemTy) := by
+  simp only [isSingleWordStaticParamType, Bool.and_eq_true, Bool.not_eq_true',
+    beq_iff_eq] at hword
+  obtain ⟨hnotDyn, hsize⟩ := hword
+  show ExternalArrayStrideFitsWord elemTy
+  simp [ExternalArrayStrideFitsWord, dynamicArrayElementStrideWords, hnotDyn, hsize,
+    Compiler.Constants.evmModulus]
+
+theorem SupportedExternalParamType_dynamicFixedArray {elemTy : ParamType} {n : Nat}
+    (hdynamic : isDynamicParamType elemTy = true) :
+    SupportedExternalParamType (ParamType.fixedArray elemTy n) := hdynamic
+
+theorem SupportedExternalParamType_dynamicTuple {elemTys : List ParamType}
+    (hdynamic : isDynamicParamTypeList elemTys = true) :
+    SupportedExternalParamType (ParamType.tuple elemTys) := hdynamic
+
+/-- The widened admission set, as the case split every downstream
+calldata-loading execution lemma performs. The composite constructors are named
+individually rather than folded into one `isLengthPrefixedDynamicShape = false`
+disjunct because `genSingleParamLoad` dispatches on the constructor. -/
+theorem supportedExternalParamType_cases {ty : ParamType}
+    (hsupported : SupportedExternalParamType ty) :
+    SupportedExternalScalarParamType ty ∨
+      ty = ParamType.bytes ∨
+      ty = ParamType.string ∨
+      (∃ elemTy, ty = ParamType.array elemTy ∧ ExternalArrayStrideFitsWord elemTy) ∨
+      (∃ elemTy n, ty = ParamType.fixedArray elemTy n ∧ isDynamicParamType elemTy = true) ∨
+      (∃ elemTys, ty = ParamType.tuple elemTys ∧ isDynamicParamTypeList elemTys = true) := by
+  cases ty <;> simp [SupportedExternalParamType] at hsupported <;>
+    simp_all [SupportedExternalScalarParamType]
+
+/-- Widened parameter lists still have 32-byte ABI head words: every admitted
+dynamic type contributes exactly one relative tail pointer to the head area. -/
 theorem supportedExternalParamType_headSize_eq_32 {ty : ParamType}
     (hsupported : SupportedExternalParamType ty) : paramHeadSize ty = 32 := by
-  cases ty <;> simp [SupportedExternalParamType] at hsupported <;> simp [paramHeadSize]
+  cases ty <;> simp [SupportedExternalParamType] at hsupported <;>
+    simp [paramHeadSize, isDynamicParamType, hsupported]
 
 /-- Return profiles admitted by the first whole-contract Layer 2 fragment.
 The initial theorem only targets zero-return or single-head-word-return entrypoints. -/
@@ -89,12 +148,17 @@ def externalParamScalarProofSupported (ty : ParamType) : Bool :=
 
 /-- Compile-driven decision procedure for the widened external-parameter
 admission set. The scalar half still delegates to the compiler's
-`isScalarParamType`; `bytes` and `string` are the two constructors admitted on
-top of it, and they are named explicitly so any future compiler-side change to
-dynamic-parameter routing shows up at the agreement oracle below rather than
-drifting silently. -/
+`isScalarParamType`; the dynamic constructors admitted on top of it are named
+explicitly, and their side conditions are phrased with the compiler's own
+`dynamicArrayElementStrideWords` / `isDynamicParamType`, so any future
+compiler-side change to dynamic-parameter routing shows up at the agreement
+oracle below rather than drifting silently. -/
 def externalParamProofSupported : ParamType → Bool
   | ParamType.bytes | ParamType.string => true
+  | ParamType.array elemTy =>
+      decide (32 * dynamicArrayElementStrideWords elemTy < Compiler.Constants.evmModulus)
+  | ParamType.fixedArray elemTy _ => isDynamicParamType elemTy
+  | ParamType.tuple elemTys => isDynamicParamTypeList elemTys
   | ty => isScalarParamType ty
 
 /-- Proof-side scalar-return-profile predicate tied to the compiler's scalar
@@ -146,7 +210,8 @@ theorem SupportedExternalParamType_iff_externalParamProofSupported
     (ty : ParamType) :
     SupportedExternalParamType ty ↔ externalParamProofSupported ty = true := by
   cases ty <;>
-    simp [SupportedExternalParamType, externalParamProofSupported, isScalarParamType]
+    simp [SupportedExternalParamType, externalParamProofSupported, isScalarParamType,
+      ExternalArrayStrideFitsWord]
 
 /-- Agreement oracle for the return-profile shape. -/
 theorem SupportedExternalReturnProfile_iff_externalReturnProfileProofSupported

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1179,6 +1179,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.AbiEncoding.bindExternalParam_bytes_of_abiEncodeArgs
   Compiler.Proofs.AbiEncoding.bindExternalParams_bytes_of_abiEncodeArgs
   Compiler.Proofs.AbiEncoding.bindExternalParams_string_of_abiEncodeArgs
+  Compiler.Proofs.AbiEncoding.bindExternalParam_scalarArray_of_abiEncodeArgs
+  Compiler.Proofs.AbiEncoding.bindExternalParams_scalarArray_of_abiEncodeArgs
 
   -- Compiler/Proofs/AbiEventObservable.lean
   -- Compiler.Proofs.AbiEventObservable.land_mod_evm_right  -- private
@@ -2527,6 +2529,10 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.Dispatch.interpretContract_correct_of_compiled_functions_with_helper_proofs_and_helper_ir_of_disjointRuntimeContract
   Compiler.Proofs.IRGeneration.Dispatch.interpretContract_correct_of_compiled_functions_with_helper_proofs_and_helper_ir_closed
 
+  -- Compiler/Proofs/IRGeneration/DispatchArrayParam.lean
+  Compiler.Proofs.IRGeneration.ArrayParamDispatch.bindExternalParams_total_of_array_calldata
+  Compiler.Proofs.IRGeneration.ArrayParamDispatch.interpretContract_correct_of_functions_array_param
+
   -- Compiler/Proofs/IRGeneration/DispatchBytesParam.lean
   Compiler.Proofs.IRGeneration.BytesParamDispatch.bindExternalParams_total_of_bytes_calldata
   Compiler.Proofs.IRGeneration.BytesParamDispatch.interpretContract_correct_of_functions_bytes_param
@@ -2574,9 +2580,17 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.DynamicParamLoading.execIRStmts_cons_continue  -- private
   Compiler.Proofs.IRGeneration.DynamicParamLoading.genSingleParamLoad_bytes
   Compiler.Proofs.IRGeneration.DynamicParamLoading.genSingleParamLoad_string
+  Compiler.Proofs.IRGeneration.DynamicParamLoading.genSingleParamLoad_array
+  Compiler.Proofs.IRGeneration.DynamicParamLoading.genSingleParamLoad_dynamicTuple
+  Compiler.Proofs.IRGeneration.DynamicParamLoading.genSingleParamLoad_dynamicFixedArray
   -- Compiler.Proofs.IRGeneration.DynamicParamLoading.calldataloadWord_eq  -- private
   -- Compiler.Proofs.IRGeneration.DynamicParamLoading.externalWordAt?_eq_calldataloadWord  -- private
+  Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_lengthPrefixedLoaderStmts_then
+  -- Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_bytesPayloadGuard_noop  -- private
   Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_bytesLoaderStmts_then
+  -- Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_arrayPayloadGuard_noop  -- private
+  Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_arrayLoaderStmts_then
+  Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_dynamicCompositeLoaderStmts_then
   -- Compiler.Proofs.IRGeneration.DynamicParamLoading.scalar_cases  -- private
   Compiler.Proofs.IRGeneration.DynamicParamLoading.genSingleParamLoad_scalar
   -- Compiler.Proofs.IRGeneration.DynamicParamLoading.decode_total_of_scalar  -- private
@@ -2585,7 +2599,11 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.DynamicParamLoading.applyBindingsToIRState_calldata
   Compiler.Proofs.IRGeneration.DynamicParamLoading.applyBindingsToIRState_selector
   Compiler.Proofs.IRGeneration.DynamicParamLoading.bytesLoaderStmts_length
+  Compiler.Proofs.IRGeneration.DynamicParamLoading.lengthPrefixedLoaderStmts_length
+  Compiler.Proofs.IRGeneration.DynamicParamLoading.dynamicCompositeLoaderStmts_length
   -- Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_bytesLikeParamLoad_then  -- private
+  -- Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_arrayParamLoad_then  -- private
+  -- Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_dynamicCompositeParamLoad_then  -- private
   Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_genSingleParamLoad_external_then
   Compiler.Proofs.IRGeneration.DynamicParamLoading.exec_genParamLoadBodyFrom_external_then
   -- Compiler.Proofs.IRGeneration.DynamicParamLoading.headSizeFoldl_go  -- private
@@ -4543,7 +4561,11 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.SupportedExternalParamType_of_scalar
   Compiler.Proofs.IRGeneration.SupportedExternalParamType_bytes
   Compiler.Proofs.IRGeneration.SupportedExternalParamType_string
-  Compiler.Proofs.IRGeneration.supportedExternalParamType_scalar_or_bytesLike
+  Compiler.Proofs.IRGeneration.SupportedExternalParamType_array
+  Compiler.Proofs.IRGeneration.SupportedExternalParamType_wordArray
+  Compiler.Proofs.IRGeneration.SupportedExternalParamType_dynamicFixedArray
+  Compiler.Proofs.IRGeneration.SupportedExternalParamType_dynamicTuple
+  Compiler.Proofs.IRGeneration.supportedExternalParamType_cases
   Compiler.Proofs.IRGeneration.supportedExternalParamType_headSize_eq_32
   Compiler.Proofs.IRGeneration.eventParamSourceShapeProofSupported_of_scalar
   Compiler.Proofs.IRGeneration.SupportedExternalParamType_iff_externalParamScalarProofSupported
@@ -7277,4 +7299,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6735 theorems/lemmas (4824 public, 1911 private, 0 sorry'd)
+-- Total: 6755 theorems/lemmas (4840 public, 1915 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -63,6 +63,7 @@ import Compiler.Proofs.IRGeneration.DenoteAgreement
 import Compiler.Proofs.IRGeneration.DenoteEquivalence
 import Compiler.Proofs.IRGeneration.DenoteFunctionAgreement
 import Compiler.Proofs.IRGeneration.Dispatch
+import Compiler.Proofs.IRGeneration.DispatchArrayParam
 import Compiler.Proofs.IRGeneration.DispatchBytesParam
 import Compiler.Proofs.IRGeneration.DispatchGeneric
 import Compiler.Proofs.IRGeneration.DispatchStringParam

--- a/Verity/Core/Model/DynamicAbi.lean
+++ b/Verity/Core/Model/DynamicAbi.lean
@@ -224,13 +224,7 @@ def decodeDynamicTupleParamDataOffset? (selector : Nat) (calldata : List Nat)
 
 private def externalDynamicPayloadShape? : ParamType → Option DynamicPayloadShape
   | .bytes | .string => some .bytesLike
-  | .array elemTy =>
-      let strideWords :=
-        if isDynamicParamType elemTy then
-          1
-        else
-          Nat.max 1 (paramHeadSize elemTy / 32)
-      some (.array strideWords)
+  | .array elemTy => some (.array (dynamicArrayElementStrideWords elemTy))
   | _ => none
 
 private def dynamicParamBindings (name : String)
@@ -518,6 +512,270 @@ theorem bindExternalParam_string_eq_some_inv
           , (s!"{name}_data_offset", baseOffset + relativeOffset + 32) ] := by
   rw [bindExternalParam_string_eq_bytes] at hbind
   exact bindExternalParam_bytes_eq_some_inv hbind
+
+/-! ### Dynamic arrays
+
+`T[]` shares the `bytes` head/tail skeleton — a relative tail offset in the head
+area, a length word at the tail head — but its length counts *elements*, not
+bytes.  The payload bound therefore divides the remaining tail by the element
+stride, which is exactly the `div` the emitter puts in the generated guard
+(verity#2085). -/
+
+/-- Inversion for the length-prefixed array decoder, mirroring
+`decodeLengthPrefixedDynamicParam?_bytesLike_eq_some_inv` with the strided
+payload bound. -/
+theorem decodeLengthPrefixedDynamicParam?_array_eq_some_inv
+    {selector : Nat} {calldata : List Nat}
+    {headSize baseOffset headOffset strideWords : Nat}
+    {decoded : LengthPrefixedDynamicParam}
+    (hdec : decodeLengthPrefixedDynamicParam? selector calldata
+      (DynamicPayloadShape.array strideWords) headSize baseOffset headOffset = some decoded) :
+    externalWordAt? selector calldata headOffset = some decoded.relativeOffset ∧
+      headSize ≤ decoded.relativeOffset ∧
+      baseOffset + decoded.relativeOffset + 32 ≤ externalCalldataSize calldata ∧
+      externalWordAt? selector calldata (baseOffset + decoded.relativeOffset) =
+        some decoded.length ∧
+      decoded.length ≤
+        (externalCalldataSize calldata - (baseOffset + decoded.relativeOffset + 32)) /
+          (32 * Nat.max 1 strideWords) ∧
+      decoded.absoluteOffset = baseOffset + decoded.relativeOffset ∧
+      decoded.tailHeadEnd = baseOffset + decoded.relativeOffset + 32 ∧
+      decoded.tailRemaining =
+        externalCalldataSize calldata - (baseOffset + decoded.relativeOffset + 32) ∧
+      decoded.dataOffset = baseOffset + decoded.relativeOffset + 32 := by
+  unfold decodeLengthPrefixedDynamicParam? at hdec
+  cases hro : externalWordAt? selector calldata headOffset with
+  | none => rw [hro] at hdec; simp at hdec
+  | some relativeOffset =>
+      rw [hro] at hdec
+      simp only [Option.bind_eq_bind, Option.bind] at hdec
+      by_cases hlt : relativeOffset < headSize
+      · simp [hlt] at hdec
+      · rw [if_neg hlt] at hdec
+        by_cases hgt : baseOffset + relativeOffset + 32 > externalCalldataSize calldata
+        · simp [hgt] at hdec
+        · rw [if_neg hgt] at hdec
+          cases hlen : externalWordAt? selector calldata (baseOffset + relativeOffset) with
+          | none => rw [hlen] at hdec; simp at hdec
+          | some length =>
+              rw [hlen] at hdec
+              simp only [DynamicPayloadShape.fitsLength] at hdec
+              by_cases hfit :
+                  length ≤
+                    (externalCalldataSize calldata - (baseOffset + relativeOffset + 32)) /
+                      (32 * Nat.max 1 strideWords)
+              · rw [if_pos (by simpa using hfit)] at hdec
+                cases hdec
+                refine ⟨rfl, ?_, ?_, hlen, hfit, rfl, rfl, rfl, rfl⟩
+                · show headSize ≤ relativeOffset
+                  omega
+                · show baseOffset + relativeOffset + 32 ≤ externalCalldataSize calldata
+                  omega
+              · rw [if_neg (by simpa using hfit)] at hdec
+                simp at hdec
+
+/-- The array counterpart of `bindExternalParam_bytes_refines_dynamic_loader`:
+given the head word, tail length word and strided payload bound the generated
+loader checks, the dispatcher binds the same six loader locals. -/
+theorem bindExternalParam_array_refines_dynamic_loader
+    {selector : Nat} {calldata : List Nat}
+    {headSize baseOffset headOffset relativeOffset length : Nat} {name : String}
+    {elemTy : ParamType}
+    (hhead : externalWordAt? selector calldata headOffset = some relativeOffset)
+    (hheadBound : headSize ≤ relativeOffset)
+    (htailBound : baseOffset + relativeOffset + 32 ≤ externalCalldataSize calldata)
+    (hlength : externalWordAt? selector calldata (baseOffset + relativeOffset) = some length)
+    (hpayloadBound :
+      length ≤ (externalCalldataSize calldata - (baseOffset + relativeOffset + 32)) /
+        (32 * dynamicArrayElementStrideWords elemTy)) :
+    bindExternalParam selector calldata headSize baseOffset headOffset
+      { name := name, ty := ParamType.array elemTy } =
+      some
+        [ (s!"{name}_offset", relativeOffset)
+        , (s!"{name}_abs_offset", baseOffset + relativeOffset)
+        , (s!"{name}_length", length)
+        , (s!"{name}_tail_head_end", baseOffset + relativeOffset + 32)
+        , (s!"{name}_tail_remaining",
+            externalCalldataSize calldata - (baseOffset + relativeOffset + 32))
+        , (s!"{name}_data_offset", baseOffset + relativeOffset + 32) ] := by
+  have hnotTailOutOfBounds :
+      ¬ baseOffset + relativeOffset + 32 > externalCalldataSize calldata := by omega
+  have hnotHeadInTail : ¬ relativeOffset < headSize := by omega
+  have hdecodeArray :
+      decodeSupportedParamWord (ParamType.array elemTy) =<< some relativeOffset = none := rfl
+  simp [bindExternalParam, externalDynamicPayloadShape?,
+    decodeLengthPrefixedDynamicParam?, DynamicPayloadShape.fitsLength,
+    dynamicParamBindings, hhead, hdecodeArray, hnotHeadInTail, hnotTailOutOfBounds, hlength,
+    hpayloadBound]
+
+/-- Converse of `bindExternalParam_array_refines_dynamic_loader`: a successful
+array binding is exactly the six loader locals and certifies the bounds the
+generated loader enforces, including the strided payload bound. -/
+theorem bindExternalParam_array_eq_some_inv
+    {selector : Nat} {calldata : List Nat}
+    {headSize baseOffset headOffset : Nat} {name : String} {elemTy : ParamType}
+    {bindings : List (String × Nat)}
+    (hbind : bindExternalParam selector calldata headSize baseOffset headOffset
+      { name := name, ty := ParamType.array elemTy } = some bindings) :
+    ∃ relativeOffset length,
+      externalWordAt? selector calldata headOffset = some relativeOffset ∧
+        headSize ≤ relativeOffset ∧
+        baseOffset + relativeOffset + 32 ≤ externalCalldataSize calldata ∧
+        externalWordAt? selector calldata (baseOffset + relativeOffset) = some length ∧
+        length ≤ (externalCalldataSize calldata - (baseOffset + relativeOffset + 32)) /
+          (32 * dynamicArrayElementStrideWords elemTy) ∧
+        bindings =
+          [ (s!"{name}_offset", relativeOffset)
+          , (s!"{name}_abs_offset", baseOffset + relativeOffset)
+          , (s!"{name}_length", length)
+          , (s!"{name}_tail_head_end", baseOffset + relativeOffset + 32)
+          , (s!"{name}_tail_remaining",
+              externalCalldataSize calldata - (baseOffset + relativeOffset + 32))
+          , (s!"{name}_data_offset", baseOffset + relativeOffset + 32) ] := by
+  have hdecode :
+      decodeSupportedParamWord (ParamType.array elemTy) =<<
+        externalWordAt? selector calldata headOffset = none := by
+    cases externalWordAt? selector calldata headOffset <;> rfl
+  unfold bindExternalParam at hbind
+  rw [hdecode] at hbind
+  simp only [externalDynamicPayloadShape?] at hbind
+  cases hdec : decodeLengthPrefixedDynamicParam? selector calldata
+      (DynamicPayloadShape.array (dynamicArrayElementStrideWords elemTy))
+      headSize baseOffset headOffset with
+  | none => rw [hdec] at hbind; simp at hbind
+  | some decoded =>
+      rw [hdec] at hbind
+      simp only [Option.bind_eq_bind, Option.bind, Option.some.injEq] at hbind
+      obtain ⟨hro, hheadBound, htailBound, hlen, hfit, habs, htailHead, htailRem, hdata⟩ :=
+        decodeLengthPrefixedDynamicParam?_array_eq_some_inv hdec
+      rw [max_one_dynamicArrayElementStrideWords] at hfit
+      refine ⟨decoded.relativeOffset, decoded.length,
+        hro, hheadBound, htailBound, hlen, hfit, ?_⟩
+      rw [← hbind]
+      unfold dynamicParamBindings
+      rw [habs, htailHead, htailRem, hdata]
+
+/-! ### Dynamic composites without a length word
+
+A `struct` with dynamic members, and a fixed-size array of such structs, are
+encoded as a relative tail offset whose target is the composite's own head area:
+no length word, so the loader binds three locals instead of six.  Both shapes go
+through the same branch of `bindExternalParam`, keyed on the compiler's
+`isLengthPrefixedDynamicShape` (verity#2085). -/
+
+private theorem decodeSupportedParamWord_eq_none_of_dynamic {ty : ParamType}
+    (hdynamic : isDynamicParamType ty = true) (word : Nat) :
+    decodeSupportedParamWord ty word = none := by
+  cases ty <;> simp_all [decodeSupportedParamWord, isDynamicParamType]
+
+private theorem externalDynamicPayloadShape?_eq_none_of_not_lengthPrefixed {ty : ParamType}
+    (hnotLengthPrefixed : isLengthPrefixedDynamicShape ty = false) :
+    externalDynamicPayloadShape? ty = none := by
+  cases ty <;> simp_all [isLengthPrefixedDynamicShape, externalDynamicPayloadShape?]
+
+/-- Inversion for the length-word-free dynamic decoder: a successful decode pins
+the absolute offset and certifies the two bounds the generated loader checks. -/
+theorem decodeDynamicTupleParamDataOffset?_eq_some_inv
+    {selector : Nat} {calldata : List Nat} {headSize baseOffset headOffset absoluteOffset : Nat}
+    (hdec : decodeDynamicTupleParamDataOffset? selector calldata headSize baseOffset headOffset
+      = some absoluteOffset) :
+    ∃ relativeOffset,
+      externalWordAt? selector calldata headOffset = some relativeOffset ∧
+        headSize ≤ relativeOffset ∧
+        baseOffset + relativeOffset + 32 ≤ externalCalldataSize calldata ∧
+        absoluteOffset = baseOffset + relativeOffset := by
+  unfold decodeDynamicTupleParamDataOffset? at hdec
+  cases hro : externalWordAt? selector calldata headOffset with
+  | none => rw [hro] at hdec; simp at hdec
+  | some relativeOffset =>
+      rw [hro] at hdec
+      simp only [Option.bind_eq_bind, Option.bind] at hdec
+      by_cases hlt : relativeOffset < headSize
+      · simp [hlt] at hdec
+      · rw [if_neg hlt] at hdec
+        by_cases hfit : baseOffset + relativeOffset + 32 ≤ externalCalldataSize calldata
+        · rw [if_pos hfit] at hdec
+          exact ⟨relativeOffset, rfl, by omega, hfit, by simpa using hdec.symm⟩
+        · rw [if_neg hfit] at hdec
+          simp at hdec
+
+/-- The dispatcher binds the three loader locals of a length-word-free dynamic
+composite from the same head word and tail bound the generated loader checks. -/
+theorem bindExternalParam_dynamicComposite_refines_dynamic_loader
+    {selector : Nat} {calldata : List Nat}
+    {headSize baseOffset headOffset relativeOffset : Nat} {name : String} {ty : ParamType}
+    (hdynamic : isDynamicParamType ty = true)
+    (hnotLengthPrefixed : isLengthPrefixedDynamicShape ty = false)
+    (hhead : externalWordAt? selector calldata headOffset = some relativeOffset)
+    (hheadBound : headSize ≤ relativeOffset)
+    (htailBound : baseOffset + relativeOffset + 32 ≤ externalCalldataSize calldata) :
+    bindExternalParam selector calldata headSize baseOffset headOffset
+      { name := name, ty := ty } =
+      some
+        [ (s!"{name}_offset", relativeOffset)
+        , (s!"{name}_abs_offset", baseOffset + relativeOffset)
+        , (s!"{name}_data_offset", baseOffset + relativeOffset) ] := by
+  have hnotHeadInTail : ¬ relativeOffset < headSize := by omega
+  have hoff :
+      decodeDynamicTupleParamDataOffset? selector calldata headSize baseOffset headOffset =
+        some (baseOffset + relativeOffset) := by
+    unfold decodeDynamicTupleParamDataOffset?
+    rw [hhead]
+    simp only [Option.bind_eq_bind, Option.bind]
+    rw [if_neg hnotHeadInTail, if_pos htailBound]
+  have hdec : decodeSupportedParamWord ty =<< some relativeOffset = none :=
+    decodeSupportedParamWord_eq_none_of_dynamic hdynamic relativeOffset
+  unfold bindExternalParam
+  rw [hhead, hdec,
+    externalDynamicPayloadShape?_eq_none_of_not_lengthPrefixed hnotLengthPrefixed,
+    if_pos hdynamic]
+  simp only [hoff, Option.bind_eq_bind, Option.bind, dynamicTupleParamBindings]
+
+/-- Converse of `bindExternalParam_dynamicComposite_refines_dynamic_loader`: a
+successful binding is exactly the three loader locals and certifies the two
+bounds the generated loader enforces. -/
+theorem bindExternalParam_dynamicComposite_eq_some_inv
+    {selector : Nat} {calldata : List Nat}
+    {headSize baseOffset headOffset : Nat} {name : String} {ty : ParamType}
+    {bindings : List (String × Nat)}
+    (hdynamic : isDynamicParamType ty = true)
+    (hnotLengthPrefixed : isLengthPrefixedDynamicShape ty = false)
+    (hbind : bindExternalParam selector calldata headSize baseOffset headOffset
+      { name := name, ty := ty } = some bindings) :
+    ∃ relativeOffset,
+      externalWordAt? selector calldata headOffset = some relativeOffset ∧
+        headSize ≤ relativeOffset ∧
+        baseOffset + relativeOffset + 32 ≤ externalCalldataSize calldata ∧
+        bindings =
+          [ (s!"{name}_offset", relativeOffset)
+          , (s!"{name}_abs_offset", baseOffset + relativeOffset)
+          , (s!"{name}_data_offset", baseOffset + relativeOffset) ] := by
+  have hdecode :
+      decodeSupportedParamWord ty =<< externalWordAt? selector calldata headOffset = none := by
+    cases externalWordAt? selector calldata headOffset with
+    | none => rfl
+    | some word => exact decodeSupportedParamWord_eq_none_of_dynamic hdynamic word
+  unfold bindExternalParam at hbind
+  rw [hdecode, externalDynamicPayloadShape?_eq_none_of_not_lengthPrefixed hnotLengthPrefixed,
+    if_pos hdynamic] at hbind
+  cases hro : externalWordAt? selector calldata headOffset with
+  | none => rw [hro] at hbind; simp at hbind
+  | some relativeOffset =>
+      rw [hro] at hbind
+      simp only [Option.bind_eq_bind, Option.bind] at hbind
+      cases hoff : decodeDynamicTupleParamDataOffset? selector calldata headSize baseOffset
+          headOffset with
+      | none => rw [hoff] at hbind; simp at hbind
+      | some absoluteOffset =>
+          rw [hoff] at hbind
+          simp only [Option.some.injEq] at hbind
+          obtain ⟨ro, hro', hheadBound, htailBound, habs⟩ :=
+            decodeDynamicTupleParamDataOffset?_eq_some_inv hoff
+          have hroEq : ro = relativeOffset := by rw [hro] at hro'; simpa using hro'.symm
+          subst hroEq
+          refine ⟨ro, rfl, hheadBound, htailBound, ?_⟩
+          rw [← hbind, habs]
+          simp [dynamicTupleParamBindings]
 
 /-- Witness that one external ABI parameter is accepted by `bindExternalParam`
 at a particular absolute head offset. -/

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -1008,6 +1008,32 @@ ALLOWLIST: set[str] = {
     # mutually dependent size facts about a single encoded block; splitting them
     # would duplicate that context in every fragment.
     "bindExternalParam_bytes_of_abiEncodeArgs",
+    # #2085 slice 5 `T[]` / `fixedArray` / `tuple` external parameters, the
+    # direct analogues of the `bytes` entries above. Both loader lemmas are
+    # straight-line symbolic executions of the generated Yul: one `have` per
+    # emitted statement, each phrased over the `IRState` its predecessor
+    # produced. That state is a growing `setVar` chain, so extracting the steps
+    # would make every fragment restate the full intermediate state.
+    "exec_lengthPrefixedLoaderStmts_then",
+    "exec_dynamicCompositeLoaderStmts_then",
+    # The array payload guard is a single `div`/`lt` statement; the length is
+    # the modular-arithmetic side conditions relating the emitted EVM `div` to
+    # `Nat` division, which are only meaningful against this guard's own state.
+    "exec_arrayPayloadGuard_noop",
+    # #2085 slice 5 decode-of-encode round trip for `T[]`, matching
+    # `bindExternalParam_bytes_of_abiEncodeArgs` above. The `have`s are mutually
+    # dependent size facts about one encoded block, and each restates the same
+    # `abiTailOffset (pre ++ ...)` index expression; splitting them would
+    # duplicate that context in every fragment.
+    "bindExternalParam_scalarArray_of_abiEncodeArgs",
+    # #2085 slice 5 binder inversions: exhaustive sweeps of the decoder's own
+    # `Option`/`if` branch structure, where every branch but the success case is
+    # a one-line contradiction discharge. Both are marginally over the limit and
+    # mirror a case split that exists only inside the decoder.
+    # (`decodeLengthPrefixedDynamicParam` is the linter's truncation of
+    # `decodeLengthPrefixedDynamicParam?_array_eq_some_inv` at the `?`.)
+    "decodeLengthPrefixedDynamicParam",
+    "bindExternalParam_array_eq_some_inv",
 }
 
 # PR #1822 native EVMYulLean generic-dispatcher closure. These regexes cover


### PR DESCRIPTION
Closes #2085 slice 5 (array / fixedArray / tuple).

Base: `c008b4a4` (`proof(L2): admit calldatacopy into the proved statement surface (#2084 slice 1)`), which is also current `origin/main`, so this applies without a rebase.

## Summary

Widens `SupportedExternalParamType` to admit `T[]`, dynamic `tuple`s, and fixed-size arrays of dynamic elements, and proves the calldata loader the compiler emits for each refines the ABI binder.

- **Shared layout defs.** `dynamicArrayElementStrideWords` and `isLengthPrefixedDynamicShape` move into `AbiTypeLayout`, so the ABI model and the Yul emitter agree on element stride by construction rather than by a restated case list.
- **Loader refinement.** The nine-statement length-prefixed loader proof is now parameterised by its payload guard, so `bytes`/`string` (slice 4) and `T[]` share one execution proof. Dynamic composites have no length word and go through a separate five-statement loader binding three locals instead of six.
- **Round trip, not an assumption.** `bindExternalParam_scalarArray_of_abiEncodeArgs` gives decode-of-encode for `AbiArg.scalarArray`, so `bindExternalParams` is *proved* total on real array calldata. This matters: `hbindTotal` cannot be recovered from arity for a dynamic parameter, so without the round trip the dispatcher theorem would be vacuous at `T[]`.
- **Dispatcher composition.** `DispatchArrayParam` mirrors `DispatchStringParam` for `T[]` entrypoints.

### Deliberate exclusions

- **Static composites stay excluded.** `bindExternalParam` returns `none` for them and their head size is not 32, so admitting them would be both vacuous and unsound for the head-offset arithmetic.
- **Arrays carry `ExternalArrayStrideFitsWord`.** The emitted guard divides by a literal stride, and EVM `div` returns 0 on a divisor that reduces to 0 mod 2^256, which would diverge from the model's `fitsLength` bound.

## Proof-length allowlist

The final commit adds six entries to `ALLOWLIST` in `scripts/check_proof_length.py`. No theorem statement, proof content, or sorry count changed — the entries only record the exemption the gate asks for.

| Proof | Lines |
| --- | --- |
| `exec_lengthPrefixedLoaderStmts_then` | 201 |
| `exec_dynamicCompositeLoaderStmts_then` | 103 |
| `bindExternalParam_scalarArray_of_abiEncodeArgs` | 88 |
| `exec_arrayPayloadGuard_noop` | 63 |
| `decodeLengthPrefixedDynamicParam?_array_eq_some_inv` | 53 |
| `bindExternalParam_array_eq_some_inv` | 52 |

Rationale, mirroring the `bytes` entries added for slice 4 directly above them in the file: the two loader lemmas are straight-line symbolic executions of the generated Yul with one `have` per emitted statement, each phrased over the `IRState` its predecessor produced. That state is a growing `setVar` chain, so extracting the steps would make every fragment restate the full intermediate state — decomposition lengthens the file rather than shortening the proof. The two binder inversions are exhaustive sweeps of the decoder's own `Option`/`if` branch structure where every branch but the success case is a one-line contradiction discharge.

Sizing context: the allowlist already carries 632 entries over the limit, 76 of them ≥200 lines, so these sit inside the established band rather than extending it. (`decodeLengthPrefixedDynamicParam` appears in the allowlist as the linter's truncation of the real name at the `?`, matching three existing entries that use the same form.)

## Receipts

- `lake build` — **exit 0**, `Build completed successfully (2473 jobs)`, zero errors.
- `make check` — **exit 0**, `All checks passed.` This covers `lean_lint.py --only proof_length` (the gate this branch had been failing), plus `lean_hygiene`, `axioms`, `trust_surface_registry`, `generate_print_axioms.py --check`, and `generate_trust_surface_report.py --check`.
- Trust surface: **zero** new `sorry` / `admit` / `axiom`. `PrintAxioms` registry regenerated and exhaustive at 6755 theorems/lemmas, 0 sorry'd; the registry diff adds theorem names only, no axiom declarations.