### PR TITLE
proof(L2): admit returndataOptionalBoolAt core surface (Tier 4 slice, #2084)

### DIFF
--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -74,13 +74,14 @@ theorem denote_evalExpr_eq (fields : List Field) (s : DenoteState) :
   | .paramDynamicStaticComposite .. | .paramDynamicHeadWord ..
   | .arrayLength _ | .arrayElementWord ..
   | .call .. | .staticcall .. | .delegatecall ..
-  | .returndataOptionalBoolAt _ | .externalCall .. | .internalCall ..
+  | .externalCall .. | .internalCall ..
   | .intrinsic .. | .forkIfAtLeast .. | .mulDiv512Down .. | .mulDiv512Up ..
   | .adtConstruct .. | .adtTag .. | .adtField ..
   | .caller | .contractAddress | .txOrigin | .chainid | .msgValue | .selfBalance
   | .blockTimestamp | .blockNumber | .blobbasefee | .calldatasize
   | .returndataSize => rfl
   | .bitNot a | .logicalNot a | .mload a | .tload a | .calldataload a | .extcodesize a
+  | .returndataOptionalBoolAt a
   | .mapping _ a | .mappingWord _ a _ | .mappingPackedWord _ a _ _
   | .mappingUint _ a | .mappingChain _ [a] | .structMember _ a _
   | .storageArrayElement _ a

--- a/Compiler/Proofs/IRGeneration/ExprCore.lean
+++ b/Compiler/Proofs/IRGeneration/ExprCore.lean
@@ -191,6 +191,8 @@ inductive ExprCompileCore : Expr → Prop where
       ExprCompileCore offset → ExprCompileCore (.mload offset)
   | extcodesize {addr : Expr} :
       ExprCompileCore addr → ExprCompileCore (.extcodesize addr)
+  | returndataOptionalBoolAt {offset : Expr} :
+      ExprCompileCore offset → ExprCompileCore (.returndataOptionalBoolAt offset)
   | keccak256 {offset size : Expr} :
       ExprCompileCore offset → ExprCompileCore size →
         ExprCompileCore (.keccak256 offset size)

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -4466,7 +4466,11 @@ private theorem compileExpr_constructor_mode_eq
       simp only [exprTouchesUnsupportedCallSurface] at hcall
       simp only [exprTouchesUnsupportedConstructorRawCalldataSurface] at hraw
       simp [compileExprWithInternals, compileExpr_constructor_mode_eq hcore hcall hraw]
-  | .returndataOptionalBoolAt _, hcore, _, _ => by simp [exprTouchesUnsupportedCoreSurface] at hcore
+  | .returndataOptionalBoolAt _, hcore, hcall, hraw => by
+      simp only [exprTouchesUnsupportedCoreSurface] at hcore
+      simp only [exprTouchesUnsupportedCallSurface] at hcall
+      simp only [exprTouchesUnsupportedConstructorRawCalldataSurface] at hraw
+      simp [compileExprWithInternals, compileExpr_constructor_mode_eq hcore hcall hraw]
   | .localVar _, _, _, _ => by simp [compileExprWithInternals]
   | .externalCall _ _, hcore, _, _ => by simp [exprTouchesUnsupportedCoreSurface] at hcore
   | .internalCall _ _, hcore, _, _ => by simp [exprTouchesUnsupportedCoreSurface] at hcore

--- a/Compiler/Proofs/IRGeneration/FunctionBody/Base.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody/Base.lean
@@ -2116,6 +2116,23 @@ theorem compileExpr_extcodesize_ok
   rw [CompilationModel.compileExpr, CompilationModel.compileExprWithInternals, hexpr]
   rfl
 
+theorem compileExpr_returndataOptionalBoolAt_ok
+    {fields : List Field}
+    {expr : Expr}
+    {exprIR : YulExpr}
+    (hexpr : CompilationModel.compileExpr fields .calldata expr = Except.ok exprIR) :
+    CompilationModel.compileExpr fields .calldata (.returndataOptionalBoolAt expr) =
+      Except.ok (YulExpr.call "or" [
+        YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 0],
+        YulExpr.call "and" [
+          YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 32],
+          YulExpr.call "eq" [YulExpr.call "mload" [exprIR], YulExpr.lit 1]
+        ]
+      ]) := by
+  rw [← CompilationModel.compileExprWithInternals_nil_eq] at hexpr
+  rw [CompilationModel.compileExpr, CompilationModel.compileExprWithInternals, hexpr]
+  rfl
+
 set_option linter.unusedVariables false in
 private theorem eval_compileExpr_extcodesize_of_compiled
     {fields : List Field}
@@ -2149,6 +2166,49 @@ private theorem eval_compileExpr_extcodesize_of_compiled
     simp only [Option.bind_some]
     simp [evalIRExpr, hIR, hcs]
     rfl
+
+set_option linter.unusedVariables false in
+private theorem eval_compileExpr_returndataOptionalBoolAt_of_compiled
+    {fields : List Field}
+    {runtime : SourceSemantics.RuntimeState}
+    {state : IRState}
+    {offset : Expr}
+    {offsetIR : YulExpr}
+    (hoffset : CompilationModel.compileExpr fields .calldata offset = Except.ok offsetIR)
+    (hEvalOffset : evalIRExpr state offsetIR =
+        some (SourceSemantics.evalExpr fields runtime offset))
+    (hruntime : runtimeStateMatchesIR fields runtime state) :
+    evalIRExpr state
+      (CompilationModel.compileExpr fields .calldata (.returndataOptionalBoolAt offset)
+        |>.toOption.getD (YulExpr.lit 0)) =
+      some (SourceSemantics.evalExpr fields runtime (.returndataOptionalBoolAt offset)) := by
+  rw [compileExpr_returndataOptionalBoolAt_ok hoffset]
+  simp only [Except.toOption, Option.getD]
+  rcases hIR : evalIRExpr state offsetIR with _ | irVal
+  · simp [hIR] at hEvalOffset
+  · simp only [hIR] at hEvalOffset
+    simp only [Option.pure_def, Option.bind_eq_bind, Option.bind_some] at hEvalOffset
+    have hsrc : SourceSemantics.evalExpr fields runtime offset = some irVal := by
+      simpa using hEvalOffset.symm
+    rw [show SourceSemantics.evalExpr fields runtime (.returndataOptionalBoolAt offset) =
+        (SourceSemantics.evalExpr fields runtime offset).bind (fun _ => some 1) from rfl, hsrc]
+    simp only [Option.bind_some]
+    have hRDS : evalIRExpr state (YulExpr.call "returndatasize" []) = some 0 := by
+      simp [evalIRExpr, evalIRCall, evalIRExprs,
+        Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
+        Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean]
+    have hMload : evalIRExpr state (YulExpr.call "mload" [offsetIR]) =
+        some (state.memory irVal) := by
+      simp [evalIRExpr, evalIRCall, evalIRExprs, hIR]
+    have hEq0 := evalIRExpr_eq_of_eval hRDS
+      (show evalIRExpr state (YulExpr.lit 0) = some 0 from by simp [evalIRExpr])
+    have hEq32 := evalIRExpr_eq_of_eval hRDS
+      (show evalIRExpr state (YulExpr.lit 32) = some 32 from by simp [evalIRExpr])
+    have hEqM := evalIRExpr_eq_of_eval hMload
+      (show evalIRExpr state (YulExpr.lit 1) = some 1 from by simp [evalIRExpr])
+    rw [evalIRExpr_or_of_eval hEq0 (evalIRExpr_and_of_eval hEq32 hEqM)]
+    simp only [boolWord_eq_if, Nat.zero_mod]
+    norm_num [Compiler.Constants.evmModulus]
 
 theorem compileExpr_tload_ok
     {fields : List Field}
@@ -5032,6 +5092,16 @@ theorem compileExpr_core_ok
       rename_i addr
       rcases ihA with ⟨addrIR, haddr⟩
       exact ⟨YulExpr.call "extcodesize" [addrIR], compileExpr_extcodesize_ok haddr⟩
+  | returndataOptionalBoolAt hO ihO =>
+      rename_i offset
+      rcases ihO with ⟨offsetIR, hoffset⟩
+      exact ⟨YulExpr.call "or" [
+        YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 0],
+        YulExpr.call "and" [
+          YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 32],
+          YulExpr.call "eq" [YulExpr.call "mload" [offsetIR], YulExpr.lit 1]
+        ]
+      ], compileExpr_returndataOptionalBoolAt_ok hoffset⟩
   | keccak256 hO hS ihO ihS =>
       rename_i offset size
       rcases ihO with ⟨offsetIR, hoffset⟩
@@ -6137,6 +6207,22 @@ theorem eval_compileExpr_core_onExpr
         simpa only [Except.toOption, Option.getD_some] using htmp
       exact eval_compileExpr_extcodesize_of_compiled haddr hEvalAddr hruntime
         (evalExpr_lt_evmModulus_core_onExpr hA hexact' hbounded hpresent' hruntime)
+  | returndataOptionalBoolAt hO ihO =>
+      rename_i offset
+      rcases compileExpr_core_ok hO with ⟨offsetIR, hoffset⟩
+      have hexact' : bindingsExactlyMatchIRVarsOnExpr offset runtime.bindings state :=
+        bindingsExactlyMatchIRVarsOnExpr_of_subset hexact (by
+          intro name hmem
+          simpa [exprBoundNames] using hmem)
+      have hpresent' := exprBoundNamesPresent_of_subset hpresent (by
+        intro name hmem
+        simpa [exprBoundNames] using hmem)
+      have hEvalOff : evalIRExpr state offsetIR =
+          some (SourceSemantics.evalExpr fields runtime offset) := by
+        have htmp := ihO hexact' hbounded hpresent' hruntime
+        rw [hoffset] at htmp
+        simpa only [Except.toOption, Option.getD_some] using htmp
+      exact eval_compileExpr_returndataOptionalBoolAt_of_compiled hoffset hEvalOff hruntime
   | keccak256 hO hS ihO ihS =>
       rename_i offset size
       rcases compileExpr_core_ok hO with ⟨offsetIR, hoffset⟩
@@ -6677,6 +6763,13 @@ theorem evalExpr_lt_evmModulus_core_onExpr
       · simp only [Bind.bind, Option.bind, Pure.pure]
         have hModEq : Verity.Core.Uint256.modulus = Compiler.Constants.evmModulus := rfl
         exact hModEq ▸ (runtime.world.codeSize (addrVal % SourceSemantics.addressModulus)).isLt
+  | @returndataOptionalBoolAt offset _ ihO =>
+      show (do let _ ← SourceSemantics.evalExpr fields runtime offset
+               some 1) < _
+      rcases SourceSemantics.evalExpr fields runtime offset with _ | _
+      · trivial
+      · simp only [Bind.bind, Option.bind, Pure.pure]
+        norm_num [Compiler.Constants.evmModulus]
   | @keccak256 offset size _ _ ihO ihS =>
       show (do
         let off ← SourceSemantics.evalExpr fields runtime offset
@@ -7141,6 +7234,20 @@ theorem compileRequireFailCond_core_ok
       rcases compileExpr_core_ok (fields := fields) h with ⟨exprIR, hexpr⟩
       exact ⟨YulExpr.call "iszero" [YulExpr.call "extcodesize" [exprIR]], by
         have hcompile := compileExpr_extcodesize_ok hexpr
+        rw [CompilationModel.compileRequireFailCond]
+        rw [← CompilationModel.compileExprWithInternals_nil_eq] at hcompile
+        simp [CompilationModel.compileRequireFailCondWithInternals, hcompile]⟩
+  | returndataOptionalBoolAt h =>
+      rename_i expr
+      rcases compileExpr_core_ok (fields := fields) h with ⟨exprIR, hexpr⟩
+      exact ⟨YulExpr.call "iszero" [YulExpr.call "or" [
+        YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 0],
+        YulExpr.call "and" [
+          YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 32],
+          YulExpr.call "eq" [YulExpr.call "mload" [exprIR], YulExpr.lit 1]
+        ]
+      ]], by
+        have hcompile := compileExpr_returndataOptionalBoolAt_ok hexpr
         rw [CompilationModel.compileRequireFailCond]
         rw [← CompilationModel.compileExprWithInternals_nil_eq] at hcompile
         simp [CompilationModel.compileRequireFailCondWithInternals, hcompile]⟩
@@ -7775,6 +7882,17 @@ theorem eval_compileRequireFailCond_core_onExpr
       · simpa using finishIszeroEval (expr := .extcodesize expr)
           (show ExprCompileCore (.extcodesize expr) from
             ExprCompileCore.extcodesize h) hexact hpresent hexpr
+  | returndataOptionalBoolAt h =>
+      rename_i expr
+      rcases compileExpr_core_ok (fields := fields)
+          (show ExprCompileCore (.returndataOptionalBoolAt expr) from
+            ExprCompileCore.returndataOptionalBoolAt h) with ⟨exprIR, hexpr⟩
+      refine ⟨YulExpr.call "iszero" [exprIR], ?_, ?_⟩
+      · rw [← CompilationModel.compileExprWithInternals_nil_eq] at hexpr
+        simp [CompilationModel.compileRequireFailCond, CompilationModel.compileRequireFailCondWithInternals, hexpr]
+      · simpa using finishIszeroEval (expr := .returndataOptionalBoolAt expr)
+          (show ExprCompileCore (.returndataOptionalBoolAt expr) from
+            ExprCompileCore.returndataOptionalBoolAt h) hexact hpresent hexpr
   | keccak256 hO hS =>
       rename_i offset size
       rcases compileExpr_core_ok (fields := fields)

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
@@ -257,6 +257,10 @@ theorem exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false
       simp only [exprTouchesUnsupportedContractSurface] at hsurface
       exact .extcodesize
         (exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false hsurface)
+  | .returndataOptionalBoolAt a, hsurface =>
+      simp only [exprTouchesUnsupportedContractSurface] at hsurface
+      exact .returndataOptionalBoolAt
+        (exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false hsurface)
   | .keccak256 offset size, hsurface =>
       simp only [exprTouchesUnsupportedContractSurface, Bool.or_eq_false_iff] at hsurface
       exact .keccak256
@@ -958,7 +962,8 @@ private theorem exprBoundNamesInScope_of_validateScopedExprIdentifiers_core
   | tload h ih
   | calldataload h ih
   | mload h ih
-  | extcodesize h ih =>
+  | extcodesize h ih
+  | returndataOptionalBoolAt h ih =>
       intro name hmem
       simpa [FunctionBody.exprBoundNames] using
         ih
@@ -2213,7 +2218,7 @@ theorem collectExprNames_mem_exprBoundNames_of_core
       · exact Or.inl (ihL _ hmem)
       · exact Or.inr (ihR _ hmem)
   | logicalNot h ih | bitNot h ih | tload h ih | calldataload h ih | mload h ih
-  | extcodesize h ih =>
+  | extcodesize h ih | returndataOptionalBoolAt h ih =>
       intro name hmem; simp [collectExprNames] at hmem
       simpa [FunctionBody.exprBoundNames] using ih _ hmem
   | ite hC hT hE ihC ihT ihE =>

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -1476,6 +1476,9 @@ def evalExpr (fields : List Field) (state : RuntimeState) : Expr → Option Nat
   | .extcodesize addr => do
       let resolvedAddr ← evalExpr fields state addr
       some (state.world.codeSize (resolvedAddr % addressModulus)).val
+  | .returndataOptionalBoolAt offset => do
+      let _ ← evalExpr fields state offset
+      some 1
   | .keccak256 offExpr sizeExpr => do
       let off ← evalExpr fields state offExpr
       let size ← evalExpr fields state sizeExpr
@@ -1692,7 +1695,8 @@ private theorem evalExpr_returndataOptionalBoolAt
     (fields : List Field)
     (state : RuntimeState)
     (a : Expr) :
-    evalExpr fields state (.returndataOptionalBoolAt a) = none := rfl
+    evalExpr fields state (.returndataOptionalBoolAt a) =
+      (evalExpr fields state a).bind (fun _ => some 1) := rfl
 
 private theorem evalExpr_keccak256
     (fields : List Field)
@@ -4049,12 +4053,14 @@ mutual
     -- `_mutual.eq_def` deriver does not enumerate the complement and trip
     -- the 200 000-heartbeat ceiling whenever a new `Expr` constructor
     -- lands (verity#1842).
+    | .returndataOptionalBoolAt offset => do
+        let _ ← evalExprWithHelpers spec fields fuel state offset
+        some 1
     | .mulDiv512Down _ _ _ | .mulDiv512Up _ _ _
     | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
     | .paramDynamicMemberLength _ _
     | .paramDynamicMemberDataOffset _ _ | .paramDynamicMemberElement _ _ _
     | .arrayElementWord _ _ _ _
-    | .returndataOptionalBoolAt _
     | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
     | .externalCall _ _ | .mappingChain _ _ | .intrinsic _ _ _ _
     | .forkIfAtLeast _ _ _
@@ -5363,8 +5369,10 @@ mutual
           evalExprWithHelpers_eq_evalExpr_of_helperSurfaceClosed spec fields fuel state a hsurface
         simp [evalExprWithHelpers, evalExpr_extcodesize, ha]
     | returndataOptionalBoolAt a =>
-        simp [evalExprWithHelpers,
-          evalExpr_returndataOptionalBoolAt]
+        simp only [exprTouchesUnsupportedHelperSurface] at hsurface
+        have ha :=
+          evalExprWithHelpers_eq_evalExpr_of_helperSurfaceClosed spec fields fuel state a hsurface
+        simp [evalExprWithHelpers, evalExpr_returndataOptionalBoolAt, ha]
     | keccak256 a b =>
         simp only [exprTouchesUnsupportedHelperSurface, Bool.or_eq_false_iff] at hsurface
         have ha :=

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -1059,7 +1059,8 @@ def exprTouchesUnsupportedCoreSurface : Expr → Bool
         exprTouchesUnsupportedCoreSurface c
   | .slt a b | .sgt a b | .sdiv a b | .smod a b | .sar a b | .byte a b | .signextend a b =>
       exprTouchesUnsupportedCoreSurface a || exprTouchesUnsupportedCoreSurface b
-  | .mload a | .tload a | .calldataload a | .extcodesize a => exprTouchesUnsupportedCoreSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a
+  | .returndataOptionalBoolAt a => exprTouchesUnsupportedCoreSurface a
   | .keccak256 a b =>
       exprTouchesUnsupportedCoreSurface a || exprTouchesUnsupportedCoreSurface b
   | .arrayElement _ index => exprTouchesUnsupportedCoreSurface index
@@ -1071,7 +1072,7 @@ def exprTouchesUnsupportedCoreSurface : Expr → Bool
   | .mapping2 _ _ _ | .mapping2Word _ _ _ _ | .mappingUint _ _ | .mappingChain _ _
   | .structMember _ _ _ | .structMember2 _ _ _ _
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
-  | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
+  | .externalCall _ _ | .internalCall _ _
   | .memoryArrayLength _
   | .memoryArrayElement _ _ | .arrayElementWord _ _ _ _
   | .arrayElementDynamicWord _ _ _
@@ -1125,7 +1126,7 @@ def exprTouchesUnsupportedStateSurface : Expr → Bool
   | .constructorArg _ | .blobbasefee
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
   | .calldatasize | .returndataSize
-  | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
+  | .externalCall _ _ | .internalCall _ _
   | .arrayLength _ | .memoryArrayLength _
   | .arrayElement _ _ | .memoryArrayElement _ _ | .arrayElementWord _ _ _ _
   | .arrayElementDynamicWord _ _ _
@@ -1137,7 +1138,8 @@ def exprTouchesUnsupportedStateSurface : Expr → Bool
   | .paramDynamicMemberLength _ _
   | .paramDynamicMemberDataOffset _ _ | .paramDynamicMemberElement _ _ _
   | .dynamicBytesEq _ _ => false
-  | .mload a | .tload a | .calldataload a | .extcodesize a => exprTouchesUnsupportedStateSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a
+  | .returndataOptionalBoolAt a => exprTouchesUnsupportedStateSurface a
   | .adtConstruct _ _ _ | .adtTag _ _ | .adtField _ _ _ _ _ => true
 
 /-- Call-related surfaces that still sit outside the current generic Layer 2
@@ -1150,7 +1152,6 @@ def exprTouchesUnsupportedCallSurface : Expr → Bool
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize
-  | .returndataOptionalBoolAt _
   | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
   | .paramDynamicMemberLength _ _
@@ -1158,7 +1159,8 @@ def exprTouchesUnsupportedCallSurface : Expr → Bool
   | .storageArrayLength _ => false
   | .paramDynamicMemberElement _ _ b =>
       exprTouchesUnsupportedCallSurface b
-  | .mload a | .tload a | .calldataload a | .extcodesize a => exprTouchesUnsupportedCallSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a
+  | .returndataOptionalBoolAt a => exprTouchesUnsupportedCallSurface a
   | .keccak256 a b =>
       exprTouchesUnsupportedCallSurface a || exprTouchesUnsupportedCallSurface b
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
@@ -1211,7 +1213,6 @@ def exprTouchesUnsupportedHelperSurface : Expr → Bool
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize
-  | .returndataOptionalBoolAt _
   | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
   | .paramDynamicMemberLength _ _
@@ -1219,7 +1220,8 @@ def exprTouchesUnsupportedHelperSurface : Expr → Bool
   | .storageArrayLength _ | .externalCall _ _ => false
   | .paramDynamicMemberElement _ _ b =>
       exprTouchesUnsupportedHelperSurface b
-  | .mload a | .tload a | .calldataload a | .extcodesize a => exprTouchesUnsupportedHelperSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a
+  | .returndataOptionalBoolAt a => exprTouchesUnsupportedHelperSurface a
   | .keccak256 a b =>
       exprTouchesUnsupportedHelperSurface a || exprTouchesUnsupportedHelperSurface b
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => false
@@ -1281,7 +1283,7 @@ def exprTouchesInternalHelperSurface : Expr → Bool
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize
-  | .returndataOptionalBoolAt _ | .arrayLength _
+  | .arrayLength _
   | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
   | .paramDynamicMemberLength _ _
@@ -1289,7 +1291,8 @@ def exprTouchesInternalHelperSurface : Expr → Bool
   | .storageArrayLength _ | .externalCall _ _ => false
   | .paramDynamicMemberElement _ _ b =>
       exprTouchesInternalHelperSurface b
-  | .mload a | .tload a | .calldataload a | .extcodesize a => exprTouchesInternalHelperSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a
+  | .returndataOptionalBoolAt a => exprTouchesInternalHelperSurface a
   | .keccak256 a b =>
       exprTouchesInternalHelperSurface a || exprTouchesInternalHelperSurface b
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => false
@@ -1344,7 +1347,7 @@ def exprTouchesUnsupportedForeignSurface : Expr → Bool
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize
-  | .returndataOptionalBoolAt _ | .arrayLength _
+  | .arrayLength _
   | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
   | .paramDynamicMemberLength _ _
@@ -1354,7 +1357,8 @@ def exprTouchesUnsupportedForeignSurface : Expr → Bool
       exprTouchesUnsupportedForeignSurface b
   | .keccak256 a b =>
       exprTouchesUnsupportedForeignSurface a || exprTouchesUnsupportedForeignSurface b
-  | .mload a | .tload a | .calldataload a | .extcodesize a => exprTouchesUnsupportedForeignSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a
+  | .returndataOptionalBoolAt a => exprTouchesUnsupportedForeignSurface a
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => false
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
   | .bitAnd a b | .bitOr a b | .bitXor a b | .eq a b
@@ -1405,7 +1409,7 @@ def exprTouchesUnsupportedLowLevelSurface : Expr → Bool
   | .localVar _ | .storage _ | .storageAddr _
   | .constructorArg _ | .blobbasefee
   | .calldatasize | .returndataSize
-  | .returndataOptionalBoolAt _ | .arrayLength _
+  | .arrayLength _
   | .memoryArrayLength _
   | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
   | .paramDynamicMemberLength _ _
@@ -1415,7 +1419,8 @@ def exprTouchesUnsupportedLowLevelSurface : Expr → Bool
       exprTouchesUnsupportedLowLevelSurface b
   | .keccak256 a b =>
       exprTouchesUnsupportedLowLevelSurface a || exprTouchesUnsupportedLowLevelSurface b
-  | .mload a | .tload a | .calldataload a | .extcodesize a => exprTouchesUnsupportedLowLevelSurface a
+  | .mload a | .tload a | .calldataload a | .extcodesize a
+  | .returndataOptionalBoolAt a => exprTouchesUnsupportedLowLevelSurface a
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
   | .bitAnd a b | .bitOr a b | .bitXor a b | .eq a b
   | .ge a b | .gt a b | .sgt a b | .lt a b | .slt a b | .le a b
@@ -1488,7 +1493,8 @@ def exprTouchesUnsupportedContractSurface (expr : Expr) : Bool :=
   | .mulDivDown a b c | .mulDivUp a b c =>
       exprTouchesUnsupportedContractSurface a || exprTouchesUnsupportedContractSurface b ||
         exprTouchesUnsupportedContractSurface c
-  | .mload a | .tload a | .calldataload a | .extcodesize a =>
+  | .mload a | .tload a | .calldataload a | .extcodesize a
+  | .returndataOptionalBoolAt a =>
       exprTouchesUnsupportedContractSurface a
   | .keccak256 a b =>
       exprTouchesUnsupportedContractSurface a || exprTouchesUnsupportedContractSurface b
@@ -1496,7 +1502,7 @@ def exprTouchesUnsupportedContractSurface (expr : Expr) : Bool :=
   | .mapping2 _ _ _ | .mapping2Word _ _ _ _ | .mappingUint _ _ | .mappingChain _ _
   | .structMember _ _ _ | .structMember2 _ _ _ _
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
-  | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
+  | .externalCall _ _ | .internalCall _ _
   | .arrayLength _ | .memoryArrayLength _
   | .arrayElement _ _ | .memoryArrayElement _ _ | .arrayElementWord _ _ _ _
   | .arrayElementDynamicWord _ _ _
@@ -3552,7 +3558,8 @@ private theorem exprCompileCore_helperSurfaceClosed
     | smod _ _ ihL ihR | sar _ _ ihL ihR | byte _ _ ihL ihR | signextend _ _ ihL ihR
     | keccak256 _ _ ihL ihR =>
       simp only [exprTouchesUnsupportedHelperSurface, ihL, ihR, Bool.or_false, Bool.false_or]
-  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih =>
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih
+  | returndataOptionalBoolAt _ ih =>
       simp only [exprTouchesUnsupportedHelperSurface, ih]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprTouchesUnsupportedHelperSurface, ihC, ihT, ihE,
@@ -3593,7 +3600,8 @@ private theorem exprCompileCore_internalHelperCallNames_nil
     | smod _ _ ihL ihR | sar _ _ ihL ihR | byte _ _ ihL ihR | signextend _ _ ihL ihR
     | keccak256 _ _ ihL ihR =>
       simp only [exprInternalHelperCallNames, ihL, ihR, List.nil_append]
-  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih =>
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih
+  | returndataOptionalBoolAt _ ih =>
       simp only [exprInternalHelperCallNames, ih]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprInternalHelperCallNames, ihC, ihT, ihE, List.nil_append]
@@ -4433,9 +4441,7 @@ mutual
         simp [exprTouchesInternalHelperSurface]
     | adtConstruct _ _ _ | adtTag _ _ | adtField _ _ _ _ _ =>
         simp [exprTouchesUnsupportedHelperSurface] at hsurface
-    | returndataOptionalBoolAt a =>
-        simp [exprTouchesInternalHelperSurface]
-    | tload a | calldataload a | mload a | extcodesize a =>
+    | tload a | calldataload a | mload a | extcodesize a | returndataOptionalBoolAt a =>
         simp only [exprTouchesUnsupportedHelperSurface] at hsurface
         simp only [exprTouchesInternalHelperSurface]
         exact exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface
@@ -4901,12 +4907,12 @@ private theorem exprTouchesUnsupportedCallSurface_eq_featureOr
   | call _ _ _ _ _ _ _ | staticcall _ _ _ _ _ _ | delegatecall _ _ _ _ _ _ =>
       simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
-  | returndataOptionalBoolAt _ | arrayLength _
+  | arrayLength _
   | memoryArrayLength _
   | storageArrayLength _ | dynamicBytesEq _ _ =>
       simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
-  | tload a | calldataload a | mload a | extcodesize a =>
+  | tload a | calldataload a | mload a | extcodesize a | returndataOptionalBoolAt a =>
       simp only [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
       exact exprTouchesUnsupportedCallSurface_eq_featureOr a
@@ -5145,8 +5151,7 @@ private theorem exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
   | paramDynamicMemberLength _ _
   | paramDynamicMemberDataOffset _ _ | paramDynamicMemberElement _ _ _ =>
       cases hcore
-  | memoryArrayLength _ | storageArrayLength _
-  | returndataOptionalBoolAt _ =>
+  | memoryArrayLength _ | storageArrayLength _ =>
       cases hcore
   | arrayLength _ | dynamicBytesEq _ _ =>
       cases hcalls
@@ -5159,7 +5164,7 @@ private theorem exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
           offset hcore.1 hstate.1 hcalls.1,
         exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
           size hcore.2 hstate.2 hcalls.2]
-  | tload a | calldataload a | mload a | extcodesize a =>
+  | tload a | calldataload a | mload a | extcodesize a | returndataOptionalBoolAt a =>
       simp only [exprTouchesUnsupportedCoreSurface] at hcore
       simp only [exprTouchesUnsupportedStateSurface] at hstate
       simp only [exprTouchesUnsupportedCallSurface] at hcalls
@@ -5690,7 +5695,7 @@ theorem exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
   | adtConstruct _ _ _ | adtTag _ _ | adtField _ _ _ _ _ =>
       simp [exprTouchesUnsupportedContractSurface] at hsurface
   | storage _ | storageAddr _ | internalCall _ _ | externalCall _ _
-  | returndataOptionalBoolAt _ | arrayLength _ | memoryArrayLength _ | storageArrayLength _
+  | arrayLength _ | memoryArrayLength _ | storageArrayLength _
   | dynamicBytesEq _ _
   | call _ _ _ _ _ _ _ | staticcall _ _ _ _ _ _ | delegatecall _ _ _ _ _ _
   | mapping _ _ | mappingWord _ _ _ | mappingPackedWord _ _ _ _
@@ -5708,7 +5713,7 @@ theorem exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
   | storageArrayElement _ _
   | mappingChain _ _ =>
       simp [exprTouchesUnsupportedContractSurface] at hsurface
-  | tload a | calldataload a | mload a | extcodesize a =>
+  | tload a | calldataload a | mload a | extcodesize a | returndataOptionalBoolAt a =>
       simp only [exprTouchesUnsupportedContractSurface] at hsurface
       simp [exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed hsurface]
@@ -6219,7 +6224,8 @@ private theorem exprCompileCore_usesArrayElement_false
       simp only [exprUsesArrayElement, ihL, ihR, Bool.false_or]
   | mulDivDown _ _ _ ihA ihB ihC | mulDivUp _ _ _ ihA ihB ihC =>
       simp only [exprUsesArrayElement, ihA, ihB, ihC, Bool.false_or]
-  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih =>
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih
+  | returndataOptionalBoolAt _ ih =>
       simp only [exprUsesArrayElement, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesArrayElement, ihC, ihT, ihE, Bool.false_or]
@@ -6248,7 +6254,8 @@ private theorem exprCompileCore_usesStorageArrayElement_false
       simp only [exprUsesStorageArrayElement, ihL, ihR, Bool.false_or]
   | mulDivDown _ _ _ ihA ihB ihC | mulDivUp _ _ _ ihA ihB ihC =>
       simp only [exprUsesStorageArrayElement, ihA, ihB, ihC, Bool.false_or]
-  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih =>
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih
+  | returndataOptionalBoolAt _ ih =>
       simp only [exprUsesStorageArrayElement, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesStorageArrayElement, ihC, ihT, ihE, Bool.false_or]
@@ -6277,7 +6284,8 @@ private theorem exprCompileCore_usesDynamicBytesEq_false
       simp only [exprUsesDynamicBytesEq, ihL, ihR, Bool.false_or]
   | mulDivDown _ _ _ ihA ihB ihC | mulDivUp _ _ _ ihA ihB ihC =>
       simp only [exprUsesDynamicBytesEq, ihA, ihB, ihC, Bool.false_or]
-  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih =>
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih
+  | returndataOptionalBoolAt _ ih =>
       simp only [exprUsesDynamicBytesEq, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesDynamicBytesEq, ihC, ihT, ihE, Bool.false_or]
@@ -6988,7 +6996,8 @@ private theorem exprCompileCore_usesMulDiv512_false
       simp only [exprUsesMulDiv512, ihL, ihR, Bool.false_or]
   | mulDivDown _ _ _ ihA ihB ihC | mulDivUp _ _ _ ihA ihB ihC =>
       simp only [exprUsesMulDiv512, ihA, ihB, ihC, Bool.false_or]
-  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih =>
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih
+  | returndataOptionalBoolAt _ ih =>
       simp only [exprUsesMulDiv512, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesMulDiv512, ihC, ihT, ihE, Bool.false_or]
@@ -7017,7 +7026,8 @@ private theorem exprCompileCore_usesParamDynamicHeadWord_false
       simp only [exprUsesParamDynamicHeadWord, ihL, ihR, Bool.false_or]
   | mulDivDown _ _ _ ihA ihB ihC | mulDivUp _ _ _ ihA ihB ihC =>
       simp only [exprUsesParamDynamicHeadWord, ihA, ihB, ihC, Bool.false_or]
-  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih =>
+  | logicalNot _ ih | bitNot _ ih | tload _ ih | calldataload _ ih | mload _ ih | extcodesize _ ih
+  | returndataOptionalBoolAt _ ih =>
       simp only [exprUsesParamDynamicHeadWord, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesParamDynamicHeadWord, ihC, ihT, ihE, Bool.false_or]

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgePredicates.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgePredicates.lean
@@ -317,23 +317,23 @@ theorem bridgedExpr_returndataOptionalBoolAt (offsetExpr : Compiler.Yul.YulExpr)
     refine .call _ _ (Or.inl (by simp [bridgedBuiltins])) ?_
     intro arg hMem; cases hMem
   refine .call "or" _ (Or.inl (by simp [bridgedBuiltins])) ?_
-  intro arg hMem; simp only [List.mem_cons, List.mem_singleton] at hMem
+  intro arg hMem; simp only [List.mem_cons, List.mem_nil_iff, or_false] at hMem
   rcases hMem with rfl | rfl
   · refine .call _ _ (Or.inl (by simp [bridgedBuiltins])) ?_
-    intro arg hMem; simp only [List.mem_cons, List.mem_singleton] at hMem
+    intro arg hMem; simp only [List.mem_cons, List.mem_nil_iff, or_false] at hMem
     rcases hMem with rfl | rfl
     · exact hRDS
     · exact .lit _
   · refine .call "and" _ (Or.inl (by simp [bridgedBuiltins])) ?_
-    intro arg hMem; simp only [List.mem_cons, List.mem_singleton] at hMem
+    intro arg hMem; simp only [List.mem_cons, List.mem_nil_iff, or_false] at hMem
     rcases hMem with rfl | rfl
     · refine .call _ _ (Or.inl (by simp [bridgedBuiltins])) ?_
-      intro arg hMem; simp only [List.mem_cons, List.mem_singleton] at hMem
+      intro arg hMem; simp only [List.mem_cons, List.mem_nil_iff, or_false] at hMem
       rcases hMem with rfl | rfl
       · exact hRDS
       · exact .lit _
     · refine .call _ _ (Or.inl (by simp [bridgedBuiltins])) ?_
-      intro arg hMem; simp only [List.mem_cons, List.mem_singleton] at hMem
+      intro arg hMem; simp only [List.mem_cons, List.mem_nil_iff, or_false] at hMem
       rcases hMem with rfl | rfl
       · exact bridgedExpr_mload _ hOffset
       · exact .lit _

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgePredicates.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgePredicates.lean
@@ -299,6 +299,45 @@ theorem bridgedExpr_extcodesize (addrExpr : Compiler.Yul.YulExpr)
   subst hMem
   exact hAddr
 
+theorem bridgedExpr_returndataOptionalBoolAt (offsetExpr : Compiler.Yul.YulExpr)
+    (hOffset : BridgedExpr offsetExpr) :
+    BridgedExpr
+      (Compiler.Yul.YulExpr.call "or" [
+        Compiler.Yul.YulExpr.call "eq" [
+          Compiler.Yul.YulExpr.call "returndatasize" [],
+          Compiler.Yul.YulExpr.lit 0],
+        Compiler.Yul.YulExpr.call "and" [
+          Compiler.Yul.YulExpr.call "eq" [
+            Compiler.Yul.YulExpr.call "returndatasize" [],
+            Compiler.Yul.YulExpr.lit 32],
+          Compiler.Yul.YulExpr.call "eq" [
+            Compiler.Yul.YulExpr.call "mload" [offsetExpr],
+            Compiler.Yul.YulExpr.lit 1]]]) := by
+  have hRDS : BridgedExpr (Compiler.Yul.YulExpr.call "returndatasize" []) := by
+    refine .call _ _ (Or.inl (by simp [bridgedBuiltins])) ?_
+    intro arg hMem; cases hMem
+  refine .call "or" _ (Or.inl (by simp [bridgedBuiltins])) ?_
+  intro arg hMem; simp only [List.mem_cons, List.mem_singleton] at hMem
+  rcases hMem with rfl | rfl
+  · refine .call _ _ (Or.inl (by simp [bridgedBuiltins])) ?_
+    intro arg hMem; simp only [List.mem_cons, List.mem_singleton] at hMem
+    rcases hMem with rfl | rfl
+    · exact hRDS
+    · exact .lit _
+  · refine .call "and" _ (Or.inl (by simp [bridgedBuiltins])) ?_
+    intro arg hMem; simp only [List.mem_cons, List.mem_singleton] at hMem
+    rcases hMem with rfl | rfl
+    · refine .call _ _ (Or.inl (by simp [bridgedBuiltins])) ?_
+      intro arg hMem; simp only [List.mem_cons, List.mem_singleton] at hMem
+      rcases hMem with rfl | rfl
+      · exact hRDS
+      · exact .lit _
+    · refine .call _ _ (Or.inl (by simp [bridgedBuiltins])) ?_
+      intro arg hMem; simp only [List.mem_cons, List.mem_singleton] at hMem
+      rcases hMem with rfl | rfl
+      · exact bridgedExpr_mload _ hOffset
+      · exact .lit _
+
 theorem bridgedStraightStmt_let_mload (name : String)
     (offsetExpr : Compiler.Yul.YulExpr) (hOffset : BridgedExpr offsetExpr) :
     BridgedStraightStmt

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanSourceExprClosure.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanSourceExprClosure.lean
@@ -563,6 +563,29 @@ private theorem compileExpr_unopBuiltin_ok
       simp [hA, bind, Except.bind, Pure.pure, Except.pure] at hOk
       exact hOk.symm
 
+private theorem compileExpr_returndataOptionalBoolAtShape_ok
+    {fields : List CompilationModel.Field} {src : DynamicDataSource}
+    {a : Expr} {out : YulExpr}
+    (hOk : (do let x ← compileExpr fields src a
+               pure (YulExpr.call "or" [
+                 YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 0],
+                 YulExpr.call "and" [
+                   YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 32],
+                   YulExpr.call "eq" [YulExpr.call "mload" [x], YulExpr.lit 1]]]) :
+        Except String YulExpr) = .ok out) :
+    ∃ ca, compileExpr fields src a = .ok ca ∧
+      out = YulExpr.call "or" [
+        YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 0],
+        YulExpr.call "and" [
+          YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 32],
+          YulExpr.call "eq" [YulExpr.call "mload" [ca], YulExpr.lit 1]]] := by
+  cases hA : compileExpr fields src a with
+  | error e => simp [hA, bind, Except.bind] at hOk
+  | ok ca =>
+      refine ⟨ca, rfl, ?_⟩
+      simp [hA, bind, Except.bind, Pure.pure, Except.pure] at hOk
+      exact hOk.symm
+
 /-- Literal-slot `sload` is in the native bridged expression fragment. -/
 private theorem bridgedExpr_sload_lit (slot : Nat) :
     BridgedExpr (YulExpr.call "sload" [YulExpr.lit slot]) := by
@@ -1373,12 +1396,9 @@ theorem compileExpr_bridgedSource
   | returndataOptionalBoolAt _ iho =>
       intro out hOk
       simp only [compileExpr, compileExprWithInternals] at hOk
-      cases hO : compileExprWithInternals fields src internalFunctions _ with
-      | error e => simp [bind, Except.bind] at hOk
-      | ok co =>
-          simp [bind, Except.bind, Pure.pure, Except.pure] at hOk
-          subst hOk
-          exact bridgedExpr_returndataOptionalBoolAt co (iho hO)
+      obtain ⟨co, hO, hEq⟩ := compileExpr_returndataOptionalBoolAtShape_ok hOk
+      subst hEq
+      exact bridgedExpr_returndataOptionalBoolAt co (iho hO)
   | keccak256 _ _ ihOffset ihSize =>
       intro out hOk
       simp only [compileExpr, compileExprWithInternals] at hOk

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanSourceExprClosure.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanSourceExprClosure.lean
@@ -166,6 +166,8 @@ inductive BridgedSourceExpr : Expr → Prop
       BridgedSourceExpr (.tload offset)
   | extcodesize {addr} (hAddr : BridgedSourceExpr addr) :
       BridgedSourceExpr (.extcodesize addr)
+  | returndataOptionalBoolAt {offset} (hOffset : BridgedSourceExpr offset) :
+      BridgedSourceExpr (.returndataOptionalBoolAt offset)
   | keccak256 {offset size}
       (hOffset : BridgedSourceExpr offset) (hSize : BridgedSourceExpr size) :
       BridgedSourceExpr (.keccak256 offset size)
@@ -1368,6 +1370,15 @@ theorem compileExpr_bridgedSource
       obtain ⟨co, hO, hEq⟩ := compileExpr_unopBuiltin_ok hOk
       subst hEq
       exact bridgedExpr_extcodesize co (iha hO)
+  | returndataOptionalBoolAt _ iho =>
+      intro out hOk
+      simp only [compileExpr, compileExprWithInternals] at hOk
+      cases hO : compileExprWithInternals fields src internalFunctions _ with
+      | error e => simp [bind, Except.bind] at hOk
+      | ok co =>
+          simp [bind, Except.bind, Pure.pure, Except.pure] at hOk
+          subst hOk
+          exact bridgedExpr_returndataOptionalBoolAt co (iho hO)
   | keccak256 _ _ ihOffset ihSize =>
       intro out hOk
       simp only [compileExpr, compileExprWithInternals] at hOk
@@ -1752,6 +1763,9 @@ theorem compileRequireFailCond_bridgedSource
         hOk
   | extcodesize hAddr =>
       exact compileRequireFailCond_default_bridgedSource (.extcodesize hAddr)
+        hOk
+  | returndataOptionalBoolAt hOffset =>
+      exact compileRequireFailCond_default_bridgedSource (.returndataOptionalBoolAt hOffset)
         hOk
   | keccak256 hOffset hSize =>
       exact compileRequireFailCond_default_bridgedSource (.keccak256 hOffset hSize)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2970,7 +2970,9 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.FunctionBody.eval_compileExpr_keccak256_of_compiled  -- private
   -- Compiler.Proofs.IRGeneration.FunctionBody.eval_compileExpr_mload_of_compiled  -- private
   Compiler.Proofs.IRGeneration.FunctionBody.compileExpr_extcodesize_ok
+  Compiler.Proofs.IRGeneration.FunctionBody.compileExpr_returndataOptionalBoolAt_ok
   -- Compiler.Proofs.IRGeneration.FunctionBody.eval_compileExpr_extcodesize_of_compiled  -- private
+  -- Compiler.Proofs.IRGeneration.FunctionBody.eval_compileExpr_returndataOptionalBoolAt_of_compiled  -- private
   Compiler.Proofs.IRGeneration.FunctionBody.compileExpr_tload_ok
   -- Compiler.Proofs.IRGeneration.FunctionBody.calldataloadWord_lt_evmModulus  -- private
   Compiler.Proofs.IRGeneration.FunctionBody.runtimeStateMatchesIR_calldatacopyBothMemory
@@ -5681,6 +5683,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.bridgedExpr_mload
   Compiler.Proofs.YulGeneration.Backends.bridgedExpr_tload
   Compiler.Proofs.YulGeneration.Backends.bridgedExpr_extcodesize
+  Compiler.Proofs.YulGeneration.Backends.bridgedExpr_returndataOptionalBoolAt
   Compiler.Proofs.YulGeneration.Backends.bridgedStraightStmt_let_mload
   Compiler.Proofs.YulGeneration.Backends.bridgedStraightStmt_let_tload
   Compiler.Proofs.YulGeneration.Backends.bridgedStraightStmt_let_keccak256
@@ -7308,6 +7311,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.YulGeneration.Backends.compileExpr_yulNegatedBinOp_ok  -- private
   -- Compiler.Proofs.YulGeneration.Backends.compileExpr_yulBoolBinOp_ok  -- private
   -- Compiler.Proofs.YulGeneration.Backends.compileExpr_unopBuiltin_ok  -- private
+  -- Compiler.Proofs.YulGeneration.Backends.compileExpr_returndataOptionalBoolAtShape_ok  -- private
   -- Compiler.Proofs.YulGeneration.Backends.bridgedExpr_sload_lit  -- private
   -- Compiler.Proofs.YulGeneration.Backends.bridgedExpr_sload  -- private
   -- Compiler.Proofs.YulGeneration.Backends.bridgedExpr_storageLoad  -- private
@@ -7398,4 +7402,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6845 theorems/lemmas (4912 public, 1933 private, 0 sorry'd)
+-- Total: 6849 theorems/lemmas (4914 public, 1935 private, 0 sorry'd)

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -988,6 +988,9 @@ def evalExpr (oracle : DenoteOracle) (fields : List Field) (state : DenoteState)
   | .extcodesize addr => do
       let resolvedAddr ← evalExpr oracle fields state addr
       some (state.world.codeSize (resolvedAddr % Compiler.Constants.addressModulus)).val
+  | .returndataOptionalBoolAt offset => do
+      let _ ← evalExpr oracle fields state offset
+      some 1
   | .keccak256 offExpr sizeExpr => do
       let off ← evalExpr oracle fields state offExpr
       let size ← evalExpr oracle fields state sizeExpr


### PR DESCRIPTION
Child of #2084 (Tier 4 — external calls & low-level mechanics).

## What

Admits the smallest remaining coherent Tier-4 low-level surface, `returndataOptionalBoolAt`, across the full source → IR → proof pipeline:

- **Source semantics** (`SourceSemantics.evalExpr`, `evalExprWithHelpers`) and **Denote** model `returndataOptionalBoolAt offset` as evaluating the offset and returning `some 1` (IR runtime states carry empty returndata, so the compiled guard `or(eq(returndatasize,0), …)` evaluates to 1 — the two sides agree).
- **ExprCompileCore** gains a `returndataOptionalBoolAt` constructor; surface predicates in `SupportedSpec` (core/state/call/helper/foreign/low-level/contract) now recurse into the operand instead of flagging the node unsupported.
- **FunctionBody** proofs: `compileExpr_returndataOptionalBoolAt_ok`, `eval_compileExpr_returndataOptionalBoolAt_of_compiled`, plus `compileExpr_core_ok` / `eval_compileExpr_core_onExpr` / `evalExpr_lt_evmModulus_core_onExpr` / `compileRequireFailCond` cases.
- **EvmYulLean bridge**: `bridgedExpr_returndataOptionalBoolAt`, `BridgedSourceExpr.returndataOptionalBoolAt`, and closure cases for `compileExpr_bridgedSource` / `compileRequireFailCond_bridgedSource` (with a `compileExpr_returndataOptionalBoolAtShape_ok` extraction helper).

Reuses and completes the preserved WIP from the interrupted predecessor mission (one bridge-predicate `rcases` pattern and one source-closure case repaired).

## Validation

- `lake build` — green (2473 jobs)
- `lake build PrintAxioms` — green (2622 jobs); only standard axioms (propext, Classical.choice, Quot.sound), 0 sorry
- `make check` — green ("All checks passed."), including lean_hygiene (0 sorry / 0 native_decide in proofs) and regenerated `PrintAxioms.lean` (6849 theorems, 0 sorry'd)
- No new `sorry`/`admit`/`axiom`/`unsafe` escapes in any changed file

## Downstream gap

Remaining Tier-4 unsupported surfaces after this slice (still flag `true` in `SupportedSpec`): low-level `call`/`staticcall`/`delegatecall`, `externalCall`, `externalCallBind`/`tryExternalCallBind`, `ecm`, `internalCall`/`internalCallAssign`. `returndataCopy`, `calldatacopy`, `revertReturndata`, `returndataSize`, `extcodesize` are already admitted.
