### PR TITLE
proof(L2): model extcodesize in source/IR semantics and close surface gates (#2084)

### DIFF
--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -2893,7 +2893,7 @@ theorem exprInternalHelperCompositionalContextResult_add_right_threaded
   let hbuiltin := evalBuiltinCallWithEvmYulLeanContext_add_of_values finalState leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState rightEntryState finalState "add" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindAdd (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindAdd (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_right_threaded_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -2989,7 +2989,7 @@ theorem exprInternalHelperCompositionalContextResult_add_left_threaded
     leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState leftFinalState finalState "add" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindAdd (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindAdd (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_left_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -3142,7 +3142,7 @@ theorem exprInternalHelperCompositionalContextResult_mul_right_threaded
   let hbuiltin := evalBuiltinCallWithEvmYulLeanContext_mul_of_values finalState leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState rightEntryState finalState "mul" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindMul (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindMul (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_right_threaded_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -3227,7 +3227,7 @@ theorem exprInternalHelperCompositionalContextResult_mul_left_threaded
     leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState leftFinalState finalState "mul" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindMul (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindMul (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_left_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -3391,7 +3391,7 @@ theorem exprInternalHelperCompositionalContextResult_sub_right_threaded
   let hbuiltin := evalBuiltinCallWithEvmYulLeanContext_sub_of_values finalState leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState rightEntryState finalState "sub" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindSub (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindSub (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_right_threaded_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -3476,7 +3476,7 @@ theorem exprInternalHelperCompositionalContextResult_sub_left_threaded
     leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState leftFinalState finalState "sub" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindSub (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindSub (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_left_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -3635,7 +3635,7 @@ theorem exprInternalHelperCompositionalContextResult_div_right_threaded
   let hbuiltin := evalBuiltinCallWithEvmYulLeanContext_div_of_values finalState leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState rightEntryState finalState "div" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindDiv (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindDiv (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_right_threaded_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -3720,7 +3720,7 @@ theorem exprInternalHelperCompositionalContextResult_div_left_threaded
     leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState leftFinalState finalState "div" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindDiv (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindDiv (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_left_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -3879,7 +3879,7 @@ theorem exprInternalHelperCompositionalContextResult_mod_right_threaded
   let hbuiltin := evalBuiltinCallWithEvmYulLeanContext_mod_of_values finalState leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState rightEntryState finalState "mod" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindMod (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindMod (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_right_threaded_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -3964,7 +3964,7 @@ theorem exprInternalHelperCompositionalContextResult_mod_left_threaded
     leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState leftFinalState finalState "mod" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindMod (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindMod (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_left_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -4116,7 +4116,7 @@ theorem exprInternalHelperCompositionalContextResult_bitAnd_right_threaded
     leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState rightEntryState finalState "and" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindAnd (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindAnd (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_right_threaded_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -4201,7 +4201,7 @@ theorem exprInternalHelperCompositionalContextResult_bitAnd_left_threaded
     leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState leftFinalState finalState "and" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindAnd (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindAnd (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_left_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -4353,7 +4353,7 @@ theorem exprInternalHelperCompositionalContextResult_bitOr_right_threaded
     leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState rightEntryState finalState "or" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindOr (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindOr (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_right_threaded_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -4438,7 +4438,7 @@ theorem exprInternalHelperCompositionalContextResult_bitOr_left_threaded
     leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState leftFinalState finalState "or" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindOr (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindOr (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_left_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -4590,7 +4590,7 @@ theorem exprInternalHelperCompositionalContextResult_bitXor_right_threaded
     leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState rightEntryState finalState "xor" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindXor (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindXor (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_right_threaded_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -4675,7 +4675,7 @@ theorem exprInternalHelperCompositionalContextResult_bitXor_left_threaded
     leftValue rightValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState leftFinalState finalState "xor" leftIR rightIR leftValue rightValue value
-    hirLeft hirRight hfindXor (by decide) (by decide) (by decide) hbuiltin
+    hirLeft hirRight hfindXor (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_left_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -4827,7 +4827,7 @@ theorem exprInternalHelperCompositionalContextResult_bitNot_threaded
   let hbuiltin := evalBuiltinCallWithEvmYulLeanContext_bitNot_of_value exprFinalState value
   let hir := evalIRExprWithInternals_unary_builtin_of_value runtimeContract (irFuel + 1)
     parentState exprFinalState "not" exprIR value (exprBitNotValue value)
-    hirChild hfindNot (by decide) (by decide) (by decide) hbuiltin
+    hirChild hfindNot (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_unary_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -4991,7 +4991,7 @@ theorem exprInternalHelperCompositionalContextResult_shl_right_threaded
     shiftValue valueValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState rightEntryState finalState "shl" shiftIR valueIR shiftValue valueValue result
-    hirShift hirRight hfindShl (by decide) (by decide) (by decide) hbuiltin
+    hirShift hirRight hfindShl (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_right_threaded_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -5076,7 +5076,7 @@ theorem exprInternalHelperCompositionalContextResult_shl_left_threaded
     shiftValue valueValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState leftFinalState finalState "shl" shiftIR valueIR shiftValue valueValue result
-    hirShift hirValue hfindShl (by decide) (by decide) (by decide) hbuiltin
+    hirShift hirValue hfindShl (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_left_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -5246,7 +5246,7 @@ theorem exprInternalHelperCompositionalContextResult_shr_right_threaded
     shiftValue valueValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState rightEntryState finalState "shr" shiftIR valueIR shiftValue valueValue result
-    hirShift hirRight hfindShr (by decide) (by decide) (by decide) hbuiltin
+    hirShift hirRight hfindShr (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_right_threaded_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -5331,7 +5331,7 @@ theorem exprInternalHelperCompositionalContextResult_shr_left_threaded
     shiftValue valueValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState leftFinalState finalState "shr" shiftIR valueIR shiftValue valueValue result
-    hirShift hirValue hfindShr (by decide) (by decide) (by decide) hbuiltin
+    hirShift hirValue hfindShr (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_left_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -5470,7 +5470,7 @@ theorem exprInternalHelperCompositionalContextResult_byte_right_threaded
     indexValue valueValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState rightEntryState finalState "byte" indexIR valueIR indexValue valueValue result
-    hirIndex hirRight hfindByte (by decide) (by decide) (by decide) hbuiltin
+    hirIndex hirRight hfindByte (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_right_threaded_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -5555,7 +5555,7 @@ theorem exprInternalHelperCompositionalContextResult_byte_left_threaded
     indexValue valueValue
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState leftFinalState finalState "byte" indexIR valueIR indexValue valueValue result
-    hirIndex hirValue hfindByte (by decide) (by decide) (by decide) hbuiltin
+    hirIndex hirValue hfindByte (by decide) (by decide) (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_left_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -5696,7 +5696,7 @@ theorem exprInternalHelperCompositionalContextResult_signextend_right_threaded
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState rightEntryState finalState "signextend" byteIdxIR valueIR byteIdxValue
     valueValue result hirByteIdx hirRight hfindSignextend (by decide) (by decide)
-    (by decide) hbuiltin
+    (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_right_threaded_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)
@@ -5784,7 +5784,7 @@ theorem exprInternalHelperCompositionalContextResult_signextend_left_threaded
   let hir := evalIRExprWithInternals_binary_builtin_of_values runtimeContract (irFuel + 1)
     parentState leftFinalState finalState "signextend" byteIdxIR valueIR byteIdxValue
     valueValue result hirByteIdx hirValue hfindSignextend (by decide) (by decide)
-    (by decide) hbuiltin
+    (by decide) (by decide) hbuiltin
   exact
     exprInternalHelperCompositionalContextResult_binary_left_context
       (runtimeContract := runtimeContract) (spec := spec) (fields := fields)

--- a/Compiler/Proofs/HelperStepProofs.lean
+++ b/Compiler/Proofs/HelperStepProofs.lean
@@ -2720,6 +2720,7 @@ theorem evalIRExprWithInternals_binary_builtin_of_values
     (hfind : findInternalFunction? runtimeContract func = none)
     (hnotTload : func ≠ "tload")
     (hnotMload : func ≠ "mload")
+    (hnotExtcodesize : func ≠ "extcodesize")
     (hnotKeccak : func ≠ "keccak256")
     (hbuiltin :
       Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext
@@ -2739,7 +2740,7 @@ theorem evalIRExprWithInternals_binary_builtin_of_values
   simp [evalIRExprWithInternals_call,
     evalIRCallWithInternals_of_builtin runtimeContract fuel state func
       [leftIR, rightIR] [leftValue, rightValue] finalState hargs hfind
-      hnotTload hnotMload hnotKeccak,
+      hnotTload hnotMload hnotExtcodesize hnotKeccak,
     hbuiltin]
 
 /-- Helper-aware compiled IR evaluation for a pure one-argument Yul builtin. -/
@@ -2756,6 +2757,7 @@ theorem evalIRExprWithInternals_unary_builtin_of_value
     (hfind : findInternalFunction? runtimeContract func = none)
     (hnotTload : func ≠ "tload")
     (hnotMload : func ≠ "mload")
+    (hnotExtcodesize : func ≠ "extcodesize")
     (hnotKeccak : func ≠ "keccak256")
     (hbuiltin :
       Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext
@@ -2774,7 +2776,7 @@ theorem evalIRExprWithInternals_unary_builtin_of_value
       exprIR argValue hexpr
   simp [evalIRExprWithInternals_call,
     evalIRCallWithInternals_of_builtin runtimeContract fuel state func
-      [exprIR] [argValue] finalState hargs hfind hnotTload hnotMload hnotKeccak,
+      [exprIR] [argValue] finalState hargs hfind hnotTload hnotMload hnotExtcodesize hnotKeccak,
     hbuiltin]
 
 /-- `Nat` values coerced to `Uint256` may be normalized before or after the

--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -73,14 +73,14 @@ theorem denote_evalExpr_eq (fields : List Field) (s : DenoteState) :
   | .paramDynamicMemberDataOffset .. | .paramDynamicMemberElement ..
   | .paramDynamicStaticComposite .. | .paramDynamicHeadWord ..
   | .arrayLength _ | .arrayElementWord ..
-  | .call .. | .staticcall .. | .delegatecall .. | .extcodesize _
+  | .call .. | .staticcall .. | .delegatecall ..
   | .returndataOptionalBoolAt _ | .externalCall .. | .internalCall ..
   | .intrinsic .. | .forkIfAtLeast .. | .mulDiv512Down .. | .mulDiv512Up ..
   | .adtConstruct .. | .adtTag .. | .adtField ..
   | .caller | .contractAddress | .txOrigin | .chainid | .msgValue | .selfBalance
   | .blockTimestamp | .blockNumber | .blobbasefee | .calldatasize
   | .returndataSize => rfl
-  | .bitNot a | .logicalNot a | .mload a | .tload a | .calldataload a
+  | .bitNot a | .logicalNot a | .mload a | .tload a | .calldataload a | .extcodesize a
   | .mapping _ a | .mappingWord _ a _ | .mappingPackedWord _ a _ _
   | .mappingUint _ a | .mappingChain _ [a] | .structMember _ a _
   | .storageArrayElement _ a

--- a/Compiler/Proofs/IRGeneration/ExprCore.lean
+++ b/Compiler/Proofs/IRGeneration/ExprCore.lean
@@ -189,6 +189,8 @@ inductive ExprCompileCore : Expr → Prop where
       ExprCompileCore offset → ExprCompileCore (.calldataload offset)
   | mload {offset : Expr} :
       ExprCompileCore offset → ExprCompileCore (.mload offset)
+  | extcodesize {addr : Expr} :
+      ExprCompileCore addr → ExprCompileCore (.extcodesize addr)
   | keccak256 {offset size : Expr} :
       ExprCompileCore offset → ExprCompileCore size →
         ExprCompileCore (.keccak256 offset size)

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -4461,7 +4461,11 @@ private theorem compileExpr_constructor_mode_eq
   | .calldatasize, _, _, hraw => by simp [exprTouchesUnsupportedConstructorRawCalldataSurface] at hraw
   | .calldataload _, _, _, hraw => by simp [exprTouchesUnsupportedConstructorRawCalldataSurface] at hraw
   | .returndataSize, _, _, _ => by simp [compileExprWithInternals]
-  | .extcodesize _, hcore, _, _ => by simp [exprTouchesUnsupportedCoreSurface] at hcore
+  | .extcodesize _, hcore, hcall, hraw => by
+      simp only [exprTouchesUnsupportedCoreSurface] at hcore
+      simp only [exprTouchesUnsupportedCallSurface] at hcall
+      simp only [exprTouchesUnsupportedConstructorRawCalldataSurface] at hraw
+      simp [compileExprWithInternals, compileExpr_constructor_mode_eq hcore hcall hraw]
   | .returndataOptionalBoolAt _, hcore, _, _ => by simp [exprTouchesUnsupportedCoreSurface] at hcore
   | .localVar _, _, _, _ => by simp [compileExprWithInternals]
   | .externalCall _ _, hcore, _, _ => by simp [exprTouchesUnsupportedCoreSurface] at hcore

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -993,7 +993,7 @@ theorem initialIRStateForTx_matches_runtime
   have htxOriginAddr : tx.txOrigin < Verity.Core.Address.modulus := by
     simpa [Verity.Core.Address.modulus, Compiler.Constants.addressModulus,
       Verity.Core.ADDRESS_MODULUS] using htxOrigin
-  refine ⟨?_, rfl, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨?_, rfl, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · simpa [FunctionBody.initialIRStateForTx, SourceSemantics.effectiveFields,
       SourceSemantics.encodeStorage] using
       (FunctionBody.encodeStorage_withTransactionContext model initialWorld tx).symm
@@ -1059,6 +1059,9 @@ theorem initialIRStateForTx_matches_runtime
       rfl
     rw [this]
     rfl
+  · -- codeSize
+    funext addr
+    simp [FunctionBody.initialIRStateForTx, SourceSemantics.withTransactionContext]
 
 /-- An address-ranged transaction-context word survives the word/address
 normalization round trip. -/

--- a/Compiler/Proofs/IRGeneration/FunctionBody/Base.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody/Base.lean
@@ -2144,10 +2144,11 @@ private theorem eval_compileExpr_extcodesize_of_compiled
       simpa using hEvalAddr.symm
     have hecs_unfold : SourceSemantics.evalExpr fields runtime (.extcodesize addr) =
         (SourceSemantics.evalExpr fields runtime addr).bind
-          (fun r => some (runtime.world.codeSize r).val) := rfl
+          (fun r => some (runtime.world.codeSize (r % SourceSemantics.addressModulus)).val) := rfl
     rw [hecs_unfold, hsrc]
     simp only [Option.bind_some]
     simp [evalIRExpr, hIR, hcs]
+    rfl
 
 theorem compileExpr_tload_ok
     {fields : List Field}
@@ -6670,12 +6671,12 @@ theorem evalExpr_lt_evmModulus_core_onExpr
         exact hModEq ▸ (runtime.world.memory offsetVal).isLt
   | @extcodesize addr _ ihA =>
       show (do let r ← SourceSemantics.evalExpr fields runtime addr
-               some (runtime.world.codeSize r).val) < _
+               some (runtime.world.codeSize (r % SourceSemantics.addressModulus)).val) < _
       rcases SourceSemantics.evalExpr fields runtime addr with _ | addrVal
       · trivial
       · simp only [Bind.bind, Option.bind, Pure.pure]
         have hModEq : Verity.Core.Uint256.modulus = Compiler.Constants.evmModulus := rfl
-        exact hModEq ▸ (runtime.world.codeSize addrVal).isLt
+        exact hModEq ▸ (runtime.world.codeSize (addrVal % SourceSemantics.addressModulus)).isLt
   | @keccak256 offset size _ _ ihO ihS =>
       show (do
         let off ← SourceSemantics.evalExpr fields runtime offset

--- a/Compiler/Proofs/IRGeneration/FunctionBody/Base.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody/Base.lean
@@ -118,7 +118,8 @@ def runtimeStateMatchesIR
   runtime.world.calldataSize.val = 4 + state.calldata.length * 32 ∧
   state.memory = (fun o => (runtime.world.memory o).val) ∧
   state.returnValue = none ∧
-  state.events = SourceSemantics.encodeEvents runtime.world.events
+  state.events = SourceSemantics.encodeEvents runtime.world.events ∧
+  state.codeSize = (fun addr => (runtime.world.codeSize addr).val)
 
 /-- Runtime/IR alignment for constructor execution, whose calldata is not
 selector-prefixed. This is the constructor-shaped analogue of
@@ -144,7 +145,8 @@ def constructorRuntimeStateMatchesIR
   runtime.world.calldataSize.val = state.calldata.length * 32 ∧
   state.memory = (fun o => (runtime.world.memory o).val) ∧
   state.returnValue = none ∧
-  state.events = SourceSemantics.encodeEvents runtime.world.events
+  state.events = SourceSemantics.encodeEvents runtime.world.events ∧
+  state.codeSize = (fun addr => (runtime.world.codeSize addr).val)
 
 def initialIRStateForTx
     (spec : CompilationModel)
@@ -166,7 +168,8 @@ def initialIRStateForTx
     blobBaseFee := tx.blobBaseFee
     txOrigin := tx.txOrigin
     selector := tx.functionSelector
-    events := SourceSemantics.encodeEvents initialWorld.events }
+    events := SourceSemantics.encodeEvents initialWorld.events
+    codeSize := fun addr => (initialWorld.codeSize addr).val }
 
 @[simp] theorem bindingsMatchIRVars_nil_initialIRStateForTx
     (spec : CompilationModel)
@@ -2101,6 +2104,50 @@ private theorem eval_compileExpr_mload_of_compiled
     rw [hmload_unfold, hsrc]
     simp only [Option.bind_some]
     simp [evalIRExpr, hIR, hmem]
+
+theorem compileExpr_extcodesize_ok
+    {fields : List Field}
+    {expr : Expr}
+    {exprIR : YulExpr}
+    (hexpr : CompilationModel.compileExpr fields .calldata expr = Except.ok exprIR) :
+    CompilationModel.compileExpr fields .calldata (.extcodesize expr) =
+      Except.ok (YulExpr.call "extcodesize" [exprIR]) := by
+  rw [← CompilationModel.compileExprWithInternals_nil_eq] at hexpr
+  rw [CompilationModel.compileExpr, CompilationModel.compileExprWithInternals, hexpr]
+  rfl
+
+set_option linter.unusedVariables false in
+private theorem eval_compileExpr_extcodesize_of_compiled
+    {fields : List Field}
+    {runtime : SourceSemantics.RuntimeState}
+    {state : IRState}
+    {addr : Expr}
+    {addrIR : YulExpr}
+    (haddr : CompilationModel.compileExpr fields .calldata addr = Except.ok addrIR)
+    (hEvalAddr : evalIRExpr state addrIR =
+        some (SourceSemantics.evalExpr fields runtime addr))
+    (hruntime : runtimeStateMatchesIR fields runtime state)
+    (hlt : SourceSemantics.evalExpr fields runtime addr <
+        Compiler.Constants.evmModulus) :
+    evalIRExpr state
+      (CompilationModel.compileExpr fields .calldata (.extcodesize addr)
+        |>.toOption.getD (YulExpr.lit 0)) =
+      some (SourceSemantics.evalExpr fields runtime (.extcodesize addr)) := by
+  rw [compileExpr_extcodesize_ok haddr]
+  simp only [Except.toOption, Option.getD]
+  rcases hruntime with ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, hcs⟩
+  rcases hIR : evalIRExpr state addrIR with _ | irVal
+  · simp [hIR] at hEvalAddr
+  · simp only [hIR] at hEvalAddr
+    simp only [Option.pure_def, Option.bind_eq_bind, Option.bind_some] at hEvalAddr
+    have hsrc : SourceSemantics.evalExpr fields runtime addr = some irVal := by
+      simpa using hEvalAddr.symm
+    have hecs_unfold : SourceSemantics.evalExpr fields runtime (.extcodesize addr) =
+        (SourceSemantics.evalExpr fields runtime addr).bind
+          (fun r => some (runtime.world.codeSize r).val) := rfl
+    rw [hecs_unfold, hsrc]
+    simp only [Option.bind_some]
+    simp [evalIRExpr, hIR, hcs]
 
 theorem compileExpr_tload_ok
     {fields : List Field}
@@ -4980,6 +5027,10 @@ theorem compileExpr_core_ok
       rename_i offset
       rcases ihO with ⟨offsetIR, hoffset⟩
       exact ⟨YulExpr.call "mload" [offsetIR], compileExpr_mload_ok hoffset⟩
+  | extcodesize hA ihA =>
+      rename_i addr
+      rcases ihA with ⟨addrIR, haddr⟩
+      exact ⟨YulExpr.call "extcodesize" [addrIR], compileExpr_extcodesize_ok haddr⟩
   | keccak256 hO hS ihO ihS =>
       rename_i offset size
       rcases ihO with ⟨offsetIR, hoffset⟩
@@ -6068,6 +6119,23 @@ theorem eval_compileExpr_core_onExpr
         rw [hoffset] at htmp
         simpa only [Except.toOption, Option.getD_some] using htmp
       exact eval_compileExpr_mload_of_compiled hoffset hEvalOff hruntime
+  | extcodesize hA ihA =>
+      rename_i addr
+      rcases compileExpr_core_ok hA with ⟨addrIR, haddr⟩
+      have hexact' : bindingsExactlyMatchIRVarsOnExpr addr runtime.bindings state :=
+        bindingsExactlyMatchIRVarsOnExpr_of_subset hexact (by
+          intro name hmem
+          simpa [exprBoundNames] using hmem)
+      have hpresent' := exprBoundNamesPresent_of_subset hpresent (by
+        intro name hmem
+        simpa [exprBoundNames] using hmem)
+      have hEvalAddr : evalIRExpr state addrIR =
+          some (SourceSemantics.evalExpr fields runtime addr) := by
+        have htmp := ihA hexact' hbounded hpresent' hruntime
+        rw [haddr] at htmp
+        simpa only [Except.toOption, Option.getD_some] using htmp
+      exact eval_compileExpr_extcodesize_of_compiled haddr hEvalAddr hruntime
+        (evalExpr_lt_evmModulus_core_onExpr hA hexact' hbounded hpresent' hruntime)
   | keccak256 hO hS ihO ihS =>
       rename_i offset size
       rcases compileExpr_core_ok hO with ⟨offsetIR, hoffset⟩
@@ -6600,6 +6668,14 @@ theorem evalExpr_lt_evmModulus_core_onExpr
       · simp only [Bind.bind, Option.bind, Pure.pure]
         have hModEq : Verity.Core.Uint256.modulus = Compiler.Constants.evmModulus := rfl
         exact hModEq ▸ (runtime.world.memory offsetVal).isLt
+  | @extcodesize addr _ ihA =>
+      show (do let r ← SourceSemantics.evalExpr fields runtime addr
+               some (runtime.world.codeSize r).val) < _
+      rcases SourceSemantics.evalExpr fields runtime addr with _ | addrVal
+      · trivial
+      · simp only [Bind.bind, Option.bind, Pure.pure]
+        have hModEq : Verity.Core.Uint256.modulus = Compiler.Constants.evmModulus := rfl
+        exact hModEq ▸ (runtime.world.codeSize addrVal).isLt
   | @keccak256 offset size _ _ ihO ihS =>
       show (do
         let off ← SourceSemantics.evalExpr fields runtime offset
@@ -7056,6 +7132,14 @@ theorem compileRequireFailCond_core_ok
       rcases compileExpr_core_ok (fields := fields) h with ⟨exprIR, hexpr⟩
       exact ⟨YulExpr.call "iszero" [YulExpr.call "mload" [exprIR]], by
         have hcompile := compileExpr_mload_ok hexpr
+        rw [CompilationModel.compileRequireFailCond]
+        rw [← CompilationModel.compileExprWithInternals_nil_eq] at hcompile
+        simp [CompilationModel.compileRequireFailCondWithInternals, hcompile]⟩
+  | extcodesize h =>
+      rename_i expr
+      rcases compileExpr_core_ok (fields := fields) h with ⟨exprIR, hexpr⟩
+      exact ⟨YulExpr.call "iszero" [YulExpr.call "extcodesize" [exprIR]], by
+        have hcompile := compileExpr_extcodesize_ok hexpr
         rw [CompilationModel.compileRequireFailCond]
         rw [← CompilationModel.compileExprWithInternals_nil_eq] at hcompile
         simp [CompilationModel.compileRequireFailCondWithInternals, hcompile]⟩
@@ -7679,6 +7763,17 @@ theorem eval_compileRequireFailCond_core_onExpr
       · simpa using finishIszeroEval (expr := .mload expr)
           (show ExprCompileCore (.mload expr) from
             ExprCompileCore.mload h) hexact hpresent hexpr
+  | extcodesize h =>
+      rename_i expr
+      rcases compileExpr_core_ok (fields := fields)
+          (show ExprCompileCore (.extcodesize expr) from
+            ExprCompileCore.extcodesize h) with ⟨exprIR, hexpr⟩
+      refine ⟨YulExpr.call "iszero" [exprIR], ?_, ?_⟩
+      · rw [← CompilationModel.compileExprWithInternals_nil_eq] at hexpr
+        simp [CompilationModel.compileRequireFailCond, CompilationModel.compileRequireFailCondWithInternals, hexpr]
+      · simpa using finishIszeroEval (expr := .extcodesize expr)
+          (show ExprCompileCore (.extcodesize expr) from
+            ExprCompileCore.extcodesize h) hexact hpresent hexpr
   | keccak256 hO hS =>
       rename_i offset size
       rcases compileExpr_core_ok (fields := fields)

--- a/Compiler/Proofs/IRGeneration/FunctionBody/Stmt.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody/Stmt.lean
@@ -428,9 +428,9 @@ theorem runtimeStateMatchesIR_updateMemoryEvents
   cases state
   simp only [runtimeStateMatchesIR] at hmatch ⊢
   obtain ⟨hstor, htrans, hsender, hmsgVal, hthis, hts, hbn, hcid, hblob, htx, hsel,
-    hcd, hcds, hmem, hret, hevt⟩ := hmatch
+    hcd, hcds, hmem, hret, hevt, hcs⟩ := hmatch
   refine ⟨?_, htrans, hsender, hmsgVal, hthis, hts, hbn, hcid, hblob, htx, hsel,
-    hcd, hcds, hmemory, hret, hevents⟩
+    hcd, hcds, hmemory, hret, hevents, hcs⟩
   rw [hstor]
   funext slot
   exact congrArg _ (SourceSemantics.encodeStorageAt_congr rfl rfl rfl)
@@ -450,8 +450,8 @@ theorem runtimeStateMatchesIR_setTransientStorage
   cases runtime
   cases state
   simp only [runtimeStateMatchesIR] at hmatch ⊢
-  obtain ⟨hstor, htrans, hsender, hmsgVal, hthis, hts, hbn, hcid, hblob, htx, hsel, hcd, hcds, hmem, hret, hevt⟩ := hmatch
-  refine ⟨?_, ?_, hsender, hmsgVal, hthis, hts, hbn, hcid, hblob, htx, hsel, hcd, hcds, hmem, hret, hevt⟩
+  obtain ⟨hstor, htrans, hsender, hmsgVal, hthis, hts, hbn, hcid, hblob, htx, hsel, hcd, hcds, hmem, hret, hevt, hcs⟩ := hmatch
+  refine ⟨?_, ?_, hsender, hmsgVal, hthis, hts, hbn, hcid, hblob, htx, hsel, hcd, hcds, hmem, hret, hevt, hcs⟩
   · -- storage: encodeStorageAt doesn't depend on transientStorage
     rw [hstor]
     funext slot

--- a/Compiler/Proofs/IRGeneration/GenericInduction/EventBridge.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/EventBridge.lean
@@ -2262,7 +2262,7 @@ private theorem eventRuntimeStateMatchesIR_after_emit
         SourceSemantics.encodeEvents (runtime.world.events ++ [event]) := by
     have hstateEvents :
         state.events = SourceSemantics.encodeEvents runtime.world.events := by
-      exact hmatch.2.2.2.2.2.2.2.2.2.2.2.2.2.2.2
+      exact hmatch.2.2.2.2.2.2.2.2.2.2.2.2.2.2.2.1
     simp [hstateEvents, hevent, eventEncodeEvents_snoc]
   exact FunctionBody.runtimeStateMatchesIR_updateMemoryEvents
     hmatch sourceMemory irMemory (runtime.world.events ++ [event])
@@ -2305,7 +2305,7 @@ private theorem eventRuntimeStateMatchesIR_after_emit_scratch
           have hstateEvents :
               ((state.setVar "__evt_ptr" ptr).setVar "__evt_topic0" topic0).events =
                 SourceSemantics.encodeEvents runtime.world.events := by
-            exact hvars.2.2.2.2.2.2.2.2.2.2.2.2.2.2.2
+            exact hvars.2.2.2.2.2.2.2.2.2.2.2.2.2.2.2.1
           rw [hstateEvents, eventEncodeEvents_snoc])
   simpa [IRState.appendYulLog, hlog] using hbase
 

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
@@ -253,6 +253,10 @@ theorem exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false
       simp only [exprTouchesUnsupportedContractSurface] at hsurface
       exact .mload
         (exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false hsurface)
+  | .extcodesize a, hsurface =>
+      simp only [exprTouchesUnsupportedContractSurface] at hsurface
+      exact .extcodesize
+        (exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false hsurface)
   | .keccak256 offset size, hsurface =>
       simp only [exprTouchesUnsupportedContractSurface, Bool.or_eq_false_iff] at hsurface
       exact .keccak256
@@ -953,7 +957,8 @@ private theorem exprBoundNamesInScope_of_validateScopedExprIdentifiers_core
   | bitNot h ih
   | tload h ih
   | calldataload h ih
-  | mload h ih =>
+  | mload h ih
+  | extcodesize h ih =>
       intro name hmem
       simpa [FunctionBody.exprBoundNames] using
         ih
@@ -2207,7 +2212,8 @@ theorem collectExprNames_mem_exprBoundNames_of_core
       rcases hmem with hmem | hmem
       · exact Or.inl (ihL _ hmem)
       · exact Or.inr (ihR _ hmem)
-  | logicalNot h ih | bitNot h ih | tload h ih | calldataload h ih | mload h ih =>
+  | logicalNot h ih | bitNot h ih | tload h ih | calldataload h ih | mload h ih
+  | extcodesize h ih =>
       intro name hmem; simp [collectExprNames] at hmem
       simpa [FunctionBody.exprBoundNames] using ih _ hmem
   | ite hC hT hE ihC ihT ihE =>

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Storage.lean
@@ -1398,8 +1398,8 @@ private theorem runtimeStateMatchesIR_writeUintSlot
       { state with
           storage := Compiler.Proofs.abstractStoreStorageOrMapping state.storage slot value } := by
   rcases hruntime with
-    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
+  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
   funext query
   ·
     by_cases hEq : query = IRStorageSlot.ofNat slot
@@ -1458,8 +1458,8 @@ private theorem runtimeStateMatchesIR_writeStorageWordSlot_zeroOffset
       { state with
           storage := Compiler.Proofs.abstractStoreStorageOrMapping state.storage slot value } := by
   rcases hruntime with
-    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
+  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
   funext query
   ·
     by_cases hEq : query = IRStorageSlot.ofNat slot
@@ -1504,8 +1504,8 @@ private theorem runtimeStateMatchesIR_writeAddressSlot
           storage := Compiler.Proofs.abstractStoreStorageOrMapping state.storage slot
             (value &&& Compiler.Constants.addressMask) } := by
     rcases hruntime with
-      ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-    refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+      ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
+    refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
     funext query
     by_cases hEq : query = IRStorageSlot.ofNat slot
     · subst hEq
@@ -1558,8 +1558,8 @@ private theorem runtimeStateMatchesIR_writeUintSlots
       { state with
           storage := abstractStoreStorageOrMappingMany state.storage slots value } := by
   rcases hruntime with
-    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
+  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
   funext query
   simp only [abstractStoreStorageOrMappingMany_eq]
   ·
@@ -1617,8 +1617,8 @@ private theorem runtimeStateMatchesIR_writeUintKeyedMappingSlot
       { state with
           storage := Compiler.Proofs.abstractStoreMappingEntry state.storage slot key value } := by
   rcases hruntime with
-    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
+  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
   funext query
   simp only [Compiler.Proofs.abstractStoreMappingEntry]
   by_cases hEq : query = IRStorageSlot.ofNat (Compiler.Proofs.solidityMappingSlot slot key)
@@ -1653,8 +1653,8 @@ private theorem runtimeStateMatchesIR_writeTransientTarget
           transientStorage := fun slot =>
             if slot = SourceSemantics.wordNormalize target then value else state.transientStorage slot } := by
   rcases hruntime with
-    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-  refine ⟨?_, ?_, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
+  refine ⟨?_, ?_, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
   · funext query
     rw [hstorage]
     exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
@@ -1699,8 +1699,8 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingChainSlot
             (SourceSemantics.mappingSlotChain slot keys)
             value } := by
   rcases hruntime with
-    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
+  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
   funext query
   by_cases hEq : query = IRStorageSlot.ofNat (SourceSemantics.mappingSlotChain slot keys)
   · subst hEq
@@ -1755,8 +1755,8 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingSlot
     · simp [SourceSemantics.writeAddressKeyedMappingSlots, SourceSemantics.writeUintKeyedMappingSlots]
     · simp [SourceSemantics.writeAddressKeyedMappingSlots, SourceSemantics.writeUintKeyedMappingSlots]
   rcases hruntime with
-    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
+  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
   funext query
   rw [hbridge]
   simp only [Compiler.Proofs.abstractStoreMappingEntry]
@@ -1801,8 +1801,8 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingWordSlot
             (mappingWordTargetSlot slot key wordOffset)
             value } := by
   rcases hruntime with
-    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
+  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
   funext query
   by_cases hEq : query = IRStorageSlot.ofNat (mappingWordTargetSlot slot key wordOffset)
   · subst hEq
@@ -1854,8 +1854,8 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingPackedWordSlot
               value
               packed) } := by
   rcases hruntime with
-    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
+  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
   funext query
   set tgt := mappingWordTargetSlot slot key wordOffset with htgt
   by_cases hEq : query = IRStorageSlot.ofNat tgt
@@ -1930,8 +1930,8 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMapping2Slot
               key2
               value } := by
   rcases hruntime with
-    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
+  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
   funext query
   simp only [Compiler.Proofs.abstractStoreMappingEntry]
   by_cases hEq : query =
@@ -1981,8 +1981,8 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMapping2WordSlot
             (mapping2WordTargetSlot slot key1 key2 wordOffset)
             value } := by
   rcases hruntime with
-    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
+  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
   funext query
   by_cases hEq : query = IRStorageSlot.ofNat (mapping2WordTargetSlot slot key1 key2 wordOffset)
   · subst hEq

--- a/Compiler/Proofs/IRGeneration/GenericInduction/StorageWord.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/StorageWord.lean
@@ -320,8 +320,8 @@ private theorem runtimeStateMatchesIR_writeStorageWordSlot
       { state with
           storage := Compiler.Proofs.abstractStoreStorageOrMapping state.storage targetSlot value } := by
   rcases hruntime with
-    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
+  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents, hcs⟩
   funext query
   by_cases hEq : query = IRStorageSlot.ofNat targetSlot
   · subst hEq

--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -2829,22 +2829,30 @@ theorem evalIRCallWithInternals_stmt_eq_of_callsDisjoint
               cases rest with
               | nil => simp
               | cons _ _ => simp
-        · by_cases hkeccak : func = "keccak256"
-          · subst hkeccak
+        · by_cases hextcodesize : func = "extcodesize"
+          · simp [hextcodesize]
             cases argVals with
             | nil => simp
-            | cons offset rest =>
+            | cons addr rest =>
                 cases rest with
                 | nil => simp
-                | cons size rest =>
-                    cases rest <;> simp
-          · simp only [htload, hmload, hkeccak, ↓reduceIte]
-            cases hbuiltin :
-                Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext
-                  state.storage state.sender state.msgValue state.thisAddress state.blockTimestamp
-                  state.blockNumber state.chainId state.blobBaseFee state.txOrigin state.selector state.calldata func argVals with
-            | none => simp [hbuiltin]
-            | some value => simp [hbuiltin]
+                | cons _ _ => simp
+          · by_cases hkeccak : func = "keccak256"
+            · subst hkeccak
+              cases argVals with
+              | nil => simp
+              | cons offset rest =>
+                  cases rest with
+                  | nil => simp
+                  | cons size rest =>
+                      cases rest <;> simp
+            · simp only [htload, hmload, hextcodesize, hkeccak, ↓reduceIte]
+              cases hbuiltin :
+                  Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext
+                    state.storage state.sender state.msgValue state.thisAddress state.blockTimestamp
+                    state.blockNumber state.chainId state.blobBaseFee state.txOrigin state.selector state.calldata func argVals with
+              | none => simp [hbuiltin]
+              | some value => simp [hbuiltin]
 
 /-- Statement-level collapse for call expressions when `internalFunctions = []`. -/
 theorem evalIRCallWithInternals_stmt_eq_of_no_internal
@@ -4942,6 +4950,7 @@ theorem evalIRCallWithInternals_of_builtin
     (hfind : findInternalFunction? contract func = none)
     (hnotTload : func ≠ "tload")
     (hnotMload : func ≠ "mload")
+    (hnotExtcodesize : func ≠ "extcodesize")
     (hnotKeccak : func ≠ "keccak256") :
     evalIRCallWithInternals contract fuel state func args =
       match Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext
@@ -4950,8 +4959,8 @@ theorem evalIRCallWithInternals_of_builtin
           state'.txOrigin state'.selector state'.calldata func argVals with
       | some value => .values [value] state'
       | none => .revert state' := by
-  simp only [evalIRCallWithInternals, hargs, hfind, hnotTload, hnotMload, hnotKeccak,
-    ↓reduceIte]
+  simp only [evalIRCallWithInternals, hargs, hfind, hnotTload, hnotMload, hnotExtcodesize,
+    hnotKeccak, ↓reduceIte]
 
 /-- When argument evaluation propagates a control-flow effect (stop/return/revert),
 `evalIRCallWithInternals` propagates it unchanged. -/

--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -286,6 +286,10 @@ def evalIRCall (state : IRState) (func : String) : List YulExpr → Option Nat
       match argVals with
       | [offset] => some (state.memory offset)
       | _ => none
+    else if func = "extcodesize" then
+      match argVals with
+      | [addr] => some (state.codeSize addr)
+      | _ => none
     else if func = "keccak256" then
       match argVals with
       | [offset, size] => some (abstractKeccakMemorySlice state.memory offset size)
@@ -329,6 +333,16 @@ end -- mutual
     evalIRCall state "mload" [argExpr] =
       (evalIRExpr state argExpr).bind
         (fun offset => some (state.memory offset)) := by
+  simp [evalIRCall, evalIRExprs]
+  cases evalIRExpr state argExpr with
+  | none => simp
+  | some val => simp
+
+@[simp] theorem evalIRCall_extcodesize_singleton
+    (state : IRState) (argExpr : YulExpr) :
+    evalIRCall state "extcodesize" [argExpr] =
+      (evalIRExpr state argExpr).bind
+        (fun addr => some (state.codeSize addr)) := by
   simp [evalIRCall, evalIRExprs]
   cases evalIRExpr state argExpr with
   | none => simp
@@ -501,6 +515,10 @@ def evalIRCallWithInternals
           if func = "tload" then
             match argVals with
             | [slot] => .values [state'.transientStorage (slot % Compiler.Constants.evmModulus)] state'
+            | _ => .revert state'
+          else if func = "extcodesize" then
+            match argVals with
+            | [addr] => .values [state'.codeSize addr] state'
             | _ => .revert state'
           else if func = "mload" then
             match argVals with

--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -288,7 +288,7 @@ def evalIRCall (state : IRState) (func : String) : List YulExpr → Option Nat
       | _ => none
     else if func = "extcodesize" then
       match argVals with
-      | [addr] => some (state.codeSize addr)
+      | [addr] => some (state.codeSize (addr % Compiler.Constants.addressModulus))
       | _ => none
     else if func = "keccak256" then
       match argVals with
@@ -342,7 +342,7 @@ end -- mutual
     (state : IRState) (argExpr : YulExpr) :
     evalIRCall state "extcodesize" [argExpr] =
       (evalIRExpr state argExpr).bind
-        (fun addr => some (state.codeSize addr)) := by
+        (fun addr => some (state.codeSize (addr % Compiler.Constants.addressModulus))) := by
   simp [evalIRCall, evalIRExprs]
   cases evalIRExpr state argExpr with
   | none => simp
@@ -518,7 +518,7 @@ def evalIRCallWithInternals
             | _ => .revert state'
           else if func = "extcodesize" then
             match argVals with
-            | [addr] => .values [state'.codeSize addr] state'
+            | [addr] => .values [state'.codeSize (addr % Compiler.Constants.addressModulus)] state'
             | _ => .revert state'
           else if func = "mload" then
             match argVals with

--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -2498,22 +2498,30 @@ theorem evalIRExprWithInternals_eq_evalIRExpr_of_no_internal
                   cases rest with
                   | nil => simp
                   | cons _ _ => simp
-            · by_cases hkeccak : func = "keccak256"
-              · subst hkeccak
+            · by_cases hextcodesize : func = "extcodesize"
+              · simp [hextcodesize]
                 cases argVals with
                 | nil => simp
-                | cons offset rest =>
+                | cons addr rest =>
                     cases rest with
                     | nil => simp
-                    | cons size rest =>
-                        cases rest <;> simp
-              · simp only [htload, hmload, hkeccak, ↓reduceIte]
-                cases hbuiltin :
-                    Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext
-                      state.storage state.sender state.msgValue state.thisAddress state.blockTimestamp
-                      state.blockNumber state.chainId state.blobBaseFee state.txOrigin state.selector state.calldata func argVals with
-                | none => simp [hbuiltin]
-                | some value => simp [hbuiltin]
+                    | cons _ _ => simp
+              · by_cases hkeccak : func = "keccak256"
+                · subst hkeccak
+                  cases argVals with
+                  | nil => simp
+                  | cons offset rest =>
+                      cases rest with
+                      | nil => simp
+                      | cons size rest =>
+                          cases rest <;> simp
+                · simp only [htload, hmload, hextcodesize, hkeccak, ↓reduceIte]
+                  cases hbuiltin :
+                      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext
+                        state.storage state.sender state.msgValue state.thisAddress state.blockTimestamp
+                        state.blockNumber state.chainId state.blobBaseFee state.txOrigin state.selector state.calldata func argVals with
+                  | none => simp [hbuiltin]
+                  | some value => simp [hbuiltin]
 
 theorem evalIRExprsWithInternals_eq_evalIRExprs_of_no_internal
     (contract : IRContract)
@@ -2661,22 +2669,30 @@ theorem evalIRExprWithInternals_eq_evalIRExpr_of_callsDisjoint
                   cases rest with
                   | nil => simp
                   | cons _ _ => simp
-            · by_cases hkeccak : func = "keccak256"
-              · subst hkeccak
+            · by_cases hextcodesize : func = "extcodesize"
+              · simp [hextcodesize]
                 cases argVals with
                 | nil => simp
-                | cons offset rest =>
+                | cons addr rest =>
                     cases rest with
                     | nil => simp
-                    | cons size rest =>
-                        cases rest <;> simp
-              · simp only [htload, hmload, hkeccak, ↓reduceIte]
-                cases hbuiltin :
-                    Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext
-                      state.storage state.sender state.msgValue state.thisAddress state.blockTimestamp
-                      state.blockNumber state.chainId state.blobBaseFee state.txOrigin state.selector state.calldata func argVals with
-                | none => simp [hbuiltin]
-                | some value => simp [hbuiltin]
+                    | cons _ _ => simp
+              · by_cases hkeccak : func = "keccak256"
+                · subst hkeccak
+                  cases argVals with
+                  | nil => simp
+                  | cons offset rest =>
+                      cases rest with
+                      | nil => simp
+                      | cons size rest =>
+                          cases rest <;> simp
+                · simp only [htload, hmload, hextcodesize, hkeccak, ↓reduceIte]
+                  cases hbuiltin :
+                      Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext
+                        state.storage state.sender state.msgValue state.thisAddress state.blockTimestamp
+                        state.blockNumber state.chainId state.blobBaseFee state.txOrigin state.selector state.calldata func argVals with
+                  | none => simp [hbuiltin]
+                  | some value => simp [hbuiltin]
 
 /-- Expression-list conservative extension under per-expression disjointness.
 Generalizes `evalIRExprsWithInternals_eq_evalIRExprs_of_no_internal`. -/
@@ -2889,22 +2905,30 @@ theorem evalIRCallWithInternals_stmt_eq_of_no_internal
               cases rest with
               | nil => simp
               | cons _ _ => simp
-        · by_cases hkeccak : func = "keccak256"
-          · subst hkeccak
+        · by_cases hextcodesize : func = "extcodesize"
+          · simp [hextcodesize]
             cases argVals with
             | nil => simp
-            | cons offset rest =>
+            | cons addr rest =>
                 cases rest with
                 | nil => simp
-                | cons size rest =>
-                    cases rest <;> simp
-          · simp only [htload, hmload, hkeccak, ↓reduceIte]
-            cases hbuiltin :
-                Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext
-                  state.storage state.sender state.msgValue state.thisAddress state.blockTimestamp
-                  state.blockNumber state.chainId state.blobBaseFee state.txOrigin state.selector state.calldata func argVals with
-            | none => simp [hbuiltin]
-            | some value => simp [hbuiltin]
+                | cons _ _ => simp
+          · by_cases hkeccak : func = "keccak256"
+            · subst hkeccak
+              cases argVals with
+              | nil => simp
+              | cons offset rest =>
+                  cases rest with
+                  | nil => simp
+                  | cons size rest =>
+                      cases rest <;> simp
+            · simp only [htload, hmload, hextcodesize, hkeccak, ↓reduceIte]
+              cases hbuiltin :
+                  Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext
+                    state.storage state.sender state.msgValue state.thisAddress state.blockTimestamp
+                    state.blockNumber state.chainId state.blobBaseFee state.txOrigin state.selector state.calldata func argVals with
+              | none => simp [hbuiltin]
+              | some value => simp [hbuiltin]
 
 /-- Shared compatibility lemma for statement-position Yul logs: once the
 argument-list evaluators agree, helper-aware and helper-free log execution agree

--- a/Compiler/Proofs/IRGeneration/IRRuntimeTypes.lean
+++ b/Compiler/Proofs/IRGeneration/IRRuntimeTypes.lean
@@ -39,6 +39,8 @@ structure IRState where
   selector : Nat
   /-- Emitted log records for this execution. -/
   events : List (List Nat) := []
+  /-- EXTCODESIZE at address (environment read, no state mutation). -/
+  codeSize : Nat → Nat := fun _ => 0
   deriving Nonempty
 
 /-- Initial state for IR execution. -/

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -1475,7 +1475,7 @@ def evalExpr (fields : List Field) (state : RuntimeState) : Expr → Option Nat
       some (Compiler.Proofs.YulGeneration.calldataloadWord state.selector state.world.calldata resolvedOffset)
   | .extcodesize addr => do
       let resolvedAddr ← evalExpr fields state addr
-      some (state.world.codeSize resolvedAddr).val
+      some (state.world.codeSize (resolvedAddr % addressModulus)).val
   | .keccak256 offExpr sizeExpr => do
       let off ← evalExpr fields state offExpr
       let size ← evalExpr fields state sizeExpr
@@ -1686,7 +1686,7 @@ private theorem evalExpr_extcodesize
     (a : Expr) :
     evalExpr fields state (.extcodesize a) =
       (evalExpr fields state a).bind
-        (fun resolvedAddr => some (state.world.codeSize resolvedAddr).val) := rfl
+        (fun resolvedAddr => some (state.world.codeSize (resolvedAddr % addressModulus)).val) := rfl
 
 private theorem evalExpr_returndataOptionalBoolAt
     (fields : List Field)
@@ -3988,7 +3988,7 @@ mutual
         some (Compiler.Proofs.YulGeneration.calldataloadWord state.selector state.world.calldata resolvedOffset)
     | .extcodesize addr => do
         let resolvedAddr ← evalExprWithHelpers spec fields fuel state addr
-        some (state.world.codeSize resolvedAddr).val
+        some (state.world.codeSize (resolvedAddr % addressModulus)).val
     | .keccak256 offExpr sizeExpr => do
         -- Keep this in sync with the helper/call surface scans, which recurse
         -- into the offset and size expressions.

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -1473,6 +1473,9 @@ def evalExpr (fields : List Field) (state : RuntimeState) : Expr → Option Nat
   | .calldataload offset => do
       let resolvedOffset ← evalExpr fields state offset
       some (Compiler.Proofs.YulGeneration.calldataloadWord state.selector state.world.calldata resolvedOffset)
+  | .extcodesize addr => do
+      let resolvedAddr ← evalExpr fields state addr
+      some (state.world.codeSize resolvedAddr).val
   | .keccak256 offExpr sizeExpr => do
       let off ← evalExpr fields state offExpr
       let size ← evalExpr fields state sizeExpr
@@ -1681,7 +1684,9 @@ private theorem evalExpr_extcodesize
     (fields : List Field)
     (state : RuntimeState)
     (a : Expr) :
-    evalExpr fields state (.extcodesize a) = none := rfl
+    evalExpr fields state (.extcodesize a) =
+      (evalExpr fields state a).bind
+        (fun resolvedAddr => some (state.world.codeSize resolvedAddr).val) := rfl
 
 private theorem evalExpr_returndataOptionalBoolAt
     (fields : List Field)
@@ -3981,6 +3986,9 @@ mutual
     | .calldataload offset => do
         let resolvedOffset ← evalExprWithHelpers spec fields fuel state offset
         some (Compiler.Proofs.YulGeneration.calldataloadWord state.selector state.world.calldata resolvedOffset)
+    | .extcodesize addr => do
+        let resolvedAddr ← evalExprWithHelpers spec fields fuel state addr
+        some (state.world.codeSize resolvedAddr).val
     | .keccak256 offExpr sizeExpr => do
         -- Keep this in sync with the helper/call surface scans, which recurse
         -- into the offset and size expressions.
@@ -4044,7 +4052,7 @@ mutual
     | .paramDynamicMemberLength _ _
     | .paramDynamicMemberDataOffset _ _ | .paramDynamicMemberElement _ _ _
     | .arrayElementWord _ _ _ _
-    | .extcodesize _ | .returndataOptionalBoolAt _
+    | .returndataOptionalBoolAt _
     | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
     | .externalCall _ _ | .mappingChain _ _ | .intrinsic _ _ _ _
     | .forkIfAtLeast _ _ _
@@ -5346,8 +5354,13 @@ mutual
         have ha :=
           evalExprWithHelpers_eq_evalExpr_of_helperSurfaceClosed spec fields fuel state a hsurface
         simp [evalExprWithHelpers, evalExpr_calldataload, ha]
-    | extcodesize a | returndataOptionalBoolAt a =>
-        simp [evalExprWithHelpers, evalExpr_extcodesize,
+    | extcodesize a =>
+        simp only [exprTouchesUnsupportedHelperSurface] at hsurface
+        have ha :=
+          evalExprWithHelpers_eq_evalExpr_of_helperSurfaceClosed spec fields fuel state a hsurface
+        simp [evalExprWithHelpers, evalExpr_extcodesize, ha]
+    | returndataOptionalBoolAt a =>
+        simp [evalExprWithHelpers,
           evalExpr_returndataOptionalBoolAt]
     | keccak256 a b =>
         simp only [exprTouchesUnsupportedHelperSurface, Bool.or_eq_false_iff] at hsurface

--- a/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
@@ -342,4 +342,18 @@ example :
       (.revertError "HelperFailed" [.internalCall "helper" []]) = true := by
   native_decide
 
+/-- Regression: extcodesize normalises its operand to 160-bit address width.
+    `extcodesize(2^160 + 1)` must query address 1, not key `2^160 + 1`. -/
+example :
+    SourceSemantics.evalExpr [] { world := Verity.defaultState, bindings := [] }
+      (.extcodesize (.literal (2 ^ 160 + 1))) =
+    some (Verity.defaultState.codeSize 1).val := by
+  native_decide
+
+/-- Regression: IR evaluator normalises extcodesize operand to 160 bits. -/
+example :
+    evalIRCall (IRState.initial 0) "extcodesize" [Compiler.Yul.YulExpr.lit (2 ^ 160 + 1)] =
+    some ((IRState.initial 0).codeSize 1) := by
+  native_decide
+
 end Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -1059,7 +1059,7 @@ def exprTouchesUnsupportedCoreSurface : Expr → Bool
         exprTouchesUnsupportedCoreSurface c
   | .slt a b | .sgt a b | .sdiv a b | .smod a b | .sar a b | .byte a b | .signextend a b =>
       exprTouchesUnsupportedCoreSurface a || exprTouchesUnsupportedCoreSurface b
-  | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedCoreSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a => exprTouchesUnsupportedCoreSurface a
   | .keccak256 a b =>
       exprTouchesUnsupportedCoreSurface a || exprTouchesUnsupportedCoreSurface b
   | .arrayElement _ index => exprTouchesUnsupportedCoreSurface index
@@ -1071,7 +1071,6 @@ def exprTouchesUnsupportedCoreSurface : Expr → Bool
   | .mapping2 _ _ _ | .mapping2Word _ _ _ _ | .mappingUint _ _ | .mappingChain _ _
   | .structMember _ _ _ | .structMember2 _ _ _ _
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
-  | .extcodesize _
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
   | .memoryArrayLength _
   | .memoryArrayElement _ _ | .arrayElementWord _ _ _ _
@@ -1489,14 +1488,14 @@ def exprTouchesUnsupportedContractSurface (expr : Expr) : Bool :=
   | .mulDivDown a b c | .mulDivUp a b c =>
       exprTouchesUnsupportedContractSurface a || exprTouchesUnsupportedContractSurface b ||
         exprTouchesUnsupportedContractSurface c
-  | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedContractSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a =>
+      exprTouchesUnsupportedContractSurface a
   | .keccak256 a b =>
       exprTouchesUnsupportedContractSurface a || exprTouchesUnsupportedContractSurface b
   | .mapping _ _ | .mappingWord _ _ _ | .mappingPackedWord _ _ _ _
   | .mapping2 _ _ _ | .mapping2Word _ _ _ _ | .mappingUint _ _ | .mappingChain _ _
   | .structMember _ _ _ | .structMember2 _ _ _ _
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
-  | .extcodesize _
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
   | .arrayLength _ | .memoryArrayLength _
   | .arrayElement _ _ | .memoryArrayElement _ _ | .arrayElementWord _ _ _ _

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -865,11 +865,11 @@ current body-level support interface until the deploy-wrapper proof exists. -/
 def exprTouchesUnsupportedConstructorRawCalldataSurface : Expr → Bool
   | .literal _ | .param _ | .immutable _ | .localVar _ | .caller | .contractAddress | .txOrigin
   | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
-  | .blobbasefee | .constructorArg _ | .returndataSize | .extcodesize _ => false
+  | .blobbasefee | .constructorArg _ | .returndataSize => false
   | .calldatasize => true
   | .storage _ | .storageAddr _ | .arrayLength _ | .memoryArrayLength _
   | .storageArrayLength _ => false
-  | .logicalNot a | .bitNot a | .mload a | .tload a | .returndataOptionalBoolAt a =>
+  | .logicalNot a | .bitNot a | .mload a | .tload a | .extcodesize a | .returndataOptionalBoolAt a =>
       exprTouchesUnsupportedConstructorRawCalldataSurface a
   | .calldataload _ =>
       true
@@ -1124,7 +1124,7 @@ def exprTouchesUnsupportedStateSurface : Expr → Bool
       exprTouchesUnsupportedStateSurface a || exprTouchesUnsupportedStateSurface b
   | .constructorArg _ | .blobbasefee
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
-  | .calldatasize | .returndataSize | .extcodesize _
+  | .calldatasize | .returndataSize
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
   | .arrayLength _ | .memoryArrayLength _
   | .arrayElement _ _ | .memoryArrayElement _ _ | .arrayElementWord _ _ _ _
@@ -1137,7 +1137,7 @@ def exprTouchesUnsupportedStateSurface : Expr → Bool
   | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _ | .paramDynamicMemberElement _ _ _
   | .dynamicBytesEq _ _ => false
-  | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedStateSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a => exprTouchesUnsupportedStateSurface a
   | .adtConstruct _ _ _ | .adtTag _ _ | .adtField _ _ _ _ _ => true
 
 /-- Call-related surfaces that still sit outside the current generic Layer 2
@@ -1149,7 +1149,7 @@ def exprTouchesUnsupportedCallSurface : Expr → Bool
   | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
-  | .calldatasize | .returndataSize | .extcodesize _
+  | .calldatasize | .returndataSize
   | .returndataOptionalBoolAt _
   | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
@@ -1158,7 +1158,7 @@ def exprTouchesUnsupportedCallSurface : Expr → Bool
   | .storageArrayLength _ => false
   | .paramDynamicMemberElement _ _ b =>
       exprTouchesUnsupportedCallSurface b
-  | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedCallSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a => exprTouchesUnsupportedCallSurface a
   | .keccak256 a b =>
       exprTouchesUnsupportedCallSurface a || exprTouchesUnsupportedCallSurface b
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
@@ -1210,7 +1210,7 @@ def exprTouchesUnsupportedHelperSurface : Expr → Bool
   | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
-  | .calldatasize | .returndataSize | .extcodesize _
+  | .calldatasize | .returndataSize
   | .returndataOptionalBoolAt _
   | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
@@ -1219,7 +1219,7 @@ def exprTouchesUnsupportedHelperSurface : Expr → Bool
   | .storageArrayLength _ | .externalCall _ _ => false
   | .paramDynamicMemberElement _ _ b =>
       exprTouchesUnsupportedHelperSurface b
-  | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedHelperSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a => exprTouchesUnsupportedHelperSurface a
   | .keccak256 a b =>
       exprTouchesUnsupportedHelperSurface a || exprTouchesUnsupportedHelperSurface b
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => false
@@ -1280,7 +1280,7 @@ def exprTouchesInternalHelperSurface : Expr → Bool
   | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
-  | .calldatasize | .returndataSize | .extcodesize _
+  | .calldatasize | .returndataSize
   | .returndataOptionalBoolAt _ | .arrayLength _
   | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
@@ -1289,7 +1289,7 @@ def exprTouchesInternalHelperSurface : Expr → Bool
   | .storageArrayLength _ | .externalCall _ _ => false
   | .paramDynamicMemberElement _ _ b =>
       exprTouchesInternalHelperSurface b
-  | .mload a | .tload a | .calldataload a => exprTouchesInternalHelperSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a => exprTouchesInternalHelperSurface a
   | .keccak256 a b =>
       exprTouchesInternalHelperSurface a || exprTouchesInternalHelperSurface b
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => false
@@ -1343,7 +1343,7 @@ def exprTouchesUnsupportedForeignSurface : Expr → Bool
   | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
-  | .calldatasize | .returndataSize | .extcodesize _
+  | .calldatasize | .returndataSize
   | .returndataOptionalBoolAt _ | .arrayLength _
   | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
@@ -1354,7 +1354,7 @@ def exprTouchesUnsupportedForeignSurface : Expr → Bool
       exprTouchesUnsupportedForeignSurface b
   | .keccak256 a b =>
       exprTouchesUnsupportedForeignSurface a || exprTouchesUnsupportedForeignSurface b
-  | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedForeignSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a => exprTouchesUnsupportedForeignSurface a
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => false
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
   | .bitAnd a b | .bitOr a b | .bitXor a b | .eq a b
@@ -1404,7 +1404,7 @@ def exprTouchesUnsupportedLowLevelSurface : Expr → Bool
   | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
-  | .calldatasize | .returndataSize | .extcodesize _
+  | .calldatasize | .returndataSize
   | .returndataOptionalBoolAt _ | .arrayLength _
   | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
@@ -1415,7 +1415,7 @@ def exprTouchesUnsupportedLowLevelSurface : Expr → Bool
       exprTouchesUnsupportedLowLevelSurface b
   | .keccak256 a b =>
       exprTouchesUnsupportedLowLevelSurface a || exprTouchesUnsupportedLowLevelSurface b
-  | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedLowLevelSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a => exprTouchesUnsupportedLowLevelSurface a
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
   | .bitAnd a b | .bitOr a b | .bitXor a b | .eq a b
   | .ge a b | .gt a b | .sgt a b | .lt a b | .slt a b | .le a b
@@ -3552,7 +3552,7 @@ private theorem exprCompileCore_helperSurfaceClosed
     | smod _ _ ihL ihR | sar _ _ ihL ihR | byte _ _ ihL ihR | signextend _ _ ihL ihR
     | keccak256 _ _ ihL ihR =>
       simp only [exprTouchesUnsupportedHelperSurface, ihL, ihR, Bool.or_false, Bool.false_or]
-  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih =>
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih =>
       simp only [exprTouchesUnsupportedHelperSurface, ih]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprTouchesUnsupportedHelperSurface, ihC, ihT, ihE,
@@ -3593,7 +3593,7 @@ private theorem exprCompileCore_internalHelperCallNames_nil
     | smod _ _ ihL ihR | sar _ _ ihL ihR | byte _ _ ihL ihR | signextend _ _ ihL ihR
     | keccak256 _ _ ihL ihR =>
       simp only [exprInternalHelperCallNames, ihL, ihR, List.nil_append]
-  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih =>
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih =>
       simp only [exprInternalHelperCallNames, ih]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprInternalHelperCallNames, ihC, ihT, ihE, List.nil_append]
@@ -4433,10 +4433,9 @@ mutual
         simp [exprTouchesInternalHelperSurface]
     | adtConstruct _ _ _ | adtTag _ _ | adtField _ _ _ _ _ =>
         simp [exprTouchesUnsupportedHelperSurface] at hsurface
-    | extcodesize a
     | returndataOptionalBoolAt a =>
         simp [exprTouchesInternalHelperSurface]
-    | tload a | calldataload a | mload a =>
+    | tload a | calldataload a | mload a | extcodesize a =>
         simp only [exprTouchesUnsupportedHelperSurface] at hsurface
         simp only [exprTouchesInternalHelperSurface]
         exact exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface
@@ -4902,13 +4901,12 @@ private theorem exprTouchesUnsupportedCallSurface_eq_featureOr
   | call _ _ _ _ _ _ _ | staticcall _ _ _ _ _ _ | delegatecall _ _ _ _ _ _ =>
       simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
-  | extcodesize _
   | returndataOptionalBoolAt _ | arrayLength _
   | memoryArrayLength _
   | storageArrayLength _ | dynamicBytesEq _ _ =>
       simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
-  | tload a | calldataload a | mload a =>
+  | tload a | calldataload a | mload a | extcodesize a =>
       simp only [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
       exact exprTouchesUnsupportedCallSurface_eq_featureOr a
@@ -5148,7 +5146,7 @@ private theorem exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
   | paramDynamicMemberDataOffset _ _ | paramDynamicMemberElement _ _ _ =>
       cases hcore
   | memoryArrayLength _ | storageArrayLength _
-  | returndataOptionalBoolAt _ | extcodesize _ =>
+  | returndataOptionalBoolAt _ =>
       cases hcore
   | arrayLength _ | dynamicBytesEq _ _ =>
       cases hcalls
@@ -5161,7 +5159,7 @@ private theorem exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
           offset hcore.1 hstate.1 hcalls.1,
         exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
           size hcore.2 hstate.2 hcalls.2]
-  | tload a | calldataload a | mload a =>
+  | tload a | calldataload a | mload a | extcodesize a =>
       simp only [exprTouchesUnsupportedCoreSurface] at hcore
       simp only [exprTouchesUnsupportedStateSurface] at hstate
       simp only [exprTouchesUnsupportedCallSurface] at hcalls
@@ -5291,7 +5289,7 @@ private theorem exprTouchesUnsupportedCallSurface_eq_false_of_coreClosed
       simp [exprTouchesUnsupportedCallSurface,
         exprTouchesUnsupportedCallSurface_eq_false_of_coreClosed a hcore.1,
         exprTouchesUnsupportedCallSurface_eq_false_of_coreClosed b hcore.2]
-  | logicalNot a | bitNot a | tload a | calldataload a | mload a =>
+  | logicalNot a | bitNot a | tload a | calldataload a | mload a | extcodesize a =>
       simp only [exprTouchesUnsupportedCoreSurface] at hcore
       simp [exprTouchesUnsupportedCallSurface,
         exprTouchesUnsupportedCallSurface_eq_false_of_coreClosed a hcore]
@@ -5692,7 +5690,6 @@ theorem exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
   | adtConstruct _ _ _ | adtTag _ _ | adtField _ _ _ _ _ =>
       simp [exprTouchesUnsupportedContractSurface] at hsurface
   | storage _ | storageAddr _ | internalCall _ _ | externalCall _ _
-  | extcodesize _
   | returndataOptionalBoolAt _ | arrayLength _ | memoryArrayLength _ | storageArrayLength _
   | dynamicBytesEq _ _
   | call _ _ _ _ _ _ _ | staticcall _ _ _ _ _ _ | delegatecall _ _ _ _ _ _
@@ -5711,7 +5708,7 @@ theorem exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
   | storageArrayElement _ _
   | mappingChain _ _ =>
       simp [exprTouchesUnsupportedContractSurface] at hsurface
-  | tload a | calldataload a | mload a =>
+  | tload a | calldataload a | mload a | extcodesize a =>
       simp only [exprTouchesUnsupportedContractSurface] at hsurface
       simp [exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed hsurface]
@@ -6063,7 +6060,7 @@ private theorem exprUsesArrayElement_eq_false_of_coreClosed
         exprUsesArrayElement_eq_false_of_coreClosed hcore.1.1,
         exprUsesArrayElement_eq_false_of_coreClosed hcore.1.2,
         exprUsesArrayElement_eq_false_of_coreClosed hcore.2]
-  | bitNot a | tload a | calldataload a | mload a =>
+  | bitNot a | tload a | calldataload a | mload a | extcodesize a =>
       simp only [exprTouchesUnsupportedCoreSurface] at hcore
       simp [exprUsesArrayElement, exprUsesArrayElement_eq_false_of_coreClosed hcore]
   | ite cond thenVal elseVal =>
@@ -6118,7 +6115,7 @@ private theorem exprUsesStorageArrayElement_eq_false_of_coreClosed
         exprUsesStorageArrayElement_eq_false_of_coreClosed hcore.1.1,
         exprUsesStorageArrayElement_eq_false_of_coreClosed hcore.1.2,
         exprUsesStorageArrayElement_eq_false_of_coreClosed hcore.2]
-  | bitNot a | tload a | calldataload a | mload a =>
+  | bitNot a | tload a | calldataload a | mload a | extcodesize a =>
       simp only [exprTouchesUnsupportedCoreSurface] at hcore
       simp [exprUsesStorageArrayElement, exprUsesStorageArrayElement_eq_false_of_coreClosed hcore]
   | ite cond thenVal elseVal =>
@@ -6175,7 +6172,7 @@ private theorem exprUsesDynamicBytesEq_eq_false_of_coreClosed
         exprUsesDynamicBytesEq_eq_false_of_coreClosed hcore.1.1,
         exprUsesDynamicBytesEq_eq_false_of_coreClosed hcore.1.2,
         exprUsesDynamicBytesEq_eq_false_of_coreClosed hcore.2]
-  | bitNot a | tload a | calldataload a | mload a =>
+  | bitNot a | tload a | calldataload a | mload a | extcodesize a =>
       simp only [exprTouchesUnsupportedCoreSurface] at hcore
       simp [exprUsesDynamicBytesEq, exprUsesDynamicBytesEq_eq_false_of_coreClosed hcore]
   | ite cond thenVal elseVal =>
@@ -6222,7 +6219,7 @@ private theorem exprCompileCore_usesArrayElement_false
       simp only [exprUsesArrayElement, ihL, ihR, Bool.false_or]
   | mulDivDown _ _ _ ihA ihB ihC | mulDivUp _ _ _ ihA ihB ihC =>
       simp only [exprUsesArrayElement, ihA, ihB, ihC, Bool.false_or]
-  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih =>
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih =>
       simp only [exprUsesArrayElement, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesArrayElement, ihC, ihT, ihE, Bool.false_or]
@@ -6251,7 +6248,7 @@ private theorem exprCompileCore_usesStorageArrayElement_false
       simp only [exprUsesStorageArrayElement, ihL, ihR, Bool.false_or]
   | mulDivDown _ _ _ ihA ihB ihC | mulDivUp _ _ _ ihA ihB ihC =>
       simp only [exprUsesStorageArrayElement, ihA, ihB, ihC, Bool.false_or]
-  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih =>
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih =>
       simp only [exprUsesStorageArrayElement, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesStorageArrayElement, ihC, ihT, ihE, Bool.false_or]
@@ -6280,7 +6277,7 @@ private theorem exprCompileCore_usesDynamicBytesEq_false
       simp only [exprUsesDynamicBytesEq, ihL, ihR, Bool.false_or]
   | mulDivDown _ _ _ ihA ihB ihC | mulDivUp _ _ _ ihA ihB ihC =>
       simp only [exprUsesDynamicBytesEq, ihA, ihB, ihC, Bool.false_or]
-  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih =>
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih =>
       simp only [exprUsesDynamicBytesEq, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesDynamicBytesEq, ihC, ihT, ihE, Bool.false_or]
@@ -6991,7 +6988,7 @@ private theorem exprCompileCore_usesMulDiv512_false
       simp only [exprUsesMulDiv512, ihL, ihR, Bool.false_or]
   | mulDivDown _ _ _ ihA ihB ihC | mulDivUp _ _ _ ihA ihB ihC =>
       simp only [exprUsesMulDiv512, ihA, ihB, ihC, Bool.false_or]
-  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih =>
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih =>
       simp only [exprUsesMulDiv512, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesMulDiv512, ihC, ihT, ihE, Bool.false_or]
@@ -7020,7 +7017,7 @@ private theorem exprCompileCore_usesParamDynamicHeadWord_false
       simp only [exprUsesParamDynamicHeadWord, ihL, ihR, Bool.false_or]
   | mulDivDown _ _ _ ihA ihB ihC | mulDivUp _ _ _ ihA ihB ihC =>
       simp only [exprUsesParamDynamicHeadWord, ihA, ihB, ihC, Bool.false_or]
-  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih =>
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih =>
       simp only [exprUsesParamDynamicHeadWord, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesParamDynamicHeadWord, ihC, ihT, ihE, Bool.false_or]

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBodyClosure/Base.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBodyClosure/Base.lean
@@ -2861,7 +2861,7 @@ private theorem revertWithCustomError_zero_bridged
     · -- hashStmt: let __err_hash = keccak256(ident "__err_ptr", lit sigBytes.length)
       refine BridgedStmt.straight _ (BridgedStraightStmt.let_ _ _ ?_)
       refine BridgedExpr.call "keccak256" _
-        (Or.inr (Or.inr (Or.inr rfl))) ?_
+        (Or.inr (Or.inr (Or.inr (Or.inl rfl)))) ?_
       intro arg hArg
       simp only [List.mem_cons, List.not_mem_nil, or_false] at hArg
       rcases hArg with rfl | rfl

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgePredicates.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgePredicates.lean
@@ -31,7 +31,8 @@ def bridgedBuiltins : List String :=
 def unbridgedBuiltins : List String := []
 
 def allowedExprCallName (func : String) : Prop :=
-  func ∈ bridgedBuiltins ∨ func = "tload" ∨ func = "mload" ∨ func = "keccak256"
+  func ∈ bridgedBuiltins ∨ func = "tload" ∨ func = "mload" ∨ func = "keccak256" ∨
+  func = "extcodesize"
 
 inductive BridgedExpr : Compiler.Yul.YulExpr → Prop
   | lit (n : Nat) : BridgedExpr (.lit n)
@@ -261,7 +262,7 @@ theorem bridgedExpr_keccak256 (offsetExpr sizeExpr : Compiler.Yul.YulExpr)
     (hOffset : BridgedExpr offsetExpr) (hSize : BridgedExpr sizeExpr) :
     BridgedExpr
       (Compiler.Yul.YulExpr.call "keccak256" [offsetExpr, sizeExpr]) := by
-  refine BridgedExpr.call "keccak256" _ (Or.inr (Or.inr (Or.inr rfl))) ?_
+  refine BridgedExpr.call "keccak256" _ (Or.inr (Or.inr (Or.inr (Or.inl rfl)))) ?_
   intro arg hMem
   simp only [List.mem_cons, List.mem_nil_iff, or_false] at hMem
   rcases hMem with rfl | rfl
@@ -287,6 +288,16 @@ theorem bridgedExpr_tload (slotExpr : Compiler.Yul.YulExpr)
   simp only [List.mem_singleton] at hMem
   subst hMem
   exact hSlot
+
+theorem bridgedExpr_extcodesize (addrExpr : Compiler.Yul.YulExpr)
+    (hAddr : BridgedExpr addrExpr) :
+    BridgedExpr
+      (Compiler.Yul.YulExpr.call "extcodesize" [addrExpr]) := by
+  refine BridgedExpr.call "extcodesize" _ (Or.inr (Or.inr (Or.inr (Or.inr rfl)))) ?_
+  intro arg hMem
+  simp only [List.mem_singleton] at hMem
+  subst hMem
+  exact hAddr
 
 theorem bridgedStraightStmt_let_mload (name : String)
     (offsetExpr : Compiler.Yul.YulExpr) (hOffset : BridgedExpr offsetExpr) :

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness/Foundation.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness/Foundation.lean
@@ -4867,6 +4867,28 @@ theorem NativePrimCallPreservesWord_tload_values
       simp [EvmYul.Yul.primCall, step_tload_overarity_invalid])
     (fun slot => NativePrimCallPreservesWord_tload name expected slot)
 
+private theorem step_extcodesize_error
+    (state : EvmYul.Yul.State) (args : List EvmYul.Literal) :
+    (EvmYul.step (τ := .Yul) EvmYul.Operation.EXTCODESIZE none) state args =
+      .error .YulEXTCODESIZENotImplemented := by
+  rfl
+
+theorem NativePrimCallPreservesWord_extcodesize_values
+    (name : EvmYul.Identifier)
+    (expected : EvmYul.Literal) :
+    ∀ fuel state values final rets,
+      state[name]! = expected →
+        EvmYul.Yul.primCall fuel state EvmYul.Operation.EXTCODESIZE values =
+          .ok (final, rets) →
+        final[name]! = expected := by
+  intro fuel state values final rets hLookup hExec
+  cases fuel with
+  | zero => simp [EvmYul.Yul.primCall] at hExec
+  | succ fuel' =>
+      simp only [EvmYul.Yul.primCall] at hExec
+      rw [step_extcodesize_error] at hExec
+      simp at hExec
+
 theorem NativePrimCallPreservesWord_tstore
     (name : EvmYul.Identifier)
     (expected slot value : EvmYul.Literal) :
@@ -6027,7 +6049,7 @@ theorem lookupRuntimePrimOp_ne_none_of_allowed_of_ne_mappingSlot
     rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
     rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
     rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
-    rfl
+    rfl | rfl
   all_goals
     simp only [Backends.lookupRuntimePrimOp_add,
       Backends.lookupRuntimePrimOp_sub, Backends.lookupRuntimePrimOp_mul,
@@ -6051,7 +6073,8 @@ theorem lookupRuntimePrimOp_ne_none_of_allowed_of_ne_mappingSlot
       Backends.lookupRuntimePrimOp_returndatasize,
       Backends.lookupRuntimePrimOp_sload, Backends.lookupRuntimePrimOp_mappingSlot,
       Backends.lookupRuntimePrimOp_tload, Backends.lookupRuntimePrimOp_mload,
-      Backends.lookupRuntimePrimOp_keccak256]
+      Backends.lookupRuntimePrimOp_keccak256,
+      Backends.lookupRuntimePrimOp_extcodesize]
   all_goals first | contradiction | decide
 
 theorem NativePrimCallPreservesWord_of_allowed_lookupRuntimePrimOp
@@ -6073,7 +6096,7 @@ theorem NativePrimCallPreservesWord_of_allowed_lookupRuntimePrimOp
     rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
     rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
     rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
-    rfl
+    rfl | rfl
   all_goals
     simp only [Backends.lookupRuntimePrimOp_add,
       Backends.lookupRuntimePrimOp_sub, Backends.lookupRuntimePrimOp_mul,
@@ -6097,7 +6120,8 @@ theorem NativePrimCallPreservesWord_of_allowed_lookupRuntimePrimOp
       Backends.lookupRuntimePrimOp_returndatasize,
       Backends.lookupRuntimePrimOp_sload, Backends.lookupRuntimePrimOp_mappingSlot,
       Backends.lookupRuntimePrimOp_tload, Backends.lookupRuntimePrimOp_mload,
-      Backends.lookupRuntimePrimOp_keccak256, Option.some.injEq] at hOp
+      Backends.lookupRuntimePrimOp_keccak256,
+      Backends.lookupRuntimePrimOp_extcodesize, Option.some.injEq] at hOp
   all_goals cases hOp
   all_goals first
     | exact NativePrimCallPreservesWord_add_values name expected
@@ -6140,6 +6164,7 @@ theorem NativePrimCallPreservesWord_of_allowed_lookupRuntimePrimOp
     | exact NativePrimCallPreservesWord_mload_values name expected
     | exact NativePrimCallPreservesWord_sload_values name expected
     | exact NativePrimCallPreservesWord_tload_values name expected
+    | exact NativePrimCallPreservesWord_extcodesize_values name expected
 
 theorem NativeExprPreservesWord_var
     (name : EvmYul.Identifier)

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeLowering.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeLowering.lean
@@ -175,6 +175,7 @@ theorem lookupRuntimePrimOp_chainid : lookupRuntimePrimOp "chainid" = some .CHAI
 theorem lookupRuntimePrimOp_blobbasefee : lookupRuntimePrimOp "blobbasefee" = some .BLOBBASEFEE := by rfl
 theorem lookupRuntimePrimOp_tload : lookupRuntimePrimOp "tload" = some .TLOAD := by rfl
 theorem lookupRuntimePrimOp_mload : lookupRuntimePrimOp "mload" = some .MLOAD := by rfl
+theorem lookupRuntimePrimOp_extcodesize : lookupRuntimePrimOp "extcodesize" = some .EXTCODESIZE := by rfl
 theorem lookupRuntimePrimOp_mappingSlot : lookupRuntimePrimOp "mappingSlot" = none := by rfl
 
 def lowerExprNative : YulExpr → EvmYul.Yul.Ast.Expr

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanSourceExprClosure.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanSourceExprClosure.lean
@@ -164,6 +164,8 @@ inductive BridgedSourceExpr : Expr → Prop
       BridgedSourceExpr (.mload offset)
   | tload {offset} (hOffset : BridgedSourceExpr offset) :
       BridgedSourceExpr (.tload offset)
+  | extcodesize {addr} (hAddr : BridgedSourceExpr addr) :
+      BridgedSourceExpr (.extcodesize addr)
   | keccak256 {offset size}
       (hOffset : BridgedSourceExpr offset) (hSize : BridgedSourceExpr size) :
       BridgedSourceExpr (.keccak256 offset size)
@@ -1360,6 +1362,12 @@ theorem compileExpr_bridgedSource
       obtain ⟨co, hO, hEq⟩ := compileExpr_unopBuiltin_ok hOk
       subst hEq
       exact bridgedExpr_tload co (iho hO)
+  | extcodesize _ iha =>
+      intro out hOk
+      simp only [compileExpr, compileExprWithInternals] at hOk
+      obtain ⟨co, hO, hEq⟩ := compileExpr_unopBuiltin_ok hOk
+      subst hEq
+      exact bridgedExpr_extcodesize co (iha hO)
   | keccak256 _ _ ihOffset ihSize =>
       intro out hOk
       simp only [compileExpr, compileExprWithInternals] at hOk
@@ -1741,6 +1749,9 @@ theorem compileRequireFailCond_bridgedSource
         hOk
   | tload hOffset =>
       exact compileRequireFailCond_default_bridgedSource (.tload hOffset)
+        hOk
+  | extcodesize hAddr =>
+      exact compileRequireFailCond_default_bridgedSource (.extcodesize hAddr)
         hOk
   | keccak256 hOffset hSize =>
       exact compileRequireFailCond_default_bridgedSource (.keccak256 hOffset hSize)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2958,6 +2958,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.FunctionBody.compileExpr_keccak256_ok
   -- Compiler.Proofs.IRGeneration.FunctionBody.eval_compileExpr_keccak256_of_compiled  -- private
   -- Compiler.Proofs.IRGeneration.FunctionBody.eval_compileExpr_mload_of_compiled  -- private
+  Compiler.Proofs.IRGeneration.FunctionBody.compileExpr_extcodesize_ok
+  -- Compiler.Proofs.IRGeneration.FunctionBody.eval_compileExpr_extcodesize_of_compiled  -- private
   Compiler.Proofs.IRGeneration.FunctionBody.compileExpr_tload_ok
   -- Compiler.Proofs.IRGeneration.FunctionBody.calldataloadWord_lt_evmModulus  -- private
   Compiler.Proofs.IRGeneration.FunctionBody.runtimeStateMatchesIR_calldatacopyBothMemory
@@ -3990,6 +3992,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.IRState.appendYulLog_events
   Compiler.Proofs.IRGeneration.evalIRCall_tload_singleton
   Compiler.Proofs.IRGeneration.evalIRCall_mload_singleton
+  Compiler.Proofs.IRGeneration.evalIRCall_extcodesize_singleton
   Compiler.Proofs.IRGeneration.evalIRCall_calldataload_singleton
   Compiler.Proofs.IRGeneration.evalIRCall_sload_singleton
   Compiler.Proofs.IRGeneration.prepareInternalCalleeState_vars
@@ -7369,4 +7372,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6819 theorems/lemmas (4889 public, 1930 private, 0 sorry'd)
+-- Total: 6822 theorems/lemmas (4891 public, 1931 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -5669,6 +5669,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.bridgedExpr_keccak256
   Compiler.Proofs.YulGeneration.Backends.bridgedExpr_mload
   Compiler.Proofs.YulGeneration.Backends.bridgedExpr_tload
+  Compiler.Proofs.YulGeneration.Backends.bridgedExpr_extcodesize
   Compiler.Proofs.YulGeneration.Backends.bridgedStraightStmt_let_mload
   Compiler.Proofs.YulGeneration.Backends.bridgedStraightStmt_let_tload
   Compiler.Proofs.YulGeneration.Backends.bridgedStraightStmt_let_keccak256
@@ -6064,6 +6065,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.Native.NativePrimCallPreservesWord_mstore8_values
   Compiler.Proofs.YulGeneration.Backends.Native.NativePrimCallPreservesWord_tload
   Compiler.Proofs.YulGeneration.Backends.Native.NativePrimCallPreservesWord_tload_values
+  -- Compiler.Proofs.YulGeneration.Backends.Native.step_extcodesize_error  -- private
+  Compiler.Proofs.YulGeneration.Backends.Native.NativePrimCallPreservesWord_extcodesize_values
   Compiler.Proofs.YulGeneration.Backends.Native.NativePrimCallPreservesWord_tstore
   Compiler.Proofs.YulGeneration.Backends.Native.NativePrimCallPreservesWord_tstore_values
   Compiler.Proofs.YulGeneration.Backends.Native.NativePrimCallPreservesWord_sstore
@@ -6742,6 +6745,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.lookupRuntimePrimOp_blobbasefee
   Compiler.Proofs.YulGeneration.Backends.lookupRuntimePrimOp_tload
   Compiler.Proofs.YulGeneration.Backends.lookupRuntimePrimOp_mload
+  Compiler.Proofs.YulGeneration.Backends.lookupRuntimePrimOp_extcodesize
   Compiler.Proofs.YulGeneration.Backends.lookupRuntimePrimOp_mappingSlot
   Compiler.Proofs.YulGeneration.Backends.lowerExprNative_call_runtimePrimOp
   Compiler.Proofs.YulGeneration.Backends.lowerExprNative_call_userFunction
@@ -7372,4 +7376,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6822 theorems/lemmas (4891 public, 1931 private, 0 sorry'd)
+-- Total: 6826 theorems/lemmas (4894 public, 1932 private, 0 sorry'd)

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -349,6 +349,7 @@ structure ContractState where
       callee's outcome in-band (`ExternalCallResult.control`) instead of
       raising a monadic revert. -/
   calls : List ExternalCall := []
+  codeSize : Nat → Uint256 := fun _ => 0
 
 namespace ContractState
 

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -497,6 +497,8 @@ def writeMap (s : ContractState) (slot : Nat) (key : Address) (value : Uint256) 
     (s.writeSlot slot value).events = s.events := rfl
 @[simp] theorem calls_writeSlot (s : ContractState) (slot : Nat) (value : Uint256) :
     (s.writeSlot slot value).calls = s.calls := rfl
+@[simp] theorem codeSize_writeSlot (s : ContractState) (slot : Nat) (value : Uint256) :
+    (s.writeSlot slot value).codeSize = s.codeSize := rfl
 
 @[simp] theorem storageWords_writeSlot (s : ContractState) (slot : Nat) (value : Uint256)
     (key : StorageKey) :
@@ -721,6 +723,9 @@ def writeMap (s : ContractState) (slot : Nat) (key : Address) (value : Uint256) 
 @[simp] theorem calls_writeMap (s : ContractState) (slot : Nat) (key : Address)
     (value : Uint256) :
     (s.writeMap slot key value).calls = s.calls := rfl
+@[simp] theorem codeSize_writeMap (s : ContractState) (slot : Nat) (key : Address)
+    (value : Uint256) :
+    (s.writeMap slot key value).codeSize = s.codeSize := rfl
 
 @[simp] theorem storageWords_writeMap (s : ContractState) (slot : Nat) (key : Address)
     (value : Uint256) (storageKey : StorageKey) :
@@ -768,6 +773,8 @@ def writeMapUint (s : ContractState) (slot : Nat) (key : Uint256) (value : Uint2
     (s.writeMapUint slot key value).blockNumber = s.blockNumber := rfl
 @[simp] theorem events_writeMapUint (s : ContractState) (slot : Nat) (key value : Uint256) :
     (s.writeMapUint slot key value).events = s.events := rfl
+@[simp] theorem codeSize_writeMapUint (s : ContractState) (slot : Nat) (key value : Uint256) :
+    (s.writeMapUint slot key value).codeSize = s.codeSize := rfl
 
 def readMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) : Uint256 :=
   s.storageMap2 slot key1 key2
@@ -816,6 +823,8 @@ def writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) (value : Ui
     (s.writeMap2 slot key1 key2 value).blockNumber = s.blockNumber := rfl
 @[simp] theorem events_writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) (value : Uint256) :
     (s.writeMap2 slot key1 key2 value).events = s.events := rfl
+@[simp] theorem codeSize_writeMap2 (s : ContractState) (slot : Nat) (key1 key2 : Address) (value : Uint256) :
+    (s.writeMap2 slot key1 key2 value).codeSize = s.codeSize := rfl
 
 def readArray (s : ContractState) (slot : Nat) : List Uint256 :=
   s.storageArray slot
@@ -955,6 +964,9 @@ private theorem not_mem_of_contains_false {α : Type} [BEq α] [LawfulBEq α]
 @[simp] theorem calldata_modifySlots (s : ContractState) (targets : List Nat)
     (f : Uint256 → Uint256) :
     (s.modifySlots targets f).calldata = s.calldata := rfl
+@[simp] theorem codeSize_modifySlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifySlots targets f).codeSize = s.codeSize := rfl
 
 @[simp] theorem storageArray_writeSlots (s : ContractState) (targets : List Nat)
     (value : Uint256) :
@@ -1166,6 +1178,9 @@ private theorem not_mem_of_contains_false {α : Type} [BEq α] [LawfulBEq α]
 @[simp] theorem calls_modifyTransientSlots (s : ContractState) (targets : List Nat)
     (f : Uint256 → Uint256) :
     (s.modifyTransientSlots targets f).calls = s.calls := rfl
+@[simp] theorem codeSize_modifyTransientSlots (s : ContractState) (targets : List Nat)
+    (f : Uint256 → Uint256) :
+    (s.modifyTransientSlots targets f).codeSize = s.codeSize := rfl
 
 @[simp] theorem storage_withStorageChannel (s : ContractState)
     (f : (Nat → Uint256) → Nat → Uint256) :

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -987,7 +987,7 @@ def evalExpr (oracle : DenoteOracle) (fields : List Field) (state : DenoteState)
       some (calldataloadWord state.selector state.world.calldata resolvedOffset)
   | .extcodesize addr => do
       let resolvedAddr ← evalExpr oracle fields state addr
-      some (state.world.codeSize resolvedAddr).val
+      some (state.world.codeSize (resolvedAddr % Compiler.Constants.addressModulus)).val
   | .keccak256 offExpr sizeExpr => do
       let off ← evalExpr oracle fields state offExpr
       let size ← evalExpr oracle fields state sizeExpr

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -985,6 +985,9 @@ def evalExpr (oracle : DenoteOracle) (fields : List Field) (state : DenoteState)
   | .calldataload offset => do
       let resolvedOffset ← evalExpr oracle fields state offset
       some (calldataloadWord state.selector state.world.calldata resolvedOffset)
+  | .extcodesize addr => do
+      let resolvedAddr ← evalExpr oracle fields state addr
+      some (state.world.codeSize resolvedAddr).val
   | .keccak256 offExpr sizeExpr => do
       let off ← evalExpr oracle fields state offExpr
       let size ← evalExpr oracle fields state sizeExpr

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 483,
+    "native_decide": 485,
     "partial def": 171
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,6 +1,6 @@
 {
   "codebase": {
-    "core_lines": 1991,
+    "core_lines": 2007,
     "example_contracts": 18
   },
   "proofs": {


### PR DESCRIPTION
## Summary

- Model `extcodesize` in source semantics (`SourceSemantics.evalExpr`), IR semantics (`evalIRCall`/`evalIRCallWithInternals`), and `Denote.evalExpr`
- Add `codeSize` field to `ContractState` and `IRState`, with 17th conjunct in `runtimeStateMatchesIR`/`constructorRuntimeStateMatchesIR`
- Add `ExprCompileCore.extcodesize` constructor and close compilation proof (`compileExpr_extcodesize_ok`, `eval_compileExpr_extcodesize_of_compiled`)
- Move `extcodesize` from leaf/unsupported to recursive in all 8+ surface predicates and propagate through ~30 proof sites
- Add `codeSize_` @[simp] lemmas for `writeSlot`, `writeMap`, `writeMapUint`, `writeMap2`, `modifySlots`, `modifyTransientSlots`

Closes the extcodesize slice of #2084. Zero new `sorry`/`admit`/`axiom`/`unsafe`.

## Test plan

- [x] `lake build` passes (2473 jobs)
- [x] `make check` passes (all lint, axioms, trust surface, verification status)
- [x] Forbidden-escape scan clean (`sorry`/`admit`/`axiom`/`unsafe`)
- [ ] `lake build PrintAxioms` (building)
- [ ] CI green

@codex review