### PR TITLE
proof(L2): close empty revert returndata gate (#2084)

### DIFF
--- a/Compiler/Proofs/IRGeneration/GenericInduction/Helpers.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Helpers.lean
@@ -1670,6 +1670,9 @@ theorem stmtListGenericCore_of_supportedStmtList_of_surface
   | returndataCopyEmptySingle hcoreDest hinScopeDest =>
       exact stmtListGenericCore_of_supportedStmtList_returndataCopyEmptySingle_of_surface
         (fields := fields) hcoreDest hinScopeDest
+  | revertReturndataEmptySingle =>
+      exact stmtListGenericCore_of_supportedStmtList_revertReturndataEmptySingle_of_surface
+        (fields := fields)
   | letStorageField hfind hfieldInScope =>
       exact stmtListGenericCore_of_supportedStmtList_letStorageField_of_surface
         hnoConflict hfind hfieldInScope

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
@@ -178,6 +178,9 @@ inductive StmtListScopeCore (fieldNames : List String) : List Stmt → Prop wher
       FunctionBody.ExprCompileCore size →
       StmtListScopeCore fieldNames rest →
       StmtListScopeCore fieldNames (.returndataCopy destOffset sourceOffset size :: rest)
+  | revertReturndata {rest : List Stmt} :
+      StmtListScopeCore fieldNames rest →
+      StmtListScopeCore fieldNames (.revertReturndata :: rest)
   | ite {cond : Expr} {thenBranch elseBranch rest : List Stmt} :
       FunctionBody.ExprCompileCore cond →
       StmtListScopeCore fieldNames thenBranch →
@@ -663,6 +666,8 @@ theorem stmtListScopeCore_prefix_of_compileStmtList_ok_of_stmtListTouchesUnsuppo
             (exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false hstmtSurface.1.2)
             (exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false hstmtSurface.2)
             (ih hrestSurface htail)
+      | revertReturndata =>
+          exact StmtListScopeCore.revertReturndata (ih hrestSurface htail)
       | ite cond thenBranch elseBranch =>
           simp only [stmtTouchesUnsupportedContractSurface,
             Bool.or_eq_false_iff] at hstmtSurface

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
@@ -509,6 +509,8 @@ private theorem stmtListScopeCore_of_unsupportedContractSurface_eq_false
             (exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false hstmtSurface.1.2)
             (exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false hstmtSurface.2)
             ihRest
+      | revertReturndata =>
+          exact .revertReturndata ihRest
       | ite cond thenBranch elseBranch =>
           simp only [stmtTouchesUnsupportedContractSurface,
             Bool.or_eq_false_iff] at hstmtSurface
@@ -728,7 +730,6 @@ theorem stmtListScopeCore_prefix_of_compileStmtList_ok_of_stmtListTouchesUnsuppo
       | storageArrayPush _ _ | storageArrayPop _ | setStorageArrayElement _ _ _
       | requireError _ _ _ | revertError _ _ | panicCode _ | returnValues _ | returnArray _
       | returnBytes _ | returnStorageWords _ | returnCodeData _
-      | revertReturndata
       | emit _ _ | internalCall _ _ | internalCallAssign _ _ _
       | rawLog _ _ _ | externalCallBind _ _ _ | tryExternalCallBind _ _ _ _ | ecm _ _
       | unsafeBlock _ _ | unsafeYul _ | matchAdt _ _ _ =>

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
@@ -98,6 +98,9 @@ inductive StmtListScopeDiscipline (fieldNames : List String) : List String → L
       StmtListScopeDiscipline fieldNames
         (stmtNextScope scope (.returndataCopy destOffset sourceOffset size)) rest →
       StmtListScopeDiscipline fieldNames scope (.returndataCopy destOffset sourceOffset size :: rest)
+  | revertReturndata {scope : List String} {rest : List Stmt} :
+      StmtListScopeDiscipline fieldNames scope rest →
+      StmtListScopeDiscipline fieldNames scope (.revertReturndata :: rest)
   | ite {scope : List String} {cond : Expr} {thenBranch elseBranch rest : List Stmt} :
       FunctionBody.ExprCompileCore cond →
       FunctionBody.exprBoundNamesInScope cond scope →
@@ -1609,6 +1612,15 @@ private theorem stmtListScopeDiscipline_of_validateScopedStmtListIdentifiers
                 (by intro other hmem
                     exact mem_stmtNextScope_of_mem_scope (hlocalsInScope other hmem))
                 (constructorArgsInScope_stmtNextScope hconstructorArgsInScope))
+  | revertReturndata hrest ih =>
+      rcases validateScopedStmtListIdentifiers_cons_ok_inv hvalidate with
+        ⟨nextLocalScope, hstmt, hrestValidate⟩
+      have hstmt' := hstmt
+      unfold validateScopedStmtIdentifiers at hstmt'
+      simp only [pure, Except.pure] at hstmt'
+      cases hstmt'
+      exact StmtListScopeDiscipline.revertReturndata
+        (ih hrestValidate hparamsInScope hlocalsInScope hconstructorArgsInScope)
   | ite hcondCore hthenCore helseCore hrest ihThen ihElse ihRest =>
       rcases validateScopedStmtListIdentifiers_cons_ok_inv hvalidate with
         ⟨nextLocalScope, hstmt, hrestValidate⟩
@@ -2038,6 +2050,16 @@ private theorem scopeNamesPresent_foldl_stmtNextScope_of_validateScopedStmtListI
               (by intro name hname
                   exact mem_stmtNextScope_of_mem_scope (hlocalsInScope name hname))
               other hmem
+  | revertReturndata hrest ih =>
+      rcases validateScopedStmtListIdentifiers_cons_ok_inv hvalidate with
+        ⟨nextLocalScope, hstmt, hrestValidate⟩
+      have hstmt' := hstmt
+      unfold validateScopedStmtIdentifiers at hstmt'
+      simp only [pure, Except.pure] at hstmt'
+      cases hstmt'
+      intro other hmem
+      simp only [List.foldl, stmtNextScope, collectStmtBindNames] at hmem ⊢
+      exact ih hrestValidate hparamsInScope hlocalsInScope other hmem
   | ite hcondCore hthenCore helseCore hrest ihThen ihElse ihRest =>
       rcases validateScopedStmtListIdentifiers_cons_ok_inv hvalidate with
         ⟨nextLocalScope, hstmt, hrestValidate⟩
@@ -2384,6 +2406,13 @@ theorem stmtListScopeDiscipline_scope_names
       · right; left; exact hbind
       · right; right; left; exact hassign
       · right; right; right; exact hfld
+  | revertReturndata _ ih =>
+      intro other hmem
+      simp only [List.foldl, stmtNextScope, collectStmtBindNames, List.nil_append] at hmem
+      have htail := ih other hmem
+      simp [collectStmtListBindNames, collectStmtBindNames,
+        collectStmtListAssignedNames, collectStmtAssignedNames] at htail ⊢
+      exact htail
   | @ite scope cond thenBranch elseBranch rest hcore hinScope _ _ _ ihThen ihElse ihRest =>
       intro other hmem
       simp only [List.foldl] at hmem

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
@@ -3185,6 +3185,64 @@ theorem compiledStmtStep_returndatacopy_empty_single
   preserves := compiledStmtStep_returndatacopy_empty_single_preserves
     hcoreDest hinScopeDest hdestIR
 
+/-- `revertReturndata` is an empty revert in the no-call fragment.  The
+compiler's temporary is exactly `returndatasize()`, which the shared EIP-211
+semantics evaluates to zero, so the copy is in range before `revert(0, 0)`. -/
+private theorem compiledStmtStep_revertReturndata_empty_single_preserves
+    {fields : List Field}
+    {scope : List String} :
+    ∀ (runtime : SourceSemantics.RuntimeState) (state : IRState) (extraFuel : Nat),
+      FunctionBody.bindingsExactlyMatchIRVarsOnScope scope runtime.bindings state →
+      FunctionBody.scopeNamesPresent scope runtime.bindings →
+      FunctionBody.bindingsBounded runtime.bindings →
+      FunctionBody.runtimeStateMatchesIR fields runtime state →
+      sizeOf [YulStmt.block [
+          YulStmt.let_ "__returndata_size" (YulExpr.call "returndatasize" []),
+          YulStmt.exprStmt (YulExpr.call "returndatacopy"
+            [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__returndata_size"]),
+          YulStmt.exprStmt (YulExpr.call "revert"
+            [YulExpr.lit 0, YulExpr.ident "__returndata_size"])
+        ]] - 1 ≤ extraFuel →
+      ∃ sourceResult irExec,
+        SourceSemantics.execStmt fields runtime .revertReturndata = sourceResult ∧
+        execIRStmts
+            ([YulStmt.block [
+              YulStmt.let_ "__returndata_size" (YulExpr.call "returndatasize" []),
+              YulStmt.exprStmt (YulExpr.call "returndatacopy"
+                [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__returndata_size"]),
+              YulStmt.exprStmt (YulExpr.call "revert"
+                [YulExpr.lit 0, YulExpr.ident "__returndata_size"])
+            ]].length + extraFuel + 1) state
+            [YulStmt.block [
+              YulStmt.let_ "__returndata_size" (YulExpr.call "returndatasize" []),
+              YulStmt.exprStmt (YulExpr.call "returndatacopy"
+                [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__returndata_size"]),
+              YulStmt.exprStmt (YulExpr.call "revert"
+                [YulExpr.lit 0, YulExpr.ident "__returndata_size"])
+            ]] = irExec ∧
+        stmtStepMatchesIRExec fields (stmtNextScope scope .revertReturndata)
+          sourceResult irExec := by
+  intro runtime state extraFuel _ _ _ _ _
+  refine ⟨.revert, .revert state, ?_, ?_, trivial⟩
+  · rfl
+  · simp [execIRStmts, execIRStmt, evalIRExpr, Nat.succ_eq_add_one,
+      Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
+
+theorem compiledStmtStep_revertReturndata_empty_single
+    {fields : List Field} {scope : List String} :
+    CompiledStmtStep fields scope .revertReturndata
+      [YulStmt.block [
+        YulStmt.let_ "__returndata_size" (YulExpr.call "returndatasize" []),
+        YulStmt.exprStmt (YulExpr.call "returndatacopy"
+          [YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__returndata_size"]),
+        YulStmt.exprStmt (YulExpr.call "revert"
+          [YulExpr.lit 0, YulExpr.ident "__returndata_size"])
+      ]] where
+  compileOk := by
+    simp [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork,
+      pure, Except.pure]
+  preserves := compiledStmtStep_revertReturndata_empty_single_preserves
+
 private theorem compiledStmtStep_setMappingUint_singleSlot_of_slotSafety_preserves
     {fields : List Field}
     {scope : List String}
@@ -7872,6 +7930,12 @@ theorem stmtListGenericCore_of_supportedStmtList_returndataCopyEmptySingle_of_su
     (scope := scope)
     (hcoreDest := hcoreDest)
     (hinScopeDest := hinScopeDest)
+
+theorem stmtListGenericCore_of_supportedStmtList_revertReturndataEmptySingle_of_surface
+    {fields : List Field} {scope : List String} :
+    StmtListGenericCore fields scope [Stmt.revertReturndata] :=
+  StmtListGenericCore.cons compiledStmtStep_revertReturndata_empty_single
+    StmtListGenericCore.nil
 
 
 end Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
@@ -302,6 +302,16 @@ example :
       (.requireError (.literal 0) "CallFree" [.literal 1]) = false := by
   native_decide
 
+/-- In the no-call fragment, EIP-211 makes `revertReturndata` exactly the
+empty revert admitted by the generic step proof. -/
+example :
+    stmtTouchesUnsupportedCallSurface .revertReturndata = false := by
+  native_decide
+
+example :
+    stmtTouchesUnsupportedLowLevelSurface .revertReturndata = false := by
+  native_decide
+
 /-- Typed-error guards and payloads remain behind the constructor raw-calldata gate. -/
 example :
     stmtTouchesUnsupportedConstructorRawCalldataSurface

--- a/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
@@ -312,6 +312,10 @@ example :
     stmtTouchesUnsupportedLowLevelSurface .revertReturndata = false := by
   native_decide
 
+example :
+    stmtTouchesUnsupportedForeignSurface .revertReturndata = false := by
+  native_decide
+
 /-- Typed-error guards and payloads remain behind the constructor raw-calldata gate. -/
 example :
     stmtTouchesUnsupportedConstructorRawCalldataSurface

--- a/Compiler/Proofs/IRGeneration/SupportedFragment.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedFragment.lean
@@ -119,6 +119,12 @@ inductive SupportedStmtList (fields : List Field) : List String → List Stmt �
       FunctionBody.exprBoundNamesInScope destOffset scope →
       SupportedStmtList fields scope
         [Stmt.returndataCopy destOffset (Expr.literal 0) (Expr.literal 0)]
+  /-- In a frame with no call-family instruction, EIP-211 leaves returndata
+  empty. `revertReturndata` therefore has the exact first-class meaning of an
+  empty revert; its generated copy is the in-range zero-extent copy. -/
+  | revertReturndataEmptySingle
+      {scope : List String} :
+      SupportedStmtList fields scope [Stmt.revertReturndata]
   | letStorageField
       {scope : List String}
       {tmp : String}

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -1682,6 +1682,7 @@ def stmtTouchesUnsupportedCallSurface : Stmt → Bool
       exprTouchesUnsupportedCallSurface destOffset ||
         exprTouchesUnsupportedCallSurface sourceOffset ||
         exprTouchesUnsupportedCallSurface size
+  | .revertReturndata => false
   | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _
   | .ecm _ _ => true
   | .stop | .storageArrayPop _
@@ -2028,6 +2029,7 @@ def stmtTouchesUnsupportedContractSurface (stmt : Stmt) : Bool :=
         exprTouchesUnsupportedContractSurface sourceOffset ||
         exprTouchesUnsupportedContractSurface size
   | .stop => false
+  | .revertReturndata => false
   | .ite cond thenBranch elseBranch =>
       exprTouchesUnsupportedContractSurface cond ||
         stmtListTouchesUnsupportedContractSurface thenBranch ||
@@ -2039,7 +2041,6 @@ def stmtTouchesUnsupportedContractSurface (stmt : Stmt) : Bool :=
   | .storageArrayPush _ _ | .storageArrayPop _ | .setStorageArrayElement _ _ _
   | .requireError _ _ _ | .revertError _ _ | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _
-  | .revertReturndata
   | .emit _ _ | .internalCall _ _ | .internalCallAssign _ _ _
   | .rawLog _ _ _ | .externalCallBind _ _ _ | .ecm _ _
   | .tryExternalCallBind _ _ _ _ | .unsafeBlock _ _ | .unsafeYul _ | .matchAdt _ _ _
@@ -2304,14 +2305,15 @@ private theorem compileStmt_eventsErrorsAgnostic_aux
         | forEachSetBit _ _ _ =>
             simp [stmtTouchesUnsupportedContractSurface] at hsurface
         | letVar | assignVar | setStorage | setStorageAddr | setImmutable | setStorageWord
-        | require | «return» | mstore | tstore | calldatacopy | returndataCopy | stop =>
+        | require | «return» | mstore | tstore | calldatacopy | returndataCopy
+        | revertReturndata | stop =>
             simp only [CompilationModel.compileStmt, CompilationModel.compileStmtWithFork]
         | setMapping | setMappingWord | setMappingPackedWord | setMapping2
         | setMapping2Word | setMappingUint | setMappingChain | setStructMember
         | setStructMember2 | storageArrayPush | storageArrayPop
         | setStorageArrayElement | requireError | revertError | returnValues
         | returnArray | returnBytes | returnStorageWords | returnCodeData
-        | revertReturndata | emit | internalCall
+        | emit | internalCall
         | internalCallAssign | rawLog | externalCallBind | ecm
         | tryExternalCallBind | unsafeBlock | unsafeYul | matchAdt | panicCode =>
             simp [stmtTouchesUnsupportedContractSurface] at hsurface
@@ -4082,6 +4084,9 @@ theorem SupportedStmtList.helperSurfaceClosed
       exact supportedStmtList_calldatacopySingle_helperSurfaceClosed hdest hsource hsize
   | returndataCopyEmptySingle hdest _ =>
       exact supportedStmtList_returndataCopyEmptySingle_helperSurfaceClosed hdest
+  | revertReturndataEmptySingle =>
+      simp [stmtListTouchesUnsupportedHelperSurface,
+        stmtTouchesUnsupportedHelperSurface]
   | letStorageField _ _ =>
       exact supportedStmtList_letStorageField_helperSurfaceClosed
   | letStorageAddrField _ _ =>
@@ -4238,6 +4243,8 @@ theorem SupportedStmtList.internalHelperCallNames_nil
         stmtInternalHelperCallNames,
         exprCompileCore_internalHelperCallNames_nil hdest,
         exprInternalHelperCallNames]
+  | revertReturndataEmptySingle =>
+      simp [stmtListInternalHelperCallNames, stmtInternalHelperCallNames]
   | letStorageField _ _ =>
       simp only [stmtListInternalHelperCallNames,
         stmtInternalHelperCallNames,
@@ -5480,6 +5487,7 @@ private theorem stmtTouchesUnsupportedContractSurface_eq_false_of_featureClosed
           elseBranch hcore.2 hstate.2 hcalls.2 heffects.2⟩
   | forEach _ _ _ | forEachSetBit _ _ _ => cases hcore
   | setStorageWord _ _ _ => cases hstate
+  | revertReturndata => simp [stmtTouchesUnsupportedContractSurface]
   | _ =>
       all_goals (simp only [stmtTouchesUnsupportedContractSurface]; assumption)
 termination_by sizeOf stmt
@@ -5816,10 +5824,12 @@ theorem stmtTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
   | storageArrayPop _ | setStorageArrayElement _ _ _ | requireError _ _ _
   | revertError _ _ | returnValues _ | returnArray _ | returnBytes _
   | returnStorageWords _ | returnCodeData _
-  | revertReturndata | emit _ _ | internalCall _ _
+  | emit _ _ | internalCall _ _
   | internalCallAssign _ _ _ | rawLog _ _ _ | externalCallBind _ _ _ | ecm _ _
   | forEachSetBit _ _ _ | panicCode _ =>
       cases hsurface
+  | revertReturndata =>
+      simp [stmtTouchesUnsupportedHelperSurface]
   | forEach varName count body =>
       cases count with
       | literal n =>
@@ -6568,6 +6578,8 @@ private theorem supportedStmtList_usesArrayElement_false
   | returndataCopyEmptySingle hdest _ =>
       simp [stmtListUsesArrayElement, stmtUsesArrayElement,
         exprCompileCore_usesArrayElement_false hdest, exprUsesArrayElement]
+  | revertReturndataEmptySingle =>
+      simp [stmtListUsesArrayElement, stmtUsesArrayElement]
   | letStorageField _ _ =>
       simp only [stmtListUsesArrayElement, stmtUsesArrayElement, exprUsesArrayElement, Bool.false_or]
   | letStorageAddrField _ _ =>
@@ -6694,6 +6706,8 @@ private theorem supportedStmtList_usesStorageArrayElement_false
   | returndataCopyEmptySingle hdest _ =>
       simp [stmtListUsesStorageArrayElement, stmtUsesStorageArrayElement,
         exprCompileCore_usesStorageArrayElement_false hdest, exprUsesStorageArrayElement]
+  | revertReturndataEmptySingle =>
+      simp [stmtListUsesStorageArrayElement, stmtUsesStorageArrayElement]
   | letStorageField _ _ =>
       simp only [stmtListUsesStorageArrayElement, stmtUsesStorageArrayElement,
         exprUsesStorageArrayElement, Bool.false_or]
@@ -6828,6 +6842,8 @@ private theorem supportedStmtList_usesDynamicBytesEq_false
   | returndataCopyEmptySingle hdest _ =>
       simp [stmtListUsesDynamicBytesEq, stmtUsesDynamicBytesEq,
         exprCompileCore_usesDynamicBytesEq_false hdest, exprUsesDynamicBytesEq]
+  | revertReturndataEmptySingle =>
+      simp [stmtListUsesDynamicBytesEq, stmtUsesDynamicBytesEq]
   | letStorageField _ _ =>
       simp only [stmtListUsesDynamicBytesEq, stmtUsesDynamicBytesEq, exprUsesDynamicBytesEq, Bool.false_or]
   | letStorageAddrField _ _ =>
@@ -7215,6 +7231,8 @@ private theorem supportedStmtList_usesMulDiv512_false
   | returndataCopyEmptySingle hdest _ =>
       simp [stmtListUsesMulDiv512, stmtUsesMulDiv512,
         exprCompileCore_usesMulDiv512_false hdest, exprUsesMulDiv512]
+  | revertReturndataEmptySingle =>
+      simp [stmtListUsesMulDiv512, stmtUsesMulDiv512]
   | letStorageField _ _ =>
       simp only [stmtListUsesMulDiv512, stmtUsesMulDiv512, exprUsesMulDiv512, Bool.false_or]
   | letStorageAddrField _ _ =>
@@ -7341,6 +7359,8 @@ private theorem supportedStmtList_usesParamDynamicHeadWord_false
   | returndataCopyEmptySingle hdest _ =>
       simp [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord,
         exprCompileCore_usesParamDynamicHeadWord_false hdest, exprUsesParamDynamicHeadWord]
+  | revertReturndataEmptySingle =>
+      simp [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord]
   | letStorageField _ _ =>
       simp only [stmtListUsesParamDynamicHeadWord, stmtUsesParamDynamicHeadWord, exprUsesParamDynamicHeadWord, Bool.false_or]
   | letStorageAddrField _ _ =>

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -1682,7 +1682,6 @@ def stmtTouchesUnsupportedCallSurface : Stmt → Bool
       exprTouchesUnsupportedCallSurface destOffset ||
         exprTouchesUnsupportedCallSurface sourceOffset ||
         exprTouchesUnsupportedCallSurface size
-  | .revertReturndata
   | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _
   | .ecm _ _ => true
   | .stop | .storageArrayPop _
@@ -1988,7 +1987,7 @@ def stmtTouchesUnsupportedLowLevelSurface : Stmt → Bool
       exprTouchesUnsupportedLowLevelSurface destOffset ||
         exprTouchesUnsupportedLowLevelSurface sourceOffset ||
         exprTouchesUnsupportedLowLevelSurface size
-  | .revertReturndata => true
+  | .revertReturndata => false
   | .stop
   | .internalCall _ _ | .internalCallAssign _ _ _ | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _
   | .ecm _ _ | .storageArrayPop _

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3774,6 +3774,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.compiledStmtStep_calldatacopy_single
   -- Compiler.Proofs.IRGeneration.compiledStmtStep_returndatacopy_empty_single_preserves  -- private
   Compiler.Proofs.IRGeneration.compiledStmtStep_returndatacopy_empty_single
+  -- Compiler.Proofs.IRGeneration.compiledStmtStep_revertReturndata_empty_single_preserves  -- private
+  Compiler.Proofs.IRGeneration.compiledStmtStep_revertReturndata_empty_single
   -- Compiler.Proofs.IRGeneration.compiledStmtStep_setMappingUint_singleSlot_of_slotSafety_preserves  -- private
   Compiler.Proofs.IRGeneration.compiledStmtStep_setMappingUint_singleSlot_of_slotSafety
   Compiler.Proofs.IRGeneration.compileExprList_core_ok
@@ -3842,6 +3844,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.stmtListGenericCore_of_supportedStmtList_tstoreSingle_of_surface
   Compiler.Proofs.IRGeneration.stmtListGenericCore_of_supportedStmtList_calldatacopySingle_of_surface
   Compiler.Proofs.IRGeneration.stmtListGenericCore_of_supportedStmtList_returndataCopyEmptySingle_of_surface
+  Compiler.Proofs.IRGeneration.stmtListGenericCore_of_supportedStmtList_revertReturndataEmptySingle_of_surface
 
   -- Compiler/Proofs/IRGeneration/GenericInduction/StorageWord.lean
   -- Compiler.Proofs.IRGeneration.compileExprWithInternals_nil_ok  -- private
@@ -7355,4 +7358,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6805 theorems/lemmas (4878 public, 1927 private, 0 sorry'd)
+-- Total: 6808 theorems/lemmas (4880 public, 1928 private, 0 sorry'd)

--- a/artifacts/interpreter_feature_matrix.json
+++ b/artifacts/interpreter_feature_matrix.json
@@ -591,7 +591,7 @@
       "SourceInterpreter_basic": "unsupported",
       "SourceInterpreter_fuel": "unsupported",
       "IRInterpreter": "n/a",
-      "proof_status": "not_modeled"
+      "proof_status": "partial"
     },
     {
       "feature": "rawLog",

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 479,
+    "native_decide": 482,
     "partial def": 171
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/docs/INTERPRETER_FEATURE_MATRIX.md
+++ b/docs/INTERPRETER_FEATURE_MATRIX.md
@@ -109,7 +109,7 @@ Legend: **ok** = supported, **0** = returns 0 (not modeled), **del** = delegated
 | Memory store | `Stmt.mstore` | **rev** | **rev** | ok | partial |
 | Calldatacopy | `Stmt.calldatacopy` | ok | ok | ok | proved |
 | Returndatacopy | `Stmt.returndataCopy` | ok | ok | ok | partial |
-| Revert returndata | `Stmt.revertReturndata` | **rev** | **rev** | -- | n/m |
+| Revert returndata | `Stmt.revertReturndata` | **rev** | **rev** | -- | partial |
 | Raw log | `Stmt.rawLog` | **rev** | **rev** | -- | n/m |
 | External call bind | `Stmt.externalCallBind` | **rev** | **rev** | -- | n/m |
 | ECM (`callWithValue` / `callWithValueBytes` included) | `Stmt.ecm` | **rev** | **rev** | -- | n/m |
@@ -205,10 +205,10 @@ Legend: **ok** = native evaluation.
 | Category | Proved | Assumed | Partial | Not Modeled |
 |---|---|---|---|---|
 | Expression features | 24 | 1 (`externalCall`) | 6 | 6 (`keccak256`, `call`, `staticcall`, `delegatecall`, `arrayElementDynamicWord`, `paramDynamicHeadWord`) |
-| Statement features | 25 | 0 | 3 (`forEach`, `mstore`, `returndataCopy`) | 4 (`revertReturndata`, `rawLog`, `externalCallBind`, `ecm`) |
+| Statement features | 25 | 0 | 4 (`forEach`, `mstore`, `returndataCopy`, `revertReturndata`) | 3 (`rawLog`, `externalCallBind`, `ecm`) |
 | Builtins (agreement) | 36 | 0 | 0 | 0 (delegated) |
 
-Proof-boundary features split across two buckets. Partially modeled features currently include runtime introspection (`blockNumber`, `contractAddress`, `chainid`) and single-word linear-memory forms (`mload`, `mstore`, `returndataOptionalBoolAt`). `returndataCopy` is partially modeled: the source and IR interpreters execute it, and the generic proof fragment admits the zero-extent copy `returndataCopy dst 0 0`, which is the only shape reachable in a fragment that issues no call-family instruction (EIP-211 leaves the frame's returndata buffer empty). Wider copies stay outside the fragment because they are the EVM's exceptional halt. `selfBalance` is also partially modeled: it is compiler-supported and source-executable, but not yet included in the generic proof interpreter fragment. Fully not-modeled features currently include `keccak256`, low-level call / returndata plumbing (`call`, `staticcall`, `delegatecall`, `revertReturndata`), event emission (`rawLog`), and external call modules (`externalCallBind`, `ecm`). Dynamic struct-array head-word decoding (`arrayElementDynamicWord`) and direct dynamic-struct parameter head-word decoding (`paramDynamicHeadWord`) are also not modeled by proof interpreters yet. These features are still compiler-supported and are validated by differential testing (70,000+ test vectors against actual EVM execution).
+Proof-boundary features split across two buckets. Partially modeled features currently include runtime introspection (`blockNumber`, `contractAddress`, `chainid`) and single-word linear-memory forms (`mload`, `mstore`, `returndataOptionalBoolAt`). `returndataCopy` is partially modeled: the source and IR interpreters execute it, and the generic proof fragment admits the zero-extent copy `returndataCopy dst 0 0`, which is the only shape reachable in a fragment that issues no call-family instruction (EIP-211 leaves the frame's returndata buffer empty). The same no-call invariant admits `revertReturndata`: its generated `returndatasize()` is zero, so it proves the exact empty revert `revert(0, 0)`. Wider copies and returndata bubbling after a call remain outside the fragment because they are the EVM's exceptional halt. `selfBalance` is also partially modeled: it is compiler-supported and source-executable, but not yet included in the generic proof interpreter fragment. Fully not-modeled features currently include `keccak256`, low-level call plumbing (`call`, `staticcall`, `delegatecall`), event emission (`rawLog`), and external call modules (`externalCallBind`, `ecm`). Dynamic struct-array head-word decoding (`arrayElementDynamicWord`) and direct dynamic-struct parameter head-word decoding (`paramDynamicHeadWord`) are also not modeled by proof interpreters yet. These features are still compiler-supported and are validated by differential testing (70,000+ test vectors against actual EVM execution).
 
 ---
 

--- a/scripts/docsync.py
+++ b/scripts/docsync.py
@@ -714,14 +714,13 @@ INTERPRETER_FEATURE_BOUNDARY_CATALOG = CategoryNoteEntry(
     categories=(
         (("blockNumber", "contractAddress", "chainid"), "partial", "runtime introspection"),
         (("mload", "mstore", "returndataOptionalBoolAt"), "partial", "single-word linear memory"),
-        (("returndataCopy",), "partial", "zero-extent returndata copy"),
+        (("returndataCopy", "revertReturndata"), "partial", "no-call returndata"),
         (
             (
                 "keccak256",
                 "call",
                 "staticcall",
                 "delegatecall",
-                "revertReturndata",
                 "rawLog",
                 "externalCallBind",
                 "ecm",
@@ -734,9 +733,10 @@ INTERPRETER_FEATURE_BOUNDARY_CATALOG = CategoryNoteEntry(
         "Partially modeled features currently include runtime introspection "
         "(`blockNumber`, `contractAddress`, `chainid`) and single-word linear-memory forms "
         "(`mload`, `mstore`, `returndataOptionalBoolAt`).",
-        "Fully not-modeled features currently include `keccak256`, low-level call / returndata "
-        "plumbing (`call`, `staticcall`, `delegatecall`, "
-        "`revertReturndata`), event emission (`rawLog`), and external call modules "
+        "The same no-call invariant admits `revertReturndata`: its generated `returndatasize()` "
+        "is zero, so it proves the exact empty revert `revert(0, 0)`.",
+        "Fully not-modeled features currently include `keccak256`, low-level call plumbing "
+        "(`call`, `staticcall`, `delegatecall`), event emission (`rawLog`), and external call modules "
         "(`externalCallBind`, `ecm`).",
     ),
     out_of_sync_message=(


### PR DESCRIPTION
## Summary

Proves the bounded no-call `revertReturndata` slice for #2084. Under the existing EIP-211 no-call invariant, `returndatasize()` is zero, so the generated `returndatacopy(0, 0, 0); revert(0, 0)` matches the source empty revert.

- adds a first-class supported singleton and generic induction step
- removes `revertReturndata` from the call, low-level, foreign, and contract unsupported gates for this precise shape
- adds native gate regressions and updates the feature matrix

## Validation

- `lake build Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest`
- `make check`
- `lake build PrintAxioms`
- `lake build` (in progress locally at PR creation)

No `sorry`, `admit`, or `axiom` declarations were added.

## Boundary

This does not model a call-produced returndata buffer. Non-empty/wider returndata copies and bubbling after `call`/`staticcall`/`delegatecall` remain outside the proved fragment.