### PR TITLE
refactor(macro): thread adversary through external calls

### DIFF
--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -692,8 +692,9 @@ def matchBranchesContainExternalCall (branches : List (String × List String × 
     `delegatecall`) stays window-opening: it reaches an external contract that
     may re-enter. -/
 def stmtReentrancyWindowNode : Stmt → Bool
-  | Stmt.ecm mod _ =>
-      mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.call
+  | Stmt.ecm mod args =>
+      mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.call ||
+        args.any exprContainsExternalCall
   | s => stmtContainsExternalCallNode s
 
 /-- Whether a statement (deeply) opens a cross-function reentrancy window. -/

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -579,7 +579,7 @@ def snapshotBalanceExecutableNeedsNoAdversary : Bool :=
   let token := Verity.wordToAddress 7
   let owner := Verity.wordToAddress 13
   match Contracts.balanceOf token owner .stub Verity.defaultState,
-      MacroERC20.snapshotBalance .stub token owner Verity.defaultState with
+      MacroERC20.snapshotBalance token owner Verity.defaultState with
   | .success expected _, .success balance state =>
       balance == expected &&
       state.storage 0 == expected &&
@@ -594,7 +594,7 @@ def snapshotAllowanceExecutableNeedsNoAdversary : Bool :=
   let owner := Verity.wordToAddress 13
   let spender := Verity.wordToAddress 17
   match Contracts.allowance token owner spender .stub Verity.defaultState,
-      MacroERC20.snapshotAllowance .stub token owner spender Verity.defaultState with
+      MacroERC20.snapshotAllowance token owner spender Verity.defaultState with
   | .success expected _, .success current state =>
       current == expected &&
       state.storage 1 == expected &&
@@ -607,7 +607,7 @@ example : snapshotAllowanceExecutableNeedsNoAdversary = true := by native_decide
 def snapshotSupplyExecutableNeedsNoAdversary : Bool :=
   let token := Verity.wordToAddress 7
   match Contracts.totalSupply token .stub Verity.defaultState,
-      MacroERC20.snapshotSupply .stub token Verity.defaultState with
+      MacroERC20.snapshotSupply token Verity.defaultState with
   | .success expected _, .success supply state =>
       supply == expected &&
       state.storage 2 == expected

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -258,18 +258,13 @@ def recoverSignerModelUsesEcrecoverEcm : Bool :=
 
 example : recoverSignerModelUsesEcrecoverEcm = true := by native_decide
 
-def recoverSignerExecutableUsesOracle : Bool :=
-  let adversary : DenoteExternalCalls.AdversaryModel := {
-    stateTransition := fun _ state => state
-    result := fun _ _ => .success [107]
-    gasUsed := fun _ _ => 0
-  }
-  match MacroEcrecover.recoverSigner adversary 10 27 30 40 Verity.defaultState with
-  | .success signer state =>
-      signer == Verity.wordToAddress 107 && state.sender == Verity.defaultState.sender
+def recoverSignerExecutableNeedsNoAdversary : Bool :=
+  match MacroEcrecover.recoverSigner 10 27 30 40 Verity.defaultState with
+  | .success _ state =>
+      state.sender == Verity.defaultState.sender
   | .revert _ _ => false
 
-example : recoverSignerExecutableUsesOracle = true := by native_decide
+example : recoverSignerExecutableNeedsNoAdversary = true := by native_decide
 
 end MacroEcrecoverSmoke
 
@@ -580,11 +575,11 @@ def snapshotSupplyModelUsesTotalSupplyModule : Bool :=
 
 example : snapshotSupplyModelUsesTotalSupplyModule = true := by native_decide
 
-def snapshotBalanceExecutableUsesStub : Bool :=
+def snapshotBalanceExecutableNeedsNoAdversary : Bool :=
   let token := Verity.wordToAddress 7
   let owner := Verity.wordToAddress 13
   match Contracts.balanceOf token owner .stub Verity.defaultState,
-      MacroERC20.snapshotBalance .stub token owner Verity.defaultState with
+      MacroERC20.snapshotBalance token owner Verity.defaultState with
   | .success expected _, .success balance state =>
       balance == expected &&
       state.storage 0 == expected &&
@@ -592,14 +587,14 @@ def snapshotBalanceExecutableUsesStub : Bool :=
   | .revert _ _, _ => false
   | _, .revert _ _ => false
 
-example : snapshotBalanceExecutableUsesStub = true := by native_decide
+example : snapshotBalanceExecutableNeedsNoAdversary = true := by native_decide
 
-def snapshotAllowanceExecutableUsesStub : Bool :=
+def snapshotAllowanceExecutableNeedsNoAdversary : Bool :=
   let token := Verity.wordToAddress 7
   let owner := Verity.wordToAddress 13
   let spender := Verity.wordToAddress 17
   match Contracts.allowance token owner spender .stub Verity.defaultState,
-      MacroERC20.snapshotAllowance .stub token owner spender Verity.defaultState with
+      MacroERC20.snapshotAllowance token owner spender Verity.defaultState with
   | .success expected _, .success current state =>
       current == expected &&
       state.storage 1 == expected &&
@@ -607,19 +602,19 @@ def snapshotAllowanceExecutableUsesStub : Bool :=
   | .revert _ _, _ => false
   | _, .revert _ _ => false
 
-example : snapshotAllowanceExecutableUsesStub = true := by native_decide
+example : snapshotAllowanceExecutableNeedsNoAdversary = true := by native_decide
 
-def snapshotSupplyExecutableUsesStub : Bool :=
+def snapshotSupplyExecutableNeedsNoAdversary : Bool :=
   let token := Verity.wordToAddress 7
   match Contracts.totalSupply token .stub Verity.defaultState,
-      MacroERC20.snapshotSupply .stub token Verity.defaultState with
+      MacroERC20.snapshotSupply token Verity.defaultState with
   | .success expected _, .success supply state =>
       supply == expected &&
       state.storage 2 == expected
   | .revert _ _, _ => false
   | _, .revert _ _ => false
 
-example : snapshotSupplyExecutableUsesStub = true := by native_decide
+example : snapshotSupplyExecutableNeedsNoAdversary = true := by native_decide
 
 end MacroERC20Smoke
 

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -185,13 +185,18 @@ def forwardCarriesProxyBoundary : Bool :=
 example : forwardCarriesProxyBoundary = true := by native_decide
 
 def forwardExecutableReadsImplementation : Bool :=
+  let adversary : DenoteExternalCalls.AdversaryModel := {
+    stateTransition := fun _ state => state
+    result := fun _ _ => .success []
+    gasUsed := fun _ _ => 0
+  }
   let seededState :=
     (ProxyUpgradeabilityMacroSmoke.initProxy (Verity.wordToAddress 11) (Verity.wordToAddress 19)).run Verity.defaultState
   match seededState with
   | .success _ state =>
-      match ProxyUpgradeabilityMacroSmoke.forward .stub 100 0 32 64 32 state with
+      match ProxyUpgradeabilityMacroSmoke.forward adversary 100 0 32 64 32 state with
       | .success ok nextState =>
-          ok == delegatecall 100 19 0 32 64 32 &&
+          ok == 1 &&
             nextState.storage ProxyUpgradeabilityMacroSmoke.initializedVersion.slot == 1 &&
             nextState.storageAddr ProxyUpgradeabilityMacroSmoke.admin.slot == Verity.wordToAddress 11 &&
             nextState.storageAddr ProxyUpgradeabilityMacroSmoke.implementation.slot == Verity.wordToAddress 19
@@ -254,7 +259,12 @@ def recoverSignerModelUsesEcrecoverEcm : Bool :=
 example : recoverSignerModelUsesEcrecoverEcm = true := by native_decide
 
 def recoverSignerExecutableUsesOracle : Bool :=
-  match MacroEcrecover.recoverSigner 10 27 30 40 Verity.defaultState with
+  let adversary : DenoteExternalCalls.AdversaryModel := {
+    stateTransition := fun _ state => state
+    result := fun _ _ => .success [107]
+    gasUsed := fun _ _ => 0
+  }
+  match MacroEcrecover.recoverSigner adversary 10 27 30 40 Verity.defaultState with
   | .success signer state =>
       signer == Verity.wordToAddress 107 && state.sender == Verity.defaultState.sender
   | .revert _ _ => false
@@ -574,7 +584,7 @@ def snapshotBalanceExecutableUsesStub : Bool :=
   let token := Verity.wordToAddress 7
   let owner := Verity.wordToAddress 13
   match Contracts.balanceOf token owner .stub Verity.defaultState,
-      MacroERC20.snapshotBalance token owner Verity.defaultState with
+      MacroERC20.snapshotBalance .stub token owner Verity.defaultState with
   | .success expected _, .success balance state =>
       balance == expected &&
       state.storage 0 == expected &&
@@ -589,7 +599,7 @@ def snapshotAllowanceExecutableUsesStub : Bool :=
   let owner := Verity.wordToAddress 13
   let spender := Verity.wordToAddress 17
   match Contracts.allowance token owner spender .stub Verity.defaultState,
-      MacroERC20.snapshotAllowance token owner spender Verity.defaultState with
+      MacroERC20.snapshotAllowance .stub token owner spender Verity.defaultState with
   | .success expected _, .success current state =>
       current == expected &&
       state.storage 1 == expected &&
@@ -602,7 +612,7 @@ example : snapshotAllowanceExecutableUsesStub = true := by native_decide
 def snapshotSupplyExecutableUsesStub : Bool :=
   let token := Verity.wordToAddress 7
   match Contracts.totalSupply token .stub Verity.defaultState,
-      MacroERC20.snapshotSupply token Verity.defaultState with
+      MacroERC20.snapshotSupply .stub token Verity.defaultState with
   | .success expected _, .success supply state =>
       supply == expected &&
       state.storage 2 == expected

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -189,7 +189,7 @@ def forwardExecutableReadsImplementation : Bool :=
     (ProxyUpgradeabilityMacroSmoke.initProxy (Verity.wordToAddress 11) (Verity.wordToAddress 19)).run Verity.defaultState
   match seededState with
   | .success _ state =>
-      match ProxyUpgradeabilityMacroSmoke.forward 100 0 32 64 32 state with
+      match ProxyUpgradeabilityMacroSmoke.forward .stub 100 0 32 64 32 state with
       | .success ok nextState =>
           ok == delegatecall 100 19 0 32 64 32 &&
             nextState.storage ProxyUpgradeabilityMacroSmoke.initializedVersion.slot == 1 &&
@@ -352,7 +352,7 @@ def storeEchoModelUsesDeclaredExternal : Bool :=
 example : storeEchoModelUsesDeclaredExternal = true := by native_decide
 
 def storeEchoExecutableUsesStub : Bool :=
-  match MacroExternal.storeEcho 33 Verity.defaultState with
+  match MacroExternal.storeEcho .stub 33 Verity.defaultState with
   | .success () state =>
       state.storage 0 == 33
   | .revert _ _ => false

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -259,7 +259,7 @@ def recoverSignerModelUsesEcrecoverEcm : Bool :=
 example : recoverSignerModelUsesEcrecoverEcm = true := by native_decide
 
 def recoverSignerExecutableNeedsNoAdversary : Bool :=
-  match MacroEcrecover.recoverSigner .stub 10 27 30 40 Verity.defaultState with
+  match MacroEcrecover.recoverSigner 10 27 30 40 Verity.defaultState with
   | .success _ state =>
       state.sender == Verity.defaultState.sender
   | .revert _ _ => false

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -259,7 +259,7 @@ def recoverSignerModelUsesEcrecoverEcm : Bool :=
 example : recoverSignerModelUsesEcrecoverEcm = true := by native_decide
 
 def recoverSignerExecutableNeedsNoAdversary : Bool :=
-  match MacroEcrecover.recoverSigner 10 27 30 40 Verity.defaultState with
+  match MacroEcrecover.recoverSigner .stub 10 27 30 40 Verity.defaultState with
   | .success _ state =>
       state.sender == Verity.defaultState.sender
   | .revert _ _ => false
@@ -579,7 +579,7 @@ def snapshotBalanceExecutableNeedsNoAdversary : Bool :=
   let token := Verity.wordToAddress 7
   let owner := Verity.wordToAddress 13
   match Contracts.balanceOf token owner .stub Verity.defaultState,
-      MacroERC20.snapshotBalance token owner Verity.defaultState with
+      MacroERC20.snapshotBalance .stub token owner Verity.defaultState with
   | .success expected _, .success balance state =>
       balance == expected &&
       state.storage 0 == expected &&
@@ -594,7 +594,7 @@ def snapshotAllowanceExecutableNeedsNoAdversary : Bool :=
   let owner := Verity.wordToAddress 13
   let spender := Verity.wordToAddress 17
   match Contracts.allowance token owner spender .stub Verity.defaultState,
-      MacroERC20.snapshotAllowance token owner spender Verity.defaultState with
+      MacroERC20.snapshotAllowance .stub token owner spender Verity.defaultState with
   | .success expected _, .success current state =>
       current == expected &&
       state.storage 1 == expected &&
@@ -607,7 +607,7 @@ example : snapshotAllowanceExecutableNeedsNoAdversary = true := by native_decide
 def snapshotSupplyExecutableNeedsNoAdversary : Bool :=
   let token := Verity.wordToAddress 7
   match Contracts.totalSupply token .stub Verity.defaultState,
-      MacroERC20.snapshotSupply token Verity.defaultState with
+      MacroERC20.snapshotSupply .stub token Verity.defaultState with
   | .success expected _, .success supply state =>
       supply == expected &&
       state.storage 2 == expected

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -527,6 +527,16 @@ instance : ExternalArg Address where
   toWords value := [value.toNat]
 instance : ExternalArg Bool where
   toWords value := [if value then 1 else 0]
+instance : ExternalArg Nat where
+  toWords value := [value]
+/-- Canonical first-word projection used when a word-like source expression
+is consumed by an executable helper whose Lean API takes `Uint256`. -/
+def externalArgWord {α : Type} [ExternalArg α] (value : α) : Uint256 :=
+  (ExternalArg.toWords value).head?.getD 0
+
+/-- Address view of the canonical external-argument word. -/
+def externalArgAddress {α : Type} [ExternalArg α] (value : α) : Address :=
+  wordToAddress (externalArgWord value)
 instance [ExternalArg α] : ExternalArg (Array α) where
   toWords values := values.size :: (values.toList.flatMap ExternalArg.toWords)
 instance : ExternalArg ByteArray where

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -646,23 +646,25 @@ def commonExternalCall (adv : AdversaryModel)
 caller's explicit adversary; unlike the old syntax fallback this crosses the
 same journaled call boundary as every other Common external-call primitive. -/
 def evmCallWords (adv : AdversaryModel) (gas target value inOffset inSize outOffset outSize : Uint256) :
-    Uint256 :=
-  let result := (commonExternalCall adv {
+    Contract Uint256 := do
+  let result ← commonExternalCall adv {
+      siteId := target.val
       kind := .call
-      target := target.toNat
+      target := target.val
       value := value.val
       gas := gas.val
-      calldata := [inOffset.val, inSize.val, outOffset.val, outSize.val] }).run defaultState |>.fst
-  if result.succeeded then 1 else 0
+      calldata := [inOffset.val, inSize.val, outOffset.val, outSize.val] }
+  pure (if result.succeeded then 1 else 0)
 
 def evmStaticCallWords (adv : AdversaryModel)
-    (gas target inOffset inSize outOffset outSize : Uint256) : Uint256 :=
-  let result := (commonExternalCall adv {
+    (gas target inOffset inSize outOffset outSize : Uint256) : Contract Uint256 := do
+  let result ← commonExternalCall adv {
+      siteId := target.val
       kind := .staticcall
-      target := target.toNat
+      target := target.val
       gas := gas.val
-      calldata := [inOffset.val, inSize.val, outOffset.val, outSize.val] }).run defaultState |>.fst
-  if result.succeeded then 1 else 0
+      calldata := [inOffset.val, inSize.val, outOffset.val, outSize.val] }
+  pure (if result.succeeded then 1 else 0)
 
 @[simp] theorem commonExternalCall_apply (adv : AdversaryModel)
     (site : Compiler.CompilationModel.DenoteExternalCalls.CallSite)
@@ -684,6 +686,19 @@ def externalCallWords {α : Type} [ExternalResult α] (name : String) (args : Li
   | .success (.failure _) _ | .success (.revert _) _ =>
       ExternalResult.fromWord (externalCallStubWord name args)
   | .revert _ _ => ExternalResult.fromWord (externalCallStubWord name args)
+
+def externalCallContractWords {α : Type} [ExternalResult α]
+    (name : String) (args : List Uint256) (adv : AdversaryModel) : Contract α := do
+  let result ← commonExternalCall adv (linkedCallSite name args 1)
+  pure (ExternalResult.fromWord (externalCallResultWord result))
+
+def externalCallEffectWords
+    (name : String) (args : List Uint256) (adv : AdversaryModel) : Contract Unit :=
+  Verity.bind (commonExternalCall adv (linkedCallSite name args 0)) fun result =>
+    match result with
+    | .success _ => pure ()
+    | .failure _ | .revert _ => fun state =>
+        ContractResult.revert "external call failed" state
 
 def failedExternalResult {α : Type} [ExternalResult α] [Inhabited α] : List Nat → α
   | [] => Inhabited.default

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -804,6 +804,10 @@ def ecmCallWords (adv : AdversaryModel) (args : List Uint256)
     (siteId : Nat := 0) : Contract Uint256 :=
   externalCallContractWords (α := Uint256) "ecm" args adv 1 siteId
 
+def ecmCallPairWords (adv : AdversaryModel) (args : List Uint256)
+    (siteId : Nat := 0) : Contract (Uint256 × Uint256) :=
+  externalCallContractWords (α := Uint256 × Uint256) "ecm" args adv 2 siteId
+
 def ecmDoWords (adv : AdversaryModel) (args : List Uint256)
     (siteId : Nat := 0) : Contract Unit :=
   externalCallEffectWords "ecm" args adv siteId

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -3,6 +3,7 @@ import Compiler.Proofs.MappingSlot
 import Verity.Core
 import Verity.Core.Semantics
 import Verity.Core.Model.ContractExternalCall
+import Verity.Core.Model.DenoteFunctionCalls
 import Verity.EVM.Uint256
 import Verity.Macro
 import Verity.Stdlib.Math
@@ -589,8 +590,8 @@ argument-word list in call order, so a call with omitted, reordered, or
 altered arguments journals a different entry. -/
 def linkedCallEntry (name : String) (argWords : List Uint256)
     (control : ExternalCallControl := .success)
-    (returndata : List Nat := []) : ExternalCall :=
-  { siteId := 0
+    (returndata : List Nat := []) (siteId : Nat := 0) : ExternalCall :=
+  { siteId := siteId
     kind := .call
     target := 0
     value := 0
@@ -611,9 +612,10 @@ def linkedCallEntryTo (name : String) (target : Address) (value : Uint256)
 /-- Model call site corresponding to one executable linked-call crossing. -/
 def linkedCallSite (name : String) (argWords : List Uint256)
     (returnArity : Nat := 0) (kind : Compiler.CompilationModel.DenoteExternalCalls.CallKind := .call)
-    (target : Nat := 0) (value : Nat := 0) (stubPrefix : List Nat := []) :
+    (target : Nat := 0) (value : Nat := 0) (stubPrefix : List Nat := [])
+    (siteId : Nat := 0) :
     Compiler.CompilationModel.DenoteExternalCalls.CallSite :=
-  { siteId := 0, kind, target, value
+  { siteId, kind, target, value
     calldata := argWords.map (fun word => (word : Nat))
     name, returnArity, stubPrefix, gas := 0 }
 
@@ -631,35 +633,73 @@ private abbrev ExternalCallResult :=
 def externalCallResultWord (result : ExternalCallResult) : Uint256 :=
   Core.Uint256.ofNat (result.returndata.head?.getD 0)
 
-/-- Common external calls use the canonical journaled source-level boundary. -/
+/-- Common external calls use the canonical journaled source-level boundary
+(`Verity.Core.Model.ContractExternalCall.externalCall`). -/
 def commonExternalCall (adv : AdversaryModel)
     (site : Compiler.CompilationModel.DenoteExternalCalls.CallSite) :
     Contract ExternalCallResult :=
   Compiler.CompilationModel.DenoteExternalCalls.externalCall adv site
 
-/-- Executable result of a raw mutable EVM call.  The macro supplies the
-caller's explicit adversary; unlike the old syntax fallback this crosses the
-same journaled call boundary as every other Common external-call primitive. -/
-def evmCallWords (adv : AdversaryModel) (gas target value inOffset inSize outOffset outSize : Uint256) :
-    Contract Uint256 := do
-  let result ← commonExternalCall adv {
-      siteId := target.val
-      kind := .call
-      target := target.val
-      value := value.val
-      gas := gas.val
-      calldata := [inOffset.val, inSize.val, outOffset.val, outSize.val] }
-  pure (if result.succeeded then 1 else 0)
+private def evmCalldata (state : ContractState) (inOffset inSize : Uint256) : List Nat :=
+  Compiler.CompilationModel.DenoteFunctionCalls.readMemoryWords
+    state.memory inOffset.val inSize.val
+
+private def evmWriteOutput (state : ContractState) (outOffset outSize : Uint256)
+    (data : List Nat) : ContractState :=
+  { state with
+    memory := Compiler.CompilationModel.DenoteFunctionCalls.writeMemoryWords
+      state.memory outOffset.val data outSize.val }
+
+/-- Executable result of a raw mutable EVM call. Mirrors `applyRawCall`:
+calldata is read from caller memory, value is debited before the adversary
+runs, successful returndata is copied to the output region, and an unfunded
+call returns bit 0 with an empty buffer without invoking the adversary. -/
+def evmCallWords (adv : AdversaryModel)
+    (gas target value inOffset inSize outOffset outSize : Uint256) :
+    Contract Uint256 := fun state =>
+  match Compiler.CompilationModel.DenoteFunctionCalls.debitSelfBalance state value.val with
+  | none =>
+      ContractResult.success 0 { state with returndata := [] }
+  | some paid =>
+      let site : Compiler.CompilationModel.DenoteExternalCalls.CallSite :=
+        { siteId := target.val, kind := .call, target := target.val
+          value := value.val, calldata := evmCalldata state inOffset inSize
+          gas := gas.val }
+      match (commonExternalCall adv site).run paid with
+      | .success (.success data) post =>
+          ContractResult.success 1 (evmWriteOutput post outOffset outSize data)
+      | .success (.failure _) post | .success (.revert _) post =>
+          ContractResult.success 0
+            { state with calls := post.calls, returndata := post.returndata }
+      | .revert message _ => ContractResult.revert message state
 
 def evmStaticCallWords (adv : AdversaryModel)
-    (gas target inOffset inSize outOffset outSize : Uint256) : Contract Uint256 := do
-  let result ← commonExternalCall adv {
-      siteId := target.val
-      kind := .staticcall
-      target := target.val
-      gas := gas.val
-      calldata := [inOffset.val, inSize.val, outOffset.val, outSize.val] }
-  pure (if result.succeeded then 1 else 0)
+    (gas target inOffset inSize outOffset outSize : Uint256) : Contract Uint256 :=
+  fun state =>
+    let site : Compiler.CompilationModel.DenoteExternalCalls.CallSite :=
+      { siteId := target.val, kind := .staticcall, target := target.val
+        value := 0, calldata := evmCalldata state inOffset inSize, gas := gas.val }
+    match (commonExternalCall adv site).run state with
+    | .success (.success data) post =>
+        ContractResult.success 1 (evmWriteOutput post outOffset outSize data)
+    | .success (.failure _) post | .success (.revert _) post =>
+        ContractResult.success 0
+          { state with calls := post.calls, returndata := post.returndata }
+    | .revert message _ => ContractResult.revert message state
+
+def evmDelegateCallWords (adv : AdversaryModel)
+    (gas target inOffset inSize outOffset outSize : Uint256) : Contract Uint256 :=
+  fun state =>
+    let site : Compiler.CompilationModel.DenoteExternalCalls.CallSite :=
+      { siteId := target.val, kind := .delegatecall, target := target.val
+        value := 0, calldata := evmCalldata state inOffset inSize, gas := gas.val }
+    match (commonExternalCall adv site).run state with
+    | .success (.success data) post =>
+        ContractResult.success 1 (evmWriteOutput post outOffset outSize data)
+    | .success (.failure _) post | .success (.revert _) post =>
+        ContractResult.success 0
+          { state with calls := post.calls, returndata := post.returndata }
+    | .revert message _ => ContractResult.revert message state
 
 @[simp] theorem commonExternalCall_apply (adv : AdversaryModel)
     (site : Compiler.CompilationModel.DenoteExternalCalls.CallSite)
@@ -671,12 +711,12 @@ def evmStaticCallWords (adv : AdversaryModel)
           returndata := (adv.result site state).returndata.map
             Compiler.CompilationModel.Denote.wordNormalize } := rfl
 
-/-- Expression-position projection used by generated external-call bodies.
-The adversary is explicit at generated call sites; transitional handwritten
-callers may continue to use the PR2 `.stub` default. -/
+/-- Expression-position projection used only by non-window `.stub` bodies.
+Generated window-opening calls hoist to `externalCallContractWords` so the
+adversary observes the live caller state. -/
 def externalCallWords {α : Type} [ExternalResult α] (name : String) (args : List Uint256)
-    (adv : AdversaryModel := .stub) : α :=
-  match commonExternalCall adv (linkedCallSite name args 1) defaultState with
+    (adv : AdversaryModel := .stub) (arity : Nat := 1) (siteId : Nat := 0) : α :=
+  match commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId) defaultState with
   | .success (.success returndata) _ =>
       ExternalResult.fromWord (Core.Uint256.ofNat (returndata.head?.getD 0))
   | .success (.failure _) _ | .success (.revert _) _ =>
@@ -684,13 +724,22 @@ def externalCallWords {α : Type} [ExternalResult α] (name : String) (args : Li
   | .revert _ _ => ExternalResult.fromWord (externalCallStubWord name args)
 
 def externalCallContractWords {α : Type} [ExternalResult α]
-    (name : String) (args : List Uint256) (adv : AdversaryModel) : Contract α := do
-  let result ← commonExternalCall adv (linkedCallSite name args 1)
-  pure (ExternalResult.fromWord (externalCallResultWord result))
+    (name : String) (args : List Uint256) (adv : AdversaryModel := .stub)
+    (arity : Nat := 1) (siteId : Nat := 0) : Contract α := fun state =>
+  match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run state with
+  | .success (.success returndata) post =>
+      if returndata.length < arity then
+        .revert "external call returned insufficient data" state
+      else
+        .success (ExternalResult.fromWord (Core.Uint256.ofNat (returndata.head?.getD 0))) post
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "external call failed" state
+  | .revert message _ => .revert message state
 
 def externalCallEffectWords
-    (name : String) (args : List Uint256) (adv : AdversaryModel) : Contract Unit :=
-  Verity.bind (commonExternalCall adv (linkedCallSite name args 0)) fun result =>
+    (name : String) (args : List Uint256) (adv : AdversaryModel := .stub)
+    (siteId : Nat := 0) : Contract Unit :=
+  Verity.bind (commonExternalCall adv (linkedCallSite name args 0 .call 0 0 [] siteId)) fun result =>
     match result with
     | .success _ => pure ()
     | .failure _ | .revert _ => fun state =>
@@ -701,32 +750,42 @@ def failedExternalResult {α : Type} [ExternalResult α] [Inhabited α] : List N
   | word :: _ => ExternalResult.fromWord (Core.Uint256.ofNat word)
 
 def callResultWords {α : Type} [ExternalResult α] [Inhabited α]
-    (name : String) (args : List Uint256) (adv : AdversaryModel := .stub) : Contract (Call.Result α) :=
+    (name : String) (args : List Uint256) (adv : AdversaryModel := .stub)
+    (arity : Nat := 1) (siteId : Nat := 0) : Contract (Call.Result α) :=
   fun state =>
-    match (commonExternalCall adv (linkedCallSite name args 1)).run state with
-    | .success (.success [word]) post =>
-        .success { success := true, returndata := ExternalResult.fromWord (Core.Uint256.ofNat word) } post
-    | .success (.success _) _ => .revert "external call returned invalid data" state
+    match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run state with
+    | .success (.success returndata) post =>
+        .success { success := true, returndata := failedExternalResult returndata } post
     | .success (.failure returndata) post | .success (.revert returndata) post =>
         .success { success := false, returndata := failedExternalResult returndata } post
     | .revert message _ => .revert message state
 
 def tryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
-    (name : String) (args : List Uint256) (adv : AdversaryModel := .stub) : Contract (Bool × α) :=
+    (name : String) (args : List Uint256) (adv : AdversaryModel := .stub)
+    (arity : Nat := 1) (siteId : Nat := 0) : Contract (Bool × α) :=
   fun state =>
-    match (commonExternalCall adv (linkedCallSite name args 1)).run state with
-    | .success (.success [word]) post =>
-        .success (true, ExternalResult.fromWord (Core.Uint256.ofNat word)) post
-    | .success (.success _) _ => .revert "external call returned invalid data" state
+    match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run state with
+    | .success (.success returndata) post =>
+        .success (true, failedExternalResult returndata) post
     | .success (.failure returndata) post | .success (.revert returndata) post =>
         .success (false, failedExternalResult returndata) post
     | .revert message _ => .revert message state
 
+/-- Mutable ECM executable crossing: consults the caller adversary instead of
+the no-op `ecmCall` syntax fallback. -/
+def ecmCallWords (adv : AdversaryModel) (args : List Uint256)
+    (siteId : Nat := 0) : Contract Uint256 :=
+  externalCallContractWords (α := Uint256) "ecm" args adv 1 siteId
+
+def ecmDoWords (adv : AdversaryModel) (args : List Uint256)
+    (siteId : Nat := 0) : Contract Unit :=
+  externalCallEffectWords "ecm" args adv siteId
+
 def externalCallBind {α : Type} [ExternalArg α]
     (names : List String) (name : String) (args : List α)
-    (adv : AdversaryModel := .stub) : Contract Unit := fun state =>
+    (adv : AdversaryModel := .stub) (siteId : Nat := 0) : Contract Unit := fun state =>
   let words := args.flatMap ExternalArg.toWords
-  match (commonExternalCall adv (linkedCallSite name words names.length)).run state with
+  match (commonExternalCall adv (linkedCallSite name words names.length .call 0 0 [] siteId)).run state with
   | .success (.success returndata) post =>
       if names.length = returndata.length then .success () post
       else .revert "external call returned insufficient data" state
@@ -774,7 +833,7 @@ definitional (`rfl`). -/
     (args : List α) (s : ContractState) :
     externalCallBind names name args adv s =
       match (commonExternalCall adv
-          (linkedCallSite name (args.flatMap ExternalArg.toWords) names.length)).run s with
+          (linkedCallSite name (args.flatMap ExternalArg.toWords) names.length .call 0 0 [] 0)).run s with
       | .success (.success returndata) post =>
           if names.length = returndata.length then ContractResult.success () post
           else ContractResult.revert "external call returned insufficient data" s
@@ -801,28 +860,41 @@ theorem externalCallBindTo_adv_apply {α : Type} [ExternalArg α]
       else ContractResult.revert "insufficient balance" s := rfl
 
 theorem callResultWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
-    (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState) :
-    callResultWords (α := α) name args adv s =
-      match (commonExternalCall adv (linkedCallSite name args 1)).run s with
-      | .success (.success [word]) post =>
-          .success (show Call.Result α from
-            { success := true,
-              returndata := ExternalResult.fromWord (Core.Uint256.ofNat word) }) post
-      | .success (.success _) _ => .revert "external call returned invalid data" s
+    (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState)
+    (arity : Nat := 1) (siteId : Nat := 0) :
+    callResultWords (α := α) name args adv arity siteId s =
+      match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run s with
+      | .success (.success returndata) post =>
+          .success { success := true, returndata := failedExternalResult returndata } post
       | .success (.failure returndata) post | .success (.revert returndata) post =>
           .success { success := false, returndata := failedExternalResult returndata } post
       | .revert message _ => .revert message s := rfl
 
 theorem tryExternalCallWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
-    (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState) :
-    tryExternalCallWords (α := α) name args adv s =
-      match (commonExternalCall adv (linkedCallSite name args 1)).run s with
-      | .success (.success [word]) post =>
-          .success (true, ExternalResult.fromWord (Core.Uint256.ofNat word)) post
-      | .success (.success _) _ => .revert "external call returned invalid data" s
+    (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState)
+    (arity : Nat := 1) (siteId : Nat := 0) :
+    tryExternalCallWords (α := α) name args adv arity siteId s =
+      match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run s with
+      | .success (.success returndata) post =>
+          .success (true, failedExternalResult returndata) post
       | .success (.failure returndata) post | .success (.revert returndata) post =>
           .success (false, failedExternalResult returndata) post
       | .revert message _ => .revert message s := rfl
+
+theorem externalCallContractWords_adv_run {α : Type} [ExternalResult α]
+    (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState)
+    (arity : Nat := 1) (siteId : Nat := 0) :
+    externalCallContractWords (α := α) name args adv arity siteId s =
+      match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run s with
+      | .success (.success returndata) post =>
+          if returndata.length < arity then
+            ContractResult.revert "external call returned insufficient data" s
+          else
+            ContractResult.success
+              (ExternalResult.fromWord (Core.Uint256.ofNat (returndata.head?.getD 0))) post
+      | .success (.failure _) _ | .success (.revert _) _ =>
+          ContractResult.revert "external call failed" s
+      | .revert message _ => ContractResult.revert message s := rfl
 
 /-! The PR1 `.stub` laws retain their original names and observable results;
 the post-state now also exposes the canonical EIP-211 returndata buffer. -/

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -831,7 +831,7 @@ definitional (`rfl`). -/
 @[simp] theorem externalCallBind_adv_apply {α : Type} [ExternalArg α]
     (adv : AdversaryModel) (names : List String) (name : String)
     (args : List α) (s : ContractState) :
-    externalCallBind names name args adv s =
+    (externalCallBind names name args adv (siteId := 0)) s =
       match (commonExternalCall adv
           (linkedCallSite name (args.flatMap ExternalArg.toWords) names.length .call 0 0 [] 0)).run s with
       | .success (.success returndata) post =>
@@ -862,7 +862,7 @@ theorem externalCallBindTo_adv_apply {α : Type} [ExternalArg α]
 theorem callResultWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
     (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState)
     (arity : Nat := 1) (siteId : Nat := 0) :
-    callResultWords (α := α) name args adv arity siteId s =
+    (callResultWords (α := α) name args adv arity siteId).run s =
       match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run s with
       | .success (.success returndata) post =>
           .success { success := true, returndata := failedExternalResult returndata } post
@@ -873,7 +873,7 @@ theorem callResultWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
 theorem tryExternalCallWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
     (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState)
     (arity : Nat := 1) (siteId : Nat := 0) :
-    tryExternalCallWords (α := α) name args adv arity siteId s =
+    (tryExternalCallWords (α := α) name args adv arity siteId).run s =
       match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run s with
       | .success (.success returndata) post =>
           .success (true, failedExternalResult returndata) post
@@ -884,7 +884,7 @@ theorem tryExternalCallWords_adv_run {α : Type} [ExternalResult α] [Inhabited 
 theorem externalCallContractWords_adv_run {α : Type} [ExternalResult α]
     (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState)
     (arity : Nat := 1) (siteId : Nat := 0) :
-    externalCallContractWords (α := α) name args adv arity siteId s =
+    (externalCallContractWords (α := α) name args adv arity siteId).run s =
       match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run s with
       | .success (.success returndata) post =>
           if returndata.length < arity then

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -529,6 +529,8 @@ instance : ExternalArg Bool where
   toWords value := [if value then 1 else 0]
 instance : ExternalArg Nat where
   toWords value := [value]
+instance [ExternalArg α] [ExternalArg β] : ExternalArg (α × β) where
+  toWords value := ExternalArg.toWords value.1 ++ ExternalArg.toWords value.2
 /-- Canonical first-word projection used when a word-like source expression
 is consumed by an executable helper whose Lean API takes `Uint256`. -/
 def externalArgWord {α : Type} [ExternalArg α] (value : α) : Uint256 :=

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -542,6 +542,11 @@ def externalArgWord {α : Type} [ExternalArg α] (value : α) : Uint256 :=
 /-- Address view of the canonical external-argument word. -/
 def externalArgAddress {α : Type} [ExternalArg α] (value : α) : Address :=
   wordToAddress (externalArgWord value)
+/-- Executable counterpart of the model's direct dynamic-parameter
+`data_offset, length` abstraction. The executable plane has no calldata
+pointer, so its canonical synthetic data offset is zero. -/
+def externalDynamicArgWords {α : Type} [ArrayLength α] (value : α) : List Uint256 :=
+  [0, ArrayLength.size value]
 instance [ExternalArg α] : ExternalArg (Array α) where
   toWords values := values.size :: (values.toList.flatMap ExternalArg.toWords)
 instance : ExternalArg ByteArray where

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -503,6 +503,9 @@ class ExternalArg (α : Type) where
   toWords : α → List Uint256
 class ExternalResult (α : Type) where
   fromWord : Uint256 → α
+  wordCount : Nat := 1
+  fromWords : List Uint256 → α := fun words =>
+    fromWord (words.head?.getD 0)
 /-- Aggregate/no-result executable stubs have no single-word decoding. Keep
 their historical inhabited default; concrete scalar decoders below have the
 normal higher priority and therefore return the journaled stub word. -/
@@ -544,6 +547,14 @@ instance : ExternalResult Address where
   fromWord value := wordToAddress value
 instance : ExternalResult Bool where
   fromWord value := value != 0
+instance [ExternalResult α] [ExternalResult β] : ExternalResult (α × β) where
+  wordCount := ExternalResult.wordCount (α := α) + ExternalResult.wordCount (α := β)
+  fromWord value :=
+    (ExternalResult.fromWord value, ExternalResult.fromWord 0)
+  fromWords words :=
+    let leftCount := ExternalResult.wordCount (α := α)
+    (ExternalResult.fromWords (words.take leftCount),
+      ExternalResult.fromWords (words.drop leftCount))
 
 namespace Call
 
@@ -728,10 +739,10 @@ def externalCallContractWords {α : Type} [ExternalResult α]
     (arity : Nat := 1) (siteId : Nat := 0) : Contract α := fun state =>
   match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run state with
   | .success (.success returndata) post =>
-      if returndata.length < arity then
-        .revert "external call returned insufficient data" state
+      if returndata.length = arity then
+        .success (ExternalResult.fromWords (returndata.map Core.Uint256.ofNat)) post
       else
-        .success (ExternalResult.fromWord (Core.Uint256.ofNat (returndata.head?.getD 0))) post
+        .revert "external call returned malformed data" state
   | .success (.failure _) _ | .success (.revert _) _ =>
       .revert "external call failed" state
   | .revert message _ => .revert message state
@@ -747,7 +758,7 @@ def externalCallEffectWords
 
 def failedExternalResult {α : Type} [ExternalResult α] [Inhabited α] : List Nat → α
   | [] => Inhabited.default
-  | word :: _ => ExternalResult.fromWord (Core.Uint256.ofNat word)
+  | words => ExternalResult.fromWords (words.map Core.Uint256.ofNat)
 
 def callResultWords {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (adv : AdversaryModel := .stub)
@@ -755,7 +766,10 @@ def callResultWords {α : Type} [ExternalResult α] [Inhabited α]
   fun state =>
     match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run state with
     | .success (.success returndata) post =>
-        .success { success := true, returndata := failedExternalResult returndata } post
+        if returndata.length = arity then
+          .success { success := true, returndata := failedExternalResult returndata } post
+        else
+          .revert "external call returned malformed data" state
     | .success (.failure returndata) post | .success (.revert returndata) post =>
         .success { success := false, returndata := failedExternalResult returndata } post
     | .revert message _ => .revert message state
@@ -766,7 +780,10 @@ def tryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
   fun state =>
     match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run state with
     | .success (.success returndata) post =>
-        .success (true, failedExternalResult returndata) post
+        if returndata.length = arity then
+          .success (true, failedExternalResult returndata) post
+        else
+          .revert "external call returned malformed data" state
     | .success (.failure returndata) post | .success (.revert returndata) post =>
         .success (false, failedExternalResult returndata) post
     | .revert message _ => .revert message state
@@ -865,7 +882,10 @@ theorem callResultWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
     callResultWords (α := α) name args adv arity siteId s =
       match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run s with
       | .success (.success returndata) post =>
-          .success { success := true, returndata := failedExternalResult returndata } post
+          if returndata.length = arity then
+            .success { success := true, returndata := failedExternalResult returndata } post
+          else
+            .revert "external call returned malformed data" s
       | .success (.failure returndata) post | .success (.revert returndata) post =>
           .success { success := false, returndata := failedExternalResult returndata } post
       | .revert message _ => .revert message s := rfl
@@ -876,7 +896,10 @@ theorem tryExternalCallWords_adv_run {α : Type} [ExternalResult α] [Inhabited 
     tryExternalCallWords (α := α) name args adv arity siteId s =
       match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run s with
       | .success (.success returndata) post =>
-          .success (true, failedExternalResult returndata) post
+          if returndata.length = arity then
+            .success (true, failedExternalResult returndata) post
+          else
+            .revert "external call returned malformed data" s
       | .success (.failure returndata) post | .success (.revert returndata) post =>
           .success (false, failedExternalResult returndata) post
       | .revert message _ => .revert message s := rfl
@@ -887,11 +910,11 @@ theorem externalCallContractWords_adv_run {α : Type} [ExternalResult α]
     externalCallContractWords (α := α) name args adv arity siteId s =
       match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run s with
       | .success (.success returndata) post =>
-          if returndata.length < arity then
-            ContractResult.revert "external call returned insufficient data" s
-          else
+          if returndata.length = arity then
             ContractResult.success
-              (ExternalResult.fromWord (Core.Uint256.ofNat (returndata.head?.getD 0))) post
+              (ExternalResult.fromWords (returndata.map Core.Uint256.ofNat)) post
+          else
+            ContractResult.revert "external call returned malformed data" s
       | .success (.failure _) _ | .success (.revert _) _ =>
           ContractResult.revert "external call failed" s
       | .revert message _ => ContractResult.revert message s := rfl
@@ -981,7 +1004,7 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
         { success := externalCallStubSuccess name
           returndata :=
             if externalCallStubSuccess name then
-              ExternalResult.fromWord (externalCallStubWord name args)
+              ExternalResult.fromWords [externalCallStubWord name args]
             else Inhabited.default }
         { s with
           calls := s.calls ++
@@ -1016,7 +1039,7 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
       ContractResult.success
         (externalCallStubSuccess name,
           if externalCallStubSuccess name then
-            ExternalResult.fromWord (externalCallStubWord name args)
+            ExternalResult.fromWords [externalCallStubWord name args]
           else Inhabited.default)
         { s with
           calls := s.calls ++

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -1019,19 +1019,32 @@ def tryExternalCallWordsResolved {α : Type} [ExternalResult α] [Inhabited α]
 
 /-- Mutable ECM executable crossing: consults the caller adversary instead of
 the no-op `ecmCall` syntax fallback. -/
+def ecmCallTypedWords {α : Type} [ExternalResult α]
+    (mod : Compiler.ECM.ExternalCallModule)
+    (adv : AdversaryModel) (args : List Uint256)
+    (siteId : Nat := 0) : Contract α := fun state =>
+  let kind := if mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.staticcall then
+    Compiler.CompilationModel.DenoteExternalCalls.CallKind.staticcall
+  else Compiler.CompilationModel.DenoteExternalCalls.CallKind.call
+  match (commonExternalCall adv
+      (linkedCallSite mod.summaryName args mod.resultVars.length kind 0 0 [] siteId)).run state with
+  | .success (.success returndata) post =>
+      if returndata.length = mod.resultVars.length then
+        .success (ExternalResult.fromWords (returndata.map Core.Uint256.ofNat)) post
+      else .revert "ECM returned malformed data" state
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "ECM call failed" state
+  | .revert message _ => .revert message state
+
 def ecmCallWords (mod : Compiler.ECM.ExternalCallModule)
     (adv : AdversaryModel) (args : List Uint256)
     (siteId : Nat := 0) : Contract Uint256 :=
-  if mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.staticcall then
-    externalStaticCallContractWords (α := Uint256) mod.summaryName args adv 1 siteId
-  else externalCallContractWords (α := Uint256) mod.summaryName args adv 1 siteId
+  ecmCallTypedWords mod adv args siteId
 
 def ecmCallPairWords (mod : Compiler.ECM.ExternalCallModule)
     (adv : AdversaryModel) (args : List Uint256)
     (siteId : Nat := 0) : Contract (Uint256 × Uint256) :=
-  if mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.staticcall then
-    externalStaticCallContractWords (α := Uint256 × Uint256) mod.summaryName args adv 2 siteId
-  else externalCallContractWords (α := Uint256 × Uint256) mod.summaryName args adv 2 siteId
+  ecmCallTypedWords mod adv args siteId
 
 def ecmDoWords (mod : Compiler.ECM.ExternalCallModule)
     (adv : AdversaryModel) (args : List Uint256)

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -673,6 +673,31 @@ private abbrev AdversaryModel :=
   Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel
 private abbrev ExternalCallResult :=
   Compiler.CompilationModel.DenoteExternalCalls.ExternalCallResult
+
+/-- Executable linked-call environment. Link resolution stays separate from
+`AdversaryModel`, preserving its ordered decision boundary. -/
+structure ExecutableCallContext where
+  adversary : AdversaryModel
+  resolve : String → Nat → Option Compiler.CompilationModel.DenoteFunctionCalls.LinkedExternal
+
+def ExecutableCallContext.ofAdversary (adv : AdversaryModel) : ExecutableCallContext :=
+  { adversary := adv
+    resolve := fun _ fallbackSiteId =>
+      some { target := 0, value := 0, siteId := fallbackSiteId } }
+
+def ExecutableCallContext.stub : ExecutableCallContext :=
+  ExecutableCallContext.ofAdversary .stub
+
+instance : Coe AdversaryModel ExecutableCallContext where
+  coe := ExecutableCallContext.ofAdversary
+
+instance : Coe ExecutableCallContext AdversaryModel where
+  coe := ExecutableCallContext.adversary
+
+def ExecutableCallContext.ofCallEnv
+    (env : Compiler.CompilationModel.DenoteFunctionCalls.CallEnv) : ExecutableCallContext :=
+  { adversary := env.adversary
+    resolve := fun name _ => env.resolve name }
 def externalCallResultWord (result : ExternalCallResult) : Uint256 :=
   Core.Uint256.ofNat (result.returndata.head?.getD 0)
 
@@ -682,6 +707,27 @@ def commonExternalCall (adv : AdversaryModel)
     (site : Compiler.CompilationModel.DenoteExternalCalls.CallSite) :
     Contract ExternalCallResult :=
   Compiler.CompilationModel.DenoteExternalCalls.externalCall adv site
+
+private def resolvedLinkedCall (ctx : ExecutableCallContext) (name : String)
+    (args : List Uint256) (arity : Nat)
+    (kind : Compiler.CompilationModel.DenoteExternalCalls.CallKind)
+    (fallbackSiteId : Nat) : Contract ExternalCallResult := fun state =>
+  match ctx.resolve name fallbackSiteId with
+  | none => ContractResult.success (.failure []) { state with returndata := [] }
+  | some link =>
+      let value := if kind == .call then link.value else 0
+      match Compiler.CompilationModel.DenoteFunctionCalls.debitSelfBalance state value with
+      | none => ContractResult.success (.failure []) { state with returndata := [] }
+      | some paid =>
+          match (commonExternalCall ctx.adversary
+              (linkedCallSite name args arity kind link.target value [] link.siteId)).run paid with
+          | .success result post =>
+              match result with
+              | .success _ => .success result post
+              | .failure _ | .revert _ =>
+                  .success result
+                    { state with calls := post.calls, returndata := post.returndata }
+          | .revert message _ => .revert message state
 
 private def evmCalldata (state : ContractState) (inOffset inSize : Uint256) : List Nat :=
   Compiler.CompilationModel.DenoteFunctionCalls.readMemoryWords
@@ -780,6 +826,19 @@ def externalCallContractWords {α : Type} [ExternalResult α]
       .revert "external call failed" state
   | .revert message _ => .revert message state
 
+def externalCallContractWordsResolved {α : Type} [ExternalResult α]
+    (name : String) (args : List Uint256) (ctx : ExecutableCallContext)
+    (arity : Nat := 1) (siteId : Nat := 0) : Contract α := fun state =>
+  match (resolvedLinkedCall ctx name args arity .call siteId).run state with
+  | .success (.success returndata) post =>
+      if arity ≤ returndata.length then
+        .success (ExternalResult.fromWords
+          ((returndata.take arity).map Core.Uint256.ofNat)) post
+      else .revert "external call returned malformed data" state
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "external call failed" state
+  | .revert message _ => .revert message state
+
 def externalStaticCallContractWords {α : Type} [ExternalResult α]
     (name : String) (args : List Uint256) (adv : AdversaryModel := .stub)
     (arity : Nat := 1) (siteId : Nat := 0) : Contract α := fun state =>
@@ -791,6 +850,19 @@ def externalStaticCallContractWords {α : Type} [ExternalResult α]
           ((returndata.take arity).map Core.Uint256.ofNat)) post
       else
         .revert "external call returned malformed data" state
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "external call failed" state
+  | .revert message _ => .revert message state
+
+def externalStaticCallContractWordsResolved {α : Type} [ExternalResult α]
+    (name : String) (args : List Uint256) (ctx : ExecutableCallContext)
+    (arity : Nat := 1) (siteId : Nat := 0) : Contract α := fun state =>
+  match (resolvedLinkedCall ctx name args arity .staticcall siteId).run state with
+  | .success (.success returndata) post =>
+      if arity ≤ returndata.length then
+        .success (ExternalResult.fromWords
+          ((returndata.take arity).map Core.Uint256.ofNat)) post
+      else .revert "external call returned malformed data" state
   | .success (.failure _) _ | .success (.revert _) _ =>
       .revert "external call failed" state
   | .revert message _ => .revert message state
@@ -835,11 +907,27 @@ def externalCallEffectWords
     | .failure _ | .revert _ => fun state =>
         ContractResult.revert "external call failed" state
 
+def externalCallEffectWordsResolved (name : String) (args : List Uint256)
+    (ctx : ExecutableCallContext) (siteId : Nat := 0) : Contract Unit :=
+  Verity.bind (resolvedLinkedCall ctx name args 0 .call siteId) fun result =>
+    match result with
+    | .success _ => pure ()
+    | .failure _ | .revert _ => fun state =>
+        ContractResult.revert "external call failed" state
+
 def externalStaticCallEffectWords
     (name : String) (args : List Uint256) (adv : AdversaryModel := .stub)
     (siteId : Nat := 0) : Contract Unit :=
   Verity.bind (commonExternalCall adv
       (linkedCallSite name args 0 .staticcall 0 0 [] siteId)) fun result =>
+    match result with
+    | .success _ => pure ()
+    | .failure _ | .revert _ => fun state =>
+        ContractResult.revert "external call failed" state
+
+def externalStaticCallEffectWordsResolved (name : String) (args : List Uint256)
+    (ctx : ExecutableCallContext) (siteId : Nat := 0) : Contract Unit :=
+  Verity.bind (resolvedLinkedCall ctx name args 0 .staticcall siteId) fun result =>
     match result with
     | .success _ => pure ()
     | .failure _ | .revert _ => fun state =>
@@ -883,6 +971,18 @@ def callResultWords {α : Type} [ExternalResult α] [Inhabited α]
         .success { success := false, returndata := failedExternalResult returndata } post
     | .revert message _ => .revert message state
 
+def callResultWordsResolved {α : Type} [ExternalResult α] [Inhabited α]
+    (name : String) (args : List Uint256) (ctx : ExecutableCallContext)
+    (arity : Nat := 1) (siteId : Nat := 0) : Contract (Call.Result α) := fun state =>
+  match (resolvedLinkedCall ctx name args arity .call siteId).run state with
+  | .success (.success returndata) post =>
+      if returndata.length = arity then
+        .success { success := true, returndata := failedExternalResult returndata } post
+      else .revert "external call returned malformed data" state
+  | .success (.failure returndata) post | .success (.revert returndata) post =>
+      .success { success := false, returndata := failedExternalResult returndata } post
+  | .revert message _ => .revert message state
+
 def tryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
     (name : String) (args : List Uint256) (adv : AdversaryModel := .stub)
     (arity : Nat := 1) (siteId : Nat := 0) : Contract (Bool × α) :=
@@ -896,6 +996,18 @@ def tryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
     | .success (.failure returndata) post | .success (.revert returndata) post =>
         .success (false, failedExternalResult returndata) post
     | .revert message _ => .revert message state
+
+def tryExternalCallWordsResolved {α : Type} [ExternalResult α] [Inhabited α]
+    (name : String) (args : List Uint256) (ctx : ExecutableCallContext)
+    (arity : Nat := 1) (siteId : Nat := 0) : Contract (Bool × α) := fun state =>
+  match (resolvedLinkedCall ctx name args arity .call siteId).run state with
+  | .success (.success returndata) post =>
+      if returndata.length = arity then
+        .success (true, failedExternalResult returndata) post
+      else .revert "external call returned malformed data" state
+  | .success (.failure returndata) post | .success (.revert returndata) post =>
+      .success (false, failedExternalResult returndata) post
+  | .revert message _ => .revert message state
 
 /-- Mutable ECM executable crossing: consults the caller adversary instead of
 the no-op `ecmCall` syntax fallback. -/
@@ -916,6 +1028,18 @@ def externalCallBind {α : Type} [ExternalArg α]
     (adv : AdversaryModel := .stub) (siteId : Nat := 0) : Contract Unit := fun state =>
   let words := args.flatMap ExternalArg.toWords
   match (commonExternalCall adv (linkedCallSite name words names.length .call 0 0 [] siteId)).run state with
+  | .success (.success returndata) post =>
+      if names.length = returndata.length then .success () post
+      else .revert "external call returned insufficient data" state
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "external call failed" state
+  | .revert message _ => .revert message state
+
+def externalCallBindResolved {α : Type} [ExternalArg α]
+    (names : List String) (name : String) (args : List α)
+    (ctx : ExecutableCallContext) (siteId : Nat := 0) : Contract Unit := fun state =>
+  let words := args.flatMap ExternalArg.toWords
+  match (resolvedLinkedCall ctx name words names.length .call siteId).run state with
   | .success (.success returndata) post =>
       if names.length = returndata.length then .success () post
       else .revert "external call returned insufficient data" state

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -492,7 +492,10 @@ def rawLog (topics : List Uint256) (dataOffset dataSize : Uint256) : Contract Un
       events := state.events ++
         [{ name := s!"log{topics.length}", args := [dataOffset, dataSize], indexedArgs := topics }]
     }
-def mstore (_offset _value : Uint256) : Contract Unit := pure ()
+def mstore (offset value : Uint256) : Contract Unit := fun state =>
+  ContractResult.success () { state with
+    memory := Compiler.CompilationModel.DenoteFunctionCalls.writeMemoryWords
+      state.memory offset.val [value.val] 32 }
 def tstore (offset value : Uint256) : Contract Unit := fun state =>
   ContractResult.success () (state.writeTransient (offset : Nat) value)
 /-- Canonical journal-word encoding for executable external-call arguments.
@@ -543,6 +546,8 @@ instance [ExternalArg α] : ExternalArg (Array α) where
   toWords values := values.size :: (values.toList.flatMap ExternalArg.toWords)
 instance : ExternalArg ByteArray where
   toWords bytes := bytes.size :: (bytes.data.toList.map (fun byte => (byte.toNat : Uint256)))
+instance : ExternalArg String where
+  toWords value := ExternalArg.toWords value.toUTF8
 instance : ExternalResult Uint256 where
   fromWord value := value
 instance : ExternalResult Uint16 where
@@ -760,10 +765,35 @@ def externalCallContractWords {α : Type} [ExternalResult α]
       .revert "external call failed" state
   | .revert message _ => .revert message state
 
+def externalStaticCallContractWords {α : Type} [ExternalResult α]
+    (name : String) (args : List Uint256) (adv : AdversaryModel := .stub)
+    (arity : Nat := 1) (siteId : Nat := 0) : Contract α := fun state =>
+  match (commonExternalCall adv
+      (linkedCallSite name args arity .staticcall 0 0 [] siteId)).run state with
+  | .success (.success returndata) post =>
+      if arity ≤ returndata.length then
+        .success (ExternalResult.fromWords
+          ((returndata.take arity).map Core.Uint256.ofNat)) post
+      else
+        .revert "external call returned malformed data" state
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "external call failed" state
+  | .revert message _ => .revert message state
+
 def externalCallEffectWords
     (name : String) (args : List Uint256) (adv : AdversaryModel := .stub)
     (siteId : Nat := 0) : Contract Unit :=
   Verity.bind (commonExternalCall adv (linkedCallSite name args 0 .call 0 0 [] siteId)) fun result =>
+    match result with
+    | .success _ => pure ()
+    | .failure _ | .revert _ => fun state =>
+        ContractResult.revert "external call failed" state
+
+def externalStaticCallEffectWords
+    (name : String) (args : List Uint256) (adv : AdversaryModel := .stub)
+    (siteId : Nat := 0) : Contract Unit :=
+  Verity.bind (commonExternalCall adv
+      (linkedCallSite name args 0 .staticcall 0 0 [] siteId)) fun result =>
     match result with
     | .success _ => pure ()
     | .failure _ | .revert _ => fun state =>

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -862,7 +862,7 @@ theorem externalCallBindTo_adv_apply {α : Type} [ExternalArg α]
 theorem callResultWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
     (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState)
     (arity : Nat := 1) (siteId : Nat := 0) :
-    (callResultWords (α := α) name args adv arity siteId).run s =
+    callResultWords (α := α) name args adv arity siteId s =
       match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run s with
       | .success (.success returndata) post =>
           .success { success := true, returndata := failedExternalResult returndata } post
@@ -873,7 +873,7 @@ theorem callResultWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
 theorem tryExternalCallWords_adv_run {α : Type} [ExternalResult α] [Inhabited α]
     (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState)
     (arity : Nat := 1) (siteId : Nat := 0) :
-    (tryExternalCallWords (α := α) name args adv arity siteId).run s =
+    tryExternalCallWords (α := α) name args adv arity siteId s =
       match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run s with
       | .success (.success returndata) post =>
           .success (true, failedExternalResult returndata) post
@@ -884,7 +884,7 @@ theorem tryExternalCallWords_adv_run {α : Type} [ExternalResult α] [Inhabited 
 theorem externalCallContractWords_adv_run {α : Type} [ExternalResult α]
     (adv : AdversaryModel) (name : String) (args : List Uint256) (s : ContractState)
     (arity : Nat := 1) (siteId : Nat := 0) :
-    (externalCallContractWords (α := α) name args adv arity siteId).run s =
+    externalCallContractWords (α := α) name args adv arity siteId s =
       match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run s with
       | .success (.success returndata) post =>
           if returndata.length < arity then

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -1019,17 +1019,26 @@ def tryExternalCallWordsResolved {α : Type} [ExternalResult α] [Inhabited α]
 
 /-- Mutable ECM executable crossing: consults the caller adversary instead of
 the no-op `ecmCall` syntax fallback. -/
-def ecmCallWords (adv : AdversaryModel) (args : List Uint256)
+def ecmCallWords (mod : Compiler.ECM.ExternalCallModule)
+    (adv : AdversaryModel) (args : List Uint256)
     (siteId : Nat := 0) : Contract Uint256 :=
-  externalCallContractWords (α := Uint256) "ecm" args adv 1 siteId
+  if mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.staticcall then
+    externalStaticCallContractWords (α := Uint256) mod.summaryName args adv 1 siteId
+  else externalCallContractWords (α := Uint256) mod.summaryName args adv 1 siteId
 
-def ecmCallPairWords (adv : AdversaryModel) (args : List Uint256)
+def ecmCallPairWords (mod : Compiler.ECM.ExternalCallModule)
+    (adv : AdversaryModel) (args : List Uint256)
     (siteId : Nat := 0) : Contract (Uint256 × Uint256) :=
-  externalCallContractWords (α := Uint256 × Uint256) "ecm" args adv 2 siteId
+  if mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.staticcall then
+    externalStaticCallContractWords (α := Uint256 × Uint256) mod.summaryName args adv 2 siteId
+  else externalCallContractWords (α := Uint256 × Uint256) mod.summaryName args adv 2 siteId
 
-def ecmDoWords (adv : AdversaryModel) (args : List Uint256)
+def ecmDoWords (mod : Compiler.ECM.ExternalCallModule)
+    (adv : AdversaryModel) (args : List Uint256)
     (siteId : Nat := 0) : Contract Unit :=
-  externalCallEffectWords "ecm" args adv siteId
+  if mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.staticcall then
+    externalStaticCallEffectWords mod.summaryName args adv siteId
+  else externalCallEffectWords mod.summaryName args adv siteId
 
 def externalCallBind {α : Type} [ExternalArg α]
     (names : List String) (name : String) (args : List α)

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -720,7 +720,8 @@ private def resolvedLinkedCall (ctx : ExecutableCallContext) (name : String)
       | none => ContractResult.success (.failure []) { state with returndata := [] }
       | some paid =>
           match (commonExternalCall ctx.adversary
-              (linkedCallSite name args arity kind link.target value [] link.siteId)).run paid with
+              { linkedCallSite name args arity kind link.target value [] link.siteId with
+                gas := paid.selfBalance.val }).run paid with
           | .success result post =>
               match result with
               | .success _ => .success result post

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -642,6 +642,28 @@ def commonExternalCall (adv : AdversaryModel)
       .success result { post with returndata := state.returndata }
   | .revert message _ => .revert message state
 
+/-- Executable result of a raw mutable EVM call.  The macro supplies the
+caller's explicit adversary; unlike the old syntax fallback this crosses the
+same journaled call boundary as every other Common external-call primitive. -/
+def evmCallWords (adv : AdversaryModel) (gas target value inOffset inSize outOffset outSize : Uint256) :
+    Uint256 :=
+  let result := (commonExternalCall adv {
+      kind := .call
+      target := target.toNat
+      value := value.val
+      gas := gas.val
+      calldata := [inOffset.val, inSize.val, outOffset.val, outSize.val] }).run defaultState |>.fst
+  if result.succeeded then 1 else 0
+
+def evmStaticCallWords (adv : AdversaryModel)
+    (gas target inOffset inSize outOffset outSize : Uint256) : Uint256 :=
+  let result := (commonExternalCall adv {
+      kind := .staticcall
+      target := target.toNat
+      gas := gas.val
+      calldata := [inOffset.val, inSize.val, outOffset.val, outSize.val] }).run defaultState |>.fst
+  if result.succeeded then 1 else 0
+
 @[simp] theorem commonExternalCall_apply (adv : AdversaryModel)
     (site : Compiler.CompilationModel.DenoteExternalCalls.CallSite)
     (state : ContractState) :
@@ -651,11 +673,11 @@ def commonExternalCall (adv : AdversaryModel)
             { world := state, gasRemaining := site.gas }).state.world with
           returndata := state.returndata } := rfl
 
-/-- Transitional expression-position boundary. Until PR3 moves macro-expanded
-external calls into the caller's `Contract` state, this pure helper can only
-soundly execute the deterministic stub adversary. -/
+/-- Expression-position projection used by generated external-call bodies.
+The adversary is explicit at generated call sites; transitional handwritten
+callers may continue to use the PR2 `.stub` default. -/
 def externalCallWords {α : Type} [ExternalResult α] (name : String) (args : List Uint256)
-    (adv : AdversaryModel := .stub) (_hadv : adv = .stub := by rfl) : α :=
+    (adv : AdversaryModel := .stub) : α :=
   match commonExternalCall adv (linkedCallSite name args 1) defaultState with
   | .success (.success returndata) _ =>
       ExternalResult.fromWord (Core.Uint256.ofNat (returndata.head?.getD 0))

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -1049,9 +1049,7 @@ def ecmCallPairWords (mod : Compiler.ECM.ExternalCallModule)
 def ecmDoWords (mod : Compiler.ECM.ExternalCallModule)
     (adv : AdversaryModel) (args : List Uint256)
     (siteId : Nat := 0) : Contract Unit :=
-  if mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.staticcall then
-    externalStaticCallEffectWords mod.summaryName args adv siteId
-  else externalCallEffectWords mod.summaryName args adv siteId
+  ecmCallTypedWords (α := Unit) mod adv args siteId
 
 def externalCallBind {α : Type} [ExternalArg α]
     (names : List String) (name : String) (args : List α)

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -4,6 +4,7 @@ import Verity.Core
 import Verity.Core.Semantics
 import Verity.Core.Model.ContractExternalCall
 import Verity.Core.Model.DenoteFunctionCalls
+import Verity.Core.Model.Denote
 import Verity.EVM.Uint256
 import Verity.Macro
 import Verity.Stdlib.Math
@@ -496,6 +497,15 @@ def mstore (offset value : Uint256) : Contract Unit := fun state =>
   ContractResult.success () { state with
     memory := Compiler.CompilationModel.DenoteFunctionCalls.writeMemoryWords
       state.memory offset.val [value.val] 32 }
+def returndataSizeLive : Contract Uint256 := fun state =>
+  ContractResult.success (Core.Uint256.ofNat (32 * state.returndata.length)) state
+def returndataCopyLive (destOffset sourceOffset size : Uint256) : Contract Unit := fun state =>
+  if sourceOffset.val + size.val <= 32 * state.returndata.length then
+    ContractResult.success () { state with
+      memory := Compiler.CompilationModel.Denote.returndatacopyMemoryPaddedUint256
+        state.returndata destOffset.val sourceOffset.val size.val state.memory }
+  else
+    ContractResult.revert "returndatacopy out of bounds" state
 def tstore (offset value : Uint256) : Contract Unit := fun state =>
   ContractResult.success () (state.writeTransient (offset : Nat) value)
 /-- Canonical journal-word encoding for executable external-call arguments.

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -749,8 +749,9 @@ def externalCallContractWords {α : Type} [ExternalResult α]
     (arity : Nat := 1) (siteId : Nat := 0) : Contract α := fun state =>
   match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run state with
   | .success (.success returndata) post =>
-      if returndata.length = arity then
-        .success (ExternalResult.fromWords (returndata.map Core.Uint256.ofNat)) post
+      if arity ≤ returndata.length then
+        .success (ExternalResult.fromWords
+          ((returndata.take arity).map Core.Uint256.ofNat)) post
       else
         .revert "external call returned malformed data" state
   | .success (.failure _) _ | .success (.revert _) _ =>
@@ -924,9 +925,10 @@ theorem externalCallContractWords_adv_run {α : Type} [ExternalResult α]
     externalCallContractWords (α := α) name args adv arity siteId s =
       match (commonExternalCall adv (linkedCallSite name args arity .call 0 0 [] siteId)).run s with
       | .success (.success returndata) post =>
-          if returndata.length = arity then
+          if arity ≤ returndata.length then
             ContractResult.success
-              (ExternalResult.fromWords (returndata.map Core.Uint256.ofNat)) post
+              (ExternalResult.fromWords
+                ((returndata.take arity).map Core.Uint256.ofNat)) post
           else
             ContractResult.revert "external call returned malformed data" s
       | .success (.failure _) _ | .success (.revert _) _ =>

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -587,6 +587,13 @@ instance [ExternalResult α] [ExternalResult β] : ExternalResult (α × β) whe
     let leftCount := ExternalResult.wordCount (α := α)
     (ExternalResult.fromWords (words.take leftCount),
       ExternalResult.fromWords (words.drop leftCount))
+instance [ExternalResult α] : ExternalResult (Array α) where
+  fromWord value := #[ExternalResult.fromWord value]
+  fromWords words :=
+    let width := ExternalResult.wordCount (α := α)
+    if width == 0 then #[] else
+      (List.range (words.length / width)).toArray.map fun i =>
+        ExternalResult.fromWords (words.drop (i * width) |>.take width)
 
 namespace Call
 

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -720,7 +720,7 @@ private def resolvedLinkedCall (ctx : ExecutableCallContext) (name : String)
     (kind : Compiler.CompilationModel.DenoteExternalCalls.CallKind)
     (fallbackSiteId : Nat) : Contract ExternalCallResult := fun state =>
   match ctx.resolve name fallbackSiteId with
-  | none => ContractResult.success (.failure []) { state with returndata := [] }
+  | none => ContractResult.success (.failure []) state
   | some link =>
       let value := if kind == .call then link.value else 0
       match Compiler.CompilationModel.DenoteFunctionCalls.debitSelfBalance state value with

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -631,16 +631,11 @@ private abbrev ExternalCallResult :=
 def externalCallResultWord (result : ExternalCallResult) : Uint256 :=
   Core.Uint256.ofNat (result.returndata.head?.getD 0)
 
-/-- PR2 compatibility boundary. The unified model owns call execution and
-state evolution; Common temporarily retains its historical live-returndata
-projection until the macro default is removed in PR3. -/
+/-- Common external calls use the canonical journaled source-level boundary. -/
 def commonExternalCall (adv : AdversaryModel)
     (site : Compiler.CompilationModel.DenoteExternalCalls.CallSite) :
-    Contract ExternalCallResult := fun state =>
-  match Compiler.CompilationModel.DenoteExternalCalls.externalCall adv site state with
-  | .success result post =>
-      .success result { post with returndata := state.returndata }
-  | .revert message _ => .revert message state
+    Contract ExternalCallResult :=
+  Compiler.CompilationModel.DenoteExternalCalls.externalCall adv site
 
 /-- Executable result of a raw mutable EVM call.  The macro supplies the
 caller's explicit adversary; unlike the old syntax fallback this crosses the
@@ -673,7 +668,8 @@ def evmStaticCallWords (adv : AdversaryModel)
       ContractResult.success (adv.result site state)
         { (Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled adv site
             { world := state, gasRemaining := site.gas }).state.world with
-          returndata := state.returndata } := rfl
+          returndata := (adv.result site state).returndata.map
+            Compiler.CompilationModel.Denote.wordNormalize } := rfl
 
 /-- Expression-position projection used by generated external-call bodies.
 The adversary is explicit at generated call sites; transitional handwritten
@@ -828,17 +824,21 @@ theorem tryExternalCallWords_adv_run {α : Type} [ExternalResult α] [Inhabited 
           .success (false, failedExternalResult returndata) post
       | .revert message _ => .revert message s := rfl
 
-/-! The PR1 `.stub` laws retain their original names and propositions. -/
+/-! The PR1 `.stub` laws retain their original names and observable results;
+the post-state now also exposes the canonical EIP-211 returndata buffer. -/
 
 @[simp] theorem externalCallBind_run {α : Type} [ExternalArg α]
     (names : List String) (name : String) (args : List α) (s : ContractState) :
     (externalCallBind names name args).run s =
       if externalCallStubSuccess name then
         ContractResult.success ()
-          { s with calls := s.calls ++
+          { s with
+            calls := s.calls ++
               [linkedCallEntry name (args.flatMap ExternalArg.toWords) .success
                 (names.map fun _ =>
-                  (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat))] }
+                  (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat))]
+            returndata := (names.map fun _ =>
+              (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat)) }
       else ContractResult.revert "external call failed" s := by
   by_cases h : name = "fail" <;>
     simp [Contract.run, externalCallBind, commonExternalCall,
@@ -867,7 +867,9 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
                 [linkedCallEntryTo name target value (args.flatMap ExternalArg.toWords)
                   .success
                   (names.map fun _ =>
-                    (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat))] }
+                    (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat))]
+              returndata := (names.map fun _ =>
+                (externalCallStubWord name (args.flatMap ExternalArg.toWords) : Nat)) }
         else ContractResult.revert "external call failed" s
       else ContractResult.revert "insufficient balance" s := by
   by_cases hbal : value ≤ s.selfBalance
@@ -909,12 +911,15 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
             if externalCallStubSuccess name then
               ExternalResult.fromWord (externalCallStubWord name args)
             else Inhabited.default }
-        { s with calls := s.calls ++
+        { s with
+          calls := s.calls ++
             [linkedCallEntry name args
               (if externalCallStubSuccess name then .success else .failure)
               (if externalCallStubSuccess name then
                 [(externalCallStubWord name args : Nat)]
-              else [])] } := by
+              else [])]
+          returndata := (if externalCallStubSuccess name then
+            [(externalCallStubWord name args : Nat)] else []) } := by
   by_cases h : name = "fail" <;>
     simp [callResultWords, commonExternalCall,
       Compiler.CompilationModel.DenoteExternalCalls.externalCall,
@@ -941,12 +946,15 @@ theorem externalCallBindTo_run {α : Type} [ExternalArg α]
           if externalCallStubSuccess name then
             ExternalResult.fromWord (externalCallStubWord name args)
           else Inhabited.default)
-        { s with calls := s.calls ++
+        { s with
+          calls := s.calls ++
             [linkedCallEntry name args
               (if externalCallStubSuccess name then .success else .failure)
               (if externalCallStubSuccess name then
                 [(externalCallStubWord name args : Nat)]
-              else [])] } := by
+              else [])]
+          returndata := (if externalCallStubSuccess name then
+            [(externalCallStubWord name args : Nat)] else []) } := by
   by_cases h : name = "fail" <;>
     simp [tryExternalCallWords, commonExternalCall,
       Compiler.CompilationModel.DenoteExternalCalls.externalCall,
@@ -1105,7 +1113,9 @@ theorem erc20Write_stub_run (name : String) (token : Address)
     (hcode : s.codeSize token.toNat ≠ 0) :
     (erc20Write .stub name token args).run s =
       ContractResult.success ()
-        { s with calls := s.calls ++ [erc20WriteEntry name token args] } := by
+        { s with
+          calls := s.calls ++ [erc20WriteEntry name token args]
+          returndata := [] } := by
   simp [erc20Write, commonExternalCall,
     Compiler.CompilationModel.DenoteExternalCalls.externalCall,
     Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
@@ -1123,9 +1133,11 @@ theorem erc20Write_stub_run (name : String) (token : Address)
     (s : ContractState) (hcode : s.codeSize token.toNat ≠ 0) :
     (safeTransfer token toAddr amount).run s =
       ContractResult.success ()
-        { s with calls := s.calls ++
+        { s with
+          calls := s.calls ++
             [erc20WriteEntry "safeTransfer" token
-              [Verity.addressToWord toAddr, amount]] } := by
+              [Verity.addressToWord toAddr, amount]]
+          returndata := [] } := by
   simpa [safeTransfer] using
     erc20Write_stub_run "safeTransfer" token [Verity.addressToWord toAddr, amount] s (by decide) hcode
 
@@ -1133,9 +1145,11 @@ theorem erc20Write_stub_run (name : String) (token : Address)
     (s : ContractState) (hcode : s.codeSize token.toNat ≠ 0) :
     (safeTransferFrom token fromAddr toAddr amount).run s =
       ContractResult.success ()
-        { s with calls := s.calls ++
+        { s with
+          calls := s.calls ++
             [erc20WriteEntry "safeTransferFrom" token
-              [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]] } := by
+              [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]]
+          returndata := [] } := by
   simpa [safeTransferFrom] using erc20Write_stub_run "safeTransferFrom" token
     [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount] s (by decide) hcode
 
@@ -1143,9 +1157,11 @@ theorem erc20Write_stub_run (name : String) (token : Address)
     (s : ContractState) (hcode : s.codeSize token.toNat ≠ 0) :
     (safeApprove token spender amount).run s =
       ContractResult.success ()
-        { s with calls := s.calls ++
+        { s with
+          calls := s.calls ++
             [erc20WriteEntry "safeApprove" token
-              [Verity.addressToWord spender, amount]] } := by
+              [Verity.addressToWord spender, amount]]
+          returndata := [] } := by
   simpa [safeApprove] using
     erc20Write_stub_run "safeApprove" token [Verity.addressToWord spender, amount] s (by decide) hcode
 
@@ -1175,7 +1191,9 @@ theorem erc20Read_stub_run (name : String) (token : Address)
     (erc20Read .stub name token args).run s =
       let result := erc20ReadStubWord name (Verity.addressToWord token :: args)
       ContractResult.success result
-        { s with calls := s.calls ++ [erc20ReadEntry name token args result] } := by
+        { s with
+          calls := s.calls ++ [erc20ReadEntry name token args result]
+          returndata := [(result : Nat)] } := by
   simp [erc20Read, commonExternalCall,
     Compiler.CompilationModel.DenoteExternalCalls.externalCall,
     Compiler.CompilationModel.DenoteExternalCalls.denoteCallJournaled,
@@ -1196,8 +1214,10 @@ theorem erc20Read_stub_run (name : String) (token : Address)
       let result := erc20ReadStubWord "balanceOf"
         [Verity.addressToWord token, Verity.addressToWord owner]
       ContractResult.success result
-        { s with calls := s.calls ++
-            [erc20ReadEntry "balanceOf" token [Verity.addressToWord owner] result] } := by
+        { s with
+          calls := s.calls ++
+            [erc20ReadEntry "balanceOf" token [Verity.addressToWord owner] result]
+          returndata := [(result : Nat)] } := by
   simpa [balanceOf] using erc20Read_stub_run "balanceOf" token
     [Verity.addressToWord owner] s (by decide)
 
@@ -1207,9 +1227,11 @@ theorem erc20Read_stub_run (name : String) (token : Address)
         [Verity.addressToWord token, Verity.addressToWord owner,
           Verity.addressToWord spender]
       ContractResult.success result
-        { s with calls := s.calls ++
+        { s with
+          calls := s.calls ++
             [erc20ReadEntry "allowance" token
-              [Verity.addressToWord owner, Verity.addressToWord spender] result] } := by
+              [Verity.addressToWord owner, Verity.addressToWord spender] result]
+          returndata := [(result : Nat)] } := by
   simpa [allowance] using erc20Read_stub_run "allowance" token
     [Verity.addressToWord owner, Verity.addressToWord spender] s (by decide)
 
@@ -1217,7 +1239,9 @@ theorem erc20Read_stub_run (name : String) (token : Address)
     (totalSupply token).run s =
       let result := erc20ReadStubWord "totalSupply" [Verity.addressToWord token]
       ContractResult.success result
-        { s with calls := s.calls ++ [erc20ReadEntry "totalSupply" token [] result] } := by
+        { s with
+          calls := s.calls ++ [erc20ReadEntry "totalSupply" token [] result]
+          returndata := [(result : Nat)] } := by
   simpa [totalSupply] using erc20Read_stub_run "totalSupply" token [] s (by decide)
 def forEach (_name : String) (_count : Uint256) (body : Contract Unit) : Contract Unit := body
 def blockTimestamp : Contract Uint256 := Verity.blockTimestamp

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -795,6 +795,37 @@ def externalStaticCallContractWords {α : Type} [ExternalResult α]
       .revert "external call failed" state
   | .revert message _ => .revert message state
 
+/-- Typed-interface variant whose callee is supplied by the interface value. -/
+def externalCallContractWordsTo {α : Type} [ExternalResult α]
+    (name : String) (target : Address) (args : List Uint256)
+    (adv : AdversaryModel := .stub) (arity : Nat := 1) (siteId : Nat := 0) :
+    Contract α := fun state =>
+  match (commonExternalCall adv
+      (linkedCallSite name args arity .call target.toNat 0 [] siteId)).run state with
+  | .success (.success returndata) post =>
+      if arity ≤ returndata.length then
+        .success (ExternalResult.fromWords
+          ((returndata.take arity).map Core.Uint256.ofNat)) post
+      else .revert "external call returned malformed data" state
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "external call failed" state
+  | .revert message _ => .revert message state
+
+def externalStaticCallContractWordsTo {α : Type} [ExternalResult α]
+    (name : String) (target : Address) (args : List Uint256)
+    (adv : AdversaryModel := .stub) (arity : Nat := 1) (siteId : Nat := 0) :
+    Contract α := fun state =>
+  match (commonExternalCall adv
+      (linkedCallSite name args arity .staticcall target.toNat 0 [] siteId)).run state with
+  | .success (.success returndata) post =>
+      if arity ≤ returndata.length then
+        .success (ExternalResult.fromWords
+          ((returndata.take arity).map Core.Uint256.ofNat)) post
+      else .revert "external call returned malformed data" state
+  | .success (.failure _) _ | .success (.revert _) _ =>
+      .revert "external call failed" state
+  | .revert message _ => .revert message state
+
 def externalCallEffectWords
     (name : String) (args : List Uint256) (adv : AdversaryModel := .stub)
     (siteId : Nat := 0) : Contract Unit :=
@@ -809,6 +840,26 @@ def externalStaticCallEffectWords
     (siteId : Nat := 0) : Contract Unit :=
   Verity.bind (commonExternalCall adv
       (linkedCallSite name args 0 .staticcall 0 0 [] siteId)) fun result =>
+    match result with
+    | .success _ => pure ()
+    | .failure _ | .revert _ => fun state =>
+        ContractResult.revert "external call failed" state
+
+def externalCallEffectWordsTo (name : String) (target : Address)
+    (args : List Uint256) (adv : AdversaryModel := .stub) (siteId : Nat := 0) :
+    Contract Unit :=
+  Verity.bind (commonExternalCall adv
+      (linkedCallSite name args 0 .call target.toNat 0 [] siteId)) fun result =>
+    match result with
+    | .success _ => pure ()
+    | .failure _ | .revert _ => fun state =>
+        ContractResult.revert "external call failed" state
+
+def externalStaticCallEffectWordsTo (name : String) (target : Address)
+    (args : List Uint256) (adv : AdversaryModel := .stub) (siteId : Nat := 0) :
+    Contract Unit :=
+  Verity.bind (commonExternalCall adv
+      (linkedCallSite name args 0 .staticcall target.toNat 0 [] siteId)) fun result =>
     match result with
     | .success _ => pure ()
     | .failure _ | .revert _ => fun state =>

--- a/Contracts/Smoke/EIP712StaticSmoke.lean
+++ b/Contracts/Smoke/EIP712StaticSmoke.lean
@@ -133,4 +133,18 @@ example :
       , Stmt.return (Expr.localVar "signer")
       ] := rfl
 
+private def ecmMetadataAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state.writeSlot 99 7
+  result := fun site _ => .success
+    [if site.name == (Compiler.Modules.Hashing.eip712DigestModule "result").summaryName &&
+        site.kind == .staticcall then 1 else 0]
+  gasUsed := fun _ _ => 0
+
+example :
+    let mod := Compiler.Modules.Hashing.eip712DigestModule "result"
+    let out := (Contracts.ecmCallWords mod ecmMetadataAdversary []).run defaultState
+    out.getValue? = some 1 ∧ out.getState.readSlot 99 = 0 := by
+  decide
+
 end Contracts.Smoke

--- a/Contracts/Smoke/EIP712StaticSmoke.lean
+++ b/Contracts/Smoke/EIP712StaticSmoke.lean
@@ -147,4 +147,19 @@ example :
     out.getValue? = some 1 ∧ out.getState.readSlot 99 = 0 := by
   decide
 
+private def oversizedEcmResultAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun _ _ => .success [1, 2]
+  gasUsed := fun _ _ => 0
+
+private def oversizedEcmResultReverts : Bool :=
+    let mod := Compiler.Modules.Hashing.eip712DigestModule "result"
+    match (Contracts.ecmCallWords mod oversizedEcmResultAdversary []).run defaultState with
+    | .revert _ _ => true
+    | _ => false
+
+example : oversizedEcmResultReverts = true := by
+  decide
+
 end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCallConstructorSmoke.lean
+++ b/Contracts/Smoke/ExternalCallConstructorSmoke.lean
@@ -1,0 +1,23 @@
+import Contracts.Common
+
+namespace Contracts.Smoke
+
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_mixin ExternalCallConstructorMixin where
+  storage
+  linked_externals
+    external initializeRemote(Uint256)
+  constructor (seed : Uint256) := do
+    callExternal initializeRemote(seed)
+
+verity_contract ExternalCallConstructorHost include ExternalCallConstructorMixin where
+  storage
+  constructor (seed : Uint256) ExternalCallConstructorMixin(seed) := do
+    pure ()
+
+example : Contract Unit := ExternalCallConstructorMixin.constructor .stub 41
+example : Contract Unit := ExternalCallConstructorHost.constructor .stub 41
+
+end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCallConstructorSmoke.lean
+++ b/Contracts/Smoke/ExternalCallConstructorSmoke.lean
@@ -10,6 +10,8 @@ verity_mixin ExternalCallConstructorMixin where
   linked_externals
     external initializeRemote(Uint256)
   constructor (seed : Uint256) := do
+    initializeHelper(seed)
+  function internal initializeHelper (seed : Uint256) : Unit := do
     callExternal initializeRemote(seed)
 
 verity_contract ExternalCallConstructorHost include ExternalCallConstructorMixin where

--- a/Contracts/Smoke/ExternalCallConstructorSmoke.lean
+++ b/Contracts/Smoke/ExternalCallConstructorSmoke.lean
@@ -1,4 +1,5 @@
 import Contracts.Common
+import Compiler.Modules.Precompiles
 
 namespace Contracts.Smoke
 
@@ -21,5 +22,24 @@ verity_contract ExternalCallConstructorHost include ExternalCallConstructorMixin
 
 example : Contract Unit := ExternalCallConstructorMixin.constructor .stub 41
 example : Contract Unit := ExternalCallConstructorHost.constructor .stub 41
+
+verity_mixin StaticCallConstructorMixin where
+  storage
+  constructor () := do
+    ecmBind [sumX, sumY]
+      (Compiler.Modules.Precompiles.bn256AddModule "sumX" "sumY")
+      [1, 2, 3, 4]
+    pure ()
+
+verity_contract StaticCallConstructorHost include StaticCallConstructorMixin where
+  storage
+  constructor () StaticCallConstructorMixin() := do
+    ecmBind [sumX, sumY]
+      (Compiler.Modules.Precompiles.bn256AddModule "sumX" "sumY")
+      [5, 6, 7, 8]
+    pure ()
+
+example : Contract Unit := StaticCallConstructorMixin.constructor
+example : Contract Unit := StaticCallConstructorHost.constructor
 
 end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -68,6 +68,14 @@ verity_contract ExternalCallInBodySmoke where
     let result := callExternal dirtyUint()
     return result
 
+  function reentrancy_trusted mutableDirtyUint () : Uint32 := do
+    let mut result := callExternal dirtyUint()
+    result := callExternal dirtyUint()
+    return result
+
+  function reentrancy_trusted adversaryNameDoesNotCapture (_adv : Uint256) : Uint32 := do
+    return callExternal dirtyUint()
+
   function reentrancy_trusted directDirtyUint () : Uint32 := do
     return callExternal dirtyUint()
 

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -60,6 +60,32 @@ verity_contract ExternalCallInBodySmoke where
   function reentrancy_trusted linkedWrite (amount : Uint256, pubkey : Bytes) : Unit := do
     callExternal deposit(amount, pubkey)
 
+  function reentrancy_trusted adversarialLeaf (value : Uint32) : Uint32 := do
+    return callExternal dirtySink(value)
+
+  function reentrancy_trusted adversarialForwarder (value : Uint32) : Uint32 := do
+    let result ← adversarialLeaf(value)
+    return result
+
+  function reentrancy_trusted transitiveAdversarialCall (value : Uint32) : Uint32 := do
+    let result ← adversarialForwarder(value)
+    return result
+
+  function reentrancy_trusted conditionalLinkedRead (takeCall : Bool) : Uint256 := do
+    if takeCall then
+      return callExternal narrowEcho(1)
+    else
+      return 7
+
+  function reentrancy_trusted revertNestedExternalArg () : Unit := do
+    revert Failure(callExternal narrowEcho(1))
+
+  function reentrancy_trusted revertErrorNestedExternalArg () : Unit := do
+    revertError Failure(callExternal narrowEcho(1))
+
+  function reentrancy_trusted panicNestedExternalArg () : Unit := do
+    panic(callExternal narrowEcho(1))
+
   function reentrancy_trusted pureNarrow () : Uint256 := do
     let result := callExternal narrowEcho(0xdeadbeef)
     return result
@@ -807,6 +833,12 @@ private def balanceAdversary :
   result := fun _ s => .success [s.selfBalance.val]
   gasUsed := fun _ _ => 0
 
+private def transitiveAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun _ _ => .success [41]
+  gasUsed := fun _ _ => 0
+
 example :
     let s : ContractState := { defaultState with selfBalance := 7 }
     (Contracts.externalCallContractWords (α := Uint256) "getDepositableEther" []
@@ -815,5 +847,22 @@ example :
         { s with
             calls := [Contracts.linkedCallEntry "getDepositableEther" [] .success [7] 0]
             returndata := [7] } := rfl
+
+example :
+    ((ExternalCallInBodySmoke.conditionalLinkedRead .stub false).run defaultState).getValue? =
+      some 7 ∧
+    ((ExternalCallInBodySmoke.conditionalLinkedRead .stub false).run defaultState).getState.calls =
+      [] := by
+  decide
+
+example :
+    ((ExternalCallInBodySmoke.conditionalLinkedRead .stub true).run defaultState).getState.calls.length =
+      1 := by
+  decide
+
+example :
+    ((ExternalCallInBodySmoke.transitiveAdversarialCall transitiveAdversary 1).run
+      defaultState).getValue? = some 41 := by
+  decide
 
 end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -43,6 +43,7 @@ verity_contract ExternalCallInBodySmoke where
     external dirtyUint_try() -> (Bool, Uint32)
     external dirtyPair() -> (NarrowPair)
     external dirtyPair_try() -> (Bool, NarrowPair)
+    external dirtyBytesArg(Bytes) -> (Uint256)
     external dirtyInt() -> (Int32)
     external dirtyBytes() -> (Bytes4)
     external dirtyAddress() -> (Address)
@@ -138,6 +139,11 @@ verity_contract ExternalCallInBodySmoke where
 
   function reentrancy_trusted duplicateIdenticalCalls () : Uint32 := do
     return callExternal dirtyUint() + callExternal dirtyUint()
+
+  function reentrancy_trusted dynamicTry (payload : Bytes) : Uint256 := do
+    let (_success, result) ← tryExternalCall "dirtyBytesArg" [payload]
+    return result
+
 
   function reentrancy_trusted bindDirtyAddress () : Address := do
     let result ← callExternal dirtyAddress()
@@ -902,6 +908,11 @@ example :
       some 7 := by
   decide
 
+example :
+    ((Contracts.externalCallContractWords (α := Array Uint256) "dirtyFixed" []
+      structResultAdversary 2).run defaultState).getValue? = some #[7, 9] := by
+  native_decide
+
 private def orderedResultAdversary :
     Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
   stateTransition := fun _ state => state
@@ -911,6 +922,23 @@ private def orderedResultAdversary :
 example :
     ((ExternalCallInBodySmoke.duplicateIdenticalCalls orderedResultAdversary).run
       defaultState).getValue? = some 3 := by
+  decide
+
+private def calldataAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun site _ => .success [site.calldata.getLast?.getD 0]
+  gasUsed := fun _ _ => 0
+
+example :
+    let s : ContractState := { defaultState with selfBalance := 20 }
+    ((ExternalCallInBodySmoke.lowLevel calldataAdversary 7 3).run s).getState.calls.head?.map
+      (fun call => call.calldata.head?.getD 0) = some 3 := by
+  decide
+
+example :
+    ((ExternalCallInBodySmoke.dynamicTry calldataAdversary "ab".toUTF8).run
+      defaultState).getValue? = some 2 := by
   decide
 
 example :

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -839,6 +839,20 @@ private def transitiveAdversary :
   result := fun _ _ => .success [41]
   gasUsed := fun _ _ => 0
 
+private def resolvedLinkAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun site state =>
+    .success [site.target + site.value + state.selfBalance.val]
+  gasUsed := fun _ _ => 0
+
+private def resolvedLinkContext : Contracts.ExecutableCallContext :=
+  { adversary := resolvedLinkAdversary
+    resolve := fun name _ =>
+      if name == "getDepositableEther" then
+        some { target := 5, value := 3, siteId := 19 }
+      else none }
+
 example :
     let s : ContractState := { defaultState with selfBalance := 7 }
     (Contracts.externalCallContractWords (α := Uint256) "getDepositableEther" []
@@ -863,6 +877,15 @@ example :
 example :
     ((ExternalCallInBodySmoke.transitiveAdversarialCall transitiveAdversary 1).run
       defaultState).getValue? = some 41 := by
+  decide
+
+example :
+    let s : ContractState := { defaultState with selfBalance := 20 }
+    let out := (ExternalCallInBodySmoke.linkedRead resolvedLinkContext).run s
+    out.getValue? = some 25 ∧
+      out.getState.selfBalance = 17 ∧
+      out.getState.calls.map (fun call => (call.siteId, call.target, call.value)) =
+        [(19, 5, 3)] := by
   decide
 
 example :

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -289,7 +289,7 @@ example : (ExternalCallInBodySmoke.linkedRead_modelBody).take 1 =
 
 example : (ExternalCallInBodySmoke.linkedWrite_modelBody).take 1 =
     [Compiler.CompilationModel.Stmt.externalCallBind [] "deposit"
-      [ .param "amount", .literal 0, .param "pubkey_length" ]] := rfl
+      [ .param "amount", .param "pubkey_data_offset", .param "pubkey_length" ]] := rfl
 
 example : (ExternalCallInBodySmoke.pureNarrow_modelBody).take 1 =
     [Compiler.CompilationModel.Stmt.letVar "result"
@@ -349,6 +349,10 @@ example : (ExternalCallInBodySmoke.tryDirtyPair_modelBody).take 4 =
     , .assignVar "result_narrow"
         (.bitAnd (.localVar "result_narrow") (.literal (2 ^ 32 - 1)))
     , .return (.localVar "result_narrow") ] := rfl
+
+example : (ExternalCallInBodySmoke.dynamicTry_modelBody).take 1 =
+    [.tryExternalCallBind "_success" ["result"] "dirtyBytesArg"
+      [.param "payload_data_offset", .param "payload_length"]] := rfl
 
 example : (ExternalCallInBodySmoke.bindDirtyAddress_modelBody).take 2 =
     [ .externalCallBind ["result"] "dirtyAddress" []

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -72,6 +72,9 @@ verity_contract ExternalCallInBodySmoke where
     let result ← adversarialForwarder(value)
     return result
 
+  function helperNameShadow (adversarialLeaf : Uint256) : Uint256 := do
+    return adversarialLeaf
+
   function reentrancy_trusted conditionalLinkedRead (takeCall : Bool) : Uint256 := do
     if takeCall then
       return callExternal narrowEcho(1)
@@ -861,6 +864,21 @@ private def resolvedLinkContext : Contracts.ExecutableCallContext :=
       if name == "getDepositableEther" then
         some { target := 5, value := 3, siteId := 19 }
       else none }
+
+private def unresolvedLinkContext : Contracts.ExecutableCallContext :=
+  { adversary := .stub
+    resolve := fun _ _ => none }
+
+example :
+    ((ExternalCallInBodySmoke.helperNameShadow 7).run defaultState).getValue? = some 7 := by
+  decide
+
+example :
+    let s : ContractState := { defaultState with returndata := [41, 42] }
+    let out := (Contracts.tryExternalCallWordsResolved (α := Uint256)
+      "missing" [] unresolvedLinkContext).run s
+    out.getValue?.map Prod.fst = some false ∧ out.getState.returndata = [41, 42] := by
+  decide
 
 example :
     let s : ContractState := { defaultState with selfBalance := 7 }

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -865,4 +865,19 @@ example :
       defaultState).getValue? = some 41 := by
   decide
 
+example :
+    ((ExternalCallInBodySmoke.customErrorNestedExternalArg transitiveAdversary).run
+      defaultState).getState.calls = [] := by
+  decide
+
+example :
+    let s : ContractState := { defaultState with selfBalance := 10 }
+    ((ExternalCallInBodySmoke.lowLevel transitiveAdversary 7 1).run s).getState.memory 96 = 41 := by
+  decide
+
+example :
+    let s : ContractState := { defaultState with returndata := [41] }
+    (ExternalCallInBodySmoke.composedReturnDataSize.run s).getValue? = some 33 := by
+  decide
+
 end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -289,7 +289,7 @@ example : (ExternalCallInBodySmoke.linkedRead_modelBody).take 1 =
 
 example : (ExternalCallInBodySmoke.linkedWrite_modelBody).take 1 =
     [Compiler.CompilationModel.Stmt.externalCallBind [] "deposit"
-      [ .param "amount", .param "pubkey_data_offset", .param "pubkey_length" ]] := rfl
+      [ .param "amount", .literal 0, .param "pubkey_length" ]] := rfl
 
 example : (ExternalCallInBodySmoke.pureNarrow_modelBody).take 1 =
     [Compiler.CompilationModel.Stmt.letVar "result"

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -136,6 +136,9 @@ verity_contract ExternalCallInBodySmoke where
     let (_success, result) ← tryExternalCall "dirtyPair" []
     return result.narrow
 
+  function reentrancy_trusted duplicateIdenticalCalls () : Uint32 := do
+    return callExternal dirtyUint() + callExternal dirtyUint()
+
   function reentrancy_trusted bindDirtyAddress () : Address := do
     let result ← callExternal dirtyAddress()
     return result
@@ -897,6 +900,17 @@ private def structResultAdversary :
 example :
     ((ExternalCallInBodySmoke.tryDirtyPair structResultAdversary).run defaultState).getValue? =
       some 7 := by
+  decide
+
+private def orderedResultAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun _ state => .success [state.calls.length + 1]
+  gasUsed := fun _ _ => 0
+
+example :
+    ((ExternalCallInBodySmoke.duplicateIdenticalCalls orderedResultAdversary).run
+      defaultState).getValue? = some 3 := by
   decide
 
 example :

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -791,4 +791,21 @@ example : ExternalCallInBodySmoke.tupleArrayLinkedIndexReturn_modelBody =
             (Compiler.CompilationModel.Expr.localVar "arrayElement_index") 2 1 ] ] := by
   rfl
 
+/-- Live-state expression/bind helpers observe the caller `selfBalance`, not
+`defaultState`. -/
+private def balanceAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun _ s => .success [s.selfBalance.val]
+  gasUsed := fun _ _ => 0
+
+example :
+    let s : ContractState := { defaultState with selfBalance := 7 }
+    (Contracts.externalCallContractWords (α := Uint256) "getDepositableEther" []
+      balanceAdversary 1 0).run s =
+      ContractResult.success (7 : Uint256)
+        { s with
+            calls := [Contracts.linkedCallEntry "getDepositableEther" [] .success [7] 0]
+            returndata := [7] } := rfl
+
 end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCallInBodySmoke.lean
+++ b/Contracts/Smoke/ExternalCallInBodySmoke.lean
@@ -843,7 +843,7 @@ private def resolvedLinkAdversary :
     Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
   stateTransition := fun _ state => state
   result := fun site state =>
-    .success [site.target + site.value + state.selfBalance.val]
+    .success [site.target + site.value + site.gas + state.selfBalance.val]
   gasUsed := fun _ _ => 0
 
 private def resolvedLinkContext : Contracts.ExecutableCallContext :=
@@ -882,10 +882,21 @@ example :
 example :
     let s : ContractState := { defaultState with selfBalance := 20 }
     let out := (ExternalCallInBodySmoke.linkedRead resolvedLinkContext).run s
-    out.getValue? = some 25 ∧
+    out.getValue? = some 42 ∧
       out.getState.selfBalance = 17 ∧
       out.getState.calls.map (fun call => (call.siteId, call.target, call.value)) =
         [(19, 5, 3)] := by
+  decide
+
+private def structResultAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun _ _ => .success [7, 9]
+  gasUsed := fun _ _ => 0
+
+example :
+    ((ExternalCallInBodySmoke.tryDirtyPair structResultAdversary).run defaultState).getValue? =
+      some 7 := by
   decide
 
 example :

--- a/Contracts/Smoke/ExternalCallObservability.lean
+++ b/Contracts/Smoke/ExternalCallObservability.lean
@@ -83,7 +83,8 @@ example :
       ContractResult.success ()
         { codedState with
             calls := [{ Contracts.erc20WriteEntry "legacyStringSafeTransfer" 7 [8, 9] with
-              returndata := [1, 37] }] } := rfl
+              returndata := [1, 37] }]
+            returndata := [1, 37] } := rfl
 
 /-- Optional-bool matching observes EVM words, so an adversarial natural
 congruent to one modulo the EVM word modulus is accepted as `true`. -/
@@ -93,7 +94,8 @@ example :
       ContractResult.success ()
         { codedState with
             calls := [{ Contracts.erc20WriteEntry "safeTransfer" 7 [8, 9] with
-              returndata := [Compiler.Constants.evmModulus + 1] }] } := rfl
+              returndata := [Compiler.Constants.evmModulus + 1] }]
+            returndata := [1] } := rfl
 
 /-- Failed `callResult` crossings retain the first returned word rather than
 replacing the compiler-observable payload with the type default. -/
@@ -103,7 +105,8 @@ example :
         Contract (Contracts.Call.Result Uint256)).run defaultState =
       ContractResult.success { success := false, returndata := 42 }
         { defaultState with
-            calls := [Contracts.linkedCallEntry "probe" [9] .failure [42, 99]] } := rfl
+            calls := [Contracts.linkedCallEntry "probe" [9] .failure [42, 99]]
+            returndata := [42, 99] } := rfl
 
 /-- Reverted try-call payloads are decoded as normalized EVM words on the
 in-band failure path, matching `Stmt.tryExternalCallBind`. -/
@@ -114,7 +117,8 @@ example :
       ContractResult.success (false, 42)
         { defaultState with
             calls := [Contracts.linkedCallEntry "probe" [9] .revert
-              [Compiler.Constants.evmModulus + 42]] } := rfl
+              [Compiler.Constants.evmModulus + 42]]
+            returndata := [42] } := rfl
 
 /-- One call appends exactly one journal entry. -/
 theorem single_call_journals_one_entry (s : ContractState) :
@@ -206,8 +210,12 @@ theorem double_send_observable (token toAddr : Address) (amount : Uint256)
       (fun _ => Contracts.safeTransfer token toAddr amount)).run s).snd.calls ≠ _
   let entry := Contracts.erc20WriteEntry "safeTransfer" token
     [Verity.addressToWord toAddr, amount]
-  let s₁ := { s with calls := s.calls ++ [entry] }
-  let s₂ := { s₁ with calls := s₁.calls ++ [entry] }
+  let s₁ := { s with
+    calls := s.calls ++ [entry]
+    returndata := [] }
+  let s₂ := { s₁ with
+    calls := s₁.calls ++ [entry]
+    returndata := [] }
   have h₁ : (Contracts.safeTransfer token toAddr amount).run s =
       ContractResult.success () s₁ := by
     simpa [s₁, entry] using Contracts.safeTransfer_run token toAddr amount s hcode
@@ -247,7 +255,8 @@ example :
         Contract (Bool × Uint256)).run defaultState) =
       ContractResult.success (true, 37)
         { defaultState with
-            calls := [Contracts.linkedCallEntry "echo" [37] .success [37]] } := rfl
+            calls := [Contracts.linkedCallEntry "echo" [37] .success [37]]
+            returndata := [37] } := rfl
 
 /-- ERC-20 reads journal the token as target, ABI arguments as calldata, and
 the returned stub word as returndata, using the same `staticcall` kind as the

--- a/Contracts/Smoke/ExternalCallObservability.lean
+++ b/Contracts/Smoke/ExternalCallObservability.lean
@@ -405,4 +405,14 @@ theorem revert_rolls_back_journal (token toAddr : Address) (amount : Uint256)
   have h₁raw := Contract.eq_of_run_success h₁
   simp [Verity.bind, Contract.run, h₁raw, Verity.require]
 
+/-- Generated linked-call journals carry the declaration-index `siteId`. -/
+example :
+    (Contracts.externalCallContractWords (α := Uint256) "getDepositableEther" []
+      .stub 1 0).run defaultState =
+      ContractResult.success (externalCallStubWord "getDepositableEther" [])
+        { defaultState with
+            calls := [Contracts.linkedCallEntry "getDepositableEther" [] .success
+              [(externalCallStubWord "getDepositableEther" [] : Nat)] 0]
+            returndata := [(externalCallStubWord "getDepositableEther" [] : Nat)] } := rfl
+
 end Contracts.Smoke.ExternalCallObservability

--- a/Contracts/Smoke/ExternalCallObservability.lean
+++ b/Contracts/Smoke/ExternalCallObservability.lean
@@ -319,6 +319,13 @@ theorem same_length_array_mutation_observable (s : ContractState) :
 /-- Dynamic byte encoding is length-delimited and retains every byte. -/
 example : ExternalArg.toWords (⟨#[0x11, 0x12]⟩ : ByteArray) = [2, 0x11, 0x12] := rfl
 
+example : ExternalArg.toWords "ab" = [2, 0x61, 0x62] := rfl
+
+example :
+    let post := ((Contracts.mstore 7 11).run defaultState).snd
+    post.memory 7 = 11 ∧ post.memory 8 = 0 := by
+  decide
+
 /-- Same-length byte content mutations are observable at the journal. -/
 theorem same_length_bytes_mutation_observable (s : ContractState) :
     ((Contracts.externalCallBind ([] : List String) "bytesArg"

--- a/Contracts/Smoke/ExternalCallValue.lean
+++ b/Contracts/Smoke/ExternalCallValue.lean
@@ -78,6 +78,14 @@ private def staleCaller : Compiler.CompilationModel.Denote.DenoteState :=
 private def rawCallSite : CallSite :=
   { siteId := 0, kind := .call, target := 9, value := 0, calldata := [7], gas := 1000 }
 
+/-- Raw-call memory operands are byte ranges: one 32-byte region denotes one
+word, and consecutive words are read at 32-byte offsets. -/
+example : readMemoryWords (fun i => if i = 0 then 7 else if i = 32 then 9 else 11) 0 32 = [7] := by
+  native_decide
+
+example : readMemoryWords (fun i => if i = 0 then 7 else if i = 32 then 9 else 11) 0 64 = [7, 9] := by
+  native_decide
+
 private def rawCallLetVarWorks : Bool :=
     match execStmtWithCalls echoEnv [] staleCaller
         (.letVar "ok" (.call (.literal 1000) (.literal 9) (.literal 0)

--- a/Contracts/Smoke/ExternalCallValue.lean
+++ b/Contracts/Smoke/ExternalCallValue.lean
@@ -69,6 +69,9 @@ private def callBitBuffer (r : Option (Nat × Compiler.CompilationModel.Denote.D
 private def outcomeBuffer (r : StmtOutcome) : Option (List Nat) :=
   match r with | .continue s => some s.world.returndata | _ => none
 
+private def outcomeBinding (name : String) (r : StmtOutcome) : Option Nat :=
+  match r with | .continue s => s.bindings.lookup name | _ => none
+
 /-- `applyRawCall` success installs the callee's words as the buffer. -/
 example :
     callBitBuffer (applyRawCall echoEnv staleCaller rawCallSite 0 0) = some (1, [7]) := by
@@ -99,6 +102,11 @@ example :
     outcomeBuffer (execTryExternalCallBind revertEnv [] staleCaller "ok" ["r"] "linked"
       [.literal 7]) = some [5] := by
   native_decide
+
+example :
+    outcomeBinding "r" (execTryExternalCallBind revertEnv [] staleCaller "ok" ["r"]
+      "linked" [.literal 7]) = some 5 := by
+  decide
 
 /-- Regression: the try-lane success branch installs the returned words. -/
 example :

--- a/Contracts/Smoke/ExternalCallValue.lean
+++ b/Contracts/Smoke/ExternalCallValue.lean
@@ -69,6 +69,11 @@ private def identityEnv : CallEnv :=
     adversary := identityAdversary
     resolve := fun _ => some { target := 9, value := 0, siteId := 0 } }
 
+private def stubEnv : CallEnv :=
+  { oracle := probeOracle
+    adversary := AdversaryModel.stub
+    resolve := fun _ => some { target := 9, value := 0, siteId := 0 } }
+
 private def nestedOnlyEnv : CallEnv :=
   { oracle := probeOracle
     adversary := echoAdversary
@@ -202,6 +207,12 @@ example :
 example :
     outcomeBuffer (execTryExternalCallBind echoEnv [] staleCaller "ok" ["r"] "linked"
       [.literal 7]) = some [7] := by
+  native_decide
+
+/-- A result-returning try call supplies its exact name and arity to `.stub`. -/
+example :
+    outcomeBinding "r" (execTryExternalCallBind stubEnv [] staleCaller "ok" ["r"]
+      "linked" [.literal 7]) = some (AdversaryModel.stubWord "linked" [7]) := by
   native_decide
 
 /-- Successful try calls reject returndata outside the declared arity. -/

--- a/Contracts/Smoke/ExternalCallValue.lean
+++ b/Contracts/Smoke/ExternalCallValue.lean
@@ -101,6 +101,42 @@ private def nestedLinkedCallWorks : Bool :=
 example : nestedLinkedCallWorks = true := by
   native_decide
 
+/-! #### Call-bearing operands in non-binding statements
+
+The widened evaluator must thread the call post-state into every statement
+family, not only local bindings and returns. -/
+
+private def linkedSeven : Compiler.CompilationModel.Expr :=
+  .externalCall "linked" [.literal 7]
+
+private def callBearingMstoreWorks : Bool :=
+  match execStmtWithCalls echoEnv [] staleCaller (.mstore (.literal 0) linkedSeven) with
+  | .continue post => post.world.memory 0 == 7 && post.world.calls.length == 1
+  | _ => false
+
+example : callBearingMstoreWorks = true := by
+  native_decide
+
+private def callBearingRequireWorks : Bool :=
+  match execStmtWithCalls echoEnv [] staleCaller (.require linkedSeven "linked") with
+  | .continue post => post.world.calls.length == 1
+  | _ => false
+
+example : callBearingRequireWorks = true := by
+  native_decide
+
+private def callStorageFields : List Compiler.CompilationModel.Field :=
+  [⟨"saved", .uint256, false, some 0, none, []⟩]
+
+private def callBearingStorageWriteWorks : Bool :=
+  match execStmtWithCalls echoEnv callStorageFields staleCaller
+      (.setStorage "saved" linkedSeven) with
+  | .continue post => post.world.storage 0 == 7 && post.world.calls.length == 1
+  | _ => false
+
+example : callBearingStorageWriteWorks = true := by
+  native_decide
+
 private def callBitBuffer (r : Option (Nat × Compiler.CompilationModel.Denote.DenoteState)) :
     Option (Nat × List Nat) :=
   r.map (fun (b, s) => (b, s.world.returndata))

--- a/Contracts/Smoke/ExternalCallValue.lean
+++ b/Contracts/Smoke/ExternalCallValue.lean
@@ -38,6 +38,12 @@ private def failAdversary :
   result := fun _ _ => .failure []
   gasUsed := fun _ _ => 0
 
+private def oversizedAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ w => w
+  result := fun _ _ => .success [7, 9]
+  gasUsed := fun _ _ => 0
+
 private def echoEnv : CallEnv :=
   { oracle := probeOracle
     adversary := echoAdversary
@@ -51,6 +57,16 @@ private def revertEnv : CallEnv :=
 private def failEnv : CallEnv :=
   { oracle := probeOracle
     adversary := failAdversary
+    resolve := fun _ => some { target := 9, value := 0, siteId := 0 } }
+
+private def oversizedEnv : CallEnv :=
+  { oracle := probeOracle
+    adversary := oversizedAdversary
+    resolve := fun _ => some { target := 9, value := 0, siteId := 0 } }
+
+private def identityEnv : CallEnv :=
+  { oracle := probeOracle
+    adversary := identityAdversary
     resolve := fun _ => some { target := 9, value := 0, siteId := 0 } }
 
 /-- Caller state whose pre-call buffer is stale, so a lane that fails to
@@ -72,6 +88,17 @@ private def rawCallLetVarWorks : Bool :=
     | _ => false
 
 example : rawCallLetVarWorks = true := by
+  native_decide
+
+/-- A linked call nested under result normalization is evaluated through the
+call environment, and its post-state is retained. -/
+private def nestedLinkedCallWorks : Bool :=
+  match evalExprCall echoEnv [] staleCaller
+      (.bitAnd (.externalCall "linked" [.literal 7]) (.literal 255)) with
+  | some (value, post) => value == 7 && post.world.calls.length == 1
+  | none => false
+
+example : nestedLinkedCallWorks = true := by
   native_decide
 
 private def callBitBuffer (r : Option (Nat × Compiler.CompilationModel.Denote.DenoteState)) :
@@ -124,6 +151,41 @@ example :
 example :
     outcomeBuffer (execTryExternalCallBind echoEnv [] staleCaller "ok" ["r"] "linked"
       [.literal 7]) = some [7] := by
+  native_decide
+
+/-- Successful try calls reject returndata outside the declared arity. -/
+private def oversizedTryReverts : Bool :=
+  match execTryExternalCallBind oversizedEnv [] staleCaller "ok" ["r"] "linked" [] with
+  | .revert => true
+  | _ => false
+
+example : oversizedTryReverts = true := by
+  native_decide
+
+private def effectOnlyEcm : Compiler.ECM.ExternalCallModule where
+  name := "effectOnly"
+  numArgs := 0
+  resultVars := []
+  writesState := false
+  readsState := false
+  axioms := []
+  compile := fun _ _ => pure []
+
+/-- ECM statements use the supplied adversary and enforce zero result words. -/
+private def oversizedEffectOnlyEcmReverts : Bool :=
+  match execStmtWithCalls oversizedEnv [] staleCaller (.ecm effectOnlyEcm []) with
+  | .revert => true
+  | _ => false
+
+example : oversizedEffectOnlyEcmReverts = true := by
+  native_decide
+
+private def emptyEffectOnlyEcmSucceeds : Bool :=
+  match execStmtWithCalls identityEnv [] staleCaller (.ecm effectOnlyEcm []) with
+  | .continue post => post.world.calls.length == 1
+  | _ => false
+
+example : emptyEffectOnlyEcmSucceeds = true := by
   native_decide
 
 /-! #### Insufficient caller balance (PR #2400 Codex P1, round 2)

--- a/Contracts/Smoke/ExternalCallValue.lean
+++ b/Contracts/Smoke/ExternalCallValue.lean
@@ -62,6 +62,18 @@ private def staleCaller : Compiler.CompilationModel.Denote.DenoteState :=
 private def rawCallSite : CallSite :=
   { siteId := 0, kind := .call, target := 9, value := 0, calldata := [7], gas := 1000 }
 
+private def rawCallLetVarWorks : Bool :=
+    match execStmtWithCalls echoEnv [] staleCaller
+        (.letVar "ok" (.call (.literal 1000) (.literal 9) (.literal 0)
+          (.literal 0) (.literal 0) (.literal 0) (.literal 0))) with
+    | .continue post =>
+        Compiler.CompilationModel.Denote.lookupValue post.bindings "ok" == 1 &&
+          post.world.calls.length == 1
+    | _ => false
+
+example : rawCallLetVarWorks = true := by
+  native_decide
+
 private def callBitBuffer (r : Option (Nat × Compiler.CompilationModel.Denote.DenoteState)) :
     Option (Nat × List Nat) :=
   r.map (fun (b, s) => (b, s.world.returndata))

--- a/Contracts/Smoke/ExternalCallValue.lean
+++ b/Contracts/Smoke/ExternalCallValue.lean
@@ -211,4 +211,35 @@ example :
       (fun frame => frame.calleeEntry.returndata) = some [] := by
   native_decide
 
+/-! ### PR3 executable `evmCallWords` memory / value close-out -/
+
+private def memState : ContractState :=
+  { Verity.defaultState with
+      selfBalance := 100
+      memory := fun i => if i = 0 then 7 else 0
+      returndata := [3] }
+
+private def echoCallAdv :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ w => w
+  result := fun site _ => .success site.calldata
+  gasUsed := fun _ _ => 0
+
+/-- Successful raw call reads caller memory as calldata, writes returndata,
+and debits value. -/
+example :
+    let r := (Contracts.evmCallWords echoCallAdv 1000 9 10 0 1 2 1).run memState
+    r.fst = (1 : Uint256) ∧
+      r.snd.selfBalance = (90 : Uint256) ∧
+      r.snd.returndata = [7] ∧
+      r.snd.memory 2 = (7 : Uint256) := by
+  native_decide
+
+/-- Unfunded raw call returns bit 0 with an empty buffer and never invokes
+the adversary (stale `[3]` does not survive). -/
+example :
+    let r := (Contracts.evmCallWords echoCallAdv 1000 9 200 0 1 0 0).run memState
+    r.fst = (0 : Uint256) ∧ r.snd.returndata = [] ∧ r.snd.calls = [] := by
+  native_decide
+
 end Contracts.Smoke.ExternalCallValue

--- a/Contracts/Smoke/ExternalCallValue.lean
+++ b/Contracts/Smoke/ExternalCallValue.lean
@@ -69,6 +69,13 @@ private def identityEnv : CallEnv :=
     adversary := identityAdversary
     resolve := fun _ => some { target := 9, value := 0, siteId := 0 } }
 
+private def nestedOnlyEnv : CallEnv :=
+  { oracle := probeOracle
+    adversary := echoAdversary
+    resolve := fun name =>
+      if name == "linked" then some { target := 9, value := 0, siteId := 0 }
+      else none }
+
 /-- Caller state whose pre-call buffer is stale, so a lane that fails to
 install the new call's data is caught reading `[3]`. -/
 private def staleCaller : Compiler.CompilationModel.Denote.DenoteState :=
@@ -204,6 +211,20 @@ private def oversizedTryReverts : Bool :=
   | _ => false
 
 example : oversizedTryReverts = true := by
+  native_decide
+
+/-- An unresolved outer try-call retains the post-state produced while
+evaluating its nested call-bearing arguments. -/
+private def unresolvedTryRetainsArgumentCall : Bool :=
+  match execTryExternalCallBind nestedOnlyEnv [] staleCaller "ok" ["r"] "missing"
+      [.externalCall "linked" [.literal 7]] with
+  | .continue post =>
+      post.world.calls.length == 1 &&
+        Compiler.CompilationModel.Denote.lookupValue post.bindings "ok" == 0 &&
+        Compiler.CompilationModel.Denote.lookupValue post.bindings "r" == 0
+  | _ => false
+
+example : unresolvedTryRetainsArgumentCall = true := by
   native_decide
 
 private def effectOnlyEcm : Compiler.ECM.ExternalCallModule where

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -853,4 +853,14 @@ example :
       (arityAdversary 1 []) 1 4).run defaultState =
       ContractResult.revert "external call returned malformed data" defaultState := rfl
 
+/-- Bound helpers decode the declared prefix and tolerate trailing returndata,
+matching the compilation model's external-call binding semantics. -/
+example :
+    (Contracts.externalCallContractWords (α := Uint256) "dirtyUint" []
+      (arityAdversary 1 [7, 9]) 1 4).run defaultState =
+      ContractResult.success 7
+        { defaultState with
+            calls := [Contracts.linkedCallEntry "dirtyUint" [] .success [7, 9] 4]
+            returndata := [7, 9] } := rfl
+
 end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -142,7 +142,7 @@ example :
       [ Compiler.CompilationModel.Stmt.return
           (Compiler.CompilationModel.Expr.externalCall
             "hashArray"
-            [ Compiler.CompilationModel.Expr.param "leaves_data_offset"
+            [ Compiler.CompilationModel.Expr.literal 0
             , Compiler.CompilationModel.Expr.param "leaves_length"
             ])
       ] := rfl
@@ -152,7 +152,7 @@ example :
       [ Compiler.CompilationModel.Stmt.externalCallBind
           []
           "notifyArray"
-          [ Compiler.CompilationModel.Expr.param "leaves_data_offset"
+          [ Compiler.CompilationModel.Expr.literal 0
           , Compiler.CompilationModel.Expr.param "leaves_length"
           ]
       , Compiler.CompilationModel.Stmt.stop
@@ -164,7 +164,7 @@ example :
           "discard"
           (Compiler.CompilationModel.Expr.externalCall
             "hashArray"
-            [ Compiler.CompilationModel.Expr.param "leaves_data_offset"
+            [ Compiler.CompilationModel.Expr.literal 0
             , Compiler.CompilationModel.Expr.param "leaves_length"
             ])
       , Compiler.CompilationModel.Stmt.stop
@@ -176,7 +176,7 @@ example :
           "_success"
           ["h"]
           "hashArray"
-          [ Compiler.CompilationModel.Expr.param "leaves_data_offset"
+          [ Compiler.CompilationModel.Expr.literal 0
           , Compiler.CompilationModel.Expr.param "leaves_length"
           ]
       , Compiler.CompilationModel.Stmt.assignVar "_success"
@@ -406,7 +406,7 @@ example :
       [ Compiler.CompilationModel.Stmt.return
           (Compiler.CompilationModel.Expr.externalCall
             "hashBytes"
-            [ Compiler.CompilationModel.Expr.param "payload_data_offset"
+            [ Compiler.CompilationModel.Expr.literal 0
             , Compiler.CompilationModel.Expr.param "payload_length"
             ])
       ] := rfl
@@ -488,6 +488,12 @@ private def tripleResultAdversary :
   result := fun _ _ => .success [1, 2, 3]
   gasUsed := fun _ _ => 0
 
+private def unexpectedEffectResultAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun _ _ => .success [1]
+  gasUsed := fun _ _ => 0
+
 example :
     (((GenericECMTripleResultSmoke.storeThird tripleResultAdversary).run defaultState).getState
       ).storage 0 = 3 := by
@@ -498,6 +504,15 @@ verity_contract GenericECMWriteSmoke where
 
   function runEffect (lhs : Uint256, rhs : Uint256) : Unit := do
     ecmDo genericECMEffectDemoModule [lhs, rhs]
+
+private def unexpectedEffectResultReverts : Bool :=
+  match (GenericECMWriteSmoke.runEffect unexpectedEffectResultAdversary 1 2).run
+      defaultState with
+  | .revert _ _ => true
+  | _ => false
+
+example : unexpectedEffectResultReverts = true := by
+  native_decide
 
 verity_contract BubblingValueCallECMSmoke where
   storage

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -465,6 +465,34 @@ verity_contract GenericECMMultiResultSmoke where
     setStorage lastX sumX
     setStorage lastY sumY
 
+def genericECMTripleResultModule : Compiler.ECM.ExternalCallModule where
+  name := "genericTripleResult"
+  numArgs := 0
+  resultVars := ["first", "second", "third"]
+  writesState := false
+  readsState := false
+  axioms := []
+  compile := fun _ctx _args => pure []
+
+verity_contract GenericECMTripleResultSmoke where
+  storage
+    last : Uint256 := slot 0
+
+  function allow_post_interaction_writes storeThird () : Unit := do
+    ecmBind [first, second, third] genericECMTripleResultModule []
+    setStorage last third
+
+private def tripleResultAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun _ _ => .success [1, 2, 3]
+  gasUsed := fun _ _ => 0
+
+example :
+    (((GenericECMTripleResultSmoke.storeThird tripleResultAdversary).run defaultState).getState
+      ).storage 0 = 3 := by
+  native_decide
+
 verity_contract GenericECMWriteSmoke where
   storage
 

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -142,7 +142,7 @@ example :
       [ Compiler.CompilationModel.Stmt.return
           (Compiler.CompilationModel.Expr.externalCall
             "hashArray"
-            [ Compiler.CompilationModel.Expr.literal 0
+            [ Compiler.CompilationModel.Expr.param "leaves_data_offset"
             , Compiler.CompilationModel.Expr.param "leaves_length"
             ])
       ] := rfl
@@ -152,7 +152,7 @@ example :
       [ Compiler.CompilationModel.Stmt.externalCallBind
           []
           "notifyArray"
-          [ Compiler.CompilationModel.Expr.literal 0
+          [ Compiler.CompilationModel.Expr.param "leaves_data_offset"
           , Compiler.CompilationModel.Expr.param "leaves_length"
           ]
       , Compiler.CompilationModel.Stmt.stop
@@ -164,7 +164,7 @@ example :
           "discard"
           (Compiler.CompilationModel.Expr.externalCall
             "hashArray"
-            [ Compiler.CompilationModel.Expr.literal 0
+            [ Compiler.CompilationModel.Expr.param "leaves_data_offset"
             , Compiler.CompilationModel.Expr.param "leaves_length"
             ])
       , Compiler.CompilationModel.Stmt.stop
@@ -176,7 +176,7 @@ example :
           "_success"
           ["h"]
           "hashArray"
-          [ Compiler.CompilationModel.Expr.literal 0
+          [ Compiler.CompilationModel.Expr.param "leaves_data_offset"
           , Compiler.CompilationModel.Expr.param "leaves_length"
           ]
       , Compiler.CompilationModel.Stmt.assignVar "_success"
@@ -406,7 +406,7 @@ example :
       [ Compiler.CompilationModel.Stmt.return
           (Compiler.CompilationModel.Expr.externalCall
             "hashBytes"
-            [ Compiler.CompilationModel.Expr.literal 0
+            [ Compiler.CompilationModel.Expr.param "payload_data_offset"
             , Compiler.CompilationModel.Expr.param "payload_length"
             ])
       ] := rfl
@@ -482,21 +482,8 @@ verity_contract GenericECMTripleResultSmoke where
     ecmBind [first, second, third] genericECMTripleResultModule []
     setStorage last third
 
-private def tripleResultAdversary :
-    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
-  stateTransition := fun _ state => state
-  result := fun _ _ => .success [1, 2, 3]
-  gasUsed := fun _ _ => 0
-
-private def unexpectedEffectResultAdversary :
-    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
-  stateTransition := fun _ state => state
-  result := fun _ _ => .success [1]
-  gasUsed := fun _ _ => 0
-
 example :
-    (((GenericECMTripleResultSmoke.storeThird tripleResultAdversary).run defaultState).getState
-      ).storage 0 = 3 := by
+    ((GenericECMTripleResultSmoke.storeThird.run defaultState).getState.calls.length) = 1 := by
   native_decide
 
 verity_contract GenericECMWriteSmoke where
@@ -505,13 +492,8 @@ verity_contract GenericECMWriteSmoke where
   function runEffect (lhs : Uint256, rhs : Uint256) : Unit := do
     ecmDo genericECMEffectDemoModule [lhs, rhs]
 
-private def unexpectedEffectResultReverts : Bool :=
-  match (GenericECMWriteSmoke.runEffect unexpectedEffectResultAdversary 1 2).run
-      defaultState with
-  | .revert _ _ => true
-  | _ => false
-
-example : unexpectedEffectResultReverts = true := by
+example :
+    ((GenericECMWriteSmoke.runEffect 1 2).run defaultState).getState.calls.length = 1 := by
   native_decide
 
 verity_contract BubblingValueCallECMSmoke where

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -504,6 +504,61 @@ example :
     ((GenericECMWriteSmoke.runEffect .stub 1 2).run defaultState).getState.calls.length = 1 := by
   native_decide
 
+def directDynamicEcmResultModule (resultVar : String) : Compiler.ECM.ExternalCallModule where
+  name := "directDynamicEcmResult"
+  numArgs := 2
+  resultVars := [resultVar]
+  writesState := false
+  readsState := false
+  axioms := []
+  compile := fun _ctx _args => pure []
+
+def directDynamicEcmEffectModule : Compiler.ECM.ExternalCallModule where
+  name := "directDynamicEcmEffect"
+  numArgs := 2
+  resultVars := []
+  writesState := false
+  readsState := false
+  axioms := []
+  compile := fun _ctx _args => pure []
+
+verity_contract DirectDynamicECMArgSmoke where
+  storage
+
+  function fromCall (payload : Bytes) : Uint256 := do
+    let result ← ecmCall directDynamicEcmResultModule [payload]
+    return result
+
+  function fromDo (message : String) : Unit := do
+    ecmDo directDynamicEcmEffectModule [message]
+
+  function fromBind (values : Array Uint256) : Unit := do
+    ecmBind [result] (directDynamicEcmResultModule "result") [values]
+
+private def successfulDynamicEcmAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun site _ => .success (List.replicate site.returnArity 9)
+  gasUsed := fun _ _ => 0
+
+/-- Executable ECM calls use the same synthetic `data_offset, length` key as
+the model for direct bytes, string, and dynamic-array parameters. -/
+example :
+    ((DirectDynamicECMArgSmoke.fromCall successfulDynamicEcmAdversary
+      (ByteArray.mk #[1, 2, 3])).run defaultState).getState.calls.head?.map
+        (fun call => call.calldata) = some [0, 3] := by
+  decide
+
+example :
+    ((DirectDynamicECMArgSmoke.fromDo successfulDynamicEcmAdversary "verity").run
+      defaultState).getState.calls.head?.map (fun call => call.calldata) = some [0, 6] := by
+  decide
+
+example :
+    ((DirectDynamicECMArgSmoke.fromBind successfulDynamicEcmAdversary #[4, 5]).run
+      defaultState).getState.calls.head?.map (fun call => call.calldata) = some [0, 2] := by
+  decide
+
 verity_contract BubblingValueCallECMSmoke where
   storage
 

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -482,16 +482,9 @@ verity_contract GenericECMTripleResultSmoke where
     ecmBind [first, second, third] genericECMTripleResultModule []
     setStorage last third
 
-private def tripleResultAdversary :
-    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
-  stateTransition := fun _ state => state
-  result := fun _ _ => .success [1, 2, 3]
-  gasUsed := fun _ _ => 0
-
-/-- A read-only ECM still receives the caller-supplied adversary. -/
+/-- A read-only ECM uses the deterministic stub without exposing an adversary parameter. -/
 example :
-    ((GenericECMTripleResultSmoke.storeThird tripleResultAdversary).run
-      defaultState).getState.storage GenericECMTripleResultSmoke.last.slot = 3 := by
+    ((GenericECMTripleResultSmoke.storeThird).run defaultState).getState.calls.length = 1 := by
   decide
 
 verity_contract GenericECMWriteSmoke where
@@ -501,7 +494,7 @@ verity_contract GenericECMWriteSmoke where
     ecmDo genericECMEffectDemoModule [lhs, rhs]
 
 example :
-    ((GenericECMWriteSmoke.runEffect .stub 1 2).run defaultState).getState.calls.length = 1 := by
+    ((GenericECMWriteSmoke.runEffect 1 2).run defaultState).getState.calls.length = 1 := by
   native_decide
 
 def directDynamicEcmResultModule (resultVar : String) : Compiler.ECM.ExternalCallModule where
@@ -535,27 +528,20 @@ verity_contract DirectDynamicECMArgSmoke where
   function fromBind (values : Array Uint256) : Unit := do
     ecmBind [result] (directDynamicEcmResultModule "result") [values]
 
-private def successfulDynamicEcmAdversary :
-    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
-  stateTransition := fun _ state => state
-  result := fun site _ => .success (List.replicate site.returnArity 9)
-  gasUsed := fun _ _ => 0
-
 /-- Executable ECM calls use the same synthetic `data_offset, length` key as
 the model for direct bytes, string, and dynamic-array parameters. -/
 example :
-    ((DirectDynamicECMArgSmoke.fromCall successfulDynamicEcmAdversary
-      (ByteArray.mk #[1, 2, 3])).run defaultState).getState.calls.head?.map
+    ((DirectDynamicECMArgSmoke.fromCall (ByteArray.mk #[1, 2, 3])).run defaultState).getState.calls.head?.map
         (fun call => call.calldata) = some [0, 3] := by
   decide
 
 example :
-    ((DirectDynamicECMArgSmoke.fromDo successfulDynamicEcmAdversary "verity").run
+    ((DirectDynamicECMArgSmoke.fromDo "verity").run
       defaultState).getState.calls.head?.map (fun call => call.calldata) = some [0, 6] := by
   decide
 
 example :
-    ((DirectDynamicECMArgSmoke.fromBind successfulDynamicEcmAdversary #[4, 5]).run
+    ((DirectDynamicECMArgSmoke.fromBind #[4, 5]).run
       defaultState).getState.calls.head?.map (fun call => call.calldata) = some [0, 2] := by
   decide
 

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -807,4 +807,50 @@ verity_contract StructMappingWrongScalarAddressReadAccessor where
     let word ← getStorageAddr positions
     return word
 
+/-! ### PR3 executable close-out: arity and failure continuation -/
+
+private def arityAdversary (arity : Nat) (words : List Nat) :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun site _ =>
+    if site.returnArity = arity then .success words else .success []
+  gasUsed := fun _ _ => 0
+
+private def failAdv :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun _ _ => .failure [5]
+  gasUsed := fun _ _ => 0
+
+/-- Declared arity 0: a successful empty payload continues as `(true, default)`. -/
+example :
+    (Contracts.tryExternalCallWords (α := Unit) "notifyBool" [1]
+      (arityAdversary 0 []) 0 15).run defaultState =
+      ContractResult.success (true, ())
+        { defaultState with
+            calls := [Contracts.linkedCallEntry "notifyBool" [1] .success [] 15]
+            returndata := [] } := rfl
+
+/-- Declared arity 2: both words are accepted; the helper no longer reverts
+on a non-singleton payload. -/
+example :
+    (Contracts.tryExternalCallWords (α := Uint256) "dirtyPair" []
+      (arityAdversary 2 [7, 9]) 2 6).run defaultState =
+      ContractResult.success (true, (7 : Uint256))
+        { defaultState with
+            calls := [Contracts.linkedCallEntry "dirtyPair" [] .success [7, 9] 6]
+            returndata := [7, 9] } := rfl
+
+/-- Bound helpers auto-revert on adversary failure instead of fabricating 0. -/
+example :
+    (Contracts.externalCallContractWords (α := Uint256) "dirtyUint" [] failAdv 1 4).run
+      defaultState =
+      ContractResult.revert "external call failed" defaultState := rfl
+
+/-- Bound helpers auto-revert when success returndata is shorter than arity. -/
+example :
+    (Contracts.externalCallContractWords (α := Uint256) "dirtyUint" []
+      (arityAdversary 1 []) 1 4).run defaultState =
+      ContractResult.revert "external call returned insufficient data" defaultState := rfl
+
 end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -482,9 +482,17 @@ verity_contract GenericECMTripleResultSmoke where
     ecmBind [first, second, third] genericECMTripleResultModule []
     setStorage last third
 
+private def tripleResultAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun _ _ => .success [1, 2, 3]
+  gasUsed := fun _ _ => 0
+
+/-- A read-only ECM still receives the caller-supplied adversary. -/
 example :
-    ((GenericECMTripleResultSmoke.storeThird.run defaultState).getState.calls.length) = 1 := by
-  native_decide
+    ((GenericECMTripleResultSmoke.storeThird tripleResultAdversary).run
+      defaultState).getState.storage GenericECMTripleResultSmoke.last.slot = 3 := by
+  decide
 
 verity_contract GenericECMWriteSmoke where
   storage
@@ -493,7 +501,7 @@ verity_contract GenericECMWriteSmoke where
     ecmDo genericECMEffectDemoModule [lhs, rhs]
 
 example :
-    ((GenericECMWriteSmoke.runEffect 1 2).run defaultState).getState.calls.length = 1 := by
+    ((GenericECMWriteSmoke.runEffect .stub 1 2).run defaultState).getState.calls.length = 1 := by
   native_decide
 
 verity_contract BubblingValueCallECMSmoke where

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -515,6 +515,8 @@ set_option linter.unusedVariables false in
 verity_contract LowLevelTryCatchSmoke where
   storage
     lastOutcome : Uint256 := slot 0
+  linked_externals
+    external catchHook() -> (Uint256)
 
   function allow_post_interaction_writes reentrancy_trusted catchFailure ()
     local_obligations [manual_low_level_refinement := assumed "Low-level call success/failure boundary still requires a manual refinement argument."]
@@ -540,6 +542,16 @@ verity_contract LowLevelTryCatchSmoke where
     := do
     tryCatch (call 0 0 1 0 0 0 0) (do
       setStorage lastOutcome 11)
+    let current ← getStorage lastOutcome
+    return current
+
+  function allow_post_interaction_writes reentrancy_trusted skipExternalCatchOnSuccess ()
+    local_obligations [manual_low_level_refinement := assumed "Low-level call success/failure boundary still requires a manual refinement argument."]
+    : Uint256
+    := do
+    tryCatch (call 1 0 0 0 0 0 0) (do
+      let value ← callExternal catchHook()
+      setStorage lastOutcome value)
     let current ← getStorage lastOutcome
     return current
 

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -851,6 +851,6 @@ example :
 example :
     (Contracts.externalCallContractWords (α := Uint256) "dirtyUint" []
       (arityAdversary 1 []) 1 4).run defaultState =
-      ContractResult.revert "external call returned insufficient data" defaultState := rfl
+      ContractResult.revert "external call returned malformed data" defaultState := rfl
 
 end Contracts.Smoke

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -515,9 +515,6 @@ set_option linter.unusedVariables false in
 verity_contract LowLevelTryCatchSmoke where
   storage
     lastOutcome : Uint256 := slot 0
-  linked_externals
-    external catchHook() -> (Uint256)
-
   function allow_post_interaction_writes reentrancy_trusted catchFailure ()
     local_obligations [manual_low_level_refinement := assumed "Low-level call success/failure boundary still requires a manual refinement argument."]
     : Uint256
@@ -550,7 +547,7 @@ verity_contract LowLevelTryCatchSmoke where
     : Uint256
     := do
     tryCatch (call 1 0 0 0 0 0 0) (do
-      let value ← callExternal catchHook()
+      let value ← evmCall(1, 0, 0, 0, 0, 0, 0)
       setStorage lastOutcome value)
     let current ← getStorage lastOutcome
     return current

--- a/Contracts/Smoke/ExternalCalls.lean
+++ b/Contracts/Smoke/ExternalCalls.lean
@@ -72,7 +72,8 @@ example :
       ContractResult.success
         { success := true, returndata := (7 : Uint256) }
         { defaultState with
-            calls := [Contracts.linkedCallEntry "echo" [7] .success [7]] } := by
+            calls := [Contracts.linkedCallEntry "echo" [7] .success [7]]
+            returndata := [7] } := by
   rfl
 
 namespace StatefulExternalSmoke

--- a/Contracts/Smoke/Include.lean
+++ b/Contracts/Smoke/Include.lean
@@ -213,6 +213,20 @@ verity_contract IncludeModifierOrderHost include IncludeOrderMixin where
 
 #check_contract IncludeModifierOrderHost
 
+verity_mixin IncludeAdversarialModifierMixin where
+  storage
+  linked_externals
+    external authorizeModifier()
+  modifier externalGuard := do
+    callExternal authorizeModifier()
+
+verity_contract IncludeAdversarialModifierHost include IncludeAdversarialModifierMixin where
+  storage
+  function reentrancy_trusted guarded () with externalGuard : Unit := do
+    pure ()
+
+example : Contract Unit := IncludeAdversarialModifierHost.guarded .stub
+
 verity_mixin IncludeHelperMixinA where
   storage
     a : Uint256 := slot 0

--- a/Contracts/Smoke/Include.lean
+++ b/Contracts/Smoke/Include.lean
@@ -218,7 +218,7 @@ verity_mixin IncludeAdversarialModifierMixin where
   linked_externals
     external authorizeModifier()
   modifier externalGuard := do
-    callExternal authorizeModifier()
+    let _success ← tryExternalCall "authorizeModifier" []
 
 verity_contract IncludeAdversarialModifierHost include IncludeAdversarialModifierMixin where
   storage

--- a/Contracts/Smoke/InternalInterfaceSmoke.lean
+++ b/Contracts/Smoke/InternalInterfaceSmoke.lean
@@ -182,17 +182,9 @@ def morphoOracleReadUsesSummary : Bool :=
 example : morphoOracleReadUsesSummary = true := by
   decide
 
-private def staticReadAdversary :
-    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
-  stateTransition := fun _ state => state
-  result := fun _ _ => .success [37]
-  gasUsed := fun _ _ => 0
-
 example :
-    let result := (MorphoStyleOracleSummarySmoke.snapshotPrice
-      staticReadAdversary (23 : Address)).run defaultState
-    result.getValue? = some 37 ∧
-      result.getState.calls.map (·.kind) = [.staticcall] ∧
+    let result := (MorphoStyleOracleSummarySmoke.snapshotPrice (23 : Address)).run defaultState
+    result.getState.calls.map (·.kind) = [.staticcall] ∧
       result.getState.calls.map (·.target) = [23] := by
   decide
 

--- a/Contracts/Smoke/InternalInterfaceSmoke.lean
+++ b/Contracts/Smoke/InternalInterfaceSmoke.lean
@@ -107,6 +107,29 @@ example :
           | _ => false)) = true := by
   decide
 
+verity_contract TypedInterfaceNestedFixedReturnSmoke where
+  storage
+
+  interfaces
+    interface IPool where
+      function fetch() returns (Tuple [FixedArray Uint256 2, Uint256])
+    end
+
+  function fetchNested (pool : IPool) : Tuple [FixedArray Uint256 2, Uint256] := do
+    let result ← pool.fetch
+    return result
+
+private def nestedFixedResultAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun _ _ => .success [7, 9, 11]
+  gasUsed := fun _ _ => 0
+
+example :
+    ((TypedInterfaceNestedFixedReturnSmoke.fetchNested nestedFixedResultAdversary 1).run
+      defaultState).getValue? = some (#[7, 9], 11) := by
+  native_decide
+
 verity_contract MorphoStyleOracleSummarySmoke where
   storage
     lastPrice : Uint256 := slot 0

--- a/Contracts/Smoke/InternalInterfaceSmoke.lean
+++ b/Contracts/Smoke/InternalInterfaceSmoke.lean
@@ -151,9 +151,10 @@ private def staticReadAdversary :
 
 example :
     let result := (MorphoStyleOracleSummarySmoke.snapshotPrice
-      staticReadAdversary (0 : Address)).run defaultState
+      staticReadAdversary (23 : Address)).run defaultState
     result.getValue? = some 37 ∧
-      result.getState.calls.map (·.kind) = [.staticcall] := by
+      result.getState.calls.map (·.kind) = [.staticcall] ∧
+      result.getState.calls.map (·.target) = [23] := by
   decide
 
 -- Void (no-`returns`) interface methods lower to the no-output `externalCallNoReturn` ECM:

--- a/Contracts/Smoke/InternalInterfaceSmoke.lean
+++ b/Contracts/Smoke/InternalInterfaceSmoke.lean
@@ -143,6 +143,19 @@ def morphoOracleReadUsesSummary : Bool :=
 example : morphoOracleReadUsesSummary = true := by
   decide
 
+private def staticReadAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun _ _ => .success [37]
+  gasUsed := fun _ _ => 0
+
+example :
+    let result := (MorphoStyleOracleSummarySmoke.snapshotPrice
+      staticReadAdversary (0 : Address)).run defaultState
+    result.getValue? = some 37 ∧
+      result.getState.calls.map (·.kind) = [.staticcall] := by
+  decide
+
 -- Void (no-`returns`) interface methods lower to the no-output `externalCallNoReturn` ECM:
 -- a selector+args `call(...)` that bubbles failure returndata but performs no `returndatasize`
 -- check and binds no result. This is what real void callees (e.g. Aave V3 `supply`/`borrow`,

--- a/Contracts/Smoke/InternalInterfaceSmoke.lean
+++ b/Contracts/Smoke/InternalInterfaceSmoke.lean
@@ -113,10 +113,15 @@ verity_contract TypedInterfaceNestedFixedReturnSmoke where
   interfaces
     interface IPool where
       function fetch() returns (Tuple [FixedArray Uint256 2, Uint256])
+      function submitFixed(FixedArray Uint256 2) returns (Uint256)
     end
 
   function fetchNested (pool : IPool) : Tuple [FixedArray Uint256 2, Uint256] := do
     let result ← pool.fetch
+    return result
+
+  function submitFixed (pool : IPool, values : FixedArray Uint256 2) : Uint256 := do
+    let result ← pool.submitFixed values
     return result
 
 private def nestedFixedResultAdversary :
@@ -125,9 +130,20 @@ private def nestedFixedResultAdversary :
   result := fun _ _ => .success [7, 9, 11]
   gasUsed := fun _ _ => 0
 
+private def fixedArgumentAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun site _ => .success [site.calldata.getLast?.getD 0]
+  gasUsed := fun _ _ => 0
+
 example :
     ((TypedInterfaceNestedFixedReturnSmoke.fetchNested nestedFixedResultAdversary 1).run
       defaultState).getValue? = some (#[7, 9], 11) := by
+  native_decide
+
+example :
+    ((TypedInterfaceNestedFixedReturnSmoke.submitFixed fixedArgumentAdversary 1 #[7, 9]).run
+      defaultState).getValue? = some 9 := by
   native_decide
 
 verity_contract MorphoStyleOracleSummarySmoke where

--- a/Contracts/Smoke/InternalInterfaceSmoke.lean
+++ b/Contracts/Smoke/InternalInterfaceSmoke.lean
@@ -182,9 +182,17 @@ def morphoOracleReadUsesSummary : Bool :=
 example : morphoOracleReadUsesSummary = true := by
   decide
 
+private def staticReadAdversary :
+    Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel where
+  stateTransition := fun _ state => state
+  result := fun _ _ => .success [37]
+  gasUsed := fun _ _ => 0
+
 example :
-    let result := (MorphoStyleOracleSummarySmoke.snapshotPrice (23 : Address)).run defaultState
-    result.getState.calls.map (·.kind) = [.staticcall] ∧
+    let result := (MorphoStyleOracleSummarySmoke.snapshotPrice
+      staticReadAdversary (23 : Address)).run defaultState
+    result.getValue? = some 37 ∧
+      result.getState.calls.map (·.kind) = [.staticcall] ∧
       result.getState.calls.map (·.target) = [23] := by
   decide
 

--- a/Contracts/Smoke/SecurityCombos.lean
+++ b/Contracts/Smoke/SecurityCombos.lean
@@ -170,7 +170,7 @@ verity_contract NonreentrantTrustedInternalHelperAccepted where
     return echoed
 
   function callerTrusted (x : Uint256) : Uint256 := do
-    let y ← trustedEntry x
+    let y ← trustedEntry .stub x
     return y
 
 #check_contract NonreentrantTrustedInternalHelperAccepted

--- a/Contracts/Smoke/SecurityCombos.lean
+++ b/Contracts/Smoke/SecurityCombos.lean
@@ -170,7 +170,7 @@ verity_contract NonreentrantTrustedInternalHelperAccepted where
     return echoed
 
   function callerTrusted (x : Uint256) : Uint256 := do
-    let y ← trustedEntry .stub x
+    let y ← trustedEntry x
     return y
 
 #check_contract NonreentrantTrustedInternalHelperAccepted

--- a/Contracts/Smoke/SpecGenAndChecks.lean
+++ b/Contracts/Smoke/SpecGenAndChecks.lean
@@ -159,7 +159,8 @@ def namedStructExecutableReadsField : Bool :=
 
 example : namedStructExecutableReadsField = true := by decide
 example : Uint8Smoke.acceptSig = (Uint8Smoke.acceptSig : (Uint256 × Uint256 × Uint256) → Verity.Contract Unit) := rfl
-example : ExternalCallSmoke.storeEcho = (ExternalCallSmoke.storeEcho : Uint256 → Verity.Contract Unit) := rfl
+example : ExternalCallSmoke.storeEcho .stub =
+    (ExternalCallSmoke.storeEcho .stub : Uint256 → Verity.Contract Unit) := rfl
 
 example :
     (Compiler.CompilationModel.FunctionSpec.body
@@ -479,15 +480,16 @@ example :
       ] := rfl
 
 example :
-    (LowLevelTryCatchSmoke.catchFailure.run Verity.defaultState).getValue? = some 0 := by
+    ((LowLevelTryCatchSmoke.catchFailure .stub).run Verity.defaultState).getValue? = some 0 := by
   decide
 
 example :
-    (LowLevelTryCatchSmoke.skipCatchOnSuccess.run Verity.defaultState).getValue? = some 0 := by
+    ((LowLevelTryCatchSmoke.skipCatchOnSuccess .stub).run Verity.defaultState).getValue? = some 0 := by
   decide
 
 example :
-    ((LowLevelTryCatchSmoke.catchFailureWithShadowedParam 5).run Verity.defaultState).getValue? = some 0 := by
+    ((LowLevelTryCatchSmoke.catchFailureWithShadowedParam .stub 5).run
+      Verity.defaultState).getValue? = some 0 := by
   decide
 
 example :

--- a/Contracts/Smoke/SpecGenAndChecks.lean
+++ b/Contracts/Smoke/SpecGenAndChecks.lean
@@ -488,6 +488,11 @@ example :
   decide
 
 example :
+    let result := (LowLevelTryCatchSmoke.skipExternalCatchOnSuccess .stub).run Verity.defaultState
+    result.getValue? = some 0 ∧ result.getState.calls.length = 1 := by
+  decide
+
+example :
     ((LowLevelTryCatchSmoke.catchFailureWithShadowedParam .stub 5).run
       Verity.defaultState).getValue? = some 11 := by
   decide

--- a/Contracts/Smoke/SpecGenAndChecks.lean
+++ b/Contracts/Smoke/SpecGenAndChecks.lean
@@ -480,7 +480,7 @@ example :
       ] := rfl
 
 example :
-    ((LowLevelTryCatchSmoke.catchFailure .stub).run Verity.defaultState).getValue? = some 0 := by
+    ((LowLevelTryCatchSmoke.catchFailure .stub).run Verity.defaultState).getValue? = some 7 := by
   decide
 
 example :
@@ -489,7 +489,7 @@ example :
 
 example :
     ((LowLevelTryCatchSmoke.catchFailureWithShadowedParam .stub 5).run
-      Verity.defaultState).getValue? = some 0 := by
+      Verity.defaultState).getValue? = some 11 := by
   decide
 
 example :

--- a/Verity/Core/Model/DenoteFunctionCalls.lean
+++ b/Verity/Core/Model/DenoteFunctionCalls.lean
@@ -251,6 +251,20 @@ def execTryExternalCallBind (env : CallEnv) (fields : List Field)
 mutual
   def execStmtWithCalls (env : CallEnv) (fields : List Field) :
       DenoteState → Stmt → StmtOutcome
+    | state, .letVar name value =>
+        match evalExprCall env fields state value with
+        | some (resolved, post) =>
+            .continue { post with bindings := bindValue post.bindings name resolved }
+        | none => .revert
+    | state, .assignVar name value =>
+        match evalExprCall env fields state value with
+        | some (resolved, post) =>
+            .continue { post with bindings := bindValue post.bindings name resolved }
+        | none => .revert
+    | state, .return value =>
+        match evalExprCall env fields state value with
+        | some (resolved, post) => .return resolved post
+        | none => .revert
     | state, .externalCallBind resultVars name args =>
         execExternalCallBind env fields state resultVars name args
     | state, .tryExternalCallBind successVar resultVars name args =>

--- a/Verity/Core/Model/DenoteFunctionCalls.lean
+++ b/Verity/Core/Model/DenoteFunctionCalls.lean
@@ -214,7 +214,9 @@ def execTryExternalCallBind (env : CallEnv) (fields : List Field)
           .continue
             { state with
               world := { state.world with returndata := [] }
-              bindings := bindValue state.bindings successVar 0 }
+              bindings := bindResultWords
+                (bindValue state.bindings successVar 0) resultVars
+                (List.replicate resultVars.length 0) }
       | some paid =>
           let site : CallSite :=
             { siteId := link.siteId, kind := .call, target := link.target
@@ -238,9 +240,13 @@ def execTryExternalCallBind (env : CallEnv) (fields : List Field)
                       returndata := obs.result.returndata.map wordNormalize
                       calls := state.world.calls ++
                         [journalEntry site obs.result] }
-                  bindings := bindValue state.bindings successVar 0 }
+                  bindings := bindResultWords
+                    (bindValue state.bindings successVar 0) resultVars
+                    (obs.result.returndata ++ List.replicate resultVars.length 0) }
   | _, _ =>
-      .continue { state with bindings := bindValue state.bindings successVar 0 }
+      .continue { state with
+        bindings := bindResultWords (bindValue state.bindings successVar 0)
+          resultVars (List.replicate resultVars.length 0) }
 
 mutual
   def execStmtWithCalls (env : CallEnv) (fields : List Field) :

--- a/Verity/Core/Model/DenoteFunctionCalls.lean
+++ b/Verity/Core/Model/DenoteFunctionCalls.lean
@@ -202,6 +202,23 @@ def evalExprCall (env : CallEnv) (fields : List Field) (state : DenoteState) :
   | e =>
       (evalExpr env.oracle fields state e).map (fun n => (n, state))
 
+/-- Evaluate statement operands left-to-right, preserving every call's post-state. -/
+def evalExprCallList (env : CallEnv) (fields : List Field) :
+    DenoteState → List Expr → Option (List Nat × DenoteState)
+  | state, [] => some ([], state)
+  | state, expr :: rest => do
+      let (value, post) ← evalExprCall env fields state expr
+      let (values, final) ← evalExprCallList env fields post rest
+      some (value :: values, final)
+
+def execResolvedExprs (env : CallEnv) (fields : List Field)
+    (state : DenoteState) (exprs : List Expr) (rebuild : List Expr → Stmt) :
+    StmtOutcome :=
+  match evalExprCallList env fields state exprs with
+  | some (values, post) =>
+      execStmt env.oracle fields post (rebuild (values.map Expr.literal))
+  | none => .revert
+
 def bindResultWords (bindings : Env) : List String → List Nat → Env
   | [], _ => bindings
   | _ :: _, [] => bindings
@@ -214,9 +231,9 @@ def bindResultWords (bindings : Env) : List String → List Nat → Env
 def execExternalCallBind (env : CallEnv) (fields : List Field)
     (state : DenoteState) (resultVars : List String) (externalName : String)
     (args : List Expr) : StmtOutcome :=
-  match env.resolve externalName, evalExprList env.oracle fields state args with
-  | some link, some argWords =>
-      match debitSelfBalance state.world link.value with
+  match env.resolve externalName, evalExprCallList env fields state args with
+  | some link, some (argWords, post) =>
+      match debitSelfBalance post.world link.value with
       | none => .revert
       | some paid =>
           let site : CallSite :=
@@ -229,10 +246,10 @@ def execExternalCallBind (env : CallEnv) (fields : List Field)
               if data.length < resultVars.length then .revert
               else
                 .continue
-                  { state with
+                  { post with
                     world := { obs.state.world with
                       returndata := data.map wordNormalize }
-                    bindings := bindResultWords state.bindings resultVars data }
+                    bindings := bindResultWords post.bindings resultVars data }
           | .failure _ | .revert _ => .revert
   | _, _ => .revert
 
@@ -241,15 +258,15 @@ def execExternalCallBind (env : CallEnv) (fields : List Field)
 def execTryExternalCallBind (env : CallEnv) (fields : List Field)
     (state : DenoteState) (successVar : String) (resultVars : List String)
     (externalName : String) (args : List Expr) : StmtOutcome :=
-  match env.resolve externalName, evalExprList env.oracle fields state args with
-  | some link, some argWords =>
-      match debitSelfBalance state.world link.value with
+  match env.resolve externalName, evalExprCallList env fields state args with
+  | some link, some (argWords, post) =>
+      match debitSelfBalance post.world link.value with
       | none =>
           .continue
-            { state with
-              world := { state.world with returndata := [] }
+            { post with
+              world := { post.world with returndata := [] }
               bindings := bindResultWords
-                (bindValue state.bindings successVar 0) resultVars
+                (bindValue post.bindings successVar 0) resultVars
                 (List.replicate resultVars.length 0) }
       | some paid =>
           let site : CallSite :=
@@ -262,22 +279,22 @@ def execTryExternalCallBind (env : CallEnv) (fields : List Field)
               if data.length != resultVars.length then .revert
               else
                 .continue
-                  { state with
+                  { post with
                     world := { obs.state.world with
                       returndata := data.map wordNormalize }
                     bindings :=
                       bindResultWords
-                        (bindValue state.bindings successVar 1) resultVars data }
+                        (bindValue post.bindings successVar 1) resultVars data }
           | .failure _ | .revert _ =>
               .continue
-                { state with
+                { post with
                   world :=
-                    { state.world with
+                    { post.world with
                       returndata := obs.result.returndata.map wordNormalize
-                      calls := state.world.calls ++
+                      calls := post.world.calls ++
                         [journalEntry site obs.result] }
                   bindings := bindResultWords
-                    (bindValue state.bindings successVar 0) resultVars
+                    (bindValue post.bindings successVar 0) resultVars
                     (obs.result.returndata ++ List.replicate resultVars.length 0) }
   | _, _ =>
       .continue { state with
@@ -301,57 +318,140 @@ mutual
         match evalExprCall env fields state value with
         | some (resolved, post) => .return resolved post
         | none => .revert
+    | state, .setStorage field value =>
+        execResolvedExprs env fields state [value]
+          (fun | [v] => .setStorage field v | _ => .setStorage field value)
+    | state, .setStorageAddr field value =>
+        execResolvedExprs env fields state [value]
+          (fun | [v] => .setStorageAddr field v | _ => .setStorageAddr field value)
+    | state, .setImmutable name value =>
+        execResolvedExprs env fields state [value]
+          (fun | [v] => .setImmutable name v | _ => .setImmutable name value)
+    | state, .setStorageWord field offset value =>
+        execResolvedExprs env fields state [value]
+          (fun | [v] => .setStorageWord field offset v | _ => .setStorageWord field offset value)
+    | state, .storageArrayPush field value =>
+        execResolvedExprs env fields state [value]
+          (fun | [v] => .storageArrayPush field v | _ => .storageArrayPush field value)
+    | state, .setStorageArrayElement field index value =>
+        execResolvedExprs env fields state [index, value]
+          (fun | [i, v] => .setStorageArrayElement field i v | _ => .setStorageArrayElement field index value)
+    | state, .setMapping field key value =>
+        execResolvedExprs env fields state [key, value]
+          (fun | [k, v] => .setMapping field k v | _ => .setMapping field key value)
+    | state, .setMappingWord field key offset value =>
+        execResolvedExprs env fields state [key, value]
+          (fun | [k, v] => .setMappingWord field k offset v | _ => .setMappingWord field key offset value)
+    | state, .setMappingPackedWord field key offset packed value =>
+        execResolvedExprs env fields state [key, value]
+          (fun | [k, v] => .setMappingPackedWord field k offset packed v | _ => .setMappingPackedWord field key offset packed value)
+    | state, .setMappingUint field key value =>
+        execResolvedExprs env fields state [key, value]
+          (fun | [k, v] => .setMappingUint field k v | _ => .setMappingUint field key value)
+    | state, .setStructMember field key member value =>
+        execResolvedExprs env fields state [key, value]
+          (fun | [k, v] => .setStructMember field k member v | _ => .setStructMember field key member value)
+    | state, .setMappingChain field keys value =>
+        execResolvedExprs env fields state (keys ++ [value])
+          (fun values => .setMappingChain field (values.take keys.length) (values.getD keys.length value))
+    | state, .setMapping2 field key1 key2 value =>
+        execResolvedExprs env fields state [key1, key2, value]
+          (fun | [k1, k2, v] => .setMapping2 field k1 k2 v | _ => .setMapping2 field key1 key2 value)
+    | state, .setMapping2Word field key1 key2 offset value =>
+        execResolvedExprs env fields state [key1, key2, value]
+          (fun | [k1, k2, v] => .setMapping2Word field k1 k2 offset v | _ => .setMapping2Word field key1 key2 offset value)
+    | state, .setStructMember2 field key1 key2 member value =>
+        execResolvedExprs env fields state [key1, key2, value]
+          (fun | [k1, k2, v] => .setStructMember2 field k1 k2 member v | _ => .setStructMember2 field key1 key2 member value)
+    | state, .require cond message =>
+        execResolvedExprs env fields state [cond]
+          (fun | [c] => .require c message | _ => .require cond message)
+    | state, .requireError cond name args =>
+        execResolvedExprs env fields state (cond :: args)
+          (fun | c :: resolved => .requireError c name resolved | _ => .requireError cond name args)
+    | state, .revertError name args =>
+        execResolvedExprs env fields state args (Stmt.revertError name)
+    | state, .panicCode code =>
+        execResolvedExprs env fields state [code]
+          (fun | [c] => .panicCode c | _ => .panicCode code)
+    | state, .returnValues values =>
+        execResolvedExprs env fields state values Stmt.returnValues
+    | state, .returnCodeData pointer =>
+        execResolvedExprs env fields state [pointer]
+          (fun | [p] => .returnCodeData p | _ => .returnCodeData pointer)
+    | state, .mstore offset value =>
+        execResolvedExprs env fields state [offset, value]
+          (fun | [o, v] => .mstore o v | _ => .mstore offset value)
+    | state, .tstore offset value =>
+        execResolvedExprs env fields state [offset, value]
+          (fun | [o, v] => .tstore o v | _ => .tstore offset value)
+    | state, .calldatacopy dest source size =>
+        execResolvedExprs env fields state [dest, source, size]
+          (fun | [d, s, n] => .calldatacopy d s n | _ => .calldatacopy dest source size)
+    | state, .returndataCopy dest source size =>
+        execResolvedExprs env fields state [dest, source, size]
+          (fun | [d, s, n] => .returndataCopy d s n | _ => .returndataCopy dest source size)
+    | state, .emit name args =>
+        execResolvedExprs env fields state args (Stmt.emit name)
+    | state, .internalCall name args =>
+        execResolvedExprs env fields state args (Stmt.internalCall name)
+    | state, .internalCallAssign names target args =>
+        execResolvedExprs env fields state args (Stmt.internalCallAssign names target)
+    | state, .rawLog topics offset size =>
+        execResolvedExprs env fields state (topics ++ [offset, size])
+          (fun values => .rawLog (values.take topics.length)
+            (values.getD topics.length offset) (values.getD (topics.length + 1) size))
     | state, .externalCallBind resultVars name args =>
         execExternalCallBind env fields state resultVars name args
     | state, .tryExternalCallBind successVar resultVars name args =>
         execTryExternalCallBind env fields state successVar resultVars name args
     | state, .ecm mod args =>
-        match evalExprList env.oracle fields state args with
-        | some argWords =>
+        match evalExprCallList env fields state args with
+        | some (argWords, post) =>
             let kind :=
               if mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.staticcall then
                 CallKind.staticcall
               else CallKind.call
             let site : CallSite :=
-              { siteId := state.externalCallIndex, kind := kind, target := 0,
+              { siteId := post.externalCallIndex, kind := kind, target := 0,
                 value := 0, calldata := argWords, name := mod.summaryName,
-                returnArity := mod.resultVars.length, gas := state.world.selfBalance.val }
+                returnArity := mod.resultVars.length, gas := post.world.selfBalance.val }
             let obs := denoteCallJournaled env.adversary site
-              { world := state.world, gasRemaining := site.gas }
+              { world := post.world, gasRemaining := site.gas }
             match obs.result with
             | .success data =>
                 if data.length != mod.resultVars.length then .revert
                 else .continue
-                  { state with
-                    world := { mod.committedWorld (some obs.state.world) state.world with
+                  { post with
+                    world := { mod.committedWorld (some obs.state.world) post.world with
                       returndata := data.map wordNormalize }
-                    bindings := bindResultWords state.bindings mod.resultVars data
-                    externalCallIndex := state.externalCallIndex + 1 }
+                    bindings := bindResultWords post.bindings mod.resultVars data
+                    externalCallIndex := post.externalCallIndex + 1 }
             | .failure _ | .revert _ => .revert
         | none => .revert
     | state, .ite cond thenBranch elseBranch =>
-        match evalExpr env.oracle fields state cond with
-        | some resolved =>
+        match evalExprCall env fields state cond with
+        | some (resolved, post) =>
             if resolved != 0 then
-              execStmtListWithCalls env fields state thenBranch
+              execStmtListWithCalls env fields post thenBranch
             else
-              execStmtListWithCalls env fields state elseBranch
+              execStmtListWithCalls env fields post elseBranch
         | none => .revert
     | state, .forEach varName count body =>
-        match evalExpr env.oracle fields state count with
-        | some bound =>
+        match evalExprCall env fields state count with
+        | some (bound, post) =>
             let initialLoopState :=
-              { state with bindings := bindValue state.bindings varName (wordNormalize 0) }
+              { post with bindings := bindValue post.bindings varName (wordNormalize 0) }
             execForEachLoop varName
               (fun loopState => execStmtListWithCalls env fields loopState body)
               initialLoopState 0 bound
         | none => .revert
     | state, .forEachSetBit varName bitmap body =>
-        match evalExpr env.oracle fields state bitmap with
-        | some bits =>
+        match evalExprCall env fields state bitmap with
+        | some (bits, post) =>
             execForEachSetBitLoop varName
               (fun loopState => execStmtListWithCalls env fields loopState body)
-              256 state bits
+              256 post bits
         | none => .revert
     | state, other =>
         execStmt env.oracle fields state other

--- a/Verity/Core/Model/DenoteFunctionCalls.lean
+++ b/Verity/Core/Model/DenoteFunctionCalls.lean
@@ -296,6 +296,10 @@ def execTryExternalCallBind (env : CallEnv) (fields : List Field)
                   bindings := bindResultWords
                     (bindValue post.bindings successVar 0) resultVars
                     (obs.result.returndata ++ List.replicate resultVars.length 0) }
+  | none, some (_, post) =>
+      .continue { post with
+        bindings := bindResultWords (bindValue post.bindings successVar 0)
+          resultVars (List.replicate resultVars.length 0) }
   | _, _ =>
       .continue { state with
         bindings := bindResultWords (bindValue state.bindings successVar 0)

--- a/Verity/Core/Model/DenoteFunctionCalls.lean
+++ b/Verity/Core/Model/DenoteFunctionCalls.lean
@@ -180,6 +180,11 @@ def evalExprCall (env : CallEnv) (fields : List Field) (state : DenoteState) :
           some (wordNormalize result, { state with world := { obs.state.world with
             returndata := [wordNormalize result] } })
       | _ => none
+  | .add a b => do
+      let (av, afterA) ← evalExprCall env fields state a
+      let (bv, afterB) ← evalExprCall env fields afterA b
+      let result ← evalExpr env.oracle fields afterB (.add (.literal av) (.literal bv))
+      some (result, afterB)
   | .bitAnd a b => do
       let (av, afterA) ← evalExprCall env fields state a
       let (bv, afterB) ← evalExprCall env fields afterA b
@@ -238,7 +243,8 @@ def execExternalCallBind (env : CallEnv) (fields : List Field)
       | some paid =>
           let site : CallSite :=
             { siteId := link.siteId, kind := .call, target := link.target
-              value := link.value, calldata := argWords, gas := paid.selfBalance.val }
+              value := link.value, calldata := argWords, name := externalName
+              returnArity := resultVars.length, gas := paid.selfBalance.val }
           let obs := denoteCallJournaled env.adversary site
             { world := paid, gasRemaining := site.gas }
           match obs.result with
@@ -271,7 +277,8 @@ def execTryExternalCallBind (env : CallEnv) (fields : List Field)
       | some paid =>
           let site : CallSite :=
             { siteId := link.siteId, kind := .call, target := link.target
-              value := link.value, calldata := argWords, gas := paid.selfBalance.val }
+              value := link.value, calldata := argWords, name := externalName
+              returnArity := resultVars.length, gas := paid.selfBalance.val }
           let obs := denoteCallJournaled env.adversary site
             { world := paid, gasRemaining := site.gas }
           match obs.result with

--- a/Verity/Core/Model/DenoteFunctionCalls.lean
+++ b/Verity/Core/Model/DenoteFunctionCalls.lean
@@ -38,9 +38,9 @@ structure CallEnv where
   adversary : AdversaryModel
   resolve : String → Option LinkedExternal
 
-/-- Word-addressed calldata read for `Expr.call` memory operands. -/
+/-- Read the words intersecting the byte range supplied to an EVM call. -/
 def readMemoryWords (mem : Nat → Core.Uint256) (offset size : Nat) : List Nat :=
-  (List.range size).map (fun i => (mem (offset + i)).val)
+  (List.range ((size + 31) / 32)).map (fun i => (mem (offset + 32 * i)).val)
 
 /-- Word-addressed returndata write. Writes `min words.length outSize` words. -/
 def writeMemoryWords (mem : Nat → Core.Uint256) (offset : Nat) :

--- a/Verity/Core/Model/DenoteFunctionCalls.lean
+++ b/Verity/Core/Model/DenoteFunctionCalls.lean
@@ -165,6 +165,40 @@ def evalExprCall (env : CallEnv) (fields : List Field) (state : DenoteState) :
         { siteId := t, kind := .delegatecall, target := t, value := 0
           calldata := readMemoryWords state.world.memory io isz, gas := g }
       applyRawCall env state site oo osz
+  | .externalCall name args => do
+      let link ← env.resolve name
+      let argWords ← evalExprList env.oracle fields state args
+      let paid ← debitSelfBalance state.world link.value
+      let site : CallSite :=
+        { siteId := link.siteId, kind := .call, target := link.target
+          value := link.value, calldata := argWords, name := name
+          returnArity := 1, gas := paid.selfBalance.val }
+      let obs := denoteCallJournaled env.adversary site
+        { world := paid, gasRemaining := site.gas }
+      match obs.result with
+      | .success [result] =>
+          some (wordNormalize result, { state with world := { obs.state.world with
+            returndata := [wordNormalize result] } })
+      | _ => none
+  | .bitAnd a b => do
+      let (av, afterA) ← evalExprCall env fields state a
+      let (bv, afterB) ← evalExprCall env fields afterA b
+      let result ← evalExpr env.oracle fields afterB (.bitAnd (.literal av) (.literal bv))
+      some (result, afterB)
+  | .signextend a b => do
+      let (av, afterA) ← evalExprCall env fields state a
+      let (bv, afterB) ← evalExprCall env fields afterA b
+      let result ← evalExpr env.oracle fields afterB (.signextend (.literal av) (.literal bv))
+      some (result, afterB)
+  | .eq a b => do
+      let (av, afterA) ← evalExprCall env fields state a
+      let (bv, afterB) ← evalExprCall env fields afterA b
+      let result ← evalExpr env.oracle fields afterB (.eq (.literal av) (.literal bv))
+      some (result, afterB)
+  | .logicalNot a => do
+      let (av, post) ← evalExprCall env fields state a
+      let result ← evalExpr env.oracle fields post (.logicalNot (.literal av))
+      some (result, post)
   | e =>
       (evalExpr env.oracle fields state e).map (fun n => (n, state))
 
@@ -225,13 +259,15 @@ def execTryExternalCallBind (env : CallEnv) (fields : List Field)
             { world := paid, gasRemaining := site.gas }
           match obs.result with
           | .success data =>
-              .continue
-                { state with
-                  world := { obs.state.world with
-                    returndata := data.map wordNormalize }
-                  bindings :=
-                    bindResultWords
-                      (bindValue state.bindings successVar 1) resultVars data }
+              if data.length != resultVars.length then .revert
+              else
+                .continue
+                  { state with
+                    world := { obs.state.world with
+                      returndata := data.map wordNormalize }
+                    bindings :=
+                      bindResultWords
+                        (bindValue state.bindings successVar 1) resultVars data }
           | .failure _ | .revert _ =>
               .continue
                 { state with
@@ -269,6 +305,30 @@ mutual
         execExternalCallBind env fields state resultVars name args
     | state, .tryExternalCallBind successVar resultVars name args =>
         execTryExternalCallBind env fields state successVar resultVars name args
+    | state, .ecm mod args =>
+        match evalExprList env.oracle fields state args with
+        | some argWords =>
+            let kind :=
+              if mod.summaryMutability == Compiler.ECM.StatefulExternal.Mutability.staticcall then
+                CallKind.staticcall
+              else CallKind.call
+            let site : CallSite :=
+              { siteId := state.externalCallIndex, kind := kind, target := 0,
+                value := 0, calldata := argWords, name := mod.summaryName,
+                returnArity := mod.resultVars.length, gas := state.world.selfBalance.val }
+            let obs := denoteCallJournaled env.adversary site
+              { world := state.world, gasRemaining := site.gas }
+            match obs.result with
+            | .success data =>
+                if data.length != mod.resultVars.length then .revert
+                else .continue
+                  { state with
+                    world := { mod.committedWorld (some obs.state.world) state.world with
+                      returndata := data.map wordNormalize }
+                    bindings := bindResultWords state.bindings mod.resultVars data
+                    externalCallIndex := state.externalCallIndex + 1 }
+            | .failure _ | .revert _ => .revert
+        | none => .revert
     | state, .ite cond thenBranch elseBranch =>
         match evalExpr env.oracle fields state cond with
         | some resolved =>

--- a/Verity/Core/Semantics.lean
+++ b/Verity/Core/Semantics.lean
@@ -17,11 +17,6 @@ structure Env where
   blockNumber : Uint256 := 0
   chainId : Uint256 := 0
   callOracle : String → List Uint256 → Uint256 := Env.defaultCallOracle
-  -- Adversarial-reentry hook: the state transformation a callee may impose on
-  -- this contract's persistent channels during an external call. Defaults to
-  -- `id` (the no-reentry case). Reentrancy proofs constrain it via the rely
-  -- condition; see `Verity/Core/Reentrancy.lean`.
-  reenter : ContractState → ContractState := id
 
 instance : Repr Env where
   reprPrec env _ :=

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -160,7 +160,24 @@ private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
 
     if isMixin then
       for modDecl in modifiers do
-        elabCommand (← mkModifierDefCommandPublic modDecl)
+        unless modifierContainsExternalCallSyntaxPublic modDecl do
+          elabCommand (← mkModifierDefCommandPublic modDecl)
+
+    -- Translation (not storage-def emission) must see mixin fields/decls so
+    -- inlined mixin-modifier CompilationModel bodies can resolve slots,
+    -- custom errors, constants, and helpers.
+    for fn in functions do
+      let fnCmds ← mkFunctionCommandsPublic translationFields translationRoleDecls
+        translationErrorDecls translationConstDecls translationImmutableDecls
+        translationExternalDecls translationFunctions fn resolvedIncludes
+        (boundImmutableDecls := immutableDecls) (hostModifiers := modifiers)
+      for cmd in fnCmds do
+        elabCommand cmd
+      elabCommand (← mkBridgeCommand fn.ident)
+
+    -- Constructors may call internal helpers, so emit them only after the
+    -- executable helper definitions are available in the namespace.
+    if isMixin then
       match ctor with
       | some ctorDecl =>
           elabCommand (← mkConstructorDefCommandPublic translationFields translationErrorDecls
@@ -175,18 +192,6 @@ private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
             translationErrorDecls translationConstDecls translationImmutableDecls
             translationExternalDecls translationFunctions resolvedIncludes ctorDecl)
       | none => pure ()
-
-    -- Translation (not storage-def emission) must see mixin fields/decls so
-    -- inlined mixin-modifier CompilationModel bodies can resolve slots,
-    -- custom errors, constants, and helpers.
-    for fn in functions do
-      let fnCmds ← mkFunctionCommandsPublic translationFields translationRoleDecls
-        translationErrorDecls translationConstDecls translationImmutableDecls
-        translationExternalDecls translationFunctions fn resolvedIncludes
-        (boundImmutableDecls := immutableDecls) (hostModifiers := modifiers)
-      for cmd in fnCmds do
-        elabCommand cmd
-      elabCommand (← mkBridgeCommand fn.ident)
 
     let specName : Ident :=
       if resolvedIncludes.isEmpty then mkIdent (Name.mkSimple "spec")

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -134,6 +134,7 @@ private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
     for structDecl in structDecls do
       elabCommand (← mkStructDefCommandPublic structDecl)
       elabCommand (← mkStructEventArgInstanceCommandPublic structDecl)
+      elabCommand (← mkStructExternalArgInstanceCommandPublic structDecl)
 
     let aliasCmds ← mkIncludeAliasCommandsPublic resolvedIncludes
     for cmd in aliasCmds do

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -135,6 +135,7 @@ private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
       elabCommand (← mkStructDefCommandPublic structDecl)
       elabCommand (← mkStructEventArgInstanceCommandPublic structDecl)
       elabCommand (← mkStructExternalArgInstanceCommandPublic structDecl)
+      elabCommand (← mkStructExternalResultInstanceCommandPublic structDecl)
 
     let aliasCmds ← mkIncludeAliasCommandsPublic resolvedIncludes
     for cmd in aliasCmds do

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -163,13 +163,17 @@ private def elabVerityContractOrMixin (stx : Syntax) : CommandElabM Unit := do
         elabCommand (← mkModifierDefCommandPublic modDecl)
       match ctor with
       | some ctorDecl =>
-          elabCommand (← mkConstructorDefCommandPublic ctorDecl)
+          elabCommand (← mkConstructorDefCommandPublic translationFields translationErrorDecls
+            translationConstDecls translationImmutableDecls translationExternalDecls
+            translationFunctions ctorDecl)
       | none => pure ()
 
     if !resolvedIncludes.isEmpty then
       match ctor with
       | some ctorDecl =>
-          elabCommand (← mkHostConstructorDefCommandPublic resolvedIncludes ctorDecl)
+          elabCommand (← mkHostConstructorDefCommandPublic translationFields
+            translationErrorDecls translationConstDecls translationImmutableDecls
+            translationExternalDecls translationFunctions resolvedIncludes ctorDecl)
       | none => pure ()
 
     -- Translation (not storage-def emission) must see mixin fields/decls so

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -158,8 +158,6 @@ macro_rules
       `(doElem| let _ ← (fun s => .success 0 s))
   | `(doElem| let $name:ident ← returnDataSize()) =>
       `(doElem| let $name ← (fun s => .success 0 s))
-  | `(callExternal $_name:ident ($[$_args:term],*)) => `(by exact default)
-  | `(evmCall($[$_args:term],*)) => `(by exact default)
   | `(evmStaticCall($[$_args:term],*)) => `(by exact default)
   | `(memoryLoad($_offset)) => `(by exact default)
   | `(returnDataSize()) => `(0)

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -158,7 +158,6 @@ macro_rules
       `(doElem| let _ ← (fun s => .success 0 s))
   | `(doElem| let $name:ident ← returnDataSize()) =>
       `(doElem| let $name ← (fun s => .success 0 s))
-  | `(evmStaticCall($[$_args:term],*)) => `(by exact default)
   | `(memoryLoad($_offset)) => `(by exact default)
   | `(returnDataSize()) => `(0)
   | `(memoryStore($_offset, $_value)) => `(by exact default)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2316,10 +2316,10 @@ private def rewriteTypedInterfaceCall?
   let rewritten ← argTerms.mapM fun arg => pure arg
   if ext.returnTys.isEmpty then
     some <$> `(term| externalCallEffectWords $(strTerm extName)
-      (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv $siteId)
+      (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $siteId)
   else
     some <$> `(term| externalCallContractWords $(strTerm extName)
-      (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv $arity $siteId)
+      (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
 
 private def rewriteLinkedCallTerm
     (externalDecls : Array ExternalDecl) (params : Array ParamDecl)
@@ -2337,10 +2337,10 @@ private def rewriteLinkedCallTerm
       let arity := natTerm (← flattenedExternalArity ext)
       if ext.returnTys.isEmpty then
         `(term| externalCallEffectWords $(strTerm extName)
-          (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv $siteId)
+          (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $siteId)
       else
         `(term| externalCallContractWords $(strTerm extName)
-          (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv $arity $siteId)
+          (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
   | `(term| externalCall $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2348,7 +2348,7 @@ private def rewriteLinkedCallTerm
         | some ext => flattenedExternalArity ext
         | none => pure 1
       `(term| externalCallContractWords $name
-          (List.flatten [ $[ExternalArg.toWords $args],* ]) $adv $(natTerm arity) $siteId)
+          (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
   | `(term| callResult $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2356,7 +2356,7 @@ private def rewriteLinkedCallTerm
         | some ext => flattenedExternalArity ext
         | none => pure 1
       `(term| callResultWords $name
-          (List.flatten [ $[ExternalArg.toWords $args],* ]) $adv $(natTerm arity) $siteId)
+          (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
   | `(term| tryExternalCall $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2364,7 +2364,7 @@ private def rewriteLinkedCallTerm
         | some ext => flattenedExternalArity ext
         | none => pure 1
       `(term| tryExternalCallWords $name
-          (List.flatten [ $[ExternalArg.toWords $args],* ]) $adv $(natTerm arity) $siteId)
+          (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
   | `(term| evmCall($gas, $target, $value, $inOffset, $inSize, $outOffset, $outSize)) =>
       `(term| evmCallWords $adv $gas $target $value $inOffset $inSize $outOffset $outSize)
   | `(term| evmStaticCall($gas, $target, $inOffset, $inSize, $outOffset, $outSize)) =>
@@ -2377,10 +2377,10 @@ private def rewriteLinkedCallTerm
       `(term| evmDelegateCallWords $adv $gas $target $inOffset $inSize $outOffset $outSize)
   | `(term| ecmCall $_moduleFactory:term $args:term) =>
       let argList ← expectTermListLiteral args
-      `(term| ecmCallWords $adv (List.flatten [ $[ExternalArg.toWords $argList],* ]))
+      `(term| ecmCallWords $adv (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
   | `(term| ecmDo $_module:term $args:term) =>
       let argList ← expectTermListLiteral args
-      `(term| ecmDoWords $adv (List.flatten [ $[ExternalArg.toWords $argList],* ]))
+      `(term| ecmDoWords $adv (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
   | `(term| externalCallBind $names:term $fnName:term $args:term) =>
       let extName ← expectStringOrIdent fnName
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2393,7 +2393,7 @@ private def rewriteLinkedCallTerm
         | none => pure 1
       let argList ← expectTermListLiteral args
       `(term| tryExternalCallWords $fnName
-          (List.flatten [ $[ExternalArg.toWords $argList],* ]) $adv $(natTerm arity) $siteId)
+          (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
   | `(term| balanceOf $token:term $owner:term) =>
       `(term| balanceOf $token $owner $adv)
   | `(term| allowance $token:term $owner:term $spender:term) =>
@@ -2518,16 +2518,16 @@ private partial def threadAdversaryThroughExecutableSyntax
       hoistLive true value fun rewritten => `(doElem| return $rewritten:term)
   | `(doElem| ecmBind $_names:term $_module:term $args:term) =>
       let argList ← expectTermListLiteral args
-      `(doElem| let _ ← ecmCallWords $adv (List.flatten [ $[ExternalArg.toWords $argList],* ]))
+      `(doElem| let _ ← ecmCallWords $adv (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
   | `(doElem| $fn:ident $args:term*) =>
       let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩
       match ← threadHelperApp? adversarialHelpers fn rewritten adv with
       | some app => `(doElem| $app:term)
       | none =>
-          let mut stmt : Term := ⟨fn.raw⟩
-          for arg in rewritten do
-            stmt ← `(term| $stmt $arg)
-          hoistLive false stmt fun rewritten => `(doElem| $rewritten:term)
+          match stx with
+          | `(doElem| $stmt:term) =>
+              hoistLive false stmt fun rewritten => `(doElem| $rewritten:term)
+          | _ => recurseChildren
   | `(doElem| $stmt:term) =>
       hoistLive false stmt fun rewritten => `(doElem| $rewritten:term)
   | `(term| $name:ident $args:term*) =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2226,15 +2226,17 @@ private def mkContractFnValueWithAdversary
   let value ← mkContractFnValue params body
   `(fun ($adv : $(← adversaryModelTypeTerm)) => $value)
 
-unsafe def translatedBodyOpensReentrancyWindow
+def translatedBodyOpensReentrancyWindow
     (stmtTerms : Array Term) : CommandElabM Bool := do
   let bodyTerm : Term ← `([ $[$stmtTerms],* ])
   liftTermElabM do
-    let stmtTy := mkConst ``Compiler.CompilationModel.Stmt
-    let expectedType := mkApp (mkConst ``List [Level.zero]) stmtTy
-    let expr ← Lean.Elab.Term.elabTermEnsuringType bodyTerm expectedType
-    let body ← Lean.Meta.evalExpr (List Compiler.CompilationModel.Stmt) expectedType expr .unsafe
-    pure (body.any Compiler.CompilationModel.stmtOpensReentrancyWindow)
+    let predicate : Term ← `($bodyTerm.any Compiler.CompilationModel.stmtOpensReentrancyWindow)
+    let expr ← Lean.Elab.Term.elabTermEnsuringType predicate (mkConst ``Bool)
+    match ← Lean.Meta.whnf expr with
+    | .const ``Bool.true _ => pure true
+    | .const ``Bool.false _ => pure false
+    | _ => throwErrorAt bodyTerm
+        "failed to reduce the translated reentrancy-window predicate"
 
 private partial def threadAdversaryThroughExecutableSyntax
     (externalDecls : Array ExternalDecl) (adv : Ident) (stx : Syntax) : CommandElabM Syntax := do
@@ -4598,7 +4600,7 @@ def mkFunctionCommandsPublic
       | some inlined => pure inlined
       | none => pure fn
   let stmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls immutableDecls externalDecls functions modelFn
-  let opensReentrancyWindow ← unsafe translatedBodyOpensReentrancyWindow stmtTerms
+  let opensReentrancyWindow ← translatedBodyOpensReentrancyWindow stmtTerms
   let advIdent := mkIdentFrom fn.ident `_adv
   let fnType ← if opensReentrancyWindow then
       mkContractFnTypeWithAdversary fn.params fn.returnTy

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2325,6 +2325,19 @@ private def executableLinkedArgWords (arg : Term) (ty : ValueType) : CommandElab
       else
         `(ExternalArg.toWords $arg)
 
+/-- Keep executable ECM request keys aligned with `expectEcmExprList`: a direct
+dynamic source parameter denotes its synthetic calldata offset and length, not
+the value-oriented `ExternalArg` length-and-contents journal encoding. -/
+private def executableEcmArgWords
+    (params : Array ParamDecl) (arg : Term) : CommandElabM Term := do
+  match directParamNameWithType? params arg with
+  | some (_, ty) =>
+      if externalCallDynamicArgSupported ty then
+        `(externalDynamicArgWords $arg)
+      else
+        `(ExternalArg.toWords $arg)
+  | none => `(ExternalArg.toWords $arg)
+
 private partial def executableExternalResultDecoder (ty : ValueType) : CommandElabM Term := do
   match ty with
   | .fixedArray elemTy size =>
@@ -2600,11 +2613,14 @@ private def rewriteLinkedCallTerm
       `(term| mstore (externalArgWord $offset) (externalArgWord $value))
   | `(term| ecmCall $moduleFactory:term $args:term) =>
       let argList ← expectTermListLiteral args
+      let argWords ← argList.mapM (executableEcmArgWords params)
       `(term| ecmCallWords (($moduleFactory) "__verity_ecm_result") $adv
-        (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
+        (List.flatten ([ $[$argWords],* ] : List (List Uint256))))
   | `(term| ecmDo $module:term $args:term) =>
       let argList ← expectTermListLiteral args
-      `(term| ecmDoWords $module $adv (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
+      let argWords ← argList.mapM (executableEcmArgWords params)
+      `(term| ecmDoWords $module $adv
+        (List.flatten ([ $[$argWords],* ] : List (List Uint256))))
   | `(term| externalCallBind ([] : List String) $fnName:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent fnName
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2998,20 +3014,21 @@ private partial def threadAdversaryThroughExecutableSyntax
       hoistLive true value fun rewritten => `(doElem| return $rewritten:term)
   | `(doElem| ecmBind $names:term $module:term $args:term) =>
       let argList ← expectTermListLiteral args
+      let argWords ← argList.mapM (executableEcmArgWords params)
       let resultNames ← expectStringList names
       let ids := resultNames.map (mkIdent ∘ Name.mkSimple)
       if ids.size == 1 then
         let id := ids[0]!
         `(doElem| let $id ← (ecmCallWords $module $adv
-          (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256)))))
+          (List.flatten ([ $[$argWords],* ] : List (List Uint256)))))
       else if ids.size == 2 then
         let left := ids[0]!
         let right := ids[1]!
         `(doElem| let ($left, $right) ← (ecmCallPairWords $module $adv
-          (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256)))))
+          (List.flatten ([ $[$argWords],* ] : List (List Uint256)))))
       else if ids.isEmpty then
         `(doElem| ecmDoWords $module $adv
-          (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
+          (List.flatten ([ $[$argWords],* ] : List (List Uint256))))
       else
         let idTerms := ids.map (fun id => (⟨id.raw⟩ : Term))
         let rec nestedTuple (terms : List Term) : CommandElabM Term := do
@@ -3033,7 +3050,7 @@ private partial def threadAdversaryThroughExecutableSyntax
         let tupleType ← nestedTupleType (ids.toList.map (fun _ => uintTy))
         `(doElem| let $tuplePattern:term ← (ecmCallTypedWords (α := $tupleType)
           $module $adv
-          (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256)))))
+          (List.flatten ([ $[$argWords],* ] : List (List Uint256)))))
   | `(doElem| $fn:ident $args:term*) =>
       let original := args.map fun arg => (⟨arg.raw⟩ : Term)
       if toString fn.getId == "__verityTypedEffect" then

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2232,7 +2232,7 @@ def translatedBodyOpensReentrancyWindow
   liftTermElabM do
     let predicate : Term ← `($(bodyTerm).any Compiler.CompilationModel.stmtOpensReentrancyWindow)
     let expr ← Lean.Elab.Term.elabTermEnsuringType predicate (mkConst ``Bool)
-    match ← Lean.Meta.whnf expr with
+    match ← Lean.Meta.withTransparency .all (Lean.Meta.whnf expr) with
     | .const ``Bool.true _ => pure true
     | .const ``Bool.false _ => pure false
     | _ => throwErrorAt bodyTerm

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2381,9 +2381,6 @@ private def rewriteLinkedCallTerm
   | `(term| ecmDo $_module:term $args:term) =>
       let argList ← expectTermListLiteral args
       `(term| ecmDoWords $adv (List.flatten [ $[ExternalArg.toWords $argList],* ]))
-  | `(term| ecmBind $names:term $_module:term $args:term) =>
-      let argList ← expectTermListLiteral args
-      `(term| ecmCallWords $adv (List.flatten [ $[ExternalArg.toWords $argList],* ]))
   | `(term| externalCallBind $names:term $fnName:term $args:term) =>
       let extName ← expectStringOrIdent fnName
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2431,7 +2428,6 @@ private def isLiveStateExternalCall (stx : Term) : Bool :=
   | `(term| delegatecall $_ $_ $_ $_ $_ $_)
   | `(term| ecmCall $_ $_)
   | `(term| ecmDo $_ $_)
-  | `(term| ecmBind $_ $_ $_)
   | `(term| externalCallBind $_ $_ $_)
   | `(term| tryExternalCallBind $_ $_ $_ $_) => true
   | _ => typedDotCallSyntax? stx |>.isSome
@@ -2482,9 +2478,9 @@ private partial def threadAdversaryThroughExecutableSyntax
           `(doElem| let $name := $rewritten:term)
   | `(doElem| return $value:term) =>
       hoistLive value fun rewritten => `(doElem| return $rewritten:term)
-  | `(doElem| ecmBind $names:term $module:term $args:term) =>
-      let rewritten ← rewriteTerm (← `(term| ecmBind $names $module $args))
-      `(doElem| let _ ← $rewritten:term)
+  | `(doElem| ecmBind $_names:term $_module:term $args:term) =>
+      let argList ← expectTermListLiteral args
+      `(doElem| let _ ← ecmCallWords $adv (List.flatten [ $[ExternalArg.toWords $argList],* ]))
   | `(doElem| $fn:ident $args:term*) =>
       let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩
       match ← threadHelperApp? adversarialHelpers fn rewritten adv with

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2094,9 +2094,20 @@ private partial def rewriteForEachExecutableDoElem
       | _ =>
           match ← typedInterfaceCallReturnType? externalDecls params locals rhs with
           | some retTy =>
-              let retTyTerm ← contractValueTypeTerm retTy
-              pure (#[← `(doElem| let $name:ident := (panic! "typed interface calls are compiler-only in executable wrappers" : $retTyTerm))],
-                locals.push (mkTypedLocal (toString name.getId) retTy))
+              match typedDotCallSyntax? rhs with
+              | some (target, methodName, argTerms) =>
+                  let targetName ←
+                    match stripParens target with
+                    | `(term| $targetIdent:ident) => pure (toString targetIdent.getId)
+                    | _ => pure ""
+                  let some interfaceName := lookupInterfaceName? params locals targetName
+                    | pure (#[elem], locals.push (mkTypedLocal (toString name.getId) retTy))
+                  let extName := interfaceExternalName interfaceName methodName
+                  let linked ← `(term| externalCall $(strTerm extName) [ $[$argTerms],* ])
+                  pure (#[← `(doElem| let $name:ident ← $linked:term)],
+                    locals.push (mkTypedLocal (toString name.getId) retTy))
+              | none =>
+                  pure (#[elem], locals.push (mkTypedLocal (toString name.getId) retTy))
           | none =>
               match stripParens rhs with
               | `(term| tryExternalCall $extNameTerm:term $_args:term) =>
@@ -2200,7 +2211,18 @@ private partial def rewriteForEachExecutableDoElem
           | _ => pure (#[elem], locals)
       | _ =>
           if (← isVoidTypedInterfaceCall? externalDecls params locals stmt) then
-            pure (#[← `(doElem| pure ())], locals)
+            match typedDotCallSyntax? stmt with
+            | some (target, methodName, argTerms) =>
+                let targetName ←
+                  match stripParens target with
+                  | `(term| $targetIdent:ident) => pure (toString targetIdent.getId)
+                  | _ => pure ""
+                let some interfaceName := lookupInterfaceName? params locals targetName
+                  | pure (#[elem], locals)
+                let extName := interfaceExternalName interfaceName methodName
+                let linked ← `(term| externalCallBind ([] : List String) $(strTerm extName) [ $[$argTerms],* ])
+                pure (#[← `(doElem| $linked:term)], locals)
+            | none => pure (#[elem], locals)
           else
             pure (#[elem], locals)
   | other =>
@@ -2238,130 +2260,259 @@ def translatedBodyOpensReentrancyWindow
     | _ => throwErrorAt bodyTerm
         "failed to reduce the translated reentrancy-window predicate"
 
-private partial def threadAdversaryThroughExecutableSyntax
+private def linkedExternalSiteId (externalDecls : Array ExternalDecl) (name : String) : Nat :=
+  (externalDecls.findIdx? (fun ext => ext.name == name)).getD 0
+
+private def flattenedExternalArity (ext : ExternalDecl) : CommandElabM Nat := do
+  match ext.returnTys.toList with
+  | [] => pure 0
+  | [ty] =>
+      match staticAbiWordCount? ty with
+      | some n => pure n
+      | none =>
+          let names ← flattenExternalResultNames "result" ty
+          pure names.length
+  | tys =>
+      let mut total := 0
+      for ty in tys do
+        match staticAbiWordCount? ty with
+        | some n => total := total + n
+        | none =>
+            let names ← flattenExternalResultNames "result" ty
+            total := total + names.length
+      pure total
+
+private def helperCallWithAdv (name : Ident) (args : Array Term) (adv : Term) : CommandElabM Term := do
+  let mut app : Term := ⟨name.raw⟩
+  app ← `(term| $app $adv)
+  for arg in args do
+    app ← `(term| $app $arg)
+  pure app
+
+private def threadHelperApp?
+    (adversarialHelpers : Array FunctionDecl) (name : Ident) (args : Array Term)
+    (adv : Term) : CommandElabM (Option Term) := do
+  let helper? := adversarialHelpers.find? fun fn =>
+    (fn.name == toString name.getId || fn.ident.getId == name.getId) &&
+      fn.params.size == args.size
+  match helper? with
+  | some _ => some <$> helperCallWithAdv name args adv
+  | none => pure none
+
+private def rewriteTypedInterfaceCall?
     (externalDecls : Array ExternalDecl)
-    (adversarialHelpers : Array FunctionDecl)
-    (adv : Term) (stx : Syntax) : CommandElabM Syntax := do
-  let go := threadAdversaryThroughExecutableSyntax externalDecls adversarialHelpers adv
-  let recurseChildren : CommandElabM Syntax := do
-    match stx with
-    | .node info kind args =>
-        pure (.node info kind (← args.mapM go))
-    | _ => pure stx
+    (params : Array ParamDecl)
+    (adv : Term) (stx : Term) : CommandElabM (Option Term) := do
+  let some (target, methodName, argTerms) := typedDotCallSyntax? stx | pure none
+  let targetName ←
+    match stripParens target with
+    | `(term| $targetIdent:ident) => pure (toString targetIdent.getId)
+    | _ => pure ""
+  let some interfaceName := lookupInterfaceName? params #[] targetName | pure none
+  let extName := interfaceExternalName interfaceName methodName
+  let some ext := externalDecls.find? (fun ext => ext.name == extName) | pure none
+  let siteId := natTerm (linkedExternalSiteId externalDecls extName)
+  let arity := natTerm (← flattenedExternalArity ext)
+  let rewritten ← argTerms.mapM fun arg => pure arg
+  if ext.returnTys.isEmpty then
+    some <$> `(term| externalCallEffectWords $(strTerm extName)
+      (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv $siteId)
+  else
+    some <$> `(term| externalCallContractWords $(strTerm extName)
+      (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv $arity $siteId)
+
+private def rewriteLinkedCallTerm
+    (externalDecls : Array ExternalDecl) (params : Array ParamDecl)
+    (adv : Term) (stx : Term) : CommandElabM Term := do
   match stx with
-  | `(doElem| let $name:ident ← callExternal $externalName:ident ($[$args:term],*)) =>
-      let extName := toString externalName.getId
-      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
-        | some ext => pure ext
-        | none => throwErrorAt externalName s!"unknown linked external '{extName}'"
-      let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
-        let arg : Term := ⟨← go arg.raw⟩
-        let tyTerm ← contractValueTypeTerm ty
-        `(($arg : $tyTerm))
-      let call ← `(term| externalCallContractWords $(strTerm extName)
-        (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
-      `(doElem| let $name ← $call:term)
-  | `(doElem| callExternal $externalName:ident ($[$args:term],*)) =>
-      let extName := toString externalName.getId
-      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
-        | some ext => pure ext
-        | none => throwErrorAt externalName s!"unknown linked external '{extName}'"
-      let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
-        let arg : Term := ⟨← go arg.raw⟩
-        let tyTerm ← contractValueTypeTerm ty
-        `(($arg : $tyTerm))
-      let call ← `(term| externalCallEffectWords $(strTerm extName)
-        (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
-      `(doElem| $call:term)
-  | `(doElem| let $name:ident ← balanceOf $token:term $owner:term) =>
-      let token : Term := ⟨← go token.raw⟩
-      let owner : Term := ⟨← go owner.raw⟩
-      `(doElem| let $name ← balanceOf $token $owner $adv)
-  | `(doElem| let $name:ident ← allowance $token:term $owner:term $spender:term) =>
-      let token : Term := ⟨← go token.raw⟩
-      let owner : Term := ⟨← go owner.raw⟩
-      let spender : Term := ⟨← go spender.raw⟩
-      `(doElem| let $name ← allowance $token $owner $spender $adv)
-  | `(doElem| let $name:ident ← totalSupply $token:term) =>
-      let token : Term := ⟨← go token.raw⟩
-      `(doElem| let $name ← totalSupply $token $adv)
-  | `(doElem| let $binder:ident ← $name:ident $args:term*) =>
-      let helper? := adversarialHelpers.find? fun fn =>
-        (fn.name == toString name.getId || fn.ident.getId == name.getId) &&
-          fn.params.size == args.size
-      match helper? with
-      | some _ =>
-          let rewritten ← args.mapM fun arg => do
-            pure ⟨← go arg.raw⟩
-          let mut app : Term := ⟨name.raw⟩
-          app ← `(term| $app $adv)
-          for arg in rewritten do
-            app ← `(term| $app $arg)
-          `(doElem| let $binder ← $app:term)
-      | none => recurseChildren
   | `(term| callExternal $name:ident ($[$args:term],*)) =>
       let extName := toString name.getId
       let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
         | some ext => pure ext
         | none => throwErrorAt name s!"unknown linked external '{extName}'"
       let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
-        let arg : Term := ⟨← go arg.raw⟩
         let tyTerm ← contractValueTypeTerm ty
         `(($arg : $tyTerm))
-      `(term| externalCallWords $(strTerm (toString name.getId))
-          (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
+      let siteId := natTerm (linkedExternalSiteId externalDecls extName)
+      let arity := natTerm (← flattenedExternalArity ext)
+      if ext.returnTys.isEmpty then
+        `(term| externalCallEffectWords $(strTerm extName)
+          (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv $siteId)
+      else
+        `(term| externalCallContractWords $(strTerm extName)
+          (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv $arity $siteId)
   | `(term| externalCall $name:term [ $[$args:term],* ]) =>
-      let rewritten ← args.mapM fun arg => do
-        pure ⟨← go arg.raw⟩
-      `(term| externalCallWords $name
-          (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
+      let extName ← expectStringOrIdent name
+      let siteId := natTerm (linkedExternalSiteId externalDecls extName)
+      let arity ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => flattenedExternalArity ext
+        | none => pure 1
+      `(term| externalCallContractWords $name
+          (List.flatten [ $[ExternalArg.toWords $args],* ]) $adv $(natTerm arity) $siteId)
   | `(term| callResult $name:term [ $[$args:term],* ]) =>
-      let rewritten ← args.mapM fun arg => do
-        pure ⟨← go arg.raw⟩
+      let extName ← expectStringOrIdent name
+      let siteId := natTerm (linkedExternalSiteId externalDecls extName)
+      let arity ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => flattenedExternalArity ext
+        | none => pure 1
       `(term| callResultWords $name
-          (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
+          (List.flatten [ $[ExternalArg.toWords $args],* ]) $adv $(natTerm arity) $siteId)
   | `(term| tryExternalCall $name:term [ $[$args:term],* ]) =>
-      let rewritten ← args.mapM fun arg => do
-        pure ⟨← go arg.raw⟩
+      let extName ← expectStringOrIdent name
+      let siteId := natTerm (linkedExternalSiteId externalDecls extName)
+      let arity ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => flattenedExternalArity ext
+        | none => pure 1
       `(term| tryExternalCallWords $name
-          (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
+          (List.flatten [ $[ExternalArg.toWords $args],* ]) $adv $(natTerm arity) $siteId)
   | `(term| evmCall($gas, $target, $value, $inOffset, $inSize, $outOffset, $outSize)) =>
-      let xs ← #[gas, target, value, inOffset, inSize, outOffset, outSize].mapM fun arg => do
-        pure ⟨← go arg.raw⟩
-      `(term| evmCallWords $adv $(xs[0]!) $(xs[1]!) $(xs[2]!) $(xs[3]!)
-          $(xs[4]!) $(xs[5]!) $(xs[6]!))
+      `(term| evmCallWords $adv $gas $target $value $inOffset $inSize $outOffset $outSize)
   | `(term| evmStaticCall($gas, $target, $inOffset, $inSize, $outOffset, $outSize)) =>
-      let xs ← #[gas, target, inOffset, inSize, outOffset, outSize].mapM fun arg => do
-        pure ⟨← go arg.raw⟩
-      `(term| evmStaticCallWords $adv $(xs[0]!) $(xs[1]!) $(xs[2]!)
-          $(xs[3]!) $(xs[4]!) $(xs[5]!))
+      `(term| evmStaticCallWords $adv $gas $target $inOffset $inSize $outOffset $outSize)
+  | `(term| call $gas $target $value $inOffset $inSize $outOffset $outSize) =>
+      `(term| evmCallWords $adv $gas $target $value $inOffset $inSize $outOffset $outSize)
+  | `(term| staticcall $gas $target $inOffset $inSize $outOffset $outSize) =>
+      `(term| evmStaticCallWords $adv $gas $target $inOffset $inSize $outOffset $outSize)
+  | `(term| delegatecall $gas $target $inOffset $inSize $outOffset $outSize) =>
+      `(term| evmDelegateCallWords $adv $gas $target $inOffset $inSize $outOffset $outSize)
+  | `(term| ecmCall $_moduleFactory:term $args:term) =>
+      let argList ← expectTermListLiteral args
+      `(term| ecmCallWords $adv (List.flatten [ $[ExternalArg.toWords $argList],* ]))
+  | `(term| ecmDo $_module:term $args:term) =>
+      let argList ← expectTermListLiteral args
+      `(term| ecmDoWords $adv (List.flatten [ $[ExternalArg.toWords $argList],* ]))
+  | `(term| ecmBind $names:term $_module:term $args:term) =>
+      let argList ← expectTermListLiteral args
+      `(term| ecmCallWords $adv (List.flatten [ $[ExternalArg.toWords $argList],* ]))
+  | `(term| externalCallBind $names:term $fnName:term $args:term) =>
+      let extName ← expectStringOrIdent fnName
+      let siteId := natTerm (linkedExternalSiteId externalDecls extName)
+      `(term| externalCallBind $names $fnName $args $adv $siteId)
+  | `(term| tryExternalCallBind $_successVar:term $_names:term $fnName:term $args:term) =>
+      let extName ← expectStringOrIdent fnName
+      let siteId := natTerm (linkedExternalSiteId externalDecls extName)
+      let arity ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => flattenedExternalArity ext
+        | none => pure 1
+      let argList ← expectTermListLiteral args
+      `(term| tryExternalCallWords $fnName
+          (List.flatten [ $[ExternalArg.toWords $argList],* ]) $adv $(natTerm arity) $siteId)
   | `(term| balanceOf $token:term $owner:term) =>
-      let token : Term := ⟨← go token.raw⟩
-      let owner : Term := ⟨← go owner.raw⟩
       `(term| balanceOf $token $owner $adv)
   | `(term| allowance $token:term $owner:term $spender:term) =>
-      let token : Term := ⟨← go token.raw⟩
-      let owner : Term := ⟨← go owner.raw⟩
-      let spender : Term := ⟨← go spender.raw⟩
       `(term| allowance $token $owner $spender $adv)
   | `(term| totalSupply $token:term) =>
-      let token : Term := ⟨← go token.raw⟩
       `(term| totalSupply $token $adv)
-  | `(term| $name:ident $args:term*) =>
-      let helper? := adversarialHelpers.find? fun fn =>
-        (fn.name == toString name.getId || fn.ident.getId == name.getId) &&
-          fn.params.size == args.size
-      match helper? with
-      | some _ =>
-          let rewritten ← args.mapM fun arg => do
-            pure ⟨← go arg.raw⟩
-          let mut app : Term := ⟨name.raw⟩
-          app ← `(term| $app $adv)
+  | `(term| safeTransfer $token:term $toAddr:term $amount:term) =>
+      `(term| safeTransfer $token $toAddr $amount $adv)
+  | `(term| safeTransferFrom $token:term $fromAddr:term $toAddr:term $amount:term) =>
+      `(term| safeTransferFrom $token $fromAddr $toAddr $amount $adv)
+  | `(term| safeApprove $token:term $spender:term $amount:term) =>
+      `(term| safeApprove $token $spender $amount $adv)
+  | `(term| legacyStringSafeTransfer $token:term $toAddr:term $amount:term) =>
+      `(term| legacyStringSafeTransfer $token $toAddr $amount $adv)
+  | `(term| legacyStringSafeTransferFrom $token:term $fromAddr:term $toAddr:term $amount:term) =>
+      `(term| legacyStringSafeTransferFrom $token $fromAddr $toAddr $amount $adv)
+  | other =>
+      match ← rewriteTypedInterfaceCall? externalDecls params adv ⟨other.raw⟩ with
+      | some rewritten => pure rewritten
+      | none => pure other
+
+private def isLiveStateExternalCall (stx : Term) : Bool :=
+  match stx with
+  | `(term| callExternal $_ ($[$_],*))
+  | `(term| externalCall $_ [ $[$_],* ])
+  | `(term| callResult $_ [ $[$_],* ])
+  | `(term| tryExternalCall $_ [ $[$_],* ])
+  | `(term| evmCall($[$_],*))
+  | `(term| evmStaticCall($[$_],*))
+  | `(term| call $_ $_ $_ $_ $_ $_ $_)
+  | `(term| staticcall $_ $_ $_ $_ $_ $_)
+  | `(term| delegatecall $_ $_ $_ $_ $_ $_)
+  | `(term| ecmCall $_ $_)
+  | `(term| ecmDo $_ $_)
+  | `(term| ecmBind $_ $_ $_)
+  | `(term| externalCallBind $_ $_ $_)
+  | `(term| tryExternalCallBind $_ $_ $_ $_) => true
+  | _ => typedDotCallSyntax? stx |>.isSome
+
+private partial def threadAdversaryThroughExecutableSyntax
+    (externalDecls : Array ExternalDecl)
+    (adversarialHelpers : Array FunctionDecl)
+    (params : Array ParamDecl)
+    (adv : Term) (stx : Syntax) : CommandElabM Syntax := do
+  let go := threadAdversaryThroughExecutableSyntax externalDecls adversarialHelpers params adv
+  let recurseChildren : CommandElabM Syntax := do
+    match stx with
+    | .node info kind args =>
+        pure (.node info kind (← args.mapM go))
+    | _ => pure stx
+  let rewriteTerm (t : Term) : CommandElabM Term :=
+    rewriteLinkedCallTerm externalDecls params adv ⟨← go t.raw⟩
+  let hoistLive (rhs : Term) (cont : Term → CommandElabM (TSyntax `doElem)) :
+      CommandElabM Syntax := do
+    let rewritten ← rewriteTerm rhs
+    if isLiveStateExternalCall rhs then
+      let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{(← mkFreshId).toString}")
+      let rest ← cont ⟨tmp.raw⟩
+      `(doElem| do
+          let $tmp ← $rewritten:term
+          $rest:doElem)
+    else
+      cont rewritten
+  match stx with
+  | `(doElem| let $name:ident ← $fn:ident $args:term*) =>
+      let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩
+      match ← threadHelperApp? adversarialHelpers fn rewritten adv with
+      | some app => `(doElem| let $name ← $app:term)
+      | none =>
+          let mut rhs : Term := ⟨fn.raw⟩
           for arg in rewritten do
-            app ← `(term| $app $arg)
-          pure app
-      | none => recurseChildren
-  | _ => recurseChildren
+            rhs ← `(term| $rhs $arg)
+          hoistLive rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
+  | `(doElem| let $name:ident ← $rhs:term) =>
+      hoistLive rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
+  | `(doElem| let $pat:term ← $rhs:term) =>
+      hoistLive rhs fun rewritten => `(doElem| let $pat ← $rewritten:term)
+  | `(doElem| let $name:ident := $rhs:term) =>
+      hoistLive rhs fun rewritten =>
+        if isLiveStateExternalCall rhs then
+          `(doElem| let $name ← $rewritten:term)
+        else
+          `(doElem| let $name := $rewritten:term)
+  | `(doElem| return $value:term) =>
+      hoistLive value fun rewritten => `(doElem| return $rewritten:term)
+  | `(doElem| ecmBind $names:term $module:term $args:term) =>
+      let rewritten ← rewriteTerm (← `(term| ecmBind $names $module $args))
+      `(doElem| let _ ← $rewritten:term)
+  | `(doElem| $fn:ident $args:term*) =>
+      let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩
+      match ← threadHelperApp? adversarialHelpers fn rewritten adv with
+      | some app => `(doElem| $app:term)
+      | none =>
+          let stmt : Term := ⟨stx⟩
+          let rewritten ← rewriteTerm stmt
+          if isLiveStateExternalCall stmt then
+            `(doElem| $rewritten:term)
+          else
+            recurseChildren
+  | `(doElem| $stmt:term) =>
+      let rewritten ← rewriteTerm stmt
+      if isLiveStateExternalCall stmt then
+        `(doElem| $rewritten:term)
+      else
+        recurseChildren
+  | `(term| $name:ident $args:term*) =>
+      let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩
+      match ← threadHelperApp? adversarialHelpers name rewritten adv with
+      | some app => pure app
+      | none => rewriteLinkedCallTerm externalDecls params adv ⟨stx⟩
+  | _ =>
+      let asTerm : Term := ⟨stx⟩
+      if isLiveStateExternalCall asTerm then
+        rewriteLinkedCallTerm externalDecls params adv asTerm
+      else
+        recurseChildren
 
 private def mkModelParamsTerm (params : Array ParamDecl) : CommandElabM Term := do
   let xs ← params.mapM fun p => do
@@ -4655,7 +4806,7 @@ def mkFunctionCommandsPublic
     else
       mkContractFnType fn.params fn.returnTy
   let fnExecutableBody := ⟨← threadAdversaryThroughExecutableSyntax externalDecls
-    adversarialHelpers advTerm fnExecutableBody.raw⟩
+    adversarialHelpers fn.params advTerm fnExecutableBody.raw⟩
   let fnValue ← if opensReentrancyWindow then
       mkContractFnValueWithAdversary advIdent fn.params fnExecutableBody
     else

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2485,9 +2485,17 @@ private partial def threadAdversaryThroughExecutableSyntax
             rhs ← `(term| $rhs $arg)
           hoistLive rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
   | `(doElem| let $name:ident ← $rhs:term) =>
-      hoistLive rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
+      if isLiveStateExternalCall rhs then
+        let rewritten ← rewriteTerm rhs
+        `(doElem| let $name ← $rewritten:term)
+      else
+        hoistLive rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
   | `(doElem| let $pat:term ← $rhs:term) =>
-      hoistLive rhs fun rewritten => `(doElem| let $pat:term ← $rewritten:term)
+      if isLiveStateExternalCall rhs then
+        let rewritten ← rewriteTerm rhs
+        `(doElem| let $pat:term ← $rewritten:term)
+      else
+        hoistLive rhs fun rewritten => `(doElem| let $pat:term ← $rewritten:term)
   | `(doElem| let $name:ident := $rhs:term) =>
       hoistLive rhs fun rewritten =>
         if isLiveStateExternalCall rhs then
@@ -2508,14 +2516,12 @@ private partial def threadAdversaryThroughExecutableSyntax
           for arg in rewritten do
             stmt ← `(term| $stmt $arg)
           if isLiveStateExternalCall stmt then
-            let rewritten ← rewriteLinkedCallTerm externalDecls params adv stmt
-            `(doElem| $rewritten:term)
+            hoistLive stmt fun rewritten => `(doElem| $rewritten:term)
           else
             recurseChildren
   | `(doElem| $stmt:term) =>
       if isLiveStateExternalCall stmt then
-        let rewritten ← rewriteLinkedCallTerm externalDecls params adv ⟨← go stmt.raw⟩
-        `(doElem| $rewritten:term)
+        hoistLive stmt fun rewritten => `(doElem| $rewritten:term)
       else
         recurseChildren
   | `(term| $name:ident $args:term*) =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2635,13 +2635,16 @@ private partial def threadAdversaryThroughExecutableSyntax
     | _ => pure stx
   let rewriteTerm (t : Term) : CommandElabM Term := do
     rewriteLinkedCallTerm externalDecls params adv t
+  let freshExternalIdent (origin : Term) : CommandElabM Ident :=
+    Lean.Elab.Term.mkFreshIdent
+      (mkIdentFrom origin.raw (Name.mkSimple "__verity_ext")).raw
   let rec hoistNested (bindSelf : Bool) (t : Term) :
       CommandElabM (Array (Ident × Term) × Term) := do
     let bindCall (binds : Array (Ident × Term)) (call : Term) :
         CommandElabM (Array (Ident × Term) × Term) := do
       let rewritten ← rewriteTerm call
       if bindSelf then
-        let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
+        let tmp ← freshExternalIdent t
         pure (binds.push (tmp, rewritten), ⟨tmp.raw⟩)
       else
         pure (binds, rewritten)
@@ -2683,7 +2686,7 @@ private partial def threadAdversaryThroughExecutableSyntax
           let thenContract ← branchContract thenBinds rewrittenThen
           let elseContract ← branchContract elseBinds rewrittenElse
           let conditional ← `(term| if $rewrittenCond then $thenContract else $elseContract)
-          let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "if")}")
+          let tmp ← freshExternalIdent t
           pure (condBinds.push (tmp, conditional), ⟨tmp.raw⟩)
     | _ => match t.raw with
       | .node info kind args =>
@@ -2700,7 +2703,7 @@ private partial def threadAdversaryThroughExecutableSyntax
           match ← rewriteTypedInterfaceCall? externalDecls params adv rebuilt with
           | some rewritten =>
               if bindSelf then
-                let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
+                let tmp ← freshExternalIdent t
                 pure (binds.push (tmp, rewritten), ⟨tmp.raw⟩)
               else
                 pure (binds, rewritten)
@@ -2712,7 +2715,7 @@ private partial def threadAdversaryThroughExecutableSyntax
           match ← rewriteTypedInterfaceCall? externalDecls params adv t with
           | some rewritten =>
               if bindSelf then
-                let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
+                let tmp ← freshExternalIdent t
                 pure (#[(tmp, rewritten)], ⟨tmp.raw⟩)
               else
                 pure (#[], rewritten)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2260,6 +2260,20 @@ def translatedBodyOpensReentrancyWindow
     | _ => throwErrorAt bodyTerm
         "failed to reduce the translated reentrancy-window predicate"
 
+private def translatedBodyContainsExternalCall
+    (stmtTerms : Array Term) : CommandElabM Bool := do
+  let bodyTerm : Term ← `([ $[$stmtTerms],* ])
+  liftTermElabM do
+    let predicate : Term ← `(
+      Compiler.CompilationModel.Stmt.anyDeepList
+        Compiler.CompilationModel.stmtContainsExternalCallNode $bodyTerm)
+    let expr ← Lean.Elab.Term.elabTermEnsuringType predicate (mkConst ``Bool)
+    match ← Lean.Meta.withTransparency .all (Lean.Meta.whnf expr) with
+    | .const ``Bool.true _ => pure true
+    | .const ``Bool.false _ => pure false
+    | _ => throwErrorAt bodyTerm
+        "failed to reduce the translated external-call predicate"
+
 private def linkedExternalSiteId (externalDecls : Array ExternalDecl) (name : String) : Nat :=
   (externalDecls.findIdx? (fun ext => ext.name == name)).getD 0
 
@@ -2327,11 +2341,19 @@ private def rewriteTypedInterfaceCall?
     let tyTerm ← contractValueTypeTerm ty
     `(($arg : $tyTerm))
   if ext.returnTys.isEmpty then
-    some <$> `(term| externalCallEffectWords $(strTerm extName)
-      (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $siteId)
+    if ext.isView then
+      some <$> `(term| externalStaticCallEffectWords $(strTerm extName)
+        (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $siteId)
+    else
+      some <$> `(term| externalCallEffectWords $(strTerm extName)
+        (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $siteId)
   else
-    some <$> `(term| externalCallContractWords $(strTerm extName)
-      (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
+    if ext.isView then
+      some <$> `(term| externalStaticCallContractWords $(strTerm extName)
+        (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
+    else
+      some <$> `(term| externalCallContractWords $(strTerm extName)
+        (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
 
 private def rewriteLinkedCallTerm
     (externalDecls : Array ExternalDecl) (params : Array ParamDecl)
@@ -5038,6 +5060,7 @@ def mkFunctionCommandsPublic
       | none => pure fn
   let stmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls immutableDecls externalDecls functions modelFn
   let opensReentrancyWindow ← translatedBodyOpensReentrancyWindow stmtTerms
+  let containsExternalCall ← translatedBodyContainsExternalCall stmtTerms
   let mut adversarialHelpers : Array FunctionDecl := #[]
   for helper in functions do
     let helperModel ←
@@ -5050,22 +5073,22 @@ def mkFunctionCommandsPublic
         | none => pure helper
     let helperStmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls
       immutableDecls externalDecls functions helperModel
-    if ← translatedBodyOpensReentrancyWindow helperStmtTerms then
+    if ← translatedBodyContainsExternalCall helperStmtTerms then
       adversarialHelpers := adversarialHelpers.push helper
   -- Keep the generated binder hygienic: source parameters and locals are allowed
   -- to use `_adv` without capturing the adversary threaded into rewritten calls.
   let advIdent ← Lean.Elab.Term.mkFreshIdent (mkIdentFrom fn.ident `_adv).raw
-  let advTerm : Term ← if opensReentrancyWindow then
+  let advTerm : Term ← if containsExternalCall then
       pure ⟨advIdent.raw⟩
     else
       `(Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub)
-  let fnType ← if opensReentrancyWindow then
+  let fnType ← if containsExternalCall then
       mkContractFnTypeWithAdversary fn.params fn.returnTy
     else
       mkContractFnType fn.params fn.returnTy
   let fnExecutableBody := ⟨← threadAdversaryThroughExecutableSyntax externalDecls
     adversarialHelpers fn.params advTerm fnExecutableBody.raw⟩
-  let fnValue ← if opensReentrancyWindow then
+  let fnValue ← if containsExternalCall then
       mkContractFnValueWithAdversary advIdent fn.params fnExecutableBody
     else
       mkContractFnValue fn.params fnExecutableBody

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2487,6 +2487,15 @@ private partial def threadAdversaryThroughExecutableSyntax
     let rest ← cont rewritten
     wrapBinds binds rest
   match stx with
+  | `(doElem| let $name:ident ← tryExternalCall $extName:term $args:term) =>
+      hoistLive false (← `(term| tryExternalCall $extName $args)) fun rewritten =>
+        `(doElem| let $name ← $rewritten:term)
+  | `(doElem| let $pat:term ← tryExternalCall $extName:term $args:term) =>
+      hoistLive false (← `(term| tryExternalCall $extName $args)) fun rewritten =>
+        `(doElem| let $pat:term ← $rewritten:term)
+  | `(doElem| let $name:ident ← callResult $extName:term $args:term) =>
+      hoistLive false (← `(term| callResult $extName $args)) fun rewritten =>
+        `(doElem| let $name ← $rewritten:term)
   | `(doElem| let $name:ident ← $fn:ident $args:term*) =>
       let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩
       match ← threadHelperApp? adversarialHelpers fn rewritten adv with
@@ -2519,15 +2528,9 @@ private partial def threadAdversaryThroughExecutableSyntax
           let mut stmt : Term := ⟨fn.raw⟩
           for arg in rewritten do
             stmt ← `(term| $stmt $arg)
-          if isLiveStateExternalCall stmt then
-            hoistLive false stmt fun rewritten => `(doElem| $rewritten:term)
-          else
-            recurseChildren
+          hoistLive false stmt fun rewritten => `(doElem| $rewritten:term)
   | `(doElem| $stmt:term) =>
-      if isLiveStateExternalCall stmt then
-        hoistLive false stmt fun rewritten => `(doElem| $rewritten:term)
-      else
-        recurseChildren
+      hoistLive false stmt fun rewritten => `(doElem| $rewritten:term)
   | `(term| $name:ident $args:term*) =>
       let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩
       match ← threadHelperApp? adversarialHelpers name rewritten adv with

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2103,7 +2103,8 @@ private partial def rewriteForEachExecutableDoElem
                   let some interfaceName := lookupInterfaceName? params locals targetName
                     | pure (#[elem], locals.push (mkTypedLocal (toString name.getId) retTy))
                   let extName := interfaceExternalName interfaceName methodName
-                  let linked ← `(term| externalCall $(strTerm extName) [ $[$argTerms],* ])
+                  let linked ← `(term| __verityTypedCall $target $(strTerm extName)
+                    [ $[$argTerms],* ])
                   pure (#[← `(doElem| let $name:ident ← $linked:term)],
                     locals.push (mkTypedLocal (toString name.getId) retTy))
               | none =>
@@ -2220,7 +2221,8 @@ private partial def rewriteForEachExecutableDoElem
                 let some interfaceName := lookupInterfaceName? params locals targetName
                   | pure (#[elem], locals)
                 let extName := interfaceExternalName interfaceName methodName
-                let linked ← `(term| externalCallBind ([] : List String) $(strTerm extName) [ $[$argTerms],* ])
+                let linked ← `(term| __verityTypedEffect $target $(strTerm extName)
+                  [ $[$argTerms],* ])
                 pure (#[← `(doElem| $linked:term)], locals)
             | none => pure (#[elem], locals)
           else
@@ -2357,23 +2359,55 @@ private def rewriteTypedInterfaceCall?
     executableLinkedArgWords (← `(($arg : $tyTerm))) ty
   if ext.returnTys.isEmpty then
     if isView then
-      some <$> `(term| externalStaticCallEffectWords $(strTerm extName)
+      some <$> `(term| externalStaticCallEffectWordsTo $(strTerm extName) $target
         (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
     else
-      some <$> `(term| externalCallEffectWords $(strTerm extName)
+      some <$> `(term| externalCallEffectWordsTo $(strTerm extName) $target
         (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
   else
     if isView then
-      some <$> `(term| externalStaticCallContractWords $(strTerm extName)
+      some <$> `(term| externalStaticCallContractWordsTo $(strTerm extName) $target
         (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
     else
-      some <$> `(term| externalCallContractWords $(strTerm extName)
+      some <$> `(term| externalCallContractWordsTo $(strTerm extName) $target
         (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
 
 private def rewriteLinkedCallTerm
     (externalDecls : Array ExternalDecl) (params : Array ParamDecl)
     (adv : Term) (stx : Term) : CommandElabM Term := do
   match stx with
+  | `(term| __verityTypedCall $target:term $name:term [ $[$args:term],* ]) =>
+      let extName ← expectStringOrIdent name
+      let ext ← match externalDecls.find? (fun candidate => candidate.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown interface external '{extName}'"
+      let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
+        let tyTerm ← contractValueTypeTerm ty
+        executableLinkedArgWords (← `(($arg : $tyTerm))) ty
+      let arity := natTerm (← flattenedExternalArity ext)
+      let siteId := natTerm (linkedExternalSiteId externalDecls extName)
+      let resultTy ← externalReturnTypeTerm ext
+      if ext.isView then
+        `(term| externalStaticCallContractWordsTo (α := $resultTy) $name $target
+          (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
+      else
+        `(term| externalCallContractWordsTo (α := $resultTy) $name $target
+          (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
+  | `(term| __verityTypedEffect $target:term $name:term [ $[$args:term],* ]) =>
+      let extName ← expectStringOrIdent name
+      let ext ← match externalDecls.find? (fun candidate => candidate.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown interface external '{extName}'"
+      let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
+        let tyTerm ← contractValueTypeTerm ty
+        executableLinkedArgWords (← `(($arg : $tyTerm))) ty
+      let siteId := natTerm (linkedExternalSiteId externalDecls extName)
+      if ext.isView then
+        `(term| externalStaticCallEffectWordsTo $name $target
+          (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
+      else
+        `(term| externalCallEffectWordsTo $name $target
+          (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
   | `(term| callExternal $name:ident ($[$args:term],*)) =>
       let extName := toString name.getId
       let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
@@ -2530,6 +2564,8 @@ private def rewriteLinkedCallTerm
 
 private def isLiveStateExternalCall (stx : Term) : Bool :=
   match stx with
+  | `(term| __verityTypedCall $_ $_ [ $[$_],* ])
+  | `(term| __verityTypedEffect $_ $_ [ $[$_],* ])
   | `(term| callExternal $_ ($[$_],*))
   | `(term| externalCall $_ [ $[$_],* ])
   | `(term| callResult $_ [ $[$_],* ])
@@ -2787,7 +2823,13 @@ private partial def threadAdversaryThroughExecutableSyntax
         | some app =>
             hoistLive false app fun rewritten => `(doElem| let $name ← $rewritten:term)
         | none =>
-          if fnName == "tryExternalCall" || fnName == "callResult" || fnName == "callExternal"
+          if fnName == "__verityTypedCall" then
+            match stx with
+            | `(doElem| let $_ ← $rhs:term) =>
+                let rewritten ← rewriteLinkedCallTerm externalDecls params adv rhs
+                `(doElem| let $name ← $rewritten:term)
+            | _ => recurseChildren
+          else if fnName == "tryExternalCall" || fnName == "callResult" || fnName == "callExternal"
               || fnName == "externalCall" || fnName == "externalCallBind" then
             match stx with
             | `(doElem| let $_ ← $rhs:term) =>
@@ -2875,7 +2917,13 @@ private partial def threadAdversaryThroughExecutableSyntax
         throwErrorAt names "executable ecmBind currently supports one or two results"
   | `(doElem| $fn:ident $args:term*) =>
       let original := args.map fun arg => (⟨arg.raw⟩ : Term)
-      match ← threadHelperApp? adversarialHelpers fn original adv with
+      if toString fn.getId == "__verityTypedEffect" then
+        match stx with
+        | `(doElem| $rhs:term) =>
+            let rewritten ← rewriteLinkedCallTerm externalDecls params adv rhs
+            `(doElem| $rewritten:term)
+        | _ => recurseChildren
+      else match ← threadHelperApp? adversarialHelpers fn original adv with
       | some app =>
           hoistLive false app fun rewritten => `(doElem| $rewritten:term)
       | none =>
@@ -5022,9 +5070,12 @@ def validateFunctionDeclsPublic
       throwErrorAt fn.ident s!"function '{fn.name}': nonreentrant and cei_safe are mutually exclusive"
     validateFunctionBodyExprTypes fields errorDecls eventDecls constDecls immutableDecls externalDecls functions fn
 
-/-- Apply `with` modifiers in declared order: mixin modifiers call the
-    imported Lean `def`; host-local modifiers are inlined (hosts do not
-    emit modifier defs). CompilationModel inlines every modifier body. -/
+def modifierContainsExternalCallSyntaxPublic (modDecl : ModifierDecl) : Bool :=
+  syntaxContainsCallExternal modDecl.body.raw
+
+/-- Apply `with` modifiers in declared order. Inline both mixin and host-local
+    bodies so the later executable adversary pass sees the same external-call
+    syntax that the CompilationModel inlines. -/
 def prefixMixinModifierExecutableBody
     (resolvedIncludes : Array Name) (fn : FunctionDecl) (body : Term)
     (hostModifiers : Array ModifierDecl := #[]) :
@@ -5034,22 +5085,32 @@ def prefixMixinModifierExecutableBody
   let mut preludes : Array (TSyntax `doElem) := #[]
   for modIdent in fn.modifiers do
     let modName := toString modIdent.getId
-    let mut qual? : Option Name := none
+    let mut resolved? : Option (Name × ModifierDecl) := none
     for mixinName in resolvedIncludes do
-      if qual?.isNone then
+      if resolved?.isNone then
         match (← lookupContractSyntax mixinName) with
         | some mixin =>
-            if mixin.modifiers.any (fun m => m.name == modName) then
-              qual? := some (mixinName ++ modIdent.getId)
+            if let some modDecl := mixin.modifiers.find? (fun m => m.name == modName) then
+              resolved? := some (mixinName ++ modIdent.getId, modDecl)
         | none => pure ()
-    match qual? with
-    | some q =>
-        preludes := preludes.push (← `(doElem| $(mkIdent q):ident))
+    match resolved? with
+    | some (qualifiedName, mixinMod) =>
+      if modifierContainsExternalCallSyntaxPublic mixinMod then
+        let modifierElems ← doElems mixinMod.body
+        let modifierLocals ← localBinderNames mixinMod.body.raw
+        if let some captured := modifierLocals.find? (fun name =>
+            fn.params.any (fun param => paramReservesName param name)) then
+          throwErrorAt modIdent
+            s!"modifier '{modName}' local '{captured}' conflicts with a function parameter; rename one of them"
+        preludes := preludes.push (← `(doElem| if true then $[$modifierElems:doElem]* else
+          require false "unreachable modifier scope"))
+      else
+        preludes := preludes.push (← `(doElem| $(mkIdent qualifiedName):ident))
     | none =>
-        let some localMod := hostModifiers.find? (fun m => m.name == modName)
+        let some hostMod := hostModifiers.find? (fun m => m.name == modName)
           | throwErrorAt modIdent s!"function '{fn.name}' references unknown modifier '{modName}'"
-        let modifierElems ← doElems localMod.body
-        let modifierLocals ← localBinderNames localMod.body.raw
+        let modifierElems ← doElems hostMod.body
+        let modifierLocals ← localBinderNames hostMod.body.raw
         if let some captured := modifierLocals.find? (fun name =>
             fn.params.any (fun param => paramReservesName param name)) then
           throwErrorAt modIdent
@@ -5074,17 +5135,43 @@ private def constructorContainsExternalCall
     immutableDecls externalDecls functions ctor
   translatedBodyContainsExternalCall stmts
 
+private def constructorAdversarialHelpers
+    (fields : Array StorageFieldDecl) (errorDecls : Array ErrorDecl)
+    (constDecls : Array ConstantDecl) (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl) (functions : Array FunctionDecl) :
+    CommandElabM (Array FunctionDecl) := do
+  let mut adversarial : Array FunctionDecl := #[]
+  for helper in functions do
+    let stmts ← translateBodyToStmtTerms fields #[] errorDecls constDecls immutableDecls
+      externalDecls functions helper
+    if ← translatedBodyContainsExternalCall stmts then
+      adversarial := adversarial.push helper
+  for _ in [:functions.size] do
+    let names := adversarial.map (·.name)
+    let mut grew := false
+    for helper in functions do
+      if !adversarial.any (fun candidate => candidate.name == helper.name) &&
+          syntaxReferencesAnyHelper names helper.body.raw then
+        adversarial := adversarial.push helper
+        grew := true
+    if !grew then break
+  pure adversarial
+
 def mkConstructorDefCommandPublic
     (fields : Array StorageFieldDecl) (errorDecls : Array ErrorDecl)
     (constDecls : Array ConstantDecl) (immutableDecls : Array ImmutableDecl)
     (externalDecls : Array ExternalDecl) (functions : Array FunctionDecl)
     (ctor : ConstructorDecl) : CommandElabM Cmd := do
-  let containsExternalCall ← constructorContainsExternalCall fields errorDecls constDecls
+  let directlyContainsExternalCall ← constructorContainsExternalCall fields errorDecls constDecls
     immutableDecls externalDecls functions ctor
+  let adversarialHelpers ← constructorAdversarialHelpers fields errorDecls constDecls
+    immutableDecls externalDecls functions
+  let containsExternalCall := directlyContainsExternalCall ||
+    syntaxReferencesAnyHelper (adversarialHelpers.map (·.name)) ctor.body.raw
   let executableBody ← rewriteForEachExecutableBody fields externalDecls ctor.params ctor.body
   let advIdent ← Lean.Elab.Term.mkFreshIdent (mkIdentFrom (mkIdent `constructor) `_adv).raw
   let advTerm : Term := ⟨advIdent.raw⟩
-  let executableBody := ⟨← threadAdversaryThroughExecutableSyntax externalDecls #[]
+  let executableBody := ⟨← threadAdversaryThroughExecutableSyntax externalDecls adversarialHelpers
     ctor.params advTerm executableBody.raw⟩
   let fnType ← if containsExternalCall then
       mkContractFnTypeWithAdversary ctor.params .unit
@@ -5102,14 +5189,21 @@ def mkHostConstructorDefCommandPublic
     (constDecls : Array ConstantDecl) (immutableDecls : Array ImmutableDecl)
     (externalDecls : Array ExternalDecl) (functions : Array FunctionDecl)
     (resolvedIncludes : Array Name) (ctor : ConstructorDecl) : CommandElabM Cmd := do
-  let ownExternal ← constructorContainsExternalCall fields errorDecls constDecls
+  let ownDirectExternal ← constructorContainsExternalCall fields errorDecls constDecls
     immutableDecls externalDecls functions ctor
+  let ownAdversarialHelpers ← constructorAdversarialHelpers fields errorDecls constDecls
+    immutableDecls externalDecls functions
+  let ownExternal := ownDirectExternal ||
+    syntaxReferencesAnyHelper (ownAdversarialHelpers.map (·.name)) ctor.body.raw
   let mut mixinExternal : Array Name := #[]
   for mixinName in resolvedIncludes do
     if let some mixin ← lookupContractSyntax mixinName then
       if let some mixinCtor := mixin.ctor then
-        if ← constructorContainsExternalCall mixin.fields mixin.errorDecls mixin.constDecls
-            mixin.immutableDecls mixin.externalDecls mixin.functions mixinCtor then
+        let direct ← constructorContainsExternalCall mixin.fields mixin.errorDecls mixin.constDecls
+          mixin.immutableDecls mixin.externalDecls mixin.functions mixinCtor
+        let helpers ← constructorAdversarialHelpers mixin.fields mixin.errorDecls mixin.constDecls
+          mixin.immutableDecls mixin.externalDecls mixin.functions
+        if direct || syntaxReferencesAnyHelper (helpers.map (·.name)) mixinCtor.body.raw then
           mixinExternal := mixinExternal.push mixinName
   let containsExternalCall := ownExternal || !mixinExternal.isEmpty
   let advIdent ← Lean.Elab.Term.mkFreshIdent (mkIdentFrom (mkIdent `constructor) `_adv).raw
@@ -5141,7 +5235,7 @@ def mkHostConstructorDefCommandPublic
             preludes := preludes.push (← `(doElem| $tgt:ident $args*))
       let body ← `(term| do $[$preludes:doElem]* $[$elems:doElem]*)
       let executableBody ← rewriteForEachExecutableBody fields externalDecls ctor.params body
-      let executableBody := ⟨← threadAdversaryThroughExecutableSyntax externalDecls #[]
+      let executableBody := ⟨← threadAdversaryThroughExecutableSyntax externalDecls ownAdversarialHelpers
         ctor.params advTerm executableBody.raw⟩
       let fnValue ← if containsExternalCall then
           mkContractFnValueWithAdversary advIdent ctor.params executableBody
@@ -5169,8 +5263,9 @@ def mkIncludeAliasCommandsPublic
             let tgt := mkIdent (mixinName ++ fn.ident.getId)
             cmds := cmds.push (← `(command| abbrev $(fn.ident) := $tgt))
         for modDecl in mixin.modifiers do
-          let tgt := mkIdent (mixinName ++ modDecl.ident.getId)
-          cmds := cmds.push (← `(command| abbrev $(modDecl.ident) := $tgt))
+          unless modifierContainsExternalCallSyntaxPublic modDecl do
+            let tgt := mkIdent (mixinName ++ modDecl.ident.getId)
+            cmds := cmds.push (← `(command| abbrev $(modDecl.ident) := $tgt))
         if mixin.ctor.isSome then
           let tgt := mkIdent (mixinName ++ Name.mkSimple "constructor")
           let id : Ident := mkIdent (Name.mkSimple s!"{mixinShortName mixinName}_constructor")

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2449,7 +2449,7 @@ private partial def threadAdversaryThroughExecutableSyntax
       CommandElabM Syntax := do
     let rewritten ← rewriteTerm rhs
     if isLiveStateExternalCall rhs then
-      let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{(← mkFreshId).toString}")
+      let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (rhs.raw.reprint.getD "x")}")
       let rest ← cont ⟨tmp.raw⟩
       `(doElem| do
           let $tmp ← $rewritten:term
@@ -2469,7 +2469,7 @@ private partial def threadAdversaryThroughExecutableSyntax
   | `(doElem| let $name:ident ← $rhs:term) =>
       hoistLive rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
   | `(doElem| let $pat:term ← $rhs:term) =>
-      hoistLive rhs fun rewritten => `(doElem| let $pat ← $rewritten:term)
+      hoistLive rhs fun rewritten => `(doElem| let $pat:term ← $rewritten:term)
   | `(doElem| let $name:ident := $rhs:term) =>
       hoistLive rhs fun rewritten =>
         if isLiveStateExternalCall rhs then

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2534,18 +2534,18 @@ private partial def threadAdversaryThroughExecutableSyntax
   | `(term| $name:ident $args:term*) =>
       let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩
       match ← threadHelperApp? adversarialHelpers name rewritten adv with
-      | some app => pure app
+      | some app => pure app.raw
       | none =>
           if isLiveStateExternalCall ⟨stx⟩ then
-            rewriteLinkedCallTerm externalDecls params adv ⟨stx⟩
+            (·.raw) <$> rewriteLinkedCallTerm externalDecls params adv ⟨stx⟩
           else
-            return ⟨← recurseChildren⟩
+            recurseChildren
   | _ =>
       let asTerm : Term := ⟨stx⟩
       if isLiveStateExternalCall asTerm then
-        rewriteLinkedCallTerm externalDecls params adv asTerm
+        (·.raw) <$> rewriteLinkedCallTerm externalDecls params adv asTerm
       else
-        return ⟨← recurseChildren⟩
+        recurseChildren
 
 private def mkModelParamsTerm (params : Array ParamDecl) : CommandElabM Term := do
   let xs ← params.mapM fun p => do

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2274,6 +2274,13 @@ private def translatedBodyContainsExternalCall
     | _ => throwErrorAt bodyTerm
         "failed to reduce the translated external-call predicate"
 
+private partial def syntaxReferencesAnyHelper
+    (helperNames : Array String) (stx : Syntax) : Bool :=
+  match stx with
+  | .ident _ _ name _ => helperNames.contains name.toString
+  | .node _ _ args => args.any (syntaxReferencesAnyHelper helperNames)
+  | _ => false
+
 private def linkedExternalSiteId (externalDecls : Array ExternalDecl) (name : String) : Nat :=
   (externalDecls.findIdx? (fun ext => ext.name == name)).getD 0
 
@@ -2323,7 +2330,8 @@ private def threadHelperApp?
     (adversarialHelpers : Array FunctionDecl) (name : Ident) (args : Array Term)
     (adv : Term) : CommandElabM (Option Term) := do
   let helper? := adversarialHelpers.find? fun fn =>
-    (fn.name == toString name.getId || fn.ident.getId == name.getId) &&
+    (fn.name == toString name.getId || fn.ident.getId == name.getId ||
+      (toString name.getId).endsWith ("." ++ fn.name)) &&
       fn.params.size == args.size
   match helper? with
   | some _ => some <$> helperCallWithAdv name args adv
@@ -2599,6 +2607,24 @@ private partial def threadAdversaryThroughExecutableSyntax
         let bodyRaw : Syntax ← go body.raw
         let rewrittenBody : Term := ⟨bodyRaw⟩
         pure (#[], ← `(term| fun $name => $rewrittenBody))
+    | `(term| do $body:doSeq) =>
+        let bodyRaw : Syntax ← go body.raw
+        let rewrittenBody : TSyntax ``Lean.Parser.Term.doSeq := ⟨bodyRaw⟩
+        pure (#[], ← `(term| do $rewrittenBody))
+    | `(term| $name:ident($[$args:term],*)) =>
+        match ← threadHelperApp? adversarialHelpers name args adv with
+        | some app => pure (#[], app)
+        | none =>
+            let mut binds : Array (Ident × Term) := #[]
+            let mut rewrittenArgs : Array Term := #[]
+            for arg in args do
+              let (inner, rewritten) ← hoistNested true arg
+              binds := binds ++ inner
+              rewrittenArgs := rewrittenArgs.push rewritten
+            let mut app : Term := ⟨name.raw⟩
+            for arg in rewrittenArgs do
+              app ← `(term| $app $arg)
+            pure (binds, app)
     | `(term| if $cond:term then $thenValue:term else $elseValue:term) =>
         let (condBinds, rewrittenCond) ← hoistNested true cond
         let (thenBinds, rewrittenThen) ← hoistNested true thenValue
@@ -2722,6 +2748,10 @@ private partial def threadAdversaryThroughExecutableSyntax
       wrapBinds binds
         (← `(doElem| let $pat:term ← (totalSupply
           (externalArgAddress $rewrittenToken) $adv)))
+  | `(doElem| let $name:ident ← $fn:ident($[$args:term],*)) =>
+      match ← threadHelperApp? adversarialHelpers fn args adv with
+      | some app => `(doElem| let $name ← $app:term)
+      | none => recurseChildren
   | `(doElem| let $name:ident ← $fn:ident $args:term*) =>
       let original := args.map fun arg => (⟨arg.raw⟩ : Term)
       let fnName := toString fn.getId
@@ -5139,8 +5169,9 @@ def mkFunctionCommandsPublic
       | none => pure fn
   let stmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls immutableDecls externalDecls functions modelFn
   let _opensReentrancyWindow ← translatedBodyOpensReentrancyWindow stmtTerms
-  let containsExternalCall ← translatedBodyContainsExternalCall stmtTerms
+  let directlyContainsExternalCall ← translatedBodyContainsExternalCall stmtTerms
   let mut adversarialHelpers : Array FunctionDecl := #[]
+  let mut translatedHelpers : Array (FunctionDecl × FunctionDecl) := #[]
   for helper in functions do
     let helperModel ←
       if helper.modifiers.isEmpty || allModifiers.isEmpty then
@@ -5152,8 +5183,25 @@ def mkFunctionCommandsPublic
         | none => pure helper
     let helperStmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls
       immutableDecls externalDecls functions helperModel
+    translatedHelpers := translatedHelpers.push (helper, helperModel)
     if ← translatedBodyContainsExternalCall helperStmtTerms then
       adversarialHelpers := adversarialHelpers.push helper
+  -- External-call capability is transitive across internal helpers. Iterate to a
+  -- fixed point so every caller in a multi-hop helper chain receives and forwards
+  -- the same adversary instead of silently falling back to the stub.
+  for _ in [:functions.size] do
+    let adversarialNames := adversarialHelpers.map (·.name)
+    let mut grew := false
+    for (helper, helperModel) in translatedHelpers do
+      if !adversarialHelpers.any (fun candidate => candidate.name == helper.name) &&
+          syntaxReferencesAnyHelper adversarialNames helperModel.body.raw then
+        adversarialHelpers := adversarialHelpers.push helper
+        grew := true
+    if !grew then
+      break
+  let adversarialNames := adversarialHelpers.map (·.name)
+  let containsExternalCall := directlyContainsExternalCall ||
+    syntaxReferencesAnyHelper adversarialNames modelFn.body.raw
   -- Keep the generated binder hygienic: source parameters and locals are allowed
   -- to use `_adv` without capturing the adversary threaded into rewritten calls.
   let advIdent ← Lean.Elab.Term.mkFreshIdent (mkIdentFrom fn.ident `_adv).raw

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2313,10 +2313,17 @@ private def flattenedExternalArity (ext : ExternalDecl) : CommandElabM Nat := do
       pure total
 
 private def executableLinkedArgWords (arg : Term) (ty : ValueType) : CommandElabM Term := do
-  if externalCallDynamicArgSupported ty then
-    `(externalDynamicArgWords $arg)
-  else
-    `(ExternalArg.toWords $arg)
+  match ty with
+  | .fixedArray elemTy _ =>
+      let value ← Lean.Elab.Term.mkFreshIdent (mkIdent `_fixedElem).raw
+      let valueTerm : Term := ⟨value.raw⟩
+      let elemWords ← executableLinkedArgWords valueTerm elemTy
+      `(term| ($arg).toList.flatMap (fun $value => $elemWords))
+  | _ =>
+      if externalCallDynamicArgSupported ty then
+        `(externalDynamicArgWords $arg)
+      else
+        `(ExternalArg.toWords $arg)
 
 private partial def executableExternalResultDecoder (ty : ValueType) : CommandElabM Term := do
   match ty with
@@ -3002,8 +3009,31 @@ private partial def threadAdversaryThroughExecutableSyntax
         let right := ids[1]!
         `(doElem| let ($left, $right) ← (ecmCallPairWords $module $adv
           (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256)))))
+      else if ids.isEmpty then
+        `(doElem| ecmDoWords $module $adv
+          (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
       else
-        throwErrorAt names "executable ecmBind currently supports one or two results"
+        let idTerms := ids.map (fun id => (⟨id.raw⟩ : Term))
+        let rec nestedTuple (terms : List Term) : CommandElabM Term := do
+          match terms with
+          | [left, right] => `(term| ($left, $right))
+          | head :: tail =>
+              let rest ← nestedTuple tail
+              `(term| ($head, $rest))
+          | _ => throwErrorAt names "ECM tuple binding requires at least two results"
+        let tuplePattern ← nestedTuple idTerms.toList
+        let uintTy ← `(term| Uint256)
+        let rec nestedTupleType (terms : List Term) : CommandElabM Term := do
+          match terms with
+          | [left, right] => `(term| $left × $right)
+          | head :: tail =>
+              let rest ← nestedTupleType tail
+              `(term| $head × $rest)
+          | _ => throwErrorAt names "ECM tuple type requires at least two results"
+        let tupleType ← nestedTupleType (ids.toList.map (fun _ => uintTy))
+        `(doElem| let $tuplePattern:term ← (ecmCallTypedWords (α := $tupleType)
+          $module $adv
+          (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256)))))
   | `(doElem| $fn:ident $args:term*) =>
       let original := args.map fun arg => (⟨arg.raw⟩ : Term)
       if toString fn.getId == "__verityTypedEffect" then

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2539,13 +2539,13 @@ private partial def threadAdversaryThroughExecutableSyntax
           if isLiveStateExternalCall ⟨stx⟩ then
             rewriteLinkedCallTerm externalDecls params adv ⟨stx⟩
           else
-            (⟨·⟩) <$> recurseChildren
+            return ⟨← recurseChildren⟩
   | _ =>
       let asTerm : Term := ⟨stx⟩
       if isLiveStateExternalCall asTerm then
         rewriteLinkedCallTerm externalDecls params adv asTerm
       else
-        (⟨·⟩) <$> recurseChildren
+        return ⟨← recurseChildren⟩
 
 private def mkModelParamsTerm (params : Array ParamDecl) : CommandElabM Term := do
   let xs ← params.mapM fun p => do

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2482,8 +2482,13 @@ private def rewriteLinkedCallTerm
       let resultTy ← match ext? with
         | some ext => externalReturnTypeTerm ext
         | none => `(Unit)
+      let rewritten ← match ext? with
+        | some ext => args.zip ext.params |>.mapM fun (arg, ty) => do
+            let tyTerm ← contractValueTypeTerm ty
+            executableLinkedArgWords (← `(($arg : $tyTerm))) ty
+        | none => args.mapM fun arg => `(ExternalArg.toWords $arg)
       `(term| callResultWordsResolved (α := $resultTy) $name
-          (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
+          (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
   | `(term| tryExternalCall $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2492,8 +2497,13 @@ private def rewriteLinkedCallTerm
       let resultTy ← match ext? with
         | some ext => externalReturnTypeTerm ext
         | none => `(Unit)
+      let rewritten ← match ext? with
+        | some ext => args.zip ext.params |>.mapM fun (arg, ty) => do
+            let tyTerm ← contractValueTypeTerm ty
+            executableLinkedArgWords (← `(($arg : $tyTerm))) ty
+        | none => args.mapM fun arg => `(ExternalArg.toWords $arg)
       `(term| tryExternalCallWordsResolved (α := $resultTy) $name
-          (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
+          (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
   | `(term| evmCall($gas, $target, $value, $inOffset, $inSize, $outOffset, $outSize)) =>
       `(term| evmCallWords $adv $gas $target $value $inOffset $inSize $outOffset $outSize)
   | `(term| evmStaticCall($gas, $target, $inOffset, $inSize, $outOffset, $outSize)) =>
@@ -2509,6 +2519,8 @@ private def rewriteLinkedCallTerm
   | `(term| returnDataCopy($destOffset, $sourceOffset, $size))
     | `(term| returndataCopy $destOffset $sourceOffset $size) =>
       `(term| returndataCopyLive $destOffset $sourceOffset $size)
+  | `(term| memoryStore($offset, $value)) =>
+      `(term| mstore (externalArgWord $offset) (externalArgWord $value))
   | `(term| ecmCall $_moduleFactory:term $args:term) =>
       let argList ← expectTermListLiteral args
       `(term| ecmCallWords $adv (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
@@ -2582,6 +2594,7 @@ private def isLiveStateExternalCall (stx : Term) : Bool :=
   | `(term| returndataSize)
   | `(term| returnDataCopy($_, $_, $_))
   | `(term| returndataCopy $_ $_ $_)
+  | `(term| memoryStore($_, $_))
   | `(term| ecmCall $_ $_)
   | `(term| ecmDo $_ $_)
   | `(term| externalCallBind $_ $_ $_)
@@ -5097,8 +5110,14 @@ def validateFunctionDeclsPublic
       throwErrorAt fn.ident s!"function '{fn.name}': nonreentrant and cei_safe are mutually exclusive"
     validateFunctionBodyExprTypes fields errorDecls eventDecls constDecls immutableDecls externalDecls functions fn
 
+private partial def syntaxContainsLiveExternalCall (stx : Syntax) : Bool :=
+  isLiveStateExternalCall ⟨stx⟩ || (typedDotCallSyntax? ⟨stx⟩).isSome ||
+    match stx with
+    | .node _ _ args => args.any syntaxContainsLiveExternalCall
+    | _ => false
+
 def modifierContainsExternalCallSyntaxPublic (modDecl : ModifierDecl) : Bool :=
-  syntaxContainsCallExternal modDecl.body.raw
+  syntaxContainsLiveExternalCall modDecl.body.raw
 
 /-- Apply `with` modifiers in declared order. Inline both mixin and host-local
     bodies so the later executable adversary pass sees the same external-call

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -5322,7 +5322,10 @@ def mkConstructorDefCommandPublic
     callsAdversarial
   let executableBody ← rewriteForEachExecutableBody fields externalDecls ctor.params ctor.body
   let advIdent ← Lean.Elab.Term.mkFreshIdent (mkIdentFrom (mkIdent `constructor) `_adv).raw
-  let advTerm : Term := ⟨advIdent.raw⟩
+  let advTerm : Term ← if opensReentrancyWindow then
+      pure ⟨advIdent.raw⟩
+    else
+      `(Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub)
   let executableBody := ⟨← threadAdversaryThroughExecutableSyntax externalDecls adversarialHelpers
     ctor.params advTerm executableBody.raw⟩
   let fnType ← if opensReentrancyWindow then
@@ -5362,7 +5365,10 @@ def mkHostConstructorDefCommandPublic
           mixinExternal := mixinExternal.push mixinName
   let containsExternalCall := ownExternal || !mixinExternal.isEmpty
   let advIdent ← Lean.Elab.Term.mkFreshIdent (mkIdentFrom (mkIdent `constructor) `_adv).raw
-  let advTerm : Term := ⟨advIdent.raw⟩
+  let advTerm : Term ← if containsExternalCall then
+      pure ⟨advIdent.raw⟩
+    else
+      `(Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub)
   let fnType ← if containsExternalCall then
       mkContractFnTypeWithAdversary ctor.params .unit
     else

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2443,7 +2443,7 @@ private partial def threadAdversaryThroughExecutableSyntax
     | .node info kind args =>
         pure (.node info kind (← args.mapM go))
     | _ => pure stx
-  let rewriteTerm (t : Term) : CommandElabM Term :=
+  let rewriteTerm (t : Term) : CommandElabM Term := do
     rewriteLinkedCallTerm externalDecls params adv ⟨← go t.raw⟩
   let hoistLive (rhs : Term) (cont : Term → CommandElabM (TSyntax `doElem)) :
       CommandElabM Syntax := do

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -5279,7 +5279,7 @@ private def constructorContainsExternalCall
     (ctor : ConstructorDecl) : CommandElabM Bool := do
   let stmts ← translateConstructorBodyToStmtTerms fields errorDecls constDecls
     immutableDecls externalDecls functions ctor
-  translatedBodyOpensReentrancyWindow stmts
+  translatedBodyContainsExternalCall stmts
 
 private def constructorAdversarialHelpers
     (fields : Array StorageFieldDecl) (errorDecls : Array ErrorDecl)
@@ -5290,7 +5290,7 @@ private def constructorAdversarialHelpers
   for helper in functions do
     let stmts ← translateBodyToStmtTerms fields #[] errorDecls constDecls immutableDecls
       externalDecls functions helper
-    if ← translatedBodyOpensReentrancyWindow stmts then
+    if ← translatedBodyContainsExternalCall stmts then
       adversarial := adversarial.push helper
   for _ in [:functions.size] do
     let names := adversarial.map (·.name)
@@ -5485,7 +5485,7 @@ def mkFunctionCommandsPublic
       | some inlined => pure inlined
       | none => pure fn
   let stmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls immutableDecls externalDecls functions modelFn
-  let directlyOpensReentrancyWindow ← translatedBodyOpensReentrancyWindow stmtTerms
+  let directlyContainsExternalCall ← translatedBodyContainsExternalCall stmtTerms
   let mut adversarialHelpers : Array FunctionDecl := #[]
   let mut translatedHelpers : Array (FunctionDecl × FunctionDecl) := #[]
   for helper in functions do
@@ -5500,7 +5500,7 @@ def mkFunctionCommandsPublic
     let helperStmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls
       immutableDecls externalDecls functions helperModel
     translatedHelpers := translatedHelpers.push (helper, helperModel)
-    if ← translatedBodyOpensReentrancyWindow helperStmtTerms then
+    if ← translatedBodyContainsExternalCall helperStmtTerms then
       adversarialHelpers := adversarialHelpers.push helper
   -- External-call capability is transitive across internal helpers. Iterate to a
   -- fixed point so every caller in a multi-hop helper chain receives and forwards
@@ -5518,7 +5518,7 @@ def mkFunctionCommandsPublic
       break
   let adversarialNames := adversarialHelpers.map (·.name)
   let callsAdversarial ← syntaxCallsAnyHelper adversarialNames modelFn.body.raw
-  let containsExternalCall := directlyOpensReentrancyWindow ||
+  let containsExternalCall := directlyContainsExternalCall ||
     callsAdversarial
   -- Keep the generated binder hygienic: source parameters and locals are allowed
   -- to use `_adv` without capturing the adversary threaded into rewritten calls.

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2279,12 +2279,16 @@ private def translatedBodyContainsExternalCall
     | _ => throwErrorAt bodyTerm
         "failed to reduce the translated external-call predicate"
 
-private partial def syntaxReferencesAnyHelper
-    (helperNames : Array String) (stx : Syntax) : Bool :=
+private partial def syntaxCallsAnyHelper
+    (helperNames : Array String) (stx : Syntax) : CommandElabM Bool := do
   match stx with
-  | .ident _ _ name _ => helperNames.contains name.toString
-  | .node _ _ args => args.any (syntaxReferencesAnyHelper helperNames)
-  | _ => false
+  | `(term| $name:ident($[$args:term],*)) =>
+      if helperNames.contains name.getId.toString then pure true
+      else args.anyM (syntaxCallsAnyHelper helperNames ∘ (fun term => term.raw))
+  | `(term| $name:ident $args:term*) =>
+      if helperNames.contains name.getId.toString then pure true
+      else args.anyM (syntaxCallsAnyHelper helperNames ∘ (fun term => term.raw))
+  | _ => stx.getArgs.anyM (syntaxCallsAnyHelper helperNames)
 
 private def linkedExternalSiteId (externalDecls : Array ExternalDecl) (name : String) : Nat :=
   (externalDecls.findIdx? (fun ext => ext.name == name)).getD 0
@@ -5262,8 +5266,9 @@ private def constructorAdversarialHelpers
     let names := adversarial.map (·.name)
     let mut grew := false
     for helper in functions do
+      let callsAdversarial ← syntaxCallsAnyHelper names helper.body.raw
       if !adversarial.any (fun candidate => candidate.name == helper.name) &&
-          syntaxReferencesAnyHelper names helper.body.raw then
+          callsAdversarial then
         adversarial := adversarial.push helper
         grew := true
     if !grew then break
@@ -5278,8 +5283,10 @@ def mkConstructorDefCommandPublic
     immutableDecls externalDecls functions ctor
   let adversarialHelpers ← constructorAdversarialHelpers fields errorDecls constDecls
     immutableDecls externalDecls functions
+  let callsAdversarial ←
+    syntaxCallsAnyHelper (adversarialHelpers.map (·.name)) ctor.body.raw
   let containsExternalCall := directlyContainsExternalCall ||
-    syntaxReferencesAnyHelper (adversarialHelpers.map (·.name)) ctor.body.raw
+    callsAdversarial
   let executableBody ← rewriteForEachExecutableBody fields externalDecls ctor.params ctor.body
   let advIdent ← Lean.Elab.Term.mkFreshIdent (mkIdentFrom (mkIdent `constructor) `_adv).raw
   let advTerm : Term := ⟨advIdent.raw⟩
@@ -5305,8 +5312,10 @@ def mkHostConstructorDefCommandPublic
     immutableDecls externalDecls functions ctor
   let ownAdversarialHelpers ← constructorAdversarialHelpers fields errorDecls constDecls
     immutableDecls externalDecls functions
+  let ownCallsAdversarial ←
+    syntaxCallsAnyHelper (ownAdversarialHelpers.map (·.name)) ctor.body.raw
   let ownExternal := ownDirectExternal ||
-    syntaxReferencesAnyHelper (ownAdversarialHelpers.map (·.name)) ctor.body.raw
+    ownCallsAdversarial
   let mut mixinExternal : Array Name := #[]
   for mixinName in resolvedIncludes do
     if let some mixin ← lookupContractSyntax mixinName then
@@ -5315,7 +5324,8 @@ def mkHostConstructorDefCommandPublic
           mixin.immutableDecls mixin.externalDecls mixin.functions mixinCtor
         let helpers ← constructorAdversarialHelpers mixin.fields mixin.errorDecls mixin.constDecls
           mixin.immutableDecls mixin.externalDecls mixin.functions
-        if direct || syntaxReferencesAnyHelper (helpers.map (·.name)) mixinCtor.body.raw then
+        let callsAdversarial ← syntaxCallsAnyHelper (helpers.map (·.name)) mixinCtor.body.raw
+        if direct || callsAdversarial then
           mixinExternal := mixinExternal.push mixinName
   let containsExternalCall := ownExternal || !mixinExternal.isEmpty
   let advIdent ← Lean.Elab.Term.mkFreshIdent (mkIdentFrom (mkIdent `constructor) `_adv).raw
@@ -5470,15 +5480,17 @@ def mkFunctionCommandsPublic
     let adversarialNames := adversarialHelpers.map (·.name)
     let mut grew := false
     for (helper, helperModel) in translatedHelpers do
+      let callsAdversarial ← syntaxCallsAnyHelper adversarialNames helperModel.body.raw
       if !adversarialHelpers.any (fun candidate => candidate.name == helper.name) &&
-          syntaxReferencesAnyHelper adversarialNames helperModel.body.raw then
+          callsAdversarial then
         adversarialHelpers := adversarialHelpers.push helper
         grew := true
     if !grew then
       break
   let adversarialNames := adversarialHelpers.map (·.name)
+  let callsAdversarial ← syntaxCallsAnyHelper adversarialNames modelFn.body.raw
   let containsExternalCall := directlyContainsExternalCall ||
-    syntaxReferencesAnyHelper adversarialNames modelFn.body.raw
+    callsAdversarial
   -- Keep the generated binder hygienic: source parameters and locals are allowed
   -- to use `_adv` without capturing the adversary threaded into rewritten calls.
   let advIdent ← Lean.Elab.Term.mkFreshIdent (mkIdentFrom fn.ident `_adv).raw

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2231,87 +2231,103 @@ unsafe def translatedBodyOpensReentrancyWindow
   let bodyTerm : Term ← `([ $[$stmtTerms],* ])
   liftTermElabM do
     let stmtTy := mkConst ``Compiler.CompilationModel.Stmt
-    let expectedType := mkApp (mkConst ``List) stmtTy
+    let expectedType := mkApp (mkConst ``List [Level.zero]) stmtTy
     let expr ← Lean.Elab.Term.elabTermEnsuringType bodyTerm expectedType
     let body ← Lean.Meta.evalExpr (List Compiler.CompilationModel.Stmt) expectedType expr .unsafe
     pure (body.any Compiler.CompilationModel.stmtOpensReentrancyWindow)
 
 private partial def threadAdversaryThroughExecutableSyntax
-    (adv : Ident) (stx : Syntax) : CommandElabM Syntax := do
+    (externalDecls : Array ExternalDecl) (adv : Ident) (stx : Syntax) : CommandElabM Syntax := do
+  let go := threadAdversaryThroughExecutableSyntax externalDecls adv
   let recurseChildren : CommandElabM Syntax := do
     match stx with
     | .node info kind args =>
-        pure (.node info kind (← args.mapM (threadAdversaryThroughExecutableSyntax adv)))
+        pure (.node info kind (← args.mapM go))
     | _ => pure stx
   match stx with
+  | `(doElem| let $name:ident ← callExternal $externalName:ident ($[$args:term],*)) =>
+      let extName := toString externalName.getId
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt externalName s!"unknown linked external '{extName}'"
+      let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
+        let arg : Term := ⟨← go arg.raw⟩
+        let tyTerm ← contractValueTypeTerm ty
+        `(($arg : $tyTerm))
+      let call ← `(term| externalCallContractWords $(strTerm extName)
+        (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
+      `(doElem| let $name ← $call:term)
+  | `(doElem| callExternal $externalName:ident ($[$args:term],*)) =>
+      let extName := toString externalName.getId
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt externalName s!"unknown linked external '{extName}'"
+      let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
+        let arg : Term := ⟨← go arg.raw⟩
+        let tyTerm ← contractValueTypeTerm ty
+        `(($arg : $tyTerm))
+      let call ← `(term| externalCallEffectWords $(strTerm extName)
+        (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
+      `(doElem| $call:term)
+  | `(doElem| let $name:ident ← balanceOf $token:term $owner:term) =>
+      let token : Term := ⟨← go token.raw⟩
+      let owner : Term := ⟨← go owner.raw⟩
+      `(doElem| let $name ← balanceOf $token $owner $adv)
+  | `(doElem| let $name:ident ← allowance $token:term $owner:term $spender:term) =>
+      let token : Term := ⟨← go token.raw⟩
+      let owner : Term := ⟨← go owner.raw⟩
+      let spender : Term := ⟨← go spender.raw⟩
+      `(doElem| let $name ← allowance $token $owner $spender $adv)
+  | `(doElem| let $name:ident ← totalSupply $token:term) =>
+      let token : Term := ⟨← go token.raw⟩
+      `(doElem| let $name ← totalSupply $token $adv)
   | `(term| callExternal $name:ident ($[$args:term],*)) =>
-      let rewritten ← args.mapM fun arg => do
-        pure ⟨← threadAdversaryThroughExecutableSyntax adv arg.raw⟩
+      let extName := toString name.getId
+      let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown linked external '{extName}'"
+      let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
+        let arg : Term := ⟨← go arg.raw⟩
+        let tyTerm ← contractValueTypeTerm ty
+        `(($arg : $tyTerm))
       `(term| externalCallWords $(strTerm (toString name.getId))
           (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
   | `(term| externalCall $name:term [ $[$args:term],* ]) =>
       let rewritten ← args.mapM fun arg => do
-        pure ⟨← threadAdversaryThroughExecutableSyntax adv arg.raw⟩
+        pure ⟨← go arg.raw⟩
       `(term| externalCallWords $name
           (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
   | `(term| callResult $name:term [ $[$args:term],* ]) =>
       let rewritten ← args.mapM fun arg => do
-        pure ⟨← threadAdversaryThroughExecutableSyntax adv arg.raw⟩
+        pure ⟨← go arg.raw⟩
       `(term| callResultWords $name
           (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
   | `(term| tryExternalCall $name:term [ $[$args:term],* ]) =>
       let rewritten ← args.mapM fun arg => do
-        pure ⟨← threadAdversaryThroughExecutableSyntax adv arg.raw⟩
+        pure ⟨← go arg.raw⟩
       `(term| tryExternalCallWords $name
           (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
   | `(term| evmCall($gas, $target, $value, $inOffset, $inSize, $outOffset, $outSize)) =>
       let xs ← #[gas, target, value, inOffset, inSize, outOffset, outSize].mapM fun arg => do
-        pure ⟨← threadAdversaryThroughExecutableSyntax adv arg.raw⟩
+        pure ⟨← go arg.raw⟩
       `(term| evmCallWords $adv $(xs[0]!) $(xs[1]!) $(xs[2]!) $(xs[3]!)
           $(xs[4]!) $(xs[5]!) $(xs[6]!))
   | `(term| evmStaticCall($gas, $target, $inOffset, $inSize, $outOffset, $outSize)) =>
       let xs ← #[gas, target, inOffset, inSize, outOffset, outSize].mapM fun arg => do
-        pure ⟨← threadAdversaryThroughExecutableSyntax adv arg.raw⟩
+        pure ⟨← go arg.raw⟩
       `(term| evmStaticCallWords $adv $(xs[0]!) $(xs[1]!) $(xs[2]!)
           $(xs[3]!) $(xs[4]!) $(xs[5]!))
-  | `(term| safeTransfer $token $toAddr $amount) =>
-      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
-      let toAddr : Term := ⟨← threadAdversaryThroughExecutableSyntax adv toAddr.raw⟩
-      let amount : Term := ⟨← threadAdversaryThroughExecutableSyntax adv amount.raw⟩
-      `(term| safeTransfer $token $toAddr $amount $adv)
-  | `(term| safeTransferFrom $token $fromAddr $toAddr $amount) =>
-      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
-      let fromAddr : Term := ⟨← threadAdversaryThroughExecutableSyntax adv fromAddr.raw⟩
-      let toAddr : Term := ⟨← threadAdversaryThroughExecutableSyntax adv toAddr.raw⟩
-      let amount : Term := ⟨← threadAdversaryThroughExecutableSyntax adv amount.raw⟩
-      `(term| safeTransferFrom $token $fromAddr $toAddr $amount $adv)
-  | `(term| safeApprove $token $spender $amount) =>
-      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
-      let spender : Term := ⟨← threadAdversaryThroughExecutableSyntax adv spender.raw⟩
-      let amount : Term := ⟨← threadAdversaryThroughExecutableSyntax adv amount.raw⟩
-      `(term| safeApprove $token $spender $amount $adv)
-  | `(term| legacyStringSafeTransfer $token $toAddr $amount) =>
-      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
-      let toAddr : Term := ⟨← threadAdversaryThroughExecutableSyntax adv toAddr.raw⟩
-      let amount : Term := ⟨← threadAdversaryThroughExecutableSyntax adv amount.raw⟩
-      `(term| legacyStringSafeTransfer $token $toAddr $amount $adv)
-  | `(term| legacyStringSafeTransferFrom $token $fromAddr $toAddr $amount) =>
-      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
-      let fromAddr : Term := ⟨← threadAdversaryThroughExecutableSyntax adv fromAddr.raw⟩
-      let toAddr : Term := ⟨← threadAdversaryThroughExecutableSyntax adv toAddr.raw⟩
-      let amount : Term := ⟨← threadAdversaryThroughExecutableSyntax adv amount.raw⟩
-      `(term| legacyStringSafeTransferFrom $token $fromAddr $toAddr $amount $adv)
-  | `(term| balanceOf $token $owner) =>
-      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
-      let owner : Term := ⟨← threadAdversaryThroughExecutableSyntax adv owner.raw⟩
+  | `(term| balanceOf $token:term $owner:term) =>
+      let token : Term := ⟨← go token.raw⟩
+      let owner : Term := ⟨← go owner.raw⟩
       `(term| balanceOf $token $owner $adv)
-  | `(term| allowance $token $owner $spender) =>
-      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
-      let owner : Term := ⟨← threadAdversaryThroughExecutableSyntax adv owner.raw⟩
-      let spender : Term := ⟨← threadAdversaryThroughExecutableSyntax adv spender.raw⟩
+  | `(term| allowance $token:term $owner:term $spender:term) =>
+      let token : Term := ⟨← go token.raw⟩
+      let owner : Term := ⟨← go owner.raw⟩
+      let spender : Term := ⟨← go spender.raw⟩
       `(term| allowance $token $owner $spender $adv)
-  | `(term| totalSupply $token) =>
-      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
+  | `(term| totalSupply $token:term) =>
+      let token : Term := ⟨← go token.raw⟩
       `(term| totalSupply $token $adv)
   | _ => recurseChildren
 
@@ -4589,7 +4605,7 @@ def mkFunctionCommandsPublic
     else
       mkContractFnType fn.params fn.returnTy
   let fnExecutableBody ← if opensReentrancyWindow then
-      pure ⟨← threadAdversaryThroughExecutableSyntax advIdent fnExecutableBody.raw⟩
+      pure ⟨← threadAdversaryThroughExecutableSyntax externalDecls advIdent fnExecutableBody.raw⟩
     else
       pure fnExecutableBody
   let fnValue ← if opensReentrancyWindow then

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2487,14 +2487,14 @@ private partial def threadAdversaryThroughExecutableSyntax
     let rest ← cont rewritten
     wrapBinds binds rest
   match stx with
-  | `(doElem| let $name:ident ← tryExternalCall $extName:term $args:term) =>
-      hoistLive false (← `(term| tryExternalCall $extName $args)) fun rewritten =>
+  | `(doElem| let $name:ident ← tryExternalCall $extName:term [ $[$args:term],* ]) =>
+      hoistLive false (← `(term| tryExternalCall $extName [ $[$args],* ])) fun rewritten =>
         `(doElem| let $name ← $rewritten:term)
-  | `(doElem| let $pat:term ← tryExternalCall $extName:term $args:term) =>
-      hoistLive false (← `(term| tryExternalCall $extName $args)) fun rewritten =>
+  | `(doElem| let $pat:term ← tryExternalCall $extName:term [ $[$args:term],* ]) =>
+      hoistLive false (← `(term| tryExternalCall $extName [ $[$args],* ])) fun rewritten =>
         `(doElem| let $pat:term ← $rewritten:term)
-  | `(doElem| let $name:ident ← callResult $extName:term $args:term) =>
-      hoistLive false (← `(term| callResult $extName $args)) fun rewritten =>
+  | `(doElem| let $name:ident ← callResult $extName:term [ $[$args:term],* ]) =>
+      hoistLive false (← `(term| callResult $extName [ $[$args],* ])) fun rewritten =>
         `(doElem| let $name ← $rewritten:term)
   | `(doElem| let $name:ident ← $fn:ident $args:term*) =>
       let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2239,8 +2239,10 @@ def translatedBodyOpensReentrancyWindow
         "failed to reduce the translated reentrancy-window predicate"
 
 private partial def threadAdversaryThroughExecutableSyntax
-    (externalDecls : Array ExternalDecl) (adv : Ident) (stx : Syntax) : CommandElabM Syntax := do
-  let go := threadAdversaryThroughExecutableSyntax externalDecls adv
+    (externalDecls : Array ExternalDecl)
+    (adversarialHelpers : Array FunctionDecl)
+    (adv : Term) (stx : Syntax) : CommandElabM Syntax := do
+  let go := threadAdversaryThroughExecutableSyntax externalDecls adversarialHelpers adv
   let recurseChildren : CommandElabM Syntax := do
     match stx with
     | .node info kind args =>
@@ -2283,6 +2285,20 @@ private partial def threadAdversaryThroughExecutableSyntax
   | `(doElem| let $name:ident ← totalSupply $token:term) =>
       let token : Term := ⟨← go token.raw⟩
       `(doElem| let $name ← totalSupply $token $adv)
+  | `(doElem| let $binder:ident ← $name:ident $args:term*) =>
+      let helper? := adversarialHelpers.find? fun fn =>
+        (fn.name == toString name.getId || fn.ident.getId == name.getId) &&
+          fn.params.size == args.size
+      match helper? with
+      | some _ =>
+          let rewritten ← args.mapM fun arg => do
+            pure ⟨← go arg.raw⟩
+          let mut app : Term := ⟨name.raw⟩
+          app ← `(term| $app $adv)
+          for arg in rewritten do
+            app ← `(term| $app $arg)
+          `(doElem| let $binder ← $app:term)
+      | none => recurseChildren
   | `(term| callExternal $name:ident ($[$args:term],*)) =>
       let extName := toString name.getId
       let ext ← match externalDecls.find? (fun ext => ext.name == extName) with
@@ -2331,6 +2347,20 @@ private partial def threadAdversaryThroughExecutableSyntax
   | `(term| totalSupply $token:term) =>
       let token : Term := ⟨← go token.raw⟩
       `(term| totalSupply $token $adv)
+  | `(term| $name:ident $args:term*) =>
+      let helper? := adversarialHelpers.find? fun fn =>
+        (fn.name == toString name.getId || fn.ident.getId == name.getId) &&
+          fn.params.size == args.size
+      match helper? with
+      | some _ =>
+          let rewritten ← args.mapM fun arg => do
+            pure ⟨← go arg.raw⟩
+          let mut app : Term := ⟨name.raw⟩
+          app ← `(term| $app $adv)
+          for arg in rewritten do
+            app ← `(term| $app $arg)
+          pure app
+      | none => recurseChildren
   | _ => recurseChildren
 
 private def mkModelParamsTerm (params : Array ParamDecl) : CommandElabM Term := do
@@ -4601,15 +4631,31 @@ def mkFunctionCommandsPublic
       | none => pure fn
   let stmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls immutableDecls externalDecls functions modelFn
   let opensReentrancyWindow ← translatedBodyOpensReentrancyWindow stmtTerms
+  let mut adversarialHelpers : Array FunctionDecl := #[]
+  for helper in functions do
+    let helperModel ←
+      if helper.modifiers.isEmpty || allModifiers.isEmpty then
+        pure helper
+      else
+        let arr ← inlineModifierPrefixes allModifiers #[helper]
+        match arr[0]? with
+        | some inlined => pure inlined
+        | none => pure helper
+    let helperStmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls
+      immutableDecls externalDecls functions helperModel
+    if ← translatedBodyOpensReentrancyWindow helperStmtTerms then
+      adversarialHelpers := adversarialHelpers.push helper
   let advIdent := mkIdentFrom fn.ident `_adv
+  let advTerm : Term ← if opensReentrancyWindow then
+      pure ⟨advIdent.raw⟩
+    else
+      `(Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub)
   let fnType ← if opensReentrancyWindow then
       mkContractFnTypeWithAdversary fn.params fn.returnTy
     else
       mkContractFnType fn.params fn.returnTy
-  let fnExecutableBody ← if opensReentrancyWindow then
-      pure ⟨← threadAdversaryThroughExecutableSyntax externalDecls advIdent fnExecutableBody.raw⟩
-    else
-      pure fnExecutableBody
+  let fnExecutableBody := ⟨← threadAdversaryThroughExecutableSyntax externalDecls
+    adversarialHelpers advTerm fnExecutableBody.raw⟩
   let fnValue ← if opensReentrancyWindow then
       mkContractFnValueWithAdversary advIdent fn.params fnExecutableBody
     else

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2296,6 +2296,12 @@ private def flattenedExternalArity (ext : ExternalDecl) : CommandElabM Nat := do
             total := total + names.length
       pure total
 
+private def executableLinkedArgWords (arg : Term) (ty : ValueType) : CommandElabM Term := do
+  if externalCallDynamicArgSupported ty then
+    `(externalDynamicArgWords $arg)
+  else
+    `(ExternalArg.toWords $arg)
+
 private def externalReturnTypeTerm (ext : ExternalDecl) : CommandElabM Term := do
   let tys ← ext.returnTys.mapM contractValueTypeTerm
   let rec tupleType : List Term → CommandElabM Term
@@ -2335,25 +2341,26 @@ private def rewriteTypedInterfaceCall?
   let some interfaceName := lookupInterfaceName? params #[] targetName | pure none
   let extName := interfaceExternalName interfaceName methodName
   let some ext := externalDecls.find? (fun ext => ext.name == extName) | pure none
+  let isView := externalDecls.any (fun candidate => candidate.name == extName && candidate.isView)
   let siteId := natTerm (linkedExternalSiteId externalDecls extName)
   let arity := natTerm (← flattenedExternalArity ext)
   let rewritten ← argTerms.zip ext.params |>.mapM fun (arg, ty) => do
     let tyTerm ← contractValueTypeTerm ty
-    `(($arg : $tyTerm))
+    executableLinkedArgWords (← `(($arg : $tyTerm))) ty
   if ext.returnTys.isEmpty then
-    if ext.isView then
+    if isView then
       some <$> `(term| externalStaticCallEffectWords $(strTerm extName)
-        (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $siteId)
+        (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
     else
       some <$> `(term| externalCallEffectWords $(strTerm extName)
-        (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $siteId)
+        (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
   else
-    if ext.isView then
+    if isView then
       some <$> `(term| externalStaticCallContractWords $(strTerm extName)
-        (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
+        (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
     else
       some <$> `(term| externalCallContractWords $(strTerm extName)
-        (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
+        (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
 
 private def rewriteLinkedCallTerm
     (externalDecls : Array ExternalDecl) (params : Array ParamDecl)
@@ -2366,16 +2373,16 @@ private def rewriteLinkedCallTerm
         | none => throwErrorAt name s!"unknown linked external '{extName}'"
       let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
         let tyTerm ← contractValueTypeTerm ty
-        `(($arg : $tyTerm))
+        executableLinkedArgWords (← `(($arg : $tyTerm))) ty
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
       let arity := natTerm (← flattenedExternalArity ext)
       if ext.returnTys.isEmpty then
         `(term| externalCallEffectWords $(strTerm extName)
-          (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $siteId)
+          (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
       else
         let resultTy ← externalReturnTypeTerm ext
         `(term| externalCallContractWords (α := $resultTy) $(strTerm extName)
-          (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
+          (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
   | `(term| externalCall $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2385,14 +2392,43 @@ private def rewriteLinkedCallTerm
           let resultTy ← externalReturnTypeTerm ext
           let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
             let tyTerm ← contractValueTypeTerm ty
-            `(($arg : $tyTerm))
-          `(term| externalCallContractWords (α := $resultTy) $name
-              (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256)))
-              $adv $arity $siteId)
+            executableLinkedArgWords (← `(($arg : $tyTerm))) ty
+          if ext.isView then
+            `(term| externalStaticCallContractWords (α := $resultTy) $name
+                (List.flatten ([ $[$rewritten],* ] : List (List Uint256)))
+                $adv $arity $siteId)
+          else
+            `(term| externalCallContractWords (α := $resultTy) $name
+                (List.flatten ([ $[$rewritten],* ] : List (List Uint256)))
+                $adv $arity $siteId)
       | none =>
           `(term| externalCallContractWords $name
               (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256)))
               $adv 1 $siteId)
+  | `(term| externalStaticCall $name:term [ $[$args:term],* ]) =>
+      let extName ← expectStringOrIdent name
+      let siteId := natTerm (linkedExternalSiteId externalDecls extName)
+      let ext ← match externalDecls.find? (fun candidate => candidate.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown interface external '{extName}'"
+      let arity := natTerm (← flattenedExternalArity ext)
+      let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
+        let tyTerm ← contractValueTypeTerm ty
+        executableLinkedArgWords (← `(($arg : $tyTerm))) ty
+      `(term| externalStaticCallContractWords $name
+          (List.flatten ([ $[$rewritten],* ] : List (List Uint256)))
+          $adv $arity $siteId)
+  | `(term| externalStaticCallEffect $name:term [ $[$args:term],* ]) =>
+      let extName ← expectStringOrIdent name
+      let siteId := natTerm (linkedExternalSiteId externalDecls extName)
+      let ext ← match externalDecls.find? (fun candidate => candidate.name == extName) with
+        | some ext => pure ext
+        | none => throwErrorAt name s!"unknown interface external '{extName}'"
+      let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
+        let tyTerm ← contractValueTypeTerm ty
+        executableLinkedArgWords (← `(($arg : $tyTerm))) ty
+      `(term| externalStaticCallEffectWords $name
+          (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
   | `(term| callResult $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2436,10 +2472,13 @@ private def rewriteLinkedCallTerm
       | some ext =>
           let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
             let tyTerm ← contractValueTypeTerm ty
-            `(($arg : $tyTerm))
-          `(term| externalCallEffectWords $fnName
-              (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256)))
-              $adv $siteId)
+            executableLinkedArgWords (← `(($arg : $tyTerm))) ty
+          if ext.isView then
+            `(term| externalStaticCallEffectWords $fnName
+                (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
+          else
+            `(term| externalCallEffectWords $fnName
+                (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
       | none =>
           `(term| externalCallBind ([] : List String) $fnName [ $[$args],* ] $adv $siteId)
   | `(term| externalCallBind $names:term $fnName:term $args:term) =>
@@ -2550,8 +2589,30 @@ private partial def threadAdversaryThroughExecutableSyntax
         pure (binds.push (tmp, rewritten), ⟨tmp.raw⟩)
       else
         pure (binds, rewritten)
-    match t.raw with
-    | .node info kind args =>
+    let branchContract (binds : Array (Ident × Term)) (value : Term) : CommandElabM Term := do
+      let mut body ← `(term| pure $value)
+      for (tmp, call) in binds.reverse do
+        body ← `(term| _root_.Verity.bind $call (fun $tmp => $body))
+      pure body
+    match t with
+    | `(term| fun $name:ident => $body:term) =>
+        let bodyRaw : Syntax ← go body.raw
+        let rewrittenBody : Term := ⟨bodyRaw⟩
+        pure (#[], ← `(term| fun $name => $rewrittenBody))
+    | `(term| if $cond:term then $thenValue:term else $elseValue:term) =>
+        let (condBinds, rewrittenCond) ← hoistNested true cond
+        let (thenBinds, rewrittenThen) ← hoistNested true thenValue
+        let (elseBinds, rewrittenElse) ← hoistNested true elseValue
+        if thenBinds.isEmpty && elseBinds.isEmpty then
+          pure (condBinds, ← `(term| if $rewrittenCond then $rewrittenThen else $rewrittenElse))
+        else
+          let thenContract ← branchContract thenBinds rewrittenThen
+          let elseContract ← branchContract elseBinds rewrittenElse
+          let conditional ← `(term| if $rewrittenCond then $thenContract else $elseContract)
+          let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "if")}")
+          pure (condBinds.push (tmp, conditional), ⟨tmp.raw⟩)
+    | _ => match t.raw with
+      | .node info kind args =>
         let mut binds : Array (Ident × Term) := #[]
         let mut newArgs := args
         for i in [:args.size] do
@@ -2570,18 +2631,18 @@ private partial def threadAdversaryThroughExecutableSyntax
               else
                 pure (binds, rewritten)
           | none => pure (binds, rebuilt)
-    | _ =>
-      if isLiveStateExternalCall t then
-        bindCall #[] t
-      else
-        match ← rewriteTypedInterfaceCall? externalDecls params adv t with
-        | some rewritten =>
-            if bindSelf then
-              let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
-              pure (#[(tmp, rewritten)], ⟨tmp.raw⟩)
-            else
-              pure (#[], rewritten)
-        | none => pure (#[], t)
+      | _ =>
+        if isLiveStateExternalCall t then
+          bindCall #[] t
+        else
+          match ← rewriteTypedInterfaceCall? externalDecls params adv t with
+          | some rewritten =>
+              if bindSelf then
+                let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
+                pure (#[(tmp, rewritten)], ⟨tmp.raw⟩)
+              else
+                pure (#[], rewritten)
+          | none => pure (#[], t)
   let wrapBinds (binds : Array (Ident × Term)) (body : TSyntax `doElem) :
       CommandElabM (TSyntax `doElem) := do
     let mut acc := body
@@ -2735,6 +2796,24 @@ private partial def threadAdversaryThroughExecutableSyntax
         rewrittenArgs := rewrittenArgs.push rewritten
       wrapBinds binds
         (← `(doElem| requireError $rewrittenCond $errorName:ident($[$rewrittenArgs],*)))
+  | `(doElem| revert $errorName:ident($args,*)) =>
+      let mut binds : Array (Ident × Term) := #[]
+      let mut rewrittenArgs : Array Term := #[]
+      for arg in args.getElems do
+        let (inner, rewritten) ← hoistNested true arg
+        binds := binds ++ inner
+        rewrittenArgs := rewrittenArgs.push rewritten
+      wrapBinds binds (← `(doElem| revert $errorName:ident($[$rewrittenArgs],*)))
+  | `(doElem| revertError $errorName:ident($args,*)) =>
+      let mut binds : Array (Ident × Term) := #[]
+      let mut rewrittenArgs : Array Term := #[]
+      for arg in args.getElems do
+        let (inner, rewritten) ← hoistNested true arg
+        binds := binds ++ inner
+        rewrittenArgs := rewrittenArgs.push rewritten
+      wrapBinds binds (← `(doElem| revertError $errorName:ident($[$rewrittenArgs],*)))
+  | `(doElem| panic($code:term)) =>
+      hoistLive true code fun rewritten => `(doElem| panic($rewritten))
   | `(doElem| return $value:term) =>
       hoistLive true value fun rewritten => `(doElem| return $rewritten:term)
   | `(doElem| ecmBind $names:term $_module:term $args:term) =>
@@ -5059,7 +5138,7 @@ def mkFunctionCommandsPublic
       | some inlined => pure inlined
       | none => pure fn
   let stmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls immutableDecls externalDecls functions modelFn
-  let opensReentrancyWindow ← translatedBodyOpensReentrancyWindow stmtTerms
+  let _opensReentrancyWindow ← translatedBodyOpensReentrancyWindow stmtTerms
   let containsExternalCall ← translatedBodyContainsExternalCall stmtTerms
   let mut adversarialHelpers : Array FunctionDecl := #[]
   for helper in functions do

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2430,7 +2430,7 @@ private def isLiveStateExternalCall (stx : Term) : Bool :=
   | `(term| ecmDo $_ $_)
   | `(term| externalCallBind $_ $_ $_)
   | `(term| tryExternalCallBind $_ $_ $_ $_) => true
-  | _ => typedDotCallSyntax? stx |>.isSome
+  | _ => false
 
 private partial def threadAdversaryThroughExecutableSyntax
     (externalDecls : Array ExternalDecl)
@@ -2467,12 +2467,26 @@ private partial def threadAdversaryThroughExecutableSyntax
         if isLiveStateExternalCall rebuilt then
           bindCall binds rebuilt
         else
-          pure (binds, rebuilt)
+          match ← rewriteTypedInterfaceCall? externalDecls params adv rebuilt with
+          | some rewritten =>
+              if bindSelf then
+                let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
+                pure (binds.push (tmp, rewritten), ⟨tmp.raw⟩)
+              else
+                pure (binds, rewritten)
+          | none => pure (binds, rebuilt)
     | _ =>
-        if isLiveStateExternalCall t then
-          bindCall #[] t
-        else
-          pure (#[], t)
+      if isLiveStateExternalCall t then
+        bindCall #[] t
+      else
+        match ← rewriteTypedInterfaceCall? externalDecls params adv t with
+        | some rewritten =>
+            if bindSelf then
+              let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
+              pure (#[(tmp, rewritten)], ⟨tmp.raw⟩)
+            else
+              pure (#[], rewritten)
+        | none => pure (#[], t)
   let wrapBinds (binds : Array (Ident × Term)) (body : TSyntax `doElem) :
       CommandElabM (TSyntax `doElem) := do
     let mut acc := body
@@ -2508,12 +2522,23 @@ private partial def threadAdversaryThroughExecutableSyntax
       hoistLive false rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
   | `(doElem| let $pat:term ← $rhs:term) =>
       hoistLive false rhs fun rewritten => `(doElem| let $pat:term ← $rewritten:term)
+  | `(doElem| let mut $name:ident := $rhs:term) =>
+      hoistLive true rhs fun rewritten =>
+        `(doElem| let mut $name := $rewritten:term)
   | `(doElem| let $name:ident := $rhs:term) =>
-      hoistLive (isLiveStateExternalCall rhs) rhs fun rewritten =>
-        if isLiveStateExternalCall rhs then
-          `(doElem| let $name ← $rewritten:term)
-        else
-          `(doElem| let $name := $rewritten:term)
+      hoistLive true rhs fun rewritten =>
+        `(doElem| let $name := $rewritten:term)
+  | `(doElem| let $pat:term := $rhs:term) =>
+      hoistLive true rhs fun rewritten =>
+        `(doElem| let $pat:term := $rewritten:term)
+  | `(doElem| $name:ident := $rhs:term) =>
+      hoistLive true rhs fun rewritten =>
+        `(doElem| $name:ident := $rewritten:term)
+  | `(doElem| if $cond:term then $thenBranch:doSeq else $elseBranch:doSeq) =>
+      let rewrittenThen := ⟨← go thenBranch.raw⟩
+      let rewrittenElse := ⟨← go elseBranch.raw⟩
+      hoistLive true cond fun rewritten =>
+        `(doElem| if $rewritten:term then $rewrittenThen:doSeq else $rewrittenElse:doSeq)
   | `(doElem| return $value:term) =>
       hoistLive true value fun rewritten => `(doElem| return $rewritten:term)
   | `(doElem| ecmBind $_names:term $_module:term $args:term) =>
@@ -4828,7 +4853,9 @@ def mkFunctionCommandsPublic
       immutableDecls externalDecls functions helperModel
     if ← translatedBodyOpensReentrancyWindow helperStmtTerms then
       adversarialHelpers := adversarialHelpers.push helper
-  let advIdent := mkIdentFrom fn.ident `_adv
+  -- Keep the generated binder hygienic: source parameters and locals are allowed
+  -- to use `_adv` without capturing the adversary threaded into rewritten calls.
+  let advIdent ← Lean.Elab.Term.mkFreshIdent (mkIdentFrom fn.ident `_adv).raw
   let advTerm : Term ← if opensReentrancyWindow then
       pure ⟨advIdent.raw⟩
     else

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2230,7 +2230,7 @@ def translatedBodyOpensReentrancyWindow
     (stmtTerms : Array Term) : CommandElabM Bool := do
   let bodyTerm : Term ← `([ $[$stmtTerms],* ])
   liftTermElabM do
-    let predicate : Term ← `($bodyTerm.any Compiler.CompilationModel.stmtOpensReentrancyWindow)
+    let predicate : Term ← `($(bodyTerm).any Compiler.CompilationModel.stmtOpensReentrancyWindow)
     let expr ← Lean.Elab.Term.elabTermEnsuringType predicate (mkConst ``Bool)
     match ← Lean.Meta.whnf expr with
     | .const ``Bool.true _ => pure true

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2314,6 +2314,59 @@ private def executableLinkedArgWords (arg : Term) (ty : ValueType) : CommandElab
   else
     `(ExternalArg.toWords $arg)
 
+private partial def executableExternalResultDecoder (ty : ValueType) : CommandElabM Term := do
+  match ty with
+  | .fixedArray elemTy size =>
+      let elemDecoder ← executableExternalResultDecoder elemTy
+      let width := (staticAbiWordCount? elemTy).getD 1
+      `(term| fun words : List Uint256 =>
+        (List.range $(natTerm size)).toArray.map fun i =>
+          $elemDecoder ((words.drop (i * $(natTerm width))).take $(natTerm width)))
+  | .tuple tys =>
+      let rec decodeTuple (rest : List ValueType) (offset : Nat) : CommandElabM Term := do
+        match rest with
+        | [] => `(term| ())
+        | [last] =>
+            let decoder ← executableExternalResultDecoder last
+            `(term| $decoder (words.drop $(natTerm offset)))
+        | head :: tail =>
+            let decoder ← executableExternalResultDecoder head
+            let width := (staticAbiWordCount? head).getD 1
+            let decodedTail ← decodeTuple tail (offset + width)
+            `(term| ($decoder ((words.drop $(natTerm offset)).take $(natTerm width)), $decodedTail))
+      let decoded ← decodeTuple tys 0
+      `(term| fun words : List Uint256 => $decoded)
+  | .struct name fields =>
+      let structId := mkIdent (Name.mkSimple name)
+      let mut offset := 0
+      let mut fieldIds : Array Ident := #[]
+      let mut values : Array Term := #[]
+      for (fieldName, fieldTy) in fields do
+        let decoder ← executableExternalResultDecoder fieldTy
+        let width := (staticAbiWordCount? fieldTy).getD 1
+        fieldIds := fieldIds.push (mkIdent (Name.mkSimple fieldName))
+        values := values.push (← `(term|
+          $decoder ((words.drop $(natTerm offset)).take $(natTerm width))))
+        offset := offset + width
+      `(term| fun words : List Uint256 =>
+        (show $structId from { $[$fieldIds:ident := $values:term],* }))
+  | .newtype _ baseTy => executableExternalResultDecoder baseTy
+  | _ => `(term| fun words : List Uint256 => ExternalResult.fromWords words)
+
+private def withDeclaredExternalResultDecoder
+    (ext : ExternalDecl) (resultTy body : Term) : CommandElabM Term := do
+  let sourceTy := match ext.returnTys.toList with
+    | [] => ValueType.unit
+    | [ty] => ty
+    | tys => .tuple tys
+  let decoder ← executableExternalResultDecoder sourceTy
+  let width ← flattenedExternalArity ext
+  `(term| letI : ExternalResult $resultTy :=
+      { wordCount := $(natTerm width)
+        fromWord := fun value => $decoder [value]
+        fromWords := $decoder }
+    $body)
+
 private def externalReturnTypeTerm (ext : ExternalDecl) : CommandElabM Term := do
   let tys ← ext.returnTys.mapM contractValueTypeTerm
   let rec tupleType : List Term → CommandElabM Term
@@ -2368,12 +2421,14 @@ private def rewriteTypedInterfaceCall?
       some <$> `(term| externalCallEffectWordsTo $(strTerm extName) $target
         (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
   else
-    if isView then
-      some <$> `(term| externalStaticCallContractWordsTo $(strTerm extName) $target
+    let resultTy ← externalReturnTypeTerm ext
+    let call ← if isView then
+      `(term| externalStaticCallContractWordsTo (α := $resultTy) $(strTerm extName) $target
         (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
     else
-      some <$> `(term| externalCallContractWordsTo $(strTerm extName) $target
+      `(term| externalCallContractWordsTo (α := $resultTy) $(strTerm extName) $target
         (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
+    some <$> withDeclaredExternalResultDecoder ext resultTy call
 
 private def rewriteLinkedCallTerm
     (externalDecls : Array ExternalDecl) (params : Array ParamDecl)
@@ -2390,12 +2445,13 @@ private def rewriteLinkedCallTerm
       let arity := natTerm (← flattenedExternalArity ext)
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
       let resultTy ← externalReturnTypeTerm ext
-      if ext.isView then
+      let call ← if ext.isView then
         `(term| externalStaticCallContractWordsTo (α := $resultTy) $name $target
           (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
       else
         `(term| externalCallContractWordsTo (α := $resultTy) $name $target
           (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
+      withDeclaredExternalResultDecoder ext resultTy call
   | `(term| __verityTypedEffect $target:term $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
       let ext ← match externalDecls.find? (fun candidate => candidate.name == extName) with
@@ -2426,8 +2482,9 @@ private def rewriteLinkedCallTerm
           (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
       else
         let resultTy ← externalReturnTypeTerm ext
-        `(term| externalCallContractWordsResolved (α := $resultTy) $(strTerm extName)
+        let call ← `(term| externalCallContractWordsResolved (α := $resultTy) $(strTerm extName)
           (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
+        withDeclaredExternalResultDecoder ext resultTy call
   | `(term| externalCall $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2438,7 +2495,7 @@ private def rewriteLinkedCallTerm
           let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
             let tyTerm ← contractValueTypeTerm ty
             executableLinkedArgWords (← `(($arg : $tyTerm))) ty
-          if ext.isView then
+          let call ← if ext.isView then
             `(term| externalStaticCallContractWordsResolved (α := $resultTy) $name
                 (List.flatten ([ $[$rewritten],* ] : List (List Uint256)))
                 $adv $arity $siteId)
@@ -2446,6 +2503,7 @@ private def rewriteLinkedCallTerm
             `(term| externalCallContractWordsResolved (α := $resultTy) $name
                 (List.flatten ([ $[$rewritten],* ] : List (List Uint256)))
                 $adv $arity $siteId)
+          withDeclaredExternalResultDecoder ext resultTy call
       | none =>
           `(term| externalCallContractWordsResolved $name
               (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256)))
@@ -2457,12 +2515,14 @@ private def rewriteLinkedCallTerm
         | some ext => pure ext
         | none => throwErrorAt name s!"unknown interface external '{extName}'"
       let arity := natTerm (← flattenedExternalArity ext)
+      let resultTy ← externalReturnTypeTerm ext
       let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
         let tyTerm ← contractValueTypeTerm ty
         executableLinkedArgWords (← `(($arg : $tyTerm))) ty
-      `(term| externalStaticCallContractWordsResolved $name
+      let call ← `(term| externalStaticCallContractWordsResolved (α := $resultTy) $name
           (List.flatten ([ $[$rewritten],* ] : List (List Uint256)))
           $adv $arity $siteId)
+      withDeclaredExternalResultDecoder ext resultTy call
   | `(term| externalStaticCallEffect $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2487,8 +2547,11 @@ private def rewriteLinkedCallTerm
             let tyTerm ← contractValueTypeTerm ty
             executableLinkedArgWords (← `(($arg : $tyTerm))) ty
         | none => args.mapM fun arg => `(ExternalArg.toWords $arg)
-      `(term| callResultWordsResolved (α := $resultTy) $name
-          (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
+      let call ← `(term| callResultWordsResolved (α := $resultTy) $name
+        (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
+      match ext? with
+      | some ext => withDeclaredExternalResultDecoder ext resultTy call
+      | none => pure call
   | `(term| tryExternalCall $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2502,8 +2565,11 @@ private def rewriteLinkedCallTerm
             let tyTerm ← contractValueTypeTerm ty
             executableLinkedArgWords (← `(($arg : $tyTerm))) ty
         | none => args.mapM fun arg => `(ExternalArg.toWords $arg)
-      `(term| tryExternalCallWordsResolved (α := $resultTy) $name
-          (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
+      let call ← `(term| tryExternalCallWordsResolved (α := $resultTy) $name
+        (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
+      match ext? with
+      | some ext => withDeclaredExternalResultDecoder ext resultTy call
+      | none => pure call
   | `(term| evmCall($gas, $target, $value, $inOffset, $inSize, $outOffset, $outSize)) =>
       `(term| evmCallWords $adv $gas $target $value $inOffset $inSize $outOffset $outSize)
   | `(term| evmStaticCall($gas, $target, $inOffset, $inSize, $outOffset, $outSize)) =>
@@ -2521,12 +2587,13 @@ private def rewriteLinkedCallTerm
       `(term| returndataCopyLive $destOffset $sourceOffset $size)
   | `(term| memoryStore($offset, $value)) =>
       `(term| mstore (externalArgWord $offset) (externalArgWord $value))
-  | `(term| ecmCall $_moduleFactory:term $args:term) =>
+  | `(term| ecmCall $moduleFactory:term $args:term) =>
       let argList ← expectTermListLiteral args
-      `(term| ecmCallWords $adv (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
-  | `(term| ecmDo $_module:term $args:term) =>
+      `(term| ecmCallWords (($moduleFactory) "__verity_ecm_result") $adv
+        (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
+  | `(term| ecmDo $module:term $args:term) =>
       let argList ← expectTermListLiteral args
-      `(term| ecmDoWords $adv (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
+      `(term| ecmDoWords $module $adv (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
   | `(term| externalCallBind ([] : List String) $fnName:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent fnName
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2918,19 +2985,18 @@ private partial def threadAdversaryThroughExecutableSyntax
       hoistLive true code fun rewritten => `(doElem| panic($rewritten))
   | `(doElem| return $value:term) =>
       hoistLive true value fun rewritten => `(doElem| return $rewritten:term)
-  | `(doElem| ecmBind $names:term $_module:term $args:term) =>
+  | `(doElem| ecmBind $names:term $module:term $args:term) =>
       let argList ← expectTermListLiteral args
       let resultNames ← expectStringList names
       let ids := resultNames.map (mkIdent ∘ Name.mkSimple)
-      let arity := natTerm ids.size
       if ids.size == 1 then
         let id := ids[0]!
-        `(doElem| let $id ← (externalCallContractWords "ecm"
-          (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))) $adv $arity))
+        `(doElem| let $id ← (ecmCallWords $module $adv
+          (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256)))))
       else if ids.size == 2 then
         let left := ids[0]!
         let right := ids[1]!
-        `(doElem| let ($left, $right) ← (ecmCallPairWords $adv
+        `(doElem| let ($left, $right) ← (ecmCallPairWords $module $adv
           (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256)))))
       else
         throwErrorAt names "executable ecmBind currently supports one or two results"

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2265,20 +2265,6 @@ def translatedBodyOpensReentrancyWindow
     | _ => throwErrorAt bodyTerm
         "failed to reduce the translated reentrancy-window predicate"
 
-private def translatedBodyContainsExternalCall
-    (stmtTerms : Array Term) : CommandElabM Bool := do
-  let bodyTerm : Term ← `([ $[$stmtTerms],* ])
-  liftTermElabM do
-    let predicate : Term ← `(
-      Compiler.CompilationModel.Stmt.anyDeepList
-        Compiler.CompilationModel.stmtContainsExternalCallNode $bodyTerm)
-    let expr ← Lean.Elab.Term.elabTermEnsuringType predicate (mkConst ``Bool)
-    match ← Lean.Meta.withTransparency .all (Lean.Meta.whnf expr) with
-    | .const ``Bool.true _ => pure true
-    | .const ``Bool.false _ => pure false
-    | _ => throwErrorAt bodyTerm
-        "failed to reduce the translated external-call predicate"
-
 private partial def syntaxCallsAnyHelper
     (helperNames : Array String) (stx : Syntax) : CommandElabM Bool := do
   match stx with
@@ -5289,14 +5275,14 @@ def prefixMixinModifierExecutableBody
 def mkModifierDefCommandPublic (modDecl : ModifierDecl) : CommandElabM Cmd := do
   `(command| def $(modDecl.ident) : Verity.Contract Unit := $(modDecl.body))
 
-private def constructorContainsExternalCall
+private def constructorOpensReentrancyWindow
     (fields : Array StorageFieldDecl) (errorDecls : Array ErrorDecl)
     (constDecls : Array ConstantDecl) (immutableDecls : Array ImmutableDecl)
     (externalDecls : Array ExternalDecl) (functions : Array FunctionDecl)
     (ctor : ConstructorDecl) : CommandElabM Bool := do
   let stmts ← translateConstructorBodyToStmtTerms fields errorDecls constDecls
     immutableDecls externalDecls functions ctor
-  translatedBodyContainsExternalCall stmts
+  translatedBodyOpensReentrancyWindow stmts
 
 private def constructorAdversarialHelpers
     (fields : Array StorageFieldDecl) (errorDecls : Array ErrorDecl)
@@ -5307,7 +5293,7 @@ private def constructorAdversarialHelpers
   for helper in functions do
     let stmts ← translateBodyToStmtTerms fields #[] errorDecls constDecls immutableDecls
       externalDecls functions helper
-    if ← translatedBodyContainsExternalCall stmts then
+    if ← translatedBodyOpensReentrancyWindow stmts then
       adversarial := adversarial.push helper
   for _ in [:functions.size] do
     let names := adversarial.map (·.name)
@@ -5326,24 +5312,24 @@ def mkConstructorDefCommandPublic
     (constDecls : Array ConstantDecl) (immutableDecls : Array ImmutableDecl)
     (externalDecls : Array ExternalDecl) (functions : Array FunctionDecl)
     (ctor : ConstructorDecl) : CommandElabM Cmd := do
-  let directlyContainsExternalCall ← constructorContainsExternalCall fields errorDecls constDecls
+  let directlyOpensReentrancyWindow ← constructorOpensReentrancyWindow fields errorDecls constDecls
     immutableDecls externalDecls functions ctor
   let adversarialHelpers ← constructorAdversarialHelpers fields errorDecls constDecls
     immutableDecls externalDecls functions
   let callsAdversarial ←
     syntaxCallsAnyHelper (adversarialHelpers.map (·.name)) ctor.body.raw
-  let containsExternalCall := directlyContainsExternalCall ||
+  let opensReentrancyWindow := directlyOpensReentrancyWindow ||
     callsAdversarial
   let executableBody ← rewriteForEachExecutableBody fields externalDecls ctor.params ctor.body
   let advIdent ← Lean.Elab.Term.mkFreshIdent (mkIdentFrom (mkIdent `constructor) `_adv).raw
   let advTerm : Term := ⟨advIdent.raw⟩
   let executableBody := ⟨← threadAdversaryThroughExecutableSyntax externalDecls adversarialHelpers
     ctor.params advTerm executableBody.raw⟩
-  let fnType ← if containsExternalCall then
+  let fnType ← if opensReentrancyWindow then
       mkContractFnTypeWithAdversary ctor.params .unit
     else
       mkContractFnType ctor.params .unit
-  let fnValue ← if containsExternalCall then
+  let fnValue ← if opensReentrancyWindow then
       mkContractFnValueWithAdversary advIdent ctor.params executableBody
     else
       mkContractFnValue ctor.params executableBody
@@ -5355,7 +5341,7 @@ def mkHostConstructorDefCommandPublic
     (constDecls : Array ConstantDecl) (immutableDecls : Array ImmutableDecl)
     (externalDecls : Array ExternalDecl) (functions : Array FunctionDecl)
     (resolvedIncludes : Array Name) (ctor : ConstructorDecl) : CommandElabM Cmd := do
-  let ownDirectExternal ← constructorContainsExternalCall fields errorDecls constDecls
+  let ownDirectExternal ← constructorOpensReentrancyWindow fields errorDecls constDecls
     immutableDecls externalDecls functions ctor
   let ownAdversarialHelpers ← constructorAdversarialHelpers fields errorDecls constDecls
     immutableDecls externalDecls functions
@@ -5367,7 +5353,7 @@ def mkHostConstructorDefCommandPublic
   for mixinName in resolvedIncludes do
     if let some mixin ← lookupContractSyntax mixinName then
       if let some mixinCtor := mixin.ctor then
-        let direct ← constructorContainsExternalCall mixin.fields mixin.errorDecls mixin.constDecls
+        let direct ← constructorOpensReentrancyWindow mixin.fields mixin.errorDecls mixin.constDecls
           mixin.immutableDecls mixin.externalDecls mixin.functions mixinCtor
         let helpers ← constructorAdversarialHelpers mixin.fields mixin.errorDecls mixin.constDecls
           mixin.immutableDecls mixin.externalDecls mixin.functions
@@ -5502,7 +5488,7 @@ def mkFunctionCommandsPublic
       | some inlined => pure inlined
       | none => pure fn
   let stmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls immutableDecls externalDecls functions modelFn
-  let directlyContainsExternalCall ← translatedBodyContainsExternalCall stmtTerms
+  let directlyOpensReentrancyWindow ← translatedBodyOpensReentrancyWindow stmtTerms
   let mut adversarialHelpers : Array FunctionDecl := #[]
   let mut translatedHelpers : Array (FunctionDecl × FunctionDecl) := #[]
   for helper in functions do
@@ -5517,9 +5503,9 @@ def mkFunctionCommandsPublic
     let helperStmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls
       immutableDecls externalDecls functions helperModel
     translatedHelpers := translatedHelpers.push (helper, helperModel)
-    if ← translatedBodyContainsExternalCall helperStmtTerms then
+    if ← translatedBodyOpensReentrancyWindow helperStmtTerms then
       adversarialHelpers := adversarialHelpers.push helper
-  -- External-call capability is transitive across internal helpers. Iterate to a
+  -- Reentrancy-window capability is transitive across internal helpers. Iterate to a
   -- fixed point so every caller in a multi-hop helper chain receives and forwards
   -- the same adversary instead of silently falling back to the stub.
   for _ in [:functions.size] do
@@ -5535,22 +5521,22 @@ def mkFunctionCommandsPublic
       break
   let adversarialNames := adversarialHelpers.map (·.name)
   let callsAdversarial ← syntaxCallsAnyHelper adversarialNames modelFn.body.raw
-  let containsExternalCall := directlyContainsExternalCall ||
+  let opensReentrancyWindow := directlyOpensReentrancyWindow ||
     callsAdversarial
   -- Keep the generated binder hygienic: source parameters and locals are allowed
   -- to use `_adv` without capturing the adversary threaded into rewritten calls.
   let advIdent ← Lean.Elab.Term.mkFreshIdent (mkIdentFrom fn.ident `_adv).raw
-  let advTerm : Term ← if containsExternalCall then
+  let advTerm : Term ← if opensReentrancyWindow then
       pure ⟨advIdent.raw⟩
     else
       `(Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel.stub)
-  let fnType ← if containsExternalCall then
+  let fnType ← if opensReentrancyWindow then
       mkContractFnTypeWithAdversary fn.params fn.returnTy
     else
       mkContractFnType fn.params fn.returnTy
   let fnExecutableBody := ⟨← threadAdversaryThroughExecutableSyntax externalDecls
     adversarialHelpers fn.params advTerm fnExecutableBody.raw⟩
-  let fnValue ← if containsExternalCall then
+  let fnValue ← if opensReentrancyWindow then
       mkContractFnValueWithAdversary advIdent fn.params fnExecutableBody
     else
       mkContractFnValue fn.params fnExecutableBody

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2323,7 +2323,9 @@ private def rewriteTypedInterfaceCall?
   let some ext := externalDecls.find? (fun ext => ext.name == extName) | pure none
   let siteId := natTerm (linkedExternalSiteId externalDecls extName)
   let arity := natTerm (← flattenedExternalArity ext)
-  let rewritten ← argTerms.mapM fun arg => pure arg
+  let rewritten ← argTerms.zip ext.params |>.mapM fun (arg, ty) => do
+    let tyTerm ← contractValueTypeTerm ty
+    `(($arg : $tyTerm))
   if ext.returnTys.isEmpty then
     some <$> `(term| externalCallEffectWords $(strTerm extName)
       (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $siteId)
@@ -4571,6 +4573,17 @@ def mkStructEventArgInstanceCommandPublic (decl : StructDecl) : CommandElabM Cmd
   let structId := decl.ident
   `(command| instance : CoeTC $structId _root_.Contracts.EventArg where
       coe _ := _root_.Contracts.EventArg.word (pure (0 : _root_.Verity.Uint256)))
+
+def mkStructExternalArgInstanceCommandPublic (decl : StructDecl) : CommandElabM Cmd := do
+  let structId := decl.ident
+  let valueId := mkIdent (Name.mkSimple "value")
+  let fieldIds := decl.fields.map (·.ident)
+  let encodedFields ← fieldIds.mapM fun fieldId =>
+    `(term| _root_.Contracts.ExternalArg.toWords $valueId.$fieldId)
+  `(command| instance : _root_.Contracts.ExternalArg $structId where
+      toWords := fun $valueId => List.flatten
+        ([ $[$encodedFields],* ] :
+          List (List _root_.Verity.Uint256)))
 
 /-- Generate a `def storageNamespace : Nat := <keccak-value>` command for
     the current contract.  Uses the resolved namespace value from

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -4800,6 +4800,27 @@ def mkStructExternalArgInstanceCommandPublic (decl : StructDecl) : CommandElabM 
         ([ $[$encodedFields],* ] :
           List (List _root_.Verity.Uint256)))
 
+def mkStructExternalResultInstanceCommandPublic (decl : StructDecl) : CommandElabM Cmd := do
+  let structId := decl.ident
+  let fieldIds := decl.fields.map (·.ident)
+  let fieldTys ← decl.fields.mapM (fun field => contractValueTypeTerm field.ty)
+  let counts ← fieldTys.mapM fun fieldTy =>
+    `(term| _root_.Contracts.ExternalResult.wordCount (α := $fieldTy))
+  let total ← counts.foldlM (init := ← `(term| 0)) fun acc count =>
+    `(term| $acc + $count)
+  let mut offset ← `(term| 0)
+  let mut decoded : Array Term := #[]
+  for fieldTy in fieldTys do
+    decoded := decoded.push (← `(term|
+      _root_.Contracts.ExternalResult.fromWords (α := $fieldTy) (words.drop $offset)))
+    offset ← `(term| $offset +
+      _root_.Contracts.ExternalResult.wordCount (α := $fieldTy))
+  `(command| instance : _root_.Contracts.ExternalResult $structId where
+      wordCount := $total
+      fromWord := fun value =>
+        _root_.Contracts.ExternalResult.fromWords [value]
+      fromWords := fun words => { $[$fieldIds:ident := $decoded:term],* })
+
 /-- Generate a `def storageNamespace : Nat := <keccak-value>` command for
     the current contract.  Uses the resolved namespace value from
     `parseContractSyntax` to respect custom `storage_namespace "key"`.

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2339,7 +2339,10 @@ private def rewriteLinkedCallTerm
         `(term| externalCallEffectWords $(strTerm extName)
           (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $siteId)
       else
-        `(term| externalCallContractWords $(strTerm extName)
+        let resultTy ← match ext.returnTys[0]? with
+          | some ty => contractValueTypeTerm ty
+          | none => `(Unit)
+        `(term| externalCallContractWords (α := $resultTy) $(strTerm extName)
           (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
   | `(term| externalCall $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
@@ -2352,18 +2355,22 @@ private def rewriteLinkedCallTerm
   | `(term| callResult $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
-      let arity ← match externalDecls.find? (fun ext => ext.name == extName) with
-        | some ext => flattenedExternalArity ext
-        | none => pure 1
-      `(term| callResultWords $name
+      let ext? := externalDecls.find? (fun ext => ext.name == extName)
+      let arity ← match ext? with | some ext => flattenedExternalArity ext | none => pure 1
+      let resultTy ← match ext?.bind (fun ext => ext.returnTys[0]?) with
+        | some ty => contractValueTypeTerm ty
+        | none => `(Unit)
+      `(term| callResultWords (α := $resultTy) $name
           (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
   | `(term| tryExternalCall $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
-      let arity ← match externalDecls.find? (fun ext => ext.name == extName) with
-        | some ext => flattenedExternalArity ext
-        | none => pure 1
-      `(term| tryExternalCallWords $name
+      let ext? := externalDecls.find? (fun ext => ext.name == extName)
+      let arity ← match ext? with | some ext => flattenedExternalArity ext | none => pure 1
+      let resultTy ← match ext?.bind (fun ext => ext.returnTys[0]?) with
+        | some ty => contractValueTypeTerm ty
+        | none => `(Unit)
+      `(term| tryExternalCallWords (α := $resultTy) $name
           (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
   | `(term| evmCall($gas, $target, $value, $inOffset, $inSize, $outOffset, $outSize)) =>
       `(term| evmCallWords $adv $gas $target $value $inOffset $inSize $outOffset $outSize)
@@ -2444,7 +2451,7 @@ private partial def threadAdversaryThroughExecutableSyntax
         pure (.node info kind (← args.mapM go))
     | _ => pure stx
   let rewriteTerm (t : Term) : CommandElabM Term := do
-    rewriteLinkedCallTerm externalDecls params adv ⟨← go t.raw⟩
+    rewriteLinkedCallTerm externalDecls params adv t
   let rec hoistNested (bindSelf : Bool) (t : Term) :
       CommandElabM (Array (Ident × Term) × Term) := do
     let bindCall (binds : Array (Ident × Term)) (call : Term) :
@@ -2500,28 +2507,81 @@ private partial def threadAdversaryThroughExecutableSyntax
     let (binds, rewritten) ← hoistNested bindSelf rhs
     let rest ← cont rewritten
     wrapBinds binds rest
+  let hoistBound (rhs : Term)
+      (monadic pureBinding : Term → CommandElabM (TSyntax `doElem)) : CommandElabM Syntax := do
+    let (binds, rewritten) ← hoistNested true rhs
+    let rewrittenIdent? : Option Name :=
+      match rewritten with
+      | `(term| $tmp:ident) => some tmp.getId
+      | `(term| ($tmp:ident : $_ty:term)) => some tmp.getId
+      | _ => none
+    let outerWasBound := rewrittenIdent?.any fun rewrittenName =>
+      binds.any fun (tmp, _) => tmp.getId == rewrittenName
+    let pureValue : Term :=
+      match rewritten with
+      | `(term| ($tmp:ident : $_ty:term)) => ⟨tmp.raw⟩
+      | _ => rewritten
+    let rest ← if outerWasBound then pureBinding pureValue else monadic rewritten
+    wrapBinds binds rest
   match stx with
+  | `(doElem| let $pat:term ← tryExternalCall $name:term [ $[$args:term],* ]) =>
+      let mut binds : Array (Ident × Term) := #[]
+      let mut rewrittenArgs : Array Term := #[]
+      for arg in args do
+        let (inner, rewritten) ← hoistNested true arg
+        binds := binds ++ inner
+        rewrittenArgs := rewrittenArgs.push rewritten
+      let call ← `(term| tryExternalCall $name [ $[$rewrittenArgs],* ])
+      let rewritten ← rewriteLinkedCallTerm externalDecls params adv call
+      wrapBinds binds (← `(doElem| let $pat:term ← $rewritten:term))
+  | `(doElem| let $pat:term ← callResult $name:term [ $[$args:term],* ]) =>
+      let mut binds : Array (Ident × Term) := #[]
+      let mut rewrittenArgs : Array Term := #[]
+      for arg in args do
+        let (inner, rewritten) ← hoistNested true arg
+        binds := binds ++ inner
+        rewrittenArgs := rewrittenArgs.push rewritten
+      let call ← `(term| callResult $name [ $[$rewrittenArgs],* ])
+      let rewritten ← rewriteLinkedCallTerm externalDecls params adv call
+      wrapBinds binds (← `(doElem| let $pat:term ← $rewritten:term))
+  | `(doElem| let $pat:term ← callExternal $name:ident ($[$args:term],*)) =>
+      let mut binds : Array (Ident × Term) := #[]
+      let mut rewrittenArgs : Array Term := #[]
+      for arg in args do
+        let (inner, rewritten) ← hoistNested true arg
+        binds := binds ++ inner
+        rewrittenArgs := rewrittenArgs.push rewritten
+      let call ← `(term| callExternal $name ($[$rewrittenArgs],*))
+      let rewritten ← rewriteLinkedCallTerm externalDecls params adv call
+      wrapBinds binds (← `(doElem| let $pat:term ← $rewritten:term))
   | `(doElem| let $name:ident ← $fn:ident $args:term*) =>
-      let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩
-      match ← threadHelperApp? adversarialHelpers fn rewritten adv with
-      | some app => `(doElem| let $name ← $app:term)
+      let original := args.map fun arg => (⟨arg.raw⟩ : Term)
+      match ← threadHelperApp? adversarialHelpers fn original adv with
+      | some app =>
+          hoistLive false app fun rewritten => `(doElem| let $name ← $rewritten:term)
       | none =>
           let fnName := toString fn.getId
           if fnName == "tryExternalCall" || fnName == "callResult" || fnName == "callExternal"
               || fnName == "externalCall" || fnName == "externalCallBind" then
             match stx with
             | `(doElem| let $_ ← $rhs:term) =>
-                hoistLive false rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
+                hoistBound rhs
+                  (fun rewritten => `(doElem| let $name ← $rewritten:term))
+                  (fun rewritten => `(doElem| let $name := $rewritten:term))
             | _ => recurseChildren
           else
             let mut rhs : Term := ⟨fn.raw⟩
-            for arg in rewritten do
+            for arg in original do
               rhs ← `(term| $rhs $arg)
             hoistLive false rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
   | `(doElem| let $name:ident ← $rhs:term) =>
-      hoistLive false rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
+      hoistBound rhs
+        (fun rewritten => `(doElem| let $name ← $rewritten:term))
+        (fun rewritten => `(doElem| let $name := $rewritten:term))
   | `(doElem| let $pat:term ← $rhs:term) =>
-      hoistLive false rhs fun rewritten => `(doElem| let $pat:term ← $rewritten:term)
+      hoistBound rhs
+        (fun rewritten => `(doElem| let $pat:term ← $rewritten:term))
+        (fun rewritten => `(doElem| let $pat:term := $rewritten:term))
   | `(doElem| let mut $name:ident := $rhs:term) =>
       hoistLive true rhs fun rewritten =>
         `(doElem| let mut $name := $rewritten:term)
@@ -2545,9 +2605,10 @@ private partial def threadAdversaryThroughExecutableSyntax
       let argList ← expectTermListLiteral args
       `(doElem| let _ ← ecmCallWords $adv (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
   | `(doElem| $fn:ident $args:term*) =>
-      let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩
-      match ← threadHelperApp? adversarialHelpers fn rewritten adv with
-      | some app => `(doElem| $app:term)
+      let original := args.map fun arg => (⟨arg.raw⟩ : Term)
+      match ← threadHelperApp? adversarialHelpers fn original adv with
+      | some app =>
+          hoistLive false app fun rewritten => `(doElem| $rewritten:term)
       | none =>
           match stx with
           | `(doElem| $stmt:term) =>
@@ -2556,8 +2617,8 @@ private partial def threadAdversaryThroughExecutableSyntax
   | `(doElem| $stmt:term) =>
       hoistLive false stmt fun rewritten => `(doElem| $rewritten:term)
   | `(term| $name:ident $args:term*) =>
-      let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩
-      match ← threadHelperApp? adversarialHelpers name rewritten adv with
+      let original := args.map fun arg => (⟨arg.raw⟩ : Term)
+      match ← threadHelperApp? adversarialHelpers name original adv with
       | some app => pure app.raw
       | none =>
           if isLiveStateExternalCall ⟨stx⟩ then

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2487,24 +2487,23 @@ private partial def threadAdversaryThroughExecutableSyntax
     let rest ← cont rewritten
     wrapBinds binds rest
   match stx with
-  | `(doElem| let $name:ident ← tryExternalCall $extName:term [ $[$args:term],* ]) =>
-      hoistLive false (← `(term| tryExternalCall $extName [ $[$args],* ])) fun rewritten =>
-        `(doElem| let $name ← $rewritten:term)
-  | `(doElem| let $pat:term ← tryExternalCall $extName:term [ $[$args:term],* ]) =>
-      hoistLive false (← `(term| tryExternalCall $extName [ $[$args],* ])) fun rewritten =>
-        `(doElem| let $pat:term ← $rewritten:term)
-  | `(doElem| let $name:ident ← callResult $extName:term [ $[$args:term],* ]) =>
-      hoistLive false (← `(term| callResult $extName [ $[$args],* ])) fun rewritten =>
-        `(doElem| let $name ← $rewritten:term)
   | `(doElem| let $name:ident ← $fn:ident $args:term*) =>
       let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩
       match ← threadHelperApp? adversarialHelpers fn rewritten adv with
       | some app => `(doElem| let $name ← $app:term)
       | none =>
-          let mut rhs : Term := ⟨fn.raw⟩
-          for arg in rewritten do
-            rhs ← `(term| $rhs $arg)
-          hoistLive false rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
+          let fnName := toString fn.getId
+          if fnName == "tryExternalCall" || fnName == "callResult" || fnName == "callExternal"
+              || fnName == "externalCall" || fnName == "externalCallBind" then
+            match stx with
+            | `(doElem| let $_ ← $rhs:term) =>
+                hoistLive false rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
+            | _ => recurseChildren
+          else
+            let mut rhs : Term := ⟨fn.raw⟩
+            for arg in rewritten do
+              rhs ← `(term| $rhs $arg)
+            hoistLive false rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
   | `(doElem| let $name:ident ← $rhs:term) =>
       hoistLive false rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
   | `(doElem| let $pat:term ← $rhs:term) =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2445,17 +2445,35 @@ private partial def threadAdversaryThroughExecutableSyntax
     | _ => pure stx
   let rewriteTerm (t : Term) : CommandElabM Term := do
     rewriteLinkedCallTerm externalDecls params adv ⟨← go t.raw⟩
+  let rec hoistNested (t : Term) : CommandElabM (Array (Ident × Term) × Term) := do
+    if isLiveStateExternalCall t then
+      let rewritten ← rewriteTerm t
+      let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
+      pure (#[(tmp, rewritten)], ⟨tmp.raw⟩)
+    else
+      match t with
+      | .node info kind args =>
+          let mut binds : Array (Ident × Term) := #[]
+          let mut newArgs := args
+          for i in [:args.size] do
+            let (inner, nt) ← hoistNested ⟨args[i]!⟩
+            binds := binds ++ inner
+            newArgs := newArgs.set! i nt.raw
+          pure (binds, ⟨.node info kind newArgs⟩)
+      | _ => pure (#[], t)
+  let wrapBinds (binds : Array (Ident × Term)) (body : TSyntax `doElem) :
+      CommandElabM (TSyntax `doElem) := do
+    let mut acc := body
+    for (tmp, call) in binds.reverse do
+      acc ← `(doElem| do
+        let $tmp ← $call:term
+        $acc:doElem)
+    pure acc
   let hoistLive (rhs : Term) (cont : Term → CommandElabM (TSyntax `doElem)) :
       CommandElabM Syntax := do
-    let rewritten ← rewriteTerm rhs
-    if isLiveStateExternalCall rhs then
-      let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (rhs.raw.reprint.getD "x")}")
-      let rest ← cont ⟨tmp.raw⟩
-      `(doElem| do
-          let $tmp ← $rewritten:term
-          $rest:doElem)
-    else
-      cont rewritten
+    let (binds, rewritten) ← hoistNested rhs
+    let rest ← cont rewritten
+    wrapBinds binds rest
   match stx with
   | `(doElem| let $name:ident ← $fn:ident $args:term*) =>
       let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2451,7 +2451,7 @@ private partial def threadAdversaryThroughExecutableSyntax
       let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
       pure (#[(tmp, rewritten)], ⟨tmp.raw⟩)
     else
-      match t with
+      match t.raw with
       | .node info kind args =>
           let mut binds : Array (Ident × Term) := #[]
           let mut newArgs := args
@@ -2459,7 +2459,7 @@ private partial def threadAdversaryThroughExecutableSyntax
             let (inner, nt) ← hoistNested ⟨args[i]!⟩
             binds := binds ++ inner
             newArgs := newArgs.set! i nt.raw
-          pure (binds, ⟨.node info kind newArgs⟩)
+          pure (binds, ⟨Syntax.node info kind newArgs⟩)
       | _ => pure (#[], t)
   let wrapBinds (binds : Array (Ident × Term)) (body : TSyntax `doElem) :
       CommandElabM (TSyntax `doElem) := do

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1908,10 +1908,13 @@ private def mkContractFnType (params : Array ParamDecl) (retTy : ValueType) : Co
 private def adversaryModelTypeTerm : CommandElabM Term :=
   `(Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel)
 
+private def executableCallContextTypeTerm : CommandElabM Term :=
+  `(ExecutableCallContext)
+
 private def mkContractFnTypeWithAdversary
     (params : Array ParamDecl) (retTy : ValueType) : CommandElabM Term := do
   let base ← mkContractFnType params retTy
-  `(($(← adversaryModelTypeTerm)) → $base)
+  `(($(← executableCallContextTypeTerm)) → $base)
 
 private def mkTupleProjectionTerm (base : Term) (elemTys : List ValueType) (idx : Nat) : CommandElabM Term := do
   let rec go (tupleTerm : Term) (remaining : List ValueType) (targetIdx : Nat) : CommandElabM Term := do
@@ -2248,7 +2251,7 @@ private def mkContractFnValue (params : Array ParamDecl) (body : Term) : Command
 private def mkContractFnValueWithAdversary
     (adv : Ident) (params : Array ParamDecl) (body : Term) : CommandElabM Term := do
   let value ← mkContractFnValue params body
-  `(fun ($adv : $(← adversaryModelTypeTerm)) => $value)
+  `(fun ($adv : $(← executableCallContextTypeTerm)) => $value)
 
 def translatedBodyOpensReentrancyWindow
     (stmtTerms : Array Term) : CommandElabM Bool := do
@@ -2419,11 +2422,11 @@ private def rewriteLinkedCallTerm
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
       let arity := natTerm (← flattenedExternalArity ext)
       if ext.returnTys.isEmpty then
-        `(term| externalCallEffectWords $(strTerm extName)
+        `(term| externalCallEffectWordsResolved $(strTerm extName)
           (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
       else
         let resultTy ← externalReturnTypeTerm ext
-        `(term| externalCallContractWords (α := $resultTy) $(strTerm extName)
+        `(term| externalCallContractWordsResolved (α := $resultTy) $(strTerm extName)
           (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
   | `(term| externalCall $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
@@ -2436,15 +2439,15 @@ private def rewriteLinkedCallTerm
             let tyTerm ← contractValueTypeTerm ty
             executableLinkedArgWords (← `(($arg : $tyTerm))) ty
           if ext.isView then
-            `(term| externalStaticCallContractWords (α := $resultTy) $name
+            `(term| externalStaticCallContractWordsResolved (α := $resultTy) $name
                 (List.flatten ([ $[$rewritten],* ] : List (List Uint256)))
                 $adv $arity $siteId)
           else
-            `(term| externalCallContractWords (α := $resultTy) $name
+            `(term| externalCallContractWordsResolved (α := $resultTy) $name
                 (List.flatten ([ $[$rewritten],* ] : List (List Uint256)))
                 $adv $arity $siteId)
       | none =>
-          `(term| externalCallContractWords $name
+          `(term| externalCallContractWordsResolved $name
               (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256)))
               $adv 1 $siteId)
   | `(term| externalStaticCall $name:term [ $[$args:term],* ]) =>
@@ -2457,7 +2460,7 @@ private def rewriteLinkedCallTerm
       let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
         let tyTerm ← contractValueTypeTerm ty
         executableLinkedArgWords (← `(($arg : $tyTerm))) ty
-      `(term| externalStaticCallContractWords $name
+      `(term| externalStaticCallContractWordsResolved $name
           (List.flatten ([ $[$rewritten],* ] : List (List Uint256)))
           $adv $arity $siteId)
   | `(term| externalStaticCallEffect $name:term [ $[$args:term],* ]) =>
@@ -2469,7 +2472,7 @@ private def rewriteLinkedCallTerm
       let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
         let tyTerm ← contractValueTypeTerm ty
         executableLinkedArgWords (← `(($arg : $tyTerm))) ty
-      `(term| externalStaticCallEffectWords $name
+      `(term| externalStaticCallEffectWordsResolved $name
           (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
   | `(term| callResult $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
@@ -2479,7 +2482,7 @@ private def rewriteLinkedCallTerm
       let resultTy ← match ext? with
         | some ext => externalReturnTypeTerm ext
         | none => `(Unit)
-      `(term| callResultWords (α := $resultTy) $name
+      `(term| callResultWordsResolved (α := $resultTy) $name
           (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
   | `(term| tryExternalCall $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
@@ -2489,7 +2492,7 @@ private def rewriteLinkedCallTerm
       let resultTy ← match ext? with
         | some ext => externalReturnTypeTerm ext
         | none => `(Unit)
-      `(term| tryExternalCallWords (α := $resultTy) $name
+      `(term| tryExternalCallWordsResolved (α := $resultTy) $name
           (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
   | `(term| evmCall($gas, $target, $value, $inOffset, $inSize, $outOffset, $outSize)) =>
       `(term| evmCallWords $adv $gas $target $value $inOffset $inSize $outOffset $outSize)
@@ -2521,17 +2524,17 @@ private def rewriteLinkedCallTerm
             let tyTerm ← contractValueTypeTerm ty
             executableLinkedArgWords (← `(($arg : $tyTerm))) ty
           if ext.isView then
-            `(term| externalStaticCallEffectWords $fnName
+            `(term| externalStaticCallEffectWordsResolved $fnName
                 (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
           else
-            `(term| externalCallEffectWords $fnName
+            `(term| externalCallEffectWordsResolved $fnName
                 (List.flatten ([ $[$rewritten],* ] : List (List Uint256))) $adv $siteId)
       | none =>
-          `(term| externalCallBind ([] : List String) $fnName [ $[$args],* ] $adv $siteId)
+          `(term| externalCallBindResolved ([] : List String) $fnName [ $[$args],* ] $adv $siteId)
   | `(term| externalCallBind $names:term $fnName:term $args:term) =>
       let extName ← expectStringOrIdent fnName
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
-      `(term| externalCallBind $names $fnName $args $adv $siteId)
+      `(term| externalCallBindResolved $names $fnName $args $adv $siteId)
   | `(term| tryExternalCallBind $_successVar:term $_names:term $fnName:term $args:term) =>
       let extName ← expectStringOrIdent fnName
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2539,7 +2542,7 @@ private def rewriteLinkedCallTerm
         | some ext => flattenedExternalArity ext
         | none => pure 1
       let argList ← expectTermListLiteral args
-      `(term| tryExternalCallWords $fnName
+      `(term| tryExternalCallWordsResolved $fnName
           (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
   | `(term| balanceOf $token:term $owner:term) =>
       `(term| balanceOf $token $owner $adv)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2446,21 +2446,28 @@ private partial def threadAdversaryThroughExecutableSyntax
   let rewriteTerm (t : Term) : CommandElabM Term := do
     rewriteLinkedCallTerm externalDecls params adv ⟨← go t.raw⟩
   let rec hoistNested (t : Term) : CommandElabM (Array (Ident × Term) × Term) := do
-    if isLiveStateExternalCall t then
-      let rewritten ← rewriteTerm t
-      let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
-      pure (#[(tmp, rewritten)], ⟨tmp.raw⟩)
-    else
-      match t.raw with
-      | .node info kind args =>
-          let mut binds : Array (Ident × Term) := #[]
-          let mut newArgs := args
-          for i in [:args.size] do
-            let (inner, nt) ← hoistNested ⟨args[i]!⟩
-            binds := binds ++ inner
-            newArgs := newArgs.set! i nt.raw
-          pure (binds, ⟨Syntax.node info kind newArgs⟩)
-      | _ => pure (#[], t)
+    match t.raw with
+    | .node info kind args =>
+        let mut binds : Array (Ident × Term) := #[]
+        let mut newArgs := args
+        for i in [:args.size] do
+          let (inner, nt) ← hoistNested ⟨args[i]!⟩
+          binds := binds ++ inner
+          newArgs := newArgs.set! i nt.raw
+        let rebuilt : Term := ⟨Syntax.node info kind newArgs⟩
+        if isLiveStateExternalCall rebuilt then
+          let rewritten ← rewriteTerm rebuilt
+          let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
+          pure (binds.push (tmp, rewritten), ⟨tmp.raw⟩)
+        else
+          pure (binds, rebuilt)
+    | _ =>
+        if isLiveStateExternalCall t then
+          let rewritten ← rewriteTerm t
+          let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
+          pure (#[(tmp, rewritten)], ⟨tmp.raw⟩)
+        else
+          pure (#[], t)
   let wrapBinds (binds : Array (Ident × Term)) (body : TSyntax `doElem) :
       CommandElabM (TSyntax `doElem) := do
     let mut acc := body
@@ -2483,7 +2490,11 @@ private partial def threadAdversaryThroughExecutableSyntax
           let mut rhs : Term := ⟨fn.raw⟩
           for arg in rewritten do
             rhs ← `(term| $rhs $arg)
-          hoistLive rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
+          if isLiveStateExternalCall rhs then
+            let rewritten ← rewriteTerm rhs
+            `(doElem| let $name ← $rewritten:term)
+          else
+            hoistLive rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
   | `(doElem| let $name:ident ← $rhs:term) =>
       if isLiveStateExternalCall rhs then
         let rewritten ← rewriteTerm rhs

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2357,11 +2357,20 @@ private def rewriteLinkedCallTerm
   | `(term| externalCall $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
-      let arity ← match externalDecls.find? (fun ext => ext.name == extName) with
-        | some ext => flattenedExternalArity ext
-        | none => pure 1
-      `(term| externalCallContractWords $name
-          (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
+      match externalDecls.find? (fun ext => ext.name == extName) with
+      | some ext =>
+          let arity := natTerm (← flattenedExternalArity ext)
+          let resultTy ← externalReturnTypeTerm ext
+          let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
+            let tyTerm ← contractValueTypeTerm ty
+            `(($arg : $tyTerm))
+          `(term| externalCallContractWords (α := $resultTy) $name
+              (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256)))
+              $adv $arity $siteId)
+      | none =>
+          `(term| externalCallContractWords $name
+              (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256)))
+              $adv 1 $siteId)
   | `(term| callResult $name:term [ $[$args:term],* ]) =>
       let extName ← expectStringOrIdent name
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
@@ -2398,6 +2407,19 @@ private def rewriteLinkedCallTerm
   | `(term| ecmDo $_module:term $args:term) =>
       let argList ← expectTermListLiteral args
       `(term| ecmDoWords $adv (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
+  | `(term| externalCallBind ([] : List String) $fnName:term [ $[$args:term],* ]) =>
+      let extName ← expectStringOrIdent fnName
+      let siteId := natTerm (linkedExternalSiteId externalDecls extName)
+      match externalDecls.find? (fun ext => ext.name == extName) with
+      | some ext =>
+          let rewritten ← args.zip ext.params |>.mapM fun (arg, ty) => do
+            let tyTerm ← contractValueTypeTerm ty
+            `(($arg : $tyTerm))
+          `(term| externalCallEffectWords $fnName
+              (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256)))
+              $adv $siteId)
+      | none =>
+          `(term| externalCallBind ([] : List String) $fnName [ $[$args],* ] $adv $siteId)
   | `(term| externalCallBind $names:term $fnName:term $args:term) =>
       let extName ← expectStringOrIdent fnName
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2282,6 +2282,16 @@ private def flattenedExternalArity (ext : ExternalDecl) : CommandElabM Nat := do
             total := total + names.length
       pure total
 
+private def externalReturnTypeTerm (ext : ExternalDecl) : CommandElabM Term := do
+  let tys ← ext.returnTys.mapM contractValueTypeTerm
+  let rec tupleType : List Term → CommandElabM Term
+    | [] => `(Unit)
+    | [ty] => pure ty
+    | ty :: rest => do
+        let tail ← tupleType rest
+        `($ty × $tail)
+  tupleType tys.toList
+
 private def helperCallWithAdv (name : Ident) (args : Array Term) (adv : Term) : CommandElabM Term := do
   let mut app : Term := ⟨name.raw⟩
   app ← `(term| $app $adv)
@@ -2339,9 +2349,7 @@ private def rewriteLinkedCallTerm
         `(term| externalCallEffectWords $(strTerm extName)
           (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $siteId)
       else
-        let resultTy ← match ext.returnTys[0]? with
-          | some ty => contractValueTypeTerm ty
-          | none => `(Unit)
+        let resultTy ← externalReturnTypeTerm ext
         `(term| externalCallContractWords (α := $resultTy) $(strTerm extName)
           (List.flatten ([ $[ExternalArg.toWords $rewritten],* ] : List (List Uint256))) $adv $arity $siteId)
   | `(term| externalCall $name:term [ $[$args:term],* ]) =>
@@ -2357,8 +2365,8 @@ private def rewriteLinkedCallTerm
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
       let ext? := externalDecls.find? (fun ext => ext.name == extName)
       let arity ← match ext? with | some ext => flattenedExternalArity ext | none => pure 1
-      let resultTy ← match ext?.bind (fun ext => ext.returnTys[0]?) with
-        | some ty => contractValueTypeTerm ty
+      let resultTy ← match ext? with
+        | some ext => externalReturnTypeTerm ext
         | none => `(Unit)
       `(term| callResultWords (α := $resultTy) $name
           (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
@@ -2367,8 +2375,8 @@ private def rewriteLinkedCallTerm
       let siteId := natTerm (linkedExternalSiteId externalDecls extName)
       let ext? := externalDecls.find? (fun ext => ext.name == extName)
       let arity ← match ext? with | some ext => flattenedExternalArity ext | none => pure 1
-      let resultTy ← match ext?.bind (fun ext => ext.returnTys[0]?) with
-        | some ty => contractValueTypeTerm ty
+      let resultTy ← match ext? with
+        | some ext => externalReturnTypeTerm ext
         | none => `(Unit)
       `(term| tryExternalCallWords (α := $resultTy) $name
           (List.flatten ([ $[ExternalArg.toWords $args],* ] : List (List Uint256))) $adv $(natTerm arity) $siteId)
@@ -2683,9 +2691,22 @@ private partial def threadAdversaryThroughExecutableSyntax
         (← `(doElem| requireError $rewrittenCond $errorName:ident($[$rewrittenArgs],*)))
   | `(doElem| return $value:term) =>
       hoistLive true value fun rewritten => `(doElem| return $rewritten:term)
-  | `(doElem| ecmBind $_names:term $_module:term $args:term) =>
+  | `(doElem| ecmBind $names:term $_module:term $args:term) =>
       let argList ← expectTermListLiteral args
-      `(doElem| let _ ← ecmCallWords $adv (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
+      let resultNames ← expectStringList names
+      let ids := resultNames.map (mkIdent ∘ Name.mkSimple)
+      let arity := natTerm ids.size
+      if ids.size == 1 then
+        let id := ids[0]!
+        `(doElem| let $id ← (externalCallContractWords "ecm"
+          (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))) $adv $arity))
+      else if ids.size == 2 then
+        let left := ids[0]!
+        let right := ids[1]!
+        `(doElem| let ($left, $right) ← (ecmCallPairWords $adv
+          (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256)))))
+      else
+        throwErrorAt names "executable ecmBind currently supports one or two results"
   | `(doElem| $fn:ident $args:term*) =>
       let original := args.map fun arg => (⟨arg.raw⟩ : Term)
       match ← threadHelperApp? adversarialHelpers fn original adv with

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2486,15 +2486,17 @@ private partial def threadAdversaryThroughExecutableSyntax
       match ← threadHelperApp? adversarialHelpers fn rewritten adv with
       | some app => `(doElem| $app:term)
       | none =>
-          let stmt : Term := ⟨stx⟩
-          let rewritten ← rewriteTerm stmt
+          let mut stmt : Term := ⟨fn.raw⟩
+          for arg in rewritten do
+            stmt ← `(term| $stmt $arg)
           if isLiveStateExternalCall stmt then
+            let rewritten ← rewriteLinkedCallTerm externalDecls params adv stmt
             `(doElem| $rewritten:term)
           else
             recurseChildren
   | `(doElem| $stmt:term) =>
-      let rewritten ← rewriteTerm stmt
       if isLiveStateExternalCall stmt then
+        let rewritten ← rewriteLinkedCallTerm externalDecls params adv ⟨← go stmt.raw⟩
         `(doElem| $rewritten:term)
       else
         recurseChildren
@@ -2502,7 +2504,11 @@ private partial def threadAdversaryThroughExecutableSyntax
       let rewritten ← args.mapM fun arg => do pure ⟨← go arg.raw⟩
       match ← threadHelperApp? adversarialHelpers name rewritten adv with
       | some app => pure app
-      | none => rewriteLinkedCallTerm externalDecls params adv ⟨stx⟩
+      | none =>
+          if isLiveStateExternalCall ⟨stx⟩ then
+            rewriteLinkedCallTerm externalDecls params adv ⟨stx⟩
+          else
+            recurseChildren
   | _ =>
       let asTerm : Term := ⟨stx⟩
       if isLiveStateExternalCall asTerm then

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2467,6 +2467,11 @@ private def rewriteLinkedCallTerm
       `(term| evmStaticCallWords $adv $gas $target $inOffset $inSize $outOffset $outSize)
   | `(term| delegatecall $gas $target $inOffset $inSize $outOffset $outSize) =>
       `(term| evmDelegateCallWords $adv $gas $target $inOffset $inSize $outOffset $outSize)
+  | `(term| returnDataSize()) | `(term| returndataSize) =>
+      `(term| returndataSizeLive)
+  | `(term| returnDataCopy($destOffset, $sourceOffset, $size))
+    | `(term| returndataCopy $destOffset $sourceOffset $size) =>
+      `(term| returndataCopyLive $destOffset $sourceOffset $size)
   | `(term| ecmCall $_moduleFactory:term $args:term) =>
       let argList ← expectTermListLiteral args
       `(term| ecmCallWords $adv (List.flatten ([ $[ExternalArg.toWords $argList],* ] : List (List Uint256))))
@@ -2534,6 +2539,10 @@ private def isLiveStateExternalCall (stx : Term) : Bool :=
   | `(term| call $_ $_ $_ $_ $_ $_ $_)
   | `(term| staticcall $_ $_ $_ $_ $_ $_)
   | `(term| delegatecall $_ $_ $_ $_ $_ $_)
+  | `(term| returnDataSize())
+  | `(term| returndataSize)
+  | `(term| returnDataCopy($_, $_, $_))
+  | `(term| returndataCopy $_ $_ $_)
   | `(term| ecmCall $_ $_)
   | `(term| ecmDo $_ $_)
   | `(term| externalCallBind $_ $_ $_)
@@ -2686,16 +2695,16 @@ private partial def threadAdversaryThroughExecutableSyntax
       (monadic pureBinding : Term → CommandElabM (TSyntax `doElem)) : CommandElabM Syntax := do
     let (binds, rewritten) ← hoistNested true rhs
     let rewrittenIdent? : Option Name :=
-      match rewritten with
+      match stripParens rewritten with
       | `(term| $tmp:ident) => some tmp.getId
       | `(term| ($tmp:ident : $_ty:term)) => some tmp.getId
       | _ => none
     let outerWasBound := rewrittenIdent?.any fun rewrittenName =>
       binds.any fun (tmp, _) => tmp.getId == rewrittenName
     let pureValue : Term :=
-      match rewritten with
+      match stripParens rewritten with
       | `(term| ($tmp:ident : $_ty:term)) => ⟨tmp.raw⟩
-      | _ => rewritten
+      | stripped => stripped
     let rest ← if outerWasBound then pureBinding pureValue else monadic rewritten
     wrapBinds binds rest
   match stx with
@@ -2818,14 +2827,16 @@ private partial def threadAdversaryThroughExecutableSyntax
         `(doElem| if $rewritten:term then $rewrittenThen:doSeq else $rewrittenElse:doSeq)
   | `(doElem| requireError $cond:term $errorName:ident($args,*)) =>
       let (condBinds, rewrittenCond) ← hoistNested true cond
-      let mut binds := condBinds
+      let mut argBinds : Array (Ident × Term) := #[]
       let mut rewrittenArgs : Array Term := #[]
       for arg in args.getElems do
         let (inner, rewritten) ← hoistNested true arg
-        binds := binds ++ inner
+        argBinds := argBinds ++ inner
         rewrittenArgs := rewrittenArgs.push rewritten
-      wrapBinds binds
-        (← `(doElem| requireError $rewrittenCond $errorName:ident($[$rewrittenArgs],*)))
+      let failure ← wrapBinds argBinds
+        (← `(doElem| revertError $errorName:ident($[$rewrittenArgs],*)))
+      wrapBinds condBinds
+        (← `(doElem| if $rewrittenCond then pure () else do $failure:doElem))
   | `(doElem| revert $errorName:ident($args,*)) =>
       let mut binds : Array (Ident × Term) := #[]
       let mut rewrittenArgs : Array Term := #[]

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2445,27 +2445,32 @@ private partial def threadAdversaryThroughExecutableSyntax
     | _ => pure stx
   let rewriteTerm (t : Term) : CommandElabM Term := do
     rewriteLinkedCallTerm externalDecls params adv ⟨← go t.raw⟩
-  let rec hoistNested (t : Term) : CommandElabM (Array (Ident × Term) × Term) := do
+  let rec hoistNested (bindSelf : Bool) (t : Term) :
+      CommandElabM (Array (Ident × Term) × Term) := do
+    let bindCall (binds : Array (Ident × Term)) (call : Term) :
+        CommandElabM (Array (Ident × Term) × Term) := do
+      let rewritten ← rewriteTerm call
+      if bindSelf then
+        let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
+        pure (binds.push (tmp, rewritten), ⟨tmp.raw⟩)
+      else
+        pure (binds, rewritten)
     match t.raw with
     | .node info kind args =>
         let mut binds : Array (Ident × Term) := #[]
         let mut newArgs := args
         for i in [:args.size] do
-          let (inner, nt) ← hoistNested ⟨args[i]!⟩
+          let (inner, nt) ← hoistNested true ⟨args[i]!⟩
           binds := binds ++ inner
           newArgs := newArgs.set! i nt.raw
         let rebuilt : Term := ⟨Syntax.node info kind newArgs⟩
         if isLiveStateExternalCall rebuilt then
-          let rewritten ← rewriteTerm rebuilt
-          let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
-          pure (binds.push (tmp, rewritten), ⟨tmp.raw⟩)
+          bindCall binds rebuilt
         else
           pure (binds, rebuilt)
     | _ =>
         if isLiveStateExternalCall t then
-          let rewritten ← rewriteTerm t
-          let tmp := mkIdent (Name.mkSimple s!"__verity_ext_{hash (t.raw.reprint.getD "x")}")
-          pure (#[(tmp, rewritten)], ⟨tmp.raw⟩)
+          bindCall #[] t
         else
           pure (#[], t)
   let wrapBinds (binds : Array (Ident × Term)) (body : TSyntax `doElem) :
@@ -2476,9 +2481,9 @@ private partial def threadAdversaryThroughExecutableSyntax
         let $tmp ← $call:term
         $acc:doElem)
     pure acc
-  let hoistLive (rhs : Term) (cont : Term → CommandElabM (TSyntax `doElem)) :
-      CommandElabM Syntax := do
-    let (binds, rewritten) ← hoistNested rhs
+  let hoistLive (bindSelf : Bool) (rhs : Term)
+      (cont : Term → CommandElabM (TSyntax `doElem)) : CommandElabM Syntax := do
+    let (binds, rewritten) ← hoistNested bindSelf rhs
     let rest ← cont rewritten
     wrapBinds binds rest
   match stx with
@@ -2490,31 +2495,19 @@ private partial def threadAdversaryThroughExecutableSyntax
           let mut rhs : Term := ⟨fn.raw⟩
           for arg in rewritten do
             rhs ← `(term| $rhs $arg)
-          if isLiveStateExternalCall rhs then
-            let rewritten ← rewriteTerm rhs
-            `(doElem| let $name ← $rewritten:term)
-          else
-            hoistLive rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
+          hoistLive false rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
   | `(doElem| let $name:ident ← $rhs:term) =>
-      if isLiveStateExternalCall rhs then
-        let rewritten ← rewriteTerm rhs
-        `(doElem| let $name ← $rewritten:term)
-      else
-        hoistLive rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
+      hoistLive false rhs fun rewritten => `(doElem| let $name ← $rewritten:term)
   | `(doElem| let $pat:term ← $rhs:term) =>
-      if isLiveStateExternalCall rhs then
-        let rewritten ← rewriteTerm rhs
-        `(doElem| let $pat:term ← $rewritten:term)
-      else
-        hoistLive rhs fun rewritten => `(doElem| let $pat:term ← $rewritten:term)
+      hoistLive false rhs fun rewritten => `(doElem| let $pat:term ← $rewritten:term)
   | `(doElem| let $name:ident := $rhs:term) =>
-      hoistLive rhs fun rewritten =>
+      hoistLive (isLiveStateExternalCall rhs) rhs fun rewritten =>
         if isLiveStateExternalCall rhs then
           `(doElem| let $name ← $rewritten:term)
         else
           `(doElem| let $name := $rewritten:term)
   | `(doElem| return $value:term) =>
-      hoistLive value fun rewritten => `(doElem| return $rewritten:term)
+      hoistLive true value fun rewritten => `(doElem| return $rewritten:term)
   | `(doElem| ecmBind $_names:term $_module:term $args:term) =>
       let argList ← expectTermListLiteral args
       `(doElem| let _ ← ecmCallWords $adv (List.flatten [ $[ExternalArg.toWords $argList],* ]))
@@ -2527,12 +2520,12 @@ private partial def threadAdversaryThroughExecutableSyntax
           for arg in rewritten do
             stmt ← `(term| $stmt $arg)
           if isLiveStateExternalCall stmt then
-            hoistLive stmt fun rewritten => `(doElem| $rewritten:term)
+            hoistLive false stmt fun rewritten => `(doElem| $rewritten:term)
           else
             recurseChildren
   | `(doElem| $stmt:term) =>
       if isLiveStateExternalCall stmt then
-        hoistLive stmt fun rewritten => `(doElem| $rewritten:term)
+        hoistLive false stmt fun rewritten => `(doElem| $rewritten:term)
       else
         recurseChildren
   | `(term| $name:ident $args:term*) =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2436,8 +2436,42 @@ private def isLiveStateExternalCall (stx : Term) : Bool :=
   | `(term| ecmCall $_ $_)
   | `(term| ecmDo $_ $_)
   | `(term| externalCallBind $_ $_ $_)
-  | `(term| tryExternalCallBind $_ $_ $_ $_) => true
+  | `(term| tryExternalCallBind $_ $_ $_ $_)
+  | `(term| balanceOf $_ $_)
+  | `(term| allowance $_ $_ $_)
+  | `(term| totalSupply $_)
+  | `(term| safeTransfer $_ $_ $_)
+  | `(term| safeTransferFrom $_ $_ $_ $_)
+  | `(term| safeApprove $_ $_ $_)
+  | `(term| legacyStringSafeTransfer $_ $_ $_)
+  | `(term| legacyStringSafeTransferFrom $_ $_ $_ $_) => true
   | _ => false
+
+/-- Restore the source language's word-like coercions after a live external
+call has been hoisted into a concretely typed Lean temporary. -/
+private def adaptHoistedWordContext (stx : Term) : CommandElabM Term := do
+  match stx with
+  | `(term| rawLog [ $[$topics:term],* ] $dataOffset:term $dataSize:term) =>
+      `(term| rawLog [ $[externalArgWord $topics],* ]
+        (externalArgWord $dataOffset) (externalArgWord $dataSize))
+  | `(term| linkedWordPassthrough $value:term) =>
+      `(term| linkedWordPassthrough (externalArgWord $value))
+  | `(term| memoryLoad($offset:term)) =>
+      `(term| memoryLoad(externalArgWord $offset))
+  | `(term| arrayElement $values:term $index:term) =>
+      `(term| arrayElement $values (externalArgWord $index))
+  | `(term| arrayElementChecked $values:term $index:term) =>
+      `(term| arrayElementChecked $values (externalArgWord $index))
+  | `(term| getMappingUint $field:term $key:term) =>
+      `(term| getMappingUint $field (externalArgWord $key))
+  | `(term| balanceOf $token:term $owner:term) =>
+      `(term| balanceOf (externalArgAddress $token) (externalArgAddress $owner))
+  | `(term| allowance $token:term $owner:term $spender:term) =>
+      `(term| allowance (externalArgAddress $token) (externalArgAddress $owner)
+        (externalArgAddress $spender))
+  | `(term| totalSupply $token:term) =>
+      `(term| totalSupply (externalArgAddress $token))
+  | _ => pure stx
 
 private partial def threadAdversaryThroughExecutableSyntax
     (externalDecls : Array ExternalDecl)
@@ -2470,7 +2504,7 @@ private partial def threadAdversaryThroughExecutableSyntax
           let (inner, nt) ← hoistNested true ⟨args[i]!⟩
           binds := binds ++ inner
           newArgs := newArgs.set! i nt.raw
-        let rebuilt : Term := ⟨Syntax.node info kind newArgs⟩
+        let rebuilt ← adaptHoistedWordContext ⟨Syntax.node info kind newArgs⟩
         if isLiveStateExternalCall rebuilt then
           bindCall binds rebuilt
         else
@@ -2554,13 +2588,51 @@ private partial def threadAdversaryThroughExecutableSyntax
       let call ← `(term| callExternal $name ($[$rewrittenArgs],*))
       let rewritten ← rewriteLinkedCallTerm externalDecls params adv call
       wrapBinds binds (← `(doElem| let $pat:term ← $rewritten:term))
+  | `(doElem| let $pat:term ← balanceOf $token:term $owner:term) =>
+      let (tokenBinds, rewrittenToken) ← hoistNested true token
+      let (ownerBinds, rewrittenOwner) ← hoistNested true owner
+      wrapBinds (tokenBinds ++ ownerBinds)
+        (← `(doElem| let $pat:term ← (balanceOf
+          (externalArgAddress $rewrittenToken) (externalArgAddress $rewrittenOwner) $adv)))
+  | `(doElem| let $pat:term ← allowance $token:term $owner:term $spender:term) =>
+      let (tokenBinds, rewrittenToken) ← hoistNested true token
+      let (ownerBinds, rewrittenOwner) ← hoistNested true owner
+      let (spenderBinds, rewrittenSpender) ← hoistNested true spender
+      wrapBinds (tokenBinds ++ ownerBinds ++ spenderBinds)
+        (← `(doElem| let $pat:term ← (allowance
+          (externalArgAddress $rewrittenToken) (externalArgAddress $rewrittenOwner)
+          (externalArgAddress $rewrittenSpender) $adv)))
+  | `(doElem| let $pat:term ← totalSupply $token:term) =>
+      let (binds, rewrittenToken) ← hoistNested true token
+      wrapBinds binds
+        (← `(doElem| let $pat:term ← (totalSupply
+          (externalArgAddress $rewrittenToken) $adv)))
   | `(doElem| let $name:ident ← $fn:ident $args:term*) =>
       let original := args.map fun arg => (⟨arg.raw⟩ : Term)
-      match ← threadHelperApp? adversarialHelpers fn original adv with
-      | some app =>
-          hoistLive false app fun rewritten => `(doElem| let $name ← $rewritten:term)
-      | none =>
-          let fnName := toString fn.getId
+      let fnName := toString fn.getId
+      if fnName == "balanceOf" && original.size == 2 then
+        let (tokenBinds, token) ← hoistNested true original[0]!
+        let (ownerBinds, owner) ← hoistNested true original[1]!
+        wrapBinds (tokenBinds ++ ownerBinds)
+          (← `(doElem| let $name ← (balanceOf
+            (externalArgAddress $token) (externalArgAddress $owner) $adv)))
+      else if fnName == "allowance" && original.size == 3 then
+        let (tokenBinds, token) ← hoistNested true original[0]!
+        let (ownerBinds, owner) ← hoistNested true original[1]!
+        let (spenderBinds, spender) ← hoistNested true original[2]!
+        wrapBinds (tokenBinds ++ ownerBinds ++ spenderBinds)
+          (← `(doElem| let $name ← (allowance
+            (externalArgAddress $token) (externalArgAddress $owner)
+            (externalArgAddress $spender) $adv)))
+      else if fnName == "totalSupply" && original.size == 1 then
+        let (binds, token) ← hoistNested true original[0]!
+        wrapBinds binds
+          (← `(doElem| let $name ← (totalSupply (externalArgAddress $token) $adv)))
+      else
+        match ← threadHelperApp? adversarialHelpers fn original adv with
+        | some app =>
+            hoistLive false app fun rewritten => `(doElem| let $name ← $rewritten:term)
+        | none =>
           if fnName == "tryExternalCall" || fnName == "callResult" || fnName == "callExternal"
               || fnName == "externalCall" || fnName == "externalCallBind" then
             match stx with
@@ -2599,6 +2671,16 @@ private partial def threadAdversaryThroughExecutableSyntax
       let rewrittenElse := ⟨← go elseBranch.raw⟩
       hoistLive true cond fun rewritten =>
         `(doElem| if $rewritten:term then $rewrittenThen:doSeq else $rewrittenElse:doSeq)
+  | `(doElem| requireError $cond:term $errorName:ident($args,*)) =>
+      let (condBinds, rewrittenCond) ← hoistNested true cond
+      let mut binds := condBinds
+      let mut rewrittenArgs : Array Term := #[]
+      for arg in args.getElems do
+        let (inner, rewritten) ← hoistNested true arg
+        binds := binds ++ inner
+        rewrittenArgs := rewrittenArgs.push rewritten
+      wrapBinds binds
+        (← `(doElem| requireError $rewrittenCond $errorName:ident($[$rewrittenArgs],*)))
   | `(doElem| return $value:term) =>
       hoistLive true value fun rewritten => `(doElem| return $rewritten:term)
   | `(doElem| ecmBind $_names:term $_module:term $args:term) =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -5065,15 +5065,59 @@ def prefixMixinModifierExecutableBody
 def mkModifierDefCommandPublic (modDecl : ModifierDecl) : CommandElabM Cmd := do
   `(command| def $(modDecl.ident) : Verity.Contract Unit := $(modDecl.body))
 
-def mkConstructorDefCommandPublic (ctor : ConstructorDecl) : CommandElabM Cmd := do
-  let fnType ← mkContractFnType ctor.params .unit
-  let fnValue ← mkContractFnValue ctor.params ctor.body
+private def constructorContainsExternalCall
+    (fields : Array StorageFieldDecl) (errorDecls : Array ErrorDecl)
+    (constDecls : Array ConstantDecl) (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl) (functions : Array FunctionDecl)
+    (ctor : ConstructorDecl) : CommandElabM Bool := do
+  let stmts ← translateConstructorBodyToStmtTerms fields errorDecls constDecls
+    immutableDecls externalDecls functions ctor
+  translatedBodyContainsExternalCall stmts
+
+def mkConstructorDefCommandPublic
+    (fields : Array StorageFieldDecl) (errorDecls : Array ErrorDecl)
+    (constDecls : Array ConstantDecl) (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl) (functions : Array FunctionDecl)
+    (ctor : ConstructorDecl) : CommandElabM Cmd := do
+  let containsExternalCall ← constructorContainsExternalCall fields errorDecls constDecls
+    immutableDecls externalDecls functions ctor
+  let executableBody ← rewriteForEachExecutableBody fields externalDecls ctor.params ctor.body
+  let advIdent ← Lean.Elab.Term.mkFreshIdent (mkIdentFrom (mkIdent `constructor) `_adv).raw
+  let advTerm : Term := ⟨advIdent.raw⟩
+  let executableBody := ⟨← threadAdversaryThroughExecutableSyntax externalDecls #[]
+    ctor.params advTerm executableBody.raw⟩
+  let fnType ← if containsExternalCall then
+      mkContractFnTypeWithAdversary ctor.params .unit
+    else
+      mkContractFnType ctor.params .unit
+  let fnValue ← if containsExternalCall then
+      mkContractFnValueWithAdversary advIdent ctor.params executableBody
+    else
+      mkContractFnValue ctor.params executableBody
   let id : Ident := mkIdent (Name.mkSimple "constructor")
   `(command| def $id : $fnType := $fnValue)
 
 def mkHostConstructorDefCommandPublic
+    (fields : Array StorageFieldDecl) (errorDecls : Array ErrorDecl)
+    (constDecls : Array ConstantDecl) (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl) (functions : Array FunctionDecl)
     (resolvedIncludes : Array Name) (ctor : ConstructorDecl) : CommandElabM Cmd := do
-  let fnType ← mkContractFnType ctor.params .unit
+  let ownExternal ← constructorContainsExternalCall fields errorDecls constDecls
+    immutableDecls externalDecls functions ctor
+  let mut mixinExternal : Array Name := #[]
+  for mixinName in resolvedIncludes do
+    if let some mixin ← lookupContractSyntax mixinName then
+      if let some mixinCtor := mixin.ctor then
+        if ← constructorContainsExternalCall mixin.fields mixin.errorDecls mixin.constDecls
+            mixin.immutableDecls mixin.externalDecls mixin.functions mixinCtor then
+          mixinExternal := mixinExternal.push mixinName
+  let containsExternalCall := ownExternal || !mixinExternal.isEmpty
+  let advIdent ← Lean.Elab.Term.mkFreshIdent (mkIdentFrom (mkIdent `constructor) `_adv).raw
+  let advTerm : Term := ⟨advIdent.raw⟩
+  let fnType ← if containsExternalCall then
+      mkContractFnTypeWithAdversary ctor.params .unit
+    else
+      mkContractFnType ctor.params .unit
   match ctor.body with
   | `(term| do $[$elems:doElem]*) =>
       let mut preludes : Array (TSyntax `doElem) := #[]
@@ -5083,16 +5127,31 @@ def mkHostConstructorDefCommandPublic
           if targetName.isNone && namesMixin (toString mixinIdent.getId) mixinName then
             targetName := some (mixinName ++ Name.mkSimple "constructor")
         let tgt := mkIdent (targetName.getD (mixinIdent.getId ++ Name.mkSimple "constructor"))
+        let needsAdversary := mixinExternal.any fun name =>
+          namesMixin (toString mixinIdent.getId) name
         if args.isEmpty then
-          preludes := preludes.push (← `(doElem| $tgt:ident))
+          if needsAdversary then
+            preludes := preludes.push (← `(doElem| $tgt:ident $advTerm))
+          else
+            preludes := preludes.push (← `(doElem| $tgt:ident))
         else
-          preludes := preludes.push (← `(doElem| $tgt:ident $args*))
+          if needsAdversary then
+            preludes := preludes.push (← `(doElem| $tgt:ident $advTerm $args*))
+          else
+            preludes := preludes.push (← `(doElem| $tgt:ident $args*))
       let body ← `(term| do $[$preludes:doElem]* $[$elems:doElem]*)
-      let fnValue ← mkContractFnValue ctor.params body
+      let executableBody ← rewriteForEachExecutableBody fields externalDecls ctor.params body
+      let executableBody := ⟨← threadAdversaryThroughExecutableSyntax externalDecls #[]
+        ctor.params advTerm executableBody.raw⟩
+      let fnValue ← if containsExternalCall then
+          mkContractFnValueWithAdversary advIdent ctor.params executableBody
+        else
+          mkContractFnValue ctor.params executableBody
       let id : Ident := mkIdent (Name.mkSimple "constructor")
       `(command| def $id : $fnType := $fnValue)
   | _ =>
-      mkConstructorDefCommandPublic ctor
+      mkConstructorDefCommandPublic fields errorDecls constDecls immutableDecls
+        externalDecls functions ctor
 
 def mkIncludeAliasCommandsPublic
     (resolvedIncludes : Array Name) : CommandElabM (Array Cmd) := do

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2539,13 +2539,13 @@ private partial def threadAdversaryThroughExecutableSyntax
           if isLiveStateExternalCall ⟨stx⟩ then
             rewriteLinkedCallTerm externalDecls params adv ⟨stx⟩
           else
-            recurseChildren
+            (⟨·⟩) <$> recurseChildren
   | _ =>
       let asTerm : Term := ⟨stx⟩
       if isLiveStateExternalCall asTerm then
         rewriteLinkedCallTerm externalDecls params adv asTerm
       else
-        recurseChildren
+        (⟨·⟩) <$> recurseChildren
 
 private def mkModelParamsTerm (params : Array ParamDecl) : CommandElabM Term := do
   let xs ← params.mapM fun p => do

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1905,6 +1905,14 @@ private def mkContractFnType (params : Array ParamDecl) (retTy : ValueType) : Co
     ty ← `(($(← contractValueTypeTerm param.ty)) → $ty)
   pure ty
 
+private def adversaryModelTypeTerm : CommandElabM Term :=
+  `(Compiler.CompilationModel.DenoteExternalCalls.AdversaryModel)
+
+private def mkContractFnTypeWithAdversary
+    (params : Array ParamDecl) (retTy : ValueType) : CommandElabM Term := do
+  let base ← mkContractFnType params retTy
+  `(($(← adversaryModelTypeTerm)) → $base)
+
 private def mkTupleProjectionTerm (base : Term) (elemTys : List ValueType) (idx : Nat) : CommandElabM Term := do
   let rec go (tupleTerm : Term) (remaining : List ValueType) (targetIdx : Nat) : CommandElabM Term := do
     match remaining with
@@ -2212,6 +2220,100 @@ private def mkContractFnValue (params : Array ParamDecl) (body : Term) : Command
     let pid := param.ident
     value ← `(fun ($pid : $(← contractValueTypeTerm param.ty)) => $value)
   pure value
+
+private def mkContractFnValueWithAdversary
+    (adv : Ident) (params : Array ParamDecl) (body : Term) : CommandElabM Term := do
+  let value ← mkContractFnValue params body
+  `(fun ($adv : $(← adversaryModelTypeTerm)) => $value)
+
+unsafe def translatedBodyOpensReentrancyWindow
+    (stmtTerms : Array Term) : CommandElabM Bool := do
+  let bodyTerm : Term ← `([ $[$stmtTerms],* ])
+  liftTermElabM do
+    let stmtTy := mkConst ``Compiler.CompilationModel.Stmt
+    let expectedType := mkApp (mkConst ``List) stmtTy
+    let expr ← Lean.Elab.Term.elabTermEnsuringType bodyTerm expectedType
+    let body ← Lean.Meta.evalExpr (List Compiler.CompilationModel.Stmt) expectedType expr .unsafe
+    pure (body.any Compiler.CompilationModel.stmtOpensReentrancyWindow)
+
+private partial def threadAdversaryThroughExecutableSyntax
+    (adv : Ident) (stx : Syntax) : CommandElabM Syntax := do
+  let recurseChildren : CommandElabM Syntax := do
+    match stx with
+    | .node info kind args =>
+        pure (.node info kind (← args.mapM (threadAdversaryThroughExecutableSyntax adv)))
+    | _ => pure stx
+  match stx with
+  | `(term| callExternal $name:ident ($[$args:term],*)) =>
+      let rewritten ← args.mapM fun arg => do
+        pure ⟨← threadAdversaryThroughExecutableSyntax adv arg.raw⟩
+      `(term| externalCallWords $(strTerm (toString name.getId))
+          (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
+  | `(term| externalCall $name:term [ $[$args:term],* ]) =>
+      let rewritten ← args.mapM fun arg => do
+        pure ⟨← threadAdversaryThroughExecutableSyntax adv arg.raw⟩
+      `(term| externalCallWords $name
+          (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
+  | `(term| callResult $name:term [ $[$args:term],* ]) =>
+      let rewritten ← args.mapM fun arg => do
+        pure ⟨← threadAdversaryThroughExecutableSyntax adv arg.raw⟩
+      `(term| callResultWords $name
+          (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
+  | `(term| tryExternalCall $name:term [ $[$args:term],* ]) =>
+      let rewritten ← args.mapM fun arg => do
+        pure ⟨← threadAdversaryThroughExecutableSyntax adv arg.raw⟩
+      `(term| tryExternalCallWords $name
+          (List.flatten [ $[ExternalArg.toWords $rewritten],* ]) $adv)
+  | `(term| evmCall($gas, $target, $value, $inOffset, $inSize, $outOffset, $outSize)) =>
+      let xs ← #[gas, target, value, inOffset, inSize, outOffset, outSize].mapM fun arg => do
+        pure ⟨← threadAdversaryThroughExecutableSyntax adv arg.raw⟩
+      `(term| evmCallWords $adv $(xs[0]!) $(xs[1]!) $(xs[2]!) $(xs[3]!)
+          $(xs[4]!) $(xs[5]!) $(xs[6]!))
+  | `(term| evmStaticCall($gas, $target, $inOffset, $inSize, $outOffset, $outSize)) =>
+      let xs ← #[gas, target, inOffset, inSize, outOffset, outSize].mapM fun arg => do
+        pure ⟨← threadAdversaryThroughExecutableSyntax adv arg.raw⟩
+      `(term| evmStaticCallWords $adv $(xs[0]!) $(xs[1]!) $(xs[2]!)
+          $(xs[3]!) $(xs[4]!) $(xs[5]!))
+  | `(term| safeTransfer $token $toAddr $amount) =>
+      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
+      let toAddr : Term := ⟨← threadAdversaryThroughExecutableSyntax adv toAddr.raw⟩
+      let amount : Term := ⟨← threadAdversaryThroughExecutableSyntax adv amount.raw⟩
+      `(term| safeTransfer $token $toAddr $amount $adv)
+  | `(term| safeTransferFrom $token $fromAddr $toAddr $amount) =>
+      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
+      let fromAddr : Term := ⟨← threadAdversaryThroughExecutableSyntax adv fromAddr.raw⟩
+      let toAddr : Term := ⟨← threadAdversaryThroughExecutableSyntax adv toAddr.raw⟩
+      let amount : Term := ⟨← threadAdversaryThroughExecutableSyntax adv amount.raw⟩
+      `(term| safeTransferFrom $token $fromAddr $toAddr $amount $adv)
+  | `(term| safeApprove $token $spender $amount) =>
+      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
+      let spender : Term := ⟨← threadAdversaryThroughExecutableSyntax adv spender.raw⟩
+      let amount : Term := ⟨← threadAdversaryThroughExecutableSyntax adv amount.raw⟩
+      `(term| safeApprove $token $spender $amount $adv)
+  | `(term| legacyStringSafeTransfer $token $toAddr $amount) =>
+      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
+      let toAddr : Term := ⟨← threadAdversaryThroughExecutableSyntax adv toAddr.raw⟩
+      let amount : Term := ⟨← threadAdversaryThroughExecutableSyntax adv amount.raw⟩
+      `(term| legacyStringSafeTransfer $token $toAddr $amount $adv)
+  | `(term| legacyStringSafeTransferFrom $token $fromAddr $toAddr $amount) =>
+      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
+      let fromAddr : Term := ⟨← threadAdversaryThroughExecutableSyntax adv fromAddr.raw⟩
+      let toAddr : Term := ⟨← threadAdversaryThroughExecutableSyntax adv toAddr.raw⟩
+      let amount : Term := ⟨← threadAdversaryThroughExecutableSyntax adv amount.raw⟩
+      `(term| legacyStringSafeTransferFrom $token $fromAddr $toAddr $amount $adv)
+  | `(term| balanceOf $token $owner) =>
+      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
+      let owner : Term := ⟨← threadAdversaryThroughExecutableSyntax adv owner.raw⟩
+      `(term| balanceOf $token $owner $adv)
+  | `(term| allowance $token $owner $spender) =>
+      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
+      let owner : Term := ⟨← threadAdversaryThroughExecutableSyntax adv owner.raw⟩
+      let spender : Term := ⟨← threadAdversaryThroughExecutableSyntax adv spender.raw⟩
+      `(term| allowance $token $owner $spender $adv)
+  | `(term| totalSupply $token) =>
+      let token : Term := ⟨← threadAdversaryThroughExecutableSyntax adv token.raw⟩
+      `(term| totalSupply $token $adv)
+  | _ => recurseChildren
 
 private def mkModelParamsTerm (params : Array ParamDecl) : CommandElabM Term := do
   let xs ← params.mapM fun p => do
@@ -4444,7 +4546,6 @@ def mkFunctionCommandsPublic
     (resolvedIncludes : Array Name := #[])
     (boundImmutableDecls : Array ImmutableDecl := immutableDecls)
     (hostModifiers : Array ModifierDecl := #[]) : CommandElabM (Array Cmd) := do
-  let fnType ← mkContractFnType fn.params fn.returnTy
   -- Mixin modifiers belong after ABI/enum, init, and role guards, matching
   -- `translateBodyToStmtTerms`. Prefix them onto the source body so those
   -- wrappers stay outside.
@@ -4462,7 +4563,6 @@ def mkFunctionCommandsPublic
   -- them outside all executable wrappers makes ABI validation happen before
   -- initializer, role, and modifier effects (the inner copy is harmless).
   let fnExecutableBody ← prependEnumGuards fn.params fnExecutableBody
-  let fnValue ← mkContractFnValue fn.params fnExecutableBody
   let modelBodyName ← mkSuffixedIdent fn.ident "_modelBody"
   let modelName ← mkSuffixedIdent fn.ident "_model"
   -- CompilationModel inlines every modifier in declared `with` order so
@@ -4482,6 +4582,20 @@ def mkFunctionCommandsPublic
       | some inlined => pure inlined
       | none => pure fn
   let stmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls immutableDecls externalDecls functions modelFn
+  let opensReentrancyWindow ← unsafe translatedBodyOpensReentrancyWindow stmtTerms
+  let advIdent := mkIdentFrom fn.ident `_adv
+  let fnType ← if opensReentrancyWindow then
+      mkContractFnTypeWithAdversary fn.params fn.returnTy
+    else
+      mkContractFnType fn.params fn.returnTy
+  let fnExecutableBody ← if opensReentrancyWindow then
+      pure ⟨← threadAdversaryThroughExecutableSyntax advIdent fnExecutableBody.raw⟩
+    else
+      pure fnExecutableBody
+  let fnValue ← if opensReentrancyWindow then
+      mkContractFnValueWithAdversary advIdent fn.params fnExecutableBody
+    else
+      mkContractFnValue fn.params fnExecutableBody
   let modelParams ← mkModelParamsTerm fn.params
   let localObligationTerms ← (functionLocalObligationsWithArithmetic fn).mapM mkModelLocalObligationTerm
   let payableTerm ← if fn.isPayable then `(true) else `(false)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -5279,7 +5279,7 @@ private def constructorContainsExternalCall
     (ctor : ConstructorDecl) : CommandElabM Bool := do
   let stmts ← translateConstructorBodyToStmtTerms fields errorDecls constDecls
     immutableDecls externalDecls functions ctor
-  translatedBodyContainsExternalCall stmts
+  translatedBodyOpensReentrancyWindow stmts
 
 private def constructorAdversarialHelpers
     (fields : Array StorageFieldDecl) (errorDecls : Array ErrorDecl)
@@ -5290,7 +5290,7 @@ private def constructorAdversarialHelpers
   for helper in functions do
     let stmts ← translateBodyToStmtTerms fields #[] errorDecls constDecls immutableDecls
       externalDecls functions helper
-    if ← translatedBodyContainsExternalCall stmts then
+    if ← translatedBodyOpensReentrancyWindow stmts then
       adversarial := adversarial.push helper
   for _ in [:functions.size] do
     let names := adversarial.map (·.name)
@@ -5485,8 +5485,7 @@ def mkFunctionCommandsPublic
       | some inlined => pure inlined
       | none => pure fn
   let stmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls immutableDecls externalDecls functions modelFn
-  let _opensReentrancyWindow ← translatedBodyOpensReentrancyWindow stmtTerms
-  let directlyContainsExternalCall ← translatedBodyContainsExternalCall stmtTerms
+  let directlyOpensReentrancyWindow ← translatedBodyOpensReentrancyWindow stmtTerms
   let mut adversarialHelpers : Array FunctionDecl := #[]
   let mut translatedHelpers : Array (FunctionDecl × FunctionDecl) := #[]
   for helper in functions do
@@ -5501,7 +5500,7 @@ def mkFunctionCommandsPublic
     let helperStmtTerms ← translateBodyToStmtTerms fields roleDecls errorDecls constDecls
       immutableDecls externalDecls functions helperModel
     translatedHelpers := translatedHelpers.push (helper, helperModel)
-    if ← translatedBodyContainsExternalCall helperStmtTerms then
+    if ← translatedBodyOpensReentrancyWindow helperStmtTerms then
       adversarialHelpers := adversarialHelpers.push helper
   -- External-call capability is transitive across internal helpers. Iterate to a
   -- fixed point so every caller in a multi-hop helper chain receives and forwards
@@ -5519,7 +5518,7 @@ def mkFunctionCommandsPublic
       break
   let adversarialNames := adversarialHelpers.map (·.name)
   let callsAdversarial ← syntaxCallsAnyHelper adversarialNames modelFn.body.raw
-  let containsExternalCall := directlyContainsExternalCall ||
+  let containsExternalCall := directlyOpensReentrancyWindow ||
     callsAdversarial
   -- Keep the generated binder hygienic: source parameters and locals are allowed
   -- to use `_adv` without capturing the adversary threaded into rewritten calls.

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -3750,7 +3750,7 @@ partial def translatePureExprWithTypes
               match directParamNameWithType? params arg with
               | some (name, ty) =>
                   if externalCallDynamicArgSupported ty then
-                    out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
+                    out := out.push (← `(Compiler.CompilationModel.Expr.literal 0))
                     out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
                   else
                     out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants linkedExternalLowerer?)
@@ -4574,7 +4574,7 @@ def translateLinkedExternalCallArgs
         match directParamNameWithType? params arg with
         | some (name, ty) =>
             if externalCallDynamicArgSupported ty then
-              out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
+              out := out.push (← `(Compiler.CompilationModel.Expr.literal 0))
               out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
             else
               out := out.push (← translateScalar)
@@ -4927,7 +4927,7 @@ def expectEcmExprList
         match directParamNameWithType? params x with
         | some (name, ty) =>
             if externalCallDynamicArgSupported ty then
-              out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
+              out := out.push (← `(Compiler.CompilationModel.Expr.literal 0))
               out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
             else
               match ← translateAbiEncodeProjection? fields constDecls immutableDecls params locals x with

--- a/Verity/Macro/Translate/Expr.lean
+++ b/Verity/Macro/Translate/Expr.lean
@@ -3750,7 +3750,7 @@ partial def translatePureExprWithTypes
               match directParamNameWithType? params arg with
               | some (name, ty) =>
                   if externalCallDynamicArgSupported ty then
-                    out := out.push (← `(Compiler.CompilationModel.Expr.literal 0))
+                    out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
                     out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
                   else
                     out := out.push (← translatePureExprWithTypes fields constDecls immutableDecls params locals arg visitingConstants linkedExternalLowerer?)
@@ -4574,7 +4574,7 @@ def translateLinkedExternalCallArgs
         match directParamNameWithType? params arg with
         | some (name, ty) =>
             if externalCallDynamicArgSupported ty then
-              out := out.push (← `(Compiler.CompilationModel.Expr.literal 0))
+              out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
               out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
             else
               out := out.push (← translateScalar)
@@ -4927,7 +4927,7 @@ def expectEcmExprList
         match directParamNameWithType? params x with
         | some (name, ty) =>
             if externalCallDynamicArgSupported ty then
-              out := out.push (← `(Compiler.CompilationModel.Expr.literal 0))
+              out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_data_offset")))
               out := out.push (← `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_length")))
             else
               match ← translateAbiEncodeProjection? fields constDecls immutableDecls params locals x with

--- a/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
+++ b/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
@@ -16,9 +16,9 @@ open Compiler.CompilationModel.DenoteExternalCalls
 private abbrev modelExternalCall :=
   Compiler.CompilationModel.DenoteExternalCalls.externalCall
 
-/-- Kept for downstream PR1 users; PR2 no longer applies this projection. -/
-def legacyPost (before after : ContractState) : ContractState :=
-  { after with returndata := before.returndata }
+/-- Compatibility name retained for downstream PR1 users.  The PR3 boundary
+is canonical, so the complete post-state (including returndata) is visible. -/
+def legacyPost (_before after : ContractState) : ContractState := after
 
 theorem commonExternalCall_eq_model (adv : AdversaryModel) (site : CallSite)
     (state : ContractState) :
@@ -188,39 +188,32 @@ theorem totalSupply_eq_stub (token : Address) (state : ContractState) :
 theorem erc20Write_eq_stub (name : String) (token : Address)
     (args : List Uint256) (state : ContractState) (h : name ≠ "fail")
     (hcode : state.codeSize token.toNat ≠ 0) :
-    (recordLinkedCall (erc20WriteEntry name token args)).run state =
+    (erc20Write .stub name token args).run state =
       (stubErc20Write name token args).run state := by
-  rw [recordLinkedCall_run]
-  simp [stubErc20Write, modelExternalCall,
+  simp [erc20Write, stubErc20Write, commonExternalCall, modelExternalCall,
     Compiler.CompilationModel.DenoteExternalCalls.externalCall,
     denoteCallJournaled, denoteCall, chargedGas, journalEntry,
     CallKind.toJournal, CallControl.toJournal, ExternalCallResult.control,
     ExternalCallResult.returndata, Contract.run, linkedCallSite,
-    AdversaryModel.stub, legacyPost, erc20WriteEntry, linkedCallEntry, h, hcode]
+    AdversaryModel.stub, legacyPost, h, hcode]
 
 theorem safeTransfer_eq_stub (token toAddr : Address) (amount : Uint256)
     (state : ContractState) (hcode : state.codeSize token.toNat ≠ 0) :
     (safeTransfer token toAddr amount .stub).run state =
       (stubErc20Write "safeTransfer" token
-        [Verity.addressToWord toAddr, amount]).run state := by
-  rw [safeTransfer_run _ _ _ _ hcode]
-  exact erc20Write_eq_stub _ _ _ _ (by decide) hcode
+        [Verity.addressToWord toAddr, amount]).run state := rfl
 
 theorem safeTransferFrom_eq_stub (token fromAddr toAddr : Address) (amount : Uint256)
     (state : ContractState) (hcode : state.codeSize token.toNat ≠ 0) :
     (safeTransferFrom token fromAddr toAddr amount .stub).run state =
       (stubErc20Write "safeTransferFrom" token
-        [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state := by
-  rw [safeTransferFrom_run _ _ _ _ _ hcode]
-  exact erc20Write_eq_stub _ _ _ _ (by decide) hcode
+        [Verity.addressToWord fromAddr, Verity.addressToWord toAddr, amount]).run state := rfl
 
 theorem safeApprove_eq_stub (token spender : Address) (amount : Uint256)
     (state : ContractState) (hcode : state.codeSize token.toNat ≠ 0) :
     (safeApprove token spender amount .stub).run state =
       (stubErc20Write "safeApprove" token
-        [Verity.addressToWord spender, amount]).run state := by
-  rw [safeApprove_run _ _ _ _ hcode]
-  exact erc20Write_eq_stub _ _ _ _ (by decide) hcode
+        [Verity.addressToWord spender, amount]).run state := rfl
 
 theorem legacyStringSafeTransfer_eq_stub (token toAddr : Address) (amount : Uint256)
     (state : ContractState) (hcode : state.codeSize token.toNat ≠ 0) :

--- a/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
+++ b/Verity/Proofs/Model/CommonExternalCallEquivalence.lean
@@ -28,24 +28,24 @@ theorem commonExternalCall_eq_model (adv : AdversaryModel) (site : CallSite)
       | .revert message _ => .revert message state := rfl
 
 def stubCallResultWords {α : Type} [ExternalResult α] [Inhabited α]
-    (name : String) (args : List Uint256) : Contract (Call.Result α) := fun state =>
-  match modelExternalCall .stub (linkedCallSite name args 1) state with
-  | .success (.success [word]) post =>
+    (name : String) (args : List Uint256) (arity : Nat := 1) (siteId : Nat := 0) :
+    Contract (Call.Result α) := fun state =>
+  match modelExternalCall .stub (linkedCallSite name args arity .call 0 0 [] siteId) state with
+  | .success (.success returndata) post =>
       .success (show Call.Result α from
         { success := true,
-          returndata := ExternalResult.fromWord (Core.Uint256.ofNat word) }) (legacyPost state post)
-  | .success (.success _) _ => .revert "external call returned invalid data" state
+          returndata := failedExternalResult returndata }) (legacyPost state post)
   | .success (.failure returndata) post | .success (.revert returndata) post =>
       .success (show Call.Result α from
         { success := false, returndata := failedExternalResult returndata }) (legacyPost state post)
   | .revert message _ => .revert message state
 
 def stubTryExternalCallWords {α : Type} [ExternalResult α] [Inhabited α]
-    (name : String) (args : List Uint256) : Contract (Bool × α) := fun state =>
-  match modelExternalCall .stub (linkedCallSite name args 1) state with
-  | .success (.success [word]) post =>
-      .success (true, ExternalResult.fromWord (Core.Uint256.ofNat word)) (legacyPost state post)
-  | .success (.success _) _ => .revert "external call returned invalid data" state
+    (name : String) (args : List Uint256) (arity : Nat := 1) (siteId : Nat := 0) :
+    Contract (Bool × α) := fun state =>
+  match modelExternalCall .stub (linkedCallSite name args arity .call 0 0 [] siteId) state with
+  | .success (.success returndata) post =>
+      .success (true, failedExternalResult returndata) (legacyPost state post)
   | .success (.failure returndata) post | .success (.revert returndata) post =>
       .success (false, failedExternalResult returndata) (legacyPost state post)
   | .revert message _ => .revert message state

--- a/artifacts/macro_property_tests/PropertyDirectDynamicECMArgSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyDirectDynamicECMArgSmoke.t.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyDirectDynamicECMArgSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/ExternalCalls.lean
+ */
+contract PropertyDirectDynamicECMArgSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("DirectDynamicECMArgSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `fromCall` result
+    function testTODO_FromCall_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("fromCall(bytes)", hex"CAFE"));
+        require(ok, "fromCall reverted unexpectedly");
+        assertEq(ret.length, 32, "fromCall ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: fromDo has no unexpected revert
+    function testAuto_FromDo_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("fromDo(string)", "verity"));
+        require(ok, "fromDo reverted unexpectedly");
+    }
+    // Property 3: fromBind has no unexpected revert
+    function testAuto_FromBind_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("fromBind(uint256[])", _singletonUintArray(1)));
+        require(ok, "fromBind reverted unexpectedly");
+    }
+
+    function _singletonUintArray(uint256 x) internal pure returns (uint256[] memory arr) {
+        arr = new uint256[](1);
+        arr[0] = x;
+    }
+}

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -194,7 +194,16 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 22: TODO decode and assert `bindDirtyAddress` result
+    // Property 22: TODO decode and assert `duplicateIdenticalCalls` result
+    function testTODO_DuplicateIdenticalCalls_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("duplicateIdenticalCalls()"));
+        require(ok, "duplicateIdenticalCalls reverted unexpectedly");
+        assertEq(ret.length, 32, "duplicateIdenticalCalls ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 23: TODO decode and assert `bindDirtyAddress` result
     function testTODO_BindDirtyAddress_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyAddress()"));
@@ -203,7 +212,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 23: TODO decode and assert `bindDirtyBool` result
+    // Property 24: TODO decode and assert `bindDirtyBool` result
     function testTODO_BindDirtyBool_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBool()"));
@@ -212,7 +221,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 24: TODO decode and assert `leanHelperNestedExternal` result
+    // Property 25: TODO decode and assert `leanHelperNestedExternal` result
     function testTODO_LeanHelperNestedExternal_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("leanHelperNestedExternal()"));
@@ -221,7 +230,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 25: TODO decode and assert `bindNestedExternalArg` result
+    // Property 26: TODO decode and assert `bindNestedExternalArg` result
     function testTODO_BindNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindNestedExternalArg()"));
@@ -230,49 +239,49 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 26: statementNestedExternalArg has no unexpected revert
+    // Property 27: statementNestedExternalArg has no unexpected revert
     function testAuto_StatementNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("statementNestedExternalArg()"));
         require(ok, "statementNestedExternalArg reverted unexpectedly");
     }
-    // Property 27: legacyNarrowArgs has no unexpected revert
+    // Property 28: legacyNarrowArgs has no unexpected revert
     function testAuto_LegacyNarrowArgs_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("legacyNarrowArgs()"));
         require(ok, "legacyNarrowArgs reverted unexpectedly");
     }
-    // Property 28: emitNestedExternalArg has no unexpected revert
+    // Property 29: emitNestedExternalArg has no unexpected revert
     function testAuto_EmitNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("emitNestedExternalArg()"));
         require(ok, "emitNestedExternalArg reverted unexpectedly");
     }
-    // Property 29: customErrorNestedExternalArg has no unexpected revert
+    // Property 30: customErrorNestedExternalArg has no unexpected revert
     function testAuto_CustomErrorNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("customErrorNestedExternalArg()"));
         require(ok, "customErrorNestedExternalArg reverted unexpectedly");
     }
-    // Property 30: consumeHelper has no unexpected revert
+    // Property 31: consumeHelper has no unexpected revert
     function testAuto_ConsumeHelper_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("consumeHelper(uint256)", uint256(1)));
         require(ok, "consumeHelper reverted unexpectedly");
     }
-    // Property 31: helperNestedExternalArg has no unexpected revert
+    // Property 32: helperNestedExternalArg has no unexpected revert
     function testAuto_HelperNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("helperNestedExternalArg()"));
         require(ok, "helperNestedExternalArg reverted unexpectedly");
     }
-    // Property 32: ecmNestedExternalArg has no unexpected revert
+    // Property 33: ecmNestedExternalArg has no unexpected revert
     function testAuto_EcmNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("ecmNestedExternalArg()"));
         require(ok, "ecmNestedExternalArg reverted unexpectedly");
     }
-    // Property 33: TODO decode and assert `erc20BalanceNestedExternalArg` result
+    // Property 34: TODO decode and assert `erc20BalanceNestedExternalArg` result
     function testTODO_Erc20BalanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20BalanceNestedExternalArg()"));
@@ -281,7 +290,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 34: TODO decode and assert `erc20AllowanceNestedExternalArg` result
+    // Property 35: TODO decode and assert `erc20AllowanceNestedExternalArg` result
     function testTODO_Erc20AllowanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20AllowanceNestedExternalArg()"));
@@ -290,7 +299,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 35: TODO decode and assert `erc20SupplyNestedExternalArg` result
+    // Property 36: TODO decode and assert `erc20SupplyNestedExternalArg` result
     function testTODO_Erc20SupplyNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20SupplyNestedExternalArg()"));
@@ -299,7 +308,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 36: TODO decode and assert `mappingNestedExternalArg` result
+    // Property 37: TODO decode and assert `mappingNestedExternalArg` result
     function testTODO_MappingNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("mappingNestedExternalArg()"));
@@ -308,7 +317,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 37: TODO decode and assert `tupleNestedExternalResult` result
+    // Property 38: TODO decode and assert `tupleNestedExternalResult` result
     function testTODO_TupleNestedExternalResult_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalResult()"));
@@ -317,7 +326,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 38: TODO decode and assert `tupleNestedExternalReturn` result
+    // Property 39: TODO decode and assert `tupleNestedExternalReturn` result
     function testTODO_TupleNestedExternalReturn_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalReturn()"));
@@ -326,7 +335,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 39: TODO decode and assert `pureDirtyInt` result
+    // Property 40: TODO decode and assert `pureDirtyInt` result
     function testTODO_PureDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
@@ -335,7 +344,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 40: TODO decode and assert `bindDirtyInt` result
+    // Property 41: TODO decode and assert `bindDirtyInt` result
     function testTODO_BindDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
@@ -344,7 +353,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 41: TODO decode and assert `pureDirtyBytes` result
+    // Property 42: TODO decode and assert `pureDirtyBytes` result
     function testTODO_PureDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
@@ -353,7 +362,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 42: TODO decode and assert `bindDirtyBytes` result
+    // Property 43: TODO decode and assert `bindDirtyBytes` result
     function testTODO_BindDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -32,7 +32,61 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("linkedWrite(uint256,bytes)", uint256(1), hex"CAFE"));
         require(ok, "linkedWrite reverted unexpectedly");
     }
-    // Property 3: TODO decode and assert `pureNarrow` result
+    // Property 3: TODO decode and assert `adversarialLeaf` result
+    function testTODO_AdversarialLeaf_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("adversarialLeaf(uint32)", uint32(1)));
+        require(ok, "adversarialLeaf reverted unexpectedly");
+        assertEq(ret.length, 32, "adversarialLeaf ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 4: TODO decode and assert `adversarialForwarder` result
+    function testTODO_AdversarialForwarder_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("adversarialForwarder(uint32)", uint32(1)));
+        require(ok, "adversarialForwarder reverted unexpectedly");
+        assertEq(ret.length, 32, "adversarialForwarder ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 5: TODO decode and assert `transitiveAdversarialCall` result
+    function testTODO_TransitiveAdversarialCall_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("transitiveAdversarialCall(uint32)", uint32(1)));
+        require(ok, "transitiveAdversarialCall reverted unexpectedly");
+        assertEq(ret.length, 32, "transitiveAdversarialCall ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 6: TODO decode and assert `conditionalLinkedRead` result
+    function testTODO_ConditionalLinkedRead_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("conditionalLinkedRead(bool)", true));
+        require(ok, "conditionalLinkedRead reverted unexpectedly");
+        assertEq(ret.length, 32, "conditionalLinkedRead ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 7: revertNestedExternalArg has no unexpected revert
+    function testAuto_RevertNestedExternalArg_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("revertNestedExternalArg()"));
+        require(ok, "revertNestedExternalArg reverted unexpectedly");
+    }
+    // Property 8: revertErrorNestedExternalArg has no unexpected revert
+    function testAuto_RevertErrorNestedExternalArg_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("revertErrorNestedExternalArg()"));
+        require(ok, "revertErrorNestedExternalArg reverted unexpectedly");
+    }
+    // Property 9: panicNestedExternalArg has no unexpected revert
+    function testAuto_PanicNestedExternalArg_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("panicNestedExternalArg()"));
+        require(ok, "panicNestedExternalArg reverted unexpectedly");
+    }
+    // Property 10: TODO decode and assert `pureNarrow` result
     function testTODO_PureNarrow_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureNarrow()"));
@@ -41,7 +95,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 4: TODO decode and assert `pureDirtyUint` result
+    // Property 11: TODO decode and assert `pureDirtyUint` result
     function testTODO_PureDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyUint()"));
@@ -50,7 +104,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 5: TODO decode and assert `mutableDirtyUint` result
+    // Property 12: TODO decode and assert `mutableDirtyUint` result
     function testTODO_MutableDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("mutableDirtyUint()"));
@@ -59,7 +113,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 6: TODO decode and assert `adversaryNameDoesNotCapture` result
+    // Property 13: TODO decode and assert `adversaryNameDoesNotCapture` result
     function testTODO_AdversaryNameDoesNotCapture_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("adversaryNameDoesNotCapture(uint256)", uint256(1)));
@@ -68,7 +122,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 7: TODO decode and assert `directDirtyUint` result
+    // Property 14: TODO decode and assert `directDirtyUint` result
     function testTODO_DirectDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("directDirtyUint()"));
@@ -77,7 +131,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 8: TODO decode and assert `nestedDirtyUint` result
+    // Property 15: TODO decode and assert `nestedDirtyUint` result
     function testTODO_NestedDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("nestedDirtyUint()"));
@@ -86,7 +140,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 9: TODO decode and assert `nestedExternalArg` result
+    // Property 16: TODO decode and assert `nestedExternalArg` result
     function testTODO_NestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("nestedExternalArg()"));
@@ -95,7 +149,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 10: TODO decode and assert `bindDirtyUint` result
+    // Property 17: TODO decode and assert `bindDirtyUint` result
     function testTODO_BindDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyUint()"));
@@ -104,7 +158,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 11: TODO decode and assert `tryDirtyUint` result
+    // Property 18: TODO decode and assert `tryDirtyUint` result
     function testTODO_TryDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryDirtyUint()"));
@@ -113,7 +167,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 12: TODO decode and assert `callResultDirtyUint` result
+    // Property 19: TODO decode and assert `callResultDirtyUint` result
     function testTODO_CallResultDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("callResultDirtyUint()"));
@@ -122,7 +176,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 13: TODO decode and assert `tryNotifyBool` result
+    // Property 20: TODO decode and assert `tryNotifyBool` result
     function testTODO_TryNotifyBool_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryNotifyBool(bool)", true));
@@ -131,7 +185,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 14: TODO decode and assert `tryDirtyPair` result
+    // Property 21: TODO decode and assert `tryDirtyPair` result
     function testTODO_TryDirtyPair_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryDirtyPair()"));
@@ -140,7 +194,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 15: TODO decode and assert `bindDirtyAddress` result
+    // Property 22: TODO decode and assert `bindDirtyAddress` result
     function testTODO_BindDirtyAddress_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyAddress()"));
@@ -149,7 +203,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 16: TODO decode and assert `bindDirtyBool` result
+    // Property 23: TODO decode and assert `bindDirtyBool` result
     function testTODO_BindDirtyBool_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBool()"));
@@ -158,7 +212,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 17: TODO decode and assert `leanHelperNestedExternal` result
+    // Property 24: TODO decode and assert `leanHelperNestedExternal` result
     function testTODO_LeanHelperNestedExternal_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("leanHelperNestedExternal()"));
@@ -167,7 +221,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 18: TODO decode and assert `bindNestedExternalArg` result
+    // Property 25: TODO decode and assert `bindNestedExternalArg` result
     function testTODO_BindNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindNestedExternalArg()"));
@@ -176,49 +230,49 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 19: statementNestedExternalArg has no unexpected revert
+    // Property 26: statementNestedExternalArg has no unexpected revert
     function testAuto_StatementNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("statementNestedExternalArg()"));
         require(ok, "statementNestedExternalArg reverted unexpectedly");
     }
-    // Property 20: legacyNarrowArgs has no unexpected revert
+    // Property 27: legacyNarrowArgs has no unexpected revert
     function testAuto_LegacyNarrowArgs_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("legacyNarrowArgs()"));
         require(ok, "legacyNarrowArgs reverted unexpectedly");
     }
-    // Property 21: emitNestedExternalArg has no unexpected revert
+    // Property 28: emitNestedExternalArg has no unexpected revert
     function testAuto_EmitNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("emitNestedExternalArg()"));
         require(ok, "emitNestedExternalArg reverted unexpectedly");
     }
-    // Property 22: customErrorNestedExternalArg has no unexpected revert
+    // Property 29: customErrorNestedExternalArg has no unexpected revert
     function testAuto_CustomErrorNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("customErrorNestedExternalArg()"));
         require(ok, "customErrorNestedExternalArg reverted unexpectedly");
     }
-    // Property 23: consumeHelper has no unexpected revert
+    // Property 30: consumeHelper has no unexpected revert
     function testAuto_ConsumeHelper_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("consumeHelper(uint256)", uint256(1)));
         require(ok, "consumeHelper reverted unexpectedly");
     }
-    // Property 24: helperNestedExternalArg has no unexpected revert
+    // Property 31: helperNestedExternalArg has no unexpected revert
     function testAuto_HelperNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("helperNestedExternalArg()"));
         require(ok, "helperNestedExternalArg reverted unexpectedly");
     }
-    // Property 25: ecmNestedExternalArg has no unexpected revert
+    // Property 32: ecmNestedExternalArg has no unexpected revert
     function testAuto_EcmNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("ecmNestedExternalArg()"));
         require(ok, "ecmNestedExternalArg reverted unexpectedly");
     }
-    // Property 26: TODO decode and assert `erc20BalanceNestedExternalArg` result
+    // Property 33: TODO decode and assert `erc20BalanceNestedExternalArg` result
     function testTODO_Erc20BalanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20BalanceNestedExternalArg()"));
@@ -227,7 +281,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 27: TODO decode and assert `erc20AllowanceNestedExternalArg` result
+    // Property 34: TODO decode and assert `erc20AllowanceNestedExternalArg` result
     function testTODO_Erc20AllowanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20AllowanceNestedExternalArg()"));
@@ -236,7 +290,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 28: TODO decode and assert `erc20SupplyNestedExternalArg` result
+    // Property 35: TODO decode and assert `erc20SupplyNestedExternalArg` result
     function testTODO_Erc20SupplyNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20SupplyNestedExternalArg()"));
@@ -245,7 +299,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 29: TODO decode and assert `mappingNestedExternalArg` result
+    // Property 36: TODO decode and assert `mappingNestedExternalArg` result
     function testTODO_MappingNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("mappingNestedExternalArg()"));
@@ -254,7 +308,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 30: TODO decode and assert `tupleNestedExternalResult` result
+    // Property 37: TODO decode and assert `tupleNestedExternalResult` result
     function testTODO_TupleNestedExternalResult_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalResult()"));
@@ -263,7 +317,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 31: TODO decode and assert `tupleNestedExternalReturn` result
+    // Property 38: TODO decode and assert `tupleNestedExternalReturn` result
     function testTODO_TupleNestedExternalReturn_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalReturn()"));
@@ -272,7 +326,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 32: TODO decode and assert `pureDirtyInt` result
+    // Property 39: TODO decode and assert `pureDirtyInt` result
     function testTODO_PureDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
@@ -281,7 +335,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 33: TODO decode and assert `bindDirtyInt` result
+    // Property 40: TODO decode and assert `bindDirtyInt` result
     function testTODO_BindDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
@@ -290,7 +344,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 34: TODO decode and assert `pureDirtyBytes` result
+    // Property 41: TODO decode and assert `pureDirtyBytes` result
     function testTODO_PureDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
@@ -299,7 +353,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 35: TODO decode and assert `bindDirtyBytes` result
+    // Property 42: TODO decode and assert `bindDirtyBytes` result
     function testTODO_BindDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -50,7 +50,25 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 5: TODO decode and assert `directDirtyUint` result
+    // Property 5: TODO decode and assert `mutableDirtyUint` result
+    function testTODO_MutableDirtyUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("mutableDirtyUint()"));
+        require(ok, "mutableDirtyUint reverted unexpectedly");
+        assertEq(ret.length, 32, "mutableDirtyUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 6: TODO decode and assert `adversaryNameDoesNotCapture` result
+    function testTODO_AdversaryNameDoesNotCapture_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("adversaryNameDoesNotCapture(uint256)", uint256(1)));
+        require(ok, "adversaryNameDoesNotCapture reverted unexpectedly");
+        assertEq(ret.length, 32, "adversaryNameDoesNotCapture ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 7: TODO decode and assert `directDirtyUint` result
     function testTODO_DirectDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("directDirtyUint()"));
@@ -59,7 +77,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 6: TODO decode and assert `nestedDirtyUint` result
+    // Property 8: TODO decode and assert `nestedDirtyUint` result
     function testTODO_NestedDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("nestedDirtyUint()"));
@@ -68,7 +86,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 7: TODO decode and assert `nestedExternalArg` result
+    // Property 9: TODO decode and assert `nestedExternalArg` result
     function testTODO_NestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("nestedExternalArg()"));
@@ -77,7 +95,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 8: TODO decode and assert `bindDirtyUint` result
+    // Property 10: TODO decode and assert `bindDirtyUint` result
     function testTODO_BindDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyUint()"));
@@ -86,7 +104,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 9: TODO decode and assert `tryDirtyUint` result
+    // Property 11: TODO decode and assert `tryDirtyUint` result
     function testTODO_TryDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryDirtyUint()"));
@@ -95,7 +113,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 10: TODO decode and assert `callResultDirtyUint` result
+    // Property 12: TODO decode and assert `callResultDirtyUint` result
     function testTODO_CallResultDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("callResultDirtyUint()"));
@@ -104,7 +122,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 11: TODO decode and assert `tryNotifyBool` result
+    // Property 13: TODO decode and assert `tryNotifyBool` result
     function testTODO_TryNotifyBool_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryNotifyBool(bool)", true));
@@ -113,7 +131,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 12: TODO decode and assert `tryDirtyPair` result
+    // Property 14: TODO decode and assert `tryDirtyPair` result
     function testTODO_TryDirtyPair_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryDirtyPair()"));
@@ -122,7 +140,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 13: TODO decode and assert `bindDirtyAddress` result
+    // Property 15: TODO decode and assert `bindDirtyAddress` result
     function testTODO_BindDirtyAddress_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyAddress()"));
@@ -131,7 +149,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 14: TODO decode and assert `bindDirtyBool` result
+    // Property 16: TODO decode and assert `bindDirtyBool` result
     function testTODO_BindDirtyBool_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBool()"));
@@ -140,7 +158,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 15: TODO decode and assert `leanHelperNestedExternal` result
+    // Property 17: TODO decode and assert `leanHelperNestedExternal` result
     function testTODO_LeanHelperNestedExternal_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("leanHelperNestedExternal()"));
@@ -149,7 +167,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 16: TODO decode and assert `bindNestedExternalArg` result
+    // Property 18: TODO decode and assert `bindNestedExternalArg` result
     function testTODO_BindNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindNestedExternalArg()"));
@@ -158,49 +176,49 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 17: statementNestedExternalArg has no unexpected revert
+    // Property 19: statementNestedExternalArg has no unexpected revert
     function testAuto_StatementNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("statementNestedExternalArg()"));
         require(ok, "statementNestedExternalArg reverted unexpectedly");
     }
-    // Property 18: legacyNarrowArgs has no unexpected revert
+    // Property 20: legacyNarrowArgs has no unexpected revert
     function testAuto_LegacyNarrowArgs_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("legacyNarrowArgs()"));
         require(ok, "legacyNarrowArgs reverted unexpectedly");
     }
-    // Property 19: emitNestedExternalArg has no unexpected revert
+    // Property 21: emitNestedExternalArg has no unexpected revert
     function testAuto_EmitNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("emitNestedExternalArg()"));
         require(ok, "emitNestedExternalArg reverted unexpectedly");
     }
-    // Property 20: customErrorNestedExternalArg has no unexpected revert
+    // Property 22: customErrorNestedExternalArg has no unexpected revert
     function testAuto_CustomErrorNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("customErrorNestedExternalArg()"));
         require(ok, "customErrorNestedExternalArg reverted unexpectedly");
     }
-    // Property 21: consumeHelper has no unexpected revert
+    // Property 23: consumeHelper has no unexpected revert
     function testAuto_ConsumeHelper_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("consumeHelper(uint256)", uint256(1)));
         require(ok, "consumeHelper reverted unexpectedly");
     }
-    // Property 22: helperNestedExternalArg has no unexpected revert
+    // Property 24: helperNestedExternalArg has no unexpected revert
     function testAuto_HelperNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("helperNestedExternalArg()"));
         require(ok, "helperNestedExternalArg reverted unexpectedly");
     }
-    // Property 23: ecmNestedExternalArg has no unexpected revert
+    // Property 25: ecmNestedExternalArg has no unexpected revert
     function testAuto_EcmNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("ecmNestedExternalArg()"));
         require(ok, "ecmNestedExternalArg reverted unexpectedly");
     }
-    // Property 24: TODO decode and assert `erc20BalanceNestedExternalArg` result
+    // Property 26: TODO decode and assert `erc20BalanceNestedExternalArg` result
     function testTODO_Erc20BalanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20BalanceNestedExternalArg()"));
@@ -209,7 +227,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 25: TODO decode and assert `erc20AllowanceNestedExternalArg` result
+    // Property 27: TODO decode and assert `erc20AllowanceNestedExternalArg` result
     function testTODO_Erc20AllowanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20AllowanceNestedExternalArg()"));
@@ -218,7 +236,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 26: TODO decode and assert `erc20SupplyNestedExternalArg` result
+    // Property 28: TODO decode and assert `erc20SupplyNestedExternalArg` result
     function testTODO_Erc20SupplyNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20SupplyNestedExternalArg()"));
@@ -227,7 +245,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 27: TODO decode and assert `mappingNestedExternalArg` result
+    // Property 29: TODO decode and assert `mappingNestedExternalArg` result
     function testTODO_MappingNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("mappingNestedExternalArg()"));
@@ -236,7 +254,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 28: TODO decode and assert `tupleNestedExternalResult` result
+    // Property 30: TODO decode and assert `tupleNestedExternalResult` result
     function testTODO_TupleNestedExternalResult_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalResult()"));
@@ -245,7 +263,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 29: TODO decode and assert `tupleNestedExternalReturn` result
+    // Property 31: TODO decode and assert `tupleNestedExternalReturn` result
     function testTODO_TupleNestedExternalReturn_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalReturn()"));
@@ -254,7 +272,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 30: TODO decode and assert `pureDirtyInt` result
+    // Property 32: TODO decode and assert `pureDirtyInt` result
     function testTODO_PureDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
@@ -263,7 +281,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 31: TODO decode and assert `bindDirtyInt` result
+    // Property 33: TODO decode and assert `bindDirtyInt` result
     function testTODO_BindDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
@@ -272,7 +290,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 32: TODO decode and assert `pureDirtyBytes` result
+    // Property 34: TODO decode and assert `pureDirtyBytes` result
     function testTODO_PureDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
@@ -281,7 +299,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 33: TODO decode and assert `bindDirtyBytes` result
+    // Property 35: TODO decode and assert `bindDirtyBytes` result
     function testTODO_BindDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -59,7 +59,16 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 6: TODO decode and assert `conditionalLinkedRead` result
+    // Property 6: helperNameShadow returns the direct parameter value
+    function testAuto_HelperNameShadow_ReturnsDirectParam() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("helperNameShadow(uint256)", uint256(1)));
+        require(ok, "helperNameShadow reverted unexpectedly");
+        assertEq(ret.length, 32, "helperNameShadow ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, uint256(1), "helperNameShadow should preserve the expected value");
+    }
+    // Property 7: TODO decode and assert `conditionalLinkedRead` result
     function testTODO_ConditionalLinkedRead_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("conditionalLinkedRead(bool)", true));
@@ -68,25 +77,25 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 7: revertNestedExternalArg has no unexpected revert
+    // Property 8: revertNestedExternalArg has no unexpected revert
     function testAuto_RevertNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("revertNestedExternalArg()"));
         require(ok, "revertNestedExternalArg reverted unexpectedly");
     }
-    // Property 8: revertErrorNestedExternalArg has no unexpected revert
+    // Property 9: revertErrorNestedExternalArg has no unexpected revert
     function testAuto_RevertErrorNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("revertErrorNestedExternalArg()"));
         require(ok, "revertErrorNestedExternalArg reverted unexpectedly");
     }
-    // Property 9: panicNestedExternalArg has no unexpected revert
+    // Property 10: panicNestedExternalArg has no unexpected revert
     function testAuto_PanicNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("panicNestedExternalArg()"));
         require(ok, "panicNestedExternalArg reverted unexpectedly");
     }
-    // Property 10: TODO decode and assert `pureNarrow` result
+    // Property 11: TODO decode and assert `pureNarrow` result
     function testTODO_PureNarrow_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureNarrow()"));
@@ -95,7 +104,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 11: TODO decode and assert `pureDirtyUint` result
+    // Property 12: TODO decode and assert `pureDirtyUint` result
     function testTODO_PureDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyUint()"));
@@ -104,7 +113,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 12: TODO decode and assert `mutableDirtyUint` result
+    // Property 13: TODO decode and assert `mutableDirtyUint` result
     function testTODO_MutableDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("mutableDirtyUint()"));
@@ -113,7 +122,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 13: TODO decode and assert `adversaryNameDoesNotCapture` result
+    // Property 14: TODO decode and assert `adversaryNameDoesNotCapture` result
     function testTODO_AdversaryNameDoesNotCapture_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("adversaryNameDoesNotCapture(uint256)", uint256(1)));
@@ -122,7 +131,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 14: TODO decode and assert `directDirtyUint` result
+    // Property 15: TODO decode and assert `directDirtyUint` result
     function testTODO_DirectDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("directDirtyUint()"));
@@ -131,7 +140,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 15: TODO decode and assert `nestedDirtyUint` result
+    // Property 16: TODO decode and assert `nestedDirtyUint` result
     function testTODO_NestedDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("nestedDirtyUint()"));
@@ -140,7 +149,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 16: TODO decode and assert `nestedExternalArg` result
+    // Property 17: TODO decode and assert `nestedExternalArg` result
     function testTODO_NestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("nestedExternalArg()"));
@@ -149,7 +158,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 17: TODO decode and assert `bindDirtyUint` result
+    // Property 18: TODO decode and assert `bindDirtyUint` result
     function testTODO_BindDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyUint()"));
@@ -158,7 +167,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 18: TODO decode and assert `tryDirtyUint` result
+    // Property 19: TODO decode and assert `tryDirtyUint` result
     function testTODO_TryDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryDirtyUint()"));
@@ -167,7 +176,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 19: TODO decode and assert `callResultDirtyUint` result
+    // Property 20: TODO decode and assert `callResultDirtyUint` result
     function testTODO_CallResultDirtyUint_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("callResultDirtyUint()"));
@@ -176,7 +185,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 20: TODO decode and assert `tryNotifyBool` result
+    // Property 21: TODO decode and assert `tryNotifyBool` result
     function testTODO_TryNotifyBool_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryNotifyBool(bool)", true));
@@ -185,7 +194,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 21: TODO decode and assert `tryDirtyPair` result
+    // Property 22: TODO decode and assert `tryDirtyPair` result
     function testTODO_TryDirtyPair_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tryDirtyPair()"));
@@ -194,7 +203,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 22: TODO decode and assert `duplicateIdenticalCalls` result
+    // Property 23: TODO decode and assert `duplicateIdenticalCalls` result
     function testTODO_DuplicateIdenticalCalls_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("duplicateIdenticalCalls()"));
@@ -203,7 +212,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 23: TODO decode and assert `dynamicTry` result
+    // Property 24: TODO decode and assert `dynamicTry` result
     function testTODO_DynamicTry_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("dynamicTry(bytes)", hex"CAFE"));
@@ -212,7 +221,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 24: TODO decode and assert `bindDirtyAddress` result
+    // Property 25: TODO decode and assert `bindDirtyAddress` result
     function testTODO_BindDirtyAddress_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyAddress()"));
@@ -221,7 +230,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 25: TODO decode and assert `bindDirtyBool` result
+    // Property 26: TODO decode and assert `bindDirtyBool` result
     function testTODO_BindDirtyBool_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBool()"));
@@ -230,7 +239,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 26: TODO decode and assert `leanHelperNestedExternal` result
+    // Property 27: TODO decode and assert `leanHelperNestedExternal` result
     function testTODO_LeanHelperNestedExternal_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("leanHelperNestedExternal()"));
@@ -239,7 +248,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 27: TODO decode and assert `bindNestedExternalArg` result
+    // Property 28: TODO decode and assert `bindNestedExternalArg` result
     function testTODO_BindNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindNestedExternalArg()"));
@@ -248,49 +257,49 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 28: statementNestedExternalArg has no unexpected revert
+    // Property 29: statementNestedExternalArg has no unexpected revert
     function testAuto_StatementNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("statementNestedExternalArg()"));
         require(ok, "statementNestedExternalArg reverted unexpectedly");
     }
-    // Property 29: legacyNarrowArgs has no unexpected revert
+    // Property 30: legacyNarrowArgs has no unexpected revert
     function testAuto_LegacyNarrowArgs_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("legacyNarrowArgs()"));
         require(ok, "legacyNarrowArgs reverted unexpectedly");
     }
-    // Property 30: emitNestedExternalArg has no unexpected revert
+    // Property 31: emitNestedExternalArg has no unexpected revert
     function testAuto_EmitNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("emitNestedExternalArg()"));
         require(ok, "emitNestedExternalArg reverted unexpectedly");
     }
-    // Property 31: customErrorNestedExternalArg has no unexpected revert
+    // Property 32: customErrorNestedExternalArg has no unexpected revert
     function testAuto_CustomErrorNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("customErrorNestedExternalArg()"));
         require(ok, "customErrorNestedExternalArg reverted unexpectedly");
     }
-    // Property 32: consumeHelper has no unexpected revert
+    // Property 33: consumeHelper has no unexpected revert
     function testAuto_ConsumeHelper_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("consumeHelper(uint256)", uint256(1)));
         require(ok, "consumeHelper reverted unexpectedly");
     }
-    // Property 33: helperNestedExternalArg has no unexpected revert
+    // Property 34: helperNestedExternalArg has no unexpected revert
     function testAuto_HelperNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("helperNestedExternalArg()"));
         require(ok, "helperNestedExternalArg reverted unexpectedly");
     }
-    // Property 34: ecmNestedExternalArg has no unexpected revert
+    // Property 35: ecmNestedExternalArg has no unexpected revert
     function testAuto_EcmNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("ecmNestedExternalArg()"));
         require(ok, "ecmNestedExternalArg reverted unexpectedly");
     }
-    // Property 35: TODO decode and assert `erc20BalanceNestedExternalArg` result
+    // Property 36: TODO decode and assert `erc20BalanceNestedExternalArg` result
     function testTODO_Erc20BalanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20BalanceNestedExternalArg()"));
@@ -299,7 +308,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 36: TODO decode and assert `erc20AllowanceNestedExternalArg` result
+    // Property 37: TODO decode and assert `erc20AllowanceNestedExternalArg` result
     function testTODO_Erc20AllowanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20AllowanceNestedExternalArg()"));
@@ -308,7 +317,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 37: TODO decode and assert `erc20SupplyNestedExternalArg` result
+    // Property 38: TODO decode and assert `erc20SupplyNestedExternalArg` result
     function testTODO_Erc20SupplyNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20SupplyNestedExternalArg()"));
@@ -317,7 +326,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 38: TODO decode and assert `mappingNestedExternalArg` result
+    // Property 39: TODO decode and assert `mappingNestedExternalArg` result
     function testTODO_MappingNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("mappingNestedExternalArg()"));
@@ -326,7 +335,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 39: TODO decode and assert `tupleNestedExternalResult` result
+    // Property 40: TODO decode and assert `tupleNestedExternalResult` result
     function testTODO_TupleNestedExternalResult_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalResult()"));
@@ -335,7 +344,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 40: TODO decode and assert `tupleNestedExternalReturn` result
+    // Property 41: TODO decode and assert `tupleNestedExternalReturn` result
     function testTODO_TupleNestedExternalReturn_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalReturn()"));
@@ -344,7 +353,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 41: TODO decode and assert `pureDirtyInt` result
+    // Property 42: TODO decode and assert `pureDirtyInt` result
     function testTODO_PureDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
@@ -353,7 +362,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 42: TODO decode and assert `bindDirtyInt` result
+    // Property 43: TODO decode and assert `bindDirtyInt` result
     function testTODO_BindDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
@@ -362,7 +371,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 43: TODO decode and assert `pureDirtyBytes` result
+    // Property 44: TODO decode and assert `pureDirtyBytes` result
     function testTODO_PureDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
@@ -371,7 +380,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 44: TODO decode and assert `bindDirtyBytes` result
+    // Property 45: TODO decode and assert `bindDirtyBytes` result
     function testTODO_BindDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));

--- a/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyExternalCallInBodySmoke.t.sol
@@ -203,7 +203,16 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 23: TODO decode and assert `bindDirtyAddress` result
+    // Property 23: TODO decode and assert `dynamicTry` result
+    function testTODO_DynamicTry_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("dynamicTry(bytes)", hex"CAFE"));
+        require(ok, "dynamicTry reverted unexpectedly");
+        assertEq(ret.length, 32, "dynamicTry ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 24: TODO decode and assert `bindDirtyAddress` result
     function testTODO_BindDirtyAddress_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyAddress()"));
@@ -212,7 +221,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 24: TODO decode and assert `bindDirtyBool` result
+    // Property 25: TODO decode and assert `bindDirtyBool` result
     function testTODO_BindDirtyBool_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBool()"));
@@ -221,7 +230,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 25: TODO decode and assert `leanHelperNestedExternal` result
+    // Property 26: TODO decode and assert `leanHelperNestedExternal` result
     function testTODO_LeanHelperNestedExternal_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("leanHelperNestedExternal()"));
@@ -230,7 +239,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 26: TODO decode and assert `bindNestedExternalArg` result
+    // Property 27: TODO decode and assert `bindNestedExternalArg` result
     function testTODO_BindNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindNestedExternalArg()"));
@@ -239,49 +248,49 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 27: statementNestedExternalArg has no unexpected revert
+    // Property 28: statementNestedExternalArg has no unexpected revert
     function testAuto_StatementNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("statementNestedExternalArg()"));
         require(ok, "statementNestedExternalArg reverted unexpectedly");
     }
-    // Property 28: legacyNarrowArgs has no unexpected revert
+    // Property 29: legacyNarrowArgs has no unexpected revert
     function testAuto_LegacyNarrowArgs_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("legacyNarrowArgs()"));
         require(ok, "legacyNarrowArgs reverted unexpectedly");
     }
-    // Property 29: emitNestedExternalArg has no unexpected revert
+    // Property 30: emitNestedExternalArg has no unexpected revert
     function testAuto_EmitNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("emitNestedExternalArg()"));
         require(ok, "emitNestedExternalArg reverted unexpectedly");
     }
-    // Property 30: customErrorNestedExternalArg has no unexpected revert
+    // Property 31: customErrorNestedExternalArg has no unexpected revert
     function testAuto_CustomErrorNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("customErrorNestedExternalArg()"));
         require(ok, "customErrorNestedExternalArg reverted unexpectedly");
     }
-    // Property 31: consumeHelper has no unexpected revert
+    // Property 32: consumeHelper has no unexpected revert
     function testAuto_ConsumeHelper_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("consumeHelper(uint256)", uint256(1)));
         require(ok, "consumeHelper reverted unexpectedly");
     }
-    // Property 32: helperNestedExternalArg has no unexpected revert
+    // Property 33: helperNestedExternalArg has no unexpected revert
     function testAuto_HelperNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("helperNestedExternalArg()"));
         require(ok, "helperNestedExternalArg reverted unexpectedly");
     }
-    // Property 33: ecmNestedExternalArg has no unexpected revert
+    // Property 34: ecmNestedExternalArg has no unexpected revert
     function testAuto_EcmNestedExternalArg_NoUnexpectedRevert() public {
         vm.prank(alice);
         (bool ok,) = target.call(abi.encodeWithSignature("ecmNestedExternalArg()"));
         require(ok, "ecmNestedExternalArg reverted unexpectedly");
     }
-    // Property 34: TODO decode and assert `erc20BalanceNestedExternalArg` result
+    // Property 35: TODO decode and assert `erc20BalanceNestedExternalArg` result
     function testTODO_Erc20BalanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20BalanceNestedExternalArg()"));
@@ -290,7 +299,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 35: TODO decode and assert `erc20AllowanceNestedExternalArg` result
+    // Property 36: TODO decode and assert `erc20AllowanceNestedExternalArg` result
     function testTODO_Erc20AllowanceNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20AllowanceNestedExternalArg()"));
@@ -299,7 +308,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 36: TODO decode and assert `erc20SupplyNestedExternalArg` result
+    // Property 37: TODO decode and assert `erc20SupplyNestedExternalArg` result
     function testTODO_Erc20SupplyNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("erc20SupplyNestedExternalArg()"));
@@ -308,7 +317,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 37: TODO decode and assert `mappingNestedExternalArg` result
+    // Property 38: TODO decode and assert `mappingNestedExternalArg` result
     function testTODO_MappingNestedExternalArg_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("mappingNestedExternalArg()"));
@@ -317,7 +326,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 38: TODO decode and assert `tupleNestedExternalResult` result
+    // Property 39: TODO decode and assert `tupleNestedExternalResult` result
     function testTODO_TupleNestedExternalResult_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalResult()"));
@@ -326,7 +335,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 39: TODO decode and assert `tupleNestedExternalReturn` result
+    // Property 40: TODO decode and assert `tupleNestedExternalReturn` result
     function testTODO_TupleNestedExternalReturn_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("tupleNestedExternalReturn()"));
@@ -335,7 +344,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 40: TODO decode and assert `pureDirtyInt` result
+    // Property 41: TODO decode and assert `pureDirtyInt` result
     function testTODO_PureDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyInt()"));
@@ -344,7 +353,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 41: TODO decode and assert `bindDirtyInt` result
+    // Property 42: TODO decode and assert `bindDirtyInt` result
     function testTODO_BindDirtyInt_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyInt()"));
@@ -353,7 +362,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 42: TODO decode and assert `pureDirtyBytes` result
+    // Property 43: TODO decode and assert `pureDirtyBytes` result
     function testTODO_PureDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("pureDirtyBytes()"));
@@ -362,7 +371,7 @@ contract PropertyExternalCallInBodySmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 43: TODO decode and assert `bindDirtyBytes` result
+    // Property 44: TODO decode and assert `bindDirtyBytes` result
     function testTODO_BindDirtyBytes_DecodeAndAssert() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("bindDirtyBytes()"));

--- a/artifacts/macro_property_tests/PropertyGenericECMTripleResultSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyGenericECMTripleResultSmoke.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyGenericECMTripleResultSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke/ExternalCalls.lean
+ */
+contract PropertyGenericECMTripleResultSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("GenericECMTripleResultSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: storeThird has no unexpected revert
+    function testAuto_StoreThird_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("storeThird()"));
+        require(ok, "storeThird reverted unexpectedly");
+    }
+}

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,8 +168,8 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 569,
-    "partial def": 174
+    "native_decide": 570,
+    "partial def": 175
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",
   "schema_version": 1

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -169,7 +169,7 @@
   "mechanisms": {
     "@[implemented_by": 1,
     "native_decide": 566,
-    "partial def": 171
+    "partial def": 172
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",
   "schema_version": 1

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,8 +168,8 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 568,
-    "partial def": 173
+    "native_decide": 569,
+    "partial def": 174
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",
   "schema_version": 1

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 578,
+    "native_decide": 581,
     "partial def": 175
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 585,
+    "native_decide": 584,
     "partial def": 175
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 570,
+    "native_decide": 573,
     "partial def": 175
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 573,
+    "native_decide": 578,
     "partial def": 175
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 584,
+    "native_decide": 585,
     "partial def": 175
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 581,
+    "native_decide": 583,
     "partial def": 175
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 566,
+    "native_decide": 568,
     "partial def": 172
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -168,7 +168,7 @@
   },
   "mechanisms": {
     "@[implemented_by": 1,
-    "native_decide": 583,
+    "native_decide": 584,
     "partial def": 175
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",

--- a/artifacts/trust_surface_report.json
+++ b/artifacts/trust_surface_report.json
@@ -169,7 +169,7 @@
   "mechanisms": {
     "@[implemented_by": 1,
     "native_decide": 568,
-    "partial def": 172
+    "partial def": 173
   },
   "notes": "native_decide trusts Lean.ofReduceBool or Lean 4.31 generated per-proof native_decide axioms + Lean.trustCompiler. Prose registry: AXIOMS.md, TRUST_ASSUMPTIONS.md (enforced by scripts/check_trust_surface_registry.py).",
   "schema_version": 1

--- a/scripts/check_macro_property_test_generation.py
+++ b/scripts/check_macro_property_test_generation.py
@@ -29,6 +29,9 @@ EXCLUDED_CONTRACTS = {
     "FixedArrayStructSmoke",
     "LinkedExternalProjectedArrayArgSmoke",
     "NestedStructArrayProjectionSmoke",
+    # Nested fixed-array return decoding is covered by its executable Lean
+    # regression; Solidity signature synthesis does not yet map FixedArray.
+    "TypedInterfaceNestedFixedReturnSmoke",
     # The generated no-revert stub cannot currently fund the contract before
     # exercising `callWithValue`; Lean/Yul/trust-report tests cover this ECM.
     "CallWithValueSmoke",


### PR DESCRIPTION
## Status: repaired and verified at `974d13736d3315970e3ae864a0abb08ad790b04e`

This branch keeps `AdversaryModel` as the sole callee notion, threads it explicitly iff a generated executable body opens a reentrancy window, and preserves the existing monotonic fragment. Staticcall-only generated functions (including `MacroERC20.snapshotBalance`) omit the adversary parameter and use the deterministic stub. It does not start contract-level external-call proofs.

The repair:
- classifies direct and transitively called helpers with `translatedBodyOpensReentrancyWindow`;
- restores dynamic ABI `{name}_data_offset` parameters across expression, linked-call, and ECM lowering;
- evaluates nested addition operands left-to-right through the call-aware model;
- supplies exact external-call name and return arity to ordinary and try-call `CallSite` values;
- adds focused executable/model regressions for static calls, dynamic offsets, nested calls, and stubbed try-call results.

Exact-tree validation:
- local focused Lean targets, full `lake build` (2474 jobs), `lake build PrintAxioms` (2627 jobs), trust-surface and macro-generator checks, changed-Lean forbidden-token scan, and `make check` (666 tests) all passed;
- canonical Verify proofs run passed in full on the exact head: https://github.com/lfglabs-dev/verity/actions/runs/34021809336;
- private x64 validation completed repository checks, full Lake build, warning regression, PrintAxioms, Lean audits, toolchain, and solc successfully: https://github.com/lfglabs-dev/verity/actions/runs/34021863853. The job was canceled only during its optional compiler-core tail after the required validation steps were green, to release the sole heavy runner;
- the first DGX attempt failed during runner cleanup before code gates because the checkout lacked the tracked cleanup script (infrastructure-only receipt): https://github.com/lfglabs-dev/verity/actions/runs/34021832776.

Review:
- exactly one fresh `@codex review` request was posted for this head: https://github.com/lfglabs-dev/verity/pull/2405#issuecomment-5558019896;
- Codex reviewed the exact commit and raised one staticcall-adversary suggestion. It conflicts with this repair's required iff/staticcall contract, so the rationale was documented and the thread resolved: https://github.com/lfglabs-dev/verity/pull/2405#discussion_r3943565760;
- the exact-head OpenCodeReview run was scout-only, advisory, and reported no findings; it was not treated as a semantic verdict.

The trust-surface report was regenerated for the added `native_decide` regression. No merge, rebase, force-push, new PR, support removal, gate weakening, forbidden proof escape, or proof-scope widening was performed.