### PR TITLE
proof(model): unify Common external calls under AdversaryModel.stub

### DIFF
--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -2,6 +2,7 @@ import Compiler.CompilationModel
 import Compiler.Proofs.MappingSlot
 import Verity.Core
 import Verity.Core.Semantics
+import Verity.Core.Model.ContractExternalCall
 import Verity.EVM.Uint256
 import Verity.Macro
 import Verity.Stdlib.Math
@@ -570,9 +571,9 @@ end Call
 word. Public (not `private`) so specs and tests can state the executable
 plane's in-band results and journal entries verbatim. -/
 def externalCallStubWord (name : String) (args : List Uint256) : Uint256 :=
-  match name, args with
-  | "echo", [value] => value
-  | _, _ => args.foldl add name.length
+  Core.Uint256.ofNat
+    (Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stubWord
+      name (args.map (fun word => (word : Nat))))
 
 /-- Executable success bit for a linked external call: every linked callee
 succeeds except the reserved name `"fail"`, which lets tests exercise the
@@ -606,6 +607,15 @@ def linkedCallEntryTo (name : String) (target : Address) (value : Uint256)
   { linkedCallEntry name argWords control returndata with
     target := target.toNat
     value := value.val }
+
+/-- Model call site corresponding to one executable linked-call crossing. -/
+def linkedCallSite (name : String) (argWords : List Uint256)
+    (returnArity : Nat := 0) (kind : Compiler.CompilationModel.DenoteExternalCalls.CallKind := .call)
+    (target : Nat := 0) (value : Nat := 0) (stubPrefix : List Nat := []) :
+    Compiler.CompilationModel.DenoteExternalCalls.CallSite :=
+  { siteId := 0, kind, target, value
+    calldata := argWords.map (fun word => (word : Nat))
+    name, returnArity, stubPrefix, gas := 0 }
 
 /-- Append one entry to the `ContractState.calls` journal. This is the sole
 observable-effect primitive of the executable linked-call family; a
@@ -758,6 +768,9 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
 
 private def erc20ReadStubWord (name : String) (args : List Uint256) : Uint256 :=
   externalCallStubWord name args
+
+@[simp] theorem erc20ReadStubWord_eq (name : String) (args : List Uint256) :
+    erc20ReadStubWord name args = externalCallStubWord name args := rfl
 macro_rules
   | `(term| externalCall $name:ident [ $[$args:term],* ]) =>
       `(externalCallWords $(Lean.quote (toString name.getId))

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -9,6 +9,7 @@ import Contracts.Smoke.HelperCalls
 import Contracts.Smoke.StructMappings
 import Contracts.Smoke.ExternalCalls
 import Contracts.Smoke.ExternalCallObservability
+import Verity.Proofs.Model.CommonExternalCallEquivalence
 import Contracts.Smoke.ExternalCallInBodySmoke
 import Contracts.Smoke.ExternalCallValue
 import Contracts.Smoke.SpecGenAndChecks

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -37,6 +37,7 @@ import Contracts.Vault.Proofs.Correctness
 import Contracts.Vault.Proofs.Native
 import Verity.Proofs.CheckedExternalCallConsumer
 import Verity.Proofs.LoopSimulationResultAware
+import Verity.Proofs.Model.CommonExternalCallEquivalence
 import Verity.Proofs.Stdlib.Automation
 import Verity.Proofs.Stdlib.ListSum
 import Verity.Proofs.Stdlib.MappingAutomation
@@ -699,6 +700,22 @@ end Verity.AxiomAudit
   Verity.Proofs.LoopSimulationResultAware.forEach_rel_execForEachLoop_result_aware
   Verity.Proofs.LoopSimulationResultAware.execResultAwareForEach_success_bridge
   Verity.Proofs.LoopSimulationResultAware.execResultAwareForEach_earlyExit_bridge
+
+  -- Verity/Proofs/Model/CommonExternalCallEquivalence.lean
+  Contracts.externalCallWords_eq_stub_result
+  Contracts.callResultWords_eq_stub
+  Contracts.tryExternalCallWords_eq_stub
+  Contracts.externalCallBind_eq_stub
+  Contracts.externalCallBindTo_eq_stub
+  Contracts.balanceOf_eq_stub
+  Contracts.allowance_eq_stub
+  Contracts.totalSupply_eq_stub
+  Contracts.erc20Write_eq_stub
+  Contracts.safeTransfer_eq_stub
+  Contracts.safeTransferFrom_eq_stub
+  Contracts.safeApprove_eq_stub
+  Contracts.legacyStringSafeTransfer_eq_stub
+  Contracts.legacyStringSafeTransferFrom_eq_stub
 
   -- Verity/Proofs/Stdlib/Automation.lean
   Verity.Proofs.Stdlib.Automation.isSuccess_success
@@ -7497,4 +7514,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6938 theorems/lemmas (4948 public, 1990 private, 0 sorry'd)
+-- Total: 6952 theorems/lemmas (4962 public, 1990 private, 0 sorry'd)

--- a/Verity/Core/Model/DenoteExternalCalls.lean
+++ b/Verity/Core/Model/DenoteExternalCalls.lean
@@ -36,6 +36,12 @@ structure CallSite where
   target : Nat
   value : Nat := 0
   calldata : List Nat := []
+  /-- Source-level linked name. Opcode-level sites leave this empty. -/
+  name : String := ""
+  /-- Number of returndata words expected by the deterministic source stub. -/
+  returnArity : Nat := 0
+  /-- Words used by source stubs but omitted from the observable calldata. -/
+  stubPrefix : List Nat := []
   gas : Nat
   deriving Repr
 
@@ -125,6 +131,45 @@ structure AdversaryModel where
   stateTransition : CallSite → Verity.ContractState → Verity.ContractState
   result : CallSite → Verity.ContractState → ExternalCallResult
   gasUsed : CallSite → Verity.ContractState → Nat
+
+namespace AdversaryModel
+
+/-- The deterministic word used by the legacy executable linked-call plane. -/
+def stubWord (name : String) (args : List Nat) : Nat :=
+  Denote.wordNormalize <|
+    if name = "echo" then
+      match args with
+      | [value] => value
+      | _ => args.foldl (fun acc arg => Denote.wordNormalize (acc + arg)) name.length
+    else
+      args.foldl (fun acc arg => Denote.wordNormalize (acc + arg)) name.length
+
+@[simp] theorem wordNormalize_stubWord (name : String) (args : List Nat) :
+    Denote.wordNormalize (stubWord name args) = stubWord name args := by
+  simp [stubWord, Denote.wordNormalize]
+
+@[simp] theorem stubWord_modulus (name : String) (args : List Nat) :
+    stubWord name args % Verity.Core.Uint256.modulus = stubWord name args := by
+  simpa [Denote.wordNormalize] using wordNormalize_stubWord name args
+
+/-- The no-reentry adversary matching the current executable linked-call stub.
+It preserves caller state, fails only for the reserved name `"fail"`, returns
+the deterministic stub word at the site's declared arity, and consumes no gas. -/
+def stub : AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun site _ =>
+    if site.name = "fail" then .failure []
+    else .success
+      (List.replicate site.returnArity (stubWord site.name (site.stubPrefix ++ site.calldata)))
+  gasUsed := fun _ _ => 0
+
+@[simp] theorem stub_stateTransition (site : CallSite) (state : Verity.ContractState) :
+    stub.stateTransition site state = state := rfl
+
+@[simp] theorem stub_gasUsed (site : CallSite) (state : Verity.ContractState) :
+    stub.gasUsed site state = 0 := rfl
+
+end AdversaryModel
 
 /-- Observable produced at one call boundary. -/
 structure CallObservation where
@@ -288,7 +333,8 @@ def journalEntry (site : CallSite) (result : ExternalCallResult) :
     value := site.value
     calldata := site.calldata
     control := result.control.toJournal
-    returndata := result.returndata }
+    returndata := result.returndata
+    name := site.name }
 
 /-- Denote one external call and record it in the caller world's journal. -/
 def denoteCallJournaled (adversary : AdversaryModel) (site : CallSite)

--- a/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
+++ b/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
@@ -1,0 +1,263 @@
+import Contracts.Common
+
+/-!
+# Common external calls are the model stub
+
+Compatibility proofs for the executable call helpers in `Contracts.Common`.
+The model boundary additionally maintains `ContractState.returndata`; the
+legacy helpers expose returndata through their return value and call journal.
+`legacyPost` is precisely that existing-state projection.
+-/
+
+namespace Contracts
+
+open Verity hiding pure bind
+open Compiler.CompilationModel.DenoteExternalCalls
+
+private abbrev modelExternalCall :=
+  Compiler.CompilationModel.DenoteExternalCalls.externalCall
+
+/-- Forget the model-only live-returndata channel after a call, retaining the
+legacy Common state and its append-only call journal. -/
+def legacyPost (before after : ContractState) : ContractState :=
+  { after with returndata := before.returndata }
+
+def stubCallResultWords {α : Type} [ExternalResult α] [Inhabited α]
+    (name : String) (args : List Uint256) : Contract (Call.Result α) := fun state =>
+  match (modelExternalCall .stub (linkedCallSite name args 1)).run state with
+  | .success result post =>
+      .success
+        { success := result.succeeded
+          returndata :=
+            match result with
+            | .success (word :: _) => ExternalResult.fromWord (Core.Uint256.ofNat word)
+            | .success [] | .failure _ | .revert _ => Inhabited.default }
+        (legacyPost state post)
+  | .revert message _ => .revert message state
+
+def stubTryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
+    (name : String) (args : List Uint256) : Contract (Bool × α) := fun state =>
+  match (modelExternalCall .stub (linkedCallSite name args 1)).run state with
+  | .success result post =>
+      .success
+        (result.succeeded,
+          match result with
+          | .success (word :: _) => ExternalResult.fromWord (Core.Uint256.ofNat word)
+          | .success [] | .failure _ | .revert _ => Inhabited.default)
+        (legacyPost state post)
+  | .revert message _ => .revert message state
+
+def stubExternalCallBind {α : Type} [ExternalArg α]
+    (names : List String) (name : String) (args : List α) : Contract Unit := fun state =>
+  let words := args.flatMap ExternalArg.toWords
+  match (modelExternalCall .stub (linkedCallSite name words names.length)).run state with
+  | .success (.success _) post => .success () (legacyPost state post)
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "external call failed" state
+  | .revert message _ => .revert message state
+
+def stubExternalCallBindTo {α : Type} [ExternalArg α]
+    (target : Address) (value : Uint256)
+    (names : List String) (name : String) (args : List α) : Contract Unit := fun state =>
+  if value ≤ state.selfBalance then
+    let words := args.flatMap ExternalArg.toWords
+    match (modelExternalCall .stub
+        (linkedCallSite name words names.length .call target.toNat value.val)).run state with
+    | .success (.success _) post =>
+        .success () { legacyPost state post with selfBalance := state.selfBalance - value }
+    | .success (.failure _) _ | .success (.revert _) _ =>
+        .revert "external call failed" state
+    | .revert message _ => .revert message state
+  else .revert "insufficient balance" state
+
+def stubErc20Read (name : String) (token : Address)
+    (args : List Uint256) : Contract Uint256 := fun state =>
+  let site := linkedCallSite name args 1 .staticcall token.toNat 0
+    [Verity.addressToWord token]
+  match (modelExternalCall .stub site).run state with
+  | .success (.success (word :: _)) post =>
+      .success (Core.Uint256.ofNat word) (legacyPost state post)
+  | .success _ post => .success 0 (legacyPost state post)
+  | .revert message _ => .revert message state
+
+def stubErc20Write (name : String) (token : Address)
+    (args : List Uint256) : Contract Unit := fun state =>
+  match (modelExternalCall .stub
+      (linkedCallSite name args 0 .call token.toNat)).run state with
+  | .success (.success _) post => .success () (legacyPost state post)
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "external call failed" state
+  | .revert message _ => .revert message state
+
+/-! ## Primitive equivalences -/
+
+theorem externalCallWords_eq_stub_result {α : Type} [ExternalResult α]
+    (name : String) (args : List Uint256) :
+    externalCallWords (α := α) name args =
+      ExternalResult.fromWord (Core.Uint256.ofNat
+        (AdversaryModel.stubWord name (args.map fun word => (word : Nat)))) := rfl
+
+theorem callResultWords_eq_stub {α : Type} [ExternalResult α] [Inhabited α]
+    (name : String) (args : List Uint256) (state : ContractState) :
+    (callResultWords (α := α) name args).run state =
+      (stubCallResultWords name args).run state := by
+  by_cases h : name = "fail"
+  · simp [callResultWords, stubCallResultWords, modelExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+      denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+      CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+      ExternalCallResult.returndata, ExternalCallResult.succeeded, Contract.run, linkedCallSite,
+      AdversaryModel.stub, legacyPost, externalCallStubSuccess, h, linkedCallEntry]
+  · simp [callResultWords, stubCallResultWords, modelExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+      denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+      CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+      ExternalCallResult.returndata, ExternalCallResult.succeeded, Contract.run, linkedCallSite,
+      AdversaryModel.stub, legacyPost, externalCallStubSuccess, h, linkedCallEntry,
+      externalCallStubWord]
+
+theorem tryExternalCallWords_eq_stub {α : Type} [ExternalResult α] [Inhabited α]
+    (name : String) (args : List Uint256) (state : ContractState) :
+    (tryExternalCallWords (α := α) name args).run state =
+      (stubTryExternalCallWords name args).run state := by
+  by_cases h : name = "fail"
+  · simp [tryExternalCallWords, stubTryExternalCallWords, modelExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+      denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+      CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+      ExternalCallResult.returndata, ExternalCallResult.succeeded, Contract.run, linkedCallSite,
+      AdversaryModel.stub, legacyPost, externalCallStubSuccess, h, linkedCallEntry]
+  · simp [tryExternalCallWords, stubTryExternalCallWords, modelExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+      denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+      CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+      ExternalCallResult.returndata, ExternalCallResult.succeeded, Contract.run, linkedCallSite,
+      AdversaryModel.stub, legacyPost, externalCallStubSuccess, h, linkedCallEntry,
+      externalCallStubWord]
+
+theorem externalCallBind_eq_stub {α : Type} [ExternalArg α]
+    (names : List String) (name : String) (args : List α) (state : ContractState) :
+    (externalCallBind names name args).run state =
+      (stubExternalCallBind names name args).run state := by
+  by_cases h : name = "fail"
+  · simp [externalCallBind, stubExternalCallBind, modelExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+      denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+      CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+      ExternalCallResult.returndata, Contract.run, linkedCallSite,
+      AdversaryModel.stub, externalCallStubSuccess, h]
+  · simp [externalCallBind, stubExternalCallBind, modelExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+      denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+      CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+      ExternalCallResult.returndata, Contract.run, linkedCallSite,
+      AdversaryModel.stub, legacyPost, externalCallStubSuccess, h, linkedCallEntry,
+      externalCallStubWord]
+
+theorem externalCallBindTo_eq_stub {α : Type} [ExternalArg α]
+    (target : Address) (value : Uint256)
+    (names : List String) (name : String) (args : List α) (state : ContractState) :
+    (externalCallBindTo target value names name args).run state =
+      (stubExternalCallBindTo target value names name args).run state := by
+  by_cases hbal : value ≤ state.selfBalance
+  · by_cases h : name = "fail"
+    · simp [externalCallBindTo, stubExternalCallBindTo, modelExternalCall,
+        Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+        denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+        CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+        ExternalCallResult.returndata, Contract.run, linkedCallSite,
+        AdversaryModel.stub, externalCallStubSuccess, hbal, h]
+    · simp [externalCallBindTo, stubExternalCallBindTo, modelExternalCall,
+        Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+        denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+        CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+        ExternalCallResult.returndata, Contract.run, linkedCallSite,
+        AdversaryModel.stub, legacyPost, externalCallStubSuccess, hbal, h,
+        linkedCallEntryTo, linkedCallEntry, externalCallStubWord]
+  · simp [externalCallBindTo, stubExternalCallBindTo, Contract.run, hbal]
+
+theorem balanceOf_eq_stub (token owner : Address) (state : ContractState) :
+    (balanceOf token owner).run state =
+      (stubErc20Read "balanceOf" token [Verity.addressToWord owner]).run state := by
+  rw [balanceOf_run]
+  simp [stubErc20Read, modelExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+    denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+    CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+    ExternalCallResult.returndata, Contract.run, linkedCallSite,
+    AdversaryModel.stub, legacyPost, erc20ReadEntry, linkedCallEntry,
+    externalCallStubWord]
+
+theorem allowance_eq_stub (token owner spender : Address) (state : ContractState) :
+    (allowance token owner spender).run state =
+      (stubErc20Read "allowance" token
+        [Verity.addressToWord owner, Verity.addressToWord spender]).run state := by
+  rw [allowance_run]
+  simp [stubErc20Read, modelExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+    denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+    CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+    ExternalCallResult.returndata, Contract.run, linkedCallSite,
+    AdversaryModel.stub, legacyPost, erc20ReadEntry, linkedCallEntry,
+    externalCallStubWord]
+
+theorem totalSupply_eq_stub (token : Address) (state : ContractState) :
+    (totalSupply token).run state =
+      (stubErc20Read "totalSupply" token []).run state := by
+  rw [totalSupply_run]
+  simp [stubErc20Read, modelExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+    denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+    CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+    ExternalCallResult.returndata, Contract.run, linkedCallSite,
+    AdversaryModel.stub, legacyPost, erc20ReadEntry, linkedCallEntry,
+    externalCallStubWord]
+
+theorem erc20Write_eq_stub (name : String) (token : Address)
+    (args : List Uint256) (state : ContractState) (h : name ≠ "fail") :
+    (recordLinkedCall (erc20WriteEntry name token args)).run state =
+      (stubErc20Write name token args).run state := by
+  rw [recordLinkedCall_run]
+  simp [stubErc20Write, modelExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+    denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+    CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+    ExternalCallResult.returndata, Contract.run, linkedCallSite,
+    AdversaryModel.stub, legacyPost, erc20WriteEntry, linkedCallEntry, h]
+
+theorem safeTransfer_eq_stub (token toAddr : Address) (amount : Uint256)
+    (state : ContractState) :
+    (safeTransfer token toAddr amount).run state =
+      (stubErc20Write "safeTransfer" token
+        [Verity.addressToWord toAddr, amount]).run state :=
+  erc20Write_eq_stub _ _ _ _ (by decide)
+
+theorem safeTransferFrom_eq_stub (token fromAddr toAddr : Address) (amount : Uint256)
+    (state : ContractState) :
+    (safeTransferFrom token fromAddr toAddr amount).run state =
+      (stubErc20Write "safeTransferFrom" token
+        [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state :=
+  erc20Write_eq_stub _ _ _ _ (by decide)
+
+theorem safeApprove_eq_stub (token spender : Address) (amount : Uint256)
+    (state : ContractState) :
+    (safeApprove token spender amount).run state =
+      (stubErc20Write "safeApprove" token
+        [Verity.addressToWord spender, amount]).run state :=
+  erc20Write_eq_stub _ _ _ _ (by decide)
+
+theorem legacyStringSafeTransfer_eq_stub (token toAddr : Address) (amount : Uint256)
+    (state : ContractState) :
+    (legacyStringSafeTransfer token toAddr amount).run state =
+      (stubErc20Write "legacyStringSafeTransfer" token
+        [Verity.addressToWord toAddr, amount]).run state :=
+  erc20Write_eq_stub _ _ _ _ (by decide)
+
+theorem legacyStringSafeTransferFrom_eq_stub
+    (token fromAddr toAddr : Address) (amount : Uint256) (state : ContractState) :
+    (legacyStringSafeTransferFrom token fromAddr toAddr amount).run state =
+      (stubErc20Write "legacyStringSafeTransferFrom" token
+        [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state :=
+  erc20Write_eq_stub _ _ _ _ (by decide)
+
+end Contracts

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -339,6 +339,45 @@ The EDSL path remains more expressive (supports arbitrary Lean, `List.foldl`, pa
 
 Internal helper call mechanics are available end-to-end, but first-class compositional proof reuse at the helper boundary is still incomplete. Today, internal helpers compile, validate, and execute through `execStmtsFuel`; the source-semantics layer now has explicit helper-summary soundness and direct-call consumption lemmas, but those summaries are not yet threaded through the body/IR preservation proofs across callers. That remaining proof-level gap is tracked in the Layer 2 completeness roadmap under [#1630](https://github.com/lfglabs-dev/verity/issues/1630), with the current interface/boundary refactor landing in [#1633](https://github.com/lfglabs-dev/verity/pull/1633).
 
+### AdversaryModel unification lane
+
+Verity currently has four inconsistent external-call semantics: the macro
+default, the deterministic `Contracts.Common` stub, the adversarial oracle in
+`SourceSemantics`, and the model-level `AdversaryModel`. Their disagreement can
+silently permit false reentrancy invariants: a proof may omit the adversarial
+call effect while executable or compiled code still opens the call boundary.
+The target architecture has one explicit `AdversaryModel` threaded through
+source execution, macro-generated definitions, compilation proofs, and
+reentrancy reasoning. Forgetting the adversary must become a type error.
+
+The decided landing order is six reviewable PRs:
+
+1. Add `AdversaryModel.stub` and prove every current `Contracts.Common`
+   external-call primitive agrees with `ContractExternalCall.externalCall`
+   under that stub, modulo the established journal representation.
+2. Thread an explicit adversary through source-level external-call semantics,
+   retaining `.stub` only at executable compatibility boundaries.
+3. Retarget `verity_contract` expansion to the adversary-parameterized source
+   definitions and eliminate the macro's independent call default.
+4. Make `SourceSemantics` consume the same model and retire its separate
+   call-oracle/reentry interpretation.
+5. Generate and connect reentrancy entrypoint registries at real call sites,
+   then migrate `Reentrancy` and `CallbackBridge` consumers to the unified
+   boundary.
+6. Carry the explicit model through the generic compilation-preservation
+   theorem and delete the superseded compatibility semantics.
+
+Acceptance requires identical behavior under `.stub`, unchanged Foundry
+differential results, a compile-time failure when an adversary is omitted after
+the compatibility boundaries are removed, and kernel-checked equivalence and
+reentrancy proofs with no new axioms. Each PR must keep generated audit
+artifacts synchronized and all repository gates green. This lane does not
+widen the supported fragment, change external-call ABI/lowering behavior,
+model new call opcodes or gas rules, alter macro syntax before its scheduled
+PR, or redesign the already-decided architecture. In particular, PR1 is only
+the stub/equivalence foundation: no explicit adversary parameters, macro
+signature changes, or fragment widening land there.
+
 ### Interpreter feature-support contract
 
 A comprehensive feature matrix documents which CompilationModel constructs each interpreter supports, their proof status, and known limitations:
@@ -521,19 +560,22 @@ The older Phase 1 / Phase 2 / Phase 3 calendar framing is no longer accurate. Th
 
 ### Active Work
 
-1. **Layer 2 widening and completeness**
+1. **Close the gap with Solidity**
+   - Close the remaining `verity_contract` EDSL and interop gaps needed for production DeFi contracts.
+   - Tracking: [#1680](https://github.com/lfglabs-dev/verity/issues/1680), [#586](https://github.com/lfglabs-dev/verity/issues/586)
+
+2. **AdversaryModel unification**
+   - Make one explicit adversary the semantics of every external-call path; see the six-PR lane above.
+
+3. **Proven-fragment extension (Layer 2 widening and completeness)**
    - Thread helper-aware proof reuse, storage/event/call coverage, and richer observables into the generic whole-contract theorem.
    - Tracking: [#1630](https://github.com/lfglabs-dev/verity/issues/1630), [#1638](https://github.com/lfglabs-dev/verity/issues/1638)
 
-2. **Trust reduction**
+4. **Trust reduction**
    - Continue the EVMYulLean bridge work and reduce remaining axiomatized / trusted boundaries.
    - Tracking: [#1683](https://github.com/lfglabs-dev/verity/issues/1683)
 
-3. **Language and interop completeness**
-   - Close the remaining `verity_contract` EDSL gaps needed for production DeFi contracts.
-   - Tracking: [#1680](https://github.com/lfglabs-dev/verity/issues/1680), [#586](https://github.com/lfglabs-dev/verity/issues/586)
-
-4. **Documentation and artifact synchronization**
+5. **Documentation and artifact synchronization**
    - Keep generated metrics, trust assumptions, parity profiles, and public docs aligned with the codebase.
    - Tracking: [#1681](https://github.com/lfglabs-dev/verity/issues/1681), [#585](https://github.com/lfglabs-dev/verity/issues/585)
 


### PR DESCRIPTION
## Summary

- define `AdversaryModel.stub` with identity state transition, zero gas use, the existing deterministic `externalCallStubWord` result, and the existing `externalCallStubSuccess` failure convention
- prove every current external-call primitive in `Contracts/Common.lean` agrees with `ContractExternalCall.externalCall .stub`, modulo the established legacy projection that restores the model-only live-returndata field while preserving the call journal
- add the decided six-PR AdversaryModel unification lane to the roadmap immediately between close-the-gap-with-Solidity and proven-fragment extension

## Scope boundaries

PR1 only: no explicit adversary parameters, macro signature changes, fragment widening, ABI/lowering changes, gas/opcode modeling, or architecture changes. Generated Yul for contracts without external calls remains byte-identical to the base.

## Equivalence coverage

The kernel-checked theorem surface covers:

- `externalCallWords`
- `callResultWords`
- `tryExternalCallWords`
- `externalCallBind`
- `externalCallBindTo`
- `balanceOf`, `allowance`, and `totalSupply`
- the shared ERC-20 write primitive and `safeTransfer`, `safeTransferFrom`, `safeApprove`
- both legacy string safe-transfer wrappers

The only projection is `legacyPost`: the model boundary owns a live EIP-211 returndata channel that legacy Common helpers do not expose in state. It restores the pre-call `ContractState.returndata` and retains the model-produced call journal, including call kind, target, value, calldata, control, returndata, and linked name.

## Validation

Base: `cca73c39a4f49176fc01c570febb31ea891b3898`

- `lake build Verity.Proofs.Model.CommonExternalCallEquivalence` — pass
- `lake build` — pass (2474 jobs)
- `lake build PrintAxioms` — pass (2626 jobs)
- `make check` — pass (666 Python tests; all repository gates)
- Lean hygiene/forbidden scan — pass: 0 sorry, 0 unexpected admit, 0 new axiom, 0 unsafe reducibility, 0 native_decide in proofs
- generated Yul identity against base — pass: no changed files under `artifacts/yul`
- `FOUNDRY_PROFILE=difftest DIFFTEST_RANDOM_SEED=42 DIFFTEST_RANDOM_SMALL=100 forge test --no-match-test 'Random10000'` — pass: 52 suites, 541 tests, 0 failures

Axiom audit remains unchanged: equivalence theorems use only ordinary kernel/library principles reported by `PrintAxioms`; the repository still has its single pre-existing documented source axiom, `solidityMappingSlot_injective`. No production axiom or trust boundary was added.

## PR2 handoff

Thread an explicit adversary through source-level external-call semantics while retaining `.stub` only at executable compatibility boundaries. Do not change the macro signature until PR3 and do not widen the supported fragment.
