### PR TITLE
proof(L2): admit the pure `exp` builtin lane to the compile core (#2084)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -333,6 +333,41 @@ sibling entrypoint.
   `Stmt.revertReturndata`, `extcodesize`, and `externalCallBind` remain
   unmodeled.
 
+## Pure `exp` Builtin Lane (2026-08)
+
+- `pow a b` / `a ^ b` in the EDSL lowers to
+  `Expr.externalCall builtinExpName [base, exponent]`, a reserved sentinel that
+  the compiler already lowered to the pure Yul `exp` builtin rather than to a
+  foreign call. The node shape made it look like an external call to every
+  proof-side surface predicate, so the whole arm was gated as Tier-4 foreign
+  behaviour. That gate is now keyed on the sentinel: the eight
+  `exprTouchesUnsupported*Surface` / `exprTouchesInternalHelperSurface`
+  predicates recurse into `base`/`exponent` for `builtinExpName` at arity two
+  and keep their previous fail-closed constant for every other
+  `Expr.externalCall`.
+- The lane is executed, not assumed, at all four planes: `SourceSemantics`
+  (`evalExpr`, `evalExprWithHelpers`), the compiler-free denotation
+  (`Denote.evalExpr`, with `DenoteAgreement` extended), the IR interpreter
+  (which routes `"exp"` to the EVMYulLean backend), and EVMYulLean itself.
+  All four denote `Uint256.pow`, i.e. `(a % 2^256) ^ (b % 2^256) % 2^256`.
+- `evalPureBuiltinViaEvmYulLean_exp_native` closes the backend leg by proving
+  `EvmYul.UInt256.exp` equals that value, via `uint256_powAux_toNat` /
+  `uint256_pow_toNat` on the square-and-multiply loop. No `native_decide`.
+- `ExprCompileCore.builtinExp` admits the lane to the generic compile core, so
+  `pow` may appear in generic-fragment expressions, `require` conditions, and
+  `emit` arguments. `compileExpr_builtinExp_ok` and
+  `eval_compileExpr_builtinExp_of_compiled` prove compilation and evaluation
+  agreement against `YulExpr.call "exp"`.
+- `collectExprNames` no longer reports `builtinExpName` as a callee identifier.
+  The sentinel never reaches generated Yul (it becomes `exp`) and is already a
+  reserved name, so it cannot collide with a compiler-generated temp. This
+  matches `TrustSurface.collectExternalExprNames`, which has always skipped it,
+  and it restores `collectExprNames ⊆ exprBoundNames` on the compile core.
+- No new axiom and no new trust assumption: this eliminates an unsupported
+  surface rather than assuming one, and it removes `pow` from the assumed
+  external-call bucket. Genuine `Expr.externalCall` targets, `Expr.call` /
+  `staticcall` / `delegatecall`, and `Stmt.externalCallBind` remain gated.
+
 ## Audit Artifacts
 
 | Artifact | Purpose | Check |

--- a/Compiler/CompilationModel/ValidationHelpers.lean
+++ b/Compiler/CompilationModel/ValidationHelpers.lean
@@ -77,7 +77,12 @@ def collectExprNames : Expr → List String
   | Expr.returndataSize => []
   | Expr.returndataOptionalBoolAt outOffset => collectExprNames outOffset
   | Expr.localVar name => [name]
-  | Expr.externalCall name args => name :: collectExprListNames args
+  | Expr.externalCall name args =>
+      -- `builtinExpName` is a reserved sentinel for the pure `exp` builtin, not a
+      -- callee identifier: it lowers to `YulExpr.call "exp"` and never reaches the
+      -- generated Yul, so it cannot collide with a compiler-generated temp name.
+      if name == builtinExpName then collectExprListNames args
+      else name :: collectExprListNames args
   | Expr.internalCall name args => name :: collectExprListNames args
   | Expr.arrayLength name | Expr.memoryArrayLength name => [name]
   | Expr.paramDynamicHeadWord name _ => [name]

--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -74,7 +74,8 @@ theorem denote_evalExpr_eq (fields : List Field) (s : DenoteState) :
   | .paramDynamicStaticComposite .. | .paramDynamicHeadWord ..
   | .arrayLength _ | .arrayElementWord ..
   | .call .. | .staticcall .. | .delegatecall ..
-  | .externalCall .. | .internalCall ..
+  | .externalCall _ [] | .externalCall _ [_] | .externalCall _ (_ :: _ :: _ :: _)
+  | .internalCall ..
   | .intrinsic .. | .forkIfAtLeast .. | .mulDiv512Down .. | .mulDiv512Up ..
   | .adtConstruct .. | .adtTag .. | .adtField ..
   | .caller | .contractAddress | .txOrigin | .chainid | .msgValue | .selfBalance
@@ -114,6 +115,15 @@ theorem denote_evalExpr_eq (fields : List Field) (s : DenoteState) :
         by_cases h : (v != 0) = true
         · simpa [h] using denote_evalExpr_eq fields s t
         · simpa [h] using denote_evalExpr_eq fields s e
+  -- Both evaluators guard the reserved `exp` builtin lane on the same name
+  -- test, so the arms agree branch-for-branch.
+  | .externalCall _ [base, exponent] => by
+      have guard : ∀ (c : Bool) (x y : Option Nat),
+          x = y → (if c then x else none) = (if c then y else none) := by
+        intro c x y h; cases c <;> simp [h]
+      exact guard _ _ _
+        (bindAgree (denote_evalExpr_eq fields s base) fun _ =>
+          bindAgree (denote_evalExpr_eq fields s exponent) fun _ => rfl)
 
 theorem denote_evalExprList_eq (fields : List Field) (s : DenoteState) :
     ∀ es : List Expr,

--- a/Compiler/Proofs/IRGeneration/ExprCore.lean
+++ b/Compiler/Proofs/IRGeneration/ExprCore.lean
@@ -196,6 +196,12 @@ inductive ExprCompileCore : Expr → Prop where
   | keccak256 {offset size : Expr} :
       ExprCompileCore offset → ExprCompileCore size →
         ExprCompileCore (.keccak256 offset size)
+  /-- The reserved `exp` builtin lane. `pow`/`^` in the EDSL surfaces as an
+  `externalCall` node, but it lowers to the pure Yul `exp` builtin and carries
+  no foreign behaviour, so it belongs to the compile core. -/
+  | builtinExp {base exponent : Expr} :
+      ExprCompileCore base → ExprCompileCore exponent →
+        ExprCompileCore (.externalCall builtinExpName [base, exponent])
 
 /-! ## Scope analysis -/
 

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -4472,7 +4472,24 @@ private theorem compileExpr_constructor_mode_eq
       simp only [exprTouchesUnsupportedConstructorRawCalldataSurface] at hraw
       simp [compileExprWithInternals, compileExpr_constructor_mode_eq hcore hcall hraw]
   | .localVar _, _, _, _ => by simp [compileExprWithInternals]
-  | .externalCall _ _, hcore, _, _ => by simp [exprTouchesUnsupportedCoreSurface] at hcore
+  | .externalCall name [base, exponent], hcore, hcall, hraw => by
+      by_cases hname : name = builtinExpName
+      · subst hname
+        simp only [exprTouchesUnsupportedCoreSurface, beq_self_eq_true, if_true,
+          Bool.or_eq_false_iff] at hcore
+        simp only [exprTouchesUnsupportedCallSurface, beq_self_eq_true, if_true,
+          Bool.or_eq_false_iff] at hcall
+        simp only [exprTouchesUnsupportedConstructorRawCalldataSurface,
+          exprListTouchesUnsupportedConstructorRawCalldataSurface, Bool.or_false,
+          Bool.or_eq_false_iff] at hraw
+        simp [compileExprWithInternals, compileExprListWithInternals,
+          compileExpr_constructor_mode_eq hcore.1 hcall.1 hraw.1,
+          compileExpr_constructor_mode_eq hcore.2 hcall.2 hraw.2]
+      · simp [exprTouchesUnsupportedCoreSurface, hname] at hcore
+  | .externalCall _ [], hcore, _, _ => by simp [exprTouchesUnsupportedCoreSurface] at hcore
+  | .externalCall _ [_], hcore, _, _ => by simp [exprTouchesUnsupportedCoreSurface] at hcore
+  | .externalCall _ (_ :: _ :: _ :: _), hcore, _, _ => by
+      simp [exprTouchesUnsupportedCoreSurface] at hcore
   | .internalCall _ _, hcore, _, _ => by simp [exprTouchesUnsupportedCoreSurface] at hcore
   | .arrayLength _, _, hcall, _ => by simp [exprTouchesUnsupportedCallSurface] at hcall
   | .arrayElement _ _, _, hcall, _ => by simp [exprTouchesUnsupportedCallSurface] at hcall

--- a/Compiler/Proofs/IRGeneration/FunctionBody/Base.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody/Base.lean
@@ -6891,7 +6891,7 @@ theorem evalExpr_lt_evmModulus_core_onExpr
       show (do
         let b ← SourceSemantics.evalExpr fields runtime base
         let e ← SourceSemantics.evalExpr fields runtime exponent
-        some (Verity.Core.Uint256.pow (Verity.Core.Uint256.ofNat b)
+        some (Verity.Core.Uint256.powEff (Verity.Core.Uint256.ofNat b)
           (Verity.Core.Uint256.ofNat e)).val) < _
       rcases SourceSemantics.evalExpr fields runtime base with _ | bv
       · trivial
@@ -6899,7 +6899,7 @@ theorem evalExpr_lt_evmModulus_core_onExpr
         · trivial
         · simp only [Bind.bind, Option.bind, Pure.pure]
           have hModEq : Verity.Core.Uint256.modulus = Compiler.Constants.evmModulus := rfl
-          exact hModEq ▸ (Verity.Core.Uint256.pow (Verity.Core.Uint256.ofNat bv)
+          exact hModEq ▸ (Verity.Core.Uint256.powEff (Verity.Core.Uint256.ofNat bv)
             (Verity.Core.Uint256.ofNat ev)).isLt
 end
 

--- a/Compiler/Proofs/IRGeneration/FunctionBody/Base.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody/Base.lean
@@ -563,6 +563,25 @@ theorem evalIRExpr_mul_of_eval
     Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
     Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean]
 
+theorem evalIRExpr_exp_of_eval
+    {state : IRState}
+    {lhs rhs : YulExpr}
+    {a b : Nat}
+    (hlhs : evalIRExpr state lhs = some a)
+    (hrhs : evalIRExpr state rhs = some b) :
+    evalIRExpr state (YulExpr.call "exp" [lhs, rhs]) =
+      some ((a % Compiler.Constants.evmModulus) ^ (b % Compiler.Constants.evmModulus)
+        % Compiler.Constants.evmModulus) := by
+  simp [evalIRExpr, evalIRCall, evalIRExprs, hlhs, hrhs,
+    Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithEvmYulLeanContext,
+    Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallViaEvmYulLean]
+
+private theorem uint256_pow_val (a b : Nat) :
+    (Verity.Core.Uint256.pow (Verity.Core.Uint256.ofNat a) (Verity.Core.Uint256.ofNat b)).val =
+      (a % Compiler.Constants.evmModulus) ^ (b % Compiler.Constants.evmModulus)
+        % Compiler.Constants.evmModulus := by
+  simp [Verity.Core.Uint256.pow, Verity.Core.Uint256.ofNat, Compiler.Constants.evmModulus]
+
 theorem evalIRExpr_div_of_eval
     {state : IRState}
     {lhs rhs : YulExpr}
@@ -2032,6 +2051,56 @@ theorem compileExpr_keccak256_ok
   rw [← CompilationModel.compileExprWithInternals_nil_eq] at hoffset hsize
   rw [CompilationModel.compileExpr, CompilationModel.compileExprWithInternals, hoffset, hsize]
   rfl
+
+/-- `pow`/`^` in the EDSL surfaces as `externalCall builtinExpName [base, exponent]`, but the
+compiler lowers it to the pure Yul `exp` builtin rather than emitting a foreign call. -/
+theorem compileExpr_builtinExp_ok
+    {fields : List Field}
+    {base exponent : Expr}
+    {baseIR exponentIR : YulExpr}
+    (hbase : CompilationModel.compileExpr fields .calldata base = Except.ok baseIR)
+    (hexp : CompilationModel.compileExpr fields .calldata exponent = Except.ok exponentIR) :
+    CompilationModel.compileExpr fields .calldata
+        (.externalCall builtinExpName [base, exponent]) =
+      Except.ok (YulExpr.call "exp" [baseIR, exponentIR]) := by
+  rw [← CompilationModel.compileExprWithInternals_nil_eq] at hbase hexp
+  rw [CompilationModel.compileExpr, CompilationModel.compileExprWithInternals]
+  simp only [CompilationModel.compileExprListWithInternals, hbase, hexp]
+  rfl
+
+private theorem eval_compileExpr_builtinExp_of_compiled
+    {fields : List Field}
+    {runtime : SourceSemantics.RuntimeState}
+    {state : IRState}
+    {base exponent : Expr}
+    {baseIR exponentIR : YulExpr}
+    (hbase : CompilationModel.compileExpr fields .calldata base = Except.ok baseIR)
+    (hexp : CompilationModel.compileExpr fields .calldata exponent = Except.ok exponentIR)
+    (hEvalBase : evalIRExpr state baseIR =
+      some (SourceSemantics.evalExpr fields runtime base))
+    (hEvalExp : evalIRExpr state exponentIR =
+      some (SourceSemantics.evalExpr fields runtime exponent)) :
+    evalIRExpr state
+      (CompilationModel.compileExpr fields .calldata
+          (.externalCall builtinExpName [base, exponent]) |>.toOption.getD (YulExpr.lit 0)) =
+      some (SourceSemantics.evalExpr fields runtime
+        (.externalCall builtinExpName [base, exponent])) := by
+  rw [compileExpr_builtinExp_ok hbase hexp]
+  simp only [Except.toOption, Option.getD]
+  rcases hB : evalIRExpr state baseIR with _ | bv
+  · simp [hB] at hEvalBase
+  · rcases hE : evalIRExpr state exponentIR with _ | ev
+    · simp [hE] at hEvalExp
+    · simp only [hB] at hEvalBase
+      simp only [hE] at hEvalExp
+      simp only [Option.pure_def, Option.bind_eq_bind, Option.bind_some] at hEvalBase hEvalExp
+      have hsrcB : SourceSemantics.evalExpr fields runtime base = some bv := by
+        simpa using hEvalBase.symm
+      have hsrcE : SourceSemantics.evalExpr fields runtime exponent = some ev := by
+        simpa using hEvalExp.symm
+      rw [evalIRExpr_exp_of_eval hB hE,
+        SourceSemantics.evalExpr_externalCall_builtinExp fields runtime base exponent]
+      simp [hsrcB, hsrcE, uint256_pow_val]
 
 private theorem eval_compileExpr_keccak256_of_compiled
     {fields : List Field}
@@ -5108,6 +5177,12 @@ theorem compileExpr_core_ok
       rcases ihS with ⟨sizeIR, hsize⟩
       exact ⟨YulExpr.call "keccak256" [offsetIR, sizeIR],
         compileExpr_keccak256_ok hoffset hsize⟩
+  | builtinExp hB hE ihB ihE =>
+      rename_i base exponent
+      rcases ihB with ⟨baseIR, hbase⟩
+      rcases ihE with ⟨exponentIR, hexp⟩
+      exact ⟨YulExpr.call "exp" [baseIR, exponentIR],
+        compileExpr_builtinExp_ok hbase hexp⟩
 
 mutual
 theorem eval_compileExpr_core_onExpr
@@ -6253,6 +6328,37 @@ theorem eval_compileExpr_core_onExpr
         simpa only [Except.toOption, Option.getD_some] using htmp
       exact eval_compileExpr_keccak256_of_compiled
         hoffset hsize hEvalOff hEvalSize hruntime
+  | builtinExp hB hE ihB ihE =>
+      rename_i base exponent
+      rcases compileExpr_core_ok hB with ⟨baseIR, hbase⟩
+      rcases compileExpr_core_ok hE with ⟨exponentIR, hexp⟩
+      have hexactB : bindingsExactlyMatchIRVarsOnExpr base runtime.bindings state :=
+        bindingsExactlyMatchIRVarsOnExpr_of_subset hexact (by
+          intro name hmem
+          simpa [exprBoundNames, exprListBoundNames] using
+            List.mem_append.mpr (Or.inl hmem))
+      have hexactE : bindingsExactlyMatchIRVarsOnExpr exponent runtime.bindings state :=
+        bindingsExactlyMatchIRVarsOnExpr_of_subset hexact (by
+          intro name hmem
+          simpa [exprBoundNames, exprListBoundNames] using
+            List.mem_append.mpr (Or.inr hmem))
+      have hpresentB := exprBoundNamesPresent_of_subset hpresent (by
+        intro name hmem
+        simpa [exprBoundNames, exprListBoundNames] using List.mem_append.mpr (Or.inl hmem))
+      have hpresentE := exprBoundNamesPresent_of_subset hpresent (by
+        intro name hmem
+        simpa [exprBoundNames, exprListBoundNames] using List.mem_append.mpr (Or.inr hmem))
+      have hEvalBase : evalIRExpr state baseIR =
+          some (SourceSemantics.evalExpr fields runtime base) := by
+        have htmp := ihB hexactB hbounded hpresentB hruntime
+        rw [hbase] at htmp
+        simpa only [Except.toOption, Option.getD_some] using htmp
+      have hEvalExp : evalIRExpr state exponentIR =
+          some (SourceSemantics.evalExpr fields runtime exponent) := by
+        have htmp := ihE hexactE hbounded hpresentE hruntime
+        rw [hexp] at htmp
+        simpa only [Except.toOption, Option.getD_some] using htmp
+      exact eval_compileExpr_builtinExp_of_compiled hbase hexp hEvalBase hEvalExp
 
 theorem eval_compileExpr_core
     {fields : List Field}
@@ -6781,6 +6887,20 @@ theorem evalExpr_lt_evmModulus_core_onExpr
         · trivial
         · simp only [Bind.bind, Option.bind, Pure.pure]
           exact Nat.mod_lt _ (by norm_num [Compiler.Constants.evmModulus])
+  | @builtinExp base exponent _ _ ihB ihE =>
+      show (do
+        let b ← SourceSemantics.evalExpr fields runtime base
+        let e ← SourceSemantics.evalExpr fields runtime exponent
+        some (Verity.Core.Uint256.pow (Verity.Core.Uint256.ofNat b)
+          (Verity.Core.Uint256.ofNat e)).val) < _
+      rcases SourceSemantics.evalExpr fields runtime base with _ | bv
+      · trivial
+      · rcases SourceSemantics.evalExpr fields runtime exponent with _ | ev
+        · trivial
+        · simp only [Bind.bind, Option.bind, Pure.pure]
+          have hModEq : Verity.Core.Uint256.modulus = Compiler.Constants.evmModulus := rfl
+          exact hModEq ▸ (Verity.Core.Uint256.pow (Verity.Core.Uint256.ofNat bv)
+            (Verity.Core.Uint256.ofNat ev)).isLt
 end
 
 theorem evalExpr_lt_evmModulus_core
@@ -7257,6 +7377,15 @@ theorem compileRequireFailCond_core_ok
       rcases compileExpr_core_ok (fields := fields) hS with ⟨sizeIR, hsize⟩
       exact ⟨YulExpr.call "iszero" [YulExpr.call "keccak256" [offsetIR, sizeIR]], by
         have hcompile := compileExpr_keccak256_ok hoffset hsize
+        rw [CompilationModel.compileRequireFailCond]
+        rw [← CompilationModel.compileExprWithInternals_nil_eq] at hcompile
+        simp [CompilationModel.compileRequireFailCondWithInternals, hcompile]⟩
+  | builtinExp hB hE =>
+      rename_i base exponent
+      rcases compileExpr_core_ok (fields := fields) hB with ⟨baseIR, hbase⟩
+      rcases compileExpr_core_ok (fields := fields) hE with ⟨exponentIR, hexp⟩
+      exact ⟨YulExpr.call "iszero" [YulExpr.call "exp" [baseIR, exponentIR]], by
+        have hcompile := compileExpr_builtinExp_ok hbase hexp
         rw [CompilationModel.compileRequireFailCond]
         rw [← CompilationModel.compileExprWithInternals_nil_eq] at hcompile
         simp [CompilationModel.compileRequireFailCondWithInternals, hcompile]⟩
@@ -7905,6 +8034,18 @@ theorem eval_compileRequireFailCond_core_onExpr
       · simpa using finishIszeroEval (expr := .keccak256 offset size)
           (show ExprCompileCore (.keccak256 offset size) from
             ExprCompileCore.keccak256 hO hS) hexact hpresent hexpr
+  | builtinExp hB hE =>
+      rename_i base exponent
+      rcases compileExpr_core_ok (fields := fields)
+          (show ExprCompileCore (.externalCall builtinExpName [base, exponent]) from
+            ExprCompileCore.builtinExp hB hE) with ⟨exprIR, hexpr⟩
+      refine ⟨YulExpr.call "iszero" [exprIR], ?_, ?_⟩
+      · rw [← CompilationModel.compileExprWithInternals_nil_eq] at hexpr
+        simp [CompilationModel.compileRequireFailCond,
+          CompilationModel.compileRequireFailCondWithInternals, hexpr]
+      · simpa using finishIszeroEval (expr := .externalCall builtinExpName [base, exponent])
+          (show ExprCompileCore (.externalCall builtinExpName [base, exponent]) from
+            ExprCompileCore.builtinExp hB hE) hexact hpresent hexpr
 
 
 end FunctionBody

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
@@ -2227,6 +2227,16 @@ theorem exprBoundNamesInScope_setStorage_of_validateFunctionIdentifierReferences
         name hname
     · exact constructorArgsInScope_foldl_stmtNextScope constructorArgsInScope_none
 
+/-- `collectExprNames` skips the reserved `builtinExpName` sentinel, so the exp
+lane contributes exactly the names of its two operands. -/
+private theorem collectExprNames_builtinExp_split
+    {base exponent : Expr} {name : String}
+    (hmem : name ∈ collectExprNames (.externalCall builtinExpName [base, exponent])) :
+    name ∈ collectExprNames base ∨ name ∈ collectExprNames exponent := by
+  simp only [collectExprNames, collectExprListNames, beq_self_eq_true, if_true,
+    List.append_nil] at hmem
+  exact List.mem_append.mp hmem
+
 theorem collectExprNames_mem_exprBoundNames_of_core
     {expr : Expr}
     (hcore : FunctionBody.ExprCompileCore expr) :
@@ -2272,12 +2282,9 @@ theorem collectExprNames_mem_exprBoundNames_of_core
       · exact List.mem_append.mpr (Or.inr (ihC _ hmem))
   | builtinExp hB hE ihB ihE =>
       intro name hmem
-      simp only [collectExprNames, collectExprListNames, beq_self_eq_true, if_true,
-        List.append_nil] at hmem
       simp only [FunctionBody.exprBoundNames, FunctionBody.exprListBoundNames, List.append_nil]
-      rcases List.mem_append.mp hmem with hmem | hmem
-      · exact List.mem_append.mpr (Or.inl (ihB _ hmem))
-      · exact List.mem_append.mpr (Or.inr (ihE _ hmem))
+      exact List.mem_append.mpr
+        ((collectExprNames_builtinExp_split hmem).imp (ihB name) (ihE name))
 
 private theorem mem_foldl_stmtNextScope_of_mem_scope
     {scope : List String}

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
@@ -1277,6 +1277,21 @@ private theorem exprBoundNamesInScope_of_validateScopedExprIdentifiers_core
       rcases hmem with hmem | hmem
       · exact ihL (validateScopedExprIdentifiers_pair_ok_left hpair) name hmem
       · exact ihR (validateScopedExprIdentifiers_pair_ok_right hpair) name hmem
+  | builtinExp hB hE ihB ihE =>
+      rename_i base exponent
+      have hpair :
+          (do
+            validateScopedExprIdentifiers
+              context params paramScope dynamicParams immutableNames localScope constructorArgCount base
+            validateScopedExprIdentifiers
+              context params paramScope dynamicParams immutableNames localScope constructorArgCount exponent) =
+            Except.ok () := by
+        simpa [validateScopedExprIdentifiers, validateScopedExprIdentifiersList] using hvalidate
+      intro name hmem
+      simp [FunctionBody.exprBoundNames, FunctionBody.exprListBoundNames] at hmem
+      rcases hmem with hmem | hmem
+      · exact ihB (validateScopedExprIdentifiers_pair_ok_left hpair) name hmem
+      · exact ihE (validateScopedExprIdentifiers_pair_ok_right hpair) name hmem
 
 private theorem stmtListScopeDiscipline_of_validateScopedStmtListIdentifiers
     {fieldNames : List String}
@@ -2255,6 +2270,14 @@ theorem collectExprNames_mem_exprBoundNames_of_core
         · exact List.mem_append.mpr (Or.inl (List.mem_append.mpr (Or.inl (ihA _ h))))
         · exact List.mem_append.mpr (Or.inl (List.mem_append.mpr (Or.inr (ihB _ h))))
       · exact List.mem_append.mpr (Or.inr (ihC _ hmem))
+  | builtinExp hB hE ihB ihE =>
+      intro name hmem
+      simp only [collectExprNames, collectExprListNames, beq_self_eq_true, if_true,
+        List.append_nil] at hmem
+      simp only [FunctionBody.exprBoundNames, FunctionBody.exprListBoundNames, List.append_nil]
+      rcases List.mem_append.mp hmem with hmem | hmem
+      · exact List.mem_append.mpr (Or.inl (ihB _ hmem))
+      · exact List.mem_append.mpr (Or.inr (ihE _ hmem))
 
 private theorem mem_foldl_stmtNextScope_of_mem_scope
     {scope : List String}

--- a/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction/Scope.lean
@@ -298,6 +298,26 @@ theorem exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false
       -- Same vacuous handling for `paramDynamicHeadWord` (verity#1832
       -- codegen-only).
       simp [exprTouchesUnsupportedContractSurface] at hsurface
+  | .externalCall name args, hsurface =>
+      -- Only the reserved two-operand `exp` builtin lane is inside the contract
+      -- surface; every other `externalCall` shape makes `hsurface` vacuous.
+      cases args with
+      | nil => simp [exprTouchesUnsupportedContractSurface] at hsurface
+      | cons base tl =>
+        cases tl with
+        | nil => simp [exprTouchesUnsupportedContractSurface] at hsurface
+        | cons exponent tl' =>
+          cases tl' with
+          | cons _ _ => simp [exprTouchesUnsupportedContractSurface] at hsurface
+          | nil =>
+            by_cases hname : name = builtinExpName
+            · subst hname
+              simp only [exprTouchesUnsupportedContractSurface, beq_self_eq_true, if_true,
+                Bool.or_eq_false_iff] at hsurface
+              exact .builtinExp
+                (exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false hsurface.1)
+                (exprCompileCore_of_exprTouchesUnsupportedContractSurface_eq_false hsurface.2)
+            · simp [exprTouchesUnsupportedContractSurface, hname] at hsurface
 
 private theorem fieldName_mem_fields_of_findFieldWithResolvedSlot_some
     {fields : List Field}

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -1486,7 +1486,7 @@ def evalExpr (fields : List Field) (state : RuntimeState) : Expr → Option Nat
       if name == builtinExpName then do
         let baseVal ← evalExpr fields state base
         let exponentVal ← evalExpr fields state exponent
-        pure (Verity.Core.Uint256.pow
+        pure (Verity.Core.Uint256.powEff
           (Verity.Core.Uint256.ofNat baseVal)
           (Verity.Core.Uint256.ofNat exponentVal)).val
       else none
@@ -1675,7 +1675,7 @@ theorem evalExpr_externalCall_builtinExp
       pure (Verity.Core.Uint256.pow
         (Verity.Core.Uint256.ofNat baseVal)
         (Verity.Core.Uint256.ofNat exponentVal)).val) := by
-  simp [evalExpr]
+  simp [evalExpr, Verity.Core.Uint256.powEff_eq_pow]
 
 private theorem evalExpr_externalCall_of_ne
     (fields : List Field)
@@ -4097,12 +4097,14 @@ mutual
         let _ ← evalExprWithHelpers spec fields fuel state offset
         some 1
     -- The reserved `exp` builtin lane: pure arithmetic wearing an
-    -- `externalCall` node, so it needs no helper environment.
+    -- `externalCall` node, so it needs no helper environment. Like the plain
+    -- evaluator it reduces modulo 2^256 at every step so full-domain uint256
+    -- exponents stay executable.
     | .externalCall name [base, exponent] =>
         if name == builtinExpName then do
           let baseVal ← evalExprWithHelpers spec fields fuel state base
           let exponentVal ← evalExprWithHelpers spec fields fuel state exponent
-          pure (Verity.Core.Uint256.pow
+          pure (Verity.Core.Uint256.powEff
             (Verity.Core.Uint256.ofNat baseVal)
             (Verity.Core.Uint256.ofNat exponentVal)).val
         else none
@@ -5414,7 +5416,8 @@ mutual
                   spec fields fuel state base hsurface.1
                 have hexp := evalExprWithHelpers_eq_evalExpr_of_helperSurfaceClosed
                   spec fields fuel state exponent hsurface.2
-                simp [evalExprWithHelpers, evalExpr_externalCall_builtinExp, hbase, hexp]
+                simp [evalExprWithHelpers, evalExpr_externalCall_builtinExp, hbase, hexp,
+                  Verity.Core.Uint256.powEff_eq_pow]
               · simp [evalExprWithHelpers, evalExpr_externalCall_of_ne _ _ _ _ hname, hname]
     | mload a =>
         simp only [exprTouchesUnsupportedHelperSurface] at hsurface

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -1479,6 +1479,17 @@ def evalExpr (fields : List Field) (state : RuntimeState) : Expr → Option Nat
   | .returndataOptionalBoolAt offset => do
       let _ ← evalExpr fields state offset
       some 1
+  -- The reserved `exp` builtin lane. `pow`/`^` in the EDSL surfaces as
+  -- `externalCall builtinExpName [base, exponent]`, but it carries no foreign
+  -- behaviour: the compiler lowers it to the pure Yul `exp` builtin.
+  | .externalCall name [base, exponent] =>
+      if name == builtinExpName then do
+        let baseVal ← evalExpr fields state base
+        let exponentVal ← evalExpr fields state exponent
+        pure (Verity.Core.Uint256.pow
+          (Verity.Core.Uint256.ofNat baseVal)
+          (Verity.Core.Uint256.ofNat exponentVal)).val
+      else none
   | .keccak256 offExpr sizeExpr => do
       let off ← evalExpr fields state offExpr
       let size ← evalExpr fields state sizeExpr
@@ -1652,12 +1663,41 @@ private theorem evalExpr_dynamicBytesEq
       some (boolWord (DynamicAbi.dynamicBytesEqCalldata state.selector state.world.calldata
         lhsOffset lhsLength rhsOffset rhsLength))) := rfl
 
-private theorem evalExpr_externalCall
+/-- The reserved `exp` builtin lane is the only `externalCall` shape the source
+semantics evaluates; it denotes `Uint256.pow` on the two operand values. -/
+private theorem evalExpr_externalCall_builtinExp
+    (fields : List Field)
+    (state : RuntimeState)
+    (base exponent : Expr) :
+    evalExpr fields state (.externalCall builtinExpName [base, exponent]) = (do
+      let baseVal ← evalExpr fields state base
+      let exponentVal ← evalExpr fields state exponent
+      pure (Verity.Core.Uint256.pow
+        (Verity.Core.Uint256.ofNat baseVal)
+        (Verity.Core.Uint256.ofNat exponentVal)).val) := by
+  simp [evalExpr]
+
+private theorem evalExpr_externalCall_of_ne
     (fields : List Field)
     (state : RuntimeState)
     (name : String)
-    (args : List Expr) :
-    evalExpr fields state (.externalCall name args) = none := rfl
+    (args : List Expr)
+    (hname : name ≠ builtinExpName) :
+    evalExpr fields state (.externalCall name args) = none := by
+  match args with
+  | [] | [_] | _ :: _ :: _ :: _ => rfl
+  | [_, _] => simp [evalExpr, hname]
+
+private theorem evalExpr_externalCall_of_arity
+    (fields : List Field)
+    (state : RuntimeState)
+    (name : String)
+    (args : List Expr)
+    (harity : args.length ≠ 2) :
+    evalExpr fields state (.externalCall name args) = none := by
+  match args with
+  | [] | [_] | _ :: _ :: _ :: _ => rfl
+  | [_, _] => simp at harity
 
 private theorem evalExpr_mload
     (fields : List Field)
@@ -4056,6 +4096,16 @@ mutual
     | .returndataOptionalBoolAt offset => do
         let _ ← evalExprWithHelpers spec fields fuel state offset
         some 1
+    -- The reserved `exp` builtin lane: pure arithmetic wearing an
+    -- `externalCall` node, so it needs no helper environment.
+    | .externalCall name [base, exponent] =>
+        if name == builtinExpName then do
+          let baseVal ← evalExprWithHelpers spec fields fuel state base
+          let exponentVal ← evalExprWithHelpers spec fields fuel state exponent
+          pure (Verity.Core.Uint256.pow
+            (Verity.Core.Uint256.ofNat baseVal)
+            (Verity.Core.Uint256.ofNat exponentVal)).val
+        else none
     | .mulDiv512Down _ _ _ | .mulDiv512Up _ _ _
     | .paramDynamicHeadWord _ _ | .paramDynamicStaticComposite _ _
     | .paramDynamicMemberLength _ _
@@ -5346,8 +5396,26 @@ mutual
         simpa [evalExprWithHelpers, evalExpr_memoryArrayLength]
     | dynamicBytesEq _ _ =>
         simpa [evalExprWithHelpers, evalExpr_dynamicBytesEq]
-    | externalCall _ _ =>
-        simpa [evalExprWithHelpers, evalExpr_externalCall]
+    | externalCall name args =>
+        cases args with
+        | nil => simp [evalExprWithHelpers, evalExpr_externalCall_of_arity]
+        | cons base tl =>
+          cases tl with
+          | nil => simp [evalExprWithHelpers, evalExpr_externalCall_of_arity]
+          | cons exponent tl' =>
+            cases tl' with
+            | cons _ _ => simp [evalExprWithHelpers, evalExpr_externalCall_of_arity]
+            | nil =>
+              by_cases hname : name = builtinExpName
+              · subst hname
+                simp only [exprTouchesUnsupportedHelperSurface, beq_self_eq_true, if_true,
+                  Bool.or_eq_false_iff] at hsurface
+                have hbase := evalExprWithHelpers_eq_evalExpr_of_helperSurfaceClosed
+                  spec fields fuel state base hsurface.1
+                have hexp := evalExprWithHelpers_eq_evalExpr_of_helperSurfaceClosed
+                  spec fields fuel state exponent hsurface.2
+                simp [evalExprWithHelpers, evalExpr_externalCall_builtinExp, hbase, hexp]
+              · simp [evalExprWithHelpers, evalExpr_externalCall_of_ne _ _ _ _ hname, hname]
     | mload a =>
         simp only [exprTouchesUnsupportedHelperSurface] at hsurface
         have ha :=

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -1665,7 +1665,7 @@ private theorem evalExpr_dynamicBytesEq
 
 /-- The reserved `exp` builtin lane is the only `externalCall` shape the source
 semantics evaluates; it denotes `Uint256.pow` on the two operand values. -/
-private theorem evalExpr_externalCall_builtinExp
+theorem evalExpr_externalCall_builtinExp
     (fields : List Field)
     (state : RuntimeState)
     (base exponent : Expr) :

--- a/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
@@ -1,4 +1,5 @@
 import Compiler.Proofs.IRGeneration.SourceSemantics
+import Verity.Core.Model.Denote
 
 namespace Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest
 
@@ -354,6 +355,47 @@ example :
 example :
     evalIRCall (IRState.initial 0) "extcodesize" [Compiler.Yul.YulExpr.lit (2 ^ 160 + 1)] =
     some ((IRState.initial 0).codeSize 1) := by
+  native_decide
+
+/-- Regression (#2397): the reserved `exp` builtin lane must reduce modulo
+    2^256 at every step. A full-domain uint256 exponent (here 2^256 - 1) may
+    not materialise `Nat.pow` before reducing, or the evaluator hangs. -/
+example :
+    SourceSemantics.evalExpr [] { world := Verity.defaultState, bindings := [] }
+      (.externalCall builtinExpName [.literal 3, .literal (2 ^ 256 - 1)]) =
+    some 77194726158210796949047323339125271902179989777093709359638389338608753093291 := by
+  native_decide
+
+/-- Regression (#2397): the modular exponentiation stays faithful to
+    `Uint256.pow` on exponents past the 256-bit reduction boundary
+    (3 ^ 300 already wraps mod 2^256). -/
+example :
+    SourceSemantics.evalExpr [] { world := Verity.defaultState, bindings := [] }
+      (.externalCall builtinExpName [.literal 3, .literal 300]) =
+    some 87572657677406793603303376128395605907379627424338442757698266976936051615345 := by
+  native_decide
+
+/-- Regression (#2397): the helper-aware evaluator shares the incremental
+    modular exponentiation, so the lane stays executable over its full input
+    domain there too. -/
+example :
+    SourceSemantics.evalExprWithHelpers storageArraySourceSpec [] 1
+      { world := Verity.defaultState, bindings := [] }
+      (.externalCall builtinExpName [.literal 3, .literal (2 ^ 256 - 1)]) =
+    some 77194726158210796949047323339125271902179989777093709359638389338608753093291 := by
+  native_decide
+
+/-- Regression (#2397): the denotation evaluates the same lane without an
+    oracle round-trip and with the same incremental modular reduction. -/
+private def expLaneDenoteOracle : Compiler.CompilationModel.Denote.DenoteOracle :=
+  { mappingSlot := fun _ _ => 0
+    keccakMemorySlice := fun _ _ _ => 0 }
+
+example :
+    Compiler.CompilationModel.Denote.evalExpr expLaneDenoteOracle []
+      { world := Verity.defaultState, bindings := [] }
+      (.externalCall builtinExpName [.literal 3, .literal (2 ^ 256 - 1)]) =
+    some 77194726158210796949047323339125271902179989777093709359638389338608753093291 := by
   native_decide
 
 end Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -1064,6 +1064,13 @@ def exprTouchesUnsupportedCoreSurface : Expr → Bool
   | .keccak256 a b =>
       exprTouchesUnsupportedCoreSurface a || exprTouchesUnsupportedCoreSurface b
   | .arrayElement _ index => exprTouchesUnsupportedCoreSurface index
+  -- The reserved `exp` builtin lane travels as `externalCall`, but it is pure
+  -- arithmetic that lowers to the Yul `exp` builtin, so only its operands
+  -- constrain the core surface. Every other `externalCall` stays excluded.
+  | .externalCall name [base, exponent] =>
+      if name == builtinExpName then
+        exprTouchesUnsupportedCoreSurface base || exprTouchesUnsupportedCoreSurface exponent
+      else true
   -- `mulDiv512Down/Up` (verity#1761) and `paramDynamicHeadWord` (verity#1832)
   -- are codegen-only additions whose runtime Yul helpers the current core
   -- proof framework does not model yet, so `SupportedSpec` continues to
@@ -1123,6 +1130,12 @@ def exprTouchesUnsupportedStateSurface : Expr → Bool
   | .intrinsic _ _ _ _ => true
   | .keccak256 a b =>
       exprTouchesUnsupportedStateSurface a || exprTouchesUnsupportedStateSurface b
+  -- The reserved `exp` builtin lane travels as `externalCall` but is pure
+  -- arithmetic, so only its operands constrain the state surface.
+  | .externalCall name [base, exponent] =>
+      if name == builtinExpName then
+        exprTouchesUnsupportedStateSurface base || exprTouchesUnsupportedStateSurface exponent
+      else false
   | .constructorArg _ | .blobbasefee
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
   | .calldatasize | .returndataSize
@@ -1145,6 +1158,12 @@ def exprTouchesUnsupportedStateSurface : Expr → Bool
 /-- Call-related surfaces that still sit outside the current generic Layer 2
 body theorem: internal helper reuse, low-level calls, and foreign call hooks. -/
 def exprTouchesUnsupportedCallSurface : Expr → Bool
+  -- The reserved `exp` builtin lane travels as `externalCall` but lowers to the
+  -- pure Yul `exp` builtin, so it introduces no call surface of its own.
+  | .externalCall name [base, exponent] =>
+      if name == builtinExpName then
+        exprTouchesUnsupportedCallSurface base || exprTouchesUnsupportedCallSurface exponent
+      else true
   | .internalCall _ _ | .externalCall _ _ => true
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => true
   | .literal _ | .param _ | .immutable _ | .caller | .contractAddress | .txOrigin
@@ -1208,6 +1227,12 @@ def exprTouchesUnsupportedCallSurface : Expr → Bool
 generic whole-contract theorem. -/
 def exprTouchesUnsupportedHelperSurface : Expr → Bool
   | .internalCall _ _ => true
+  -- The reserved `exp` builtin lane now evaluates in the source semantics, so
+  -- its operands have to be screened rather than ignored.
+  | .externalCall name [base, exponent] =>
+      if name == builtinExpName then
+        exprTouchesUnsupportedHelperSurface base || exprTouchesUnsupportedHelperSurface exponent
+      else false
   | .literal _ | .param _ | .immutable _ | .caller | .contractAddress | .txOrigin
   | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
   | .localVar _ | .storage _ | .storageAddr _
@@ -1278,6 +1303,12 @@ still-unsupported expression shapes that currently share the coarse
 `exprTouchesUnsupportedHelperSurface` approximation. -/
 def exprTouchesInternalHelperSurface : Expr → Bool
   | .internalCall _ _ => true
+  -- The reserved `exp` builtin lane now evaluates in the source semantics, so
+  -- its operands have to be screened rather than ignored.
+  | .externalCall name [base, exponent] =>
+      if name == builtinExpName then
+        exprTouchesInternalHelperSurface base || exprTouchesInternalHelperSurface exponent
+      else false
   | .literal _ | .param _ | .immutable _ | .caller | .contractAddress | .txOrigin
   | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
   | .localVar _ | .storage _ | .storageAddr _
@@ -1341,6 +1372,14 @@ def exprTouchesInternalHelperSurface : Expr → Bool
 /-- Foreign-call/library-hook surfaces still outside the current generic
 whole-contract theorem. -/
 def exprTouchesUnsupportedForeignSurface : Expr → Bool
+  -- `pow`/`^` in the EDSL surfaces as `externalCall builtinExpName [b, e]`, but
+  -- it carries no foreign behaviour: the compiler lowers it to the pure Yul
+  -- `exp` builtin, and the source semantics evaluates it with `Uint256.pow`.
+  -- Genuine foreign calls keep the blanket exclusion.
+  | .externalCall name [base, exponent] =>
+      if name == builtinExpName then
+        exprTouchesUnsupportedForeignSurface base || exprTouchesUnsupportedForeignSurface exponent
+      else true
   | .externalCall _ _ => true
   | .literal _ | .param _ | .immutable _ | .caller | .contractAddress | .txOrigin
   | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
@@ -1404,6 +1443,12 @@ def exprTouchesUnsupportedForeignSurface : Expr → Bool
 whole-contract theorem. -/
 def exprTouchesUnsupportedLowLevelSurface : Expr → Bool
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _ => true
+  -- The reserved `exp` builtin lane now evaluates in the source semantics, so
+  -- its operands have to be screened rather than ignored.
+  | .externalCall name [base, exponent] =>
+      if name == builtinExpName then
+        exprTouchesUnsupportedLowLevelSurface base || exprTouchesUnsupportedLowLevelSurface exponent
+      else false
   | .literal _ | .param _ | .immutable _ | .caller | .contractAddress | .txOrigin
   | .chainid | .msgValue | .selfBalance | .blockTimestamp | .blockNumber
   | .localVar _ | .storage _ | .storageAddr _
@@ -1498,6 +1543,14 @@ def exprTouchesUnsupportedContractSurface (expr : Expr) : Bool :=
       exprTouchesUnsupportedContractSurface a
   | .keccak256 a b =>
       exprTouchesUnsupportedContractSurface a || exprTouchesUnsupportedContractSurface b
+  -- The reserved `exp` builtin lane travels as `externalCall` but is pure
+  -- arithmetic lowered to the Yul `exp` builtin. Every other `externalCall`
+  -- stays excluded below.
+  | .externalCall name [base, exponent] =>
+      if name == builtinExpName then
+        exprTouchesUnsupportedContractSurface base ||
+          exprTouchesUnsupportedContractSurface exponent
+      else true
   | .mapping _ _ | .mappingWord _ _ _ | .mappingPackedWord _ _ _ _
   | .mapping2 _ _ _ | .mapping2Word _ _ _ _ | .mappingUint _ _ | .mappingChain _ _
   | .structMember _ _ _ | .structMember2 _ _ _ _
@@ -3567,6 +3620,9 @@ private theorem exprCompileCore_helperSurfaceClosed
   | mulDivDown _ _ _ ihA ihB ihC | mulDivUp _ _ _ ihA ihB ihC =>
       simp only [exprTouchesUnsupportedHelperSurface, ihA, ihB, ihC,
         Bool.or_false, Bool.false_or]
+  | builtinExp _ _ ihB ihE =>
+      simp only [exprTouchesUnsupportedHelperSurface, beq_self_eq_true, if_true, ihB, ihE,
+        Bool.or_false, Bool.false_or]
 
 private theorem exprCompileCore_internalHelperCallNames_nil
     {expr : Expr}
@@ -3607,6 +3663,9 @@ private theorem exprCompileCore_internalHelperCallNames_nil
       simp only [exprInternalHelperCallNames, ihC, ihT, ihE, List.nil_append]
   | mulDivDown _ _ _ ihA ihB ihC | mulDivUp _ _ _ ihA ihB ihC =>
       simp only [exprInternalHelperCallNames, ihA, ihB, ihC, List.nil_append]
+  | builtinExp _ _ ihB ihE =>
+      simp only [exprInternalHelperCallNames, exprListInternalHelperCallNames, ihB, ihE,
+        List.nil_append, List.append_nil]
 
 private theorem exprListCompileCore_helperSurfaceClosed
     {exprs : List Expr}
@@ -4436,9 +4495,28 @@ mutual
     | arrayLength _ | memoryArrayLength _ | storageArrayLength _ | dynamicBytesEq _ _
     | paramDynamicHeadWord _ _ | paramDynamicStaticComposite _ _
     | paramDynamicMemberLength _ _
-    | paramDynamicMemberDataOffset _ _
-    | externalCall _ _ =>
+    | paramDynamicMemberDataOffset _ _ =>
         simp [exprTouchesInternalHelperSurface]
+    | externalCall name args =>
+        -- Only the reserved two-operand `exp` builtin lane recurses; every other
+        -- `externalCall` shape is still uniformly outside the helper surface.
+        cases args with
+        | nil => simp [exprTouchesInternalHelperSurface]
+        | cons base tl =>
+          cases tl with
+          | nil => simp [exprTouchesInternalHelperSurface]
+          | cons exponent tl' =>
+            cases tl' with
+            | cons _ _ => simp [exprTouchesInternalHelperSurface]
+            | nil =>
+              by_cases hname : name = builtinExpName
+              · subst hname
+                simp only [exprTouchesUnsupportedHelperSurface, beq_self_eq_true, if_true,
+                  Bool.or_eq_false_iff] at hsurface
+                simp [exprTouchesInternalHelperSurface,
+                  exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.1,
+                  exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface.2]
+              · simp [exprTouchesInternalHelperSurface, hname]
     | adtConstruct _ _ _ | adtTag _ _ | adtField _ _ _ _ _ =>
         simp [exprTouchesUnsupportedHelperSurface] at hsurface
     | tload a | calldataload a | mload a | extcodesize a | returndataOptionalBoolAt a =>
@@ -4898,9 +4976,43 @@ private theorem exprTouchesUnsupportedCallSurface_eq_featureOr
   | adtConstruct _ _ _ | adtTag _ _ | adtField _ _ _ _ _ =>
       simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
-  | internalCall _ _ | externalCall _ _ =>
+  | internalCall _ _ =>
       simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
+  | externalCall name args =>
+      -- All four predicates recurse identically on the reserved `exp` builtin
+      -- lane, so the decomposition holds there by associativity/commutativity.
+      cases args with
+      | nil =>
+          simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
+            exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
+      | cons base tl =>
+        cases tl with
+        | nil =>
+            simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
+              exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
+        | cons exponent tl' =>
+          cases tl' with
+          | cons _ _ =>
+              simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
+                exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
+          | nil =>
+            by_cases hname : name = builtinExpName
+            · subst hname
+              simp only [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
+                exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface,
+                beq_self_eq_true, if_true]
+              rw [exprTouchesUnsupportedCallSurface_eq_featureOr base,
+                exprTouchesUnsupportedCallSurface_eq_featureOr exponent]
+              cases exprTouchesUnsupportedHelperSurface base <;>
+                cases exprTouchesUnsupportedForeignSurface base <;>
+                cases exprTouchesUnsupportedLowLevelSurface base <;>
+                cases exprTouchesUnsupportedHelperSurface exponent <;>
+                cases exprTouchesUnsupportedForeignSurface exponent <;>
+                cases exprTouchesUnsupportedLowLevelSurface exponent <;> rfl
+            · simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
+                exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface,
+                hname]
   | intrinsic _ _ _ _ =>
       simp [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
@@ -5251,8 +5363,32 @@ private theorem exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
   | arrayElementDynamicMemberElement _ _ _ _
   | storageArrayElement _ _
   | call _ _ _ _ _ _ _ | staticcall _ _ _ _ _ _ | delegatecall _ _ _ _ _ _
-  | externalCall _ _ | internalCall _ _ =>
+  | internalCall _ _ =>
       cases hcore
+  | externalCall name args =>
+      cases args with
+      | nil => cases hcore
+      | cons base tl =>
+        cases tl with
+        | nil => cases hcore
+        | cons exponent tl' =>
+          cases tl' with
+          | cons _ _ => cases hcore
+          | nil =>
+            by_cases hname : name = builtinExpName
+            · subst hname
+              simp only [exprTouchesUnsupportedCoreSurface, beq_self_eq_true, if_true,
+                Bool.or_eq_false_iff] at hcore
+              simp only [exprTouchesUnsupportedStateSurface, beq_self_eq_true, if_true,
+                Bool.or_eq_false_iff] at hstate
+              simp only [exprTouchesUnsupportedCallSurface, beq_self_eq_true, if_true,
+                Bool.or_eq_false_iff] at hcalls
+              simp [exprTouchesUnsupportedContractSurface,
+                exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed base
+                  hcore.1 hstate.1 hcalls.1,
+                exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed exponent
+                  hcore.2 hstate.2 hcalls.2]
+            · simp [exprTouchesUnsupportedCoreSurface, hname] at hcore
   | arrayElement _ index =>
       cases hcalls
 termination_by sizeOf expr
@@ -5694,7 +5830,25 @@ theorem exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
       simp [exprTouchesUnsupportedContractSurface] at hsurface
   | adtConstruct _ _ _ | adtTag _ _ | adtField _ _ _ _ _ =>
       simp [exprTouchesUnsupportedContractSurface] at hsurface
-  | storage _ | storageAddr _ | internalCall _ _ | externalCall _ _
+  | externalCall name args =>
+      cases args with
+      | nil => simp [exprTouchesUnsupportedContractSurface] at hsurface
+      | cons base tl =>
+        cases tl with
+        | nil => simp [exprTouchesUnsupportedContractSurface] at hsurface
+        | cons exponent tl' =>
+          cases tl' with
+          | cons _ _ => simp [exprTouchesUnsupportedContractSurface] at hsurface
+          | nil =>
+            by_cases hname : name = builtinExpName
+            · subst hname
+              simp only [exprTouchesUnsupportedContractSurface, beq_self_eq_true, if_true,
+                Bool.or_eq_false_iff] at hsurface
+              simp [exprTouchesUnsupportedHelperSurface,
+                exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed hsurface.1,
+                exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed hsurface.2]
+            · simp [exprTouchesUnsupportedContractSurface, hname] at hsurface
+  | storage _ | storageAddr _ | internalCall _ _
   | arrayLength _ | memoryArrayLength _ | storageArrayLength _
   | dynamicBytesEq _ _
   | call _ _ _ _ _ _ _ | staticcall _ _ _ _ _ _ | delegatecall _ _ _ _ _ _
@@ -6229,6 +6383,9 @@ private theorem exprCompileCore_usesArrayElement_false
       simp only [exprUsesArrayElement, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesArrayElement, ihC, ihT, ihE, Bool.false_or]
+  | builtinExp _ _ ihB ihE =>
+      simp only [exprUsesArrayElement, exprListUsesArrayElement, ihB, ihE, Bool.false_or,
+        Bool.or_false]
 
 -- Helper: ExprCompileCore expressions never use storageArrayElement
 private theorem exprCompileCore_usesStorageArrayElement_false
@@ -6259,6 +6416,9 @@ private theorem exprCompileCore_usesStorageArrayElement_false
       simp only [exprUsesStorageArrayElement, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesStorageArrayElement, ihC, ihT, ihE, Bool.false_or]
+  | builtinExp _ _ ihB ihE =>
+      simp only [exprUsesStorageArrayElement, exprListUsesStorageArrayElement, ihB, ihE,
+        Bool.false_or, Bool.or_false]
 
 -- Helper: ExprCompileCore expressions never use dynamicBytesEq
 private theorem exprCompileCore_usesDynamicBytesEq_false
@@ -6289,6 +6449,9 @@ private theorem exprCompileCore_usesDynamicBytesEq_false
       simp only [exprUsesDynamicBytesEq, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesDynamicBytesEq, ihC, ihT, ihE, Bool.false_or]
+  | builtinExp _ _ ihB ihE =>
+      simp only [exprUsesDynamicBytesEq, exprListUsesDynamicBytesEq, ihB, ihE, Bool.false_or,
+        Bool.or_false]
 
 -- Helper: ExprCompileCore lists never use arrayElement
 private theorem exprListCompileCore_usesArrayElement_false
@@ -7001,6 +7164,9 @@ private theorem exprCompileCore_usesMulDiv512_false
       simp only [exprUsesMulDiv512, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesMulDiv512, ihC, ihT, ihE, Bool.false_or]
+  | builtinExp _ _ ihB ihE =>
+      simp only [exprUsesMulDiv512, exprListUsesMulDiv512, ihB, ihE, Bool.false_or,
+        Bool.or_false]
 
 -- Helper: ExprCompileCore expressions never use paramDynamicHeadWord (verity#1832)
 private theorem exprCompileCore_usesParamDynamicHeadWord_false
@@ -7031,6 +7197,9 @@ private theorem exprCompileCore_usesParamDynamicHeadWord_false
       simp only [exprUsesParamDynamicHeadWord, ih, Bool.false_or]
   | ite _ _ _ ihC ihT ihE =>
       simp only [exprUsesParamDynamicHeadWord, ihC, ihT, ihE, Bool.false_or]
+  | builtinExp _ _ ihB ihE =>
+      simp only [exprUsesParamDynamicHeadWord, exprListUsesParamDynamicHeadWord, ihB, ihE,
+        Bool.false_or, Bool.or_false]
 
 -- Helper: ExprCompileCore lists never use mulDiv512
 private theorem exprListCompileCore_usesMulDiv512_false

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -1374,7 +1374,8 @@ whole-contract theorem. -/
 def exprTouchesUnsupportedForeignSurface : Expr → Bool
   -- `pow`/`^` in the EDSL surfaces as `externalCall builtinExpName [b, e]`, but
   -- it carries no foreign behaviour: the compiler lowers it to the pure Yul
-  -- `exp` builtin, and the source semantics evaluates it with `Uint256.pow`.
+  -- `exp` builtin, and the source semantics evaluates it with
+  -- `Uint256.powEff` (modular square-and-multiply, equal to `Uint256.pow`).
   -- Genuine foreign calls keep the blanket exclusion.
   | .externalCall name [base, exponent] =>
       if name == builtinExpName then

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanPureBuiltinLemmas.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanPureBuiltinLemmas.lean
@@ -80,6 +80,65 @@ private theorem word_lt_uint256_size (x : Nat) :
     simp [hb, EvmYul.UInt256.toNat]
     rfl
 
+private theorem uint256_mul_toNat (a c : EvmYul.UInt256) :
+    (a * c).toNat = (a.toNat * c.toNat) % EvmYul.UInt256.size := by
+  show (EvmYul.UInt256.mul a c).toNat = _
+  simp [EvmYul.UInt256.mul, EvmYul.UInt256.toNat, Fin.mul_def]
+
+private theorem nat_pow_two_mul_succ (base acc m : Nat) :
+    base * acc ^ (2 * m + 1) = base * acc * (acc * acc) ^ m := by
+  rw [pow_succ, pow_mul]; ring
+
+private theorem nat_pow_two_mul (base acc m : Nat) :
+    base * acc ^ (2 * m) = base * (acc * acc) ^ m := by
+  rw [pow_mul]; ring
+
+/-- EVMYulLean computes `EXP` by binary exponentiation over `Fin 2^256`; this
+identifies the accumulator with the closed form `a * c ^ n` reduced mod `2^256`. -/
+private theorem uint256_powAux_toNat (n : Nat) : ∀ (a c : EvmYul.UInt256),
+    (EvmYul.UInt256.powAux a c n).toNat
+      = (a.toNat * c.toNat ^ n) % EvmYul.UInt256.size := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    intro a c
+    match n with
+    | 0 =>
+      have ha : a.toNat < EvmYul.UInt256.size := a.val.isLt
+      simp [EvmYul.UInt256.powAux, Nat.mod_eq_of_lt ha]
+    | (k + 1) =>
+      have hlt : (k + 1) / 2 < k + 1 := Nat.div_lt_self (Nat.succ_pos k) (by omega)
+      rw [EvmYul.UInt256.powAux]
+      by_cases hodd : (k + 1) % 2 = 1
+      · rw [if_pos (by simp [hodd])]
+        rw [ih _ hlt, uint256_mul_toNat, uint256_mul_toNat]
+        have hk : 2 * ((k + 1) / 2) + 1 = k + 1 := by omega
+        have harith := nat_pow_two_mul_succ a.toNat c.toNat ((k + 1) / 2)
+        rw [hk] at harith
+        rw [harith]
+        exact Nat.ModEq.mul (Nat.mod_modEq _ _) (Nat.ModEq.pow _ (Nat.mod_modEq _ _))
+      · rw [if_neg (by simp [hodd])]
+        rw [ih _ hlt, uint256_mul_toNat]
+        have hk : 2 * ((k + 1) / 2) = k + 1 := by omega
+        have harith := nat_pow_two_mul a.toNat c.toNat ((k + 1) / 2)
+        rw [hk] at harith
+        rw [harith]
+        exact Nat.ModEq.mul_left _ (Nat.ModEq.pow _ (Nat.mod_modEq _ _))
+
+private theorem uint256_pow_toNat (b n : EvmYul.UInt256) :
+    (EvmYul.UInt256.pow b n).toNat = (b.toNat ^ n.toNat) % EvmYul.UInt256.size := by
+  rw [EvmYul.UInt256.pow, uint256_powAux_toNat]
+  simp [EvmYul.UInt256.toNat]
+
+@[simp] theorem evalPureBuiltinViaEvmYulLean_exp_native (a b : Nat) :
+    evalPureBuiltinViaEvmYulLean "exp" [a, b] =
+      some ((a % Compiler.Constants.evmModulus) ^ (b % Compiler.Constants.evmModulus)
+        % Compiler.Constants.evmModulus) := by
+  rw [← uint256_size_eq_evmModulus]
+  change some (EvmYul.UInt256.toNat
+      (EvmYul.UInt256.exp (EvmYul.UInt256.ofNat a) (EvmYul.UInt256.ofNat b))) = _
+  rw [EvmYul.UInt256.exp, uint256_pow_toNat]
+  rfl
+
 @[simp] theorem evalPureBuiltinViaEvmYulLean_eq_native (a b : Nat) :
     evalPureBuiltinViaEvmYulLean "eq" [a, b] =
       some (if a % Compiler.Constants.evmModulus = b % Compiler.Constants.evmModulus then 1 else 0) := by

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2876,6 +2876,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.FunctionBody.evalIRExpr_add_of_eval
   Compiler.Proofs.IRGeneration.FunctionBody.evalIRExpr_sub_of_eval
   Compiler.Proofs.IRGeneration.FunctionBody.evalIRExpr_mul_of_eval
+  Compiler.Proofs.IRGeneration.FunctionBody.evalIRExpr_exp_of_eval
+  -- Compiler.Proofs.IRGeneration.FunctionBody.uint256_pow_val  -- private
   Compiler.Proofs.IRGeneration.FunctionBody.evalIRExpr_div_of_eval
   Compiler.Proofs.IRGeneration.FunctionBody.evalIRExpr_mod_of_eval
   Compiler.Proofs.IRGeneration.FunctionBody.evalIRExpr_eq_of_eval
@@ -2967,6 +2969,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.FunctionBody.compileExpr_mod_ok
   Compiler.Proofs.IRGeneration.FunctionBody.compileExpr_mload_ok
   Compiler.Proofs.IRGeneration.FunctionBody.compileExpr_keccak256_ok
+  Compiler.Proofs.IRGeneration.FunctionBody.compileExpr_builtinExp_ok
+  -- Compiler.Proofs.IRGeneration.FunctionBody.eval_compileExpr_builtinExp_of_compiled  -- private
   -- Compiler.Proofs.IRGeneration.FunctionBody.eval_compileExpr_keccak256_of_compiled  -- private
   -- Compiler.Proofs.IRGeneration.FunctionBody.eval_compileExpr_mload_of_compiled  -- private
   Compiler.Proofs.IRGeneration.FunctionBody.compileExpr_extcodesize_ok
@@ -3691,6 +3695,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.stmtListScopeDiscipline_of_validateFunctionIdentifierReferences_prefix
   -- Compiler.Proofs.IRGeneration.scopeNamesPresent_foldl_stmtNextScope_of_validateScopedStmtListIdentifiers  -- private
   Compiler.Proofs.IRGeneration.exprBoundNamesInScope_setStorage_of_validateFunctionIdentifierReferences
+  -- Compiler.Proofs.IRGeneration.collectExprNames_builtinExp_split  -- private
   Compiler.Proofs.IRGeneration.collectExprNames_mem_exprBoundNames_of_core
   -- Compiler.Proofs.IRGeneration.mem_foldl_stmtNextScope_of_mem_scope  -- private
   Compiler.Proofs.IRGeneration.stmtListBindNames_subset_foldl_stmtNextScope
@@ -4395,7 +4400,9 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayLength  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_memoryArrayLength  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_dynamicBytesEq  -- private
-  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_externalCall  -- private
+  Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_externalCall_builtinExp
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_externalCall_of_ne  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_externalCall_of_arity  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mload  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_tload  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_calldataload  -- private
@@ -7247,6 +7254,12 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.Backends.evalPureBuiltinViaEvmYulLean_mul_native
   Compiler.Proofs.YulGeneration.Backends.evalPureBuiltinViaEvmYulLean_div_native
   Compiler.Proofs.YulGeneration.Backends.evalPureBuiltinViaEvmYulLean_mod_native
+  -- Compiler.Proofs.YulGeneration.Backends.uint256_mul_toNat  -- private
+  -- Compiler.Proofs.YulGeneration.Backends.nat_pow_two_mul_succ  -- private
+  -- Compiler.Proofs.YulGeneration.Backends.nat_pow_two_mul  -- private
+  -- Compiler.Proofs.YulGeneration.Backends.uint256_powAux_toNat  -- private
+  -- Compiler.Proofs.YulGeneration.Backends.uint256_pow_toNat  -- private
+  Compiler.Proofs.YulGeneration.Backends.evalPureBuiltinViaEvmYulLean_exp_native
   Compiler.Proofs.YulGeneration.Backends.evalPureBuiltinViaEvmYulLean_eq_native
   Compiler.Proofs.YulGeneration.Backends.evalPureBuiltinViaEvmYulLean_iszero_native
   Compiler.Proofs.YulGeneration.Backends.evalPureBuiltinViaEvmYulLean_lt_native
@@ -7402,4 +7415,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6849 theorems/lemmas (4914 public, 1935 private, 0 sorry'd)
+-- Total: 6862 theorems/lemmas (4918 public, 1944 private, 0 sorry'd)

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -997,7 +997,7 @@ def evalExpr (oracle : DenoteOracle) (fields : List Field) (state : DenoteState)
       if name == builtinExpName then do
         let baseVal ← evalExpr oracle fields state base
         let exponentVal ← evalExpr oracle fields state exponent
-        pure (Verity.Core.Uint256.pow
+        pure (Verity.Core.Uint256.powEff
           (Verity.Core.Uint256.ofNat baseVal)
           (Verity.Core.Uint256.ofNat exponentVal)).val
       else none

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -991,6 +991,16 @@ def evalExpr (oracle : DenoteOracle) (fields : List Field) (state : DenoteState)
   | .returndataOptionalBoolAt offset => do
       let _ ← evalExpr oracle fields state offset
       some 1
+  -- The reserved `exp` builtin lane: pure arithmetic wearing an `externalCall`
+  -- node, so it needs no oracle. Genuine foreign calls stay undenoted.
+  | .externalCall name [base, exponent] =>
+      if name == builtinExpName then do
+        let baseVal ← evalExpr oracle fields state base
+        let exponentVal ← evalExpr oracle fields state exponent
+        pure (Verity.Core.Uint256.pow
+          (Verity.Core.Uint256.ofNat baseVal)
+          (Verity.Core.Uint256.ofNat exponentVal)).val
+      else none
   | .keccak256 offExpr sizeExpr => do
       let off ← evalExpr oracle fields state offExpr
       let size ← evalExpr oracle fields state sizeExpr

--- a/Verity/Core/Uint256.lean
+++ b/Verity/Core/Uint256.lean
@@ -126,6 +126,67 @@ def mul (a b : Uint256) : Uint256 := ofNat (a.val * b.val)
 /-- EVM EXP semantics: exponentiation modulo `2^256`. -/
 def pow (base exponent : Uint256) : Uint256 := ofNat (base.val ^ exponent.val)
 
+/-- Binary exponentiation over `Uint256`; accumulates `acc * base ^ exp` modulo
+    `2^256` without materializing `Nat.pow`. -/
+def powBySquaring (acc base : Uint256) (exp : Nat) : Uint256 :=
+  match exp with
+  | 0 => acc
+  | n + 1 =>
+    if (n + 1) % 2 = 1 then
+      powBySquaring (mul acc base) (mul base base) ((n + 1) / 2)
+    else
+      powBySquaring acc (mul base base) ((n + 1) / 2)
+termination_by exp
+
+private theorem mul_val (a b : Uint256) : (mul a b).val = (a.val * b.val) % modulus := by
+  simp [mul, ofNat]
+
+private theorem mod_mul_pow_mod (a b k m : Nat) :
+    (a % m * (b % m) ^ k) % m = (a * b ^ k) % m := by
+  rw [Nat.mul_mod (a % m) ((b % m) ^ k) m, Nat.mod_mod, ← Nat.pow_mod, ← Nat.mul_mod]
+
+private theorem mul_pow_mod (a b k m : Nat) :
+    (a * (b % m) ^ k) % m = (a * b ^ k) % m := by
+  rw [Nat.mul_mod, ← Nat.pow_mod, ← Nat.mul_mod]
+
+theorem powBySquaring_val (acc base : Uint256) (n : Nat) :
+    (powBySquaring acc base n).val = (acc.val * base.val ^ n) % modulus := by
+  induction n using Nat.strongRecOn generalizing acc base with
+  | _ n ih =>
+    match n with
+    | 0 =>
+      simp only [powBySquaring, Nat.pow_zero, Nat.mul_one]
+      exact (Nat.mod_eq_of_lt acc.isLt).symm
+    | (k + 1) =>
+      have hlt : (k + 1) / 2 < k + 1 := Nat.div_lt_self (Nat.succ_pos k) (by omega)
+      unfold powBySquaring
+      split
+      · rename_i hodd
+        rw [ih _ hlt, mul_val, mul_val, mod_mul_pow_mod]
+        congr 1
+        rw [Nat.mul_assoc, Nat.mul_comm base.val ((base.val * base.val) ^ _)]
+        congr 1
+        rw [show base.val * base.val = base.val ^ 2 from by rw [Nat.pow_succ, Nat.pow_one],
+            ← Nat.pow_mul, ← Nat.pow_succ]
+        congr 1; omega
+      · rename_i heven
+        rw [ih _ hlt, mul_val, mul_pow_mod]
+        congr 1; congr 1
+        rw [show base.val * base.val = base.val ^ 2 from by rw [Nat.pow_succ, Nat.pow_one],
+            ← Nat.pow_mul]
+        congr 1; omega
+
+/-- `powEff` computes the same result as `pow` using binary exponentiation. -/
+def powEff (base exponent : Uint256) : Uint256 :=
+  powBySquaring (ofNat 1) base exponent.val
+
+private theorem val_injective {a b : Uint256} (h : a.val = b.val) : a = b := by
+  cases a with | mk av ah => cases b with | mk bv bh => simp_all
+
+theorem powEff_eq_pow (base exponent : Uint256) :
+    powEff base exponent = pow base exponent :=
+  val_injective (by simp [powEff, powBySquaring_val, pow, ofNat])
+
 -- Division (returns 0 on division by zero, matching EVM)
 def div (a b : Uint256) : Uint256 :=
   if b.val = 0 then ofNat 0 else ofNat (a.val / b.val)

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 485,
+    "native_decide": 489,
     "partial def": 171
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",


### PR DESCRIPTION
## Summary

Closes one more Tier-4 *external-call/foreign* surface from #2084 by giving the pure `exp` builtin a first-class compiler/proof surface instead of leaving it misfiled as a foreign call.

`pow a b` / `a ^ b` in the EDSL desugars to `Expr.externalCall builtinExpName [base, exponent]` (`Verity/Macro/Translate/Expr.lean:3404`). That node shape is pure arithmetic — it lowers to the Yul `exp` builtin and never reaches a foreign address — but every unsupported-surface predicate treated it as an opaque `externalCall`, so it was excluded from the compile core and undenoted.

This slice admits exactly that one sentinel-keyed shape:

- **Surface predicates** (`SupportedSpec.lean`): all 8 predicates now recurse into `base`/`exponent` when `name == builtinExpName`, and keep their original constant for every other `externalCall`. Genuine foreign calls remain unsupported.
- **Compile core** (`ExprCore.lean`): new `ExprCompileCore.builtinExp` constructor.
- **Source semantics** (`SourceSemantics.lean`): `evalExpr_externalCall_builtinExp`, plus `_of_ne` / `_of_arity` lemmas pinning the non-exp behaviour.
- **Compiler-free denotation** (`Verity/Core/Model/Denote.lean`): the exp lane denotes without an oracle; other `externalCall`s stay `none`.
- **IR bridge** (`FunctionBody/Base.lean`): `evalIRExpr_exp_of_eval`, `compileExpr_builtinExp_ok`, `eval_compileExpr_builtinExp_of_compiled`.
- **EVMYulLean native lowering** (`EvmYulLeanPureBuiltinLemmas.lean`): `evalPureBuiltinViaEvmYulLean_exp_native`, proved through `uint256_powAux_toNat` / `uint256_pow_toNat`. No `native_decide`.

All four planes agree on `Uint256.pow`, i.e. `(a % 2^256) ^ (b % 2^256) % 2^256`.

### `collectExprNames` consistency fix

`ValidationHelpers.collectExprNames` prepended `builtinExpName` to its result. That is a fresh-name-avoidance collector feeding only `pickFreshName` (`Compile.lean:109/116/123, 308/323/341`), and `builtinExpName` is already in the reserved-identifier list (`ValidationCalls.lean:83`) so no user can bind it. `TrustSurface.collectExternalExprNames:579-583` already skips the sentinel identically — this brings the two collectors into agreement. Without it, `collectExprNames_mem_exprBoundNames_of_core` is genuinely false for the exp lane and its downstream consumer `eventCollectExprListNames_subset_scope` breaks.

No gate was weakened: the proof-length limit hit on `collectExprNames_mem_exprBoundNames_of_core` (52 lines) was resolved by extracting `collectExprNames_builtinExp_split`, not by allowlisting.

## Validation receipts

```
lake build                                              Build completed successfully (2473 jobs).   exit 0
lake build PrintAxioms                                  Build completed successfully (2622 jobs).   exit 0
lake build ...GenericInduction.Scope                    ✔ [1211/1211] (25s)                          exit 0
lake build ...IRGeneration.Function                     ✔ [1226/1226] (61s)                          exit 0
make check                                              All checks passed.                           exit 0
  └ 666 Python tests OK in 77.9s
lean_lint --only proof_length     Proof length check passed. 7275 scanned / 5417 <30 / 1218 30-50 / 640 allowlisted
lean_lint --only lean_hygiene     0 debug commands, 0 allowUnsafeReducibility, 0 sorry, 0 native_decide in proofs
check_compiler_boundaries.py      all 7 sub-checks passed
```

**Forbidden-token scan** on added lines vs `origin/main`: zero new `sorry` / `admit` / `axiom` / `unsafe`. Two benign textual hits only — the AUDIT.md prose "No `native_decide`." and the generated `PrintAxioms.lean` counter line `0 sorry'd`.

`PrintAxioms.lean` regenerated via `scripts/generate_print_axioms.py`: 6849 → 6862 theorems (4918 public, 1944 private, 0 sorry'd). No new axiom, no new trust assumption; `AUDIT.md` gains a "Pure `exp` Builtin Lane (2026-08)" section.

## Test plan

- [x] `lake build` green
- [x] `lake build PrintAxioms` green (note: `Compiler.Proofs.IRGeneration.Function` is reachable *only* through this target)
- [x] `make check` green
- [x] Proof-length and hygiene lints green without new allowlist entries
- [x] Forbidden-token scan clean