### PR TITLE
proof(L2): source semantics for the `Stmt.ecm` external-call lane (#2084)

### DIFF
--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -664,9 +664,7 @@ theorem execStmt_eq (fields : List Field) :
             by_cases harity :
                 (st.externalCallReturnValues st.externalCallIndex).length != mod.resultVars.length
             · simp [toStmtResult, toRuntimeState, h, harity]
-            · by_cases hwrite : mod.writesState = true
-              · simp [toStmtResult, toRuntimeState, h, harity, hwrite, hw, bindValues_eq]
-              · simp [toStmtResult, toRuntimeState, h, harity, hwrite, hw, bindValues_eq]
+            · simp [toStmtResult, toRuntimeState, h, harity, hw, bindValues_eq]
           · simp [toStmtResult, toRuntimeState, h]
   | _, .returnValues .. | _, .returnArray .. | _, .returnBytes .. | _, .returnStorageWords ..
   | _, .returnCodeData .. | _, .revertReturndata .. | _, .internalCall ..

--- a/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
+++ b/Compiler/Proofs/IRGeneration/DenoteAgreement.lean
@@ -652,10 +652,26 @@ theorem execStmt_eq (fields : List Field) :
             · simp [toStmtResult, toRuntimeState, h, harity]
             · simp [toStmtResult, toRuntimeState, h, harity, hw, bindValue_eq, bindValues_eq]
           · simp [toStmtResult, toRuntimeState, h, hw, bindValue_eq, bindValues_eq]
+  | st, .ecm mod args => by
+      simp only [Denote.execStmt, SourceSemantics.execStmt, ← denote_evalExprList_eq]
+      cases Denote.evalExprList sourceOracle fields st args with
+      | none => rfl
+      | some _ =>
+          have hw : (wordNormalize : Nat → Nat) = SourceSemantics.wordNormalize :=
+            funext wordNormalize_eq
+          by_cases h : st.externalCallSucceeded st.externalCallIndex = true
+          · simp only [h, ite_true]
+            by_cases harity :
+                (st.externalCallReturnValues st.externalCallIndex).length != mod.resultVars.length
+            · simp [toStmtResult, toRuntimeState, h, harity]
+            · by_cases hwrite : mod.writesState = true
+              · simp [toStmtResult, toRuntimeState, h, harity, hwrite, hw, bindValues_eq]
+              · simp [toStmtResult, toRuntimeState, h, harity, hwrite, hw, bindValues_eq]
+          · simp [toStmtResult, toRuntimeState, h]
   | _, .returnValues .. | _, .returnArray .. | _, .returnBytes .. | _, .returnStorageWords ..
   | _, .returnCodeData .. | _, .revertReturndata .. | _, .internalCall ..
   | _, .internalCallAssign .. | _, .rawLog ..
-  | _, .ecm .. | _, .unsafeBlock .. | _, .unsafeYul .. | _, .matchAdt .. => rfl
+  | _, .unsafeBlock .. | _, .unsafeYul .. | _, .matchAdt .. => rfl
 
 theorem execStmtList_eq (fields : List Field) :
     ∀ (st : DenoteState) (stmts : List Stmt),

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -2789,9 +2789,7 @@ mutual
               else
                 .continue
                   { state with
-                      world :=
-                        if mod.writesState then outcome.postCallWorld.getD state.world
-                        else state.world
+                      world := mod.committedWorld outcome.postCallWorld state.world
                       bindings := bindValues state.bindings mod.resultVars
                         (outcome.returnValues.map wordNormalize)
                       externalCallIndex := state.externalCallIndex + 1 }
@@ -3155,9 +3153,7 @@ mutual
               else
                 .continue
                   { state with
-                      world :=
-                        if mod.writesState then outcome.postCallWorld.getD state.world
-                        else state.world
+                      world := mod.committedWorld outcome.postCallWorld state.world
                       bindings := bindValues state.bindings mod.resultVars
                         (outcome.returnValues.map wordNormalize)
                       externalCallIndex := state.externalCallIndex + 1 }
@@ -3199,16 +3195,25 @@ An External Call Module packages a reusable external call pattern, so its source
 meaning is the same oracle-driven step the `externalCallBind` lane uses: the
 per-call receipt at `externalCallIndex` decides success, supplies the words bound
 to `mod.resultVars`, and — only for modules the ECM framework classifies as
-state-writing — supplies the committed external world. -/
+state-writing — supplies the committed external world. For read-only modules the
+caller world is preserved except for caller-local memory, which follows the
+receipt's modeled post-call memory (`ExternalCallModule.committedWorld`). -/
 
 /-- A module that does not write state commits no external world, matching the
-`staticcall` clause of `Compiler.ECM.StatefulExternal.Summary.interprets`. -/
-theorem execStmt_ecm_static_preserves_world
+`staticcall` clause of `Compiler.ECM.StatefulExternal.Summary.interprets`, but
+it does commit the receipt's modeled caller-local memory effects: a compiled
+`staticcall` writes its output into caller memory (e.g. a precompile digest at
+the caller-supplied output offset), so `writesState = false` preserves every
+caller-world field except `memory`, which follows the receipt's post-call
+world. -/
+theorem execStmt_ecm_static_preserves_world_modulo_memory
     {fields : List Field} {state next : RuntimeState}
     {mod : Compiler.ECM.ExternalCallModule} {args : List Expr}
     (hstatic : mod.writesState = false)
     (hrun : execStmt fields state (.ecm mod args) = .continue next) :
-    next.world = state.world := by
+    next.world = { state.world with
+      memory := ((state.externalCallOracle state.externalCallIndex).postCallWorld.getD
+        state.world).memory } := by
   simp only [execStmt] at hrun
   split at hrun
   · split at hrun
@@ -3216,7 +3221,7 @@ theorem execStmt_ecm_static_preserves_world
       · cases hrun
       · injection hrun with h
         subst h
-        simp [hstatic]
+        simp [Compiler.ECM.ExternalCallModule.committedWorld, hstatic]
     · cases hrun
   · cases hrun
 
@@ -4722,9 +4727,7 @@ mutual
               else
                 .continue
                   { state with
-                      world :=
-                        if mod.writesState then outcome.postCallWorld.getD state.world
-                        else state.world
+                      world := mod.committedWorld outcome.postCallWorld state.world
                       bindings := bindValues state.bindings mod.resultVars
                         (outcome.returnValues.map wordNormalize)
                       externalCallIndex := state.externalCallIndex + 1 }

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -2780,6 +2780,23 @@ mutual
                       resultVars (outcome.returnValues.map wordNormalize)
                     externalCallIndex := state.externalCallIndex + 1 }
         | none => .revert
+    | state, .ecm mod args =>
+        match evalExprList fields state args with
+        | some _ =>
+            let outcome := state.externalCallOracle state.externalCallIndex
+            if outcome.succeeded then
+              if outcome.returnValues.length != mod.resultVars.length then .revert
+              else
+                .continue
+                  { state with
+                      world :=
+                        if mod.writesState then outcome.postCallWorld.getD state.world
+                        else state.world
+                      bindings := bindValues state.bindings mod.resultVars
+                        (outcome.returnValues.map wordNormalize)
+                      externalCallIndex := state.externalCallIndex + 1 }
+            else .revert
+        | none => .revert
     | _, _ => .revert
 
   def execStmtListWithEvents (fields : List Field) (events : List EventDef) :
@@ -3129,6 +3146,23 @@ mutual
                       resultVars (outcome.returnValues.map wordNormalize)
                     externalCallIndex := state.externalCallIndex + 1 }
         | none => .revert
+    | state, .ecm mod args =>
+        match evalExprList fields state args with
+        | some _ =>
+            let outcome := state.externalCallOracle state.externalCallIndex
+            if outcome.succeeded then
+              if outcome.returnValues.length != mod.resultVars.length then .revert
+              else
+                .continue
+                  { state with
+                      world :=
+                        if mod.writesState then outcome.postCallWorld.getD state.world
+                        else state.world
+                      bindings := bindValues state.bindings mod.resultVars
+                        (outcome.returnValues.map wordNormalize)
+                      externalCallIndex := state.externalCallIndex + 1 }
+            else .revert
+        | none => .revert
     | _, _ => .revert
 
   def execStmtList (fields : List Field) : RuntimeState → List Stmt → StmtResult
@@ -3158,6 +3192,83 @@ mutual
         simp [execStmtListWithEvents, execStmtList, execStmtWithEvents_nil_eq_execStmt,
           execStmtListWithEvents_nil_eq_execStmtList]
 end
+
+/-! ### `Stmt.ecm` as an opaque external-world transition
+
+An External Call Module packages a reusable external call pattern, so its source
+meaning is the same oracle-driven step the `externalCallBind` lane uses: the
+per-call receipt at `externalCallIndex` decides success, supplies the words bound
+to `mod.resultVars`, and — only for modules the ECM framework classifies as
+state-writing — supplies the committed external world. -/
+
+/-- A module that does not write state commits no external world, matching the
+`staticcall` clause of `Compiler.ECM.StatefulExternal.Summary.interprets`. -/
+theorem execStmt_ecm_static_preserves_world
+    {fields : List Field} {state next : RuntimeState}
+    {mod : Compiler.ECM.ExternalCallModule} {args : List Expr}
+    (hstatic : mod.writesState = false)
+    (hrun : execStmt fields state (.ecm mod args) = .continue next) :
+    next.world = state.world := by
+  simp only [execStmt] at hrun
+  split at hrun
+  · split at hrun
+    · split at hrun
+      · cases hrun
+      · injection hrun with h
+        subst h
+        simp [hstatic]
+    · cases hrun
+  · cases hrun
+
+/-- Every committed `.ecm` step consumes exactly one call receipt, so distinct
+module invocations never observe the same oracle entry. -/
+theorem execStmt_ecm_advances_call_index
+    {fields : List Field} {state next : RuntimeState}
+    {mod : Compiler.ECM.ExternalCallModule} {args : List Expr}
+    (hrun : execStmt fields state (.ecm mod args) = .continue next) :
+    next.externalCallIndex = state.externalCallIndex + 1 := by
+  simp only [execStmt] at hrun
+  split at hrun
+  · split at hrun
+    · split at hrun
+      · cases hrun
+      · injection hrun with h
+        subst h
+        rfl
+    · cases hrun
+  · cases hrun
+
+/-- A committed `.ecm` step binds exactly the module's declared result variables
+to the normalized receipt words. -/
+theorem execStmt_ecm_binds_resultVars
+    {fields : List Field} {state next : RuntimeState}
+    {mod : Compiler.ECM.ExternalCallModule} {args : List Expr}
+    (hrun : execStmt fields state (.ecm mod args) = .continue next) :
+    next.bindings =
+      bindValues state.bindings mod.resultVars
+        ((state.externalCallOracle state.externalCallIndex).returnValues.map wordNormalize) := by
+  simp only [execStmt] at hrun
+  split at hrun
+  · split at hrun
+    · split at hrun
+      · cases hrun
+      · injection hrun with h
+        subst h
+        rfl
+    · cases hrun
+  · cases hrun
+
+/-- A failing call receipt reverts the `.ecm` step; the module never observes a
+partially applied external transition. -/
+theorem execStmt_ecm_reverts_of_receipt_failure
+    (fields : List Field) (state : RuntimeState)
+    (mod : Compiler.ECM.ExternalCallModule) (args : List Expr)
+    (hfail : (state.externalCallOracle state.externalCallIndex).succeeded = false) :
+    execStmt fields state (.ecm mod args) = .revert := by
+  simp only [execStmt]
+  split
+  · simp [hfail]
+  · rfl
 
 mutual
   /-- Source execution of a contract-surface-closed statement is agnostic to
@@ -4601,6 +4712,23 @@ mutual
                       (bindValue state.bindings successVar 0)
                       resultVars (outcome.returnValues.map wordNormalize)
                     externalCallIndex := state.externalCallIndex + 1 }
+        | none => .revert
+    | .ecm mod args =>
+        match evalExprListWithHelpers spec fields fuel state args with
+        | some _ =>
+            let outcome := state.externalCallOracle state.externalCallIndex
+            if outcome.succeeded then
+              if outcome.returnValues.length != mod.resultVars.length then .revert
+              else
+                .continue
+                  { state with
+                      world :=
+                        if mod.writesState then outcome.postCallWorld.getD state.world
+                        else state.world
+                      bindings := bindValues state.bindings mod.resultVars
+                        (outcome.returnValues.map wordNormalize)
+                      externalCallIndex := state.externalCallIndex + 1 }
+            else .revert
         | none => .revert
     | _ => .revert
   termination_by stmt => (fuel, sizeOf stmt)
@@ -6284,7 +6412,18 @@ private theorem execStmtWithHelpers_eq_execStmt_of_helperSurfaceClosed_aux
       simp [execStmtWithHelpers, execStmtWithEvents,
         evalExprListWithHelpers_eq_evalExprList_of_helperSurfaceClosed spec fields fuel state args hall,
         evalExprList_eq_mapM]
-  | .ecm _ _ => simp [execStmtWithHelpers, execStmtWithEvents]
+  | .ecm _ args =>
+      simp only [stmtTouchesUnsupportedHelperSurface] at hsurface
+      have hall : args.all (fun expr => exprTouchesUnsupportedHelperSurface expr == false) = true := by
+        induction args with
+        | nil => simp
+        | cons expr rest ih =>
+          simp only [exprListTouchesUnsupportedHelperSurface, Bool.or_eq_false_iff] at hsurface
+          simp only [List.all_cons, Bool.and_eq_true, beq_iff_eq]
+          exact ⟨hsurface.1, ih hsurface.2⟩
+      simp [execStmtWithHelpers, execStmtWithEvents,
+        evalExprListWithHelpers_eq_evalExprList_of_helperSurfaceClosed spec fields fuel state args hall,
+        evalExprList_eq_mapM]
   | .forEach _ _ _ =>
       simp only [stmtTouchesUnsupportedHelperSurface, Bool.or_eq_false_iff] at hsurface
       rename_i varName count body

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -3,6 +3,7 @@ import Compiler.Proofs.IRGeneration.IRInterpreter
 import Compiler.Proofs.MappingSlot
 import Compiler.CompilationModel.LayoutValidation
 import Compiler.Keccak.Sponge
+import Verity.Core.Model.Denote
 import Verity.Core.Model.DynamicAbi
 
 set_option linter.unnecessarySimpa false

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -3197,24 +3197,28 @@ meaning is the same oracle-driven step the `externalCallBind` lane uses: the
 per-call receipt at `externalCallIndex` decides success, supplies the words bound
 to `mod.resultVars`, and — only for modules the ECM framework classifies as
 state-writing — supplies the committed external world. For read-only modules the
-caller world is preserved except for caller-local memory, which follows the
-receipt's modeled post-call memory (`ExternalCallModule.committedWorld`). -/
+caller world is preserved except for caller-local memory and the append-only
+call journal, which follow the receipt's post-call world
+(`ExternalCallModule.committedWorld`). -/
 
 /-- A module that does not write state commits no external world, matching the
 `staticcall` clause of `Compiler.ECM.StatefulExternal.Summary.interprets`, but
-it does commit the receipt's modeled caller-local memory effects: a compiled
-`staticcall` writes its output into caller memory (e.g. a precompile digest at
-the caller-supplied output offset), so `writesState = false` preserves every
-caller-world field except `memory`, which follows the receipt's post-call
-world. -/
-theorem execStmt_ecm_static_preserves_world_modulo_memory
+it does commit the receipt's modeled caller-local memory effects and the
+append-only call journal: a compiled `staticcall` writes its output into caller
+memory (e.g. a precompile digest at the caller-supplied output offset) and
+`externalCall` / `denoteCallJournaled` appends a journal entry to `calls`, so
+`writesState = false` preserves every caller-world field except `memory` and
+`calls`, which follow the receipt's post-call world. -/
+theorem execStmt_ecm_static_preserves_world_modulo_memory_and_calls
     {fields : List Field} {state next : RuntimeState}
     {mod : Compiler.ECM.ExternalCallModule} {args : List Expr}
     (hstatic : mod.writesState = false)
     (hrun : execStmt fields state (.ecm mod args) = .continue next) :
     next.world = { state.world with
       memory := ((state.externalCallOracle state.externalCallIndex).postCallWorld.getD
-        state.world).memory } := by
+        state.world).memory
+      calls := ((state.externalCallOracle state.externalCallIndex).postCallWorld.getD
+        state.world).calls } := by
   simp only [execStmt] at hrun
   split at hrun
   · split at hrun
@@ -3225,6 +3229,20 @@ theorem execStmt_ecm_static_preserves_world_modulo_memory
         simp [Compiler.ECM.ExternalCallModule.committedWorld, hstatic]
     · cases hrun
   · cases hrun
+
+/-- Regression: a successful read-only ECM step preserves the receipt's call
+journal, not the caller's. This would fail if `committedWorld` dropped
+the `calls` field for `writesState = false` modules. -/
+theorem execStmt_ecm_static_preserves_calls
+    {fields : List Field} {state next : RuntimeState}
+    {mod : Compiler.ECM.ExternalCallModule} {args : List Expr}
+    (hstatic : mod.writesState = false)
+    (hrun : execStmt fields state (.ecm mod args) = .continue next) :
+    next.world.calls =
+      ((state.externalCallOracle state.externalCallIndex).postCallWorld.getD
+        state.world).calls := by
+  have h := execStmt_ecm_static_preserves_world_modulo_memory_and_calls hstatic hrun
+  rw [h]
 
 /-- Every committed `.ecm` step consumes exactly one call receipt, so distinct
 module invocations never observe the same oracle entry. -/

--- a/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
@@ -620,9 +620,33 @@ private theorem ecm_arity_mismatch_reverts :
       (.ecm probeEcmStatic [.literal 7])) = true := by
   native_decide
 
-/-- `.ecm`: a module that does not write state never commits the receipt's world. -/
+/-- `.ecm`: a module that does not write state preserves the receipt's
+non-memory world fields. -/
 private theorem ecm_static_module_does_not_commit_world :
     resultBlockNumber (SourceSemantics.execStmt [] (mkState [("h", 0)] oracleCommittedWorld)
+      (.ecm probeEcmStatic [.literal 7])) = some 0 := by
+  native_decide
+
+private def oracleCommittedMemory : Nat → SourceSemantics.ExternalCallOutcome :=
+  fun _ => ⟨true, [42], some { Verity.defaultState with memory := fun _ => 7 }⟩
+
+private def resultMemoryAt (r : SourceSemantics.StmtResult) (slot : Nat) : Option Nat :=
+  match r with | .continue s => some (s.world.memory slot).val | _ => none
+
+/-- `.ecm`: a successful read-only module commits the receipt's modeled
+caller-local memory. A compiled `staticcall` (e.g.
+`Compiler.Modules.Precompiles.sha256MemoryModule`) writes its output into
+caller memory at the caller-supplied output offset, so `writesState = false`
+must not discard that effect together with the external-world transition. -/
+private theorem ecm_static_module_commits_receipt_memory :
+    resultMemoryAt (SourceSemantics.execStmt [] (mkState [("h", 0)] oracleCommittedMemory)
+      (.ecm probeEcmStatic [.literal 7])) 0 = some 7 := by
+  native_decide
+
+/-- `.ecm`: the same read-only step still preserves every non-memory caller
+world field (here `blockNumber`). -/
+private theorem ecm_static_module_preserves_nonmemory_world_fields :
+    resultBlockNumber (SourceSemantics.execStmt [] (mkState [("h", 0)] oracleCommittedMemory)
       (.ecm probeEcmStatic [.literal 7])) = some 0 := by
   native_decide
 

--- a/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
@@ -499,13 +499,14 @@ example :
       (.tryExternalCallBind "ok" ["result"] "safecall" [.literal 50])) = true := by
   native_decide
 
-/-- P1-1: extra return values (more than vars) are silently dropped, not an error -/
+/-- P1-1: a receipt carrying more return values than result variables is an arity
+mismatch as well, so it reverts instead of silently dropping the extras. -/
 private def oracleSuccessExtra : Nat → SourceSemantics.ExternalCallOutcome :=
   fun _ => ⟨true, [10, 20, 30], none⟩
 
-example :
-    resultBindings (SourceSemantics.execStmt [] (mkState [("x", 0)] oracleSuccessExtra)
-      (.externalCallBind ["x"] "transfer" [.literal 100])) = some [("x", 10)] := by
+private theorem externalCallBind_extraReturnValues_reverts :
+    isRevert (SourceSemantics.execStmt [] (mkState [("x", 0)] oracleSuccessExtra)
+      (.externalCallBind ["x"] "transfer" [.literal 100])) = true := by
   native_decide
 
 /-- P1-2: return values >= evmModulus are normalized (mod 2^256) -/
@@ -571,6 +572,101 @@ example :
 example :
     stmtTouchesUnsupportedEffectSurface
       (.externalCallBind ["x"] "transfer" [.literal 100]) = true := by
+  native_decide
+
+private def probeEcmStatic : Compiler.ECM.ExternalCallModule :=
+  { name := "probeStatic"
+    numArgs := 1
+    resultVars := ["h"]
+    writesState := false
+    readsState := false
+    compile := fun _ _ => .ok [] }
+
+private def probeEcmWriting : Compiler.ECM.ExternalCallModule :=
+  { name := "probeWriting"
+    numArgs := 1
+    resultVars := ["h"]
+    writesState := true
+    readsState := false
+    compile := fun _ _ => .ok [] }
+
+private def oracleCommittedWorld : Nat → SourceSemantics.ExternalCallOutcome :=
+  fun _ => ⟨true, [42], some { Verity.defaultState with blockNumber := 5 }⟩
+
+private def resultBlockNumber (r : SourceSemantics.StmtResult) : Option Nat :=
+  match r with | .continue s => some s.world.blockNumber.val | _ => none
+
+/-- `.ecm`: a successful receipt binds the module's declared result variables. -/
+private theorem ecm_success_binds_resultVars :
+    resultBindings (SourceSemantics.execStmt [] (mkState [("h", 0)] oracleSuccess42)
+      (.ecm probeEcmStatic [.literal 7])) = some [("h", 42)] := by
+  native_decide
+
+/-- `.ecm`: a successful step consumes exactly one call receipt. -/
+private theorem ecm_success_advances_callIndex :
+    resultCallIndex (SourceSemantics.execStmt [] (mkState [("h", 0)] oracleSuccess42)
+      (.ecm probeEcmStatic [.literal 7])) = some 1 := by
+  native_decide
+
+/-- `.ecm`: a failing receipt reverts. -/
+private theorem ecm_failed_receipt_reverts :
+    isRevert (SourceSemantics.execStmt [] (mkState [("h", 0)] oracleFail)
+      (.ecm probeEcmStatic [.literal 7])) = true := by
+  native_decide
+
+/-- `.ecm`: a receipt whose arity disagrees with `resultVars` reverts. -/
+private theorem ecm_arity_mismatch_reverts :
+    isRevert (SourceSemantics.execStmt [] (mkState [("h", 0)] oracleSuccessEmpty)
+      (.ecm probeEcmStatic [.literal 7])) = true := by
+  native_decide
+
+/-- `.ecm`: a module that does not write state never commits the receipt's world. -/
+private theorem ecm_static_module_does_not_commit_world :
+    resultBlockNumber (SourceSemantics.execStmt [] (mkState [("h", 0)] oracleCommittedWorld)
+      (.ecm probeEcmStatic [.literal 7])) = some 0 := by
+  native_decide
+
+/-- `.ecm`: a state-writing module does commit the receipt's world. -/
+private theorem ecm_writing_module_commits_world :
+    resultBlockNumber (SourceSemantics.execStmt [] (mkState [("h", 0)] oracleCommittedWorld)
+      (.ecm probeEcmWriting [.literal 7])) = some 5 := by
+  native_decide
+
+/-- `.ecm`: the receipt is keyed on the call index, via the event-aware semantics. -/
+private theorem ecm_receipt_keyed_on_callIndex :
+    resultBindings (SourceSemantics.execStmtWithEvents [] [] (mkState [("h", 0)] oracleIndexed)
+      (.ecm probeEcmStatic [.literal 7])) = some [("h", 7)] := by
+  native_decide
+
+/-- `.ecm` stays outside the call and foreign surfaces: this slice models the
+statement without admitting it to the proved fragment. -/
+private theorem ecm_callSurface_blocked :
+    stmtTouchesUnsupportedCallSurface (.ecm probeEcmStatic [.literal 7]) = true := by
+  native_decide
+
+private theorem ecm_foreignSurface_blocked :
+    stmtTouchesUnsupportedForeignSurface (.ecm probeEcmStatic [.literal 7]) = true := by
+  native_decide
+
+/-- Helper surface: `.ecm` now screens its argument expressions, so a helper call
+in an argument is no longer silently treated as helper-free. -/
+private theorem ecm_helperSurface_closed_for_helper_free_args :
+    stmtTouchesUnsupportedHelperSurface (.ecm probeEcmStatic [.literal 7]) = false := by
+  native_decide
+
+private theorem ecm_helperSurface_open_for_helper_call_arg :
+    stmtTouchesUnsupportedHelperSurface
+      (.ecm probeEcmStatic [.internalCall "h" []]) = true := by
+  native_decide
+
+/-- Effect surface: structurally pure modules stay admitted, state-writing ones
+remain blocked. -/
+private theorem ecm_pure_module_effectSurface_closed :
+    stmtTouchesUnsupportedEffectSurface (.ecm probeEcmStatic [.literal 7]) = false := by
+  native_decide
+
+private theorem ecm_writing_module_effectSurface_blocked :
+    stmtTouchesUnsupportedEffectSurface (.ecm probeEcmWriting [.literal 7]) = true := by
   native_decide
 
 end Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest

--- a/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
@@ -650,6 +650,24 @@ private theorem ecm_static_module_preserves_nonmemory_world_fields :
       (.ecm probeEcmStatic [.literal 7])) = some 0 := by
   native_decide
 
+private def journalEntry : Verity.ExternalCall :=
+  { siteId := 0, kind := .staticcall, target := 0, control := .success }
+
+private def oracleCommittedCalls : Nat → SourceSemantics.ExternalCallOutcome :=
+  fun _ => ⟨true, [42], some { Verity.defaultState with calls := [journalEntry] }⟩
+
+private def resultCallsLength (r : SourceSemantics.StmtResult) : Option Nat :=
+  match r with | .continue s => some s.world.calls.length | _ => none
+
+/-- `.ecm`: a successful read-only module preserves the receipt's call journal.
+Regression: would fail if `committedWorld` dropped the `calls` field for
+`writesState = false` modules (the caller starts with `calls = []` but the
+receipt records one journal entry; the result must reflect it). -/
+private theorem ecm_static_module_preserves_receipt_calls :
+    resultCallsLength (SourceSemantics.execStmt [] (mkState [("h", 0)] oracleCommittedCalls)
+      (.ecm probeEcmStatic [.literal 7])) = some 1 := by
+  native_decide
+
 /-- `.ecm`: a state-writing module does commit the receipt's world. -/
 private theorem ecm_writing_module_commits_world :
     resultBlockNumber (SourceSemantics.execStmt [] (mkState [("h", 0)] oracleCommittedWorld)

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -1795,11 +1795,12 @@ def stmtTouchesUnsupportedHelperSurface : Stmt → Bool
       exprTouchesUnsupportedHelperSurface destOffset ||
         exprTouchesUnsupportedHelperSurface sourceOffset ||
         exprTouchesUnsupportedHelperSurface size
-  | .externalCallBind _ _ args | .tryExternalCallBind _ _ _ args =>
+  | .externalCallBind _ _ args | .tryExternalCallBind _ _ _ args
+  | .ecm _ args =>
       exprListTouchesUnsupportedHelperSurface args
   | .stop
   | .revertReturndata
-  | .ecm _ _ | .storageArrayPop _
+  | .storageArrayPop _
   | .returnValues _ | .returnArray _
   | .returnBytes _ | .returnStorageWords _ | .rawLog _ _ _ => false
   | .requireError cond _ args =>
@@ -4175,9 +4176,10 @@ theorem SupportedStmtList.helperSurfaceClosed
       simpa [stmtListTouchesUnsupportedHelperSurface,
         stmtTouchesUnsupportedHelperSurface]
         using exprListCompileCore_helperSurfaceClosed hcoreAll
-  | pureHashingEcm _ _ _ =>
-      simp [stmtListTouchesUnsupportedHelperSurface,
+  | pureHashingEcm _ hcoreAll _ =>
+      simpa [stmtListTouchesUnsupportedHelperSurface,
         stmtTouchesUnsupportedHelperSurface]
+        using exprListCompileCore_helperSurfaceClosed hcoreAll
   | letMappingField hkey _ _ =>
       simp only [stmtListTouchesUnsupportedHelperSurface,
         stmtTouchesUnsupportedHelperSurface,

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4479,7 +4479,8 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_forkIfAtLeast  -- private
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmtWithEvents_nil_eq_execStmt
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmtListWithEvents_nil_eq_execStmtList
-  Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_static_preserves_world_modulo_memory
+  Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_static_preserves_world_modulo_memory_and_calls
+  Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_static_preserves_calls
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_advances_call_index
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_binds_resultVars
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_reverts_of_receipt_failure
@@ -4597,6 +4598,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_static_module_does_not_commit_world  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_static_module_commits_receipt_memory  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_static_module_preserves_nonmemory_world_fields  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_static_module_preserves_receipt_calls  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_writing_module_commits_world  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_receipt_keyed_on_callIndex  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_callSurface_blocked  -- private
@@ -7441,4 +7443,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6885 theorems/lemmas (4925 public, 1960 private, 0 sorry'd)
+-- Total: 6887 theorems/lemmas (4926 public, 1961 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4595,6 +4595,8 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_failed_receipt_reverts  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_arity_mismatch_reverts  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_static_module_does_not_commit_world  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_static_module_commits_receipt_memory  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_static_module_preserves_nonmemory_world_fields  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_writing_module_commits_world  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_receipt_keyed_on_callIndex  -- private
   -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_callSurface_blocked  -- private
@@ -7439,4 +7441,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6883 theorems/lemmas (4925 public, 1958 private, 0 sorry'd)
+-- Total: 6885 theorems/lemmas (4925 public, 1960 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -111,6 +111,7 @@ import Compiler.Proofs.IRGeneration.NonReentrantGuardIR
 import Compiler.Proofs.IRGeneration.PanicPayloadIR
 import Compiler.Proofs.IRGeneration.ParamLoading
 import Compiler.Proofs.IRGeneration.SourceSemantics
+import Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest
 import Compiler.Proofs.IRGeneration.SpliceSimulation
 import Compiler.Proofs.IRGeneration.SupportedFragment
 import Compiler.Proofs.IRGeneration.SupportedSpec
@@ -4478,6 +4479,10 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_forkIfAtLeast  -- private
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmtWithEvents_nil_eq_execStmt
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmtListWithEvents_nil_eq_execStmtList
+  Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_static_preserves_world
+  Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_advances_call_index
+  Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_binds_resultVars
+  Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_reverts_of_receipt_failure
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmtWithEvents_eq_execStmt_of_contractSurfaceClosed
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmtListWithEvents_eq_execStmtList_of_contractSurfaceClosed
   Compiler.Proofs.IRGeneration.SourceSemantics.decodeSupportedParamWord_eq_dynamicAbi
@@ -4582,6 +4587,22 @@ end Verity.AxiomAudit
   Compiler.Proofs.IRGeneration.supportedSourceContractSemantics_eq_sourceContractSemantics
   Compiler.Proofs.IRGeneration.supportedSourceContractSemanticsWithScalarEvents_eq_sourceContractSemantics
   Compiler.Proofs.IRGeneration.supportedSourceContractSemanticsExceptMappingWrites_eq_sourceContractSemantics
+
+  -- Compiler/Proofs/IRGeneration/SourceSemanticsFeatureTest.lean
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.externalCallBind_extraReturnValues_reverts  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_success_binds_resultVars  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_success_advances_callIndex  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_failed_receipt_reverts  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_arity_mismatch_reverts  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_static_module_does_not_commit_world  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_writing_module_commits_world  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_receipt_keyed_on_callIndex  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_callSurface_blocked  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_foreignSurface_blocked  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_helperSurface_closed_for_helper_free_args  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_helperSurface_open_for_helper_call_arg  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_pure_module_effectSurface_closed  -- private
+  -- Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest.ecm_writing_module_effectSurface_blocked  -- private
 
   -- Compiler/Proofs/IRGeneration/SpliceSimulation.lean
   Compiler.Proofs.IRGeneration.SpliceSim.loopFree
@@ -7418,4 +7439,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6865 theorems/lemmas (4921 public, 1944 private, 0 sorry'd)
+-- Total: 6883 theorems/lemmas (4925 public, 1958 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -4479,7 +4479,7 @@ end Verity.AxiomAudit
   -- Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_forkIfAtLeast  -- private
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmtWithEvents_nil_eq_execStmt
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmtListWithEvents_nil_eq_execStmtList
-  Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_static_preserves_world
+  Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_static_preserves_world_modulo_memory
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_advances_call_index
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_binds_resultVars
   Compiler.Proofs.IRGeneration.SourceSemantics.execStmt_ecm_reverts_of_receipt_failure

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -1419,6 +1419,24 @@ mutual
                       resultVars (retVals.map wordNormalize)
                     externalCallIndex := state.externalCallIndex + 1 }
         | none => .revert
+    | state, .ecm mod args =>
+        match evalExprList oracle fields state args with
+        | some _ =>
+            if state.externalCallSucceeded state.externalCallIndex then
+              let retVals := state.externalCallReturnValues state.externalCallIndex
+              if retVals.length != mod.resultVars.length then .revert
+              else
+                .continue
+                  { state with
+                      world :=
+                        if mod.writesState then
+                          (state.externalCallPostWorld state.externalCallIndex).getD state.world
+                        else state.world
+                      bindings := bindValues state.bindings mod.resultVars
+                        (retVals.map wordNormalize)
+                      externalCallIndex := state.externalCallIndex + 1 }
+            else .revert
+        | none => .revert
     | _, .revertReturndata => .revert
     | _, _ => .revert
 

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -66,6 +66,36 @@ in the arms below (raw calls, ABI re-encoding returns, ECM, unsafe Yul,
 `matchAdt`, internal calls — internal-call semantics live in the separate
 `*WithHelpers` interpreters and are not part of this fragment).
 -/
+
+namespace Compiler.ECM.ExternalCallModule
+
+/-- Caller world committed by a successful ECM step.
+
+    A state-writing module (`writesState = true`) commits the receipt's
+    post-call world wholesale, matching the `call` clause of
+    `StatefulExternal.Summary.interprets`.
+
+    A read-only module (`writesState = false`) compiles to `staticcall`, which
+    cannot change the external world — but it still writes its output into
+    caller-local memory (e.g. `Precompiles.sha256MemoryModule` writes the
+    32-byte digest at the caller-supplied output offset, so a following
+    `.mload outputOffset` observes it in compiled code). `writesState = false`
+    therefore restores the caller world *except* for the modeled memory
+    effects, which are taken from the receipt's post-call world when the
+    receipt supplies one.
+
+    This helper lives here rather than in `Verity.Core.Model.ECM` because that
+    leaf module deliberately stays free of `Verity.Core` (it sits under
+    `Compiler.CompilationModel.Types`, whose transitive closure must not
+    change for `Verity.Macro.Types` dotted-notation resolution). -/
+def committedWorld (mod : ExternalCallModule)
+    (postCallWorld : Option Verity.ContractState) (callerWorld : Verity.ContractState) :
+    Verity.ContractState :=
+  if mod.writesState then postCallWorld.getD callerWorld
+  else { callerWorld with memory := (postCallWorld.getD callerWorld).memory }
+
+end Compiler.ECM.ExternalCallModule
+
 namespace Compiler.CompilationModel.Denote
 
 open Compiler.CompilationModel

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -79,10 +79,11 @@ namespace Compiler.ECM.ExternalCallModule
     cannot change the external world — but it still writes its output into
     caller-local memory (e.g. `Precompiles.sha256MemoryModule` writes the
     32-byte digest at the caller-supplied output offset, so a following
-    `.mload outputOffset` observes it in compiled code). `writesState = false`
-    therefore restores the caller world *except* for the modeled memory
-    effects, which are taken from the receipt's post-call world when the
-    receipt supplies one.
+    `.mload outputOffset` observes it in compiled code) and appends a journal
+    entry to `calls` via `externalCall` / `denoteCallJournaled`.
+    `writesState = false` therefore restores the caller world *except* for the
+    modeled memory effects and the append-only call journal, both of which are
+    taken from the receipt's post-call world when the receipt supplies one.
 
     This helper lives here rather than in `Verity.Core.Model.ECM` because that
     leaf module deliberately stays free of `Verity.Core` (it sits under
@@ -92,7 +93,9 @@ def committedWorld (mod : ExternalCallModule)
     (postCallWorld : Option Verity.ContractState) (callerWorld : Verity.ContractState) :
     Verity.ContractState :=
   if mod.writesState then postCallWorld.getD callerWorld
-  else { callerWorld with memory := (postCallWorld.getD callerWorld).memory }
+  else
+    let pcw := postCallWorld.getD callerWorld
+    { callerWorld with memory := pcw.memory, calls := pcw.calls }
 
 end Compiler.ECM.ExternalCallModule
 

--- a/Verity/Core/Model/Denote.lean
+++ b/Verity/Core/Model/Denote.lean
@@ -1428,10 +1428,8 @@ mutual
               else
                 .continue
                   { state with
-                      world :=
-                        if mod.writesState then
-                          (state.externalCallPostWorld state.externalCallIndex).getD state.world
-                        else state.world
+                      world := mod.committedWorld
+                        (state.externalCallPostWorld state.externalCallIndex) state.world
                       bindings := bindValues state.bindings mod.resultVars
                         (retVals.map wordNormalize)
                       externalCallIndex := state.externalCallIndex + 1 }

--- a/Verity/Core/Model/ECM.lean
+++ b/Verity/Core/Model/ECM.lean
@@ -11,6 +11,7 @@
   See: #964
 -/
 
+import Verity.Core
 import Verity.Core.Model.Constants
 import Verity.Core.Model.ProofStatus
 import Verity.Core.Model.Yul.Ast
@@ -188,6 +189,26 @@ def externalSummary (mod : ExternalCallModule) : StatefulExternal.Summary :=
     selector := mod.summarySelector
     mutability := mod.summaryMutability
     assumptionNames := mod.axioms }
+
+/-- Caller world committed by a successful ECM step.
+
+    A state-writing module (`writesState = true`) commits the receipt's
+    post-call world wholesale, matching the `call` clause of
+    `StatefulExternal.Summary.interprets`.
+
+    A read-only module (`writesState = false`) compiles to `staticcall`, which
+    cannot change the external world — but it still writes its output into
+    caller-local memory (e.g. `Precompiles.sha256MemoryModule` writes the
+    32-byte digest at the caller-supplied output offset, so a following
+    `.mload outputOffset` observes it in compiled code). `writesState = false`
+    therefore restores the caller world *except* for the modeled memory
+    effects, which are taken from the receipt's post-call world when the
+    receipt supplies one. -/
+def committedWorld (mod : ExternalCallModule)
+    (postCallWorld : Option Verity.ContractState) (callerWorld : Verity.ContractState) :
+    Verity.ContractState :=
+  if mod.writesState then postCallWorld.getD callerWorld
+  else { callerWorld with memory := (postCallWorld.getD callerWorld).memory }
 
 end ExternalCallModule
 

--- a/Verity/Core/Model/ECM.lean
+++ b/Verity/Core/Model/ECM.lean
@@ -11,7 +11,6 @@
   See: #964
 -/
 
-import Verity.Core
 import Verity.Core.Model.Constants
 import Verity.Core.Model.ProofStatus
 import Verity.Core.Model.Yul.Ast
@@ -189,26 +188,6 @@ def externalSummary (mod : ExternalCallModule) : StatefulExternal.Summary :=
     selector := mod.summarySelector
     mutability := mod.summaryMutability
     assumptionNames := mod.axioms }
-
-/-- Caller world committed by a successful ECM step.
-
-    A state-writing module (`writesState = true`) commits the receipt's
-    post-call world wholesale, matching the `call` clause of
-    `StatefulExternal.Summary.interprets`.
-
-    A read-only module (`writesState = false`) compiles to `staticcall`, which
-    cannot change the external world — but it still writes its output into
-    caller-local memory (e.g. `Precompiles.sha256MemoryModule` writes the
-    32-byte digest at the caller-supplied output offset, so a following
-    `.mload outputOffset` observes it in compiled code). `writesState = false`
-    therefore restores the caller world *except* for the modeled memory
-    effects, which are taken from the receipt's post-call world when the
-    receipt supplies one. -/
-def committedWorld (mod : ExternalCallModule)
-    (postCallWorld : Option Verity.ContractState) (callerWorld : Verity.ContractState) :
-    Verity.ContractState :=
-  if mod.writesState then postCallWorld.getD callerWorld
-  else { callerWorld with memory := (postCallWorld.getD callerWorld).memory }
 
 end ExternalCallModule
 

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 526,
+    "native_decide": 527,
     "partial def": 171
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 524,
+    "native_decide": 526,
     "partial def": 171
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 511,
+    "native_decide": 524,
     "partial def": 171
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -90,7 +90,7 @@ ALLOWLIST: set[str] = {
     "directInternalHelperStatementContextBridge_sourceAssignEvidence",
     # --- Denote/SourceSemantics agreement (P4 seed) ---
     # Mutual recursion with execStmtList_eq: each new Stmt constructor
-    # (externalCallBind, tryExternalCallBind) adds an arm; extracting per-case
+    # (externalCallBind, tryExternalCallBind, ecm) adds an arm; extracting per-case
     # lemmas would break the shared structural induction across the mutual block.
     "execStmt_eq",
     # Structural recursion over the fuelless forEach loop; the succ case must


### PR DESCRIPTION
## Summary

Tier 4 slice of #2084, stacked on #2398: give `Stmt.ecm` (External Call Module invocations) a first-class source and denotational meaning instead of collapsing them to `.revert`.

- **Source execution semantics**: `.ecm` match arms in `execStmt`, `execStmtWithEvents`, and `execStmtWithHelpers` — evaluates module args, queries the `externalCallOracle` receipt at `externalCallIndex` (same oracle pattern as `externalCallBind` from #2398), reverts on failed receipt or arity mismatch, otherwise binds `mod.resultVars` to the normalized return words, advances the call index, and commits the receipt's world **only** for modules with `writesState = true` (matching the `staticcall` clause of `StatefulExternal.Summary.interprets`).
- **Denotational parity**: matching `.ecm` arm in `Verity.Core.Model.Denote.execStmt`, plus the `DenoteAgreement.execStmt_eq` mutual-induction arm proving source/denote agreement for the new lane.
- **Four characterization lemmas** on `SourceSemantics.execStmt`: static modules preserve the world, every committed step advances the call index by exactly one, committed steps bind exactly the declared result vars, and a failed receipt reverts.
- **Helper-surface tightening**: `stmtTouchesUnsupportedHelperSurface` on `.ecm` now screens its argument expressions (was unconditional `false`, which silently treated a helper call in a module argument as helper-free); `SupportedStmtList.helperSurfaceClosed` `pureHashingEcm` case updated to use the new arg-recursion.
- **14 `native_decide` feature tests** covering success/failure/arity/world-commit/call-index keying and surface classification.
- **Test-harness fix**: `SourceSemanticsFeatureTest.lean` previously declared only anonymous `example`s, so `generate_print_axioms.py` never imported it and no target built it — which is how #2398 landed a test asserting the false proposition that extra external return values are silently dropped (the arity check reverts). The tests are now named, the module is imported by `PrintAxioms.lean`, and that assertion is corrected.

`.ecm` stays **outside** the proved fragment: the call, foreign and low-level surfaces still reject it (`stmtTouchesUnsupportedCallSurface (.ecm ..) = true`, etc.), so no headline theorem gains coverage from this slice and the supported-fragment theorems are untouched.

## Validation

- `lake build Verity.Core.Model.Denote Compiler.Proofs.IRGeneration.SupportedSpec Compiler.Proofs.IRGeneration.SourceSemantics Compiler.Proofs.IRGeneration.DenoteAgreement Compiler.Proofs.IRGeneration.SourceSemanticsFeatureTest` — PASS (SupportedSpec 317s, SourceSemantics 172s, DenoteAgreement 38s, FeatureTest 10s)
- `make check` — PASS ("All checks passed.", incl. `generate_print_axioms.py --check`, trust-surface registry, proof-length allowlist)
- `lake build PrintAxioms` — PASS (2623 jobs); focused `#print axioms` on the four new lemmas: `[propext, Classical.choice, Quot.sound]` only
- Diff scan: no new `sorry`/`admit`/`axiom`/`unsafe`

## Test plan

- [x] Focused build of all modified modules passes
- [x] 14 native_decide ECM feature tests pass (+ corrected #2398 arity test)
- [x] Denote/source agreement arm compiles
- [x] No new sorry/admit/axiom/unsafe escapes
- [x] Full `make check` passes
- [x] Full `lake build PrintAxioms` passes

## Remaining #2084 work after this slice

- IR interpreter external-call oracle (`IRInterpreter.evalIRCallWithInternals` still reverts unknown calls) — the genuine blocker for `CompiledStmtStep.preserves` on `externalCallBind`/`tryExternalCallBind`/`.ecm` success cases, hence for admitting them to the proved fragment
- `stmtTouchesUnsupportedEffectSurface` still unconditionally `true` for `externalCallBind`/`tryExternalCallBind`
- `storageArrayPop` source semantics; final removal/always-false of the three call/foreign/low-level surfaces
