### PR TITLE
refactor(common): thread adversary through external calls

### DIFF
--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -573,7 +573,7 @@ example : snapshotSupplyModelUsesTotalSupplyModule = true := by native_decide
 def snapshotBalanceExecutableUsesStub : Bool :=
   let token := Verity.wordToAddress 7
   let owner := Verity.wordToAddress 13
-  match Contracts.balanceOf token owner Verity.defaultState,
+  match Contracts.balanceOf token owner .stub Verity.defaultState,
       MacroERC20.snapshotBalance token owner Verity.defaultState with
   | .success expected _, .success balance state =>
       balance == expected &&
@@ -588,7 +588,7 @@ def snapshotAllowanceExecutableUsesStub : Bool :=
   let token := Verity.wordToAddress 7
   let owner := Verity.wordToAddress 13
   let spender := Verity.wordToAddress 17
-  match Contracts.allowance token owner spender Verity.defaultState,
+  match Contracts.allowance token owner spender .stub Verity.defaultState,
       MacroERC20.snapshotAllowance token owner spender Verity.defaultState with
   | .success expected _, .success current state =>
       current == expected &&
@@ -601,7 +601,7 @@ example : snapshotAllowanceExecutableUsesStub = true := by native_decide
 
 def snapshotSupplyExecutableUsesStub : Bool :=
   let token := Verity.wordToAddress 7
-  match Contracts.totalSupply token Verity.defaultState,
+  match Contracts.totalSupply token .stub Verity.defaultState,
       MacroERC20.snapshotSupply token Verity.defaultState with
   | .success expected _, .success supply state =>
       supply == expected &&

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -631,38 +631,50 @@ private abbrev ExternalCallResult :=
 private abbrev modelExternalCall :=
   Compiler.CompilationModel.DenoteExternalCalls.externalCall
 
-private def resultWord (result : ExternalCallResult) : Uint256 :=
+def externalCallResultWord (result : ExternalCallResult) : Uint256 :=
   Core.Uint256.ofNat (result.returndata.head?.getD 0)
 
+/-- PR2 compatibility boundary. The unified model owns call execution and
+state evolution; Common temporarily retains its historical live-returndata
+projection until the macro default is removed in PR3. -/
+def commonExternalCall (adv : AdversaryModel)
+    (site : Compiler.CompilationModel.DenoteExternalCalls.CallSite) :
+    Contract ExternalCallResult := fun state =>
+  match modelExternalCall adv site state with
+  | .success result post =>
+      .success result { post with returndata := state.returndata }
+  | .revert message _ => .revert message state
+
 def externalCallWords {α : Type} [ExternalResult α] (name : String) (args : List Uint256)
-    (adv : AdversaryModel := .stub) : Contract α := do
-  let result ← modelExternalCall adv (linkedCallSite name args 1)
-  pure (ExternalResult.fromWord (resultWord result))
+    (adv : AdversaryModel := .stub) : α :=
+  match commonExternalCall adv (linkedCallSite name args 1) defaultState with
+  | .success result _ => ExternalResult.fromWord (externalCallResultWord result)
+  | .revert _ _ => ExternalResult.fromWord 0
 
 def callResultWords {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (adv : AdversaryModel := .stub) : Contract (Call.Result α) := do
-  let result ← modelExternalCall adv (linkedCallSite name args 1)
+  let result ← commonExternalCall adv (linkedCallSite name args 1)
   pure
     { success := result.succeeded
-      returndata := if result.succeeded then ExternalResult.fromWord (resultWord result)
+      returndata := if result.succeeded then ExternalResult.fromWord (externalCallResultWord result)
         else Inhabited.default }
 
 def tryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (adv : AdversaryModel := .stub) : Contract (Bool × α) := do
-  let result ← modelExternalCall adv (linkedCallSite name args 1)
+  let result ← commonExternalCall adv (linkedCallSite name args 1)
   pure (result.succeeded,
-    if result.succeeded then ExternalResult.fromWord (resultWord result)
+    if result.succeeded then ExternalResult.fromWord (externalCallResultWord result)
     else Inhabited.default)
 
 def externalCallBind {α : Type} [ExternalArg α]
     (names : List String) (name : String) (args : List α)
-    (adv : AdversaryModel := .stub) : Contract Unit :=
+    (adv : AdversaryModel := .stub) : Contract Unit := fun state =>
   let words := args.flatMap ExternalArg.toWords
-  Verity.bind (modelExternalCall adv (linkedCallSite name words names.length)) fun result =>
-    match result with
-    | .success _ => pure ()
-    | .failure _ | .revert _ => fun state =>
-        ContractResult.revert "external call failed" state
+  match (commonExternalCall adv (linkedCallSite name words names.length)).run state with
+  | .success (.success _) post => .success () post
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "external call failed" state
+  | .revert message _ => .revert message state
 
 /-- Linked bind with explicit target and ETH value. Debits `selfBalance`
     only on success; insufficient balance or a failing stub reverts the
@@ -675,7 +687,7 @@ def externalCallBindTo {α : Type} [ExternalArg α]
   fun state =>
     if value ≤ state.selfBalance then
       let argWords := args.flatMap ExternalArg.toWords
-      match (modelExternalCall adv
+      match (commonExternalCall adv
           (linkedCallSite name argWords names.length .call target.toNat value.val)).run state with
       | .success (.success _) post =>
           ContractResult.success () { post with selfBalance := post.selfBalance - value }
@@ -700,39 +712,48 @@ definitional (`rfl`). -/
 @[simp] theorem externalCallBind_run {α : Type} [ExternalArg α]
     (adv : AdversaryModel) (names : List String) (name : String)
     (args : List α) (s : ContractState) :
-    (externalCallBind names name args adv).run s =
-      (let words := args.flatMap ExternalArg.toWords
-       Verity.bind (modelExternalCall adv (linkedCallSite name words names.length)) fun result =>
-         match result with
-         | .success _ => pure ()
-         | .failure _ | .revert _ => fun state =>
-             ContractResult.revert "external call failed" state).run s := rfl
+    externalCallBind names name args adv s =
+      match (commonExternalCall adv
+          (linkedCallSite name (args.flatMap ExternalArg.toWords) names.length)).run s with
+      | .success (.success _) post => ContractResult.success () post
+      | .success (.failure _) _ | .success (.revert _) _ =>
+          ContractResult.revert "external call failed" s
+      | .revert message _ => ContractResult.revert message s := rfl
 
 theorem externalCallBindTo_run {α : Type} [ExternalArg α]
     (adv : AdversaryModel)
     (target : Address) (value : Uint256)
     (names : List String) (name : String) (args : List α) (s : ContractState) :
-    (externalCallBindTo target value names name args adv).run s =
-      (externalCallBindTo target value names name args adv).run s := rfl
+    externalCallBindTo target value names name args adv s =
+      if value ≤ s.selfBalance then
+        match (commonExternalCall adv
+            (linkedCallSite name (args.flatMap ExternalArg.toWords) names.length
+              .call target.toNat value.val)).run s with
+        | .success (.success _) post =>
+            ContractResult.success () { post with selfBalance := post.selfBalance - value }
+        | .success (.failure _) _ | .success (.revert _) _ =>
+            ContractResult.revert "external call failed" s
+        | .revert message _ => ContractResult.revert message s
+      else ContractResult.revert "insufficient balance" s := rfl
 
 @[simp] theorem callResultWords_run {α : Type} [ExternalResult α] [Inhabited α]
     (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState) :
     (callResultWords (α := α) name args adv).run s =
       (do
-        let result ← modelExternalCall adv (linkedCallSite name args 1)
+        let result ← commonExternalCall adv (linkedCallSite name args 1)
         pure
           (show Call.Result α from
           { success := result.succeeded
-            returndata := if result.succeeded then ExternalResult.fromWord (resultWord result)
+            returndata := if result.succeeded then ExternalResult.fromWord (externalCallResultWord result)
               else Inhabited.default })).run s := rfl
 
 @[simp] theorem tryExternalCallWords_run {α : Type} [ExternalResult α] [Inhabited α]
     (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState) :
     (tryExternalCallWords (α := α) name args adv).run s =
       (do
-        let result ← modelExternalCall adv (linkedCallSite name args 1)
+        let result ← commonExternalCall adv (linkedCallSite name args 1)
         pure (result.succeeded,
-          if result.succeeded then ExternalResult.fromWord (resultWord result)
+          if result.succeeded then ExternalResult.fromWord (externalCallResultWord result)
           else Inhabited.default)).run s := rfl
 
 private def erc20ReadStubWord (name : String) (args : List Uint256) : Uint256 :=
@@ -790,18 +811,18 @@ def erc20ReadEntry (name : String) (token : Address) (args : List Uint256)
 
 def erc20Read (adv : AdversaryModel) (name : String) (token : Address)
     (args : List Uint256) : Contract Uint256 := do
-  let result ← modelExternalCall adv
+  let result ← commonExternalCall adv
     (linkedCallSite name args 1 .staticcall token.toNat 0 [Verity.addressToWord token])
-  pure (resultWord result)
+  pure (externalCallResultWord result)
 
-private def erc20Write (adv : AdversaryModel) (name : String) (token : Address)
-    (args : List Uint256) : Contract Unit :=
-  Verity.bind (modelExternalCall adv
-      (linkedCallSite name args 0 .call token.toNat)) fun result =>
-    match result with
-    | .success _ => pure ()
-    | .failure _ | .revert _ => fun state =>
-        ContractResult.revert "external call failed" state
+def erc20Write (adv : AdversaryModel) (name : String) (token : Address)
+    (args : List Uint256) : Contract Unit := fun state =>
+  match (commonExternalCall adv
+      (linkedCallSite name args 0 .call token.toNat)).run state with
+  | .success (.success _) post => .success () post
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "external call failed" state
+  | .revert message _ => .revert message state
 
 def safeTransfer (token toAddr : Address) (amount : Uint256) (adv : AdversaryModel := .stub) : Contract Unit :=
   erc20Write adv "safeTransfer" token [Verity.addressToWord toAddr, amount]

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -624,43 +624,45 @@ snapshot semantics, matching EVM top-level revert observability. -/
 def recordLinkedCall (entry : ExternalCall) : Contract Unit := fun state =>
   ContractResult.success () { state with calls := state.calls ++ [entry] }
 
-def externalCallWords {α : Type} [ExternalResult α] (name : String) (args : List Uint256) : α :=
-  ExternalResult.fromWord (externalCallStubWord name args)
-def callResultWords {α : Type} [ExternalResult α] [Inhabited α] (name : String) (args : List Uint256) :
-    Contract (Call.Result α) := fun state =>
-  let success := externalCallStubSuccess name
-  let word := externalCallStubWord name args
-  let payload : α :=
-    if success then ExternalResult.fromWord word else Inhabited.default
-  let entry := linkedCallEntry name args
-    (if success then .success else .failure)
-    (if success then [(word : Nat)] else [])
-  ContractResult.success { success := success, returndata := payload }
-    { state with calls := state.calls ++ [entry] }
+private abbrev AdversaryModel :=
+  Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel
+private abbrev ExternalCallResult :=
+  Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult
+private abbrev modelExternalCall :=
+  Compiler.CompilationModel.DenoteExternalCalls.externalCall
+
+private def resultWord (result : ExternalCallResult) : Uint256 :=
+  Core.Uint256.ofNat (result.returndata.head?.getD 0)
+
+def externalCallWords {α : Type} [ExternalResult α] (name : String) (args : List Uint256)
+    (adv : AdversaryModel := .stub) : Contract α := do
+  let result ← modelExternalCall adv (linkedCallSite name args 1)
+  pure (ExternalResult.fromWord (resultWord result))
+
+def callResultWords {α : Type} [ExternalResult α] [Inhabited α]
+    (name : String) (args : List Uint256) (adv : AdversaryModel := .stub) : Contract (Call.Result α) := do
+  let result ← modelExternalCall adv (linkedCallSite name args 1)
+  pure
+    { success := result.succeeded
+      returndata := if result.succeeded then ExternalResult.fromWord (resultWord result)
+        else Inhabited.default }
+
 def tryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
-    (name : String) (args : List Uint256) : Contract (Bool × α) :=
-  fun state =>
-    let success := externalCallStubSuccess name
-    let word := externalCallStubWord name args
-    let payload : α :=
-      if success then ExternalResult.fromWord word else Inhabited.default
-    let entry := linkedCallEntry name args
-      (if success then .success else .failure)
-      (if success then [(word : Nat)] else [])
-    ContractResult.success (success, payload)
-      { state with calls := state.calls ++ [entry] }
-def externalCallBind {α : Type} [ExternalArg α] (names : List String) (name : String) (args : List α) : Contract Unit :=
-  fun state =>
-    let argWords := args.flatMap ExternalArg.toWords
-    let success := externalCallStubSuccess name
-    let entry := linkedCallEntry name argWords
-      (if success then .success else .failure)
-      (if success then
-        names.map (fun _ => (externalCallStubWord name argWords : Nat))
-      else [])
-    let next := { state with calls := state.calls ++ [entry] }
-    if success then ContractResult.success () next
-    else ContractResult.revert "external call failed" next
+    (name : String) (args : List Uint256) (adv : AdversaryModel := .stub) : Contract (Bool × α) := do
+  let result ← modelExternalCall adv (linkedCallSite name args 1)
+  pure (result.succeeded,
+    if result.succeeded then ExternalResult.fromWord (resultWord result)
+    else Inhabited.default)
+
+def externalCallBind {α : Type} [ExternalArg α]
+    (names : List String) (name : String) (args : List α)
+    (adv : AdversaryModel := .stub) : Contract Unit :=
+  let words := args.flatMap ExternalArg.toWords
+  Verity.bind (modelExternalCall adv (linkedCallSite name words names.length)) fun result =>
+    match result with
+    | .success _ => pure ()
+    | .failure _ | .revert _ => fun state =>
+        ContractResult.revert "external call failed" state
 
 /-- Linked bind with explicit target and ETH value. Debits `selfBalance`
     only on success; insufficient balance or a failing stub reverts the
@@ -668,23 +670,18 @@ def externalCallBind {α : Type} [ExternalArg α] (names : List String) (name : 
     `Verity.MultiContract`, not in this single-world stub. -/
 def externalCallBindTo {α : Type} [ExternalArg α]
     (target : Address) (value : Uint256)
-    (names : List String) (name : String) (args : List α) : Contract Unit :=
+    (names : List String) (name : String) (args : List α)
+    (adv : AdversaryModel := .stub) : Contract Unit :=
   fun state =>
     if value ≤ state.selfBalance then
       let argWords := args.flatMap ExternalArg.toWords
-      let success := externalCallStubSuccess name
-      let entry := linkedCallEntryTo name target value argWords
-        (if success then .success else .failure)
-        (if success then
-          names.map (fun _ => (externalCallStubWord name argWords : Nat))
-        else [])
-      if success then
-        ContractResult.success ()
-          { state with
-            selfBalance := state.selfBalance - value
-            calls := state.calls ++ [entry] }
-      else
-        ContractResult.revert "external call failed" state
+      match (modelExternalCall adv
+          (linkedCallSite name argWords names.length .call target.toNat value.val)).run state with
+      | .success (.success _) post =>
+          ContractResult.success () { post with selfBalance := post.selfBalance - value }
+      | .success (.failure _) _ | .success (.revert _) _ =>
+          ContractResult.revert "external call failed" state
+      | .revert message _ => ContractResult.revert message state
     else
       ContractResult.revert "insufficient balance" state
 
@@ -701,70 +698,42 @@ definitional (`rfl`). -/
       ContractResult.success () { s with calls := s.calls ++ [entry] } := rfl
 
 @[simp] theorem externalCallBind_run {α : Type} [ExternalArg α]
-    (names : List String) (name : String) (args : List α) (s : ContractState) :
-    (externalCallBind names name args).run s =
-      if externalCallStubSuccess name then
-        ContractResult.success ()
-          { s with calls := s.calls ++
-              [linkedCallEntry name (args.flatMap ExternalArg.toWords) .success
-                (names.map fun _ =>
-                  (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat))] }
-      else ContractResult.revert "external call failed" s := by
-  by_cases h : externalCallStubSuccess name = true <;>
-    simp [Contract.run, externalCallBind, h]
+    (adv : AdversaryModel) (names : List String) (name : String)
+    (args : List α) (s : ContractState) :
+    (externalCallBind names name args adv).run s =
+      (let words := args.flatMap ExternalArg.toWords
+       Verity.bind (modelExternalCall adv (linkedCallSite name words names.length)) fun result =>
+         match result with
+         | .success _ => pure ()
+         | .failure _ | .revert _ => fun state =>
+             ContractResult.revert "external call failed" state).run s := rfl
 
 theorem externalCallBindTo_run {α : Type} [ExternalArg α]
+    (adv : AdversaryModel)
     (target : Address) (value : Uint256)
     (names : List String) (name : String) (args : List α) (s : ContractState) :
-    (externalCallBindTo target value names name args).run s =
-      if value ≤ s.selfBalance then
-        if externalCallStubSuccess name then
-          ContractResult.success ()
-            { s with
-              selfBalance := s.selfBalance - value
-              calls := s.calls ++
-                [linkedCallEntryTo name target value (args.flatMap ExternalArg.toWords)
-                  .success
-                  (names.map fun _ =>
-                    (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat))] }
-        else ContractResult.revert "external call failed" s
-      else ContractResult.revert "insufficient balance" s := by
-  by_cases hbal : value ≤ s.selfBalance
-  · by_cases h : externalCallStubSuccess name = true
-    · simp [Contract.run, externalCallBindTo, hbal, h, linkedCallEntryTo]
-    · simp [Contract.run, externalCallBindTo, hbal, h]
-  · simp [Contract.run, externalCallBindTo, hbal]
+    (externalCallBindTo target value names name args adv).run s =
+      (externalCallBindTo target value names name args adv).run s := rfl
 
 @[simp] theorem callResultWords_run {α : Type} [ExternalResult α] [Inhabited α]
-    (name : String) (args : List Uint256) (s : ContractState) :
-    (callResultWords (α := α) name args).run s =
-      ContractResult.success
-        { success := externalCallStubSuccess name
-          returndata :=
-            if externalCallStubSuccess name then
-              ExternalResult.fromWord (externalCallStubWord name args)
-            else Inhabited.default }
-        { s with calls := s.calls ++
-            [linkedCallEntry name args
-              (if externalCallStubSuccess name then .success else .failure)
-              (if externalCallStubSuccess name then
-                [(externalCallStubWord name args : Nat)]
-              else [])] } := rfl
+    (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState) :
+    (callResultWords (α := α) name args adv).run s =
+      (do
+        let result ← modelExternalCall adv (linkedCallSite name args 1)
+        pure
+          (show Call.Result α from
+          { success := result.succeeded
+            returndata := if result.succeeded then ExternalResult.fromWord (resultWord result)
+              else Inhabited.default })).run s := rfl
 
 @[simp] theorem tryExternalCallWords_run {α : Type} [ExternalResult α] [Inhabited α]
-    (name : String) (args : List Uint256) (s : ContractState) :
-    (tryExternalCallWords (α := α) name args).run s =
-      ContractResult.success
-        (externalCallStubSuccess name,
-          if externalCallStubSuccess name then
-            ExternalResult.fromWord (externalCallStubWord name args)
-          else Inhabited.default)
-        { s with calls := s.calls ++
-            [linkedCallEntry name args
-              (if externalCallStubSuccess name then .success else .failure)
-              (if externalCallStubSuccess name then
-                [(externalCallStubWord name args : Nat)]
-              else [])] } := rfl
+    (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState) :
+    (tryExternalCallWords (α := α) name args adv).run s =
+      (do
+        let result ← modelExternalCall adv (linkedCallSite name args 1)
+        pure (result.succeeded,
+          if result.succeeded then ExternalResult.fromWord (resultWord result)
+          else Inhabited.default)).run s := rfl
 
 private def erc20ReadStubWord (name : String) (args : List Uint256) : Uint256 :=
   externalCallStubWord name args
@@ -774,19 +743,19 @@ private def erc20ReadStubWord (name : String) (args : List Uint256) : Uint256 :=
 macro_rules
   | `(term| externalCall $name:ident [ $[$args:term],* ]) =>
       `(externalCallWords $(Lean.quote (toString name.getId))
-          (List.flatten [ $[ExternalArg.toWords $args],* ]))
+          (List.flatten [ $[ExternalArg.toWords $args],* ]) .stub)
   | `(term| externalCall $name:str [ $[$args:term],* ]) =>
-      `(externalCallWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]))
+      `(externalCallWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]) .stub)
   | `(term| callResult $name:str [ $[$args:term],* ]) =>
-      `(callResultWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]))
+      `(callResultWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]) .stub)
   | `(term| callResult $name:ident [ $[$args:term],* ]) =>
       `(callResultWords $(Lean.quote (toString name.getId))
-          (List.flatten [ $[ExternalArg.toWords $args],* ]))
+          (List.flatten [ $[ExternalArg.toWords $args],* ]) .stub)
   | `(term| tryExternalCall $name:str [ $[$args:term],* ]) =>
-      `(tryExternalCallWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]))
+      `(tryExternalCallWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]) .stub)
   | `(term| tryExternalCall $name:ident [ $[$args:term],* ]) =>
       `(tryExternalCallWords $(Lean.quote (toString name.getId))
-          (List.flatten [ $[ExternalArg.toWords $args],* ]))
+          (List.flatten [ $[ExternalArg.toWords $args],* ]) .stub)
 def getMappingWord (_slot : StorageSlot (Uint256 → Uint256)) (_key _wordOffset : Uint256) :
     Contract Uint256 := pure 0
 def setMappingWord (_slot : StorageSlot (Uint256 → Uint256)) (_key _wordOffset _value : Uint256) :
@@ -819,81 +788,73 @@ def erc20ReadEntry (name : String) (token : Address) (args : List Uint256)
       kind := .staticcall
       target := token.toNat }
 
-def erc20Read (name : String) (token : Address) (args : List Uint256) : Contract Uint256 :=
-  fun state =>
-    let result := erc20ReadStubWord name (Verity.addressToWord token :: args)
-    ContractResult.success result
-      { state with calls := state.calls ++ [erc20ReadEntry name token args result] }
+def erc20Read (adv : AdversaryModel) (name : String) (token : Address)
+    (args : List Uint256) : Contract Uint256 := do
+  let result ← modelExternalCall adv
+    (linkedCallSite name args 1 .staticcall token.toNat 0 [Verity.addressToWord token])
+  pure (resultWord result)
 
-def safeTransfer (token toAddr : Address) (amount : Uint256) : Contract Unit :=
-  recordLinkedCall (erc20WriteEntry "safeTransfer" token
-    [Verity.addressToWord toAddr, amount])
-def safeTransferFrom (token fromAddr toAddr : Address) (amount : Uint256) : Contract Unit :=
-  recordLinkedCall (erc20WriteEntry "safeTransferFrom" token
-    [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount])
-def safeApprove (token spender : Address) (amount : Uint256) : Contract Unit :=
-  recordLinkedCall (erc20WriteEntry "safeApprove" token
-    [Verity.addressToWord spender, amount])
-def legacyStringSafeTransfer (token toAddr : Address) (amount : Uint256) : Contract Unit :=
-  recordLinkedCall (erc20WriteEntry "legacyStringSafeTransfer" token
-    [Verity.addressToWord toAddr, amount])
-def legacyStringSafeTransferFrom (token fromAddr toAddr : Address) (amount : Uint256) : Contract Unit :=
-  recordLinkedCall (erc20WriteEntry "legacyStringSafeTransferFrom" token
-    [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount])
+private def erc20Write (adv : AdversaryModel) (name : String) (token : Address)
+    (args : List Uint256) : Contract Unit :=
+  Verity.bind (modelExternalCall adv
+      (linkedCallSite name args 0 .call token.toNat)) fun result =>
+    match result with
+    | .success _ => pure ()
+    | .failure _ | .revert _ => fun state =>
+        ContractResult.revert "external call failed" state
 
-@[simp] theorem safeTransfer_run (token toAddr : Address) (amount : Uint256) (s : ContractState) :
-    (safeTransfer token toAddr amount).run s =
-      ContractResult.success ()
-        { s with calls := s.calls ++
-            [erc20WriteEntry "safeTransfer" token
-              [Verity.addressToWord toAddr, amount]] } := rfl
+def safeTransfer (token toAddr : Address) (amount : Uint256) (adv : AdversaryModel := .stub) : Contract Unit :=
+  erc20Write adv "safeTransfer" token [Verity.addressToWord toAddr, amount]
+def safeTransferFrom (token fromAddr toAddr : Address) (amount : Uint256)
+    (adv : AdversaryModel := .stub) : Contract Unit :=
+  erc20Write adv "safeTransferFrom" token
+    [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]
+def safeApprove (token spender : Address) (amount : Uint256) (adv : AdversaryModel := .stub) : Contract Unit :=
+  erc20Write adv "safeApprove" token [Verity.addressToWord spender, amount]
+def legacyStringSafeTransfer (token toAddr : Address) (amount : Uint256)
+    (adv : AdversaryModel := .stub) : Contract Unit :=
+  erc20Write adv "legacyStringSafeTransfer" token [Verity.addressToWord toAddr, amount]
+def legacyStringSafeTransferFrom (token fromAddr toAddr : Address) (amount : Uint256)
+    (adv : AdversaryModel := .stub) : Contract Unit :=
+  erc20Write adv "legacyStringSafeTransferFrom" token
+    [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]
 
-@[simp] theorem safeTransferFrom_run (token fromAddr toAddr : Address) (amount : Uint256)
+@[simp] theorem safeTransfer_run (adv : AdversaryModel) (token toAddr : Address)
+    (amount : Uint256) (s : ContractState) :
+    (safeTransfer token toAddr amount adv).run s =
+      (erc20Write adv "safeTransfer" token [Verity.addressToWord toAddr, amount]).run s := rfl
+
+@[simp] theorem safeTransferFrom_run (adv : AdversaryModel) (token fromAddr toAddr : Address) (amount : Uint256)
     (s : ContractState) :
-    (safeTransferFrom token fromAddr toAddr amount).run s =
-      ContractResult.success ()
-        { s with calls := s.calls ++
-            [erc20WriteEntry "safeTransferFrom" token
-              [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]] } := rfl
+    (safeTransferFrom token fromAddr toAddr amount adv).run s =
+      (erc20Write adv "safeTransferFrom" token
+        [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run s := rfl
 
-@[simp] theorem safeApprove_run (token spender : Address) (amount : Uint256)
+@[simp] theorem safeApprove_run (adv : AdversaryModel) (token spender : Address) (amount : Uint256)
     (s : ContractState) :
-    (safeApprove token spender amount).run s =
-      ContractResult.success ()
-        { s with calls := s.calls ++
-            [erc20WriteEntry "safeApprove" token
-              [Verity.addressToWord spender, amount]] } := rfl
+    (safeApprove token spender amount adv).run s =
+      (erc20Write adv "safeApprove" token [Verity.addressToWord spender, amount]).run s := rfl
 
-def balanceOf (token owner : Address) : Contract Uint256 :=
-  erc20Read "balanceOf" token [Verity.addressToWord owner]
-def allowance (token owner spender : Address) : Contract Uint256 :=
-  erc20Read "allowance" token
+def balanceOf (token owner : Address) (adv : AdversaryModel := .stub) : Contract Uint256 :=
+  erc20Read adv "balanceOf" token [Verity.addressToWord owner]
+def allowance (token owner spender : Address) (adv : AdversaryModel := .stub) : Contract Uint256 :=
+  erc20Read adv "allowance" token
     [Verity.addressToWord owner, Verity.addressToWord spender]
-def totalSupply (token : Address) : Contract Uint256 := erc20Read "totalSupply" token []
+def totalSupply (token : Address) (adv : AdversaryModel := .stub) : Contract Uint256 :=
+  erc20Read adv "totalSupply" token []
 
-@[simp] theorem balanceOf_run (token owner : Address) (s : ContractState) :
-    (balanceOf token owner).run s =
-      let result := erc20ReadStubWord "balanceOf"
-        [Verity.addressToWord token, Verity.addressToWord owner]
-      ContractResult.success result
-        { s with calls := s.calls ++
-            [erc20ReadEntry "balanceOf" token [Verity.addressToWord owner] result] } := rfl
+@[simp] theorem balanceOf_run (adv : AdversaryModel) (token owner : Address) (s : ContractState) :
+    (balanceOf token owner adv).run s =
+      (erc20Read adv "balanceOf" token [Verity.addressToWord owner]).run s := rfl
 
-@[simp] theorem allowance_run (token owner spender : Address) (s : ContractState) :
-    (allowance token owner spender).run s =
-      let result := erc20ReadStubWord "allowance"
-        [Verity.addressToWord token, Verity.addressToWord owner,
-          Verity.addressToWord spender]
-      ContractResult.success result
-        { s with calls := s.calls ++
-            [erc20ReadEntry "allowance" token
-              [Verity.addressToWord owner, Verity.addressToWord spender] result] } := rfl
+@[simp] theorem allowance_run (adv : AdversaryModel) (token owner spender : Address)
+    (s : ContractState) :
+    (allowance token owner spender adv).run s =
+      (erc20Read adv "allowance" token
+        [Verity.addressToWord owner, Verity.addressToWord spender]).run s := rfl
 
-@[simp] theorem totalSupply_run (token : Address) (s : ContractState) :
-    (totalSupply token).run s =
-      let result := erc20ReadStubWord "totalSupply" [Verity.addressToWord token]
-      ContractResult.success result
-        { s with calls := s.calls ++ [erc20ReadEntry "totalSupply" token [] result] } := rfl
+@[simp] theorem totalSupply_run (adv : AdversaryModel) (token : Address) (s : ContractState) :
+    (totalSupply token adv).run s = (erc20Read adv "totalSupply" token []).run s := rfl
 def forEach (_name : String) (_count : Uint256) (body : Contract Unit) : Contract Unit := body
 def blockTimestamp : Contract Uint256 := Verity.blockTimestamp
 def blockNumber : Contract Uint256 := Verity.blockNumber

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -911,19 +911,19 @@ private def erc20ReadStubWord (name : String) (args : List Uint256) : Uint256 :=
 macro_rules
   | `(term| externalCall $name:ident [ $[$args:term],* ]) =>
       `(externalCallWords $(Lean.quote (toString name.getId))
-          (List.flatten [ $[ExternalArg.toWords $args],* ]) .stub)
+          (List.flatten [ $[ExternalArg.toWords $args],* ]))
   | `(term| externalCall $name:str [ $[$args:term],* ]) =>
-      `(externalCallWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]) .stub)
+      `(externalCallWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]))
   | `(term| callResult $name:str [ $[$args:term],* ]) =>
-      `(callResultWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]) .stub)
+      `(callResultWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]))
   | `(term| callResult $name:ident [ $[$args:term],* ]) =>
       `(callResultWords $(Lean.quote (toString name.getId))
-          (List.flatten [ $[ExternalArg.toWords $args],* ]) .stub)
+          (List.flatten [ $[ExternalArg.toWords $args],* ]))
   | `(term| tryExternalCall $name:str [ $[$args:term],* ]) =>
-      `(tryExternalCallWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]) .stub)
+      `(tryExternalCallWords $name (List.flatten [ $[ExternalArg.toWords $args],* ]))
   | `(term| tryExternalCall $name:ident [ $[$args:term],* ]) =>
       `(tryExternalCallWords $(Lean.quote (toString name.getId))
-          (List.flatten [ $[ExternalArg.toWords $args],* ]) .stub)
+          (List.flatten [ $[ExternalArg.toWords $args],* ]))
 def getMappingWord (_slot : StorageSlot (Uint256 → Uint256)) (_key _wordOffset : Uint256) :
     Contract Uint256 := pure 0
 def setMappingWord (_slot : StorageSlot (Uint256 → Uint256)) (_key _wordOffset _value : Uint256) :

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -981,7 +981,10 @@ def erc20Write (adv : AdversaryModel) (name : String) (token : Address)
     (args : List Uint256) : Contract Unit := fun state =>
   match (commonExternalCall adv
       (linkedCallSite name args 0 .call token.toNat)).run state with
-  | .success (.success _) post => .success () post
+  | .success (.success returndata) post =>
+      match returndata with
+      | [] | [1] => .success () post
+      | _ => .revert "external call returned false or invalid data" state
   | .success (.failure _) _ | .success (.revert _) _ =>
       .revert "external call failed" state
   | .revert message _ => .revert message state

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -663,6 +663,10 @@ def externalCallWords {α : Type} [ExternalResult α] (name : String) (args : Li
       ExternalResult.fromWord (externalCallStubWord name args)
   | .revert _ _ => ExternalResult.fromWord (externalCallStubWord name args)
 
+def failedExternalResult {α : Type} [ExternalResult α] [Inhabited α] : List Nat → α
+  | [] => Inhabited.default
+  | word :: _ => ExternalResult.fromWord (Core.Uint256.ofNat word)
+
 def callResultWords {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (adv : AdversaryModel := .stub) : Contract (Call.Result α) :=
   fun state =>
@@ -670,8 +674,8 @@ def callResultWords {α : Type} [ExternalResult α] [Inhabited α]
     | .success (.success [word]) post =>
         .success { success := true, returndata := ExternalResult.fromWord (Core.Uint256.ofNat word) } post
     | .success (.success _) _ => .revert "external call returned invalid data" state
-    | .success (.failure _) post | .success (.revert _) post =>
-        .success { success := false, returndata := Inhabited.default } post
+    | .success (.failure returndata) post | .success (.revert returndata) post =>
+        .success { success := false, returndata := failedExternalResult returndata } post
     | .revert message _ => .revert message state
 
 def tryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
@@ -681,8 +685,8 @@ def tryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
     | .success (.success [word]) post =>
         .success (true, ExternalResult.fromWord (Core.Uint256.ofNat word)) post
     | .success (.success _) _ => .revert "external call returned invalid data" state
-    | .success (.failure _) post | .success (.revert _) post =>
-        .success (false, Inhabited.default) post
+    | .success (.failure returndata) post | .success (.revert returndata) post =>
+        .success (false, failedExternalResult returndata) post
     | .revert message _ => .revert message state
 
 def externalCallBind {α : Type} [ExternalArg α]
@@ -772,8 +776,8 @@ theorem callResultWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
             { success := true,
               returndata := ExternalResult.fromWord (Core.Uint256.ofNat word) }) post
       | .success (.success _) _ => .revert "external call returned invalid data" s
-      | .success (.failure _) post | .success (.revert _) post =>
-          .success { success := false, returndata := Inhabited.default } post
+      | .success (.failure returndata) post | .success (.revert returndata) post =>
+          .success { success := false, returndata := failedExternalResult returndata } post
       | .revert message _ => .revert message s := rfl
 
 theorem tryExternalCallWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
@@ -783,8 +787,8 @@ theorem tryExternalCallWords_adv_run {α : Type} [ExternalResult α] [Inhabited 
       | .success (.success [word]) post =>
           .success (true, ExternalResult.fromWord (Core.Uint256.ofNat word)) post
       | .success (.success _) _ => .revert "external call returned invalid data" s
-      | .success (.failure _) post | .success (.revert _) post =>
-          .success (false, Inhabited.default) post
+      | .success (.failure returndata) post | .success (.revert returndata) post =>
+          .success (false, failedExternalResult returndata) post
       | .revert message _ => .revert message s := rfl
 
 /-! The PR1 `.stub` laws retain their original names and propositions. -/
@@ -889,7 +893,8 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
       Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
       Contract.run, Verity.bind, Verity.pure, Verity.instMonadContract, Bind.bind, Pure.pure,
       linkedCallSite, linkedCallEntry,
-      externalCallStubSuccess, externalCallStubWord, externalCallResultWord, h]
+      externalCallStubSuccess, externalCallStubWord, externalCallResultWord,
+      failedExternalResult, h]
 
 @[simp] theorem tryExternalCallWords_run {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (s : ContractState) :
@@ -920,7 +925,8 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
       Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
       Contract.run, Verity.bind, Verity.pure, Verity.instMonadContract, Bind.bind, Pure.pure,
       linkedCallSite, linkedCallEntry,
-      externalCallStubSuccess, externalCallStubWord, externalCallResultWord, h]
+      externalCallStubSuccess, externalCallStubWord, externalCallResultWord,
+      failedExternalResult, h]
 
 private def erc20ReadStubWord (name : String) (args : List Uint256) : Uint256 :=
   externalCallStubWord name args

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -664,19 +664,26 @@ def externalCallWords {α : Type} [ExternalResult α] (name : String) (args : Li
   | .revert _ _ => ExternalResult.fromWord (externalCallStubWord name args)
 
 def callResultWords {α : Type} [ExternalResult α] [Inhabited α]
-    (name : String) (args : List Uint256) (adv : AdversaryModel := .stub) : Contract (Call.Result α) := do
-  let result ← commonExternalCall adv (linkedCallSite name args 1)
-  pure
-    { success := result.succeeded
-      returndata := if result.succeeded then ExternalResult.fromWord (externalCallResultWord result)
-        else Inhabited.default }
+    (name : String) (args : List Uint256) (adv : AdversaryModel := .stub) : Contract (Call.Result α) :=
+  fun state =>
+    match (commonExternalCall adv (linkedCallSite name args 1)).run state with
+    | .success (.success [word]) post =>
+        .success { success := true, returndata := ExternalResult.fromWord (Core.Uint256.ofNat word) } post
+    | .success (.success _) _ => .revert "external call returned invalid data" state
+    | .success (.failure _) post | .success (.revert _) post =>
+        .success { success := false, returndata := Inhabited.default } post
+    | .revert message _ => .revert message state
 
 def tryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
-    (name : String) (args : List Uint256) (adv : AdversaryModel := .stub) : Contract (Bool × α) := do
-  let result ← commonExternalCall adv (linkedCallSite name args 1)
-  pure (result.succeeded,
-    if result.succeeded then ExternalResult.fromWord (externalCallResultWord result)
-    else Inhabited.default)
+    (name : String) (args : List Uint256) (adv : AdversaryModel := .stub) : Contract (Bool × α) :=
+  fun state =>
+    match (commonExternalCall adv (linkedCallSite name args 1)).run state with
+    | .success (.success [word]) post =>
+        .success (true, ExternalResult.fromWord (Core.Uint256.ofNat word)) post
+    | .success (.success _) _ => .revert "external call returned invalid data" state
+    | .success (.failure _) post | .success (.revert _) post =>
+        .success (false, Inhabited.default) post
+    | .revert message _ => .revert message state
 
 def externalCallBind {α : Type} [ExternalArg α]
     (names : List String) (name : String) (args : List α)
@@ -756,25 +763,29 @@ theorem externalCallBindTo_adv_apply {α : Type} [ExternalArg α]
         | .revert message _ => ContractResult.revert message s
       else ContractResult.revert "insufficient balance" s := rfl
 
-@[simp] theorem callResultWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
+theorem callResultWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
     (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState) :
-    (callResultWords (α := α) name args adv).run s =
-      (do
-        let result ← commonExternalCall adv (linkedCallSite name args 1)
-        pure
-          (show Call.Result α from
-          { success := result.succeeded
-            returndata := if result.succeeded then ExternalResult.fromWord (externalCallResultWord result)
-              else Inhabited.default })).run s := rfl
+    callResultWords (α := α) name args adv s =
+      match (commonExternalCall adv (linkedCallSite name args 1)).run s with
+      | .success (.success [word]) post =>
+          .success (show Call.Result α from
+            { success := true,
+              returndata := ExternalResult.fromWord (Core.Uint256.ofNat word) }) post
+      | .success (.success _) _ => .revert "external call returned invalid data" s
+      | .success (.failure _) post | .success (.revert _) post =>
+          .success { success := false, returndata := Inhabited.default } post
+      | .revert message _ => .revert message s := rfl
 
-@[simp] theorem tryExternalCallWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
+theorem tryExternalCallWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
     (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState) :
-    (tryExternalCallWords (α := α) name args adv).run s =
-      (do
-        let result ← commonExternalCall adv (linkedCallSite name args 1)
-        pure (result.succeeded,
-          if result.succeeded then ExternalResult.fromWord (externalCallResultWord result)
-          else Inhabited.default)).run s := rfl
+    tryExternalCallWords (α := α) name args adv s =
+      match (commonExternalCall adv (linkedCallSite name args 1)).run s with
+      | .success (.success [word]) post =>
+          .success (true, ExternalResult.fromWord (Core.Uint256.ofNat word)) post
+      | .success (.success _) _ => .revert "external call returned invalid data" s
+      | .success (.failure _) post | .success (.revert _) post =>
+          .success (false, Inhabited.default) post
+      | .revert message _ => .revert message s := rfl
 
 /-! The PR1 `.stub` laws retain their original names and propositions. -/
 
@@ -983,11 +994,36 @@ def erc20Write (adv : AdversaryModel) (name : String) (token : Address)
       (linkedCallSite name args 0 .call token.toNat)).run state with
   | .success (.success returndata) post =>
       match returndata with
-      | [] | [1] => .success () post
+      | [] =>
+          if state.codeSize token.toNat = 0 then
+            .revert "external call target has no code" state
+          else .success () post
+      | [word] =>
+          if Core.Uint256.ofNat word = (1 : Uint256) then .success () post
+          else .revert "external call returned false or invalid data" state
       | _ => .revert "external call returned false or invalid data" state
   | .success (.failure _) _ | .success (.revert _) _ =>
       .revert "external call failed" state
   | .revert message _ => .revert message state
+
+/-- Legacy string-error ERC-20 writes require code at the target, but accept
+any nonempty returndata whose first normalized EVM word is true. -/
+def erc20WriteLegacy (adv : AdversaryModel) (name : String) (token : Address)
+    (args : List Uint256) : Contract Unit := fun state =>
+  if state.codeSize token.toNat = 0 then
+    .revert "external call target has no code" state
+  else
+    match (commonExternalCall adv
+        (linkedCallSite name args 0 .call token.toNat)).run state with
+    | .success (.success returndata) post =>
+        match returndata with
+        | [] => .success () post
+        | word :: _ =>
+            if Core.Uint256.ofNat word = (1 : Uint256) then .success () post
+            else .revert "external call returned false or invalid data" state
+    | .success (.failure _) _ | .success (.revert _) _ =>
+        .revert "external call failed" state
+    | .revert message _ => .revert message state
 
 def safeTransfer (token toAddr : Address) (amount : Uint256) (adv : AdversaryModel := .stub) : Contract Unit :=
   erc20Write adv "safeTransfer" token [Verity.addressToWord toAddr, amount]
@@ -999,10 +1035,10 @@ def safeApprove (token spender : Address) (amount : Uint256) (adv : AdversaryMod
   erc20Write adv "safeApprove" token [Verity.addressToWord spender, amount]
 def legacyStringSafeTransfer (token toAddr : Address) (amount : Uint256)
     (adv : AdversaryModel := .stub) : Contract Unit :=
-  erc20Write adv "legacyStringSafeTransfer" token [Verity.addressToWord toAddr, amount]
+  erc20WriteLegacy adv "legacyStringSafeTransfer" token [Verity.addressToWord toAddr, amount]
 def legacyStringSafeTransferFrom (token fromAddr toAddr : Address) (amount : Uint256)
     (adv : AdversaryModel := .stub) : Contract Unit :=
-  erc20Write adv "legacyStringSafeTransferFrom" token
+  erc20WriteLegacy adv "legacyStringSafeTransferFrom" token
     [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]
 
 @[simp] theorem safeTransfer_adv_run (adv : AdversaryModel) (token toAddr : Address)
@@ -1022,7 +1058,8 @@ def legacyStringSafeTransferFrom (token fromAddr toAddr : Address) (amount : Uin
       (erc20Write adv "safeApprove" token [Verity.addressToWord spender, amount]).run s := rfl
 
 theorem erc20Write_stub_run (name : String) (token : Address)
-    (args : List Uint256) (s : ContractState) (h : name ≠ "fail") :
+    (args : List Uint256) (s : ContractState) (h : name ≠ "fail")
+    (hcode : s.codeSize token.toNat ≠ 0) :
     (erc20Write .stub name token args).run s =
       ContractResult.success ()
         { s with calls := s.calls ++ [erc20WriteEntry name token args] } := by
@@ -1037,37 +1074,37 @@ theorem erc20Write_stub_run (name : String) (token : Address)
     Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
     Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
     Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
-    Contract.run, linkedCallSite, erc20WriteEntry, linkedCallEntry, h]
+    Contract.run, linkedCallSite, erc20WriteEntry, linkedCallEntry, h, hcode]
 
 @[simp] theorem safeTransfer_run (token toAddr : Address) (amount : Uint256)
-    (s : ContractState) :
+    (s : ContractState) (hcode : s.codeSize token.toNat ≠ 0) :
     (safeTransfer token toAddr amount).run s =
       ContractResult.success ()
         { s with calls := s.calls ++
             [erc20WriteEntry "safeTransfer" token
               [Verity.addressToWord toAddr, amount]] } := by
   simpa [safeTransfer] using
-    erc20Write_stub_run "safeTransfer" token [Verity.addressToWord toAddr, amount] s (by decide)
+    erc20Write_stub_run "safeTransfer" token [Verity.addressToWord toAddr, amount] s (by decide) hcode
 
 @[simp] theorem safeTransferFrom_run (token fromAddr toAddr : Address) (amount : Uint256)
-    (s : ContractState) :
+    (s : ContractState) (hcode : s.codeSize token.toNat ≠ 0) :
     (safeTransferFrom token fromAddr toAddr amount).run s =
       ContractResult.success ()
         { s with calls := s.calls ++
             [erc20WriteEntry "safeTransferFrom" token
               [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]] } := by
   simpa [safeTransferFrom] using erc20Write_stub_run "safeTransferFrom" token
-    [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount] s (by decide)
+    [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount] s (by decide) hcode
 
 @[simp] theorem safeApprove_run (token spender : Address) (amount : Uint256)
-    (s : ContractState) :
+    (s : ContractState) (hcode : s.codeSize token.toNat ≠ 0) :
     (safeApprove token spender amount).run s =
       ContractResult.success ()
         { s with calls := s.calls ++
             [erc20WriteEntry "safeApprove" token
               [Verity.addressToWord spender, amount]] } := by
   simpa [safeApprove] using
-    erc20Write_stub_run "safeApprove" token [Verity.addressToWord spender, amount] s (by decide)
+    erc20Write_stub_run "safeApprove" token [Verity.addressToWord spender, amount] s (by decide) hcode
 
 def balanceOf (token owner : Address) (adv : AdversaryModel := .stub) : Contract Uint256 :=
   erc20Read adv "balanceOf" token [Verity.addressToWord owner]

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -651,8 +651,11 @@ def commonExternalCall (adv : AdversaryModel)
             { world := state, gasRemaining := site.gas }).state.world with
           returndata := state.returndata } := rfl
 
+/-- Transitional expression-position boundary. Until PR3 moves macro-expanded
+external calls into the caller's `Contract` state, this pure helper can only
+soundly execute the deterministic stub adversary. -/
 def externalCallWords {α : Type} [ExternalResult α] (name : String) (args : List Uint256)
-    (adv : AdversaryModel := .stub) : α :=
+    (adv : AdversaryModel := .stub) (_hadv : adv = .stub := by rfl) : α :=
   match commonExternalCall adv (linkedCallSite name args 1) defaultState with
   | .success (.success returndata) _ =>
       ExternalResult.fromWord (Core.Uint256.ofNat (returndata.head?.getD 0))
@@ -680,7 +683,9 @@ def externalCallBind {α : Type} [ExternalArg α]
     (adv : AdversaryModel := .stub) : Contract Unit := fun state =>
   let words := args.flatMap ExternalArg.toWords
   match (commonExternalCall adv (linkedCallSite name words names.length)).run state with
-  | .success (.success _) post => .success () post
+  | .success (.success returndata) post =>
+      if names.length ≤ returndata.length then .success () post
+      else .revert "external call returned insufficient data" state
   | .success (.failure _) _ | .success (.revert _) _ =>
       .revert "external call failed" state
   | .revert message _ => .revert message state
@@ -696,10 +701,12 @@ def externalCallBindTo {α : Type} [ExternalArg α]
   fun state =>
     if value ≤ state.selfBalance then
       let argWords := args.flatMap ExternalArg.toWords
+      let debited := { state with selfBalance := state.selfBalance - value }
       match (commonExternalCall adv
-          (linkedCallSite name argWords names.length .call target.toNat value.val)).run state with
-      | .success (.success _) post =>
-          ContractResult.success () { post with selfBalance := post.selfBalance - value }
+          (linkedCallSite name argWords names.length .call target.toNat value.val)).run debited with
+      | .success (.success returndata) post =>
+          if names.length ≤ returndata.length then ContractResult.success () post
+          else ContractResult.revert "external call returned insufficient data" state
       | .success (.failure _) _ | .success (.revert _) _ =>
           ContractResult.revert "external call failed" state
       | .revert message _ => ContractResult.revert message state
@@ -724,7 +731,9 @@ definitional (`rfl`). -/
     externalCallBind names name args adv s =
       match (commonExternalCall adv
           (linkedCallSite name (args.flatMap ExternalArg.toWords) names.length)).run s with
-      | .success (.success _) post => ContractResult.success () post
+      | .success (.success returndata) post =>
+          if names.length ≤ returndata.length then ContractResult.success () post
+          else ContractResult.revert "external call returned insufficient data" s
       | .success (.failure _) _ | .success (.revert _) _ =>
           ContractResult.revert "external call failed" s
       | .revert message _ => ContractResult.revert message s := rfl
@@ -735,11 +744,13 @@ theorem externalCallBindTo_adv_apply {α : Type} [ExternalArg α]
     (names : List String) (name : String) (args : List α) (s : ContractState) :
     externalCallBindTo target value names name args adv s =
       if value ≤ s.selfBalance then
+        let debited := { s with selfBalance := s.selfBalance - value }
         match (commonExternalCall adv
             (linkedCallSite name (args.flatMap ExternalArg.toWords) names.length
-              .call target.toNat value.val)).run s with
-        | .success (.success _) post =>
-            ContractResult.success () { post with selfBalance := post.selfBalance - value }
+              .call target.toNat value.val)).run debited with
+        | .success (.success returndata) post =>
+            if names.length ≤ returndata.length then ContractResult.success () post
+            else ContractResult.revert "external call returned insufficient data" s
         | .success (.failure _) _ | .success (.revert _) _ =>
             ContractResult.revert "external call failed" s
         | .revert message _ => ContractResult.revert message s
@@ -954,10 +965,17 @@ def erc20ReadEntry (name : String) (token : Address) (args : List Uint256)
       target := token.toNat }
 
 def erc20Read (adv : AdversaryModel) (name : String) (token : Address)
-    (args : List Uint256) : Contract Uint256 := do
-  let result ← commonExternalCall adv
-    (linkedCallSite name args 1 .staticcall token.toNat 0 [Verity.addressToWord token])
-  pure (externalCallResultWord result)
+    (args : List Uint256) : Contract Uint256 := fun state =>
+  match (commonExternalCall adv
+      (linkedCallSite name args 1 .staticcall token.toNat 0
+        [Verity.addressToWord token])).run state with
+  | .success (.success [word]) post =>
+      .success (Core.Uint256.ofNat word) post
+  | .success (.success _) _ =>
+      .revert "external call returned invalid data" state
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "external call failed" state
+  | .revert message _ => .revert message state
 
 def erc20Write (adv : AdversaryModel) (name : String) (token : Address)
     (args : List Uint256) : Contract Unit := fun state =>

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -691,7 +691,7 @@ def externalCallBind {α : Type} [ExternalArg α]
   let words := args.flatMap ExternalArg.toWords
   match (commonExternalCall adv (linkedCallSite name words names.length)).run state with
   | .success (.success returndata) post =>
-      if names.length ≤ returndata.length then .success () post
+      if names.length = returndata.length then .success () post
       else .revert "external call returned insufficient data" state
   | .success (.failure _) _ | .success (.revert _) _ =>
       .revert "external call failed" state
@@ -712,7 +712,7 @@ def externalCallBindTo {α : Type} [ExternalArg α]
       match (commonExternalCall adv
           (linkedCallSite name argWords names.length .call target.toNat value.val)).run debited with
       | .success (.success returndata) post =>
-          if names.length ≤ returndata.length then ContractResult.success () post
+          if names.length = returndata.length then ContractResult.success () post
           else ContractResult.revert "external call returned insufficient data" state
       | .success (.failure _) _ | .success (.revert _) _ =>
           ContractResult.revert "external call failed" state
@@ -739,7 +739,7 @@ definitional (`rfl`). -/
       match (commonExternalCall adv
           (linkedCallSite name (args.flatMap ExternalArg.toWords) names.length)).run s with
       | .success (.success returndata) post =>
-          if names.length ≤ returndata.length then ContractResult.success () post
+          if names.length = returndata.length then ContractResult.success () post
           else ContractResult.revert "external call returned insufficient data" s
       | .success (.failure _) _ | .success (.revert _) _ =>
           ContractResult.revert "external call failed" s
@@ -756,7 +756,7 @@ theorem externalCallBindTo_adv_apply {α : Type} [ExternalArg α]
             (linkedCallSite name (args.flatMap ExternalArg.toWords) names.length
               .call target.toNat value.val)).run debited with
         | .success (.success returndata) post =>
-            if names.length ≤ returndata.length then ContractResult.success () post
+            if names.length = returndata.length then ContractResult.success () post
             else ContractResult.revert "external call returned insufficient data" s
         | .success (.failure _) _ | .success (.revert _) _ =>
             ContractResult.revert "external call failed" s

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -995,7 +995,7 @@ def erc20Write (adv : AdversaryModel) (name : String) (token : Address)
   | .success (.success returndata) post =>
       match returndata with
       | [] =>
-          if state.codeSize token.toNat = 0 then
+          if post.codeSize token.toNat = 0 then
             .revert "external call target has no code" state
           else .success () post
       | [word] =>

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -640,16 +640,28 @@ projection until the macro default is removed in PR3. -/
 def commonExternalCall (adv : AdversaryModel)
     (site : Compiler.CompilationModel.DenoteExternalCalls.CallSite) :
     Contract ExternalCallResult := fun state =>
-  match modelExternalCall adv site state with
+  match Compiler.CompilationModel.DenoteExternalCalls.externalCall adv site state with
   | .success result post =>
       .success result { post with returndata := state.returndata }
   | .revert message _ => .revert message state
 
+@[simp] theorem commonExternalCall_apply (adv : AdversaryModel)
+    (site : Compiler.CompilationModel.DenoteExternalCalls.CallSite)
+    (state : ContractState) :
+    commonExternalCall adv site state =
+      ContractResult.success (adv.result site state)
+        { (Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled adv site
+            { world := state, gasRemaining := site.gas }).state.world with
+          returndata := state.returndata } := rfl
+
 def externalCallWords {α : Type} [ExternalResult α] (name : String) (args : List Uint256)
     (adv : AdversaryModel := .stub) : α :=
   match commonExternalCall adv (linkedCallSite name args 1) defaultState with
-  | .success result _ => ExternalResult.fromWord (externalCallResultWord result)
-  | .revert _ _ => ExternalResult.fromWord 0
+  | .success (.success returndata) _ =>
+      ExternalResult.fromWord (Core.Uint256.ofNat (returndata.head?.getD 0))
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      ExternalResult.fromWord (externalCallStubWord name args)
+  | .revert _ _ => ExternalResult.fromWord (externalCallStubWord name args)
 
 def callResultWords {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (adv : AdversaryModel := .stub) : Contract (Call.Result α) := do
@@ -709,7 +721,7 @@ definitional (`rfl`). -/
     (recordLinkedCall entry).run s =
       ContractResult.success () { s with calls := s.calls ++ [entry] } := rfl
 
-@[simp] theorem externalCallBind_run {α : Type} [ExternalArg α]
+@[simp] theorem externalCallBind_adv_apply {α : Type} [ExternalArg α]
     (adv : AdversaryModel) (names : List String) (name : String)
     (args : List α) (s : ContractState) :
     externalCallBind names name args adv s =
@@ -720,7 +732,7 @@ definitional (`rfl`). -/
           ContractResult.revert "external call failed" s
       | .revert message _ => ContractResult.revert message s := rfl
 
-theorem externalCallBindTo_run {α : Type} [ExternalArg α]
+theorem externalCallBindTo_adv_apply {α : Type} [ExternalArg α]
     (adv : AdversaryModel)
     (target : Address) (value : Uint256)
     (names : List String) (name : String) (args : List α) (s : ContractState) :
@@ -736,7 +748,7 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
         | .revert message _ => ContractResult.revert message s
       else ContractResult.revert "insufficient balance" s := rfl
 
-@[simp] theorem callResultWords_run {α : Type} [ExternalResult α] [Inhabited α]
+@[simp] theorem callResultWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
     (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState) :
     (callResultWords (α := α) name args adv).run s =
       (do
@@ -747,7 +759,7 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
             returndata := if result.succeeded then ExternalResult.fromWord (externalCallResultWord result)
               else Inhabited.default })).run s := rfl
 
-@[simp] theorem tryExternalCallWords_run {α : Type} [ExternalResult α] [Inhabited α]
+@[simp] theorem tryExternalCallWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
     (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState) :
     (tryExternalCallWords (α := α) name args adv).run s =
       (do
@@ -755,6 +767,141 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
         pure (result.succeeded,
           if result.succeeded then ExternalResult.fromWord (externalCallResultWord result)
           else Inhabited.default)).run s := rfl
+
+/-! The PR1 `.stub` laws retain their original names and propositions. -/
+
+@[simp] theorem externalCallBind_run {α : Type} [ExternalArg α]
+    (names : List String) (name : String) (args : List α) (s : ContractState) :
+    (externalCallBind names name args).run s =
+      if externalCallStubSuccess name then
+        ContractResult.success ()
+          { s with calls := s.calls ++
+              [linkedCallEntry name (args.flatMap ExternalArg.toWords) .success
+                (names.map fun _ =>
+                  (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat))] }
+      else ContractResult.revert "external call failed" s := by
+  by_cases h : name = "fail" <;>
+    simp [Contract.run, externalCallBind, commonExternalCall, modelExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
+      Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
+      Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
+      Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
+      Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
+      Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
+      Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
+      Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
+      Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
+      externalCallStubSuccess, linkedCallSite, linkedCallEntry, externalCallStubWord, h]
+
+theorem externalCallBindTo_run {α : Type} [ExternalArg α]
+    (target : Address) (value : Uint256)
+    (names : List String) (name : String) (args : List α) (s : ContractState) :
+    (externalCallBindTo target value names name args).run s =
+      if value ≤ s.selfBalance then
+        if externalCallStubSuccess name then
+          ContractResult.success ()
+            { s with
+              selfBalance := s.selfBalance - value
+              calls := s.calls ++
+                [linkedCallEntryTo name target value (args.flatMap ExternalArg.toWords)
+                  .success
+                  (names.map fun _ =>
+                    (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat))] }
+        else ContractResult.revert "external call failed" s
+      else ContractResult.revert "insufficient balance" s := by
+  by_cases hbal : value ≤ s.selfBalance
+  · by_cases h : name = "fail"
+    · simp [Contract.run, externalCallBindTo, commonExternalCall, modelExternalCall,
+        Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+        Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
+        Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
+        Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
+        Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
+        Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
+        Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
+        Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
+        Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
+        Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
+        externalCallStubSuccess, linkedCallSite, linkedCallEntryTo, linkedCallEntry,
+        externalCallStubWord, hbal, h]
+    · simp [Contract.run, externalCallBindTo, commonExternalCall, modelExternalCall,
+        Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+        Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
+        Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
+        Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
+        Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
+        Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
+        Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
+        Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
+        Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
+        Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
+        externalCallStubSuccess, linkedCallSite, linkedCallEntryTo, linkedCallEntry,
+        externalCallStubWord, hbal, h]
+  · simp [Contract.run, externalCallBindTo, hbal]
+
+@[simp] theorem callResultWords_run {α : Type} [ExternalResult α] [Inhabited α]
+    (name : String) (args : List Uint256) (s : ContractState) :
+    (callResultWords (α := α) name args).run s =
+      ContractResult.success
+        { success := externalCallStubSuccess name
+          returndata :=
+            if externalCallStubSuccess name then
+              ExternalResult.fromWord (externalCallStubWord name args)
+            else Inhabited.default }
+        { s with calls := s.calls ++
+            [linkedCallEntry name args
+              (if externalCallStubSuccess name then .success else .failure)
+              (if externalCallStubSuccess name then
+                [(externalCallStubWord name args : Nat)]
+              else [])] } := by
+  by_cases h : name = "fail" <;>
+    simp [callResultWords, commonExternalCall, modelExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
+      Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
+      Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
+      Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
+      Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
+      Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
+      Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
+      Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
+      Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.succeeded,
+      Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
+      Contract.run, Verity.bind, Verity.pure, Verity.instMonadContract, Bind.bind, Pure.pure,
+      linkedCallSite, linkedCallEntry,
+      externalCallStubSuccess, externalCallStubWord, externalCallResultWord, h]
+
+@[simp] theorem tryExternalCallWords_run {α : Type} [ExternalResult α] [Inhabited α]
+    (name : String) (args : List Uint256) (s : ContractState) :
+    (tryExternalCallWords (α := α) name args).run s =
+      ContractResult.success
+        (externalCallStubSuccess name,
+          if externalCallStubSuccess name then
+            ExternalResult.fromWord (externalCallStubWord name args)
+          else Inhabited.default)
+        { s with calls := s.calls ++
+            [linkedCallEntry name args
+              (if externalCallStubSuccess name then .success else .failure)
+              (if externalCallStubSuccess name then
+                [(externalCallStubWord name args : Nat)]
+              else [])] } := by
+  by_cases h : name = "fail" <;>
+    simp [tryExternalCallWords, commonExternalCall, modelExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
+      Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
+      Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
+      Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
+      Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
+      Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
+      Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
+      Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
+      Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.succeeded,
+      Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
+      Contract.run, Verity.bind, Verity.pure, Verity.instMonadContract, Bind.bind, Pure.pure,
+      linkedCallSite, linkedCallEntry,
+      externalCallStubSuccess, externalCallStubWord, externalCallResultWord, h]
 
 private def erc20ReadStubWord (name : String) (args : List Uint256) : Uint256 :=
   externalCallStubWord name args
@@ -840,21 +987,69 @@ def legacyStringSafeTransferFrom (token fromAddr toAddr : Address) (amount : Uin
   erc20Write adv "legacyStringSafeTransferFrom" token
     [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]
 
-@[simp] theorem safeTransfer_run (adv : AdversaryModel) (token toAddr : Address)
+@[simp] theorem safeTransfer_adv_run (adv : AdversaryModel) (token toAddr : Address)
     (amount : Uint256) (s : ContractState) :
     (safeTransfer token toAddr amount adv).run s =
       (erc20Write adv "safeTransfer" token [Verity.addressToWord toAddr, amount]).run s := rfl
 
-@[simp] theorem safeTransferFrom_run (adv : AdversaryModel) (token fromAddr toAddr : Address) (amount : Uint256)
+@[simp] theorem safeTransferFrom_adv_run (adv : AdversaryModel) (token fromAddr toAddr : Address) (amount : Uint256)
     (s : ContractState) :
     (safeTransferFrom token fromAddr toAddr amount adv).run s =
       (erc20Write adv "safeTransferFrom" token
         [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run s := rfl
 
-@[simp] theorem safeApprove_run (adv : AdversaryModel) (token spender : Address) (amount : Uint256)
+@[simp] theorem safeApprove_adv_run (adv : AdversaryModel) (token spender : Address) (amount : Uint256)
     (s : ContractState) :
     (safeApprove token spender amount adv).run s =
       (erc20Write adv "safeApprove" token [Verity.addressToWord spender, amount]).run s := rfl
+
+theorem erc20Write_stub_run (name : String) (token : Address)
+    (args : List Uint256) (s : ContractState) (h : name ≠ "fail") :
+    (erc20Write .stub name token args).run s =
+      ContractResult.success ()
+        { s with calls := s.calls ++ [erc20WriteEntry name token args] } := by
+  simp [erc20Write, commonExternalCall, modelExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
+    Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
+    Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
+    Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
+    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
+    Contract.run, linkedCallSite, erc20WriteEntry, linkedCallEntry, h]
+
+@[simp] theorem safeTransfer_run (token toAddr : Address) (amount : Uint256)
+    (s : ContractState) :
+    (safeTransfer token toAddr amount).run s =
+      ContractResult.success ()
+        { s with calls := s.calls ++
+            [erc20WriteEntry "safeTransfer" token
+              [Verity.addressToWord toAddr, amount]] } := by
+  simpa [safeTransfer] using
+    erc20Write_stub_run "safeTransfer" token [Verity.addressToWord toAddr, amount] s (by decide)
+
+@[simp] theorem safeTransferFrom_run (token fromAddr toAddr : Address) (amount : Uint256)
+    (s : ContractState) :
+    (safeTransferFrom token fromAddr toAddr amount).run s =
+      ContractResult.success ()
+        { s with calls := s.calls ++
+            [erc20WriteEntry "safeTransferFrom" token
+              [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]] } := by
+  simpa [safeTransferFrom] using erc20Write_stub_run "safeTransferFrom" token
+    [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount] s (by decide)
+
+@[simp] theorem safeApprove_run (token spender : Address) (amount : Uint256)
+    (s : ContractState) :
+    (safeApprove token spender amount).run s =
+      ContractResult.success ()
+        { s with calls := s.calls ++
+            [erc20WriteEntry "safeApprove" token
+              [Verity.addressToWord spender, amount]] } := by
+  simpa [safeApprove] using
+    erc20Write_stub_run "safeApprove" token [Verity.addressToWord spender, amount] s (by decide)
 
 def balanceOf (token owner : Address) (adv : AdversaryModel := .stub) : Contract Uint256 :=
   erc20Read adv "balanceOf" token [Verity.addressToWord owner]
@@ -864,18 +1059,68 @@ def allowance (token owner spender : Address) (adv : AdversaryModel := .stub) : 
 def totalSupply (token : Address) (adv : AdversaryModel := .stub) : Contract Uint256 :=
   erc20Read adv "totalSupply" token []
 
-@[simp] theorem balanceOf_run (adv : AdversaryModel) (token owner : Address) (s : ContractState) :
+@[simp] theorem balanceOf_adv_run (adv : AdversaryModel) (token owner : Address) (s : ContractState) :
     (balanceOf token owner adv).run s =
       (erc20Read adv "balanceOf" token [Verity.addressToWord owner]).run s := rfl
 
-@[simp] theorem allowance_run (adv : AdversaryModel) (token owner spender : Address)
+@[simp] theorem allowance_adv_run (adv : AdversaryModel) (token owner spender : Address)
     (s : ContractState) :
     (allowance token owner spender adv).run s =
       (erc20Read adv "allowance" token
         [Verity.addressToWord owner, Verity.addressToWord spender]).run s := rfl
 
-@[simp] theorem totalSupply_run (adv : AdversaryModel) (token : Address) (s : ContractState) :
+@[simp] theorem totalSupply_adv_run (adv : AdversaryModel) (token : Address) (s : ContractState) :
     (totalSupply token adv).run s = (erc20Read adv "totalSupply" token []).run s := rfl
+
+theorem erc20Read_stub_run (name : String) (token : Address)
+    (args : List Uint256) (s : ContractState) (h : name ≠ "fail") :
+    (erc20Read .stub name token args).run s =
+      let result := erc20ReadStubWord name (Verity.addressToWord token :: args)
+      ContractResult.success result
+        { s with calls := s.calls ++ [erc20ReadEntry name token args result] } := by
+  simp [erc20Read, commonExternalCall, modelExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
+    Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
+    Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
+    Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
+    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
+    Contract.run, Verity.bind, Verity.pure, Verity.instMonadContract, Bind.bind, Pure.pure,
+    linkedCallSite, externalCallResultWord, erc20ReadStubWord, externalCallStubWord,
+    erc20ReadEntry, linkedCallEntry, h]
+
+@[simp] theorem balanceOf_run (token owner : Address) (s : ContractState) :
+    (balanceOf token owner).run s =
+      let result := erc20ReadStubWord "balanceOf"
+        [Verity.addressToWord token, Verity.addressToWord owner]
+      ContractResult.success result
+        { s with calls := s.calls ++
+            [erc20ReadEntry "balanceOf" token [Verity.addressToWord owner] result] } := by
+  simpa [balanceOf] using erc20Read_stub_run "balanceOf" token
+    [Verity.addressToWord owner] s (by decide)
+
+@[simp] theorem allowance_run (token owner spender : Address) (s : ContractState) :
+    (allowance token owner spender).run s =
+      let result := erc20ReadStubWord "allowance"
+        [Verity.addressToWord token, Verity.addressToWord owner,
+          Verity.addressToWord spender]
+      ContractResult.success result
+        { s with calls := s.calls ++
+            [erc20ReadEntry "allowance" token
+              [Verity.addressToWord owner, Verity.addressToWord spender] result] } := by
+  simpa [allowance] using erc20Read_stub_run "allowance" token
+    [Verity.addressToWord owner, Verity.addressToWord spender] s (by decide)
+
+@[simp] theorem totalSupply_run (token : Address) (s : ContractState) :
+    (totalSupply token).run s =
+      let result := erc20ReadStubWord "totalSupply" [Verity.addressToWord token]
+      ContractResult.success result
+        { s with calls := s.calls ++ [erc20ReadEntry "totalSupply" token [] result] } := by
+  simpa [totalSupply] using erc20Read_stub_run "totalSupply" token [] s (by decide)
 def forEach (_name : String) (_count : Uint256) (body : Contract Unit) : Contract Unit := body
 def blockTimestamp : Contract Uint256 := Verity.blockTimestamp
 def blockNumber : Contract Uint256 := Verity.blockNumber

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -628,9 +628,6 @@ private abbrev AdversaryModel :=
   Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel
 private abbrev ExternalCallResult :=
   Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult
-private abbrev modelExternalCall :=
-  Compiler.CompilationModel.DenoteExternalCalls.externalCall
-
 def externalCallResultWord (result : ExternalCallResult) : Uint256 :=
   Core.Uint256.ofNat (result.returndata.head?.getD 0)
 
@@ -781,7 +778,7 @@ theorem externalCallBindTo_adv_apply {α : Type} [ExternalArg α]
                   (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat))] }
       else ContractResult.revert "external call failed" s := by
   by_cases h : name = "fail" <;>
-    simp [Contract.run, externalCallBind, commonExternalCall, modelExternalCall,
+    simp [Contract.run, externalCallBind, commonExternalCall,
       Compiler.CompilationModel.DenoteExternalCalls.externalCall,
       Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
       Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
@@ -812,7 +809,7 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
       else ContractResult.revert "insufficient balance" s := by
   by_cases hbal : value ≤ s.selfBalance
   · by_cases h : name = "fail"
-    · simp [Contract.run, externalCallBindTo, commonExternalCall, modelExternalCall,
+    · simp [Contract.run, externalCallBindTo, commonExternalCall,
         Compiler.CompilationModel.DenoteExternalCalls.externalCall,
         Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
         Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
@@ -825,7 +822,7 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
         Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
         externalCallStubSuccess, linkedCallSite, linkedCallEntryTo, linkedCallEntry,
         externalCallStubWord, hbal, h]
-    · simp [Contract.run, externalCallBindTo, commonExternalCall, modelExternalCall,
+    · simp [Contract.run, externalCallBindTo, commonExternalCall,
         Compiler.CompilationModel.DenoteExternalCalls.externalCall,
         Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
         Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
@@ -856,7 +853,7 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
                 [(externalCallStubWord name args : Nat)]
               else [])] } := by
   by_cases h : name = "fail" <;>
-    simp [callResultWords, commonExternalCall, modelExternalCall,
+    simp [callResultWords, commonExternalCall,
       Compiler.CompilationModel.DenoteExternalCalls.externalCall,
       Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
       Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
@@ -887,7 +884,7 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
                 [(externalCallStubWord name args : Nat)]
               else [])] } := by
   by_cases h : name = "fail" <;>
-    simp [tryExternalCallWords, commonExternalCall, modelExternalCall,
+    simp [tryExternalCallWords, commonExternalCall,
       Compiler.CompilationModel.DenoteExternalCalls.externalCall,
       Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
       Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
@@ -1008,7 +1005,7 @@ theorem erc20Write_stub_run (name : String) (token : Address)
     (erc20Write .stub name token args).run s =
       ContractResult.success ()
         { s with calls := s.calls ++ [erc20WriteEntry name token args] } := by
-  simp [erc20Write, commonExternalCall, modelExternalCall,
+  simp [erc20Write, commonExternalCall,
     Compiler.CompilationModel.DenoteExternalCalls.externalCall,
     Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
     Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
@@ -1078,7 +1075,7 @@ theorem erc20Read_stub_run (name : String) (token : Address)
       let result := erc20ReadStubWord name (Verity.addressToWord token :: args)
       ContractResult.success result
         { s with calls := s.calls ++ [erc20ReadEntry name token args result] } := by
-  simp [erc20Read, commonExternalCall, modelExternalCall,
+  simp [erc20Read, commonExternalCall,
     Compiler.CompilationModel.DenoteExternalCalls.externalCall,
     Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
     Compiler.CompilationModel.DenoteExternalCalls.denoteCall,

--- a/Contracts/Smoke/ExternalCallObservability.lean
+++ b/Contracts/Smoke/ExternalCallObservability.lean
@@ -31,6 +31,43 @@ private def notify (arg : Uint256) : Contract Unit :=
 private def notifyEntry (arg : Uint256) : ExternalCall :=
   Contracts.linkedCallEntry "notify" [arg]
 
+private def returningAdversary (returndata : List Nat) :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun _ _ => .success returndata
+  gasUsed := fun _ _ => 0
+
+private def codedState : ContractState :=
+  { defaultState with codeSize := fun _ => 1 }
+
+/-! ### ERC-20 optional-bool policy regressions -/
+
+/-- OpenZeppelin-style wrappers must not treat a successful empty return from
+an address without code as a successful token operation. -/
+example :
+    (Contracts.safeTransfer 7 8 9 (returningAdversary [])).run defaultState =
+      ContractResult.revert "external call target has no code" defaultState := rfl
+
+/-- Legacy wrappers accept returndata longer than one word when its first word
+is true, matching their compiled `returndatasize() > 31` policy. -/
+example :
+    (Contracts.legacyStringSafeTransfer 7 8 9
+      (returningAdversary [1, 37])).run codedState =
+      ContractResult.success ()
+        { codedState with
+            calls := [{ Contracts.erc20WriteEntry "legacyStringSafeTransfer" 7 [8, 9] with
+              returndata := [1, 37] }] } := rfl
+
+/-- Optional-bool matching observes EVM words, so an adversarial natural
+congruent to one modulo the EVM word modulus is accepted as `true`. -/
+example :
+    (Contracts.safeTransfer 7 8 9
+      (returningAdversary [Compiler.Constants.evmModulus + 1])).run codedState =
+      ContractResult.success ()
+        { codedState with
+            calls := [{ Contracts.erc20WriteEntry "safeTransfer" 7 [8, 9] with
+              returndata := [Compiler.Constants.evmModulus + 1] }] } := rfl
+
 /-- One call appends exactly one journal entry. -/
 theorem single_call_journals_one_entry (s : ContractState) :
     ((notify 1).run s).snd.calls = s.calls ++ [notifyEntry 1] := rfl

--- a/Contracts/Smoke/ExternalCallObservability.lean
+++ b/Contracts/Smoke/ExternalCallObservability.lean
@@ -162,48 +162,16 @@ example (token owner : Address) :
         [Verity.addressToWord owner]
         (Contracts.externalCallStubWord "balanceOf"
           [Verity.addressToWord token, Verity.addressToWord owner])] := by
-  simp [Contracts.balanceOf, Contracts.erc20Read, Contracts.commonExternalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
-    Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
-    Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
-    Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
-    Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
-    Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
-    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
-    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
-    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
-    Contracts.linkedCallSite, Contract.run, Verity.bind, Verity.instMonadContract,
-    Contracts.externalCallStubWord,
-    Contracts.erc20ReadEntry, Contracts.linkedCallEntry, Verity.defaultState]
-  rfl
+  rw [Contracts.balanceOf_run]
+  simp [Contracts.erc20ReadEntry,
+    Contracts.linkedCallEntry, Verity.defaultState]
 
 example (token owner : Address) :
     ((Contracts.balanceOf token owner .stub).run defaultState).snd.calls.map
       (fun call => call.kind) = [.staticcall] := by
-  have hjournal :
-      ((Contracts.balanceOf token owner .stub).run defaultState).snd.calls =
-        [Contracts.erc20ReadEntry "balanceOf" token
-          [Verity.addressToWord owner]
-          (Contracts.externalCallStubWord "balanceOf"
-            [Verity.addressToWord token, Verity.addressToWord owner])] := by
-    simp [Contracts.balanceOf, Contracts.erc20Read, Contracts.commonExternalCall,
-      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-      Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
-      Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
-      Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
-      Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
-      Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
-      Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
-      Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
-      Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
-      Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
-      Contracts.linkedCallSite, Contract.run, Verity.bind, Verity.instMonadContract,
-      Contracts.externalCallStubWord, Contracts.erc20ReadEntry,
-      Contracts.linkedCallEntry, Verity.defaultState]
-    rfl
-  rw [hjournal]
-  rfl
+  rw [Contracts.balanceOf_run]
+  simp [Contracts.erc20ReadEntry,
+    Contracts.linkedCallEntry, Verity.defaultState]
 
 example (token owner spender : Address) :
     ((Contracts.allowance token owner spender .stub).run defaultState).snd.calls =
@@ -212,41 +180,17 @@ example (token owner spender : Address) :
         (Contracts.externalCallStubWord "allowance"
           [Verity.addressToWord token, Verity.addressToWord owner,
             Verity.addressToWord spender])] := by
-  simp [Contracts.allowance, Contracts.erc20Read, Contracts.commonExternalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
-    Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
-    Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
-    Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
-    Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
-    Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
-    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
-    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
-    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
-    Contracts.linkedCallSite, Contract.run, Verity.bind, Verity.instMonadContract,
-    Contracts.externalCallStubWord,
-    Contracts.erc20ReadEntry, Contracts.linkedCallEntry, Verity.defaultState]
-  rfl
+  rw [Contracts.allowance_run]
+  simp [Contracts.erc20ReadEntry,
+    Contracts.linkedCallEntry, Verity.defaultState]
 
 example (token : Address) :
     ((Contracts.totalSupply token .stub).run defaultState).snd.calls =
       [Contracts.erc20ReadEntry "totalSupply" token []
         (Contracts.externalCallStubWord "totalSupply" [Verity.addressToWord token])] := by
-  simp [Contracts.totalSupply, Contracts.erc20Read, Contracts.commonExternalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
-    Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
-    Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
-    Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
-    Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
-    Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
-    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
-    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
-    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
-    Contracts.linkedCallSite, Contract.run, Verity.bind, Verity.instMonadContract,
-    Contracts.externalCallStubWord,
-    Contracts.erc20ReadEntry, Contracts.linkedCallEntry, Verity.defaultState]
-  rfl
+  rw [Contracts.totalSupply_run]
+  simp [Contracts.erc20ReadEntry,
+    Contracts.linkedCallEntry, Verity.defaultState]
 
 /-- Dynamic array encoding is length-delimited and retains every element. -/
 example : ExternalArg.toWords (#[11, 12] : Array Uint256) = [2, 11, 12] := rfl
@@ -293,16 +237,8 @@ example (token toAddr : Address) (amount : Uint256) :
       [{ siteId := 0, kind := .call, target := token.toNat, value := 0
          calldata := [Core.Uint256.ofNat toAddr.toNat, amount], control := .success
          returndata := [], name := "safeTransfer" }] := by
-  simp [Contracts.safeTransfer, Contracts.erc20Write, Contracts.commonExternalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
-    Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
-    Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
-    Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
-    Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
-    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
-    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
-    Contracts.linkedCallSite, Contract.run, Verity.bind, Verity.defaultState]
+  rw [Contracts.safeTransfer_run]
+  simp [Contracts.erc20WriteEntry, Contracts.linkedCallEntry, Verity.defaultState]
 
 example (token fromAddr toAddr : Address) (amount : Uint256) :
     ((Contracts.safeTransferFrom token fromAddr toAddr amount .stub).run defaultState).snd.calls =
@@ -310,32 +246,16 @@ example (token fromAddr toAddr : Address) (amount : Uint256) :
          calldata := [Core.Uint256.ofNat fromAddr.toNat,
            Core.Uint256.ofNat toAddr.toNat, amount], control := .success
          returndata := [], name := "safeTransferFrom" }] := by
-  simp [Contracts.safeTransferFrom, Contracts.erc20Write, Contracts.commonExternalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
-    Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
-    Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
-    Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
-    Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
-    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
-    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
-    Contracts.linkedCallSite, Contract.run, Verity.bind, Verity.defaultState]
+  rw [Contracts.safeTransferFrom_run]
+  simp [Contracts.erc20WriteEntry, Contracts.linkedCallEntry, Verity.defaultState]
 
 example (token spender : Address) (amount : Uint256) :
     ((Contracts.safeApprove token spender amount .stub).run defaultState).snd.calls =
       [{ siteId := 0, kind := .call, target := token.toNat, value := 0
          calldata := [Core.Uint256.ofNat spender.toNat, amount], control := .success
          returndata := [], name := "safeApprove" }] := by
-  simp [Contracts.safeApprove, Contracts.erc20Write, Contracts.commonExternalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
-    Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
-    Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
-    Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
-    Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
-    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
-    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
-    Contracts.linkedCallSite, Contract.run, Verity.bind, Verity.defaultState]
+  rw [Contracts.safeApprove_run]
+  simp [Contracts.erc20WriteEntry, Contracts.linkedCallEntry, Verity.defaultState]
 
 /-- The reserved `"fail"` callee journals a failure-control entry with no
 returndata, and reports `success := false` in-band. -/

--- a/Contracts/Smoke/ExternalCallObservability.lean
+++ b/Contracts/Smoke/ExternalCallObservability.lean
@@ -147,7 +147,7 @@ example :
 journal exposes as returndata. This distinguishes the old default-return
 mutant even when the call itself succeeded. -/
 example :
-    ((Contracts.tryExternalCallWords "echo" [37] :
+    ((Contracts.tryExternalCallWords "echo" [37] .stub :
         Contract (Bool × Uint256)).run defaultState) =
       ContractResult.success (true, 37)
         { defaultState with
@@ -157,28 +157,96 @@ example :
 the returned stub word as returndata, using the same `staticcall` kind as the
 compiled ERC-20 modules. -/
 example (token owner : Address) :
-    ((Contracts.balanceOf token owner).run defaultState).snd.calls =
+    ((Contracts.balanceOf token owner .stub).run defaultState).snd.calls =
       [Contracts.erc20ReadEntry "balanceOf" token
         [Verity.addressToWord owner]
         (Contracts.externalCallStubWord "balanceOf"
-          [Verity.addressToWord token, Verity.addressToWord owner])] := rfl
+          [Verity.addressToWord token, Verity.addressToWord owner])] := by
+  simp [Contracts.balanceOf, Contracts.erc20Read, Contracts.commonExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
+    Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
+    Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
+    Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
+    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
+    Contracts.linkedCallSite, Contract.run, Verity.bind, Verity.instMonadContract,
+    Contracts.externalCallStubWord,
+    Contracts.erc20ReadEntry, Contracts.linkedCallEntry, Verity.defaultState]
+  rfl
 
 example (token owner : Address) :
-    ((Contracts.balanceOf token owner).run defaultState).snd.calls.map
-      (fun call => call.kind) = [.staticcall] := rfl
+    ((Contracts.balanceOf token owner .stub).run defaultState).snd.calls.map
+      (fun call => call.kind) = [.staticcall] := by
+  have hjournal :
+      ((Contracts.balanceOf token owner .stub).run defaultState).snd.calls =
+        [Contracts.erc20ReadEntry "balanceOf" token
+          [Verity.addressToWord owner]
+          (Contracts.externalCallStubWord "balanceOf"
+            [Verity.addressToWord token, Verity.addressToWord owner])] := by
+    simp [Contracts.balanceOf, Contracts.erc20Read, Contracts.commonExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
+      Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
+      Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
+      Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
+      Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
+      Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
+      Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
+      Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
+      Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
+      Contracts.linkedCallSite, Contract.run, Verity.bind, Verity.instMonadContract,
+      Contracts.externalCallStubWord, Contracts.erc20ReadEntry,
+      Contracts.linkedCallEntry, Verity.defaultState]
+    rfl
+  rw [hjournal]
+  rfl
 
 example (token owner spender : Address) :
-    ((Contracts.allowance token owner spender).run defaultState).snd.calls =
+    ((Contracts.allowance token owner spender .stub).run defaultState).snd.calls =
       [Contracts.erc20ReadEntry "allowance" token
         [Verity.addressToWord owner, Verity.addressToWord spender]
         (Contracts.externalCallStubWord "allowance"
           [Verity.addressToWord token, Verity.addressToWord owner,
-            Verity.addressToWord spender])] := rfl
+            Verity.addressToWord spender])] := by
+  simp [Contracts.allowance, Contracts.erc20Read, Contracts.commonExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
+    Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
+    Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
+    Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
+    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
+    Contracts.linkedCallSite, Contract.run, Verity.bind, Verity.instMonadContract,
+    Contracts.externalCallStubWord,
+    Contracts.erc20ReadEntry, Contracts.linkedCallEntry, Verity.defaultState]
+  rfl
 
 example (token : Address) :
-    ((Contracts.totalSupply token).run defaultState).snd.calls =
+    ((Contracts.totalSupply token .stub).run defaultState).snd.calls =
       [Contracts.erc20ReadEntry "totalSupply" token []
-        (Contracts.externalCallStubWord "totalSupply" [Verity.addressToWord token])] := rfl
+        (Contracts.externalCallStubWord "totalSupply" [Verity.addressToWord token])] := by
+  simp [Contracts.totalSupply, Contracts.erc20Read, Contracts.commonExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
+    Compiler.CompilationModel.DenoteExternalCalls.chargedGas,
+    Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
+    Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.control,
+    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
+    Contracts.linkedCallSite, Contract.run, Verity.bind, Verity.instMonadContract,
+    Contracts.externalCallStubWord,
+    Contracts.erc20ReadEntry, Contracts.linkedCallEntry, Verity.defaultState]
+  rfl
 
 /-- Dynamic array encoding is length-delimited and retains every element. -/
 example : ExternalArg.toWords (#[11, 12] : Array Uint256) = [2, 11, 12] := rfl
@@ -221,26 +289,53 @@ theorem same_length_bytes_mutation_observable (s : ContractState) :
 /-- ERC-20 wrappers journal the token as the actual call target and only the
 wrapper arguments as calldata. -/
 example (token toAddr : Address) (amount : Uint256) :
-    ((Contracts.safeTransfer token toAddr amount).run defaultState).snd.calls =
+    ((Contracts.safeTransfer token toAddr amount .stub).run defaultState).snd.calls =
       [{ siteId := 0, kind := .call, target := token.toNat, value := 0
          calldata := [Core.Uint256.ofNat toAddr.toNat, amount], control := .success
          returndata := [], name := "safeTransfer" }] := by
-  simp [Contracts.erc20WriteEntry, Contracts.linkedCallEntry, Verity.defaultState]
+  simp [Contracts.safeTransfer, Contracts.erc20Write, Contracts.commonExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
+    Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
+    Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
+    Contracts.linkedCallSite, Contract.run, Verity.bind, Verity.defaultState]
 
 example (token fromAddr toAddr : Address) (amount : Uint256) :
-    ((Contracts.safeTransferFrom token fromAddr toAddr amount).run defaultState).snd.calls =
+    ((Contracts.safeTransferFrom token fromAddr toAddr amount .stub).run defaultState).snd.calls =
       [{ siteId := 0, kind := .call, target := token.toNat, value := 0
          calldata := [Core.Uint256.ofNat fromAddr.toNat,
            Core.Uint256.ofNat toAddr.toNat, amount], control := .success
          returndata := [], name := "safeTransferFrom" }] := by
-  simp [Contracts.erc20WriteEntry, Contracts.linkedCallEntry, Verity.defaultState]
+  simp [Contracts.safeTransferFrom, Contracts.erc20Write, Contracts.commonExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
+    Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
+    Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
+    Contracts.linkedCallSite, Contract.run, Verity.bind, Verity.defaultState]
 
 example (token spender : Address) (amount : Uint256) :
-    ((Contracts.safeApprove token spender amount).run defaultState).snd.calls =
+    ((Contracts.safeApprove token spender amount .stub).run defaultState).snd.calls =
       [{ siteId := 0, kind := .call, target := token.toNat, value := 0
          calldata := [Core.Uint256.ofNat spender.toNat, amount], control := .success
          returndata := [], name := "safeApprove" }] := by
-  simp [Contracts.erc20WriteEntry, Contracts.linkedCallEntry, Verity.defaultState]
+  simp [Contracts.safeApprove, Contracts.erc20Write, Contracts.commonExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
+    Compiler.CompilationModel.DenoteExternalCalls.denoteCall,
+    Compiler.CompilationModel.DenoteExternalCalls.journalEntry,
+    Compiler.CompilationModel.DenoteExternalCalls.CallKind.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.CallControl.toJournal,
+    Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult.returndata,
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub,
+    Contracts.linkedCallSite, Contract.run, Verity.bind, Verity.defaultState]
 
 /-- The reserved `"fail"` callee journals a failure-control entry with no
 returndata, and reports `success := false` in-band. -/

--- a/Contracts/Smoke/ExternalCallObservability.lean
+++ b/Contracts/Smoke/ExternalCallObservability.lean
@@ -114,19 +114,13 @@ theorem quantified over `calls` therefore rejects the double-send mutant by
 running the program, not by auxiliary record arithmetic. -/
 theorem double_send_observable (token toAddr : Address) (amount : Uint256)
     (s : ContractState) :
-    (((do Contracts.safeTransfer token toAddr amount
-          Contracts.safeTransfer token toAddr amount) : Contract Unit).run s).snd.calls ≠
-      ((Contracts.safeTransfer token toAddr amount).run s).snd.calls := by
-  intro h
-  have hlen := congrArg List.length h
-  have : (s.calls ++ [Contracts.erc20WriteEntry "safeTransfer" token
-      [Verity.addressToWord toAddr, amount]] ++
-      [Contracts.erc20WriteEntry "safeTransfer" token
-        [Verity.addressToWord toAddr, amount]]).length =
-      (s.calls ++ [Contracts.erc20WriteEntry "safeTransfer" token
-        [Verity.addressToWord toAddr, amount]]).length := hlen
-  simp only [List.length_append, List.length_cons, List.length_nil] at this
-  omega
+    s.calls ++ [Contracts.erc20WriteEntry "safeTransfer" token
+        [Verity.addressToWord toAddr, amount]] ++
+        [Contracts.erc20WriteEntry "safeTransfer" token
+          [Verity.addressToWord toAddr, amount]] ≠
+      s.calls ++ [Contracts.erc20WriteEntry "safeTransfer" token
+        [Verity.addressToWord toAddr, amount]] := by
+  simp
 
 /-- `callResult` and `tryExternalCall` journal their crossing too: the
 success path records the callee name, argument words, control, and the
@@ -232,30 +226,29 @@ theorem same_length_bytes_mutation_observable (s : ContractState) :
 
 /-- ERC-20 wrappers journal the token as the actual call target and only the
 wrapper arguments as calldata. -/
-example (token toAddr : Address) (amount : Uint256) :
-    ((Contracts.safeTransfer token toAddr amount .stub).run defaultState).snd.calls =
-      [{ siteId := 0, kind := .call, target := token.toNat, value := 0
-         calldata := [Core.Uint256.ofNat toAddr.toNat, amount], control := .success
-         returndata := [], name := "safeTransfer" }] := by
-  rw [Contracts.safeTransfer_run]
-  simp [Contracts.erc20WriteEntry, Contracts.linkedCallEntry, Verity.defaultState]
+example (token toAddr : Address) (amount : Uint256) (s : ContractState)
+    (hcode : s.codeSize token.toNat ≠ 0) :
+    ((Contracts.safeTransfer token toAddr amount .stub).run s).snd.calls =
+      s.calls ++ [Contracts.erc20WriteEntry "safeTransfer" token
+        [Verity.addressToWord toAddr, amount]] := by
+  rw [Contracts.safeTransfer_run _ _ _ _ hcode]
+  rfl
 
-example (token fromAddr toAddr : Address) (amount : Uint256) :
-    ((Contracts.safeTransferFrom token fromAddr toAddr amount .stub).run defaultState).snd.calls =
-      [{ siteId := 0, kind := .call, target := token.toNat, value := 0
-         calldata := [Core.Uint256.ofNat fromAddr.toNat,
-           Core.Uint256.ofNat toAddr.toNat, amount], control := .success
-         returndata := [], name := "safeTransferFrom" }] := by
-  rw [Contracts.safeTransferFrom_run]
-  simp [Contracts.erc20WriteEntry, Contracts.linkedCallEntry, Verity.defaultState]
+example (token fromAddr toAddr : Address) (amount : Uint256) (s : ContractState)
+    (hcode : s.codeSize token.toNat ≠ 0) :
+    ((Contracts.safeTransferFrom token fromAddr toAddr amount .stub).run s).snd.calls =
+      s.calls ++ [Contracts.erc20WriteEntry "safeTransferFrom" token
+        [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]] := by
+  rw [Contracts.safeTransferFrom_run _ _ _ _ _ hcode]
+  rfl
 
-example (token spender : Address) (amount : Uint256) :
-    ((Contracts.safeApprove token spender amount .stub).run defaultState).snd.calls =
-      [{ siteId := 0, kind := .call, target := token.toNat, value := 0
-         calldata := [Core.Uint256.ofNat spender.toNat, amount], control := .success
-         returndata := [], name := "safeApprove" }] := by
-  rw [Contracts.safeApprove_run]
-  simp [Contracts.erc20WriteEntry, Contracts.linkedCallEntry, Verity.defaultState]
+example (token spender : Address) (amount : Uint256) (s : ContractState)
+    (hcode : s.codeSize token.toNat ≠ 0) :
+    ((Contracts.safeApprove token spender amount .stub).run s).snd.calls =
+      s.calls ++ [Contracts.erc20WriteEntry "safeApprove" token
+        [Verity.addressToWord spender, amount]] := by
+  rw [Contracts.safeApprove_run _ _ _ _ hcode]
+  rfl
 
 /-- The reserved `"fail"` callee journals a failure-control entry with no
 returndata, and reports `success := false` in-band. -/
@@ -291,9 +284,14 @@ example (s : ContractState) :
 nothing observable, matching EVM top-level behaviour (and the documented
 contrast with the model plane's revert-surviving journal). -/
 theorem revert_rolls_back_journal (token toAddr : Address) (amount : Uint256)
-    (s : ContractState) :
+    (s : ContractState) (hcode : s.codeSize token.toNat ≠ 0) :
     (((do Contracts.safeTransfer token toAddr amount
           require false "boom") : Contract Unit).run s) =
-      ContractResult.revert "boom" s := rfl
+      ContractResult.revert "boom" s := by
+  change (Verity.bind (Contracts.safeTransfer token toAddr amount)
+      (fun _ => require false "boom")).run s = _
+  have h₁ := Contracts.safeTransfer_run token toAddr amount s hcode
+  have h₁raw := Contract.eq_of_run_success h₁
+  simp [Verity.bind, Contract.run, h₁raw, Verity.require]
 
 end Contracts.Smoke.ExternalCallObservability

--- a/Contracts/Smoke/ExternalCallObservability.lean
+++ b/Contracts/Smoke/ExternalCallObservability.lean
@@ -43,6 +43,13 @@ private def codeTransitionAdversary (codeSize : Uint256) :
   result := fun _ _ => .success []
   gasUsed := fun _ _ => 0
 
+private def controlledAdversary
+    (result : Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult) :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun _ _ => result
+  gasUsed := fun _ _ => 0
+
 private def codedState : ContractState :=
   { defaultState with codeSize := fun _ => 1 }
 
@@ -87,6 +94,27 @@ example :
         { codedState with
             calls := [{ Contracts.erc20WriteEntry "safeTransfer" 7 [8, 9] with
               returndata := [Compiler.Constants.evmModulus + 1] }] } := rfl
+
+/-- Failed `callResult` crossings retain the first returned word rather than
+replacing the compiler-observable payload with the type default. -/
+example :
+    (Contracts.callResultWords "probe" [9]
+      (controlledAdversary (.failure [42, 99])) :
+        Contract (Contracts.Call.Result Uint256)).run defaultState =
+      ContractResult.success { success := false, returndata := 42 }
+        { defaultState with
+            calls := [Contracts.linkedCallEntry "probe" [9] .failure [42, 99]] } := rfl
+
+/-- Reverted try-call payloads are decoded as normalized EVM words on the
+in-band failure path, matching `Stmt.tryExternalCallBind`. -/
+example :
+    (Contracts.tryExternalCallWords "probe" [9]
+      (controlledAdversary (.revert [Compiler.Constants.evmModulus + 42])) :
+        Contract (Bool × Uint256)).run defaultState =
+      ContractResult.success (false, 42)
+        { defaultState with
+            calls := [Contracts.linkedCallEntry "probe" [9] .revert
+              [Compiler.Constants.evmModulus + 42]] } := rfl
 
 /-- One call appends exactly one journal entry. -/
 theorem single_call_journals_one_entry (s : ContractState) :

--- a/Contracts/Smoke/ExternalCallObservability.lean
+++ b/Contracts/Smoke/ExternalCallObservability.lean
@@ -113,14 +113,31 @@ observably different from sending once, in every pre-state. A deposit-style
 theorem quantified over `calls` therefore rejects the double-send mutant by
 running the program, not by auxiliary record arithmetic. -/
 theorem double_send_observable (token toAddr : Address) (amount : Uint256)
-    (s : ContractState) :
-    s.calls ++ [Contracts.erc20WriteEntry "safeTransfer" token
-        [Verity.addressToWord toAddr, amount]] ++
-        [Contracts.erc20WriteEntry "safeTransfer" token
-          [Verity.addressToWord toAddr, amount]] ≠
-      s.calls ++ [Contracts.erc20WriteEntry "safeTransfer" token
-        [Verity.addressToWord toAddr, amount]] := by
-  simp
+    (s : ContractState) (hcode : s.codeSize token.toNat ≠ 0) :
+    (((do Contracts.safeTransfer token toAddr amount
+          Contracts.safeTransfer token toAddr amount) : Contract Unit).run s).snd.calls ≠
+      ((Contracts.safeTransfer token toAddr amount).run s).snd.calls := by
+  change ((Verity.bind (Contracts.safeTransfer token toAddr amount)
+      (fun _ => Contracts.safeTransfer token toAddr amount)).run s).snd.calls ≠ _
+  let entry := Contracts.erc20WriteEntry "safeTransfer" token
+    [Verity.addressToWord toAddr, amount]
+  let s₁ := { s with calls := s.calls ++ [entry] }
+  let s₂ := { s₁ with calls := s₁.calls ++ [entry] }
+  have h₁ : (Contracts.safeTransfer token toAddr amount).run s =
+      ContractResult.success () s₁ := by
+    simpa [s₁, entry] using Contracts.safeTransfer_run token toAddr amount s hcode
+  have hcode₁ : s₁.codeSize token.toNat ≠ 0 := hcode
+  have h₂ : (Contracts.safeTransfer token toAddr amount).run s₁ =
+      ContractResult.success () s₂ := by
+    simpa [s₂, entry] using Contracts.safeTransfer_run token toAddr amount s₁ hcode₁
+  have h₁raw := Contract.eq_of_run_success h₁
+  have h₂raw := Contract.eq_of_run_success h₂
+  have hrun : (Verity.bind (Contracts.safeTransfer token toAddr amount)
+      (fun _ => Contracts.safeTransfer token toAddr amount)).run s =
+      ContractResult.success () s₂ := by
+    simp [Verity.bind, Contract.run, h₁raw, h₂raw]
+  rw [hrun, h₁]
+  simp [s₂, s₁, entry]
 
 /-- `callResult` and `tryExternalCall` journal their crossing too: the
 success path records the callee name, argument words, control, and the

--- a/Contracts/Smoke/ExternalCallObservability.lean
+++ b/Contracts/Smoke/ExternalCallObservability.lean
@@ -37,6 +37,12 @@ private def returningAdversary (returndata : List Nat) :
   result := fun _ _ => .success returndata
   gasUsed := fun _ _ => 0
 
+private def codeTransitionAdversary (codeSize : Uint256) :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => { state with codeSize := fun _ => codeSize }
+  result := fun _ _ => .success []
+  gasUsed := fun _ _ => 0
+
 private def codedState : ContractState :=
   { defaultState with codeSize := fun _ => 1 }
 
@@ -47,6 +53,20 @@ an address without code as a successful token operation. -/
 example :
     (Contracts.safeTransfer 7 8 9 (returningAdversary [])).run defaultState =
       ContractResult.revert "external call target has no code" defaultState := rfl
+
+/-- The code-existence guard observes the committed post-call world: losing
+code during a successful empty-return call is rejected and rolled back. -/
+example :
+    (Contracts.safeTransfer 7 8 9 (codeTransitionAdversary 0)).run codedState =
+      ContractResult.revert "external call target has no code" codedState := rfl
+
+/-- Conversely, code installed by the successful call transition is visible
+to the post-call guard, so an empty return is accepted. -/
+example :
+    (Contracts.safeTransfer 7 8 9 (codeTransitionAdversary 1)).run defaultState =
+      ContractResult.success ()
+        { codedState with
+            calls := [Contracts.erc20WriteEntry "safeTransfer" 7 [8, 9]] } := rfl
 
 /-- Legacy wrappers accept returndata longer than one word when its first word
 is true, matching their compiled `returndatasize() > 31` policy. -/

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -702,6 +702,7 @@ end Verity.AxiomAudit
   Verity.Proofs.LoopSimulationResultAware.execResultAwareForEach_earlyExit_bridge
 
   -- Verity/Proofs/Model/CommonExternalCallEquivalence.lean
+  Contracts.commonExternalCall_eq_model
   Contracts.externalCallWords_eq_stub_result
   Contracts.callResultWords_eq_stub
   Contracts.tryExternalCallWords_eq_stub
@@ -7514,4 +7515,4 @@ end Verity.AxiomAudit
   Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
 ]
 
--- Total: 6952 theorems/lemmas (4962 public, 1990 private, 0 sorry'd)
+-- Total: 6953 theorems/lemmas (4963 public, 1990 private, 0 sorry'd)

--- a/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
+++ b/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
@@ -35,9 +35,9 @@ def stubCallResultWords {α : Type} [ExternalResult α] [Inhabited α]
         { success := true,
           returndata := ExternalResult.fromWord (Core.Uint256.ofNat word) }) (legacyPost state post)
   | .success (.success _) _ => .revert "external call returned invalid data" state
-  | .success (.failure _) post | .success (.revert _) post =>
+  | .success (.failure returndata) post | .success (.revert returndata) post =>
       .success (show Call.Result α from
-        { success := false, returndata := Inhabited.default }) (legacyPost state post)
+        { success := false, returndata := failedExternalResult returndata }) (legacyPost state post)
   | .revert message _ => .revert message state
 
 def stubTryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
@@ -46,8 +46,8 @@ def stubTryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
   | .success (.success [word]) post =>
       .success (true, ExternalResult.fromWord (Core.Uint256.ofNat word)) (legacyPost state post)
   | .success (.success _) _ => .revert "external call returned invalid data" state
-  | .success (.failure _) post | .success (.revert _) post =>
-      .success (false, Inhabited.default) (legacyPost state post)
+  | .success (.failure returndata) post | .success (.revert returndata) post =>
+      .success (false, failedExternalResult returndata) (legacyPost state post)
   | .revert message _ => .revert message state
 
 def stubExternalCallBind {α : Type} [ExternalArg α]

--- a/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
+++ b/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
@@ -20,13 +20,36 @@ private abbrev modelExternalCall :=
 def legacyPost (before after : ContractState) : ContractState :=
   { after with returndata := before.returndata }
 
+theorem commonExternalCall_eq_model (adv : AdversaryModel) (site : CallSite)
+    (state : ContractState) :
+    (commonExternalCall adv site).run state =
+      match modelExternalCall adv site state with
+      | .success result post => .success result (legacyPost state post)
+      | .revert message _ => .revert message state := rfl
+
 def stubCallResultWords {α : Type} [ExternalResult α] [Inhabited α]
-    (name : String) (args : List Uint256) : Contract (Call.Result α) :=
-  callResultWords name args .stub
+    (name : String) (args : List Uint256) : Contract (Call.Result α) := fun state =>
+  match modelExternalCall .stub (linkedCallSite name args 1) state with
+  | .success result post =>
+      .success
+        { success := result.succeeded
+          returndata := if result.succeeded then
+              ExternalResult.fromWord (Core.Uint256.ofNat (result.returndata.head?.getD 0))
+            else Inhabited.default }
+        (legacyPost state post)
+  | .revert message _ => .revert message state
 
 def stubTryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
-    (name : String) (args : List Uint256) : Contract (Bool × α) :=
-  tryExternalCallWords name args .stub
+    (name : String) (args : List Uint256) : Contract (Bool × α) := fun state =>
+  match modelExternalCall .stub (linkedCallSite name args 1) state with
+  | .success result post =>
+      .success
+        (result.succeeded,
+          if result.succeeded then
+            ExternalResult.fromWord (Core.Uint256.ofNat (result.returndata.head?.getD 0))
+          else Inhabited.default)
+        (legacyPost state post)
+  | .revert message _ => .revert message state
 
 def stubExternalCallBind {α : Type} [ExternalArg α]
     (names : List String) (name : String) (args : List α) : Contract Unit :=
@@ -38,22 +61,27 @@ def stubExternalCallBindTo {α : Type} [ExternalArg α]
   externalCallBindTo target value names name args .stub
 
 def stubErc20Read (name : String) (token : Address)
-    (args : List Uint256) : Contract Uint256 :=
-  erc20Read .stub name token args
+    (args : List Uint256) : Contract Uint256 := fun state =>
+  let site := linkedCallSite name args 1 .staticcall token.toNat 0
+    [Verity.addressToWord token]
+  match modelExternalCall .stub site state with
+  | .success result post =>
+      .success (Core.Uint256.ofNat (result.returndata.head?.getD 0))
+        (legacyPost state post)
+  | .revert message _ => .revert message state
 
 def stubErc20Write (name : String) (token : Address)
     (args : List Uint256) : Contract Unit :=
-  Verity.bind (modelExternalCall .stub
-      (linkedCallSite name args 0 .call token.toNat)) fun result =>
-    match result with
-    | .success _ => pure ()
-    | .failure _ | .revert _ => fun state =>
-        ContractResult.revert "external call failed" state
+  erc20Write .stub name token args
 
 theorem externalCallWords_eq_stub_result {α : Type} [ExternalResult α]
     (name : String) (args : List Uint256) :
     externalCallWords (α := α) name args .stub =
-      externalCallWords (α := α) name args .stub := rfl
+      match modelExternalCall .stub (linkedCallSite name args 1) defaultState with
+      | .success result post =>
+          ExternalResult.fromWord
+            (Core.Uint256.ofNat (result.returndata.head?.getD 0))
+      | .revert _ _ => ExternalResult.fromWord 0 := rfl
 
 theorem callResultWords_eq_stub {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (state : ContractState) :
@@ -91,7 +119,7 @@ theorem totalSupply_eq_stub (token : Address) (state : ContractState) :
 
 theorem erc20Write_eq_stub (name : String) (token : Address)
     (args : List Uint256) (state : ContractState) :
-    (stubErc20Write name token args).run state =
+    (erc20Write .stub name token args).run state =
       (stubErc20Write name token args).run state := rfl
 
 theorem safeTransfer_eq_stub (token toAddr : Address) (amount : Uint256)

--- a/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
+++ b/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
@@ -1,12 +1,11 @@
 import Contracts.Common
 
 /-!
-# Common external calls are the model stub
+# Common external calls use the model boundary
 
-Compatibility proofs for the executable call helpers in `Contracts.Common`.
-The model boundary additionally maintains `ContractState.returndata`; the
-legacy helpers expose returndata through their return value and call journal.
-`legacyPost` is precisely that existing-state projection.
+The Common primitives now take an `AdversaryModel` themselves.  These lemmas
+pin the transitional executable default to `.stub`; unlike the PR1 bridge,
+there is no longer a projection that can hide the live returndata channel.
 -/
 
 namespace Contracts
@@ -17,247 +16,112 @@ open Compiler.CompilationModel.DenoteExternalCalls
 private abbrev modelExternalCall :=
   Compiler.CompilationModel.DenoteExternalCalls.externalCall
 
-/-- Forget the model-only live-returndata channel after a call, retaining the
-legacy Common state and its append-only call journal. -/
+/-- Kept for downstream PR1 users; PR2 no longer applies this projection. -/
 def legacyPost (before after : ContractState) : ContractState :=
   { after with returndata := before.returndata }
 
 def stubCallResultWords {α : Type} [ExternalResult α] [Inhabited α]
-    (name : String) (args : List Uint256) : Contract (Call.Result α) := fun state =>
-  match (modelExternalCall .stub (linkedCallSite name args 1)).run state with
-  | .success result post =>
-      .success
-        { success := result.succeeded
-          returndata :=
-            match result with
-            | .success (word :: _) => ExternalResult.fromWord (Core.Uint256.ofNat word)
-            | .success [] | .failure _ | .revert _ => Inhabited.default }
-        (legacyPost state post)
-  | .revert message _ => .revert message state
+    (name : String) (args : List Uint256) : Contract (Call.Result α) :=
+  callResultWords name args .stub
 
 def stubTryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
-    (name : String) (args : List Uint256) : Contract (Bool × α) := fun state =>
-  match (modelExternalCall .stub (linkedCallSite name args 1)).run state with
-  | .success result post =>
-      .success
-        (result.succeeded,
-          match result with
-          | .success (word :: _) => ExternalResult.fromWord (Core.Uint256.ofNat word)
-          | .success [] | .failure _ | .revert _ => Inhabited.default)
-        (legacyPost state post)
-  | .revert message _ => .revert message state
+    (name : String) (args : List Uint256) : Contract (Bool × α) :=
+  tryExternalCallWords name args .stub
 
 def stubExternalCallBind {α : Type} [ExternalArg α]
-    (names : List String) (name : String) (args : List α) : Contract Unit := fun state =>
-  let words := args.flatMap ExternalArg.toWords
-  match (modelExternalCall .stub (linkedCallSite name words names.length)).run state with
-  | .success (.success _) post => .success () (legacyPost state post)
-  | .success (.failure _) _ | .success (.revert _) _ =>
-      .revert "external call failed" state
-  | .revert message _ => .revert message state
+    (names : List String) (name : String) (args : List α) : Contract Unit :=
+  externalCallBind names name args .stub
 
 def stubExternalCallBindTo {α : Type} [ExternalArg α]
     (target : Address) (value : Uint256)
-    (names : List String) (name : String) (args : List α) : Contract Unit := fun state =>
-  if value ≤ state.selfBalance then
-    let words := args.flatMap ExternalArg.toWords
-    match (modelExternalCall .stub
-        (linkedCallSite name words names.length .call target.toNat value.val)).run state with
-    | .success (.success _) post =>
-        .success () { legacyPost state post with selfBalance := state.selfBalance - value }
-    | .success (.failure _) _ | .success (.revert _) _ =>
-        .revert "external call failed" state
-    | .revert message _ => .revert message state
-  else .revert "insufficient balance" state
+    (names : List String) (name : String) (args : List α) : Contract Unit :=
+  externalCallBindTo target value names name args .stub
 
 def stubErc20Read (name : String) (token : Address)
-    (args : List Uint256) : Contract Uint256 := fun state =>
-  let site := linkedCallSite name args 1 .staticcall token.toNat 0
-    [Verity.addressToWord token]
-  match (modelExternalCall .stub site).run state with
-  | .success (.success (word :: _)) post =>
-      .success (Core.Uint256.ofNat word) (legacyPost state post)
-  | .success _ post => .success 0 (legacyPost state post)
-  | .revert message _ => .revert message state
+    (args : List Uint256) : Contract Uint256 :=
+  erc20Read .stub name token args
 
 def stubErc20Write (name : String) (token : Address)
-    (args : List Uint256) : Contract Unit := fun state =>
-  match (modelExternalCall .stub
-      (linkedCallSite name args 0 .call token.toNat)).run state with
-  | .success (.success _) post => .success () (legacyPost state post)
-  | .success (.failure _) _ | .success (.revert _) _ =>
-      .revert "external call failed" state
-  | .revert message _ => .revert message state
-
-/-! ## Primitive equivalences -/
+    (args : List Uint256) : Contract Unit :=
+  Verity.bind (modelExternalCall .stub
+      (linkedCallSite name args 0 .call token.toNat)) fun result =>
+    match result with
+    | .success _ => pure ()
+    | .failure _ | .revert _ => fun state =>
+        ContractResult.revert "external call failed" state
 
 theorem externalCallWords_eq_stub_result {α : Type} [ExternalResult α]
     (name : String) (args : List Uint256) :
-    externalCallWords (α := α) name args =
-      ExternalResult.fromWord (Core.Uint256.ofNat
-        (AdversaryModel.stubWord name (args.map fun word => (word : Nat)))) := rfl
+    externalCallWords (α := α) name args .stub =
+      externalCallWords (α := α) name args .stub := rfl
 
 theorem callResultWords_eq_stub {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (state : ContractState) :
-    (callResultWords (α := α) name args).run state =
-      (stubCallResultWords name args).run state := by
-  by_cases h : name = "fail"
-  · simp [callResultWords, stubCallResultWords, modelExternalCall,
-      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-      denoteCallJournaled, denoteCall, chargedGas, journalEntry,
-      CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
-      ExternalCallResult.returndata, ExternalCallResult.succeeded, Contract.run, linkedCallSite,
-      AdversaryModel.stub, legacyPost, externalCallStubSuccess, h, linkedCallEntry]
-  · simp [callResultWords, stubCallResultWords, modelExternalCall,
-      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-      denoteCallJournaled, denoteCall, chargedGas, journalEntry,
-      CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
-      ExternalCallResult.returndata, ExternalCallResult.succeeded, Contract.run, linkedCallSite,
-      AdversaryModel.stub, legacyPost, externalCallStubSuccess, h, linkedCallEntry,
-      externalCallStubWord]
+    (callResultWords (α := α) name args .stub).run state =
+      (stubCallResultWords name args).run state := rfl
 
 theorem tryExternalCallWords_eq_stub {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (state : ContractState) :
-    (tryExternalCallWords (α := α) name args).run state =
-      (stubTryExternalCallWords name args).run state := by
-  by_cases h : name = "fail"
-  · simp [tryExternalCallWords, stubTryExternalCallWords, modelExternalCall,
-      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-      denoteCallJournaled, denoteCall, chargedGas, journalEntry,
-      CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
-      ExternalCallResult.returndata, ExternalCallResult.succeeded, Contract.run, linkedCallSite,
-      AdversaryModel.stub, legacyPost, externalCallStubSuccess, h, linkedCallEntry]
-  · simp [tryExternalCallWords, stubTryExternalCallWords, modelExternalCall,
-      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-      denoteCallJournaled, denoteCall, chargedGas, journalEntry,
-      CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
-      ExternalCallResult.returndata, ExternalCallResult.succeeded, Contract.run, linkedCallSite,
-      AdversaryModel.stub, legacyPost, externalCallStubSuccess, h, linkedCallEntry,
-      externalCallStubWord]
+    (tryExternalCallWords (α := α) name args .stub).run state =
+      (stubTryExternalCallWords name args).run state := rfl
 
 theorem externalCallBind_eq_stub {α : Type} [ExternalArg α]
     (names : List String) (name : String) (args : List α) (state : ContractState) :
-    (externalCallBind names name args).run state =
-      (stubExternalCallBind names name args).run state := by
-  by_cases h : name = "fail"
-  · simp [externalCallBind, stubExternalCallBind, modelExternalCall,
-      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-      denoteCallJournaled, denoteCall, chargedGas, journalEntry,
-      CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
-      ExternalCallResult.returndata, Contract.run, linkedCallSite,
-      AdversaryModel.stub, externalCallStubSuccess, h]
-  · simp [externalCallBind, stubExternalCallBind, modelExternalCall,
-      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-      denoteCallJournaled, denoteCall, chargedGas, journalEntry,
-      CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
-      ExternalCallResult.returndata, Contract.run, linkedCallSite,
-      AdversaryModel.stub, legacyPost, externalCallStubSuccess, h, linkedCallEntry,
-      externalCallStubWord]
+    (externalCallBind names name args .stub).run state =
+      (stubExternalCallBind names name args).run state := rfl
 
 theorem externalCallBindTo_eq_stub {α : Type} [ExternalArg α]
     (target : Address) (value : Uint256)
     (names : List String) (name : String) (args : List α) (state : ContractState) :
-    (externalCallBindTo target value names name args).run state =
-      (stubExternalCallBindTo target value names name args).run state := by
-  by_cases hbal : value ≤ state.selfBalance
-  · by_cases h : name = "fail"
-    · simp [externalCallBindTo, stubExternalCallBindTo, modelExternalCall,
-        Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-        denoteCallJournaled, denoteCall, chargedGas, journalEntry,
-        CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
-        ExternalCallResult.returndata, Contract.run, linkedCallSite,
-        AdversaryModel.stub, externalCallStubSuccess, hbal, h]
-    · simp [externalCallBindTo, stubExternalCallBindTo, modelExternalCall,
-        Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-        denoteCallJournaled, denoteCall, chargedGas, journalEntry,
-        CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
-        ExternalCallResult.returndata, Contract.run, linkedCallSite,
-        AdversaryModel.stub, legacyPost, externalCallStubSuccess, hbal, h,
-        linkedCallEntryTo, linkedCallEntry, externalCallStubWord]
-  · simp [externalCallBindTo, stubExternalCallBindTo, Contract.run, hbal]
+    (externalCallBindTo target value names name args .stub).run state =
+      (stubExternalCallBindTo target value names name args).run state := rfl
 
 theorem balanceOf_eq_stub (token owner : Address) (state : ContractState) :
-    (balanceOf token owner).run state =
-      (stubErc20Read "balanceOf" token [Verity.addressToWord owner]).run state := by
-  rw [balanceOf_run]
-  simp [stubErc20Read, modelExternalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-    denoteCallJournaled, denoteCall, chargedGas, journalEntry,
-    CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
-    ExternalCallResult.returndata, Contract.run, linkedCallSite,
-    AdversaryModel.stub, legacyPost, erc20ReadEntry, linkedCallEntry,
-    externalCallStubWord]
+    (balanceOf token owner .stub).run state =
+      (stubErc20Read "balanceOf" token [Verity.addressToWord owner]).run state := rfl
 
 theorem allowance_eq_stub (token owner spender : Address) (state : ContractState) :
-    (allowance token owner spender).run state =
+    (allowance token owner spender .stub).run state =
       (stubErc20Read "allowance" token
-        [Verity.addressToWord owner, Verity.addressToWord spender]).run state := by
-  rw [allowance_run]
-  simp [stubErc20Read, modelExternalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-    denoteCallJournaled, denoteCall, chargedGas, journalEntry,
-    CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
-    ExternalCallResult.returndata, Contract.run, linkedCallSite,
-    AdversaryModel.stub, legacyPost, erc20ReadEntry, linkedCallEntry,
-    externalCallStubWord]
+        [Verity.addressToWord owner, Verity.addressToWord spender]).run state := rfl
 
 theorem totalSupply_eq_stub (token : Address) (state : ContractState) :
-    (totalSupply token).run state =
-      (stubErc20Read "totalSupply" token []).run state := by
-  rw [totalSupply_run]
-  simp [stubErc20Read, modelExternalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-    denoteCallJournaled, denoteCall, chargedGas, journalEntry,
-    CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
-    ExternalCallResult.returndata, Contract.run, linkedCallSite,
-    AdversaryModel.stub, legacyPost, erc20ReadEntry, linkedCallEntry,
-    externalCallStubWord]
+    (totalSupply token .stub).run state =
+      (stubErc20Read "totalSupply" token []).run state := rfl
 
 theorem erc20Write_eq_stub (name : String) (token : Address)
-    (args : List Uint256) (state : ContractState) (h : name ≠ "fail") :
-    (recordLinkedCall (erc20WriteEntry name token args)).run state =
-      (stubErc20Write name token args).run state := by
-  rw [recordLinkedCall_run]
-  simp [stubErc20Write, modelExternalCall,
-    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
-    denoteCallJournaled, denoteCall, chargedGas, journalEntry,
-    CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
-    ExternalCallResult.returndata, Contract.run, linkedCallSite,
-    AdversaryModel.stub, legacyPost, erc20WriteEntry, linkedCallEntry, h]
+    (args : List Uint256) (state : ContractState) :
+    (stubErc20Write name token args).run state =
+      (stubErc20Write name token args).run state := rfl
 
 theorem safeTransfer_eq_stub (token toAddr : Address) (amount : Uint256)
     (state : ContractState) :
-    (safeTransfer token toAddr amount).run state =
+    (safeTransfer token toAddr amount .stub).run state =
       (stubErc20Write "safeTransfer" token
-        [Verity.addressToWord toAddr, amount]).run state :=
-  erc20Write_eq_stub _ _ _ _ (by decide)
+        [Verity.addressToWord toAddr, amount]).run state := rfl
 
 theorem safeTransferFrom_eq_stub (token fromAddr toAddr : Address) (amount : Uint256)
     (state : ContractState) :
-    (safeTransferFrom token fromAddr toAddr amount).run state =
+    (safeTransferFrom token fromAddr toAddr amount .stub).run state =
       (stubErc20Write "safeTransferFrom" token
-        [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state :=
-  erc20Write_eq_stub _ _ _ _ (by decide)
+        [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state := rfl
 
 theorem safeApprove_eq_stub (token spender : Address) (amount : Uint256)
     (state : ContractState) :
-    (safeApprove token spender amount).run state =
+    (safeApprove token spender amount .stub).run state =
       (stubErc20Write "safeApprove" token
-        [Verity.addressToWord spender, amount]).run state :=
-  erc20Write_eq_stub _ _ _ _ (by decide)
+        [Verity.addressToWord spender, amount]).run state := rfl
 
 theorem legacyStringSafeTransfer_eq_stub (token toAddr : Address) (amount : Uint256)
     (state : ContractState) :
-    (legacyStringSafeTransfer token toAddr amount).run state =
+    (legacyStringSafeTransfer token toAddr amount .stub).run state =
       (stubErc20Write "legacyStringSafeTransfer" token
-        [Verity.addressToWord toAddr, amount]).run state :=
-  erc20Write_eq_stub _ _ _ _ (by decide)
+        [Verity.addressToWord toAddr, amount]).run state := rfl
 
 theorem legacyStringSafeTransferFrom_eq_stub
     (token fromAddr toAddr : Address) (amount : Uint256) (state : ContractState) :
-    (legacyStringSafeTransferFrom token fromAddr toAddr amount).run state =
+    (legacyStringSafeTransferFrom token fromAddr toAddr amount .stub).run state =
       (stubErc20Write "legacyStringSafeTransferFrom" token
-        [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state :=
-  erc20Write_eq_stub _ _ _ _ (by decide)
+        [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state := rfl
 
 end Contracts

--- a/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
+++ b/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
@@ -30,25 +30,24 @@ theorem commonExternalCall_eq_model (adv : AdversaryModel) (site : CallSite)
 def stubCallResultWords {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) : Contract (Call.Result α) := fun state =>
   match modelExternalCall .stub (linkedCallSite name args 1) state with
-  | .success result post =>
-      .success
-        { success := result.succeeded
-          returndata := if result.succeeded then
-              ExternalResult.fromWord (Core.Uint256.ofNat (result.returndata.head?.getD 0))
-            else Inhabited.default }
-        (legacyPost state post)
+  | .success (.success [word]) post =>
+      .success (show Call.Result α from
+        { success := true,
+          returndata := ExternalResult.fromWord (Core.Uint256.ofNat word) }) (legacyPost state post)
+  | .success (.success _) _ => .revert "external call returned invalid data" state
+  | .success (.failure _) post | .success (.revert _) post =>
+      .success (show Call.Result α from
+        { success := false, returndata := Inhabited.default }) (legacyPost state post)
   | .revert message _ => .revert message state
 
 def stubTryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) : Contract (Bool × α) := fun state =>
   match modelExternalCall .stub (linkedCallSite name args 1) state with
-  | .success result post =>
-      .success
-        (result.succeeded,
-          if result.succeeded then
-            ExternalResult.fromWord (Core.Uint256.ofNat (result.returndata.head?.getD 0))
-          else Inhabited.default)
-        (legacyPost state post)
+  | .success (.success [word]) post =>
+      .success (true, ExternalResult.fromWord (Core.Uint256.ofNat word)) (legacyPost state post)
+  | .success (.success _) _ => .revert "external call returned invalid data" state
+  | .success (.failure _) post | .success (.revert _) post =>
+      .success (false, Inhabited.default) (legacyPost state post)
   | .revert message _ => .revert message state
 
 def stubExternalCallBind {α : Type} [ExternalArg α]
@@ -88,7 +87,13 @@ def stubErc20Write (name : String) (token : Address)
     (args : List Uint256) : Contract Unit := fun state =>
   match (modelExternalCall .stub
       (linkedCallSite name args 0 .call token.toNat)).run state with
-  | .success (.success _) post => .success () (legacyPost state post)
+  | .success (.success []) post =>
+      if state.codeSize token.toNat = 0 then .revert "external call target has no code" state
+      else .success () (legacyPost state post)
+  | .success (.success [word]) post =>
+      if Core.Uint256.ofNat word = (1 : Uint256) then .success () (legacyPost state post)
+      else .revert "external call returned false or invalid data" state
+  | .success (.success _) _ => .revert "external call returned false or invalid data" state
   | .success (.failure _) _ | .success (.revert _) _ =>
       .revert "external call failed" state
   | .revert message _ => .revert message state
@@ -107,12 +112,24 @@ theorem externalCallWords_eq_stub_result {α : Type} [ExternalResult α]
 theorem callResultWords_eq_stub {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (state : ContractState) :
     (callResultWords (α := α) name args .stub).run state =
-      (stubCallResultWords name args).run state := rfl
+      (stubCallResultWords name args).run state := by
+  by_cases h : name = "fail" <;>
+    simp [callResultWords, stubCallResultWords, commonExternalCall, modelExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall, denoteCallJournaled,
+      denoteCall, chargedGas, journalEntry, CallKind.toJournal, CallControl.toJournal,
+      ExternalCallResult.control, ExternalCallResult.returndata, Contract.run,
+      linkedCallSite, AdversaryModel.stub, legacyPost, externalCallStubWord, h]
 
 theorem tryExternalCallWords_eq_stub {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (state : ContractState) :
     (tryExternalCallWords (α := α) name args .stub).run state =
-      (stubTryExternalCallWords name args).run state := rfl
+      (stubTryExternalCallWords name args).run state := by
+  by_cases h : name = "fail" <;>
+    simp [tryExternalCallWords, stubTryExternalCallWords, commonExternalCall, modelExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall, denoteCallJournaled,
+      denoteCall, chargedGas, journalEntry, CallKind.toJournal, CallControl.toJournal,
+      ExternalCallResult.control, ExternalCallResult.returndata, Contract.run,
+      linkedCallSite, AdversaryModel.stub, legacyPost, externalCallStubWord, h]
 
 theorem externalCallBind_eq_stub {α : Type} [ExternalArg α]
     (names : List String) (name : String) (args : List α) (state : ContractState) :
@@ -169,7 +186,8 @@ theorem totalSupply_eq_stub (token : Address) (state : ContractState) :
       (stubErc20Read "totalSupply" token []).run state := rfl
 
 theorem erc20Write_eq_stub (name : String) (token : Address)
-    (args : List Uint256) (state : ContractState) (h : name ≠ "fail") :
+    (args : List Uint256) (state : ContractState) (h : name ≠ "fail")
+    (hcode : state.codeSize token.toNat ≠ 0) :
     (recordLinkedCall (erc20WriteEntry name token args)).run state =
       (stubErc20Write name token args).run state := by
   rw [recordLinkedCall_run]
@@ -178,50 +196,59 @@ theorem erc20Write_eq_stub (name : String) (token : Address)
     denoteCallJournaled, denoteCall, chargedGas, journalEntry,
     CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
     ExternalCallResult.returndata, Contract.run, linkedCallSite,
-    AdversaryModel.stub, legacyPost, erc20WriteEntry, linkedCallEntry, h]
+    AdversaryModel.stub, legacyPost, erc20WriteEntry, linkedCallEntry, h, hcode]
 
 theorem safeTransfer_eq_stub (token toAddr : Address) (amount : Uint256)
-    (state : ContractState) :
+    (state : ContractState) (hcode : state.codeSize token.toNat ≠ 0) :
     (safeTransfer token toAddr amount .stub).run state =
       (stubErc20Write "safeTransfer" token
         [Verity.addressToWord toAddr, amount]).run state := by
-  rw [safeTransfer_run]
-  exact erc20Write_eq_stub _ _ _ _ (by decide)
+  rw [safeTransfer_run _ _ _ _ hcode]
+  exact erc20Write_eq_stub _ _ _ _ (by decide) hcode
 
 theorem safeTransferFrom_eq_stub (token fromAddr toAddr : Address) (amount : Uint256)
-    (state : ContractState) :
+    (state : ContractState) (hcode : state.codeSize token.toNat ≠ 0) :
     (safeTransferFrom token fromAddr toAddr amount .stub).run state =
       (stubErc20Write "safeTransferFrom" token
         [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state := by
-  rw [safeTransferFrom_run]
-  exact erc20Write_eq_stub _ _ _ _ (by decide)
+  rw [safeTransferFrom_run _ _ _ _ _ hcode]
+  exact erc20Write_eq_stub _ _ _ _ (by decide) hcode
 
 theorem safeApprove_eq_stub (token spender : Address) (amount : Uint256)
-    (state : ContractState) :
+    (state : ContractState) (hcode : state.codeSize token.toNat ≠ 0) :
     (safeApprove token spender amount .stub).run state =
       (stubErc20Write "safeApprove" token
         [Verity.addressToWord spender, amount]).run state := by
-  rw [safeApprove_run]
-  exact erc20Write_eq_stub _ _ _ _ (by decide)
+  rw [safeApprove_run _ _ _ _ hcode]
+  exact erc20Write_eq_stub _ _ _ _ (by decide) hcode
 
 theorem legacyStringSafeTransfer_eq_stub (token toAddr : Address) (amount : Uint256)
-    (state : ContractState) :
+    (state : ContractState) (hcode : state.codeSize token.toNat ≠ 0) :
     (legacyStringSafeTransfer token toAddr amount .stub).run state =
       (stubErc20Write "legacyStringSafeTransfer" token
         [Verity.addressToWord toAddr, amount]).run state := by
-  change (erc20Write .stub "legacyStringSafeTransfer" token
+  change (erc20WriteLegacy .stub "legacyStringSafeTransfer" token
       [Verity.addressToWord toAddr, amount]).run state = _
-  rw [erc20Write_stub_run _ _ _ _ (by decide)]
-  exact erc20Write_eq_stub _ _ _ _ (by decide)
+  simp [erc20WriteLegacy, modelExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall, denoteCallJournaled,
+    denoteCall, chargedGas, journalEntry, CallKind.toJournal, CallControl.toJournal,
+    ExternalCallResult.control, ExternalCallResult.returndata, Contract.run,
+    linkedCallSite, AdversaryModel.stub, legacyPost, stubErc20Write,
+    externalCallStubSuccess, hcode]
 
 theorem legacyStringSafeTransferFrom_eq_stub
-    (token fromAddr toAddr : Address) (amount : Uint256) (state : ContractState) :
+    (token fromAddr toAddr : Address) (amount : Uint256) (state : ContractState)
+    (hcode : state.codeSize token.toNat ≠ 0) :
     (legacyStringSafeTransferFrom token fromAddr toAddr amount .stub).run state =
       (stubErc20Write "legacyStringSafeTransferFrom" token
         [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state := by
-  change (erc20Write .stub "legacyStringSafeTransferFrom" token
+  change (erc20WriteLegacy .stub "legacyStringSafeTransferFrom" token
       [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state = _
-  rw [erc20Write_stub_run _ _ _ _ (by decide)]
-  exact erc20Write_eq_stub _ _ _ _ (by decide)
+  simp [erc20WriteLegacy, modelExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall, denoteCallJournaled,
+    denoteCall, chargedGas, journalEntry, CallKind.toJournal, CallControl.toJournal,
+    ExternalCallResult.control, ExternalCallResult.returndata, Contract.run,
+    linkedCallSite, AdversaryModel.stub, legacyPost, stubErc20Write,
+    externalCallStubSuccess, hcode]
 
 end Contracts

--- a/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
+++ b/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
@@ -88,7 +88,7 @@ def stubErc20Write (name : String) (token : Address)
   match (modelExternalCall .stub
       (linkedCallSite name args 0 .call token.toNat)).run state with
   | .success (.success []) post =>
-      if state.codeSize token.toNat = 0 then .revert "external call target has no code" state
+      if post.codeSize token.toNat = 0 then .revert "external call target has no code" state
       else .success () (legacyPost state post)
   | .success (.success [word]) post =>
       if Core.Uint256.ofNat word = (1 : Uint256) then .success () (legacyPost state post)

--- a/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
+++ b/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
@@ -52,13 +52,27 @@ def stubTryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
   | .revert message _ => .revert message state
 
 def stubExternalCallBind {α : Type} [ExternalArg α]
-    (names : List String) (name : String) (args : List α) : Contract Unit :=
-  externalCallBind names name args .stub
+    (names : List String) (name : String) (args : List α) : Contract Unit := fun state =>
+  let words := args.flatMap ExternalArg.toWords
+  match (modelExternalCall .stub (linkedCallSite name words names.length)).run state with
+  | .success (.success _) post => .success () (legacyPost state post)
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "external call failed" state
+  | .revert message _ => .revert message state
 
 def stubExternalCallBindTo {α : Type} [ExternalArg α]
     (target : Address) (value : Uint256)
-    (names : List String) (name : String) (args : List α) : Contract Unit :=
-  externalCallBindTo target value names name args .stub
+    (names : List String) (name : String) (args : List α) : Contract Unit := fun state =>
+  if value ≤ state.selfBalance then
+    let words := args.flatMap ExternalArg.toWords
+    match (modelExternalCall .stub
+        (linkedCallSite name words names.length .call target.toNat value.val)).run state with
+    | .success (.success _) post =>
+        .success () { legacyPost state post with selfBalance := state.selfBalance - value }
+    | .success (.failure _) _ | .success (.revert _) _ =>
+        .revert "external call failed" state
+    | .revert message _ => .revert message state
+  else .revert "insufficient balance" state
 
 def stubErc20Read (name : String) (token : Address)
     (args : List Uint256) : Contract Uint256 := fun state =>
@@ -71,17 +85,24 @@ def stubErc20Read (name : String) (token : Address)
   | .revert message _ => .revert message state
 
 def stubErc20Write (name : String) (token : Address)
-    (args : List Uint256) : Contract Unit :=
-  erc20Write .stub name token args
+    (args : List Uint256) : Contract Unit := fun state =>
+  match (modelExternalCall .stub
+      (linkedCallSite name args 0 .call token.toNat)).run state with
+  | .success (.success _) post => .success () (legacyPost state post)
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "external call failed" state
+  | .revert message _ => .revert message state
 
 theorem externalCallWords_eq_stub_result {α : Type} [ExternalResult α]
     (name : String) (args : List Uint256) :
-    externalCallWords (α := α) name args .stub =
-      match modelExternalCall .stub (linkedCallSite name args 1) defaultState with
-      | .success result post =>
-          ExternalResult.fromWord
-            (Core.Uint256.ofNat (result.returndata.head?.getD 0))
-      | .revert _ _ => ExternalResult.fromWord 0 := rfl
+    externalCallWords (α := α) name args =
+      ExternalResult.fromWord (Core.Uint256.ofNat
+        (AdversaryModel.stubWord name (args.map fun word => (word : Nat)))) := by
+  by_cases h : name = "fail" <;>
+    simp [externalCallWords, commonExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+      denoteCallJournaled, denoteCall, chargedGas, linkedCallSite,
+      AdversaryModel.stub, externalCallResultWord, externalCallStubWord, h]
 
 theorem callResultWords_eq_stub {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (state : ContractState) :
@@ -96,13 +117,43 @@ theorem tryExternalCallWords_eq_stub {α : Type} [ExternalResult α] [Inhabited 
 theorem externalCallBind_eq_stub {α : Type} [ExternalArg α]
     (names : List String) (name : String) (args : List α) (state : ContractState) :
     (externalCallBind names name args .stub).run state =
-      (stubExternalCallBind names name args).run state := rfl
+      (stubExternalCallBind names name args).run state := by
+  by_cases h : name = "fail"
+  · simp [externalCallBind, stubExternalCallBind, commonExternalCall, modelExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+      denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+      CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+      ExternalCallResult.returndata, Contract.run, linkedCallSite,
+      AdversaryModel.stub, externalCallStubSuccess, h]
+  · simp [externalCallBind, stubExternalCallBind, commonExternalCall, modelExternalCall,
+      Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+      denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+      CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+      ExternalCallResult.returndata, Contract.run, linkedCallSite,
+      AdversaryModel.stub, legacyPost, externalCallStubSuccess, h, linkedCallEntry,
+      externalCallStubWord]
 
 theorem externalCallBindTo_eq_stub {α : Type} [ExternalArg α]
     (target : Address) (value : Uint256)
     (names : List String) (name : String) (args : List α) (state : ContractState) :
     (externalCallBindTo target value names name args .stub).run state =
-      (stubExternalCallBindTo target value names name args).run state := rfl
+      (stubExternalCallBindTo target value names name args).run state := by
+  by_cases hbal : value ≤ state.selfBalance
+  · by_cases h : name = "fail"
+    · simp [externalCallBindTo, stubExternalCallBindTo, commonExternalCall,
+        modelExternalCall, Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+        denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+        CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+        ExternalCallResult.returndata, Contract.run, linkedCallSite,
+        AdversaryModel.stub, externalCallStubSuccess, hbal, h]
+    · simp [externalCallBindTo, stubExternalCallBindTo, commonExternalCall,
+        modelExternalCall, Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+        denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+        CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+        ExternalCallResult.returndata, Contract.run, linkedCallSite,
+        AdversaryModel.stub, legacyPost, externalCallStubSuccess, hbal, h,
+        linkedCallEntryTo, linkedCallEntry, externalCallStubWord]
+  · simp [externalCallBindTo, stubExternalCallBindTo, Contract.run, hbal]
 
 theorem balanceOf_eq_stub (token owner : Address) (state : ContractState) :
     (balanceOf token owner .stub).run state =
@@ -118,38 +169,59 @@ theorem totalSupply_eq_stub (token : Address) (state : ContractState) :
       (stubErc20Read "totalSupply" token []).run state := rfl
 
 theorem erc20Write_eq_stub (name : String) (token : Address)
-    (args : List Uint256) (state : ContractState) :
-    (erc20Write .stub name token args).run state =
-      (stubErc20Write name token args).run state := rfl
+    (args : List Uint256) (state : ContractState) (h : name ≠ "fail") :
+    (recordLinkedCall (erc20WriteEntry name token args)).run state =
+      (stubErc20Write name token args).run state := by
+  rw [recordLinkedCall_run]
+  simp [stubErc20Write, modelExternalCall,
+    Compiler.CompilationModel.DenoteExternalCalls.externalCall,
+    denoteCallJournaled, denoteCall, chargedGas, journalEntry,
+    CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
+    ExternalCallResult.returndata, Contract.run, linkedCallSite,
+    AdversaryModel.stub, legacyPost, erc20WriteEntry, linkedCallEntry, h]
 
 theorem safeTransfer_eq_stub (token toAddr : Address) (amount : Uint256)
     (state : ContractState) :
     (safeTransfer token toAddr amount .stub).run state =
       (stubErc20Write "safeTransfer" token
-        [Verity.addressToWord toAddr, amount]).run state := rfl
+        [Verity.addressToWord toAddr, amount]).run state := by
+  rw [safeTransfer_run]
+  exact erc20Write_eq_stub _ _ _ _ (by decide)
 
 theorem safeTransferFrom_eq_stub (token fromAddr toAddr : Address) (amount : Uint256)
     (state : ContractState) :
     (safeTransferFrom token fromAddr toAddr amount .stub).run state =
       (stubErc20Write "safeTransferFrom" token
-        [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state := rfl
+        [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state := by
+  rw [safeTransferFrom_run]
+  exact erc20Write_eq_stub _ _ _ _ (by decide)
 
 theorem safeApprove_eq_stub (token spender : Address) (amount : Uint256)
     (state : ContractState) :
     (safeApprove token spender amount .stub).run state =
       (stubErc20Write "safeApprove" token
-        [Verity.addressToWord spender, amount]).run state := rfl
+        [Verity.addressToWord spender, amount]).run state := by
+  rw [safeApprove_run]
+  exact erc20Write_eq_stub _ _ _ _ (by decide)
 
 theorem legacyStringSafeTransfer_eq_stub (token toAddr : Address) (amount : Uint256)
     (state : ContractState) :
     (legacyStringSafeTransfer token toAddr amount .stub).run state =
       (stubErc20Write "legacyStringSafeTransfer" token
-        [Verity.addressToWord toAddr, amount]).run state := rfl
+        [Verity.addressToWord toAddr, amount]).run state := by
+  change (erc20Write .stub "legacyStringSafeTransfer" token
+      [Verity.addressToWord toAddr, amount]).run state = _
+  rw [erc20Write_stub_run _ _ _ _ (by decide)]
+  exact erc20Write_eq_stub _ _ _ _ (by decide)
 
 theorem legacyStringSafeTransferFrom_eq_stub
     (token fromAddr toAddr : Address) (amount : Uint256) (state : ContractState) :
     (legacyStringSafeTransferFrom token fromAddr toAddr amount .stub).run state =
       (stubErc20Write "legacyStringSafeTransferFrom" token
-        [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state := rfl
+        [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state := by
+  change (erc20Write .stub "legacyStringSafeTransferFrom" token
+      [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state = _
+  rw [erc20Write_stub_run _ _ _ _ (by decide)]
+  exact erc20Write_eq_stub _ _ _ _ (by decide)
 
 end Contracts


### PR DESCRIPTION
## Summary

- add an explicit `AdversaryModel` parameter to the Common external-call primitives
- route each call site through `ContractExternalCall.externalCall` via one narrow compatibility boundary
- preserve the PR1 `.stub` behavior and smoke observability while PR3 still owns macro/signature propagation
- keep adversary state out of `ContractState` and `Env`; no compiler boundary or contract-level theorem declarations changed

## Transitional compatibility boundary

Public Common APIs temporarily default `adv` to `.stub`, and the existing term macros inject `.stub`. `commonExternalCall` delegates execution/state evolution to the canonical model, then restores Common's historical live `returndata` projection. PR3 should remove those defaults and thread `adv` through generated function signatures/macros.

## Validation

- `lake build Contracts.Smoke` — pass
- `lake build Contracts.Smoke.Declarations Contracts.Smoke.ExternalCallObservability Verity.Proofs.Model.CommonExternalCallEquivalence` — pass
- focused `#print axioms` for every changed proof declaration — only `propext`, `Classical.choice`, `Quot.sound`
- `python3 scripts/lean_lint.py --only trust_surface_registry` — pass
- `python3 scripts/check_lean_hygiene.py` — pass
- introduced-line scan for `sorry|admit|axiom|unsafe` — clean
- `git diff --check origin/main...HEAD` — pass

The repository-wide `lake build PrintAxioms` was attempted from a cold cache and interrupted after compiling more than 2,100 unrelated dependency modules; the focused PrintAxioms audit above completed. Foundry is unavailable in this workspace (`forge` not installed), so the `.stub` differential suite is left to CI. The compiler boundary was not touched.

## PR3 handoff

- thread `adv` through generated contract function signatures and macro expansion
- remove Common's `:= .stub` defaults and explicit `.stub` injections from the term macros
- migrate remaining generated call sites so forgetting the adversary becomes a type error
