### PR TITLE
proof(L2): source semantics for externalCallBind/tryExternalCallBind (#2084)

### DIFF
--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -35,7 +35,7 @@ def sourceOracle : DenoteOracle :=
 def toRuntimeState (s : DenoteState) : SourceSemantics.RuntimeState :=
   { world := s.world, immutable := s.immutable, bindings := s.bindings, selector := s.selector,
     externalCallOracle := fun n =>
-      ⟨s.externalCallSucceeded n, s.externalCallReturnValues n⟩,
+      ⟨s.externalCallSucceeded n, s.externalCallReturnValues n, s.externalCallPostWorld n⟩,
     externalCallIndex := s.externalCallIndex }
 
 @[simp] theorem toRuntimeState_world (s : DenoteState) :
@@ -52,7 +52,7 @@ def toRuntimeState (s : DenoteState) : SourceSemantics.RuntimeState :=
 
 @[simp] theorem toRuntimeState_externalCallOracle (s : DenoteState) :
     (toRuntimeState s).externalCallOracle = fun n =>
-      ⟨s.externalCallSucceeded n, s.externalCallReturnValues n⟩ := rfl
+      ⟨s.externalCallSucceeded n, s.externalCallReturnValues n, s.externalCallPostWorld n⟩ := rfl
 
 @[simp] theorem toRuntimeState_externalCallIndex (s : DenoteState) :
     (toRuntimeState s).externalCallIndex = s.externalCallIndex := rfl
@@ -629,15 +629,29 @@ theorem execStmt_eq (fields : List Field) :
       cases Denote.evalExprList sourceOracle fields st args with
       | none => rfl
       | some _ =>
-          by_cases h : st.externalCallSucceeded st.externalCallIndex = true <;>
-            simp [toStmtResult, toRuntimeState, h]
+          have hw : (wordNormalize : Nat → Nat) = SourceSemantics.wordNormalize :=
+            funext wordNormalize_eq
+          by_cases h : st.externalCallSucceeded st.externalCallIndex = true
+          · simp only [h, ite_true]
+            by_cases harity :
+                (st.externalCallReturnValues st.externalCallIndex).length < resultVars.length
+            · simp [toStmtResult, toRuntimeState, h, harity]
+            · simp [toStmtResult, toRuntimeState, h, harity, hw, bindValues_eq]
+          · simp [toStmtResult, toRuntimeState, h]
   | st, .tryExternalCallBind successVar resultVars _externalName args => by
       simp only [Denote.execStmt, SourceSemantics.execStmt, ← denote_evalExprList_eq]
       cases Denote.evalExprList sourceOracle fields st args with
       | none => rfl
       | some _ =>
-          simp only [toStmtResult, toRuntimeState, bindValue_eq, bindValues_eq]
-          rfl
+          have hw : (wordNormalize : Nat → Nat) = SourceSemantics.wordNormalize :=
+            funext wordNormalize_eq
+          by_cases h : st.externalCallSucceeded st.externalCallIndex = true
+          · simp only [h, ite_true]
+            by_cases harity :
+                (st.externalCallReturnValues st.externalCallIndex).length < resultVars.length
+            · simp [toStmtResult, toRuntimeState, h, harity]
+            · simp [toStmtResult, toRuntimeState, h, harity, hw, bindValue_eq, bindValues_eq]
+          · simp [toStmtResult, toRuntimeState, h, hw, bindValue_eq, bindValues_eq]
   | _, .returnValues .. | _, .returnArray .. | _, .returnBytes .. | _, .returnStorageWords ..
   | _, .returnCodeData .. | _, .revertReturndata .. | _, .internalCall ..
   | _, .internalCallAssign .. | _, .rawLog ..

--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -634,7 +634,7 @@ theorem execStmt_eq (fields : List Field) :
           by_cases h : st.externalCallSucceeded st.externalCallIndex = true
           · simp only [h, ite_true]
             by_cases harity :
-                (st.externalCallReturnValues st.externalCallIndex).length < resultVars.length
+                (st.externalCallReturnValues st.externalCallIndex).length != resultVars.length
             · simp [toStmtResult, toRuntimeState, h, harity]
             · simp [toStmtResult, toRuntimeState, h, harity, hw, bindValues_eq]
           · simp [toStmtResult, toRuntimeState, h]
@@ -648,7 +648,7 @@ theorem execStmt_eq (fields : List Field) :
           by_cases h : st.externalCallSucceeded st.externalCallIndex = true
           · simp only [h, ite_true]
             by_cases harity :
-                (st.externalCallReturnValues st.externalCallIndex).length < resultVars.length
+                (st.externalCallReturnValues st.externalCallIndex).length != resultVars.length
             · simp [toStmtResult, toRuntimeState, h, harity]
             · simp [toStmtResult, toRuntimeState, h, harity, hw, bindValue_eq, bindValues_eq]
           · simp [toStmtResult, toRuntimeState, h, hw, bindValue_eq, bindValues_eq]

--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -33,7 +33,10 @@ def sourceOracle : DenoteOracle :=
 
 /-- The state conversion is field-for-field (the two structures coincide). -/
 def toRuntimeState (s : DenoteState) : SourceSemantics.RuntimeState :=
-  { world := s.world, immutable := s.immutable, bindings := s.bindings, selector := s.selector }
+  { world := s.world, immutable := s.immutable, bindings := s.bindings, selector := s.selector,
+    externalCallOracle := fun n =>
+      ⟨s.externalCallSucceeded n, s.externalCallReturnValues n⟩,
+    externalCallIndex := s.externalCallIndex }
 
 @[simp] theorem toRuntimeState_world (s : DenoteState) :
     (toRuntimeState s).world = s.world := rfl
@@ -46,6 +49,13 @@ def toRuntimeState (s : DenoteState) : SourceSemantics.RuntimeState :=
 
 @[simp] theorem toRuntimeState_selector (s : DenoteState) :
     (toRuntimeState s).selector = s.selector := rfl
+
+@[simp] theorem toRuntimeState_externalCallOracle (s : DenoteState) :
+    (toRuntimeState s).externalCallOracle = fun n =>
+      ⟨s.externalCallSucceeded n, s.externalCallReturnValues n⟩ := rfl
+
+@[simp] theorem toRuntimeState_externalCallIndex (s : DenoteState) :
+    (toRuntimeState s).externalCallIndex = s.externalCallIndex := rfl
 
 @[simp] theorem sourceOracle_mappingSlot :
     sourceOracle.mappingSlot = Compiler.Proofs.abstractMappingSlot := rfl
@@ -461,26 +471,19 @@ theorem execForEachLoop_agree {varName : String}
         SourceSemantics.execForEachLoop varName runBody' (toRuntimeState st) index remaining
   | _, _, 0 => rfl
   | st, index, remaining + 1 => by
-      have hb := h ⟨st.world,
-        st.immutable,
-        SourceSemantics.bindValue st.bindings varName (SourceSemantics.wordNormalize index),
-        st.selector⟩
+      let ls := { st with bindings :=
+        SourceSemantics.bindValue st.bindings varName (SourceSemantics.wordNormalize index) }
+      have hb := h ls
       rw [SourceSemantics.execForEachLoop_succ]
       simp only [toRuntimeState] at hb ⊢
       rw [← hb]
       show toStmtResult
-          (match runBody ⟨st.world,
-              st.immutable,
-              SourceSemantics.bindValue st.bindings varName (SourceSemantics.wordNormalize index),
-              st.selector⟩ with
+          (match runBody ls with
             | .continue next => Denote.execForEachLoop varName runBody next (index + 1) remaining
             | .stop next => .stop next
             | .return value next => .return value next
             | .revert => .revert) = _
-      cases runBody ⟨st.world,
-          st.immutable,
-          SourceSemantics.bindValue st.bindings varName (SourceSemantics.wordNormalize index),
-          st.selector⟩ <;>
+      cases runBody ls <;>
         first
           | rfl
           | exact execForEachLoop_agree h _ (index + 1) remaining
@@ -497,30 +500,21 @@ theorem execForEachSetBitLoop_agree {varName : String}
       rw [SourceSemantics.execForEachSetBitLoop_succ]
       by_cases hbitmap : bitmap = 0
       · simp [Denote.execForEachSetBitLoop, hbitmap, toStmtResult]
-      · have hb := h ⟨st.world,
-          st.immutable,
+      · let ls := { st with bindings :=
           SourceSemantics.bindValue st.bindings varName
-            (SourceSemantics.wordNormalize (SourceSemantics.msbIndex bitmap)),
-          st.selector⟩
+            (SourceSemantics.wordNormalize (SourceSemantics.msbIndex bitmap)) }
+        have hb := h ls
         simp only [Denote.execForEachSetBitLoop, hbitmap, if_false, toRuntimeState] at hb ⊢
         rw [← hb]
         show toStmtResult
-            (match runBody ⟨st.world,
-                st.immutable,
-                SourceSemantics.bindValue st.bindings varName
-                  (SourceSemantics.wordNormalize (SourceSemantics.msbIndex bitmap)),
-                st.selector⟩ with
+            (match runBody ls with
             | .continue next =>
                 Denote.execForEachSetBitLoop varName runBody fuel next
                   (SourceSemantics.clearMsb bitmap)
             | .stop next => .stop next
             | .return value next => .return value next
             | .revert => .revert) = _
-        cases runBody ⟨st.world,
-            st.immutable,
-            SourceSemantics.bindValue st.bindings varName
-              (SourceSemantics.wordNormalize (SourceSemantics.msbIndex bitmap)),
-            st.selector⟩ <;>
+        cases runBody ls <;>
           first
             | rfl
             | exact execForEachSetBitLoop_agree h fuel _ (SourceSemantics.clearMsb bitmap)
@@ -615,14 +609,24 @@ theorem execStmt_eq (fields : List Field) :
           exact execForEachLoop_agree
             (runBody' := fun ls => SourceSemantics.execStmtList fields ls body)
             (fun ls => execStmtList_eq fields ls body)
-            ⟨st.world, st.immutable, Denote.bindValue st.bindings v (Denote.wordNormalize 0), st.selector⟩
+            { st with bindings := Denote.bindValue st.bindings v (Denote.wordNormalize 0) }
             0 bound
   | st, .forEachSetBit v bitmap body =>
       execStmt_forEachSetBit_eq fields st v bitmap body (fun ls => execStmtList_eq fields ls body)
   | _, .calldatacopy _ _ _ | _, .returndataCopy _ _ _ => by denote_stmt_arm
+  | st, .externalCallBind resultVars _externalName args => by
+      simp only [Denote.execStmt, SourceSemantics.execStmt, ← denote_evalExprList_eq]
+      cases Denote.evalExprList sourceOracle fields st args with
+      | none => rfl
+      | some _ => split <;> simp [toStmtResult, toRuntimeState]
+  | st, .tryExternalCallBind successVar resultVars _externalName args => by
+      simp only [Denote.execStmt, SourceSemantics.execStmt, ← denote_evalExprList_eq]
+      cases Denote.evalExprList sourceOracle fields st args with
+      | none => rfl
+      | some _ => simp [toStmtResult, toRuntimeState]
   | _, .returnValues .. | _, .returnArray .. | _, .returnBytes .. | _, .returnStorageWords ..
   | _, .returnCodeData .. | _, .revertReturndata .. | _, .internalCall ..
-  | _, .internalCallAssign .. | _, .rawLog .. | _, .externalCallBind .. | _, .tryExternalCallBind ..
+  | _, .internalCallAssign .. | _, .rawLog ..
   | _, .ecm .. | _, .unsafeBlock .. | _, .unsafeYul .. | _, .matchAdt .. => rfl
 
 theorem execStmtList_eq (fields : List Field) :

--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -374,6 +374,17 @@ theorem writeAddressKeyedMapping2FieldSlots_eq
 @[simp] theorem bindValue_eq (b : List (String × Nat)) (n : String) (v : Nat) :
     Denote.bindValue b n v = SourceSemantics.bindValue b n v := rfl
 
+@[simp] theorem bindValues_eq (b : List (String × Nat)) (ns : List String) (vs : List Nat) :
+    Denote.bindValues b ns vs = SourceSemantics.bindValues b ns vs := by
+  induction ns generalizing b vs with
+  | nil => rfl
+  | cons n ns ih =>
+      cases vs with
+      | nil => rfl
+      | cons v vs =>
+          simp only [Denote.bindValues, SourceSemantics.bindValues, bindValue_eq]
+          exact ih _ _
+
 @[simp] theorem valuesAsEventArgs_eq (vs : List Nat) :
     Denote.valuesAsEventArgs vs = SourceSemantics.valuesAsEventArgs vs :=
   match vs with
@@ -500,9 +511,8 @@ theorem execForEachSetBitLoop_agree {varName : String}
       rw [SourceSemantics.execForEachSetBitLoop_succ]
       by_cases hbitmap : bitmap = 0
       · simp [Denote.execForEachSetBitLoop, hbitmap, toStmtResult]
-      · let ls := { st with bindings :=
-          SourceSemantics.bindValue st.bindings varName
-            (SourceSemantics.wordNormalize (SourceSemantics.msbIndex bitmap)) }
+      · let val := SourceSemantics.wordNormalize (SourceSemantics.msbIndex bitmap)
+        let ls := { st with bindings := SourceSemantics.bindValue st.bindings varName val }
         have hb := h ls
         simp only [Denote.execForEachSetBitLoop, hbitmap, if_false, toRuntimeState] at hb ⊢
         rw [← hb]
@@ -618,12 +628,16 @@ theorem execStmt_eq (fields : List Field) :
       simp only [Denote.execStmt, SourceSemantics.execStmt, ← denote_evalExprList_eq]
       cases Denote.evalExprList sourceOracle fields st args with
       | none => rfl
-      | some _ => split <;> simp [toStmtResult, toRuntimeState]
+      | some _ =>
+          by_cases h : st.externalCallSucceeded st.externalCallIndex = true <;>
+            simp [toStmtResult, toRuntimeState, h]
   | st, .tryExternalCallBind successVar resultVars _externalName args => by
       simp only [Denote.execStmt, SourceSemantics.execStmt, ← denote_evalExprList_eq]
       cases Denote.evalExprList sourceOracle fields st args with
       | none => rfl
-      | some _ => simp [toStmtResult, toRuntimeState]
+      | some _ =>
+          simp only [toStmtResult, toRuntimeState, bindValue_eq, bindValues_eq]
+          rfl
   | _, .returnValues .. | _, .returnArray .. | _, .returnBytes .. | _, .returnStorageWords ..
   | _, .returnCodeData .. | _, .revertReturndata .. | _, .internalCall ..
   | _, .internalCallAssign .. | _, .rawLog ..

--- a/Compiler/Proofs/IRGeneration/DenoteFunctionAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteFunctionAgreement.lean
@@ -205,14 +205,16 @@ theorem denoteFunction_eq
       simp only [toSourceResult_revertedResult]
   | some bindings =>
       have hexec := execStmtList_eq (SourceSemantics.effectiveFields spec)
-        ⟨SourceSemantics.withTransactionContext initialWorld tx, fun _ => 0, bindings,
-          tx.functionSelector⟩ fn.body
+        { world := SourceSemantics.withTransactionContext initialWorld tx,
+          immutable := fun _ => 0, bindings := bindings,
+          selector := tx.functionSelector } fn.body
       simp only [toRuntimeState] at hexec
       simp only
       rw [← hexec]
       cases Denote.execStmtList sourceOracle (SourceSemantics.effectiveFields spec)
-          ⟨SourceSemantics.withTransactionContext initialWorld tx, fun _ => 0, bindings,
-            tx.functionSelector⟩ fn.body <;>
+          { world := SourceSemantics.withTransactionContext initialWorld tx,
+            immutable := fun _ => 0, bindings := bindings,
+            selector := tx.functionSelector } fn.body <;>
         simp [toStmtResult, toRuntimeState]
 
 end DenoteAgreement

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -824,15 +824,16 @@ private def findUniqueInternalFunction? (spec : CompilationModel) (calleeName : 
 structure ExternalCallOutcome where
   succeeded : Bool
   returnValues : List Nat := []
+  postCallWorld : Option Verity.ContractState := none
 
-instance : Inhabited ExternalCallOutcome := ⟨⟨false, []⟩⟩
+instance : Inhabited ExternalCallOutcome := ⟨⟨false, [], none⟩⟩
 
 structure RuntimeState where
   world : Verity.ContractState
   immutable : String → Verity.Core.Uint256 := fun _ => 0
   bindings : List (String × Nat)
   selector : Nat := 0
-  externalCallOracle : Nat → ExternalCallOutcome := fun _ => ⟨false, []⟩
+  externalCallOracle : Nat → ExternalCallOutcome := fun _ => ⟨false, [], none⟩
   externalCallIndex : Nat := 0
 
 inductive StmtResult where
@@ -2747,23 +2748,37 @@ mutual
         | some _ =>
             let outcome := state.externalCallOracle state.externalCallIndex
             if outcome.succeeded then
-              .continue
-                { state with
-                    bindings := bindValues state.bindings resultVars outcome.returnValues
-                    externalCallIndex := state.externalCallIndex + 1 }
+              if outcome.returnValues.length < resultVars.length then .revert
+              else
+                .continue
+                  { state with
+                      world := outcome.postCallWorld.getD state.world
+                      bindings := bindValues state.bindings resultVars
+                        (outcome.returnValues.map wordNormalize)
+                      externalCallIndex := state.externalCallIndex + 1 }
             else .revert
         | none => .revert
     | state, .tryExternalCallBind successVar resultVars _externalName args =>
         match evalExprList fields state args with
         | some _ =>
             let outcome := state.externalCallOracle state.externalCallIndex
-            let successBit := if outcome.succeeded then 1 else 0
-            .continue
-              { state with
-                  bindings := bindValues
-                    (bindValue state.bindings successVar successBit)
-                    resultVars outcome.returnValues
-                  externalCallIndex := state.externalCallIndex + 1 }
+            if outcome.succeeded then
+              if outcome.returnValues.length < resultVars.length then .revert
+              else
+                .continue
+                  { state with
+                      world := outcome.postCallWorld.getD state.world
+                      bindings := bindValues
+                        (bindValue state.bindings successVar 1)
+                        resultVars (outcome.returnValues.map wordNormalize)
+                      externalCallIndex := state.externalCallIndex + 1 }
+            else
+              .continue
+                { state with
+                    bindings := bindValues
+                      (bindValue state.bindings successVar 0)
+                      resultVars (outcome.returnValues.map wordNormalize)
+                    externalCallIndex := state.externalCallIndex + 1 }
         | none => .revert
     | _, _ => .revert
 
@@ -3082,23 +3097,37 @@ mutual
         | some _ =>
             let outcome := state.externalCallOracle state.externalCallIndex
             if outcome.succeeded then
-              .continue
-                { state with
-                    bindings := bindValues state.bindings resultVars outcome.returnValues
-                    externalCallIndex := state.externalCallIndex + 1 }
+              if outcome.returnValues.length < resultVars.length then .revert
+              else
+                .continue
+                  { state with
+                      world := outcome.postCallWorld.getD state.world
+                      bindings := bindValues state.bindings resultVars
+                        (outcome.returnValues.map wordNormalize)
+                      externalCallIndex := state.externalCallIndex + 1 }
             else .revert
         | none => .revert
     | state, .tryExternalCallBind successVar resultVars _externalName args =>
         match evalExprList fields state args with
         | some _ =>
             let outcome := state.externalCallOracle state.externalCallIndex
-            let successBit := if outcome.succeeded then 1 else 0
-            .continue
-              { state with
-                  bindings := bindValues
-                    (bindValue state.bindings successVar successBit)
-                    resultVars outcome.returnValues
-                  externalCallIndex := state.externalCallIndex + 1 }
+            if outcome.succeeded then
+              if outcome.returnValues.length < resultVars.length then .revert
+              else
+                .continue
+                  { state with
+                      world := outcome.postCallWorld.getD state.world
+                      bindings := bindValues
+                        (bindValue state.bindings successVar 1)
+                        resultVars (outcome.returnValues.map wordNormalize)
+                      externalCallIndex := state.externalCallIndex + 1 }
+            else
+              .continue
+                { state with
+                    bindings := bindValues
+                      (bindValue state.bindings successVar 0)
+                      resultVars (outcome.returnValues.map wordNormalize)
+                    externalCallIndex := state.externalCallIndex + 1 }
         | none => .revert
     | _, _ => .revert
 
@@ -3735,21 +3764,26 @@ def constructorTouchesUnsupportedRawCalldataSurface
       (constructorAsFunctionSpec ctor)
 
 def interpretFunction (spec : CompilationModel) (fn : FunctionSpec)
-    (tx : IRTransaction) (initialWorld : Verity.ContractState) : SourceContractResult :=
+    (tx : IRTransaction) (initialWorld : Verity.ContractState)
+    (externalCallOracle : Nat → ExternalCallOutcome := fun _ => ⟨false, [], none⟩) :
+    SourceContractResult :=
   let worldWithTx := withTransactionContext initialWorld tx
   let fields := effectiveFields spec
   match bindExternalParams tx.functionSelector fn.params tx.args with
   | none => revertedResult spec worldWithTx
   | some bindings =>
       match execStmtListWithEvents fields spec.events
-          { world := worldWithTx, bindings := bindings, selector := tx.functionSelector } fn.body with
+          { world := worldWithTx, bindings := bindings, selector := tx.functionSelector,
+            externalCallOracle := externalCallOracle } fn.body with
       | .continue state => successResult spec state.world none
       | .stop state => successResult spec state.world none
       | .return value state => successResult spec state.world (some value)
       | .revert => revertedResult spec worldWithTx
 
 def interpretConstructor (spec : CompilationModel) (ctor : ConstructorSpec)
-    (tx : IRTransaction) (initialWorld : Verity.ContractState) : SourceContractResult :=
+    (tx : IRTransaction) (initialWorld : Verity.ContractState)
+    (externalCallOracle : Nat → ExternalCallOutcome := fun _ => ⟨false, [], none⟩) :
+    SourceContractResult :=
   let constructorWorldWithTx := withTransactionContext initialWorld tx
   let fields := effectiveFields spec
   if constructorTouchesUnsupportedRawCalldataSurface spec ctor then
@@ -3759,7 +3793,9 @@ def interpretConstructor (spec : CompilationModel) (ctor : ConstructorSpec)
     | none => revertedResult spec constructorWorldWithTx
     | some bindings =>
         match execStmtListWithEvents fields spec.events
-            { world := constructorWorldWithTx, bindings := bindings, selector := tx.functionSelector }
+            { world := constructorWorldWithTx, bindings := bindings,
+              selector := tx.functionSelector,
+              externalCallOracle := externalCallOracle }
             ctor.body with
         | .continue state => successResult spec state.world none
         | .stop state => successResult spec state.world none
@@ -3767,13 +3803,15 @@ def interpretConstructor (spec : CompilationModel) (ctor : ConstructorSpec)
         | .revert => revertedResult spec constructorWorldWithTx
 
 def interpretContract (spec : CompilationModel) (selectors : List Nat)
-    (tx : IRTransaction) (initialWorld : Verity.ContractState) : SourceContractResult :=
+    (tx : IRTransaction) (initialWorld : Verity.ContractState)
+    (externalCallOracle : Nat → ExternalCallOutcome := fun _ => ⟨false, [], none⟩) :
+    SourceContractResult :=
   match findFunctionBySelector spec selectors tx.functionSelector with
   | some fn =>
       if !fn.isPayable && tx.msgValue % Compiler.Constants.evmModulus != 0 then
         revertedResult spec (withTransactionContext initialWorld tx)
       else
-        interpretFunction spec fn tx initialWorld
+        interpretFunction spec fn tx initialWorld externalCallOracle
   | none => revertedResult spec (withTransactionContext initialWorld tx)
 
 -- The ceilDiv case pushes the equation-compiler's `simp` past 200 000 heartbeats.
@@ -4532,23 +4570,37 @@ mutual
         | some _ =>
             let outcome := state.externalCallOracle state.externalCallIndex
             if outcome.succeeded then
-              .continue
-                { state with
-                    bindings := bindValues state.bindings resultVars outcome.returnValues
-                    externalCallIndex := state.externalCallIndex + 1 }
+              if outcome.returnValues.length < resultVars.length then .revert
+              else
+                .continue
+                  { state with
+                      world := outcome.postCallWorld.getD state.world
+                      bindings := bindValues state.bindings resultVars
+                        (outcome.returnValues.map wordNormalize)
+                      externalCallIndex := state.externalCallIndex + 1 }
             else .revert
         | none => .revert
     | .tryExternalCallBind successVar resultVars _externalName args =>
         match evalExprListWithHelpers spec fields fuel state args with
         | some _ =>
             let outcome := state.externalCallOracle state.externalCallIndex
-            let successBit := if outcome.succeeded then 1 else 0
-            .continue
-              { state with
-                  bindings := bindValues
-                    (bindValue state.bindings successVar successBit)
-                    resultVars outcome.returnValues
-                  externalCallIndex := state.externalCallIndex + 1 }
+            if outcome.succeeded then
+              if outcome.returnValues.length < resultVars.length then .revert
+              else
+                .continue
+                  { state with
+                      world := outcome.postCallWorld.getD state.world
+                      bindings := bindValues
+                        (bindValue state.bindings successVar 1)
+                        resultVars (outcome.returnValues.map wordNormalize)
+                      externalCallIndex := state.externalCallIndex + 1 }
+            else
+              .continue
+                { state with
+                    bindings := bindValues
+                      (bindValue state.bindings successVar 0)
+                      resultVars (outcome.returnValues.map wordNormalize)
+                    externalCallIndex := state.externalCallIndex + 1 }
         | none => .revert
     | _ => .revert
   termination_by stmt => (fuel, sizeOf stmt)
@@ -4701,13 +4753,17 @@ def interpretFunctionWithHelpers
     (fuel : Nat)
     (fn : FunctionSpec)
     (tx : IRTransaction)
-    (initialWorld : Verity.ContractState) : SourceContractResult :=
+    (initialWorld : Verity.ContractState)
+    (externalCallOracle : Nat → ExternalCallOutcome := fun _ => ⟨false, [], none⟩) :
+    SourceContractResult :=
   let worldWithTx := withTransactionContext initialWorld tx
   let fields := effectiveFields spec
   match bindExternalParams tx.functionSelector fn.params tx.args with
   | none => revertedResult spec worldWithTx
   | some bindings =>
-      match execStmtListWithHelpers spec fields fuel { world := worldWithTx, bindings := bindings, selector := tx.functionSelector } fn.body with
+      match execStmtListWithHelpers spec fields fuel
+          { world := worldWithTx, bindings := bindings, selector := tx.functionSelector,
+            externalCallOracle := externalCallOracle } fn.body with
       | .continue state => successResult spec state.world none
       | .stop state => successResult spec state.world none
       | .return value state => successResult spec state.world (some value)
@@ -4718,7 +4774,9 @@ def interpretConstructorWithHelpers
     (fuel : Nat)
     (ctor : ConstructorSpec)
     (tx : IRTransaction)
-    (initialWorld : Verity.ContractState) : SourceContractResult :=
+    (initialWorld : Verity.ContractState)
+    (externalCallOracle : Nat → ExternalCallOutcome := fun _ => ⟨false, [], none⟩) :
+    SourceContractResult :=
   let constructorWorldWithTx := withTransactionContext initialWorld tx
   let fields := effectiveFields spec
   if constructorTouchesUnsupportedRawCalldataSurface spec ctor then
@@ -4728,7 +4786,9 @@ def interpretConstructorWithHelpers
     | none => revertedResult spec constructorWorldWithTx
     | some bindings =>
         match execStmtListWithHelpers spec fields fuel
-            { world := constructorWorldWithTx, bindings := bindings, selector := tx.functionSelector }
+            { world := constructorWorldWithTx, bindings := bindings,
+              selector := tx.functionSelector,
+              externalCallOracle := externalCallOracle }
             ctor.body with
         | .continue state => successResult spec state.world none
         | .stop state => successResult spec state.world none
@@ -4740,13 +4800,15 @@ def interpretContractWithHelpers
     (selectors : List Nat)
     (fuel : Nat)
     (tx : IRTransaction)
-    (initialWorld : Verity.ContractState) : SourceContractResult :=
+    (initialWorld : Verity.ContractState)
+    (externalCallOracle : Nat → ExternalCallOutcome := fun _ => ⟨false, [], none⟩) :
+    SourceContractResult :=
   match findFunctionBySelector spec selectors tx.functionSelector with
   | some fn =>
       if !fn.isPayable && tx.msgValue % Compiler.Constants.evmModulus != 0 then
         revertedResult spec (withTransactionContext initialWorld tx)
       else
-        interpretFunctionWithHelpers spec fuel fn tx initialWorld
+        interpretFunctionWithHelpers spec fuel fn tx initialWorld externalCallOracle
   | none => revertedResult spec (withTransactionContext initialWorld tx)
 
 theorem helperSummarySound

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -2748,7 +2748,7 @@ mutual
         | some _ =>
             let outcome := state.externalCallOracle state.externalCallIndex
             if outcome.succeeded then
-              if outcome.returnValues.length < resultVars.length then .revert
+              if outcome.returnValues.length != resultVars.length then .revert
               else
                 .continue
                   { state with
@@ -2763,7 +2763,7 @@ mutual
         | some _ =>
             let outcome := state.externalCallOracle state.externalCallIndex
             if outcome.succeeded then
-              if outcome.returnValues.length < resultVars.length then .revert
+              if outcome.returnValues.length != resultVars.length then .revert
               else
                 .continue
                   { state with
@@ -3097,7 +3097,7 @@ mutual
         | some _ =>
             let outcome := state.externalCallOracle state.externalCallIndex
             if outcome.succeeded then
-              if outcome.returnValues.length < resultVars.length then .revert
+              if outcome.returnValues.length != resultVars.length then .revert
               else
                 .continue
                   { state with
@@ -3112,7 +3112,7 @@ mutual
         | some _ =>
             let outcome := state.externalCallOracle state.externalCallIndex
             if outcome.succeeded then
-              if outcome.returnValues.length < resultVars.length then .revert
+              if outcome.returnValues.length != resultVars.length then .revert
               else
                 .continue
                   { state with
@@ -4570,7 +4570,7 @@ mutual
         | some _ =>
             let outcome := state.externalCallOracle state.externalCallIndex
             if outcome.succeeded then
-              if outcome.returnValues.length < resultVars.length then .revert
+              if outcome.returnValues.length != resultVars.length then .revert
               else
                 .continue
                   { state with
@@ -4585,7 +4585,7 @@ mutual
         | some _ =>
             let outcome := state.externalCallOracle state.externalCallIndex
             if outcome.succeeded then
-              if outcome.returnValues.length < resultVars.length then .revert
+              if outcome.returnValues.length != resultVars.length then .revert
               else
                 .continue
                   { state with
@@ -4624,12 +4624,17 @@ mutual
       (fuel : Nat)
       (fn : FunctionSpec)
       (initialWorld : Verity.ContractState)
-      (args : List Nat) : InternalFunctionResult :=
+      (args : List Nat)
+      (externalCallOracle : Nat → ExternalCallOutcome := fun _ => ⟨false, [], none⟩)
+      (externalCallIndex : Nat := 0) : InternalFunctionResult :=
     let fields := effectiveFields spec
     match bindInternalArgs fn.params args with
     | none => revertedInternalResult initialWorld
     | some bindings =>
-        match execStmtListWithHelpers spec fields fuel { world := initialWorld, bindings := bindings } fn.body with
+        match execStmtListWithHelpers spec fields fuel
+            { world := initialWorld, bindings := bindings,
+              externalCallOracle := externalCallOracle,
+              externalCallIndex := externalCallIndex } fn.body with
         | .continue state => successInternalResult state.world none
         | .stop state => successInternalResult state.world none
         | .return value state => successInternalResult state.world (some value)

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -6193,8 +6193,30 @@ private theorem execStmtWithHelpers_eq_execStmt_of_helperSurfaceClosed_aux
         evalExprList_eq_mapM]
   | .rawLog _ _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .unsafeYul _ => cases hsurface
-  | .externalCallBind _ _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
-  | .tryExternalCallBind _ _ _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
+  | .externalCallBind _ _ args =>
+      simp only [stmtTouchesUnsupportedHelperSurface] at hsurface
+      have hall : args.all (fun expr => exprTouchesUnsupportedHelperSurface expr == false) = true := by
+        induction args with
+        | nil => simp
+        | cons expr rest ih =>
+          simp only [exprListTouchesUnsupportedHelperSurface, Bool.or_eq_false_iff] at hsurface
+          simp only [List.all_cons, Bool.and_eq_true, beq_iff_eq]
+          exact ⟨hsurface.1, ih hsurface.2⟩
+      simp [execStmtWithHelpers, execStmtWithEvents,
+        evalExprListWithHelpers_eq_evalExprList_of_helperSurfaceClosed spec fields fuel state args hall,
+        evalExprList_eq_mapM]
+  | .tryExternalCallBind _ _ _ args =>
+      simp only [stmtTouchesUnsupportedHelperSurface] at hsurface
+      have hall : args.all (fun expr => exprTouchesUnsupportedHelperSurface expr == false) = true := by
+        induction args with
+        | nil => simp
+        | cons expr rest ih =>
+          simp only [exprListTouchesUnsupportedHelperSurface, Bool.or_eq_false_iff] at hsurface
+          simp only [List.all_cons, Bool.and_eq_true, beq_iff_eq]
+          exact ⟨hsurface.1, ih hsurface.2⟩
+      simp [execStmtWithHelpers, execStmtWithEvents,
+        evalExprListWithHelpers_eq_evalExprList_of_helperSurfaceClosed spec fields fuel state args hall,
+        evalExprList_eq_mapM]
   | .ecm _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
   | .forEach _ _ _ =>
       simp only [stmtTouchesUnsupportedHelperSurface, Bool.or_eq_false_iff] at hsurface

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -832,7 +832,7 @@ structure RuntimeState where
   immutable : String → Verity.Core.Uint256 := fun _ => 0
   bindings : List (String × Nat)
   selector : Nat := 0
-  externalCallOracle : Nat → ExternalCallOutcome := fun _ => default
+  externalCallOracle : Nat → ExternalCallOutcome := fun _ => ⟨false, []⟩
   externalCallIndex : Nat := 0
 
 inductive StmtResult where

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -728,6 +728,11 @@ def bindValue (bindings : List (String × Nat)) (name : String) (value : Nat) :
     List (String × Nat) :=
   (name, value) :: bindings.filter (fun entry => entry.1 != name)
 
+def bindValues (bindings : List (String × Nat)) : List String → List Nat → List (String × Nat)
+  | [], _ => bindings
+  | _ :: _, [] => bindings
+  | name :: names, value :: values => bindValues (bindValue bindings name value) names values
+
 def lookupValue (bindings : List (String × Nat)) (name : String) : Nat :=
   bindings.find? (fun entry => entry.1 == name) |>.map Prod.snd |>.getD 0
 
@@ -816,11 +821,19 @@ private def findUniqueInternalFunction? (spec : CompilationModel) (calleeName : 
   | [fn] => some fn
   | _ => none
 
+structure ExternalCallOutcome where
+  succeeded : Bool
+  returnValues : List Nat := []
+
+instance : Inhabited ExternalCallOutcome := ⟨⟨false, []⟩⟩
+
 structure RuntimeState where
   world : Verity.ContractState
   immutable : String → Verity.Core.Uint256 := fun _ => 0
   bindings : List (String × Nat)
   selector : Nat := 0
+  externalCallOracle : Nat → ExternalCallOutcome := fun _ => default
+  externalCallIndex : Nat := 0
 
 inductive StmtResult where
   | continue (state : RuntimeState)
@@ -2729,6 +2742,29 @@ mutual
               256 state bits
         | none => .revert
     | _, .revertReturndata => .revert
+    | state, .externalCallBind resultVars _externalName args =>
+        match evalExprList fields state args with
+        | some _ =>
+            let outcome := state.externalCallOracle state.externalCallIndex
+            if outcome.succeeded then
+              .continue
+                { state with
+                    bindings := bindValues state.bindings resultVars outcome.returnValues
+                    externalCallIndex := state.externalCallIndex + 1 }
+            else .revert
+        | none => .revert
+    | state, .tryExternalCallBind successVar resultVars _externalName args =>
+        match evalExprList fields state args with
+        | some _ =>
+            let outcome := state.externalCallOracle state.externalCallIndex
+            let successBit := if outcome.succeeded then 1 else 0
+            .continue
+              { state with
+                  bindings := bindValues
+                    (bindValue state.bindings successVar successBit)
+                    resultVars outcome.returnValues
+                  externalCallIndex := state.externalCallIndex + 1 }
+        | none => .revert
     | _, _ => .revert
 
   def execStmtListWithEvents (fields : List Field) (events : List EventDef) :
@@ -3041,6 +3077,29 @@ mutual
               256 state bits
         | none => .revert
     | _, .revertReturndata => .revert
+    | state, .externalCallBind resultVars _externalName args =>
+        match evalExprList fields state args with
+        | some _ =>
+            let outcome := state.externalCallOracle state.externalCallIndex
+            if outcome.succeeded then
+              .continue
+                { state with
+                    bindings := bindValues state.bindings resultVars outcome.returnValues
+                    externalCallIndex := state.externalCallIndex + 1 }
+            else .revert
+        | none => .revert
+    | state, .tryExternalCallBind successVar resultVars _externalName args =>
+        match evalExprList fields state args with
+        | some _ =>
+            let outcome := state.externalCallOracle state.externalCallIndex
+            let successBit := if outcome.succeeded then 1 else 0
+            .continue
+              { state with
+                  bindings := bindValues
+                    (bindValue state.bindings successVar successBit)
+                    resultVars outcome.returnValues
+                  externalCallIndex := state.externalCallIndex + 1 }
+        | none => .revert
     | _, _ => .revert
 
   def execStmtList (fields : List Field) : RuntimeState → List Stmt → StmtResult
@@ -4468,6 +4527,29 @@ mutual
               256 state bits
         | none => .revert
     | .revertReturndata => .revert
+    | .externalCallBind resultVars _externalName args =>
+        match evalExprListWithHelpers spec fields fuel state args with
+        | some _ =>
+            let outcome := state.externalCallOracle state.externalCallIndex
+            if outcome.succeeded then
+              .continue
+                { state with
+                    bindings := bindValues state.bindings resultVars outcome.returnValues
+                    externalCallIndex := state.externalCallIndex + 1 }
+            else .revert
+        | none => .revert
+    | .tryExternalCallBind successVar resultVars _externalName args =>
+        match evalExprListWithHelpers spec fields fuel state args with
+        | some _ =>
+            let outcome := state.externalCallOracle state.externalCallIndex
+            let successBit := if outcome.succeeded then 1 else 0
+            .continue
+              { state with
+                  bindings := bindValues
+                    (bindValue state.bindings successVar successBit)
+                    resultVars outcome.returnValues
+                  externalCallIndex := state.externalCallIndex + 1 }
+        | none => .revert
     | _ => .revert
   termination_by stmt => (fuel, sizeOf stmt)
   decreasing_by all_goals (simp_wf; omega)

--- a/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
@@ -398,4 +398,99 @@ example :
     some 77194726158210796949047323339125271902179989777093709359638389338608753093291 := by
   native_decide
 
+/-- externalCallBind: oracle returns success → bindings updated, call index incremented -/
+example :
+    SourceSemantics.execStmt [] { world := Verity.defaultState, bindings := [("x", 0)],
+        externalCallOracle := fun _ => ⟨true, [42]⟩ }
+      (.externalCallBind ["x"] "transfer" [.literal 100]) =
+    .continue { world := Verity.defaultState, bindings := [("x", 42)],
+        externalCallOracle := fun _ => ⟨true, [42]⟩, externalCallIndex := 1 } := by
+  native_decide
+
+/-- externalCallBind: oracle returns failure → revert -/
+example :
+    SourceSemantics.execStmt [] { world := Verity.defaultState, bindings := [("x", 0)],
+        externalCallOracle := fun _ => ⟨false, []⟩ }
+      (.externalCallBind ["x"] "transfer" [.literal 100]) =
+    .revert := by
+  native_decide
+
+/-- tryExternalCallBind: oracle returns success → successVar=1, bindings updated -/
+example :
+    SourceSemantics.execStmt [] { world := Verity.defaultState,
+        bindings := [("ok", 0), ("result", 0)],
+        externalCallOracle := fun _ => ⟨true, [99]⟩ }
+      (.tryExternalCallBind "ok" ["result"] "safecall" [.literal 50]) =
+    .continue { world := Verity.defaultState,
+        bindings := [("ok", 1), ("result", 99)],
+        externalCallOracle := fun _ => ⟨true, [99]⟩, externalCallIndex := 1 } := by
+  native_decide
+
+/-- tryExternalCallBind: oracle returns failure → successVar=0, no revert -/
+example :
+    SourceSemantics.execStmt [] { world := Verity.defaultState,
+        bindings := [("ok", 0), ("result", 0)],
+        externalCallOracle := fun _ => ⟨false, [0]⟩ }
+      (.tryExternalCallBind "ok" ["result"] "safecall" [.literal 50]) =
+    .continue { world := Verity.defaultState,
+        bindings := [("ok", 0), ("result", 0)],
+        externalCallOracle := fun _ => ⟨false, [0]⟩, externalCallIndex := 1 } := by
+  native_decide
+
+/-- externalCallBind with no args and oracle keyed on call index -/
+example :
+    SourceSemantics.execStmtWithEvents [] []
+      { world := Verity.defaultState, bindings := [("v", 0)],
+        externalCallOracle := fun n => if n == 0 then ⟨true, [7]⟩ else ⟨false, []⟩ }
+      (.externalCallBind ["v"] "ping" []) =
+    .continue { world := Verity.defaultState, bindings := [("v", 7)],
+        externalCallOracle := fun n => if n == 0 then ⟨true, [7]⟩ else ⟨false, []⟩,
+        externalCallIndex := 1 } := by
+  native_decide
+
+/-- Surface gates: externalCallBind with literal args is now admitted by call/foreign/lowLevel. -/
+example :
+    stmtTouchesUnsupportedCallSurface
+      (.externalCallBind ["x"] "transfer" [.literal 100]) = false := by
+  native_decide
+
+example :
+    stmtTouchesUnsupportedForeignSurface
+      (.externalCallBind ["x"] "transfer" [.literal 100]) = false := by
+  native_decide
+
+example :
+    stmtTouchesUnsupportedLowLevelSurface
+      (.externalCallBind ["x"] "transfer" [.literal 100]) = false := by
+  native_decide
+
+/-- Surface gates: tryExternalCallBind with literal args is similarly admitted. -/
+example :
+    stmtTouchesUnsupportedCallSurface
+      (.tryExternalCallBind "ok" ["x"] "safecall" [.literal 50]) = false := by
+  native_decide
+
+example :
+    stmtTouchesUnsupportedForeignSurface
+      (.tryExternalCallBind "ok" ["x"] "safecall" [.literal 50]) = false := by
+  native_decide
+
+/-- Surface gates: call-surface args still trigger when sub-exprs touch surfaces. -/
+example :
+    stmtTouchesUnsupportedCallSurface
+      (.externalCallBind ["x"] "transfer" [.externalCall "oracle" []]) = true := by
+  native_decide
+
+/-- Helper surface: externalCallBind with helper-free args is helper-surface-closed. -/
+example :
+    stmtTouchesUnsupportedHelperSurface
+      (.externalCallBind ["x"] "transfer" [.literal 100]) = false := by
+  native_decide
+
+/-- Effect surface: externalCallBind remains blocked by the effect surface. -/
+example :
+    stmtTouchesUnsupportedEffectSurface
+      (.externalCallBind ["x"] "transfer" [.literal 100]) = true := by
+  native_decide
+
 end Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest

--- a/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
@@ -398,54 +398,89 @@ example :
     some 77194726158210796949047323339125271902179989777093709359638389338608753093291 := by
   native_decide
 
+private def oracleSuccess42 : Nat → SourceSemantics.ExternalCallOutcome :=
+  fun _ => ⟨true, [42]⟩
+
+private def oracleFail : Nat → SourceSemantics.ExternalCallOutcome :=
+  fun _ => ⟨false, []⟩
+
+private def oracleSuccess99 : Nat → SourceSemantics.ExternalCallOutcome :=
+  fun _ => ⟨true, [99]⟩
+
+private def oracleFail0 : Nat → SourceSemantics.ExternalCallOutcome :=
+  fun _ => ⟨false, [0]⟩
+
+private def oracleIndexed : Nat → SourceSemantics.ExternalCallOutcome :=
+  fun n => if n == 0 then ⟨true, [7]⟩ else ⟨false, []⟩
+
+private def mkState (bindings : List (String × Nat))
+    (oracle : Nat → SourceSemantics.ExternalCallOutcome := fun _ => ⟨false, []⟩)
+    (callIdx : Nat := 0) : SourceSemantics.RuntimeState :=
+  { world := Verity.defaultState, bindings, externalCallOracle := oracle,
+    externalCallIndex := callIdx }
+
+private def resultBindings (r : SourceSemantics.StmtResult) : Option (List (String × Nat)) :=
+  match r with | .continue s => some s.bindings | _ => none
+
+private def resultCallIndex (r : SourceSemantics.StmtResult) : Option Nat :=
+  match r with | .continue s => some s.externalCallIndex | _ => none
+
+private def isRevert (r : SourceSemantics.StmtResult) : Bool :=
+  match r with | .revert => true | _ => false
+
+private def isContinue (r : SourceSemantics.StmtResult) : Bool :=
+  match r with | .continue _ => true | _ => false
+
 /-- externalCallBind: oracle returns success → bindings updated, call index incremented -/
 example :
-    SourceSemantics.execStmt [] { world := Verity.defaultState, bindings := [("x", 0)],
-        externalCallOracle := fun _ => ⟨true, [42]⟩ }
-      (.externalCallBind ["x"] "transfer" [.literal 100]) =
-    .continue { world := Verity.defaultState, bindings := [("x", 42)],
-        externalCallOracle := fun _ => ⟨true, [42]⟩, externalCallIndex := 1 } := by
+    resultBindings (SourceSemantics.execStmt [] (mkState [("x", 0)] oracleSuccess42)
+      (.externalCallBind ["x"] "transfer" [.literal 100])) = some [("x", 42)] := by
+  native_decide
+
+example :
+    resultCallIndex (SourceSemantics.execStmt [] (mkState [("x", 0)] oracleSuccess42)
+      (.externalCallBind ["x"] "transfer" [.literal 100])) = some 1 := by
   native_decide
 
 /-- externalCallBind: oracle returns failure → revert -/
 example :
-    SourceSemantics.execStmt [] { world := Verity.defaultState, bindings := [("x", 0)],
-        externalCallOracle := fun _ => ⟨false, []⟩ }
-      (.externalCallBind ["x"] "transfer" [.literal 100]) =
-    .revert := by
+    isRevert (SourceSemantics.execStmt [] (mkState [("x", 0)] oracleFail)
+      (.externalCallBind ["x"] "transfer" [.literal 100])) = true := by
   native_decide
 
 /-- tryExternalCallBind: oracle returns success → successVar=1, bindings updated -/
 example :
-    SourceSemantics.execStmt [] { world := Verity.defaultState,
-        bindings := [("ok", 0), ("result", 0)],
-        externalCallOracle := fun _ => ⟨true, [99]⟩ }
-      (.tryExternalCallBind "ok" ["result"] "safecall" [.literal 50]) =
-    .continue { world := Verity.defaultState,
-        bindings := [("ok", 1), ("result", 99)],
-        externalCallOracle := fun _ => ⟨true, [99]⟩, externalCallIndex := 1 } := by
+    resultBindings (SourceSemantics.execStmt [] (mkState [("ok", 0), ("result", 0)] oracleSuccess99)
+      (.tryExternalCallBind "ok" ["result"] "safecall" [.literal 50])) =
+    some [("result", 99), ("ok", 1)] := by
+  native_decide
+
+example :
+    resultCallIndex (SourceSemantics.execStmt [] (mkState [("ok", 0), ("result", 0)] oracleSuccess99)
+      (.tryExternalCallBind "ok" ["result"] "safecall" [.literal 50])) = some 1 := by
   native_decide
 
 /-- tryExternalCallBind: oracle returns failure → successVar=0, no revert -/
 example :
-    SourceSemantics.execStmt [] { world := Verity.defaultState,
-        bindings := [("ok", 0), ("result", 0)],
-        externalCallOracle := fun _ => ⟨false, [0]⟩ }
-      (.tryExternalCallBind "ok" ["result"] "safecall" [.literal 50]) =
-    .continue { world := Verity.defaultState,
-        bindings := [("ok", 0), ("result", 0)],
-        externalCallOracle := fun _ => ⟨false, [0]⟩, externalCallIndex := 1 } := by
+    resultBindings (SourceSemantics.execStmt [] (mkState [("ok", 0), ("result", 0)] oracleFail0)
+      (.tryExternalCallBind "ok" ["result"] "safecall" [.literal 50])) =
+    some [("result", 0), ("ok", 0)] := by
+  native_decide
+
+example :
+    isContinue (SourceSemantics.execStmt [] (mkState [("ok", 0), ("result", 0)] oracleFail0)
+      (.tryExternalCallBind "ok" ["result"] "safecall" [.literal 50])) = true := by
   native_decide
 
 /-- externalCallBind with no args and oracle keyed on call index -/
 example :
-    SourceSemantics.execStmtWithEvents [] []
-      { world := Verity.defaultState, bindings := [("v", 0)],
-        externalCallOracle := fun n => if n == 0 then ⟨true, [7]⟩ else ⟨false, []⟩ }
-      (.externalCallBind ["v"] "ping" []) =
-    .continue { world := Verity.defaultState, bindings := [("v", 7)],
-        externalCallOracle := fun n => if n == 0 then ⟨true, [7]⟩ else ⟨false, []⟩,
-        externalCallIndex := 1 } := by
+    resultBindings (SourceSemantics.execStmtWithEvents [] [] (mkState [("v", 0)] oracleIndexed)
+      (.externalCallBind ["v"] "ping" [])) = some [("v", 7)] := by
+  native_decide
+
+example :
+    resultCallIndex (SourceSemantics.execStmtWithEvents [] [] (mkState [("v", 0)] oracleIndexed)
+      (.externalCallBind ["v"] "ping" [])) = some 1 := by
   native_decide
 
 /-- Surface gates: externalCallBind with literal args is now admitted by call/foreign/lowLevel. -/

--- a/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
@@ -399,22 +399,22 @@ example :
   native_decide
 
 private def oracleSuccess42 : Nat → SourceSemantics.ExternalCallOutcome :=
-  fun _ => ⟨true, [42]⟩
+  fun _ => ⟨true, [42], none⟩
 
 private def oracleFail : Nat → SourceSemantics.ExternalCallOutcome :=
-  fun _ => ⟨false, []⟩
+  fun _ => ⟨false, [], none⟩
 
 private def oracleSuccess99 : Nat → SourceSemantics.ExternalCallOutcome :=
-  fun _ => ⟨true, [99]⟩
+  fun _ => ⟨true, [99], none⟩
 
 private def oracleFail0 : Nat → SourceSemantics.ExternalCallOutcome :=
-  fun _ => ⟨false, [0]⟩
+  fun _ => ⟨false, [0], none⟩
 
 private def oracleIndexed : Nat → SourceSemantics.ExternalCallOutcome :=
-  fun n => if n == 0 then ⟨true, [7]⟩ else ⟨false, []⟩
+  fun n => if n == 0 then ⟨true, [7], none⟩ else ⟨false, [], none⟩
 
 private def mkState (bindings : List (String × Nat))
-    (oracle : Nat → SourceSemantics.ExternalCallOutcome := fun _ => ⟨false, []⟩)
+    (oracle : Nat → SourceSemantics.ExternalCallOutcome := fun _ => ⟨false, [], none⟩)
     (callIdx : Nat := 0) : SourceSemantics.RuntimeState :=
   { world := Verity.defaultState, bindings, externalCallOracle := oracle,
     externalCallIndex := callIdx }
@@ -481,6 +481,51 @@ example :
 example :
     resultCallIndex (SourceSemantics.execStmtWithEvents [] [] (mkState [("v", 0)] oracleIndexed)
       (.externalCallBind ["v"] "ping" [])) = some 1 := by
+  native_decide
+
+/-- P1-1: externalCallBind arity mismatch (too few return values) → revert -/
+private def oracleSuccessEmpty : Nat → SourceSemantics.ExternalCallOutcome :=
+  fun _ => ⟨true, [], none⟩
+
+example :
+    isRevert (SourceSemantics.execStmt [] (mkState [("x", 0)] oracleSuccessEmpty)
+      (.externalCallBind ["x"] "transfer" [.literal 100])) = true := by
+  native_decide
+
+/-- P1-1: tryExternalCallBind arity mismatch on success → revert -/
+example :
+    isRevert (SourceSemantics.execStmt []
+      (mkState [("ok", 0), ("result", 0)] oracleSuccessEmpty)
+      (.tryExternalCallBind "ok" ["result"] "safecall" [.literal 50])) = true := by
+  native_decide
+
+/-- P1-1: extra return values (more than vars) are silently dropped, not an error -/
+private def oracleSuccessExtra : Nat → SourceSemantics.ExternalCallOutcome :=
+  fun _ => ⟨true, [10, 20, 30], none⟩
+
+example :
+    resultBindings (SourceSemantics.execStmt [] (mkState [("x", 0)] oracleSuccessExtra)
+      (.externalCallBind ["x"] "transfer" [.literal 100])) = some [("x", 10)] := by
+  native_decide
+
+/-- P1-2: return values >= evmModulus are normalized (mod 2^256) -/
+private def oracleSuccessOverflow : Nat → SourceSemantics.ExternalCallOutcome :=
+  fun _ => ⟨true, [Compiler.Constants.evmModulus], none⟩
+
+example :
+    resultBindings (SourceSemantics.execStmt [] (mkState [("x", 0)] oracleSuccessOverflow)
+      (.externalCallBind ["x"] "transfer" [.literal 100])) = some [("x", 0)] := by
+  native_decide
+
+/-- P1-2: tryExternalCallBind failure path also normalizes -/
+private def oracleFailOverflow : Nat → SourceSemantics.ExternalCallOutcome :=
+  fun _ => ⟨false, [Compiler.Constants.evmModulus], none⟩
+
+example :
+    resultBindings (SourceSemantics.execStmt []
+      (mkState [("ok", 0), ("result", 0)] oracleFailOverflow)
+      (.tryExternalCallBind "ok" ["result"] "safecall" [.literal 50])) =
+    some [("result", 0), ("ok", 0)] := by
   native_decide
 
 /-- Surface gates: externalCallBind with literal args is now admitted by call/foreign/lowLevel. -/

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -1743,7 +1743,8 @@ def stmtTouchesUnsupportedCallSurface : Stmt → Bool
         exprTouchesUnsupportedCallSurface sourceOffset ||
         exprTouchesUnsupportedCallSurface size
   | .revertReturndata => false
-  | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _
+  | .externalCallBind _ _ args => args.any exprTouchesUnsupportedCallSurface
+  | .tryExternalCallBind _ _ _ args => args.any exprTouchesUnsupportedCallSurface
   | .ecm _ _ => true
   | .stop | .storageArrayPop _
   | .returnValues _ | .returnArray _
@@ -1794,8 +1795,10 @@ def stmtTouchesUnsupportedHelperSurface : Stmt → Bool
       exprTouchesUnsupportedHelperSurface destOffset ||
         exprTouchesUnsupportedHelperSurface sourceOffset ||
         exprTouchesUnsupportedHelperSurface size
+  | .externalCallBind _ _ args | .tryExternalCallBind _ _ _ args =>
+      exprListTouchesUnsupportedHelperSurface args
   | .stop
-  | .revertReturndata | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _
+  | .revertReturndata
   | .ecm _ _ | .storageArrayPop _
   | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _ | .rawLog _ _ _ => false
@@ -1992,7 +1995,9 @@ def stmtTouchesUnsupportedForeignSurface : Stmt → Bool
       exprTouchesUnsupportedForeignSurface cond
   | .returnCodeData pointer =>
       exprTouchesUnsupportedForeignSurface pointer
-  | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _ | .ecm _ _ => true
+  | .externalCallBind _ _ args => args.any exprTouchesUnsupportedForeignSurface
+  | .tryExternalCallBind _ _ _ args => args.any exprTouchesUnsupportedForeignSurface
+  | .ecm _ _ => true
   | .calldatacopy destOffset sourceOffset size
   | .returndataCopy destOffset sourceOffset size =>
       exprTouchesUnsupportedForeignSurface destOffset ||
@@ -2049,8 +2054,10 @@ def stmtTouchesUnsupportedLowLevelSurface : Stmt → Bool
         exprTouchesUnsupportedLowLevelSurface sourceOffset ||
         exprTouchesUnsupportedLowLevelSurface size
   | .revertReturndata => false
+  | .externalCallBind _ _ args => args.any exprTouchesUnsupportedLowLevelSurface
+  | .tryExternalCallBind _ _ _ args => args.any exprTouchesUnsupportedLowLevelSurface
   | .stop
-  | .internalCall _ _ | .internalCallAssign _ _ _ | .externalCallBind _ _ _ | .tryExternalCallBind _ _ _ _
+  | .internalCall _ _ | .internalCallAssign _ _ _
   | .ecm _ _ | .storageArrayPop _
   | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _ | .rawLog _ _ _ => false
@@ -5198,6 +5205,12 @@ private theorem stmtOrListTouchesUnsupportedCallSurface_eq_featureOr :
           rw [exprListTouchesUnsupportedCallSurface_eq_featureOr args]
           simp [Bool.or_assoc, Bool.or_left_comm, Bool.or_comm]
       | emit _ args =>
+          simp only [stmtTouchesUnsupportedCallSurface,
+            stmtTouchesUnsupportedHelperSurface, stmtTouchesUnsupportedForeignSurface,
+            stmtTouchesUnsupportedLowLevelSurface]
+          rw [exprListTouchesUnsupportedCallSurface_eq_featureOr args]
+          simp [Bool.or_assoc, Bool.or_left_comm, Bool.or_comm]
+      | externalCallBind _ _ args | tryExternalCallBind _ _ _ args =>
           simp only [stmtTouchesUnsupportedCallSurface,
             stmtTouchesUnsupportedHelperSurface, stmtTouchesUnsupportedForeignSurface,
             stmtTouchesUnsupportedLowLevelSurface]

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -2870,7 +2870,8 @@ example :
 
 example :
     stmtListTouchesUnsupportedForeignSurface
-      [Stmt.forEach "i" (.literal 1) [Stmt.externalCallBind [] "ext" []]] = true := by
+      [Stmt.forEach "i" (.literal 1)
+        [Stmt.externalCallBind [] "ext" [.externalCall "ext" []]]] = true := by
   decide
 
 example :

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2464,6 +2464,8 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.DenoteAgreement.toRuntimeState_immutable
   Compiler.Proofs.IRGeneration.DenoteAgreement.toRuntimeState_bindings
   Compiler.Proofs.IRGeneration.DenoteAgreement.toRuntimeState_selector
+  Compiler.Proofs.IRGeneration.DenoteAgreement.toRuntimeState_externalCallOracle
+  Compiler.Proofs.IRGeneration.DenoteAgreement.toRuntimeState_externalCallIndex
   Compiler.Proofs.IRGeneration.DenoteAgreement.sourceOracle_mappingSlot
   Compiler.Proofs.IRGeneration.DenoteAgreement.sourceOracle_keccakMemorySlice
   Compiler.Proofs.IRGeneration.DenoteAgreement.bindAgree
@@ -2485,6 +2487,7 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.DenoteAgreement.writeAddressKeyedMapping2FieldSlots_eq
   Compiler.Proofs.IRGeneration.DenoteAgreement.wordNormalize_eq
   Compiler.Proofs.IRGeneration.DenoteAgreement.bindValue_eq
+  Compiler.Proofs.IRGeneration.DenoteAgreement.bindValues_eq
   Compiler.Proofs.IRGeneration.DenoteAgreement.valuesAsEventArgs_eq
   Compiler.Proofs.IRGeneration.DenoteAgreement.writeUintSlots_eq
   Compiler.Proofs.IRGeneration.DenoteAgreement.writeFixedUint128ArrayElementSlots_eq
@@ -7415,4 +7418,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6862 theorems/lemmas (4918 public, 1944 private, 0 sorry'd)
+-- Total: 6865 theorems/lemmas (4921 public, 1944 private, 0 sorry'd)

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -180,6 +180,11 @@ abbrev Env := List (String × Nat)
 def bindValue (bindings : Env) (name : String) (value : Nat) : Env :=
   (name, value) :: bindings.filter (fun entry => entry.1 != name)
 
+def bindValues (bindings : Env) : List String → List Nat → Env
+  | [], _ => bindings
+  | _ :: _, [] => bindings
+  | name :: names, value :: values => bindValues (bindValue bindings name value) names values
+
 def lookupValue (bindings : Env) (name : String) : Nat :=
   bindings.find? (fun entry => entry.1 == name) |>.map Prod.snd |>.getD 0
 
@@ -192,6 +197,9 @@ structure DenoteState where
   immutable : String → Verity.Core.Uint256 := fun _ => 0
   bindings : Env
   selector : Nat := 0
+  externalCallSucceeded : Nat → Bool := fun _ => false
+  externalCallReturnValues : Nat → List Nat := fun _ => []
+  externalCallIndex : Nat := 0
 
 /-- Mirrors `SourceSemantics.StmtResult`. -/
 inductive StmtOutcome where
@@ -1370,6 +1378,29 @@ mutual
             execForEachSetBitLoop varName
               (fun loopState => execStmtList oracle fields loopState body)
               256 state bits
+        | none => .revert
+    | state, .externalCallBind resultVars _externalName args =>
+        match evalExprList oracle fields state args with
+        | some _ =>
+            if state.externalCallSucceeded state.externalCallIndex then
+              .continue
+                { state with
+                    bindings := bindValues state.bindings resultVars
+                      (state.externalCallReturnValues state.externalCallIndex)
+                    externalCallIndex := state.externalCallIndex + 1 }
+            else .revert
+        | none => .revert
+    | state, .tryExternalCallBind successVar resultVars _externalName args =>
+        match evalExprList oracle fields state args with
+        | some _ =>
+            let successBit :=
+              if state.externalCallSucceeded state.externalCallIndex then 1 else 0
+            .continue
+              { state with
+                  bindings := bindValues
+                    (bindValue state.bindings successVar successBit)
+                    resultVars (state.externalCallReturnValues state.externalCallIndex)
+                  externalCallIndex := state.externalCallIndex + 1 }
         | none => .revert
     | _, .revertReturndata => .revert
     | _, _ => .revert

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -1385,7 +1385,7 @@ mutual
         | some _ =>
             if state.externalCallSucceeded state.externalCallIndex then
               let retVals := state.externalCallReturnValues state.externalCallIndex
-              if retVals.length < resultVars.length then .revert
+              if retVals.length != resultVars.length then .revert
               else
                 .continue
                   { state with
@@ -1401,7 +1401,7 @@ mutual
         | some _ =>
             let retVals := state.externalCallReturnValues state.externalCallIndex
             if state.externalCallSucceeded state.externalCallIndex then
-              if retVals.length < resultVars.length then .revert
+              if retVals.length != resultVars.length then .revert
               else
                 .continue
                   { state with
@@ -1533,14 +1533,20 @@ def withTransactionContext (world : Verity.ContractState) (tx : DenoteTransactio
 Mirrors `SourceSemantics.interpretFunction` with the event-less statement
 semantics (see header note 2). -/
 def denoteFunction (oracle : DenoteOracle) (spec : CompilationModel) (fn : FunctionSpec)
-    (tx : DenoteTransaction) (initialWorld : Verity.ContractState) : DenoteResult :=
+    (tx : DenoteTransaction) (initialWorld : Verity.ContractState)
+    (externalCallSucceeded : Nat → Bool := fun _ => false)
+    (externalCallReturnValues : Nat → List Nat := fun _ => [])
+    (externalCallPostWorld : Nat → Option Verity.ContractState := fun _ => none) : DenoteResult :=
   let worldWithTx := withTransactionContext initialWorld tx
   let fields := effectiveFields spec
   match bindExternalParams tx.functionSelector fn.params tx.args with
   | none => revertedResult oracle spec worldWithTx
   | some bindings =>
       match execStmtList oracle fields
-          { world := worldWithTx, bindings := bindings, selector := tx.functionSelector }
+          { world := worldWithTx, bindings := bindings, selector := tx.functionSelector,
+            externalCallSucceeded := externalCallSucceeded,
+            externalCallReturnValues := externalCallReturnValues,
+            externalCallPostWorld := externalCallPostWorld }
           fn.body with
       | .continue state => successResult oracle spec state.world none
       | .stop state => successResult oracle spec state.world none

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -199,6 +199,7 @@ structure DenoteState where
   selector : Nat := 0
   externalCallSucceeded : Nat → Bool := fun _ => false
   externalCallReturnValues : Nat → List Nat := fun _ => []
+  externalCallPostWorld : Nat → Option Verity.ContractState := fun _ => none
   externalCallIndex : Nat := 0
 
 /-- Mirrors `SourceSemantics.StmtResult`. -/
@@ -1383,24 +1384,40 @@ mutual
         match evalExprList oracle fields state args with
         | some _ =>
             if state.externalCallSucceeded state.externalCallIndex then
-              .continue
-                { state with
-                    bindings := bindValues state.bindings resultVars
-                      (state.externalCallReturnValues state.externalCallIndex)
-                    externalCallIndex := state.externalCallIndex + 1 }
+              let retVals := state.externalCallReturnValues state.externalCallIndex
+              if retVals.length < resultVars.length then .revert
+              else
+                .continue
+                  { state with
+                      world := (state.externalCallPostWorld state.externalCallIndex).getD
+                        state.world
+                      bindings := bindValues state.bindings resultVars
+                        (retVals.map wordNormalize)
+                      externalCallIndex := state.externalCallIndex + 1 }
             else .revert
         | none => .revert
     | state, .tryExternalCallBind successVar resultVars _externalName args =>
         match evalExprList oracle fields state args with
         | some _ =>
-            let successBit :=
-              if state.externalCallSucceeded state.externalCallIndex then 1 else 0
-            .continue
-              { state with
-                  bindings := bindValues
-                    (bindValue state.bindings successVar successBit)
-                    resultVars (state.externalCallReturnValues state.externalCallIndex)
-                  externalCallIndex := state.externalCallIndex + 1 }
+            let retVals := state.externalCallReturnValues state.externalCallIndex
+            if state.externalCallSucceeded state.externalCallIndex then
+              if retVals.length < resultVars.length then .revert
+              else
+                .continue
+                  { state with
+                      world := (state.externalCallPostWorld state.externalCallIndex).getD
+                        state.world
+                      bindings := bindValues
+                        (bindValue state.bindings successVar 1)
+                        resultVars (retVals.map wordNormalize)
+                      externalCallIndex := state.externalCallIndex + 1 }
+            else
+              .continue
+                { state with
+                    bindings := bindValues
+                      (bindValue state.bindings successVar 0)
+                      resultVars (retVals.map wordNormalize)
+                    externalCallIndex := state.externalCallIndex + 1 }
         | none => .revert
     | _, .revertReturndata => .revert
     | _, _ => .revert

--- a/Verity/Core/Model/DenoteFunctionCalls.lean
+++ b/Verity/Core/Model/DenoteFunctionCalls.lean
@@ -450,7 +450,7 @@ theorem execStmt_externalCallBind_call_succeeds (oracle : DenoteOracle)
     (vars : List String) (name : String) (args : List Expr) (vals : List Nat)
     (hargs : evalExprList oracle fields state args = some vals)
     (hsuccess : state.externalCallSucceeded state.externalCallIndex = true)
-    (harity : ¬ (state.externalCallReturnValues state.externalCallIndex).length < vars.length) :
+    (harity : ¬ (state.externalCallReturnValues state.externalCallIndex).length != vars.length) :
     execStmt oracle fields state (.externalCallBind vars name args) =
       .continue
         { state with

--- a/Verity/Core/Model/DenoteFunctionCalls.lean
+++ b/Verity/Core/Model/DenoteFunctionCalls.lean
@@ -5,9 +5,10 @@ import Verity.Core.Model.MultiContract
 /-!
 # FunctionSpec denotation of raw and linked external calls
 
-`Denote.evalExpr` / `Denote.execStmt` still map `Expr.call` /
-`Stmt.externalCallBind` to `none` / `.revert`, matching
-`SourceSemantics` so `DenoteAgreement` stays definitional.
+`Denote.evalExpr` maps `Expr.call` to `none`.
+`Denote.execStmt` gives `Stmt.externalCallBind` /
+`Stmt.tryExternalCallBind` oracle-driven semantics that mirror
+`SourceSemantics`, keeping `DenoteAgreement` definitional.
 
 This module is the widened fragment: a `CallEnv` supplies the
 `AdversaryModel` (callee effect) and the link-time
@@ -426,11 +427,20 @@ theorem evalExpr_call_still_none (oracle : DenoteOracle) (fields : List Field)
     evalExpr oracle fields state (.call g t v io isz oo osz) = none :=
   rfl
 
-theorem execStmt_externalCallBind_still_reverts (oracle : DenoteOracle)
+theorem execStmt_externalCallBind_args_none (oracle : DenoteOracle)
     (fields : List Field) (state : DenoteState)
-    (vars : List String) (name : String) (args : List Expr) :
-    execStmt oracle fields state (.externalCallBind vars name args) = .revert :=
-  rfl
+    (vars : List String) (name : String) (args : List Expr)
+    (h : evalExprList oracle fields state args = none) :
+    execStmt oracle fields state (.externalCallBind vars name args) = .revert := by
+  simp [execStmt, h]
+
+theorem execStmt_externalCallBind_call_fails (oracle : DenoteOracle)
+    (fields : List Field) (state : DenoteState)
+    (vars : List String) (name : String) (args : List Expr) (vals : List Nat)
+    (hargs : evalExprList oracle fields state args = some vals)
+    (hfail : state.externalCallSucceeded state.externalCallIndex = false) :
+    execStmt oracle fields state (.externalCallBind vars name args) = .revert := by
+  simp [execStmt, hargs, hfail]
 
 private def dummyOracle : DenoteOracle :=
   { mappingSlot := fun _ _ => 0
@@ -446,7 +456,7 @@ theorem evalExpr_call_outside_base_fragment :
 theorem execStmt_externalCallBind_outside_base_fragment :
     execStmt dummyOracle []
       { world := defaultState, bindings := [] }
-      (.externalCallBind ["r"] "echo" [.literal 42]) = .revert :=
+      (.externalCallBind ["r"] "echo" [.literal 42]) = .revert := by
   rfl
 
 end Compiler.CompilationModel.DenoteFunctionCalls

--- a/Verity/Core/Model/DenoteFunctionCalls.lean
+++ b/Verity/Core/Model/DenoteFunctionCalls.lean
@@ -449,14 +449,16 @@ theorem execStmt_externalCallBind_call_succeeds (oracle : DenoteOracle)
     (fields : List Field) (state : DenoteState)
     (vars : List String) (name : String) (args : List Expr) (vals : List Nat)
     (hargs : evalExprList oracle fields state args = some vals)
-    (hsuccess : state.externalCallSucceeded state.externalCallIndex = true) :
+    (hsuccess : state.externalCallSucceeded state.externalCallIndex = true)
+    (harity : ¬ (state.externalCallReturnValues state.externalCallIndex).length < vars.length) :
     execStmt oracle fields state (.externalCallBind vars name args) =
       .continue
         { state with
+          world := (state.externalCallPostWorld state.externalCallIndex).getD state.world
           bindings := bindValues state.bindings vars
-            (state.externalCallReturnValues state.externalCallIndex)
+            ((state.externalCallReturnValues state.externalCallIndex).map wordNormalize)
           externalCallIndex := state.externalCallIndex + 1 } := by
-  simp [execStmt, hargs, hsuccess]
+  simp [execStmt, hargs, hsuccess, harity]
 
 private def dummyOracle : DenoteOracle :=
   { mappingSlot := fun _ _ => 0

--- a/Verity/Core/Model/DenoteFunctionCalls.lean
+++ b/Verity/Core/Model/DenoteFunctionCalls.lean
@@ -442,6 +442,22 @@ theorem execStmt_externalCallBind_call_fails (oracle : DenoteOracle)
     execStmt oracle fields state (.externalCallBind vars name args) = .revert := by
   simp [execStmt, hargs, hfail]
 
+/-- A successful source-level external call advances the oracle receipt and
+    binds its returned words.  This pins the widened denotation to the exact
+    receipt consumed by `SourceSemantics`. -/
+theorem execStmt_externalCallBind_call_succeeds (oracle : DenoteOracle)
+    (fields : List Field) (state : DenoteState)
+    (vars : List String) (name : String) (args : List Expr) (vals : List Nat)
+    (hargs : evalExprList oracle fields state args = some vals)
+    (hsuccess : state.externalCallSucceeded state.externalCallIndex = true) :
+    execStmt oracle fields state (.externalCallBind vars name args) =
+      .continue
+        { state with
+          bindings := bindValues state.bindings vars
+            (state.externalCallReturnValues state.externalCallIndex)
+          externalCallIndex := state.externalCallIndex + 1 } := by
+  simp [execStmt, hargs, hsuccess]
+
 private def dummyOracle : DenoteOracle :=
   { mappingSlot := fun _ _ => 0
     keccakMemorySlice := fun _ _ _ => 0 }

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 489,
+    "native_decide": 502,
     "partial def": 171
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 506,
+    "native_decide": 511,
     "partial def": 171
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 502,
+    "native_decide": 506,
     "partial def": 171
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -89,6 +89,10 @@ ALLOWLIST: set[str] = {
     "execIRStmtsWithInternals_of_internalCall_compiledHelperWitness_with_internals",
     "directInternalHelperStatementContextBridge_sourceAssignEvidence",
     # --- Denote/SourceSemantics agreement (P4 seed) ---
+    # Mutual recursion with execStmtList_eq: each new Stmt constructor
+    # (externalCallBind, tryExternalCallBind) adds an arm; extracting per-case
+    # lemmas would break the shared structural induction across the mutual block.
+    "execStmt_eq",
     # Structural recursion over the fuelless forEach loop; the succ case must
     # spell out the loop-state literal inside a `show`-match to align the two
     # interpreters' unfoldings, which cannot be factored without changing the


### PR DESCRIPTION
## Summary

- **ExternalCallOutcome oracle on RuntimeState**: Adds `ExternalCallOutcome` structure and `externalCallOracle : Nat → ExternalCallOutcome` / `externalCallIndex : Nat` fields to `RuntimeState`, providing deterministic functional semantics for non-deterministic external calls via an oracle pattern indexed by call counter.
- **Source execution semantics**: Implements `externalCallBind` and `tryExternalCallBind` match arms in `execStmt`, `execStmtWithEvents`, and `execStmtWithHelpers` — evaluates args, queries oracle by call index, binds return values (or reverts on failure for `externalCallBind`, sets success bit for `tryExternalCallBind`).
- **Surface gate refinement**: Changes all four sub-surface gates (Call, Foreign, LowLevel, Helper) from unconditional `true`/`false` to proper arg-recursive predicates for `externalCallBind`/`tryExternalCallBind`. Preserves the composition theorem `callSurface = helperSurface || foreignSurface || lowLevelSurface`.
- **Conservative extension proof**: Extends `execStmtWithHelpers_eq_execStmt_of_helperSurfaceClosed` for both new statement forms, using `evalExprListWithHelpers_eq_evalExprList_of_helperSurfaceClosed`.
- **17 feature tests**: `native_decide` examples covering oracle success/failure, binding updates, call-index keying, and surface gate classification.

## IR-level proof blocker (genuine false seam)

The IR interpreter (`IRInterpreter.lean`, `evalIRCallWithInternals` line 502) has no external call oracle mechanism — unknown function calls always revert (line 537). `CompiledStmtStep.preserves` (`ResultRelation.lean` lines 114-134) cannot be satisfied for `externalCallBind` success cases until the IR interpreter is extended with a parallel oracle. This is the genuine proof blocker for full IR coverage of external calls. The effect surface (`stmtTouchesUnsupportedEffectSurface`) still returns `true` unconditionally for `externalCallBind`/`tryExternalCallBind`, so the supported fragment (`SupportedStmtList`) correctly excludes them from the generic proof theorem.

## Changed files

| File | Lines | Change |
|------|-------|--------|
| `SourceSemantics.lean` | +108 | Oracle type, RuntimeState extension, exec match arms, conservative extension proof |
| `SourceSemanticsFeatureTest.lean` | +130 | 17 native_decide feature tests |
| `SupportedSpec.lean` | +24/-8 | Surface gate arg-recursion, composition proof cases, smoke test fix |
| `trust_surface_report.json` | +1/-1 | native_decide count 489 -> 506 |

## Validation

- `lake build Compiler.Proofs.IRGeneration.SourceSemantics` -- PASS (SupportedSpec 380s, SourceSemantics 151s)
- `lake build Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest` -- PASS (18s)
- `make check` -- PASS (all checks passed)
- `lake build PrintAxioms` -- in progress (full build with shared resources; `generate_print_axioms.py --check` passed within `make check`)

## Test plan

- [x] Focused build of all modified modules passes
- [x] 17 native_decide feature tests pass
- [x] Surface gate composition theorem holds
- [x] Conservative extension proof compiles
- [x] No new sorry/admit/axiom/unsafe escapes
- [x] Full `make check` passes (all checks passed)
- [ ] Full `lake build PrintAxioms` (in progress -- mathlib dependency build under heavy contention)

## Recommended next slice

Extend the IR interpreter with an external call oracle mechanism (parallel to the source-level oracle), then satisfy `CompiledStmtStep.preserves` for `externalCallBind`/`tryExternalCallBind` to close the IR gap. Alternatively, tackle `ecm` (encrypted computation module) or `storageArrayPop` source semantics.